### PR TITLE
[MNT] temporarily remove stochastically failing tapnet from tests

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -29,6 +29,9 @@ EXCLUDE_ESTIMATORS = [
     "RandomIntervalClassifier",
     "MiniRocket",
     "MatrixProfileTransformer",
+    # tapnet based estimators fail stochastically for unknown reasons, see #3525
+    "TapNetRegressor",
+    "TapNetClassifier",
 ]
 
 


### PR DESCRIPTION
This PR emergency-removes tapnet based estimators from tests to avoid failures unrelated to PR from CI.
See https://github.com/sktime/sktime/issues/3525 for the bug.