### PR TITLE
[ENH] extend `evaluate` to hierarchical and panel data

### DIFF
--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -248,5 +248,6 @@ def _check_strategy(strategy):
 def _subset_keep_freq(y, idx):
     y_idx = y.loc[idx]
     if hasattr(y.index, "freq") and y.index.freq is not None:
-        y_idx.index.freq = y.index.freq
+        if hasattr(y_idx.index, "freq") and y_idx.index.freq is None:
+            y_idx.index.freq = y.index.freq
     return y_idx

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -246,6 +246,7 @@ def _check_strategy(strategy):
 
 
 def _subset_keep_freq(y, idx):
+    """Subset y using y.loc[idx] but ensure that index.freq preserved."""
     y_idx = y.loc[idx]
     if hasattr(y.index, "freq") and y.index.freq is not None:
         if hasattr(y_idx.index, "freq") and y_idx.index.freq is None:

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -38,13 +38,13 @@ def evaluate(
     Parameters
     ----------
     forecaster : sktime.forecaster
-        Any forecaster
+        sktime forecaster (concrete BaseForecaster descendant)
     cv : Temporal cross-validation splitter
         Splitter of how to split the data into test data and train data
-    y : pd.Series
-        Target time series to which to fit the forecaster.
-    X : pd.DataFrame, default=None
-        Exogenous variables
+    y : sktime time series container
+        Target (endogeneous) time series used in the evaluation experiment
+    X : sktime time series container, of same mtype as y
+        Exogenous time series used in the evaluation experiment
     strategy : {"refit", "update", "no-update_params"}, optional, default="refit"
         defines the ingestion mode when the forecaster sees new data when window expands
         "refit" = forecaster is refitted to each training window

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -149,7 +149,16 @@ def evaluate(
             X_test = None
 
         # create forecasting horizon
-        fh = ForecastingHorizon(y_test.index, is_relative=False)
+        # if cv object has fh, we use that
+        if hasattr(cv, "fh") and cv.fh is not None:
+            fh = cv.fh
+        # otherwise, if y_test is not hierarchical, we simply take the index of y_test
+        elif not isinstance(y_test.index, pd.MultiIndex):
+            fh = ForecastingHorizon(y_test.index, is_relative=False)
+        # otherwise, y_test is hierarchical, and we take its unique time indices
+        else:
+            fh_idx = y_test.index.get_level_values(-1).unique()
+            fh = ForecastingHorizon(fh_idx, is_relative=False)
 
         try:
             # fit/update

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -140,7 +140,10 @@ def evaluate(
 
         if X is not None:
             X_train = _subset_keep_freq(X_inner, train)
-            X_test = _subset_keep_freq(X_inner, test)
+            # For X_test, we select the full range of test/train values.
+            # for those transformers that change the size of input.
+            test_plus_train = train.union(test)
+            X_test = _subset_keep_freq(X_inner, test_plus_train)
         else:
             X_train = None
             X_test = None

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -135,12 +135,12 @@ def evaluate(
         y_pred = np.nan
 
         # split data according to cv
-        y_train = y_inner.loc[train]
-        y_test = y_inner.loc[test]
+        y_train = _subset_keep_freq(y_inner, train)
+        y_test = _subset_keep_freq(y_inner, test)
 
         if X is not None:
-            X_train = X_inner.loc[train]
-            X_test = X_inner.loc[test]
+            X_train = _subset_keep_freq(X_inner, train)
+            X_test = _subset_keep_freq(X_inner, test)
         else:
             X_train = None
             X_test = None
@@ -190,6 +190,7 @@ def evaluate(
             cutoff = forecaster.cutoff
 
         except Exception as e:
+            raise e
             if error_score == "raise":
                 raise e
             else:
@@ -243,3 +244,10 @@ def _check_strategy(strategy):
     valid_strategies = ("refit", "update", "no-update_params")
     if strategy not in valid_strategies:
         raise ValueError(f"`strategy` must be one of {valid_strategies}")
+
+
+def _subset_keep_freq(y, idx):
+    y_idx = y.loc[idx]
+    if hasattr(y.index, "freq") and y.index.freq is not None:
+        y_idx.index.freq = y.index.freq
+    return y_idx

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -190,7 +190,6 @@ def evaluate(
             cutoff = forecaster.cutoff
 
         except Exception as e:
-            raise e
             if error_score == "raise":
                 raise e
             else:

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -17,13 +17,12 @@ __all__ = [
 import numpy as np
 import pandas as pd
 import pytest
-
 from sklearn.linear_model import LinearRegression
 
 from sktime.datasets import load_airline, load_longley
 from sktime.exceptions import FitFailedWarning
-from sktime.forecasting.compose._reduce import DirectReductionForecaster
 from sktime.forecasting.arima import ARIMA
+from sktime.forecasting.compose._reduce import DirectReductionForecaster
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.model_evaluation import evaluate
 from sktime.forecasting.model_selection import (

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -7,7 +7,7 @@ In particular, function `evaluate`, that performs time series
 cross-validation, is tested with various configurations for correct output.
 """
 
-__author__ = ["aiwalter", "mloning"]
+__author__ = ["aiwalter", "mloning", "fkiraly"]
 __all__ = [
     "test_evaluate_common_configs",
     "test_evaluate_initial_window",
@@ -34,6 +34,7 @@ from sktime.performance_metrics.forecasting import (
     MeanAbsoluteScaledError,
 )
 from sktime.utils._testing.forecasting import make_forecasting_problem
+from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils.validation._dependencies import _check_estimator_deps
 
 
@@ -196,3 +197,25 @@ def test_evaluate_error_score(error_score, return_data, strategy):
                 error_score=error_score,
                 strategy=strategy,
             )
+
+
+def test_evaluate_hierarchical():
+    """Check that adding exogenous data produces different results."""
+    y = _make_hierarchical(
+        random_state=0, hierarchy_levels=(2, 2), min_timepoints=20, max_timepoints=20
+    )
+    X = _make_hierarchical(
+        random_state=42, hierarchy_levels=(2, 2), min_timepoints=20, max_timepoints=20
+    )
+
+    forecaster = NaiveForecaster()
+
+    cv = SlidingWindowSplitter()
+    scoring = MeanAbsolutePercentageError(symmetric=True)
+
+    out_exog = evaluate(forecaster, cv, y, X=X, scoring=scoring)
+
+    out_no_exog = evaluate(forecaster, cv, y, X=None, scoring=scoring)
+
+    scoring_name = f"test_{scoring.name}"
+    assert np.all(out_exog[scoring_name] != out_no_exog[scoring_name])

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -18,8 +18,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from sklearn.linear_model import LinearRegression
+
 from sktime.datasets import load_airline, load_longley
 from sktime.exceptions import FitFailedWarning
+from sktime.forecasting.compose._reduce import DirectReductionForecaster
 from sktime.forecasting.arima import ARIMA
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.model_evaluation import evaluate
@@ -211,7 +214,7 @@ def test_evaluate_hierarchical():
     y = y.sort_index()
     X = X.sort_index()
 
-    forecaster = NaiveForecaster()
+    forecaster = DirectReductionForecaster(LinearRegression())
 
     cv = SlidingWindowSplitter()
     scoring = MeanAbsolutePercentageError(symmetric=True)

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -208,14 +208,19 @@ def test_evaluate_hierarchical():
         random_state=42, hierarchy_levels=(2, 2), min_timepoints=20, max_timepoints=20
     )
 
+    y = y.sort_index()
+    X = X.sort_index()
+
     forecaster = NaiveForecaster()
 
     cv = SlidingWindowSplitter()
     scoring = MeanAbsolutePercentageError(symmetric=True)
 
-    out_exog = evaluate(forecaster, cv, y, X=X, scoring=scoring)
+    out_exog = evaluate(forecaster, cv, y, X=X, scoring=scoring, error_score="raise")
 
-    out_no_exog = evaluate(forecaster, cv, y, X=None, scoring=scoring)
+    out_no_exog = evaluate(
+        forecaster, cv, y, X=None, scoring=scoring, error_score="raise"
+    )
 
     scoring_name = f"test_{scoring.name}"
     assert np.all(out_exog[scoring_name] != out_no_exog[scoring_name])


### PR DESCRIPTION
Carries out item from https://github.com/sktime/sktime/issues/2243.

Extends `evaluate` to accept hierarchical `X` and `y`.

By extension, should enable `GridSearchCV` to handle hierarchical data and resolve bug https://github.com/sktime/sktime/issues/3464.

Less hacky version of https://github.com/sktime/sktime/pull/3509 which uses the centralized checker functions and hierarchical functionality of splitters instead of custom duplicates.

FYI @aiwalter, @danbartl, @ngupta23