### PR TITLE
[ENH] deprecation warning for start_with_window in ExpandingWindowSplitter

### DIFF
--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1178,11 +1178,16 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
         super(ExpandingWindowSplitter, self).__init__(
             fh=fh,
             window_length=initial_window,
-            initial_window=None,
+            initial_window=initial_window,
             step_length=step_length,
             start_with_window=start_with_window,
         )
-
+        if not self.start_with_window:
+            warnings.warn(
+                    "Please use initial_window=0 instead of start_with_window=False as the"
+                    + "start_with_window parameter is going to be deprecated in the future.",
+                    FutureWarning
+                )
     def _split_windows(self, **kwargs) -> SPLIT_GENERATOR_TYPE:
         return self._split_windows_generic(expanding=True, **kwargs)
 


### PR DESCRIPTION
#### Realizes #2678 


#### What does this implement/fix? Explain your changes.
Helps to make the code less confusing for the users and lets them set values in a more intuitive and direct manner. This PR lays the groundwork for the planned deprecation of `start_with_window` in `ExpandingWindowSplitter`. The tasks this PR seeks to realize are:

1. provide users the ability to set initial_window to 0 _and have it actually be set to 0_
2. displays a new `FutureWarning` message prompted when the user sets the default for `start_with_window` to be `False` instead of the default value which is `True`. This way we can warn our users about the coming change and allow them time to make the necessary changes.