### PR TITLE
[ENH] refactor mtype conversion extension utils into one location

### DIFF
--- a/sktime/datatypes/_convert_utils/__init__.py
+++ b/sktime/datatypes/_convert_utils/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Conversion auxiliary utilities."""

--- a/sktime/datatypes/_convert_utils/_convert.py
+++ b/sktime/datatypes/_convert_utils/_convert.py
@@ -16,6 +16,7 @@ def _concat(fun1, fun2):
     function in converter signature, see datatypes._convert
         concatenation fun2 o fun1, using the same store
     """
+
     def concat_fun(obj, store=None):
         obj1 = fun1(obj, store=store)
         obj2 = fun2(obj1, store=store)

--- a/sktime/datatypes/_convert_utils/_convert.py
+++ b/sktime/datatypes/_convert_utils/_convert.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""Conversion utilities for mtypes."""
+
+__author__ = ["fkiraly"]
+
+
+def _concat(fun1, fun2):
+    """Concatenation of two converter functions, using the same store.
+
+    Parameters
+    ----------
+    fun1, fun2 : functions in converter signature, see datatypes._convert
+
+    Returns
+    -------
+    function in converter signature, see datatypes._convert
+        concatenation fun2 o fun1, using the same store
+    """
+    def concat_fun(obj, store=None):
+        obj1 = fun1(obj, store=store)
+        obj2 = fun2(obj1, store=store)
+        return obj2
+
+    return concat_fun
+
+
+def _extend_conversions(mtype, anchor_mtype, convert_dict, mtype_universe=None):
+    """Obtain all conversions from and to mtype via conversion to anchor_mtype.
+
+    Mutates convert_dict by adding all conversions from and to mtype.
+
+    Assumes:
+    convert_dict contains
+    * conversion from `mtype` to `anchor_mtype`
+    * conversion from `anchor_mtype` to `mtype`
+    * conversions from `anchor_mtype` to all mtypes in `mtype_universe`
+    * conversions from all mtypes in `mtype_universe` to `anchor_mtype`
+
+    Guarantees:
+    convert_dict contains
+    * conversions from `mtype` to all mtypes in mtype_universe
+    * conversions from all mtypes in mtype_universe to `mtype`
+
+    conversions <mtype to mtype2> not in convert_dict at start are filled in as
+    _concat(<from mtype to anchor_type>, <from anchor_type to mtype2>)
+    conversions <mtype2 to mtype> not in convert_dict at start are filled in as
+    _concat(<from mtype2 to anchor_type>, <from anchor_type to mtype>)
+
+    Parameters
+    ----------
+    mtype : mtype string in convert_dict
+    anchor_mtype : mtype string in convert_dict
+    convert_dict : conversion dictionary with entries of converter signature
+        see docstring of datatypes._convert
+    mtype_universe : iterable of mtype strings in convert_dict, coercable to list or set
+
+    Returns
+    -------
+    reference to convert_dict
+    CAVEAT: convert_dict passed to this function gets mutated, this is a referene
+    """
+    keys = convert_dict.keys()
+    scitype = list(keys)[0][2]
+
+    if mtype_universe is None:
+        mtype_universe = set([x[1] for x in list(keys)])
+        mtype_universe = mtype_universe.union([x[0] for x in list(keys)])
+
+    for tp in set(mtype_universe).difference([mtype, anchor_mtype]):
+        if (anchor_mtype, tp, scitype) in convert_dict.keys():
+            if (mtype, tp, scitype) not in convert_dict.keys():
+                convert_dict[(mtype, tp, scitype)] = _concat(
+                    convert_dict[(mtype, anchor_mtype, scitype)],
+                    convert_dict[(anchor_mtype, tp, scitype)],
+                )
+        if (tp, anchor_mtype, scitype) in convert_dict.keys():
+            if (tp, mtype, scitype) not in convert_dict.keys():
+                convert_dict[(tp, mtype, scitype)] = _concat(
+                    convert_dict[(tp, anchor_mtype, scitype)],
+                    convert_dict[(anchor_mtype, mtype, scitype)],
+                )
+
+    return convert_dict

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -34,6 +34,7 @@ __all__ = [
     "convert_dict",
 ]
 
+from sktime.datatypes._convert_utils._convert import _extend_conversions
 from sktime.datatypes._panel._registry import MTYPE_LIST_PANEL
 
 # dictionary indexed by triples of types
@@ -1059,27 +1060,6 @@ def from_numpyflat_to_numpy3d(obj, store=None):
 
 convert_dict[("numpyflat", "numpy3D", "Panel")] = from_numpyflat_to_numpy3d
 
-
-# obtain other conversions from/to numpyflat via concatenation to numpy3D
-def _concat(fun1, fun2):
-    def concat_fun(obj, store=None):
-        obj1 = fun1(obj, store=store)
-        obj2 = fun2(obj1, store=store)
-        return obj2
-
-    return concat_fun
-
-
-for tp in set(MTYPE_LIST_PANEL).difference(["numpyflat", "numpy3D"]):
-    if ("numpy3D", tp, "Panel") in convert_dict.keys():
-        if ("numpyflat", tp, "Panel") not in convert_dict.keys():
-            convert_dict[("numpyflat", tp, "Panel")] = _concat(
-                convert_dict[("numpyflat", "numpy3D", "Panel")],
-                convert_dict[("numpy3D", tp, "Panel")],
-            )
-    if (tp, "numpy3D", "Panel") in convert_dict.keys():
-        if (tp, "numpyflat", "Panel") not in convert_dict.keys():
-            convert_dict[(tp, "numpyflat", "Panel")] = _concat(
-                convert_dict[(tp, "numpy3D", "Panel")],
-                convert_dict[("numpy3D", "numpyflat", "Panel")],
-            )
+_extend_conversions(
+    "numpyflat", "numpy3D", convert_dict, mtype_universe=MTYPE_LIST_PANEL
+)

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -37,6 +37,7 @@ import pandas as pd
 ##############################################################
 # methods to convert one machine type to another machine type
 ##############################################################
+from sktime.datatypes._convert_utils._convert import _extend_conversions
 from sktime.datatypes._registry import MTYPE_LIST_SERIES
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
@@ -176,33 +177,6 @@ def convert_np_to_UvS_as_Series(obj: np.ndarray, store=None) -> pd.Series:
 convert_dict[("np.ndarray", "pd.Series", "Series")] = convert_np_to_UvS_as_Series
 
 
-# obtain other conversions from/to numpyflat via concatenation to numpy3D
-def _concat(fun1, fun2):
-    def concat_fun(obj, store=None):
-        obj1 = fun1(obj, store=store)
-        obj2 = fun2(obj1, store=store)
-        return obj2
-
-    return concat_fun
-
-
-def _extend_conversions(mtype, anchor_mtype, convert_dict):
-    keys = convert_dict.keys()
-    scitype = list(keys)[0][2]
-
-    for tp in set(MTYPE_LIST_SERIES).difference([mtype, anchor_mtype]):
-        if (anchor_mtype, tp, scitype) in convert_dict.keys():
-            convert_dict[(mtype, tp, scitype)] = _concat(
-                convert_dict[(mtype, anchor_mtype, scitype)],
-                convert_dict[(anchor_mtype, tp, scitype)],
-            )
-        if (tp, anchor_mtype, scitype) in convert_dict.keys():
-            convert_dict[(tp, mtype, scitype)] = _concat(
-                convert_dict[(tp, anchor_mtype, scitype)],
-                convert_dict[(anchor_mtype, mtype, scitype)],
-            )
-
-
 if _check_soft_dependencies("xarray", severity="none"):
     import xarray as xr
 
@@ -240,4 +214,6 @@ if _check_soft_dependencies("xarray", severity="none"):
         ("pd.DataFrame", "xr.DataArray", "Series")
     ] = convert_Mvs_to_xrdatarray_as_Series
 
-    _extend_conversions("xr.DataArray", "pd.DataFrame", convert_dict)
+    _extend_conversions(
+        "xr.DataArray", "pd.DataFrame", convert_dict, mtype_universe=MTYPE_LIST_SERIES
+    )

--- a/sktime/datatypes/_table/_convert.py
+++ b/sktime/datatypes/_table/_convert.py
@@ -34,6 +34,7 @@ __all__ = ["convert_dict"]
 import numpy as np
 import pandas as pd
 
+from sktime.datatypes._convert_utils._convert import _extend_conversions
 from sktime.datatypes._table._registry import MTYPE_LIST_TABLE
 
 ##############################################################
@@ -239,35 +240,9 @@ convert_dict[
 ] = convert_df_to_list_of_dict_as_table
 
 
-# obtain other conversions from/to numpyflat via concatenation to DataFrame
-def _concat(fun1, fun2):
-    def concat_fun(obj, store=None):
-        obj1 = fun1(obj, store=store)
-        obj2 = fun2(obj1, store=store)
-        return obj2
-
-    return concat_fun
-
-
-def _extend_conversions(mtype, anchor_mtype, convert_dict, mtype_list=None):
-
-    keys = convert_dict.keys()
-    scitype = list(keys)[0][2]
-    if mtype_list is None:
-        mtype_list = [key[0] for key in keys]
-
-    for tp in set(MTYPE_LIST_TABLE).difference([mtype, anchor_mtype]):
-        if (anchor_mtype, tp, scitype) in convert_dict.keys():
-            convert_dict[(mtype, tp, scitype)] = _concat(
-                convert_dict[(mtype, anchor_mtype, scitype)],
-                convert_dict[(anchor_mtype, tp, scitype)],
-            )
-        if (tp, anchor_mtype, scitype) in convert_dict.keys():
-            convert_dict[(tp, mtype, scitype)] = _concat(
-                convert_dict[(tp, anchor_mtype, scitype)],
-                convert_dict[(anchor_mtype, mtype, scitype)],
-            )
-
-
-_extend_conversions("pd_Series_Table", "pd_DataFrame_Table", convert_dict)
-_extend_conversions("list_of_dict", "pd_DataFrame_Table", convert_dict)
+_extend_conversions(
+    "pd_Series_Table", "pd_DataFrame_Table", convert_dict, MTYPE_LIST_TABLE
+)
+_extend_conversions(
+    "list_of_dict", "pd_DataFrame_Table", convert_dict, MTYPE_LIST_TABLE
+)


### PR DESCRIPTION
This PR refactors mtype conversion extension utils into one location.

Three almost identical instances of `_concat` and two of `_extend_conversions` ( in `_convert` modules of `_series`, `_panel`, and `_table`) are moved into the new module `datatypes._convert_utils` and replaced by imports.
One instance of `_extend_conversions` without function wrapping in `_series._convert` is also replaced by use of `_extend_conversions`.

This should make future addition of mtypes, e.g., dask support, or further xarray support, easier.

FYI @benHeid, @topher-lo 