### PR TITLE
[ENH] add forecaster test case with string columns

### DIFF
--- a/sktime/utils/_testing/scenarios_forecasting.py
+++ b/sktime/utils/_testing/scenarios_forecasting.py
@@ -179,7 +179,9 @@ class ForecasterFitPredictUnivariateWithX(ForecasterTestScenario):
 
     args = {
         "fit": {
-            "y": pd.DataFrame(_make_series(n_timepoints=20, random_state=RAND_SEED)),
+            "y": pd.DataFrame(
+                _make_series(n_timepoints=20, random_state=RAND_SEED, columns=["foo"])
+            ),
             "X": X.copy(),
             "fh": 1,
         },

--- a/sktime/utils/_testing/scenarios_forecasting.py
+++ b/sktime/utils/_testing/scenarios_forecasting.py
@@ -180,7 +180,7 @@ class ForecasterFitPredictUnivariateWithX(ForecasterTestScenario):
     args = {
         "fit": {
             "y": pd.DataFrame(
-                _make_series(n_timepoints=20, random_state=RAND_SEED, columns=["foo"])
+                _make_series(n_timepoints=20, random_state=RAND_SEED), columns=["foo"]
             ),
             "X": X.copy(),
             "fh": 1,


### PR DESCRIPTION
Changes one of the forecaster scenarios to include a string `pd.DataFrame` column name.

Somewhat surprisingly, none of the test cases covered string column names, all were integers.

Also see https://github.com/sktime/sktime/issues/3502, a very straightforward failure for string columns.

The new test should pick up #3502 before it is fixed.