### PR TITLE
[BUG] bug in the interaction between Numba and np.zeros identified in #2397

### DIFF
--- a/sktime/utils/estimators/tests/__init__.py
+++ b/sktime/utils/estimators/tests/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-"""Tests for Mock Estimnators."""
+"""Tests for Mock Estimators."""
 
 __author__ = ["ltsaprounis"]

--- a/sktime/utils/numba/general.py
+++ b/sktime/utils/numba/general.py
@@ -34,6 +34,5 @@ def z_normalise_series(X):
     if std > 0:
         X_n = (X - np.mean(X)) / std
     else:
-        X_n = np.zeros(len(X))
-
+        X_n = X - np.mean(X)
     return X_n

--- a/sktime/utils/numba/tests/__init__.py
+++ b/sktime/utils/numba/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+"""Tests for numba utils."""
+
+__author__ = ["TonyBagnall"]

--- a/sktime/utils/numba/tests/test_general.py
+++ b/sktime/utils/numba/tests/test_general.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""Tests for numba functiond."""
+
+__author__ = ["TonyBagnall"]
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+from utils.numba.general import z_normalise_series
+
+DATATYPES = ["int32", "int64", "float32", "float64"]
+
+
+@pytest.mark.parametrize("type", DATATYPES)
+def test_z_normalise_series(type):
+    """Test the function z_normalise_series."""
+    a = np.array([2, 2, 2], dtype=type)
+    a_expected = np.array([0, 0, 0], dtype=type)
+    a_result = z_normalise_series(a)
+    assert_array_equal(a_result, a_expected)

--- a/sktime/utils/numba/tests/test_general.py
+++ b/sktime/utils/numba/tests/test_general.py
@@ -6,7 +6,8 @@ __author__ = ["TonyBagnall"]
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
-from utils.numba.general import z_normalise_series
+
+from sktime.utils.numba.general import z_normalise_series
 
 DATATYPES = ["int32", "int64", "float32", "float64"]
 

--- a/sktime/utils/numba/tests/test_general.py
+++ b/sktime/utils/numba/tests/test_general.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Tests for numba functiond."""
+"""Tests for numba functions."""
 
 __author__ = ["TonyBagnall"]
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

 Fixes #2397 


#### What does this implement/fix? Explain your changes.

#2397 identified that STC could fail when passed float32 data instead of float64. On investigation, it turns out that the actual problem was with the call to np.zeros in the numba method z_normalise_series. Numba does some strange type checking, and it does not like the return signature of np.zeros when called with float32. We could fix this by setting the dtype for np.zeros, but this would not work with int32 or int64. 

So the simplest solution is to replace the function with this

```
@njit(fastmath=True, cache=True)
def z_normalise_series(X):
    """Numba z-normalisation function for a single time series."""
    std = np.std(X)
    if std > 0:
        X_n = (X - np.mean(X)) / std
    else:
        X_n = X - np.mean(X)
    return X_n
```

adapting the original code in #2397 

```
def debug_numba_stc_2397(type):
    """See https://github.com/sktime/sktime/issues/2397."""
    import warnings
    warnings.simplefilter("ignore", category=FutureWarning)
    from sklearn.model_selection import train_test_split
    from sktime.classification.shapelet_based import ShapeletTransformClassifier
    from sktime.classification.sklearn import RotationForest
    # make fake data
    if type == "int32" or type == "int64": # Ensure not all zeros
        data = pd.DataFrame(100 * np.random.random((500, 25))).astype(type)
    else:
        data = pd.DataFrame(np.random.random((500, 25))).astype(type)

    # reshape to input into Shapelet Classifier
    data4train = data.apply(
        lambda row: pd.Series({"time-series": pd.Series(row.values)}), axis=1
    )

    # make targets
    targets = pd.Series(250 * [1] + 250 * [0])

    # train test split
    X_train, X_test, y_train, y_test = train_test_split(
        data4train, targets, test_size=0.7, random_state=42
    )

    # train
    clf = ShapeletTransformClassifier(n_shapelet_samples=100)

    clf.fit(X_train, y_train)
```

this now works

```
    debug_numba_stc_2397("int32")
    debug_numba_stc_2397("float64")
    debug_numba_stc_2397("float32")
    debug_numba_stc_2397("int64")
```

I have added a unit test for this function. 

#### Does your contribution introduce a new dependency? If yes, which one?

no

#### What should a reviewer concentrate their feedback on?


#### Any other comments?

there is a wider issue as to whether the datatypes converter should automatically convert input data into a standard type (float32 probably), but that is beyond the scope of this tiny bug fix!

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ x] I've added unit tests and made sure they pass locally.
- [ x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

<!--
Thanks for contributing!
-->
