### PR TITLE
[BUG] Fixes 1788 - Add statsmodels append() to _update() in _StatsModelsAdapter

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1760,17 +1760,6 @@
         "test"
       ]
     },
-    {
-      "login": "chillerobscuro",
-      "name": "Logan Duffy",
-      "avatar_url": "https://avatars.githubusercontent.com/u/5232872?v=4",
-      "profile": "https://github.com/chillerobscuro",
-      "contributions": [
-        "code",
-        "ideas",
-        "bug"
-      ]
-    },
   ],
   "projectName": "sktime",
   "projectOwner": "alan-turing-institute",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1760,6 +1760,17 @@
         "test"
       ]
     },
+    {
+      "login": "chillerobscuro",
+      "name": "Logan Duffy",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5232872?v=4",
+      "profile": "https://github.com/chillerobscuro",
+      "contributions": [
+        "code",
+        "ideas",
+        "bug"
+      ]
+    },
   ],
   "projectName": "sktime",
   "projectOwner": "alan-turing-institute",

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -7,6 +7,7 @@ __author__ = ["mloning"]
 __all__ = ["_StatsModelsAdapter"]
 
 import inspect
+from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -62,7 +63,14 @@ class _StatsModelsAdapter(BaseForecaster):
         if update_params or self.is_composite():
             super()._update(y, X, update_params=update_params)
         else:
-            self._fitted_forecaster = self._fitted_forecaster.append(y)
+            if not hasattr(self._fitted_forecaster, "append"):
+                warn(
+                    f"NotImplementedWarning: {self.__class__.__name__} "
+                    f"can not accept new data when update_params=False. "
+                    f"Call with update_params=True to refit with new data."
+                )
+            else:
+                self._fitted_forecaster = self._fitted_forecaster.append(y)
 
     def _predict(self, fh, X=None):
         """Make forecasts.

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -57,6 +57,13 @@ class _StatsModelsAdapter(BaseForecaster):
         """Log used internally in fit."""
         raise NotImplementedError("abstract method")
 
+    def _update(self, y, X=None, update_params=True):
+        """Update used internally in update."""
+        if update_params or self.is_composite():
+            super()._update(y, X, update_params=update_params)
+        else:
+            self._fitted_forecaster = self._fitted_forecaster.append(y)
+
     def _predict(self, fh, X=None):
         """Make forecasts.
 

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -98,6 +98,7 @@ class _StatsModelsAdapter(BaseForecaster):
         # statsmodels requires zero-based indexing starting at the
         # beginning of the training series when passing integers
         start, end = fh.to_absolute_int(self._y.index[0], self.cutoff)[[0, -1]]
+
         if "exog" in inspect.signature(self._forecaster.__init__).parameters.keys():
             y_pred = self._fitted_forecaster.predict(start=start, end=end, exog=X)
         else:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes [1788](https://github.com/sktime/sktime/issues/1788)

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
When `update_params=False`, calling `update` with any `_StatsModelsAdapter` model does not work as expected. This PR changes behavior only when `update_params=False` and `self.is_composite=False`, and now uses the `statsmodels` `append` functionality to add new observed data without refitting the model.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No
#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
The following outstanding questions
#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
1. For now if the user doesn't pass data with the correct index to `update()`, they will get the error message from `statsmodels` that `ValueError: Given endog does not have an index that extends the index of the model.` I could add functionality to check if the updated data intersects with the original data and only take the new subset, but could use advice on which data types we would need to handle (pandas only? also numpy? etc).
2. In the base `update()` method, if `self._is_vectorized=True`, then `_vectorize("update", ...)` is called instead of `_update()`. Do we need to add logic to handle this case?
3. Do we need to update the logic if both `self.is_composite=True` and `update_params=False`? This PR does not affect current behavior in the composite case.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

<!--
Thanks for contributing!
-->
