### PR TITLE
[BUG] fast test parameters for `TapNet` estimators and docstring/interface cleanup

### DIFF
--- a/sktime/classification/deep_learning/tapnet.py
+++ b/sktime/classification/deep_learning/tapnet.py
@@ -134,8 +134,6 @@ class TapNetClassifier(BaseDeepClassifier):
         self.callbacks = callbacks
         self.verbose = verbose
 
-        self._is_fitted = False
-
         self.dropout = dropout
         self.use_lstm = use_lstm
         self.use_cnn = use_cnn

--- a/sktime/classification/deep_learning/tapnet.py
+++ b/sktime/classification/deep_learning/tapnet.py
@@ -253,10 +253,20 @@ class TapNetClassifier(BaseDeepClassifier):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
-        return {
+        param1 = {
             "n_epochs": 50,
             "batch_size": 32,
+            "use_lstm": False,
+            "use_att": False,
             "filter_sizes": (128, 128, 64),
             "dilation": 2,
-            "layers": (200, 100),
+            "layers": (50, 25),
         }
+
+        param2 = {
+            "n_epochs": 100,
+            "use_cnn": False,
+            "layers": (25, 25),
+        }
+
+        return [param1, param2]

--- a/sktime/regression/deep_learning/tapnet.py
+++ b/sktime/regression/deep_learning/tapnet.py
@@ -239,7 +239,7 @@ class TapNetRegressor(BaseDeepRegressor):
             "batch_size": 32,
             "padding": "valid",
             "filter_sizes": (64, 64, 64),
-            "kernel_sizes": (3, 3, 1),
+            "kernel_size": (3, 3, 1),
             "layers": (25, 50),
         }
 

--- a/sktime/regression/deep_learning/tapnet.py
+++ b/sktime/regression/deep_learning/tapnet.py
@@ -38,10 +38,10 @@ class TapNetRegressor(BaseDeepRegressor):
         dilation value
     activation          : str, default = "sigmoid"
         activation function for the last output layer
-    loss                : str, default = "binary_crossentropy"
+    loss                : str, default = "mean_squared_error"
         loss function for the classifier
     optimizer           : str or None, default = "Adam(lr=0.01)"
-        gradient updating function for the classifer
+        gradient updating function for the classifier
     use_bias            : bool, default = True
         whether to use bias in the output dense layer
     use_rp              : bool, default = True
@@ -118,8 +118,6 @@ class TapNetRegressor(BaseDeepRegressor):
         self.metrics = metrics
         self.callbacks = callbacks
         self.verbose = verbose
-
-        self._is_fitted = False
 
         self.dropout = dropout
         self.use_lstm = use_lstm
@@ -213,3 +211,33 @@ class TapNetRegressor(BaseDeepRegressor):
         )
 
         return self
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            For classifiers, a "default" set of parameters should be provided for
+            general testing, and a "results_comparison" set for comparing against
+            previously recorded results if the general set does not produce suitable
+            probabilities to compare against.
+
+        Returns
+        -------
+        params : dict or list of dict, default={}
+            Parameters to create testing instances of the class.
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`.
+        """
+        return {
+            "n_epochs": 50,
+            "batch_size": 32,
+            "filter_sizes": (128, 128, 64),
+            "dilation": 2,
+            "layers": (200, 100),
+        }

--- a/sktime/regression/deep_learning/tapnet.py
+++ b/sktime/regression/deep_learning/tapnet.py
@@ -234,10 +234,19 @@ class TapNetRegressor(BaseDeepRegressor):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
-        return {
-            "n_epochs": 50,
+        param1 = {
+            "n_epochs": 25,
             "batch_size": 32,
-            "filter_sizes": (128, 128, 64),
-            "dilation": 2,
-            "layers": (200, 100),
+            "padding": "valid",
+            "filter_sizes": (64, 64, 64),
+            "kernel_sizes": (3, 3, 1),
+            "layers": (25, 50),
         }
+
+        param2 = {
+            "n_epochs": 75,
+            "use_rp": False,
+            "layers": (50, 25),
+        }
+
+        return [param1, param2]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #3525

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
- Add `get_test_params()` for `TapNetRegressor` and `TapNetClassifier` with two parameter set.
- Remove the redundant `is_fitted` variable from TapNet estimators.
- Correct minor typos.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
@TonyBagnall LMK if we should make any more changes here.
