### PR TITLE
[MNT] Remove `ABCMeta` inheritance from `_HeterogeneousMetaEstimator`

### DIFF
--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -6,13 +6,12 @@
 __author__ = ["mloning, fkiraly"]
 __all__ = ["_HeterogenousMetaEstimator"]
 
-from abc import ABCMeta
 from inspect import isclass
 
 from sktime.base import BaseEstimator
 
 
-class _HeterogenousMetaEstimator(BaseEstimator, metaclass=ABCMeta):
+class _HeterogenousMetaEstimator(BaseEstimator):
     """Handles parameter management for estimators composed of named estimators.
 
     Partly adapted from sklearn utils.metaestimator.py.


### PR DESCRIPTION
This PR removes `ABCMeta` inheritance from `_HeterogeneousMetaEstimator` which fails currently due to `flake8` `B024`, i.e., abstract base class without abstract decorators.

In fact, `_HeterogeneousMetaEstimator` is a mixin and not an abstract base class, so this is indeed a style/pattern failure which was not picked up earlier (possibly since `flake8` was not enabled back then).