### PR TITLE
[ENH] `get_args` default handling for keys not present

### DIFF
--- a/sktime/utils/_testing/scenarios.py
+++ b/sktime/utils/_testing/scenarios.py
@@ -86,7 +86,7 @@ class TestScenario:
             names for keys need not equal names of methods these are used in
                 but scripted method will look at key with same name as default
         """
-        args = self.args[key]
+        args = self.args.get(key, {})
         if deepcopy_args:
             args = deepcopy(args)
         return args

--- a/sktime/utils/_testing/scenarios_classification.py
+++ b/sktime/utils/_testing/scenarios_classification.py
@@ -52,7 +52,7 @@ class ClassifierTestScenario(TestScenario, BaseObject):
         if key in ["predict_proba", "decision_function"]:
             key = "predict"
 
-        args = self.args[key]
+        args = self.args.get(key, {})
 
         if deepcopy_args:
             args = deepcopy(args)

--- a/sktime/utils/_testing/scenarios_classification.py
+++ b/sktime/utils/_testing/scenarios_classification.py
@@ -12,7 +12,6 @@ __all__ = [
     "scenarios_regression",
 ]
 
-from copy import deepcopy
 from inspect import isclass
 
 from sktime.base import BaseObject
@@ -52,12 +51,9 @@ class ClassifierTestScenario(TestScenario, BaseObject):
         if key in ["predict_proba", "decision_function"]:
             key = "predict"
 
-        args = self.args.get(key, {})
-
-        if deepcopy_args:
-            args = deepcopy(args)
-
-        return args
+        return super(ClassifierTestScenario, self).get_args(
+            key=key, obj=obj, deepcopy_args=deepcopy_args
+        )
 
     def is_applicable(self, obj):
         """Check whether scenario is applicable to obj.

--- a/sktime/utils/_testing/scenarios_clustering.py
+++ b/sktime/utils/_testing/scenarios_clustering.py
@@ -8,8 +8,6 @@ __author__ = ["fkiraly"]
 
 __all__ = ["scenarios_clustering"]
 
-from copy import deepcopy
-
 from sktime.base import BaseObject
 from sktime.utils._testing.panel import _make_panel_X, make_clustering_problem
 from sktime.utils._testing.scenarios import TestScenario
@@ -44,12 +42,9 @@ class ClustererTestScenario(TestScenario, BaseObject):
         if key in ["predict_proba"]:
             key = "predict"
 
-        args = self.args.get(key, {})
-
-        if deepcopy_args:
-            args = deepcopy(args)
-
-        return args
+        return super(ClustererTestScenario, self).get_args(
+            key=key, obj=obj, deepcopy_args=deepcopy_args
+        )
 
 
 class ClustererFitPredict(ClustererTestScenario):

--- a/sktime/utils/_testing/scenarios_clustering.py
+++ b/sktime/utils/_testing/scenarios_clustering.py
@@ -44,7 +44,7 @@ class ClustererTestScenario(TestScenario, BaseObject):
         if key in ["predict_proba"]:
             key = "predict"
 
-        args = self.args[key]
+        args = self.args.get(key, {})
 
         if deepcopy_args:
             args = deepcopy(args)

--- a/sktime/utils/_testing/scenarios_forecasting.py
+++ b/sktime/utils/_testing/scenarios_forecasting.py
@@ -13,7 +13,6 @@ __all__ = [
 ]
 
 
-from copy import deepcopy
 from inspect import isclass
 
 import pandas as pd
@@ -106,12 +105,9 @@ class ForecasterTestScenario(TestScenario, BaseObject):
         if key in PREDICT_LIKE_FUNCTIONS:
             key = "predict"
 
-        args = self.args.get(key, {})
-
-        if deepcopy_args:
-            args = deepcopy(args)
-
-        return args
+        return super(ForecasterTestScenario, self).get_args(
+            key=key, obj=obj, deepcopy_args=deepcopy_args
+        )
 
 
 class ForecasterFitPredictUnivariateNoX(ForecasterTestScenario):

--- a/sktime/utils/_testing/scenarios_forecasting.py
+++ b/sktime/utils/_testing/scenarios_forecasting.py
@@ -106,7 +106,7 @@ class ForecasterTestScenario(TestScenario, BaseObject):
         if key in PREDICT_LIKE_FUNCTIONS:
             key = "predict"
 
-        args = self.args[key]
+        args = self.args.get(key, {})
 
         if deepcopy_args:
             args = deepcopy(args)

--- a/sktime/utils/_testing/scenarios_transformers.py
+++ b/sktime/utils/_testing/scenarios_transformers.py
@@ -170,7 +170,7 @@ class TransformerTestScenario(TestScenario, BaseObject):
 
         else:
             # default behaviour, happens except when key = "inverse_transform"
-            args = self.args[key]
+            args = self.args.get(key, {})
 
         if deepcopy_args:
             args = deepcopy(args)


### PR DESCRIPTION
This PR handles the edge case of `get_args` in scenarios, where the requested key does not exist in the scenario.

In that case, `get_args` returns an empty parameter set.

Also resolves some copy-paste by `super` calls.