### PR TITLE
[BUG] Pass all average params to kmeans

### DIFF
--- a/sktime/clustering/k_means.py
+++ b/sktime/clustering/k_means.py
@@ -96,8 +96,10 @@ class TimeSeriesKMeans(TimeSeriesLloyds):
                 ]
             if "averaging_distance_metric" in self._average_params:
                 average_dist = self._average_params["averaging_distance_metric"]
-                if average_dist == "ddtw" or average_dist == "wddtw":
+                if average_dist == "ddtw":
                     self._average_params["averaging_distance_metric"] = "dtw"
+                if average_dist == "wddtw":
+                    self._average_params["averaging_distance_metric"] = "wdtw"
 
         super(TimeSeriesKMeans, self).__init__(
             n_clusters,

--- a/sktime/clustering/k_means.py
+++ b/sktime/clustering/k_means.py
@@ -83,22 +83,21 @@ class TimeSeriesKMeans(TimeSeriesLloyds):
         self.averaging_method = averaging_method
         self._averaging_method = _resolve_average_callable(averaging_method)
 
+        self.average_params = average_params
+        self._average_params = average_params
+        if self.average_params is None:
+            self._average_params = {}
         if averaging_method == "dba":
             self._dba_medoids_distance_metric = "dtw"
             self._precomputed_pairwise = None
-            if (
-                average_params is not None
-                and "medoids_distance_metric" in average_params
-            ):
-                self._dba_medoids_distance_metric = average_params[
+            if "medoids_distance_metric" in self._average_params:
+                self._dba_medoids_distance_metric = self._average_params[
                     "medoids_distance_metric"
                 ]
-
-        self.average_params = average_params
-        if self.average_params is None:
-            self._average_params = {}
-        else:
-            self._average_params = average_params
+            if "averaging_distance_metric" in self._average_params:
+                average_dist = self._average_params["averaging_distance_metric"]
+                if average_dist == "ddtw" or average_dist == "wddtw":
+                    self._average_params["averaging_distance_metric"] = "dtw"
 
         super(TimeSeriesKMeans, self).__init__(
             n_clusters,

--- a/sktime/clustering/metrics/averaging/_averaging.py
+++ b/sktime/clustering/metrics/averaging/_averaging.py
@@ -2,7 +2,7 @@
 """Clustering averaging metrics."""
 __author__ = ["chrisholder", "TonyBagnall"]
 
-from typing import Callable
+from typing import Callable, Dict
 
 import numpy as np
 
@@ -32,7 +32,7 @@ _AVERAGE_DICT = {"mean": mean_average, "dba": dba}
 
 def _resolve_average_callable(
     averaging_method: [str, Callable[[np.ndarray], np.ndarray]]
-) -> Callable[[np.ndarray], np.ndarray]:
+) -> Callable[[np.ndarray, Dict], np.ndarray]:
     """Resolve a string or callable to a averaging callable.
 
     Parameters


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Updated kmeans to handle average params when using derivative.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Not all average params were able to be properly passed to kmeans when using DBA. This pr fixes it. In particular the fix is for ddtw and wddtw distances as preprocessing of the time series is done inside the clusterer and therefore doesn't need to be redone each iteration in the DBA function.

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [x] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

##### For new estimators
- [x] I've added the estimator to the online documentation.
- [x] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
