### PR TITLE
[ENH] test that `TruncationTransformer` preserves index and column names in `pd-multiindex`

### DIFF
--- a/sktime/transformations/panel/tests/test_Truncate.py
+++ b/sktime/transformations/panel/tests/test_Truncate.py
@@ -38,7 +38,7 @@ def test_truncation_paramterised_transformer():
 def test_truncation_pd_multiindex():
     """Test that column and index names in a pd-multiindex container are preserved."""
     # get a multiindex dataframe, ensure instance levels are string, not int
-    X = get_examples("pd-multiindex")[0]
+    X = get_examples("pd-multiindex")[0].copy()
     X.index = X.index.set_levels(["a", "b", "c"], level=0)
 
     t = TruncationTransformer(1, 2)

--- a/sktime/transformations/panel/tests/test_Truncate.py
+++ b/sktime/transformations/panel/tests/test_Truncate.py
@@ -2,6 +2,7 @@
 """Test Truncator transformer."""
 
 from sktime.datasets import load_basic_motions
+from sktime.datatypes import get_examples
 from sktime.transformations.panel.truncation import TruncationTransformer
 
 from sktime.datatypes._panel._convert import from_nested_to_2d_array
@@ -33,3 +34,17 @@ def test_truncation_paramterised_transformer():
     # and we've truncated them all to (10-2) long.
     data = from_nested_to_2d_array(Xt)
     assert len(data.columns) == 8 * 6
+
+
+def test_truncation_pd_multiindex():
+    """Test that column and index names in a pd-multiindex container are preserved."""
+    # get a multiindex dataframe, ensure instance levels are string, not int
+    X = get_examples("pd-multiindex")[0]
+    X.index = X.index.set_levels(["a", "b", "c"], level=0)
+
+    t = TruncationTransformer(1, 2)
+    Xt = t.fit_transform(X)
+
+    # assert that column names and index names are preserved
+    assert (X.index.get_level_values(0).unique().values == ["a", "b", "c"]).all()
+    assert (Xt.columns == X.columns).all()

--- a/sktime/transformations/panel/tests/test_Truncate.py
+++ b/sktime/transformations/panel/tests/test_Truncate.py
@@ -3,9 +3,8 @@
 
 from sktime.datasets import load_basic_motions
 from sktime.datatypes import get_examples
-from sktime.transformations.panel.truncation import TruncationTransformer
-
 from sktime.datatypes._panel._convert import from_nested_to_2d_array
+from sktime.transformations.panel.truncation import TruncationTransformer
 
 
 def test_truncation_transformer():

--- a/sktime/transformations/panel/truncation.py
+++ b/sktime/transformations/panel/truncation.py
@@ -118,6 +118,7 @@ class TruncationTransformer(BaseTransformer):
 
         Xt = pd.DataFrame(truncate)
         Xt.columns = X.columns
+        Xt.index = X.index
 
         return Xt
 


### PR DESCRIPTION
Tests the failure case in https://github.com/sktime/sktime/issues/2998, where `TruncationTransformer` could destroy column and index names.

Also makes the `TruncationTransformer` safer by preserving index explicitly.