### PR TITLE
ENH] isolate `statsmodels` imports

### DIFF
--- a/sktime/forecasting/ardl.py
+++ b/sktime/forecasting/ardl.py
@@ -4,8 +4,6 @@
 import warnings
 
 import pandas as pd
-from statsmodels.tsa.ardl import ARDL as _ARDL
-from statsmodels.tsa.ardl import ardl_select_order as _ardl_select_order
 
 from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.base.adapters import _StatsModelsAdapter
@@ -317,6 +315,9 @@ class ARDL(_StatsModelsAdapter):
         -------
         self : reference to self
         """
+        from statsmodels.tsa.ardl import ARDL as _ARDL
+        from statsmodels.tsa.ardl import ardl_select_order as _ardl_select_order
+
         # statsmodels does not support the pd.Int64Index as required,
         # so we coerce them here to pd.RangeIndex
         if isinstance(y, pd.Series) and y.index.is_integer():
@@ -496,6 +497,9 @@ class ARDL(_StatsModelsAdapter):
         fitted_params : dict
         """
         self.check_is_fitted()
+
+        from statsmodels.tsa.ardl import ARDL as _ARDL
+
         fitted_params = {}
         if isinstance(self._forecaster, _ARDL):
             fitted_params["score"] = self._forecaster.score(

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -22,6 +22,7 @@ class _StatsModelsAdapter(BaseForecaster):
         "ignores-exogeneous-X": True,
         "requires-fh-in-fit": False,
         "handles-missing-data": False,
+        "python_dependencies": "statsmodels",
     }
 
     def __init__(self, random_state=None):

--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -6,7 +6,6 @@ import inspect
 
 import numpy as np
 import pandas as pd
-from statsmodels.tsa.statespace.dynamic_factor import DynamicFactor as _DynamicFactor
 
 from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
@@ -351,6 +350,8 @@ class DynamicFactor(_StatsModelsAdapter):
         X:pd.DataFrame , optional (default=None)
           Exogenous variables
         """
+        from statsmodels.tsa.statespace.dynamic_factor import DynamicFactor as _DynamicFactor
+
         self._forecaster = _DynamicFactor(
             endog=y,
             exog=X,

--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -350,7 +350,9 @@ class DynamicFactor(_StatsModelsAdapter):
         X:pd.DataFrame , optional (default=None)
           Exogenous variables
         """
