### PR TITLE
[BUG] RandomShapeletTransform: floor the maximum number of shapelets to be the number of classes

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -29,8 +29,6 @@ EXCLUDE_ESTIMATORS = [
     "RandomIntervalClassifier",
     "MiniRocket",
     "MatrixProfileTransformer",
-    # RandomShapeletTransform is breaking with empty lists, see #3138
-    "RandomShapeletTransform",
 ]
 
 

--- a/sktime/transformations/panel/shapelet_transform.py
+++ b/sktime/transformations/panel/shapelet_transform.py
@@ -1151,7 +1151,8 @@ class RandomShapeletTransform(BaseTransformer):
 
         if self.max_shapelets is None:
             self._max_shapelets = min(10 * self.n_instances, 1000)
-
+        if self._max_shapelets < self.n_classes:
+            self._max_shapelets = self.n_classes
         if self.max_shapelet_length is None:
             self._max_shapelet_length = self.series_length
 


### PR DESCRIPTION
…avoid empty shapelet lists for edge case

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
fixes #3138 

#### What does this implement/fix? Explain your changes.
#3138 describes an edge case bug where RandomShapeletTransform returns an empty list of shapelets. This happens when the max number of shapelets

>self = RandomShapeletTransform(batch_size=20, max_shapelets=5, n_shapelet_samples=50)

is set to be less than the number of classes.

>y          = array([4, 3, 6, 8, 1, 2, 9, 7, 0, 5])

these makes the transform set

max_shapelets_per_class = 0.5

this PR simply floors the max_shapelets_per_class to be 1, ensuring that at least one shapelet per class is returned. 

#### Does your contribution introduce a new dependency? If yes, which one?

no

#### What should a reviewer concentrate their feedback on?

I guess the alternative would be to throw an exception or actually return max_shapelets so that some classes have no shapelets. I think this is more sensible and robust solution. 

