### PR TITLE
[BUG] Numba/np.median interaction raises error for large data sets run with n_jobs>1 issue #3582

### DIFF
--- a/sktime/classification/sklearn/_continuous_interval_tree.py
+++ b/sktime/classification/sklearn/_continuous_interval_tree.py
@@ -18,7 +18,7 @@ from sklearn.base import BaseEstimator
 from sklearn.utils import check_random_state
 
 from sktime.exceptions import NotFittedError
-from sktime.utils.numba.stats import iqr, mean, median, numba_max, numba_min, slope, std
+from sktime.utils.numba.stats import iqr, mean, numba_max, numba_min, slope, std
 from sktime.utils.validation.panel import check_X
 
 
@@ -670,7 +670,7 @@ def _summary_stat(X, att):
     elif att == 24:
         function = slope
     elif att == 25:
-        function = median
+        function = np.median
     elif att == 26:
         function = iqr
     elif att == 27:

--- a/sktime/utils/numba/stats.py
+++ b/sktime/utils/numba/stats.py
@@ -11,30 +11,6 @@ def mean(X):
     return np.mean(X)
 
 
-def median(X):
-    """Numba median function for a single time series.
-
-    This function clones the data if the array passed is not writable before finding
-    the median. This is because of a known bug in the interaction between numba and
-    numpy np.median function that causes an error with threaded jobs with large
-    datasets. See
-    https://github.com/numba/numba/issues/3070
-    and
-    https://github.com/sktime/sktime/issues/3582
-    """
-    if X.flags.writeable:
-        return _median(X)
-    else:
-        X = X.copy()
-        X.setflags(write=True)
-        return _median(X)
-
-
-@njit(fastmath=True, cache=True)
-def _median(X):
-    return np.median(X)
-
-
 @njit(fastmath=True, cache=True)
 def std(X):
     """Numba standard deviation function for a single time series."""

--- a/sktime/utils/numba/stats.py
+++ b/sktime/utils/numba/stats.py
@@ -11,9 +11,18 @@ def mean(X):
     return np.mean(X)
 
 
-@njit(fastmath=True, cache=True)
 def median(X):
     """Numba median function for a single time series."""
+    if X.flags.writeable:
+        return _median(X)
+    else:
+        X = X.copy()
+        X.setflags(write=True)
+        return _median(X)
+
+
+@njit(fastmath=True, cache=True)
+def _median(X):
     return np.median(X)
 
 

--- a/sktime/utils/numba/stats.py
+++ b/sktime/utils/numba/stats.py
@@ -12,7 +12,15 @@ def mean(X):
 
 
 def median(X):
-    """Numba median function for a single time series."""
+    """Numba median function for a single time series.
+
+    This function clones the data if the array passed is not writable before finding
+    the median. This is because of a known bug in the interaction between numba and
+    numpy np.median function. See
+    https://github.com/numba/numba/issues/3070
+    and
+    https://github.com/sktime/sktime/issues/3582
+    """
     if X.flags.writeable:
         return _median(X)
     else:

--- a/sktime/utils/numba/stats.py
+++ b/sktime/utils/numba/stats.py
@@ -16,7 +16,8 @@ def median(X):
 
     This function clones the data if the array passed is not writable before finding
     the median. This is because of a known bug in the interaction between numba and
-    numpy np.median function. See
+    numpy np.median function that causes an error with threaded jobs with large
+    datasets. See
     https://github.com/numba/numba/issues/3070
     and
     https://github.com/sktime/sktime/issues/3582


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3582

#### What does this implement/fix? Explain your changes.

#3582 identified a bug that occurs with DrCIF classifier when n_jobs > 1 and the dataset is large. This originated in the numbaversion of the median function in utils/numba/stats.py. The problem is that when the data is beyond some size threshold, Parallel uses mmap to write the data to local storage to avoid unnecessary data cloning. When this happens, a bug occurs in the interaction between numba and np.median caused by write permissions. See 
https://github.com/numba/numba/issues/3070

The np.median implementation in Numba doesn't support read-only arrays, and once the mmap condition in Parallel is triggered, the cached arrays are all read-only (and need to be to avoid thread interference). This triggers the error seen in #3582. It was not detected in testing since it only happens with data beyond a certain size. 

This solution simply clones the array before calling median if it is not writable. Alternatives considered are described in #3582. Profiling shows that the cloning does not introduce much of an overhead, and we think this is the safest solution until numba/numpy problem is fixed. 

   
#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?


#### Any other comments?

Alternative solutions welcome. We could, for example, implement a local median function. However, this bug has been identified by two users, and even if temporary, this solution will move things forward.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added unit tests and made sure they pass locally.
- [x ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

<!--
Thanks for contributing!
-->
