### PR TITLE
[BUG] fix `get_fitted_params` for non-conformant estimators

### DIFF
--- a/sktime/classification/interval_based/_tsf.py
+++ b/sktime/classification/interval_based/_tsf.py
@@ -170,6 +170,11 @@ class TimeSeriesForestClassifier(
         )
         return output
 
+    def _get_fitted_params(self):
+        params = super(TimeSeriesForestClassifier, self)._get_fitted_params()
+        params.update({"n_classes": self.n_classes_, "fit_time": self.fit_time_,})
+        return params
+
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.

--- a/sktime/classification/interval_based/_tsf.py
+++ b/sktime/classification/interval_based/_tsf.py
@@ -172,7 +172,7 @@ class TimeSeriesForestClassifier(
 
     def _get_fitted_params(self):
         params = super(TimeSeriesForestClassifier, self)._get_fitted_params()
-        params.update({"n_classes": self.n_classes_, "fit_time": self.fit_time_,})
+        params.update({"n_classes": self.n_classes_, "fit_time": self.fit_time_})
         return params
 
     @classmethod

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -301,17 +301,16 @@ class _PmdArimaAdapter(BaseForecaster):
 
         return pred_int
 
-    def get_fitted_params(self):
+    def _get_fitted_params(self):
         """Get fitted parameters.
 
         Returns
         -------
         fitted_params : dict
         """
-        self.check_is_fitted()
         names = self._get_fitted_param_names()
-        params = self._get_fitted_params()
-        fitted_params = {name: param for name, param in zip(names, params)}
+        params = self._get_fitted_params_arima_res()
+        fitted_params = {str(name): param for name, param in zip(names, params)}
 
         if hasattr(self._forecaster, "model_"):  # AutoARIMA
             fitted_params["order"] = self._forecaster.model_.order
@@ -327,8 +326,8 @@ class _PmdArimaAdapter(BaseForecaster):
 
         return fitted_params
 
-    def _get_fitted_params(self):
-        # Return parameter values under `arima_res_`
+    def _get_fitted_params_arima_res(self):
+        """Return parameter values under `arima_res_`."""
         if hasattr(self._forecaster, "model_"):  # AutoARIMA
             return self._forecaster.model_.arima_res_._results.params
         elif hasattr(self._forecaster, "arima_res_"):  # ARIMA

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -102,7 +102,7 @@ class BaseGridSearch(_DelegatedForecaster):
             tagval = tagval + ["pd_multiindex_hier"]
         self.set_tags(**{tagname: tagval})
 
-    def get_fitted_params(self):
+    def _get_fitted_params(self):
         """Get fitted parameters.
 
         Returns
@@ -112,12 +112,6 @@ class BaseGridSearch(_DelegatedForecaster):
             the best estimator (if available), merged together with the former
             taking precedence.
         """
-        if not self.is_fitted:
-            raise NotFittedError
-
-        if self._is_vectorized:
-            return {"forecasters_": self.forecasters_}
-
         fitted_params = {}
         try:
             fitted_params = self.best_forecaster_.get_fitted_params()

--- a/sktime/series_as_features/base/estimators/_ensemble.py
+++ b/sktime/series_as_features/base/estimators/_ensemble.py
@@ -368,3 +368,10 @@ class BaseTimeSeriesForest(BaseForest):
             fis /= fis_count
 
         return fis
+
+    def _get_fitted_params(self):
+
+        return {
+            "classes": self.classes_,
+            "estimators": self.estimators_,
+        }

--- a/sktime/series_as_features/base/estimators/interval_based/_tsf.py
+++ b/sktime/series_as_features/base/estimators/interval_based/_tsf.py
@@ -161,4 +161,3 @@ def _fit_estimator(estimator, X, y, intervals):
     """Fit an estimator on input data (X, y)."""
     transformed_x = _transform(X, intervals)
     return estimator.fit(transformed_x, y)
-

--- a/sktime/series_as_features/base/estimators/interval_based/_tsf.py
+++ b/sktime/series_as_features/base/estimators/interval_based/_tsf.py
@@ -104,6 +104,14 @@ class BaseTimeSeriesForest:
         self._is_fitted = True
         return self
 
+    def _get_fitted_params(self):
+
+        return {
+            "classes": self.classes_,
+            "intervals": self.intervals_,
+            "estimators": self.estimators_,
+        }
+
 
 def _transform(X, intervals):
     """Transform X for given intervals.
@@ -153,3 +161,4 @@ def _fit_estimator(estimator, X, y, intervals):
     """Fit an estimator on input data (X, y)."""
     transformed_x = _transform(X, intervals)
     return estimator.fit(transformed_x, y)
+

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -799,7 +799,7 @@ class FitInTransform(BaseTransformer):
         -------
         fitted_params : dict
         """
-        return self.transformer_.get_fitted_params()
+        return {}
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -792,7 +792,7 @@ class FitInTransform(BaseTransformer):
         """
         return clone(self.transformer).fit(X=X, y=y).inverse_transform(X=X, y=y)
 
-    def get_fitted_params(self):
+    def _get_fitted_params(self):
         """Get fitted parameters.
 
         Returns

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -1287,6 +1287,20 @@ class Id(_DelegatedTransformer):
         """
         return X
 
+    def _get_fitted_params(self):
+        """Get fitted parameters.
+
+        private _get_fitted_params, called from get_fitted_params
+
+        State required:
+            Requires state to be "fitted".
+
+        Returns
+        -------
+        fitted_params : dict
+        """
+        return {}
+
 
 class OptionalPassthrough(_DelegatedTransformer):
     """Wrap an existing transformer to tune whether to include it in a pipeline.

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -1238,7 +1238,7 @@ class InvertTransform(_DelegatedTransformer):
         return [params1, params2]
 
 
-class Id(_DelegatedTransformer):
+class Id(BaseTransformer):
     """Identity transformer, returns data unchanged in transform/inverse_transform."""
 
     _tags = {


### PR DESCRIPTION
This fixes `get_fitted_params` for estimators that were non-conformant to the interface specification or where the standard call would break, highlighted by new tests in https://github.com/sktime/sktime/pull/3590

* `pmdarima` based estimators returned dict with non-str keys, this was fixed
* time series forests broke due to call to attribute in `sklearn` that was not used, this was fixed by overriding with a custom `_get_fitted_params`
* `Id` broke since it was accidentally inheriting from the delegator, not from the `BaseTransformer`
* `FitInTransform` did not raise `NotFittedError`, was broken in vectorization/broadcasting case
* grid searches did not raise exception with expected error message, was broken in vectorization/broadcasting case