### PR TITLE
fix typo that stops pytests running locally

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ multi_line_output = 3
 
 [tool:pytest]
 # ignore certain folders and pytest warnings
-addopts =
+adopts =
     --ignore build_tools
     --ignore examples
     --ignore docs


### PR DESCRIPTION
fixes a typo in setup.cfg that stops pytest running correctly locally

addopts -> adopts