-        from statsmodels.tsa.statespace.dynamic_factor import DynamicFactor as _DynamicFactor
+        from statsmodels.tsa.statespace.dynamic_factor import (
+            DynamicFactor as _DynamicFactor,
+        )
 
         self._forecaster = _DynamicFactor(
             endog=y,

--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -237,9 +237,7 @@ class AutoETS(_StatsModelsAdapter):
         super(AutoETS, self).__init__(random_state=random_state)
 
     def _fit_forecaster(self, y, X=None):
-        from statsmodels.tsa.exponential_smoothing.ets import (
-            ETSModel as _ETSModel,
-        )
+        from statsmodels.tsa.exponential_smoothing.ets import ETSModel as _ETSModel
 
         # Select model automatically
         if self.auto:

--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -299,7 +299,7 @@ class AutoETS(_StatsModelsAdapter):
             # Fit function
             def _fit(error, trend, seasonal, damped):
                 from statsmodels.tsa.exponential_smoothing.ets import (
-                    ETSModel as _ETSModel
+                    ETSModel as _ETSModel,
                 )
 
                 _forecaster = _ETSModel(

--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -237,6 +237,9 @@ class AutoETS(_StatsModelsAdapter):
         super(AutoETS, self).__init__(random_state=random_state)
 
     def _fit_forecaster(self, y, X=None):
+        from statsmodels.tsa.exponential_smoothing.ets import (
+            ETSModel as _ETSModel,
+        )
 
         # Select model automatically
         if self.auto:
@@ -298,10 +301,6 @@ class AutoETS(_StatsModelsAdapter):
 
             # Fit function
             def _fit(error, trend, seasonal, damped):
-                from statsmodels.tsa.exponential_smoothing.ets import (
-                    ETSModel as _ETSModel,
-                )
-
                 _forecaster = _ETSModel(
                     y,
                     error=error,

--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -298,7 +298,9 @@ class AutoETS(_StatsModelsAdapter):
 
             # Fit function
             def _fit(error, trend, seasonal, damped):
-                from statsmodels.tsa.exponential_smoothing.ets import ETSModel as _ETSModel
+                from statsmodels.tsa.exponential_smoothing.ets import (
+                    ETSModel as _ETSModel
+                )
 
                 _forecaster = _ETSModel(
                     y,

--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -13,7 +13,6 @@ from itertools import product
 import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
-from statsmodels.tsa.exponential_smoothing.ets import ETSModel as _ETSModel
 
 from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
@@ -299,6 +298,8 @@ class AutoETS(_StatsModelsAdapter):
 
             # Fit function
             def _fit(error, trend, seasonal, damped):
+                from statsmodels.tsa.exponential_smoothing.ets import ETSModel as _ETSModel
+
                 _forecaster = _ETSModel(
                     y,
                     error=error,

--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -166,7 +166,7 @@ class ExponentialSmoothing(_StatsModelsAdapter):
 
     def _fit_forecaster(self, y, X=None):
         from statsmodels.tsa.holtwinters import (
-            ExponentialSmoothing as _ExponentialSmoothing
+            ExponentialSmoothing as _ExponentialSmoothing,
         )
 
         self._forecaster = _ExponentialSmoothing(

--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -165,7 +165,9 @@ class ExponentialSmoothing(_StatsModelsAdapter):
         super().__init__(random_state=random_state)
 
     def _fit_forecaster(self, y, X=None):
-        from statsmodels.tsa.holtwinters import ExponentialSmoothing as _ExponentialSmoothing
+        from statsmodels.tsa.holtwinters import (
+            ExponentialSmoothing as _ExponentialSmoothing
+        )
 
         self._forecaster = _ExponentialSmoothing(
             y,

--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -6,8 +6,6 @@
 __all__ = ["ExponentialSmoothing"]
 __author__ = ["mloning", "big-o"]
 
-from statsmodels.tsa.holtwinters import ExponentialSmoothing as _ExponentialSmoothing
-
 from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
 
@@ -167,6 +165,8 @@ class ExponentialSmoothing(_StatsModelsAdapter):
         super().__init__(random_state=random_state)
 
     def _fit_forecaster(self, y, X=None):
+        from statsmodels.tsa.holtwinters import ExponentialSmoothing as _ExponentialSmoothing
+
         self._forecaster = _ExponentialSmoothing(
             y,
             trend=self.trend,

--- a/sktime/forecasting/sarimax.py
+++ b/sktime/forecasting/sarimax.py
@@ -6,8 +6,6 @@
 __all__ = ["SARIMAX"]
 __author__ = ["TNTran92"]
 
-from statsmodels.tsa.api import SARIMAX as _SARIMAX
-
 from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
 
@@ -161,6 +159,8 @@ class SARIMAX(_StatsModelsAdapter):
         super().__init__(random_state=random_state)
 
     def _fit_forecaster(self, y, X=None):
+        from statsmodels.tsa.api import SARIMAX as _SARIMAX
+
         self._forecaster = _SARIMAX(
             endog=y,
             exog=X,

--- a/sktime/forecasting/structural.py
+++ b/sktime/forecasting/structural.py
@@ -7,9 +7,6 @@ __all__ = ["UnobservedComponents"]
 __author__ = ["juanitorduz"]
 
 import pandas as pd
-from statsmodels.tsa.statespace.structural import (
-    UnobservedComponents as _UnobservedComponents,
-)
 
 from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
@@ -291,6 +288,10 @@ class UnobservedComponents(_StatsModelsAdapter):
         X : pd.DataFrame, optional (default=None)
             Exogenous variables.
         """
+        from statsmodels.tsa.statespace.structural import (
+            UnobservedComponents as _UnobservedComponents,
+        )
+
         self._forecaster = _UnobservedComponents(
             endog=y,
             exog=X,

--- a/sktime/forecasting/tests/test_ardl.py
+++ b/sktime/forecasting/tests/test_ardl.py
@@ -3,17 +3,23 @@
 __author__ = ["kcc-lion"]
 
 from numpy.testing import assert_allclose
-from statsmodels.datasets import danish_data, grunfeld, longley
-from statsmodels.tsa.ardl import ARDL as _ARDL
-from statsmodels.tsa.ardl import ardl_select_order as _ardl_select_order
+import pytest
 
 from sktime.datasets import load_macroeconomic
 from sktime.forecasting.ardl import ARDL
 from sktime.forecasting.base import ForecastingHorizon
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_against_statsmodels():
     """Compare sktime's ARDL interface with statsmodels ARDL."""
+    from statsmodels.datasets import longley
+    from statsmodels.tsa.ardl import ARDL as _ARDL
+
     # data
     data = longley.load_pandas().data
     oos = data.iloc[-5:, :]
@@ -34,8 +40,15 @@ def test_against_statsmodels():
     return assert_allclose(y_pred, y_pred_stats)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_against_statsmodels_2():
     """Compare sktime's ARDL interface with statsmodels ARDL with different data."""
+    from statsmodels.datasets import grunfeld
+    from statsmodels.tsa.ardl import ARDL as _ARDL
+
     # data
     data = grunfeld.load_pandas().data
     oos = data.iloc[-5:, :]
@@ -59,8 +72,15 @@ def test_against_statsmodels_2():
     return assert_allclose(y_pred, y_pred_stats)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_against_statsmodels_3():
     """Compare sktime's ARDL interface with statsmodels ARDL with X=None."""
+    from statsmodels.datasets import longley
+    from statsmodels.tsa.ardl import ARDL as _ARDL
+
     # data
     data = longley.load_pandas().data
     data = data.iloc[:-5, :]
@@ -80,8 +100,14 @@ def test_against_statsmodels_3():
     return assert_allclose(y_pred, y_pred_stats)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_against_statsmodels_4():
     """Compare sktime's ARDL interface with statsmodels ARDL."""
+    from statsmodels.tsa.ardl import ARDL as _ARDL
+
     # data
     data = load_macroeconomic()
     data = data.iloc[:-5, :]
@@ -101,8 +127,15 @@ def test_against_statsmodels_4():
     return assert_allclose(y_pred, y_pred_stats)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_auto_ardl():
     """Compare sktime's ARDL interface with statsmodels ardl_select_order."""
+    from statsmodels.datasets import longley
+    from statsmodels.tsa.ardl import ardl_select_order as _ardl_select_order
+
     # data
     data = longley.load_pandas().data
     oos = data.iloc[-5:, :]
@@ -128,8 +161,15 @@ def test_auto_ardl():
     return assert_allclose(y_pred, y_pred_stats)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_against_statsmodels_5():
     """Compare sktime's ARDL interface with statsmodels ARDL."""
+    from statsmodels.datasets import danish_data
+    from statsmodels.tsa.ardl import ardl_select_order as _ardl_select_order
+
     # data
     data = danish_data.load().data
     data[["lrm", "lry", "ibo", "ide"]]

--- a/sktime/forecasting/tests/test_ardl.py
+++ b/sktime/forecasting/tests/test_ardl.py
@@ -2,8 +2,8 @@
 """Tests the ARDL model."""
 __author__ = ["kcc-lion"]
 
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 from sktime.datasets import load_macroeconomic
 from sktime.forecasting.ardl import ARDL

--- a/sktime/forecasting/tests/test_sarimax.py
+++ b/sktime/forecasting/tests/test_sarimax.py
@@ -2,8 +2,8 @@
 """Tests the SARIMAX model."""
 __author__ = ["TNTran92"]
 
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 from sktime.forecasting.sarimax import SARIMAX
 from sktime.utils._testing.forecasting import make_forecasting_problem

--- a/sktime/forecasting/tests/test_sarimax.py
+++ b/sktime/forecasting/tests/test_sarimax.py
@@ -1,17 +1,25 @@
 # -*- coding: utf-8 -*-
 """Tests the SARIMAX model."""
 __author__ = ["TNTran92"]
+
 from numpy.testing import assert_allclose
-from statsmodels.tsa.api import SARIMAX as _SARIMAX
+import pytest
 
 from sktime.forecasting.sarimax import SARIMAX
 from sktime.utils._testing.forecasting import make_forecasting_problem
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 df = make_forecasting_problem()
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_SARIMAX_against_statsmodels():
     """Compares Sktime's and Statsmodel's SARIMAX."""
+    from statsmodels.tsa.api import SARIMAX as _SARIMAX
+
     sktime_model = SARIMAX(order=(1, 0, 0), trend="t", seasonal_order=(1, 0, 0, 6))
     sktime_model.fit(df)
     y_pred = sktime_model.predict(df.index)

--- a/sktime/forecasting/tests/test_structural.py
+++ b/sktime/forecasting/tests/test_structural.py
@@ -8,7 +8,8 @@ import pytest
 from pandas.testing import assert_series_equal
 
 from sktime.datasets import load_airline
-from sktime.forecasting.structural import UnobservedComponents, _UnobservedComponents
+from sktime.forecasting.structural import UnobservedComponents
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 
 class ModelSpec:
@@ -183,10 +184,18 @@ def y_airlines():
     return load_airline()
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 @pytest.mark.parametrize("level", [m.level for m in MODELS])
 @pytest.mark.parametrize("fh_length", [1, 3, 5, 10, 20])
 def test_results_consistency(level, fh_length, y_airlines):
     """Check consistency between wrapper and statsmodels original implementation."""
+    from statsmodels.tsa.statespace.structural import (
+        UnobservedComponents as _UnobservedComponents,
+    )
+
     fh = np.arange(fh_length) + 1
     # Fit and predict with forecaster.
     forecaster = UnobservedComponents(level=level)
@@ -201,11 +210,19 @@ def test_results_consistency(level, fh_length, y_airlines):
     assert len(fh) == y_pred_forecaster.shape[0]
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_result_consistency_exog(level_sample_data_split):
     """Check consistency between wrapper and statsmodels original implementation.
 
     We add external regressors and a seasonality component.
     """
+    from statsmodels.tsa.statespace.structural import (
+        UnobservedComponents as _UnobservedComponents,
+    )
+
     level, y_train, X_train, X_test, fh = level_sample_data_split
 
     model_spec = {

--- a/sktime/forecasting/tests/test_var.py
+++ b/sktime/forecasting/tests/test_var.py
@@ -3,14 +3,15 @@
 __author__ = ["thayeylolu"]
 import numpy as np
 import pandas as pd
+import pytest
 from numpy.testing import assert_allclose
-from statsmodels.tsa.api import VAR as _VAR
 
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.model_selection import temporal_train_test_split
 
 #
 from sktime.forecasting.var import VAR
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 index = pd.date_range(start="2005", end="2006-12", freq="M")
 df = pd.DataFrame(
@@ -20,8 +21,14 @@ df = pd.DataFrame(
 )
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_VAR_against_statsmodels():
     """Compares Sktime's and Statsmodel's VAR."""
+    from statsmodels.tsa.api import VAR as _VAR
+
     train, test = temporal_train_test_split(df)
     sktime_model = VAR()
     fh = ForecastingHorizon([1, 3, 4, 5, 7, 9])

--- a/sktime/forecasting/tests/test_varmax.py
+++ b/sktime/forecasting/tests/test_varmax.py
@@ -4,12 +4,13 @@ __author__ = ["KatieBuc"]
 
 import numpy as np
 import pandas as pd
+import pytest
 from numpy.testing import assert_allclose
-from statsmodels.tsa.api import VARMAX as _VARMAX
 
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.forecasting.varmax import VARMAX
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 np.random.seed(13455)
 index = pd.date_range(start="2020-01", end="2021-12", freq="M")
@@ -20,11 +21,17 @@ df = pd.DataFrame(
 )
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_VARMAX_against_statsmodels():
     """Compares Sktime's and Statsmodel's VARMAX.
 
     with default variables.
     """
+    from statsmodels.tsa.api import VARMAX as _VARMAX
+
     train, _ = temporal_train_test_split(df.astype("float64"))
     y = train[["A", "B"]]
 
@@ -42,11 +49,17 @@ def test_VARMAX_against_statsmodels():
     assert_allclose(y_pred, y_pred_stats)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_VARMAX_against_statsmodels_with_exog():
     """Compares Sktime's and Statsmodel's VARMAX.
 
     with exogenous input.
     """
+    from statsmodels.tsa.api import VARMAX as _VARMAX
+
     train, test = temporal_train_test_split(df.astype("float64"))
     y_train, X_train = train[["A", "B"]], train[["C"]]
     _, X_test = test[["A", "B"]], test[["C"]]

--- a/sktime/forecasting/tests/test_vecm.py
+++ b/sktime/forecasting/tests/test_vecm.py
@@ -3,12 +3,13 @@
 __author__ = ["thayeylolu", "AurumnPegasus"]
 import numpy as np
 import pandas as pd
+import pytest
 from numpy.testing import assert_allclose
-from statsmodels.tsa.api import VECM as _VECM
 
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.forecasting.vecm import VECM
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 index = pd.date_range(start="2005", end="2006-12", freq="M")
 df = pd.DataFrame(
@@ -18,8 +19,14 @@ df = pd.DataFrame(
 )
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_VAR_against_statsmodels():
     """Compares Sktime's and Statsmodel's VECM."""
+    from statsmodels.tsa.api import VECM as _VECM
+
     train, test = temporal_train_test_split(df)
     sktime_model = VECM()
     fh = ForecastingHorizon([1, 3, 4, 5, 7, 9])

--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -466,6 +466,8 @@ class STLForecaster(BaseForecaster):
         -------
         self : reference to self
         """
+        from statsmodels.tsa.seasonal import STL as _STL
+
         self._stl = _STL(
             y.values,
             period=self.sp,

--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -12,7 +12,6 @@ from sklearn.base import clone
 from sklearn.linear_model import LinearRegression
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import PolynomialFeatures
-from statsmodels.tsa.seasonal import STL as _STL
 
 from sktime.forecasting.base import BaseForecaster
 from sktime.utils.datetime import _get_duration
@@ -330,6 +329,7 @@ class STLForecaster(BaseForecaster):
         "y_inner_mtype": "pd.Series",  # which types do _fit, _predict, assume for y?
         "X_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for X?
         "requires-fh-in-fit": False,  # is forecasting horizon already required in fit?
+        "python_dependencies": "statsmodels",
     }
 
     def __init__(
@@ -384,6 +384,8 @@ class STLForecaster(BaseForecaster):
         -------
         self : returns an instance of self.
         """
+        from statsmodels.tsa.seasonal import STL as _STL
+
         from sktime.forecasting.naive import NaiveForecaster
 
         self._stl = _STL(

--- a/sktime/forecasting/var.py
+++ b/sktime/forecasting/var.py
@@ -9,7 +9,6 @@ from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
-from statsmodels.tsa.api import VAR as _VAR
 
 from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
@@ -124,6 +123,8 @@ class VAR(_StatsModelsAdapter):
         -------
         self : returns an instance of self.
         """
+        from statsmodels.tsa.api import VAR as _VAR
+
         self._forecaster = _VAR(
             endog=y, exog=X, dates=self.dates, freq=self.freq, missing=self.missing
         )

--- a/sktime/forecasting/varmax.py
+++ b/sktime/forecasting/varmax.py
@@ -6,7 +6,6 @@ __author__ = ["KatieBuc"]
 import warnings
 
 import pandas as pd
-from statsmodels.tsa.statespace.varmax import VARMAX as _VARMAX
 
 from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
@@ -299,6 +298,8 @@ class VARMAX(_StatsModelsAdapter):
         """
         if self.suppress_warnings:
             warnings.filterwarnings("ignore")
+
+        from statsmodels.tsa.statespace.varmax import VARMAX as _VARMAX
 
         self._forecaster = _VARMAX(
             endog=y,

--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -9,7 +9,6 @@ __author__ = ["thayeylolu", "AurumnPegasus"]
 
 import numpy as np
 import pandas as pd
-from statsmodels.tsa.vector_ar.vecm import VECM as _VECM
 
 from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
@@ -138,6 +137,8 @@ class VECM(_StatsModelsAdapter):
         -------
         self : reference to self
         """
+        from statsmodels.tsa.vector_ar.vecm import VECM as _VECM
+
         self._forecaster = _VECM(
             endog=y,
             exog=X,

--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -6,8 +6,6 @@ __author__ = ["fkiraly"]
 __all__ = ["SeasonalityACF"]
 
 import numpy as np
-from statsmodels.stats.multitest import multipletests
-from statsmodels.tsa.stattools import acf
 
 from sktime.param_est.base import BaseParamFitter
 
@@ -92,6 +90,7 @@ class SeasonalityACF(BaseParamFitter):
         "scitype:X": "Series",  # which X scitypes are supported natively?
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:multivariate": False,  # can estimator handle multivariate data?
+        "python_dependencies": "statsmodels",
     }
 
     def __init__(
@@ -128,6 +127,8 @@ class SeasonalityACF(BaseParamFitter):
         -------
         self : reference to self
         """
+        from statsmodels.tsa.stattools import acf
+
         p_threshold = self.p_threshold
         adjusted = self.adjusted
 
@@ -309,6 +310,9 @@ class SeasonalityACFqstat(BaseParamFitter):
         -------
         self : reference to self
         """
+        from statsmodels.stats.multitest import multipletests
+        from statsmodels.tsa.stattools import acf
+
         p_threshold = self.p_threshold
         p_adjust = self.p_adjust
         adjusted = self.adjusted

--- a/sktime/transformations/bootstrap/_mbb.py
+++ b/sktime/transformations/bootstrap/_mbb.py
@@ -10,7 +10,6 @@ from typing import Tuple, Union
 import numpy as np
 import pandas as pd
 from sklearn.utils import check_random_state
-from statsmodels.tsa.api import STL as _STL
 
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.series.boxcox import BoxCoxTransformer
@@ -185,6 +184,7 @@ class STLBootstrapTransformer(BaseTransformer):
         "enforce_index_type": None,  # index type that needs to be enforced in X/y
         "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
         "transform-returns-same-time-index": False,
+        "python_dependencies": "statsmodels",
     }
 
     def __init__(
@@ -293,6 +293,8 @@ class STLBootstrapTransformer(BaseTransformer):
         -------
         transformed version of X
         """
+        from statsmodels.tsa.api import STL as _STL
+
         Xcol = X.columns
         X = X[X.columns[0]]
 

--- a/sktime/transformations/series/acf.py
+++ b/sktime/transformations/series/acf.py
@@ -12,7 +12,6 @@ __author__ = ["afzal442"]
 __all__ = ["AutoCorrelationTransformer", "PartialAutoCorrelationTransformer"]
 
 import pandas as pd
-from statsmodels.tsa.stattools import acf, pacf
 
 from sktime.transformations.base import BaseTransformer
 
@@ -78,6 +77,7 @@ class AutoCorrelationTransformer(BaseTransformer):
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
         "univariate-only": True,
         "fit_is_empty": True,
+        "python_dependencies": "statsmodels",
     }
 
     def __init__(
@@ -109,6 +109,8 @@ class AutoCorrelationTransformer(BaseTransformer):
         -------
         transformed version of X
         """
+        from statsmodels.tsa.stattools import acf
+
         # Passing an alpha values other than None would return confidence intervals
         # and break the signature of the series-to-series transformer
         zt = acf(
@@ -234,6 +236,8 @@ class PartialAutoCorrelationTransformer(BaseTransformer):
         -------
         transformed version of X
         """
+        from statsmodels.tsa.stattools import pacf
+
         # Passing an alpha values other than None would return confidence intervals
         # and break the signature of the series-to-series transformer
         zt = pacf(X, nlags=self.n_lags, method=self.method, alpha=None)

--- a/sktime/transformations/series/clear_sky.py
+++ b/sktime/transformations/series/clear_sky.py
@@ -7,7 +7,6 @@ __author__ = ["ciaran-g"]
 import numpy as np
 import pandas as pd
 from scipy.stats import vonmises
-from statsmodels.stats.weightstats import DescrStatsW
 
 from sktime.transformations.base import BaseTransformer
 
@@ -91,6 +90,7 @@ class ClearSky(BaseTransformer):
         "handles-missing-data": False,
         "capability:missing_values:removes": True,
         "python_version": None,  # PEP 440 python version specifier to limit versions
+        "python_dependencies": "statsmodels",
     }
 
     def __init__(
@@ -271,6 +271,8 @@ def _clearskypower(y, q, tod_i, doy_i, tod_vec, doy_vec, bw_tod, bw_doy):
     csp : float
         The clear sky power at tod_i and doy_i
     """
+    from statsmodels.stats.weightstats import DescrStatsW
+
     wts_tod = vonmises.pdf(
         x=tod_i * 2 * np.pi / 24, kappa=bw_tod, loc=tod_vec * 2 * np.pi / 24
     )

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -8,8 +8,6 @@ __all__ = ["Deseasonalizer", "ConditionalDeseasonalizer", "STLTransformer"]
 
 import numpy as np
 import pandas as pd
-from statsmodels.tsa.seasonal import STL as _STL
-from statsmodels.tsa.seasonal import seasonal_decompose
 
 from sktime.transformations.base import BaseTransformer
 from sktime.utils.datetime import _get_duration, _get_freq
@@ -78,6 +76,7 @@ class Deseasonalizer(BaseTransformer):
         "capability:inverse_transform": True,
         "transform-returns-same-time-index": True,
         "univariate-only": True,
+        "python_dependencies": "statsmodels",
     }
 
     def __init__(self, sp=1, model="additive"):
@@ -120,6 +119,8 @@ class Deseasonalizer(BaseTransformer):
         -------
         self: a fitted instance of the estimator
         """
+        from statsmodels.tsa.seasonal import seasonal_decompose
+
         self._X = X
         sp = self.sp
 
@@ -302,6 +303,8 @@ class ConditionalDeseasonalizer(Deseasonalizer):
         -------
         self: a fitted instance of the estimator
         """
+        from statsmodels.tsa.seasonal import seasonal_decompose
+
         self._X = X
         sp = self.sp
 
@@ -486,6 +489,8 @@ class STLTransformer(BaseTransformer):
         -------
         self: a fitted instance of the estimator
         """
+        from statsmodels.tsa.seasonal import STL as _STL
+
         # remember X for transform
         self._X = X
         sp = self.sp
@@ -512,6 +517,8 @@ class STLTransformer(BaseTransformer):
         return self
 
     def _transform(self, X, y=None):
+
+        from statsmodels.tsa.seasonal import STL as _STL
 
         # fit again if indices not seen, but don't store anything
         if not X.index.equals(self._X.index):

--- a/sktime/transformations/series/detrend/tests/test_deseasonalise.py
+++ b/sktime/transformations/series/detrend/tests/test_deseasonalise.py
@@ -7,12 +7,12 @@ __all__ = []
 
 import numpy as np
 import pytest
-from statsmodels.tsa.seasonal import seasonal_decompose
 
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.forecasting.tests._config import TEST_SPS
 from sktime.transformations.series.detrend import Deseasonalizer
 from sktime.utils._testing.forecasting import make_forecasting_problem
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 MODELS = ["additive", "multiplicative"]
 
@@ -20,8 +20,14 @@ y = make_forecasting_problem()
 y_train, y_test = temporal_train_test_split(y, train_size=0.75)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 @pytest.mark.parametrize("sp", TEST_SPS)
 def test_deseasonalised_values(sp):
+    from statsmodels.tsa.seasonal import seasonal_decompose
+
     transformer = Deseasonalizer(sp=sp)
     transformer.fit(y_train)
     actual = transformer.transform(y_train)

--- a/sktime/utils/seasonality.py
+++ b/sktime/utils/seasonality.py
@@ -11,8 +11,8 @@ from warnings import warn
 import numpy as np
 import pytest
 
-from sktime.utils.validation.forecasting import check_sp, check_y
 from sktime.utils.validation._dependencies import _check_soft_dependencies
+from sktime.utils.validation.forecasting import check_sp, check_y
 
 
 @pytest.mark.skipif(

--- a/sktime/utils/seasonality.py
+++ b/sktime/utils/seasonality.py
@@ -10,7 +10,6 @@ from warnings import warn
 
 import numpy as np
 
-from sktime.utils.validation._dependencies import _check_soft_dependencies
 from sktime.utils.validation.forecasting import check_sp, check_y
 
 

--- a/sktime/utils/seasonality.py
+++ b/sktime/utils/seasonality.py
@@ -3,17 +3,22 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 # noqa: D100
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = []
 
 from warnings import warn
 
 import numpy as np
-from statsmodels.tsa.stattools import acf
+import pytest
 
 from sktime.utils.validation.forecasting import check_sp, check_y
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def autocorrelation_seasonality_test(y, sp):
     """Seasonality test used in M4 competition.
 
@@ -32,6 +37,8 @@ def autocorrelation_seasonality_test(y, sp):
     .. [1]  https://github.com/Mcompetitions/M4-methods/blob/master
     /Benchmarks%20and%20Evaluation.R
     """
+    from statsmodels.tsa.stattools import acf
+
     y = check_y(y)
     sp = check_sp(sp)
 

--- a/sktime/utils/seasonality.py
+++ b/sktime/utils/seasonality.py
@@ -9,16 +9,11 @@ __all__ = []
 from warnings import warn
 
 import numpy as np
-import pytest
 
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 from sktime.utils.validation.forecasting import check_sp, check_y
 
 
-@pytest.mark.skipif(
-    not _check_soft_dependencies("statsmodels", severity="none"),
-    reason="skip test if required soft dependency not available",
-)
 def autocorrelation_seasonality_test(y, sp):
     """Seasonality test used in M4 competition.
 


### PR DESCRIPTION
This PR isolates `statsmodels` imports in estimators in the `fit` methods of said estimators.

It also adds the `statsmodels` package as a python dependency tag to the `_StatsModelsAdapter`.

This is beneficial because:

* it prevents imports of new `statsmodels` submodules like `ARDL` when not needed, thus making `sktime` compatible with older versions of `statsmodels`
* it reduces the number of `statsmodels` imports at typical use, making the import & interface behaviour of `sktime` cleaner
* it makes handling of `statsmodels` more consistent with other estimator interface dependencies
* it prepares a potential move of `statsmodels` to a soft dependency (although due to afew non-estimator dependencies this seems unlikely in the near future)