### PR TITLE
[BUG] Add `get_test_params()` to TapNet Estimators

### DIFF
--- a/sktime/classification/deep_learning/tapnet.py
+++ b/sktime/classification/deep_learning/tapnet.py
@@ -3,6 +3,8 @@
 
 __author__ = [
     "Jack Russon",
+    "TonyBagnall",
+    "achieveordie",
 ]
 __all__ = [
     "TapNetClassifier",
@@ -230,3 +232,33 @@ class TapNetClassifier(BaseDeepClassifier):
         )
 
         return self
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            For classifiers, a "default" set of parameters should be provided for
+            general testing, and a "results_comparison" set for comparing against
+            previously recorded results if the general set does not produce suitable
+            probabilities to compare against.
+
+        Returns
+        -------
+        params : dict or list of dict, default={}
+            Parameters to create testing instances of the class.
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`.
+        """
+        return {
+            "n_epochs": 50,
+            "batch_size": 32,
+            "filter_sizes": (128, 128, 64),
+            "dilation": 2,
+            "layers": (200, 100),
+        }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

@TonyBagnall Here's the PR that we talked about. Let's work on it together.

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #3525

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Add a class method `get_test_params()` similar to other estimators that is to be used by runners during tests. 

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
We want to reduce total time taken for tests to run on `TapNetClassifier` and `TapNetRegressor`.
