### PR TITLE
[BUG] Fix residuals formula in NaiveForecaster predict_var for non-null window_length

### DIFF
--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -436,8 +436,10 @@ class NaiveForecaster(_BaseWindowForecaster):
                     # T / self.sp times to match the length of trained y
                     # NOTE: +1 extra tile to defend against off-by-one errors
                     reps = math.ceil(T / sp) + 1
-                    seasonal_means = self.predict(fh=list(range(1, sp + 1))).to_numpy()
-                    y_pred = np.tile(seasonal_means, reps)[0:T]
+                    seasonal_means = self.predict(fh=list(range(1, sp + 1)))
+                    if isinstance(seasonal_means, pd.DataFrame):
+                        seasonal_means = seasonal_means.squeeze()
+                    y_pred = np.tile(seasonal_means.to_numpy(), reps)[0:T]
                 else:
                     # Since this strategy returns a constant, just predict fh=1 and
                     # transform the constant into a repeated array


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #3469 

#### What does this implement/fix? Explain your changes.
The current `_predict_var` implementation for `NaiveForecaster` does not deal with "mean" strategies with `sp > 1` or `window_length != None`. Moreover, the "drift" strategy does not account for the fact that the "starting" point for the line is set to `y[-window_length]` if `window_length` is not null.

This PR fixes both issues by computing residuals for rolling means (seasonal and non-seasonal) and setting the starting point of the drift line to `-(window_length or len(y))`

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Logic for computing residuals for rolling means and rolling seasonal means
- Prior art (R fable): https://github.com/sktime/sktime/issues/3469#issuecomment-1256862149

#### Any other comments?
Please note the debate on computing residuals across rolling windows vs computing residuals against a single y hat array (#3469).

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

<!--
Thanks for contributing!
-->
