### PR TITLE
[BUG] fix erroneous asserts in input checkers

### DIFF
--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -86,8 +86,9 @@ def check_pdmultiindex_hierarchical(obj, return_metadata=False, var_name="obj"):
         return _ret(False, msg, None, return_metadata)
 
     # check that columns are unique
-    msg = f"{var_name} must have " f"unique column indices, but found {obj.columns}"
-    assert obj.columns.is_unique, msg
+    if not obj.columns.is_unique:
+        msg = f"{var_name} must have unique column indices, but found {obj.columns}"
+        return _ret(False, msg, None, return_metadata)
 
     # check that there are 3 or more index levels
     nlevels = obj.index.nlevels

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -161,8 +161,9 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj"):
         return _ret(False, msg, None, return_metadata)
 
     # check that columns are unique
-    msg = f"{var_name} must have " f"unique column indices, but found {obj.columns}"
-    assert obj.columns.is_unique, msg
+    if not obj.columns.is_unique:
+        msg = f"{var_name} must have unique column indices, but found {obj.columns}"
+        return _ret(False, msg, None, return_metadata)
 
     # check that there are precisely two index levels
     nlevels = obj.index.nlevels
@@ -315,8 +316,9 @@ def is_nested_dataframe(obj, return_metadata=False, var_name="obj"):
             return _ret(False, msg, None, return_metadata)
 
     # check that columns are unique
-    msg = f"{var_name} must have " f"unique column indices, but found {obj.columns}"
-    assert obj.columns.is_unique, msg
+    if not obj.columns.is_unique:
+        msg = f"{var_name} must have unique column indices, but found {obj.columns}"
+        return _ret(False, msg, None, return_metadata)
 
     # Check instance index is unique
     if not obj.index.is_unique:

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -72,8 +72,9 @@ def check_pddataframe_series(obj, return_metadata=False, var_name="obj"):
     metadata["is_univariate"] = len(obj.columns) < 2
 
     # check that columns are unique
-    msg = f"{var_name} must have " f"unique column indices, but found {obj.columns}"
-    assert obj.columns.is_unique, msg
+    if not obj.columns.is_unique:
+        msg = f"{var_name} must have " f"unique column indices, but found {obj.columns}"
+        return ret(False, msg, None, return_metadata)
 
     # check whether the time index is of valid type
     if not is_in_valid_index_types(index):
@@ -266,8 +267,9 @@ if _check_soft_dependencies("xarray", severity="none"):
         metadata["is_univariate"] = len(obj.dims) == 1 or len(obj[obj.dims[1]]) < 2
 
         # check that columns are unique
-        msg = f"{var_name} must have " f"unique column indices, but found {obj.dims}"
-        assert len(obj.dims) == len(set(obj.dims)), msg
+        if not len(obj.dims) == len(set(obj.dims)):
+            msg = f"{var_name} must have " f"unique column indices, but found {obj.dims}"
+            return ret(False, msg, None, return_metadata)
 
         # check whether the time index is of valid type
         if not is_in_valid_index_types(index):

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -73,7 +73,7 @@ def check_pddataframe_series(obj, return_metadata=False, var_name="obj"):
 
     # check that columns are unique
     if not obj.columns.is_unique:
-        msg = f"{var_name} must have " f"unique column indices, but found {obj.columns}"
+        msg = f"{var_name} must have unique column indices, but found {obj.columns}"
         return ret(False, msg, None, return_metadata)
 
     # check whether the time index is of valid type
@@ -268,7 +268,7 @@ if _check_soft_dependencies("xarray", severity="none"):
 
         # check that columns are unique
         if not len(obj.dims) == len(set(obj.dims)):
-            msg = f"{var_name} must have " f"unique column indices, but found {obj.dims}"
+            msg = f"{var_name} must have unique column indices, but found {obj.dims}"
             return ret(False, msg, None, return_metadata)
 
         # check whether the time index is of valid type


### PR DESCRIPTION
This PR fixes erroneous asserts in input checkers for some `pandas` based types.

The result is that no informative error message would be returned (none instead of one), "informative" is not picked up by tests (and perhaps not testable)