### PR TITLE
[BUG] Implement missing `colalign` parameter in `ScipyDist`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1487,7 +1487,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/74055102?v=4",
       "profile": "https://github.com/Saransh-cpp",
       "contributions": [
-        "doc"
+        "doc",
+        "code"
       ]
     }
   ],

--- a/sktime/dists_kernels/scipy_dist.py
+++ b/sktime/dists_kernels/scipy_dist.py
@@ -8,7 +8,6 @@ Interface module to scipy.spatial's pairwise distance function cdist
 __author__ = ["fkiraly"]
 
 import pandas as pd
-
 from scipy.spatial.distance import cdist
 
 from sktime.dists_kernels._base import BasePairwiseTransformer
@@ -78,6 +77,20 @@ class ScipyDist(BasePairwiseTransformer):
         """
         p = self.p
         metric = self.metric
+        common_columns = X.columns.intersection(X2.columns)
+
+        if self.colalign == "intersect":
+            X = X[common_columns]
+            X2 = X2[common_columns]
+        elif self.colalign == "force-align":
+            if common_columns == X.columns and common_columns == X2.columns:
+                X = X[common_columns]
+                X2 = X2[common_columns]
+            else:
+                raise ValueError(
+                    "The set of columns in X and X2 must be same when using",
+                    "'force-align'",
+                )
 
         if isinstance(X, pd.DataFrame):
             X = X.select_dtypes("number").to_numpy(dtype="float")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #1942
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Implements the `colalign` parameter in `ScipyDist`. For reference -
```
colalign: string, one of 'intersect' (default), 'force-align', 'none'
        controls column alignment if X, X2 passed in fit are pd.DataFrame
        columns between X and X2 are aligned via column names
        if 'intersect', distance is computed on columns occurring both in X and X2,
            other columns are discarded; column ordering in X2 is copied from X
        if 'force-align', raises an error if the set of columns in X, X2 differs;
            column ordering in X2 is copied from X
        if 'none', X and X2 are passed through unmodified (no columns are aligned)
            note: this will potentially align "non-matching" columns
```
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?
At present, the implementation works, but is this the desired implementation?
<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
I haven't added any tests yet, wanted some initial reviews on the implementation.
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
