### PR TITLE
[BUG] fix `get_fitted_params` default for unfittable components

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -901,7 +901,7 @@ class BaseEstimator(BaseObject):
 
         for c in c_dict.keys():
             comp = c_dict[c]
-            if comp._is_fitted:
+            if isinstance(comp, BaseEstimator) and comp._is_fitted:
                 c_f_params = c_dict[c].get_fitted_params()
                 c_f_params = {f"{sh(c)}__{k}": c_f_params[k] for k in c_f_params.keys()}
                 fitted_params.update(c_f_params)


### PR DESCRIPTION
The default `get_fitted_params` would break if unfittable components were present, i.e., `BaseObject` children that were not `BaseEstimator` children due to a query to the `_is_fitted` attribute that only `BaseEstimator` children have.

This has been fixed.

Fixes various issues in https://github.com/sktime/sktime/pull/3590 which occur for calling `get_fitted_params` on composites with unfittable components.