### PR TITLE
[ENH] design for generic save/load aka serialization/deserialization of estimators

### DIFF
--- a/sktime/base/__init__.py
+++ b/sktime/base/__init__.py
@@ -9,7 +9,9 @@ __all__ = [
     "BaseObject",
     "BaseEstimator",
     "_HeterogenousMetaEstimator",
+    "load",
 ]
 
 from sktime.base._base import BaseObject, BaseEstimator
 from sktime.base._meta import _HeterogenousMetaEstimator
+from sktime.base._serialize import load

--- a/sktime/base/__init__.py
+++ b/sktime/base/__init__.py
@@ -12,6 +12,6 @@ __all__ = [
     "load",
 ]
 
-from sktime.base._base import BaseObject, BaseEstimator
+from sktime.base._base import BaseEstimator, BaseObject
 from sktime.base._meta import _HeterogenousMetaEstimator
 from sktime.base._serialize import load

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -616,7 +616,7 @@ class BaseObject(_BaseEstimator):
         Returns
         -------
         if `path` is None - in-memory serialized self
-        if `path` is file location - BaseObjectFile with reference to location
+        if `path` is file location - ZipFile with reference to location
         """
         import pickle
 
@@ -631,10 +631,43 @@ class BaseObject(_BaseEstimator):
             with zipfile.open("object", mode="w") as object:
                 object.write(pickle.dumps(self))
 
+        return ZipFile(path)
 
-class BaseObjectFile:
+    @classmethod
+    def load_from_serial(cls, serial):
+        """Load object from serialized memory container.
 
-    pass
+        Parameters
+        ----------
+        serial : output of `cls.save(None)`
+
+        Returns
+        -------
+        unserialized self resulting in output `serial`, of `cls.save(None)`
+        """
+        import pickle
+
+        return pickle.loads(serial)
+
+    @classmethod
+    def load_from_path(cls, path):
+        """Load object from file location.
+
+        Parameters
+        ----------
+        path : file location (str or Path)
+
+        Returns
+        -------
+        unserialized self resulting in output at `path`, of `cls.save(path)`
+        """
+        import pickle
+        from zipfile import ZipFile
+
+        with ZipFile(path) as zipfile:
+            with zipfile.open("object", mode="r") as object:
+                pickled = object.read()
+                return pickle.reads(pickled)
 
 
 class TagAliaserMixin:

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -596,6 +596,46 @@ class BaseObject(_BaseEstimator):
 
         return comp_dict
 
+    def save(self, path=None):
+        """Save serialized self to bytes-like object or to file.
+
+        Behaviour:
+        if `path` is None, returns an in-memory serialized self
+        if `path` is a file location, stores self at that location
+
+        saved files are zip files with following contents:
+        metadata - contains class name of self, i.e., type(self).__name__
+        object - serialized self. This class uses the default serialization (pickle).
+
+        Parameters
+        ----------
+        path : None or file location (str or Path)
+            if None, self is saved to an in-memory object
+            if file location, self is saved to that file location
+
+        Returns
+        -------
+        if `path` is None - in-memory serialized self
+        if `path` is file location - BaseObjectFile with reference to location
+        """
+        import pickle
+
+        if path is None:
+            return pickle.dumps(self)
+
+        from zipfile import ZipFile
+
+        with ZipFile(path) as zipfile:
+            with zipfile.open("metadata", mode="w") as meta_file:
+                meta_file.write(type(self).__name__)
+            with zipfile.open("object", mode="w") as object:
+                object.write(pickle.dumps(self))
+
+
+class BaseObjectFile:
+
+    pass
+
 
 class TagAliaserMixin:
     """Mixin class for tag aliasing and deprecation of old tags.

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -643,7 +643,7 @@ class BaseObject(_BaseEstimator):
 
         Returns
         -------
-        unserialized self resulting in output `serial`, of `cls.save(None)`
+        deserialized self resulting in output `serial`, of `cls.save(None)`
         """
         import pickle
 
@@ -659,7 +659,7 @@ class BaseObject(_BaseEstimator):
 
         Returns
         -------
-        unserialized self resulting in output at `path`, of `cls.save(path)`
+        deserialized self resulting in output at `path`, of `cls.save(path)`
         """
         import pickle
 

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -604,7 +604,7 @@ class BaseObject(_BaseEstimator):
         if `path` is a file location, stores self at that location
 
         saved files are zip files with following contents:
