### PR TITLE
[MNT] loosen `scipy` bound to <2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pandas>=1.1.0,<1.6.0",
     "scikit-learn>=0.24.0,<1.2.0",
     "statsmodels>=0.12.1",
-    "scipy<1.9.0",
+    "scipy<2.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR loosens the upper version bound for `scipy` to `<2.0.0`, thus removing any restriction on `1.X.X` versions.

We had the MINOR bound introduced after repeated breakage, this was mostly on `sktime` side using private methods (which was a mistake). Afaik we are no longer doing that, and `scipy` is very good at deprecation, so I think we can safely move the bound up to the MAJOR cycle.

Fixes #3586.