### PR TITLE
& canbooo [BUG] fix `ColumnEnsembleForecaster` for str index; extend `ColumnEnsembleForecaster` to allow application of multivariate forecasters

### DIFF
--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -62,7 +62,8 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
     ...     [("foo", NaiveForecaster(), "a"), ("bar", NaiveForecaster(), "b")]
     ... )
     >>> fc.fit(df, fh=[1, 42])
-    >>> fc.predict()
+    ColumnEnsembleForecaster(...)
+    >>> y_pred = fc.predict()
 
     Applying one forecaster to multiple columns, multivariate:
     >>>     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
@@ -70,7 +71,8 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
     ...    [("ab", NaiveForecaster(), ["a", 1]), ("c", NaiveForecaster(), 2)]
     ... )
     >>> fc.fit(df, fh=[1, 42])
-    >>> fc.predict()
+    ColumnEnsembleForecaster(...)
+    >>> y_pred = fc.predict()
     """
 
     _tags = {

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -66,7 +66,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
     >>> y_pred = fc.predict()
 
     Applying one forecaster to multiple columns, multivariate:
-    >>>     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
+    >>> df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
     >>> fc = ColumnEnsembleForecaster(
     ...    [("ab", NaiveForecaster(), ["a", 1]), ("c", NaiveForecaster(), 2)]
     ... )

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -41,8 +41,11 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
     --------
     >>> from sktime.forecasting.compose import ColumnEnsembleForecaster
     >>> from sktime.forecasting.exp_smoothing import ExponentialSmoothing
+    >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.forecasting.trend import PolynomialTrendForecaster
     >>> from sktime.datasets import load_macroeconomic
+
+    Using integers (column iloc refernces= for indexing:
     >>> y = load_macroeconomic()[["realgdp", "realcons"]]
     >>> forecasters = [
     ...     ("trend", PolynomialTrendForecaster(), 0),

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -56,12 +56,12 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
     Using strings for indexing:
     >>> df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     >>> fc = ColumnEnsembleForecaster(
-    ...     [(f"trans_{col}", NaiveForecaster(), col) for col in "ab"]
+    ...     [("foo", NaiveForecaster(), "a"), ("bar", NaiveForecaster(), "b")]
     ... )
     >>> fc.fit(df, fh=[1, 42])
     >>> fc.predict()
 
-    Applying one forecaster ot multiple columns, multivariate:
+    Applying one forecaster to multiple columns, multivariate:
     >>>     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
     >>> fc = ColumnEnsembleForecaster(
     ...    [("ab", NaiveForecaster(), ["a", 1]), ("c", NaiveForecaster(), 2)]

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -443,12 +443,18 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
         index_flat = flatten(indices)
         index_set = set(index_flat)
         not_in_y_idx = index_set.difference(y.columns)
+        y_cols_not_found = set(y.columns).difference(index_set)
 
         if len(not_in_y_idx) > 0:
             raise ValueError(
                 f"Column identifier must be indices in y.columns, or integers within "
                 f"the range of the total number of columns, "
                 f"but found column identifiers that are neither: {list(not_in_y_idx)}"
+            )
+        if len(y_cols_not_found) > 0:
+            raise ValueError(
+                f"All columns of y must be indexed by column identifiers, but "
+                f"the following columns of y are not indexed: {list(y_cols_not_found)}"
             )
 
         if len(index_set) != len(index_flat):

--- a/sktime/forecasting/compose/tests/test_column_ensemble.py
+++ b/sktime/forecasting/compose/tests/test_column_ensemble.py
@@ -52,7 +52,7 @@ def test_invalid_forecasters_indices(forecasters):
     """Check if invalid forecaster indices return correct Error."""
     y = pd.DataFrame(np.random.randint(0, 100, size=(100, 3)), columns=list("ABC"))
     forecaster = ColumnEnsembleForecaster(forecasters=forecasters)
-    with pytest.raises(ValueError, match=r"estimator per column"):
+    with pytest.raises(ValueError, match=r"column"):
         forecaster.fit(y, fh=[1, 2])
 
 

--- a/sktime/forecasting/compose/tests/test_column_ensemble.py
+++ b/sktime/forecasting/compose/tests/test_column_ensemble.py
@@ -54,3 +54,13 @@ def test_invalid_forecasters_indices(forecasters):
     forecaster = ColumnEnsembleForecaster(forecasters=forecasters)
     with pytest.raises(ValueError, match=r"estimator per column"):
         forecaster.fit(y, fh=[1, 2])
+
+
+def test_column_ensemble_string_cols():
+    """Check that ColumnEnsembleForecaster works with string columns."""
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    fc = ColumnEnsembleForecaster(
+        [(f"trans_{col}", NaiveForecaster(), col) for col in "ab"]
+    )
+    fc.fit(df, fh=[1, 42])
+    fc.predict()

--- a/sktime/forecasting/compose/tests/test_column_ensemble.py
+++ b/sktime/forecasting/compose/tests/test_column_ensemble.py
@@ -3,7 +3,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file).
 """Unit tests of ColumnEnsembleForecaster functionality."""
 
-__author__ = ["GuzalBulatova"]
+__author__ = ["GuzalBulatova", "canbooo", "fkiraly"]
 
 import numpy as np
 import pandas as pd
@@ -61,6 +61,16 @@ def test_column_ensemble_string_cols():
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     fc = ColumnEnsembleForecaster(
         [(f"trans_{col}", NaiveForecaster(), col) for col in "ab"]
+    )
+    fc.fit(df, fh=[1, 42])
+    fc.predict()
+
+
+def test_column_ensemble_multivariate_and_int():
+    """Check that ColumnEnsembleForecaster works with string columns."""
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
+    fc = ColumnEnsembleForecaster(
+        [("ab", NaiveForecaster(), ["a", 1]), ("c", NaiveForecaster(), 2)]
     )
     fc.fit(df, fh=[1, 42])
     fc.predict()


### PR DESCRIPTION
Fixes #3502, `ColumnEnsembleForecaster` failed for str indices.

This was a little involved, as it seems that string indices were not properly parsed at all.

Also adds a test based on @canbooo's example

Also extends `ColumnEnsembleForecaster` so that multiple columns can be passed, in which case a forecaster is applied as multivariate.