-        metadata - contains class name of self, i.e., type(self).__name__
+        metadata - contains class of self, i.e., type(self)
         object - serialized self. This class uses the default serialization (pickle).
 
         Parameters
@@ -621,13 +621,13 @@ class BaseObject(_BaseEstimator):
         import pickle
 
         if path is None:
-            return pickle.dumps(self)
+            return (type(self), pickle.dumps(self))
 
         from zipfile import ZipFile
 
         with ZipFile(path) as zipfile:
             with zipfile.open("metadata", mode="w") as meta_file:
-                meta_file.write(type(self).__name__)
+                meta_file.write(type(self))
             with zipfile.open("object", mode="w") as object:
                 object.write(pickle.dumps(self))
 
@@ -639,7 +639,7 @@ class BaseObject(_BaseEstimator):
 
         Parameters
         ----------
-        serial : output of `cls.save(None)`
+        serial : 1st element of output of `cls.save(None)`
 
         Returns
         -------
@@ -650,24 +650,20 @@ class BaseObject(_BaseEstimator):
         return pickle.loads(serial)
 
     @classmethod
-    def load_from_path(cls, path):
+    def load_from_path(cls, serial):
         """Load object from file location.
 
         Parameters
         ----------
-        path : file location (str or Path)
+        serial : result of ZipFile(path).open("object)
 
         Returns
         -------
         unserialized self resulting in output at `path`, of `cls.save(path)`
         """
         import pickle
-        from zipfile import ZipFile
 
-        with ZipFile(path) as zipfile:
-            with zipfile.open("object", mode="r") as object:
-                pickled = object.read()
-                return pickle.reads(pickled)
+        return pickle.loads(serial)
 
 
 class TagAliaserMixin:

--- a/sktime/base/_serialize.py
+++ b/sktime/base/_serialize.py
@@ -14,7 +14,7 @@ def load(serial):
 
     Returns
     -------
-    unserialized self resulting in output `serial`, of `cls.save`
+    deserialized self resulting in output `serial`, of `cls.save`
 
     Example
     -------

--- a/sktime/base/_serialize.py
+++ b/sktime/base/_serialize.py
@@ -15,6 +15,18 @@ def load(serial):
     Returns
     -------
     unserialized self resulting in output `serial`, of `cls.save`
+
+    Example
+    -------
+    >>> from sktime.base import load
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.naive import NaiveForecaster
+    >>> y = load_airline()
+    >>> forecaster = NaiveForecaster()
+    >>> forecaster.fit(y, fh=[1, 2, 3])
+    >>> pkl = forecaster.save()
+    >>> forecaster_loaded = load(pkl)
+    >>> forecaster_loaded.predict()
     """
     from zipfile import ZipFile
 

--- a/sktime/base/_serialize.py
+++ b/sktime/base/_serialize.py
@@ -24,9 +24,10 @@ def load(serial):
     >>> y = load_airline()
     >>> forecaster = NaiveForecaster()
     >>> forecaster.fit(y, fh=[1, 2, 3])
+    NaiveForecaster()
     >>> pkl = forecaster.save()
     >>> forecaster_loaded = load(pkl)
-    >>> forecaster_loaded.predict()
+    >>> y_pred = forecaster_loaded.predict()
     """
     from zipfile import ZipFile
 

