### PR TITLE
[ENH] enforces row index of `pandas.DataFrame` based mtypes to be sorted and unique

### DIFF
--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -85,7 +85,15 @@ def check_pdmultiindex_hierarchical(obj, return_metadata=False, var_name="obj"):
         msg = f"{var_name} must have a MultiIndex, found {type(obj.index)}"
         return _ret(False, msg, None, return_metadata)
 
-    # check that columns are unique
+    # check that row index is unique
+    msg = f"{var_name} must have unique row indices, but found {obj.index}"
+    assert obj.index.is_unique, msg
+
+    # check that rows are sorted
+    msg = f"{var_name} must have lexsorted row index, but found {obj.index}"
+    assert obj.index.is_monotonic_increasing, msg
+
+    # check that column index is unique
     msg = f"{var_name} must have " f"unique column indices, but found {obj.columns}"
     assert obj.columns.is_unique, msg
 

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -160,7 +160,15 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj"):
         msg = f"{var_name} must have a MultiIndex, found {type(obj.index)}"
         return _ret(False, msg, None, return_metadata)
 
-    # check that columns are unique
+    # check that row index is unique
+    msg = f"{var_name} must have unique row indices, but found {obj.index}"
+    assert obj.index.is_unique, msg
+
+    # check that rows are sorted
+    msg = f"{var_name} must have lexsorted row index, but found {obj.index}"
+    assert obj.index.is_monotonic_increasing, msg
+
+    # check that column index is unique
     msg = f"{var_name} must have " f"unique column indices, but found {obj.columns}"
     assert obj.columns.is_unique, msg
 

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -88,6 +88,10 @@ def check_pddataframe_series(obj, return_metadata=False, var_name="obj"):
         msg = f"{var_name} should not have column of 'object' dtype"
         return ret(False, msg, None, return_metadata)
 
+    # check that time (row) index is unique
+    msg = f"{var_name} must have unique row indices, but found {obj.index}"
+    assert obj.index.is_unique, msg
+
     # Check time index is ordered in time
     if not index.is_monotonic_increasing:
         msg = (


### PR DESCRIPTION
This adds two lines to the checkers for `pandas.DataFrame` based mtypes which enforce row indices to be lexsorted and unique.