### PR TITLE
[BUG] fix `check_estimator` exclude arguments not working for non-base scitype tests

### DIFF
--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -133,6 +133,8 @@ def check_estimator(
             return_exceptions=return_exceptions,
             tests_to_run=tests_to_run,
             fixtures_to_run=fixtures_to_run,
+            tests_to_exclude=tests_to_exclude,
+            fixtures_to_exclude=fixtures_to_exclude,
         )
         results.update(results_scitype)
 

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -37,8 +37,14 @@ def test_check_estimator_does_not_raise(estimator_class):
 
 def test_check_estimator_subset_tests():
     """Test that subsetting by tests_to_run and tests_to_exclude works as intended."""
-    tests_to_run = ["test_get_params", "test_set_params", "test_clone", "test_repr"]
-    tests_to_exclude = ["test_repr"]
+    tests_to_run = [
+        "test_get_params",
+        "test_set_params",
+        "test_clone", "test_repr",
+        "test_capability_inverse_tag_is_correct",
+        "test_remember_data_tag_is_correct",
+    ]
+    tests_to_exclude = ["test_repr", "test_remember_data_tag_is_correct"]
 
     expected_tests = set(tests_to_run).difference(tests_to_exclude)
 

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -40,7 +40,8 @@ def test_check_estimator_subset_tests():
     tests_to_run = [
         "test_get_params",
         "test_set_params",
-        "test_clone", "test_repr",
+        "test_clone",
+        "test_repr",
         "test_capability_inverse_tag_is_correct",
         "test_remember_data_tag_is_correct",
     ]


### PR DESCRIPTION
Fixes #3565, i.e.,. `check_estimator` exclude arguments would not work for non-base scitype specific tests

This was due to the exclude arguments not being passed on properly to `run_tests`.

The existing test did not cover this failure because it looked at base scitype tests only. It has been modified to also include some non-base scitype tests.