### PR TITLE
[BUG] add get_test_params method to TapNet

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,14 +12,14 @@ addopts =
     --ignore examples
     --ignore docs
     --doctest-modules
-    --durations 10
-    --timeout 600
-    --cov sktime
-    --cov-report xml
-    --cov-report html
-    --showlocals
-    --matrixdesign True
-    -n auto
+#    --durations 10
+#    --timeout 600
+#    --cov sktime
+#    --cov-report xml
+#    --cov-report html
+#    --showlocals
+#    --matrixdesign True
+#    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed

--- a/sktime/classification/deep_learning/tapnet.py
+++ b/sktime/classification/deep_learning/tapnet.py
@@ -230,3 +230,35 @@ class TapNetClassifier(BaseDeepClassifier):
         )
 
         return self
+
+
+@classmethod
+def get_test_params(cls, parameter_set="default"):
+    """Return testing parameter settings for the estimator.
+
+    Parameters
+    ----------
+    parameter_set : str, default="default"
+        Name of the set of test parameters to return, for use in tests. If no
+        special parameters are defined for a value, will return `"default"` set.
+        For classifiers, a "default" set of parameters should be provided for
+        general testing, and a "results_comparison" set for comparing against
+        previously recorded results if the general set does not produce suitable
+        probabilities to compare against.
+
+    Returns
+    -------
+    params : dict or list of dict, default={}
+        Parameters to create testing instances of the class.
+        Each dict are parameters to construct an "interesting" test instance, i.e.,
+        `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+        `create_test_instance` uses the first (or only) dictionary in `params`.
+    """
+    return {"n_epochs": 100, "batch_size": 2, "dilation": 2}
+
+
+# dropout = 0.5, \
+# filter_sizes = (256, 256, 128), \
+# kernel_size = (8, 5, 3), \
+# dilation = 1, \
+# layers = (500,300),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #3525 , the tests for TapNet were either timing out or taking a very long time. 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
adds a get_test_params to the TapNet classifier. 

#### Does your contribution introduce a new dependency? If yes, which one?

no

#### What should a reviewer concentrate their feedback on?

the parameter settings in the generator test. Ive tried these
{"n_epochs": 100, "batch_size": 2, "dilation": 2}
but would appreciate feedback/review from @achieveordie on this.
