### PR TITLE
[BUG] fix `get_cutoff` for numpy format

### DIFF
--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -241,6 +241,8 @@ def get_cutoff(
                 "if cutoff is a pd.Index, its length must be 1, but"
                 f" found a pd.Index with length {len(cutoff)}"
             )
+        if len(obj) == 0 and return_index:
+            return cutoff
         cutoff = cutoff[0]
 
     if len(obj) == 0:
@@ -253,7 +255,7 @@ def get_cutoff(
         if obj.ndim < 3 and obj.ndim > 0:
             cutoff_ind = obj.shape[0] + cutoff - 1
         if reverse_order:
-            cutoff_ind = 0
+            cutoff_ind = cutoff
         if return_index:
             return pd.RangeIndex(cutoff_ind, cutoff_ind + 1)
         else:
@@ -365,10 +367,10 @@ def update_data(X, X_new=None):
     if isinstance(X, np.ndarray):
         # if 1D or 2D, axis 0 is "time"
         if X_new.ndim in [1, 2]:
-            return np.concatenate(X, X_new, axis=0)
+            return np.concatenate([X, X_new], axis=0)
         # if 3D, axis 2 is "time"
         elif X_new.ndim == 3:
-            return np.concatenate(X, X_new, axis=2)
+            return np.concatenate([X, X_new], axis=2)
     #  if y is pandas, we use combine_first to update
     elif isinstance(X_new, (pd.Series, pd.DataFrame)) and len(X_new) > 0:
         return X_new.combine_first(X)


### PR DESCRIPTION
Fixes `get_cutoff` for `numpy` formats.

Was apparently not tested.

Todo: tests.