### PR TITLE
[BUG] Fix pipeline tag for NaN values

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -299,7 +299,7 @@ class ForecastingPipeline(_Pipeline):
         "X_inner_mtype": SUPPORTED_MTYPES,
         "ignores-exogeneous-X": False,
         "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "handles-missing-data": True,
         "capability:pred_int": True,
         "X-y-must-have-same-index": False,
     }
@@ -311,7 +311,6 @@ class ForecastingPipeline(_Pipeline):
         tags_to_clone = [
             "ignores-exogeneous-X",  # does estimator ignore the exogeneous X?
             "capability:pred_int",  # can the estimator produce prediction intervals?
-            "handles-missing-data",  # can estimator handle missing data?
             "requires-fh-in-fit",  # is forecasting horizon already required in fit?
             "enforce_index_type",  # index type that needs to be enforced in X/y
         ]
@@ -713,7 +712,7 @@ class TransformedTargetForecaster(_Pipeline):
         "X_inner_mtype": SUPPORTED_MTYPES,
         "ignores-exogeneous-X": False,
         "requires-fh-in-fit": False,
-        "handles-missing-data": False,
+        "handles-missing-data": True,
         "capability:pred_int": True,
         "X-y-must-have-same-index": False,
     }
@@ -727,7 +726,6 @@ class TransformedTargetForecaster(_Pipeline):
         tags_to_clone = [
             "ignores-exogeneous-X",  # does estimator ignore the exogeneous X?
             "capability:pred_int",  # can the estimator produce prediction intervals?
-            "handles-missing-data",  # can estimator handle missing data?
             "requires-fh-in-fit",  # is forecasting horizon already required in fit?
             "enforce_index_type",  # index type that needs to be enforced in X/y
         ]

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -352,10 +352,8 @@ def test_tag_handles_missing_data():
     This test is based on bug issue #3547.
     """
     forecaster = MockForecaster()
-    forecaster.set_tags(**{"handles-missing-data": False})
-
     # make sure that test forecaster cant handle missing data
-    assert forecaster.get_tag("handles-missing-data") is False
+    forecaster.set_tags(**{"handles-missing-data": False})
 
     y = _make_series()
     y[10] = np.nan


### PR DESCRIPTION
closes #3547 

@ngupta23 please have a look

I removed the tag inheritance bcz if the forecaster cant handle missing values, it will raise an exception then anyways but it will work if an `Imputer` was used in the pipe.