### PR TITLE
[ENH] `numpy` integer support for `ColumnEnsembleForecaster`

### DIFF
--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -6,6 +6,7 @@
 __author__ = ["GuzalBulatova", "mloning", "fkiraly"]
 __all__ = ["ColumnEnsembleForecaster"]
 
+import numpy as np
 import pandas as pd
 
 from sktime.base._meta import flatten
@@ -138,6 +139,11 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
         # replace ints by column names
         obj = self._get_indices(self._y, obj)
 
+        # deal with numpy int by coercing to python int
+        if np.issubdtype(type(obj), np.integer):
+            obj = int(obj)
+
+        # coerce to pd.Index
         if isinstance(obj, (int, str)):
             return pd.Index([obj])
         else:

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -408,6 +408,10 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
         """Convert integer indices if necessary."""
 
         def _get_index(y, ix):
+            # deal with numpy int by coercing to python int
+            if np.issubdtype(type(ix), np.integer):
+                ix = int(ix)
+
             if isinstance(ix, int) and ix not in y.columns and ix < len(y.columns):
                 return y.columns[ix]
             else:

--- a/sktime/forecasting/compose/tests/test_column_ensemble.py
+++ b/sktime/forecasting/compose/tests/test_column_ensemble.py
@@ -70,7 +70,7 @@ def test_column_ensemble_multivariate_and_int():
     """Check that ColumnEnsembleForecaster works with string columns."""
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
     fc = ColumnEnsembleForecaster(
-        [("ab", NaiveForecaster(), ["a", np.int64(1)]), ("c", NaiveForecaster(), 2)]
+        [("ab", NaiveForecaster(), ["a", 1]), ("c", NaiveForecaster(), np.int64(2))]
     )
     fc.fit(df, fh=[1, 42])
     fc.predict()

--- a/sktime/forecasting/compose/tests/test_column_ensemble.py
+++ b/sktime/forecasting/compose/tests/test_column_ensemble.py
@@ -70,7 +70,7 @@ def test_column_ensemble_multivariate_and_int():
     """Check that ColumnEnsembleForecaster works with string columns."""
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
     fc = ColumnEnsembleForecaster(
-        [("ab", NaiveForecaster(), ["a", 1]), ("c", NaiveForecaster(), 2)]
+        [("ab", NaiveForecaster(), ["a", np.int64(1)]), ("c", NaiveForecaster(), 2)]
     )
     fc.fit(df, fh=[1, 42])
     fc.predict()


### PR DESCRIPTION
This PR adds support for `numpy` based integer types in `ColumnEnsembleForecaster`, previously this would have broken.

Also changes one of the current tests to cover this case.