### PR TITLE
[DOC] update extension templates and docstrings for `_get_fitted_params`

### DIFF
--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -223,15 +223,32 @@ class MyTimeSeriesClassifier(BaseClassifier):
         # IMPORTANT: avoid side effects to X
 
     # todo: consider implementing this, optional
+    # implement only if different from default:
+    #   default retrieves all self attributes ending in "_"
+    #   and returns them with keys that have the "_" removed
     # if not implementing, delete the method
-    def get_fitted_params(self):
+    #   avoid overriding get_fitted_params
+    def _get_fitted_params(self):
         """Get fitted parameters.
+
+        private _get_fitted_params, called from get_fitted_params
+
+        State required:
+            Requires state to be "fitted".
 
         Returns
         -------
-        fitted_params : dict
+        fitted_params : dict with str keys
+            fitted parameters, keyed by names of fitted parameter
         """
         # implement here
+        #
+        # when this function is reached, it is already guaranteed that self is fitted
+        #   this does not need to be checked separately
+        #
+        # parameters of components should follow the sklearn convention:
+        #   separate component name from parameter name by double-underscore
+        #   e.g., componentname__paramname
 
     # todo: return default parameters, so that a test instance can be created
     #   required for automated unit and integration testing of estimator

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -26,7 +26,7 @@ Mandatory implements:
 
 Optional implements:
     data conversion and capabilities tags - _tags
-    fitted parameter inspection           - get_fitted_params()
+    fitted parameter inspection           - _get_fitted_params()
     predicting class probabilities        - _predict_proba(self, X)
 
 Testing - implement if sktime classifier (not needed locally):

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -24,8 +24,8 @@ Mandatory implements:
     fitting            - _fit(self, X)
 
 Optional implements:
-    cluster assignment - _predict(self, X)
-    fitted parameter inspection - get_fitted_params()
+    cluster assignment          -  _predict(self, X)
+    fitted parameter inspection -  _get_fitted_params()
 
 Testing - implement if sktime forecaster (not needed locally):
     get default parameters for test instance(s) - get_test_params()
@@ -135,18 +135,34 @@ class MyClusterer(BaseClusterer):
         # IMPORTANT: avoid side effects to X
 
     # todo: consider implementing this, optional
+    # implement only if different from default:
+    #   default retrieves all self attributes ending in "_"
+    #   and returns them with keys that have the "_" removed
+    # if not implementing, delete the method
+    #   avoid overriding get_fitted_params
     # this is typically important for clustering
-    # at least one of _predict and _get_fitted_params should be implemented
+    #   at least one of _predict and _get_fitted_params should be functional
     def _get_fitted_params(self):
-        """Retrieve fitted parameters of cluster model.
+        """Get fitted parameters.
 
-            core logic
+        private _get_fitted_params, called from get_fitted_params
+
+        State required:
+            Requires state to be "fitted".
 
         Returns
         -------
-        param_dict: dictionary of fitted parameters
+        fitted_params : dict with str keys
+            fitted parameters, keyed by names of fitted parameter
         """
         # implement here
+        #
+        # when this function is reached, it is already guaranteed that self is fitted
+        #   this does not need to be checked separately
+        #
+        # parameters of components should follow the sklearn convention:
+        #   separate component name from parameter name by double-underscore
+        #   e.g., componentname__paramname
 
     # todo: return default parameters, so that a test instance can be created
     #   required for automated unit and integration testing of estimator

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -303,15 +303,32 @@ class MyEarlyTimeSeriesClassifier(BaseEarlyClassifier):
         # HM: (2 * accuracy * (1 - earliness)) / (accuracy + (1 - earliness))
 
     # todo: consider implementing this, optional
+    # implement only if different from default:
+    #   default retrieves all self attributes ending in "_"
+    #   and returns them with keys that have the "_" removed
     # if not implementing, delete the method
-    def get_fitted_params(self):
+    #   avoid overriding get_fitted_params
+    def _get_fitted_params(self):
         """Get fitted parameters.
+
+        private _get_fitted_params, called from get_fitted_params
+
+        State required:
+            Requires state to be "fitted".
 
         Returns
         -------
-        fitted_params : dict
+        fitted_params : dict with str keys
+            fitted parameters, keyed by names of fitted parameter
         """
         # implement here
+        #
+        # when this function is reached, it is already guaranteed that self is fitted
+        #   this does not need to be checked separately
+        #
+        # parameters of components should follow the sklearn convention:
+        #   separate component name from parameter name by double-underscore
+        #   e.g., componentname__paramname
 
     # todo: return default parameters, so that a test instance can be created
     #   required for automated unit and integration testing of estimator

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -26,7 +26,7 @@ Mandatory implements:
 
 Optional implements:
     data conversion and capabilities tags - _tags
-    fitted parameter inspection           - get_fitted_params()
+    fitted parameter inspection           - _get_fitted_params()
     predicting class probabilities        - _predict_proba(self, X)
     updating probability predictions      - _update_predict_proba(self, X)
 

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -31,7 +31,7 @@ Optional implements:
     OR predicting intervals     - _predict_interval(self, fh, X=None, coverage=None)
     predicting variance         - _predict_var(self, fh, X=None, cov=False)
     distribution forecast       - _predict_proba(self, fh, X=None)
-    fitted parameter inspection - get_fitted_params()
+    fitted parameter inspection - _get_fitted_params()
 
 Testing - implement if sktime forecaster (not needed locally):
     get default parameters for test instance(s) - get_test_params()

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -539,15 +539,32 @@ class MyForecaster(BaseForecaster):
         # IMPORTANT: avoid side effects to y, X, cv
 
     # todo: consider implementing this, optional
-    # if not implementing, delete the get_fitted_params method
-    def get_fitted_params(self):
+    # implement only if different from default:
+    #   default retrieves all self attributes ending in "_"
+    #   and returns them with keys that have the "_" removed
+    # if not implementing, delete the method
+    #   avoid overriding get_fitted_params
+    def _get_fitted_params(self):
         """Get fitted parameters.