--- a/sktime/base/_serialize.py
+++ b/sktime/base/_serialize.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Utilities for serializing and deserializing objects."""
+
+__author__ = ["fkiraly"]
+
+
+def load(serial):
+    """Load object from serialized location - in-memory or file.
+
+    Parameters
+    ----------
+    serial : serialized container, or str (path)
+
+    Returns
+    -------
+    unserialized self resulting in output `serial`, of `cls.save`
+    """
+    if isinstance(serial, tuple):
+        cls = serial[0]
+        stored = serial[1]
+        return stored.load_from_serial(stored)
+    elif isinstance(serial, str):
+        from zipfile import ZipFile
+
+        with ZipFile(serial) as zipfile:
+            with zipfile.open("metadata", mode="r") as metadata:
+                cls = metadata.read()
+            with zipfile.open("object", mode="r") as object:
+                return cls.load_from_path(object.read())
+    else:
+        raise TypeError(
+            "serial must either be a serialized in-memory sktime object, "
+            "or a str pointing to a file which is a serialized sktime object, "
+            "created by save of an sktime object; but found serial "
+            f"of type {serial}"
+        )

--- a/sktime/base/_serialize.py
+++ b/sktime/base/_serialize.py
@@ -10,28 +10,31 @@ def load(serial):
 
     Parameters
     ----------
-    serial : serialized container, or str (path)
+    serial : serialized container, str (path), or ZipFile (reference)
 
     Returns
     -------
     unserialized self resulting in output `serial`, of `cls.save`
     """
+    from zipfile import ZipFile
+
     if isinstance(serial, tuple):
         cls = serial[0]
         stored = serial[1]
-        return stored.load_from_serial(stored)
-    elif isinstance(serial, str):
-        from zipfile import ZipFile
+        return cls.load_from_serial(stored)
+    elif isinstance(serial, (str, ZipFile)):
 
-        with ZipFile(serial) as zipfile:
-            with zipfile.open("metadata", mode="r") as metadata:
-                cls = metadata.read()
-            with zipfile.open("object", mode="r") as object:
-                return cls.load_from_path(object.read())
+        if isinstance(serial, str):
+            zipfile = ZipFile(serial)
+
+        with zipfile.open("metadata", mode="r") as metadata:
+            cls = metadata.read()
+        with zipfile.open("object", mode="r") as object:
+            return cls.load_from_path(object.read())
     else:
         raise TypeError(
             "serial must either be a serialized in-memory sktime object, "
-            "or a str pointing to a file which is a serialized sktime object, "
-            "created by save of an sktime object; but found serial "
+            "or a str or ZipFile pointing to a file which is a serialized sktime "
+            "object, created by save of an sktime object; but found serial "
             f"of type {serial}"
         )

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -8,7 +8,6 @@ adapted from scikit-learn's estimator_checks
 __author__ = ["mloning", "fkiraly"]
 
 import numbers
-import pickle
 import types
 from copy import deepcopy
 from inspect import getfullargspec, isclass, signature
@@ -21,7 +20,7 @@ from sklearn.utils.estimator_checks import (
     check_get_params_invariance as _check_get_params_invariance,
 )
 
-from sktime.base import BaseEstimator, BaseObject
+from sktime.base import BaseEstimator, BaseObject, load
 from sktime.dists_kernels._base import (
     BasePairwiseTransformer,
     BasePairwiseTransformerPanel,
@@ -1162,12 +1161,12 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         # Generate results before pickling
         vanilla_result = scenario.run(estimator, method_sequence=[method_nsc])
 
-        # Pickle and unpickle
-        pickled_estimator = pickle.dumps(estimator)
-        unpickled_estimator = pickle.loads(pickled_estimator)
+        # Serialize and unserialize
+        serialized_estimator = estimator.save()
+        deserialized_estimator = load(serialized_estimator)
 
-        unpickled_result = scenario.run(
-            unpickled_estimator, method_sequence=[method_nsc]
+        deserialized_result = scenario.run(
+            deserialized_estimator, method_sequence=[method_nsc]
         )
 
         msg = (
@@ -1176,7 +1175,7 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         )
         _assert_array_almost_equal(
             vanilla_result,
-            unpickled_result,
+            deserialized_result,
             decimal=6,
             err_msg=msg,
         )


### PR DESCRIPTION
This adds a prototype design for serializing and deserializing estimators.
This follows the current (Aug 19) draft STEP 27 https://github.com/sktime/enhancement-proposals/pull/27.

This is done via `save` and two `load` methods which can be overridden by class, and a generic `load` (class agnostic), in the `BaseObject` module.

Also changes the pickle/unpickle test to a generic serialize/deserialize test which allows custom, class specific implementations of serialize and deserialize.

FYI @AurumnPegasus - design alternative to https://github.com/alan-turing-institute/sktime/pull/3128 which avoids the workflow where we have to construct an object first when we load.