### PR TITLE
[ENH] Make `evaluate` compatible with hierarchical formats

### DIFF
--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -41,7 +41,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.utils.validation._dependencies import _check_soft_dependencies
-from sktime.utils.validation.series import is_in_valid_index_types
+from sktime.utils.validation.series import is_in_valid_index_types, is_integer_index
 
 VALID_INDEX_TYPES = (pd.RangeIndex, pd.PeriodIndex, pd.DatetimeIndex)
 
@@ -76,7 +76,7 @@ def check_pddataframe_series(obj, return_metadata=False, var_name="obj"):
     assert obj.columns.is_unique, msg
 
     # check whether the time index is of valid type
-    if not is_in_valid_index_types(index):
+    if not (isinstance(index, VALID_INDEX_TYPES) or is_integer_index(index)):
         msg = (
             f"{type(index)} is not supported for {var_name}, use "
             f"one of {VALID_INDEX_TYPES} or integer index instead."
@@ -103,6 +103,7 @@ def check_pddataframe_series(obj, return_metadata=False, var_name="obj"):
 
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
+
     if return_metadata:
         metadata["is_equally_spaced"] = _index_equally_spaced(index)
         metadata["has_nans"] = obj.isna().values.any()

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -12,6 +12,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
+from sktime.datatypes._utilities import get_time_index
 from sktime.exceptions import FitFailedWarning
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.utils.validation.forecasting import (
@@ -131,8 +132,9 @@ def evaluate(
         # split data
         y_train, y_test, X_train, X_test = _split(y, X, train, test, cv.fh)
 
+        y_index = get_time_index(y_test)
         # create forecasting horizon
-        fh = ForecastingHorizon(y_test.index, is_relative=False)
+        fh = ForecastingHorizon(y_index, is_relative=False)
 
         try:
             # fit/update

--- a/sktime/utils/validation/series.py
+++ b/sktime/utils/validation/series.py
@@ -18,9 +18,15 @@ import pandas as pd
 
 # We currently support the following types for input data and time index types.
 VALID_DATA_TYPES = (pd.DataFrame, pd.Series, np.ndarray)
-VALID_INDEX_TYPES = (pd.RangeIndex, pd.PeriodIndex, pd.DatetimeIndex, pd.TimedeltaIndex)
+VALID_INDEX_TYPES = (
+    pd.RangeIndex,
+    pd.PeriodIndex,
+    pd.DatetimeIndex,
+    pd.TimedeltaIndex,
+    pd.MultiIndex,
+)
 RELATIVE_INDEX_TYPES = (pd.RangeIndex, pd.TimedeltaIndex)
-ABSOLUTE_INDEX_TYPES = (pd.RangeIndex, pd.DatetimeIndex, pd.PeriodIndex)
+ABSOLUTE_INDEX_TYPES = (pd.RangeIndex, pd.DatetimeIndex, pd.PeriodIndex, pd.MultiIndex)
 assert set(RELATIVE_INDEX_TYPES).issubset(VALID_INDEX_TYPES)
 assert set(ABSOLUTE_INDEX_TYPES).issubset(VALID_INDEX_TYPES)
 
@@ -167,8 +173,9 @@ def check_series(
             var_name=var_name,
         )
 
-    if not allow_index_names and not isinstance(Z, np.ndarray):
-        Z.index.names = [None for name in Z.index.names]
+    if not (hasattr(Z, "index") and isinstance(Z.index, pd.MultiIndex)):
+        if not allow_index_names and not isinstance(Z, np.ndarray):
+            Z.index.names = [None for name in Z.index.names]
 
     return Z
 


### PR DESCRIPTION
Hierachical formats are not supported by cross validation, which is fixed here