### PR TITLE
[DOC] minor clarifications of governance

### DIFF
--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -298,8 +298,8 @@ stay open for 5 days excluding weekends. Approval of appointment requires:
 * a 2/3 majority of all cast votes, and
 * a simple majority approval of all the current CC members.
 
-The core developer vote takes place in private communication channels, visible only to core developers, and is anonymous.
-The CC members' vote takes place in private communication channels, visible only to CC members, and is anonymous.
+The core developer vote takes place in private communication channels, visible to, and only to core developers, and is anonymous.
+The CC members' vote takes place in private communication channels, visibleto, and only to, CC members, and is anonymous.
 
 In case one or both of the core developer vote and the CC members' vote are tied,
 the CC member with the shortest continuous tenure has a tie breaking privilege.

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -290,26 +290,30 @@ concurrent with the 5 day discussion period (see below).
 Appointment
 ^^^^^^^^^^^
 
-Membership of the CC is by nomination by a core developer and a vote by
+Appointment to the CC is by nomination by a core developer and a vote by
 all core developers. A nomination will result in discussion which stay open
 for 5 days excluding weekends and then a vote by core developers which will
-stay open for 5 days excluding weekends. CC membership votes are subject to:
+stay open for 5 days excluding weekends. Approval of appointment requires:
 
 * a 2/3 majority of all cast votes, and
 * a simple majority approval of all the current CC members.
 
-The vote will take place in private communication channels and will be
-anonymous.
+The core developer vote takes place in private communication channels, visible only to core developers, and is anonymous.
+The CC members' vote takes place in private communication channels, visible only to CC members, and is anonymous.
 
-In case of ties, the CC member with shortest tenure breaks the tie.
+In case one or both of the core developer vote and the CC members' vote are tied,
+the CC member with the longest continuous tenure has a tie breaking privilege.
 
 End of tenure
 ^^^^^^^^^^^^^
 
 CC members can resign voluntarily at any point in time, by informing the CC in writing.
 
-CC members who do not actively engage with the responsibilities are
-expected to resign.
+CC members who do not actively engage with their CC member role responsibilities are
+expected to resign voluntarily.
+
+Tenure also ends automatically when a CC member's tenure as core developer ends,
+e.g., through resignation or inactivity.
 
 Communications
 ^^^^^^^^^^^^^^

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -291,7 +291,7 @@ Appointment
 ^^^^^^^^^^^
 
 Appointment to the CC is by nomination by a core developer and a vote by
-all core developers. A nomination will result in discussion which stay open
+all core developers. A nomination will result in discussion which stays open
 for 5 days excluding weekends and then a vote by core developers which will
 stay open for 5 days excluding weekends. Approval of appointment requires:
 

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -306,8 +306,9 @@ visible to, and only to, CC members, and is anonymous.
 In case the CC members' vote is tied,
 the CC member with the shortest continuous tenure has a tie breaking privilege.
 
-The tie breaking is by construction visible to CC members, need not follow
-the tie breaking CC member's anonymous vote, and does not require said member to have voted in the anonymous vote.
+The tie breaking is by construction visible to CC members,
+does not require the tie breaking CC member to have voted in the anonymous vote,
+and need not follow their anonymous vote if they have voted
 
 End of tenure
 ^^^^^^^^^^^^^

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -298,8 +298,10 @@ stay open for 5 days excluding weekends. Approval of appointment requires:
 * a 2/3 majority of all cast votes, and
 * a simple majority approval of all the current CC members.
 
-The core developer vote takes place in private communication channels, visible to, and only to core developers, and is anonymous.
-The CC members' vote takes place in private communication channels, visible to, and only to, CC members, and is anonymous.
+The core developer vote takes place in private communication channels,
+visible to, and only to, core developers, and is anonymous.
+The CC members' vote takes place in private communication channels,
+visible to, and only to, CC members, and is anonymous.
 
 In case one or both of the core developer vote and the CC members' vote are tied,
 the CC member with the shortest continuous tenure has a tie breaking privilege.

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -299,7 +299,7 @@ stay open for 5 days excluding weekends. Approval of appointment requires:
 * a simple majority approval of all the current CC members.
 
 The core developer vote takes place in private communication channels, visible to, and only to core developers, and is anonymous.
-The CC members' vote takes place in private communication channels, visibleto, and only to, CC members, and is anonymous.
+The CC members' vote takes place in private communication channels, visible to, and only to, CC members, and is anonymous.
 
 In case one or both of the core developer vote and the CC members' vote are tied,
 the CC member with the shortest continuous tenure has a tie breaking privilege.

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -308,7 +308,7 @@ the CC member with the shortest continuous tenure has a tie breaking privilege.
 
 The tie breaking is by construction visible to CC members,
 does not require the tie breaking CC member to have voted in the anonymous vote,
-and need not follow their anonymous vote if they have voted
+and need not follow their anonymous vote if they have voted.
 
 End of tenure
 ^^^^^^^^^^^^^

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -303,8 +303,11 @@ visible to, and only to, core developers, and is anonymous.
 The CC members' vote takes place in private communication channels,
 visible to, and only to, CC members, and is anonymous.
 
-In case one or both of the core developer vote and the CC members' vote are tied,
+In case the CC members' vote is tied,
 the CC member with the shortest continuous tenure has a tie breaking privilege.
+
+The tie breaking is by construction visible to CC members, need not follow
+the tie breaking CC member's anonymous vote, and does not require said member to have voted in the anonymous vote.
 
 End of tenure
 ^^^^^^^^^^^^^

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -302,7 +302,7 @@ The core developer vote takes place in private communication channels, visible o
 The CC members' vote takes place in private communication channels, visible only to CC members, and is anonymous.
 
 In case one or both of the core developer vote and the CC members' vote are tied,
-the CC member with the longest continuous tenure has a tie breaking privilege.
+the CC member with the shortest continuous tenure has a tie breaking privilege.
 
 End of tenure
 ^^^^^^^^^^^^^


### PR DESCRIPTION
This PR adds some minor clarifications to the governance document, without changing any of the rules.

The nature of most changes is removing vagueness or reference ambiguity in the governance rules.

These changes are from https://github.com/sktime/sktime/pull/1237, without the changes proposed in that PR.