+
+        private _get_fitted_params, called from get_fitted_params
+
+        State required:
+            Requires state to be "fitted".
 
         Returns
         -------
-        fitted_params : dict
+        fitted_params : dict with str keys
+            fitted parameters, keyed by names of fitted parameter
         """
         # implement here
+        #
+        # when this function is reached, it is already guaranteed that self is fitted
+        #   this does not need to be checked separately
+        #
+        # parameters of components should follow the sklearn convention:
+        #   separate component name from parameter name by double-underscore
+        #   e.g., componentname__paramname
 
     # todo: implement this if this is an estimator contributed to sktime
     #   or to run local automated unit and integration testing of estimator

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -28,7 +28,7 @@ Mandatory implements:
 Optional implements:
     inverse transformation      - _inverse_transform(self, X, y=None)
     update                      - _update(self, X, y=None)
-    fitted parameter inspection - get_fitted_params()
+    fitted parameter inspection - _get_fitted_params()
 
 Testing - implement if sktime transformer (not needed locally):
     get default parameters for test instance(s) - get_test_params()

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -424,15 +424,32 @@ class MyTransformer(BaseTransformer):
         #  the clones, not the originals, should be used or fitted if needed
 
     # todo: consider implementing this, optional
+    # implement only if different from default:
+    #   default retrieves all self attributes ending in "_"
+    #   and returns them with keys that have the "_" removed
     # if not implementing, delete the method
-    def get_fitted_params(self):
+    #   avoid overriding get_fitted_params
+    def _get_fitted_params(self):
         """Get fitted parameters.
+
+        private _get_fitted_params, called from get_fitted_params
+
+        State required:
+            Requires state to be "fitted".
 
         Returns
         -------
-        fitted_params : dict
+        fitted_params : dict with str keys
+            fitted parameters, keyed by names of fitted parameter
         """
         # implement here
+        #
+        # when this function is reached, it is already guaranteed that self is fitted
+        #   this does not need to be checked separately
+        #
+        # parameters of components should follow the sklearn convention:
+        #   separate component name from parameter name by double-underscore
+        #   e.g., componentname__paramname
 
     # todo: return default parameters, so that a test instance can be created
     #   required for automated unit and integration testing of estimator

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -920,7 +920,8 @@ class BaseEstimator(BaseObject):
 
         Returns
         -------
-        fitted_params : dict
+        fitted_params : dict with str keys
+            fitted parameters, keyed by names of fitted parameter
         """
         # default retrieves all self attributes ending in "_"
         # and returns them with keys that have the "_" removed

--- a/sktime/classification/_delegate.py
+++ b/sktime/classification/_delegate.py
@@ -133,7 +133,8 @@ class _DelegatedClassifier(BaseClassifier):
 
         Returns
         -------
-        fitted_params : dict
+        fitted_params : dict with str keys
+            fitted parameters, keyed by names of fitted parameter
         """
         estimator = self._get_delegate()
         return estimator.get_fitted_params()

--- a/sktime/forecasting/base/_delegate.py
+++ b/sktime/forecasting/base/_delegate.py
@@ -296,7 +296,8 @@ class _DelegatedForecaster(BaseForecaster):
 
         Returns
         -------
-        fitted_params : dict
+        fitted_params : dict with str keys
+            fitted parameters, keyed by names of fitted parameter
         """
         estimator = self._get_delegate()
         return estimator.get_fitted_params()

--- a/sktime/regression/_delegate.py
+++ b/sktime/regression/_delegate.py
@@ -102,7 +102,8 @@ class _DelegatedRegressor(BaseRegressor):
 
         Returns
         -------
-        fitted_params : dict
+        fitted_params : dict with str keys
+            fitted parameters, keyed by names of fitted parameter
         """
         estimator = self._get_delegate()
         return estimator.get_fitted_params()

--- a/sktime/transformations/_delegate.py
+++ b/sktime/transformations/_delegate.py
@@ -177,7 +177,8 @@ class _DelegatedTransformer(BaseTransformer):
 
         Returns
         -------
-        fitted_params : dict
+        fitted_params : dict with str keys
+            fitted parameters, keyed by names of fitted parameter
         """
         estimator = self._get_delegate()
         return estimator.get_fitted_params()


### PR DESCRIPTION
This PR updates the extension templates to be in line with the extender contract for `get_fitted_params` introduced a while ago.

Users should implement `_get_fitted_params`, similar to the template pattern used in the extension contracts for `fit`, `predict`, etc.

Also updates the docstrings of present `_get_fitted_params` methods to be clearer about the return.