### PR TITLE
[BUG] `ClearSky` fix missing value problem after transform

### DIFF
--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -13,6 +13,7 @@ __author__ = [
     "aiwalter",
     "jasonlines",
     "achieveordie",
+    "ciaran-g",
 ]
 
 __all__ = [
@@ -24,6 +25,7 @@ __all__ = [
     "load_italy_power_demand",
     "load_basic_motions",
     "load_japanese_vowels",
+    "load_solar",
     "load_shampoo_sales",
     "load_longley",
     "load_lynx",

--- a/sktime/transformations/series/clear_sky.py
+++ b/sktime/transformations/series/clear_sky.py
@@ -181,7 +181,7 @@ class ClearSky(BaseTransformer):
         X_trafo = X / csp
 
         # threshold for small morning/evening values
-        X_trafo[csp <= self.min_thresh] = 0
+        X_trafo[(csp <= self.min_thresh) & (X.notnull())] = 0
 
         return X_trafo
 

--- a/sktime/transformations/series/tests/test_clear_sky.py
+++ b/sktime/transformations/series/tests/test_clear_sky.py
@@ -7,8 +7,8 @@ __author__ = ["ciaran-g"]
 
 import numpy as np
 
-from sktime.transformations.series.clear_sky import ClearSky
 from sktime.datasets import load_solar
+from sktime.transformations.series.clear_sky import ClearSky
 
 
 def test_clearsky_trafo_vals():

--- a/sktime/transformations/series/tests/test_clear_sky.py
+++ b/sktime/transformations/series/tests/test_clear_sky.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3 -u
+# -*- coding: utf-8 -*-
+"""Tests for ClearSky transformer."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+__author__ = ["ciaran-g"]
+
+import numpy as np
+
+from sktime.transformations.series.clear_sky import ClearSky
+from sktime.datasets import load_solar
+
+
+def test_clearsky_trafo_vals():
+    """Tests the returned length of trafo with and without missing values."""
+    y = load_solar(start="2021-05-01", end="2021-05-07")
+
+    cs_model = ClearSky()
+    y_trafo = cs_model.fit_transform(y)
+
+    y_missing = y.copy()
+    y_missing.iloc[48:96] = np.nan
+    cs_model_missing = ClearSky()
+    y_trafo_missing = cs_model_missing.fit_transform(y_missing)
+
+    msg = "ClearSky transformer not returning correct number of values"
+    assert y.count() == y_trafo.count(), msg
+    assert y_missing.count() == y_trafo_missing.count(), msg


### PR DESCRIPTION


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Missing values which should be retained as missing in the transformed domain were being overwritten to zero.

* Simple fix to only set transformed values to zero when they are below the clear sky power threshold **and** if the original value is not null

