### PR TITLE
[ENH] forecast default update warning to point to stream forecasting wrappers

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1776,7 +1776,9 @@ class BaseForecaster(BaseEstimator):
                 f"NotImplementedWarning: {self.__class__.__name__} "
                 f"does not have a custom `update` method implemented. "
                 f"{self.__class__.__name__} will be refit each time "
-                f"`update` is called with update_params=True."
+                f"`update` is called with update_params=True. "
+                "To refit less often, use the wrappers in the "
+                "forecasting.stream module, e.g., UpdateEvery."
             )
             # we need to overwrite the mtype last seen and converter store, since the _y
             #    may have been converted


### PR DESCRIPTION
This updates the warning raised by the default `BaseForecaster._update` to point to the `forecasting.stream` module, to point out to users the possibility to update less often or turn off refitting at `update` call (which is available but extrinsic as wrapper).