### PR TITLE
[MNT] Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,40 +3,42 @@
 
 * @fkiraly @aiwalter
 
-sktime/classification/dummy/ @ZiyaoWei
+sktime/alignment/
+
+sktime/annotation/clasp.py @patrickzib @ermshaua
+sktime/annotation/igts.py @lmmentel
+sktime/annotation/ggs.py @lmmentel
+sktime/annotation/datagen.py @lmmentel
+
+sktime/benchmarking/
+
+sktime/classification/compose/_column_ensemble
+sktime/classification/compose/_ensemble
+sktime/classification/compose/_pipeline
+sktime/classification/deep_learning/cnn @TonyBagnall
+sktime/classification/deep_learning/fcn
+sktime/classification/deep_learning/mlp
+sktime/classification/deep_learning/tapnet
 sktime/classification/dictionary_based/ @patrickzib @MatthewMiddlehurst @TonyBagnall
 sktime/classification/distance_based/ @jasonlines @goaster @TonyBagnall
+sktime/classification/dummy/ @ZiyaoWei
 sktime/classification/early_classification/ @MatthewMiddlehurst @TonyBagnall
 sktime/classification/early_classification/_teaser.py @patrickzib @MatthewMiddlehurst @TonyBagnall
 sktime/classification/feature_based/ @MatthewMiddlehurst @TonyBagnall
-sktime/classification/feature_based/_signature_classifier.py @jambo6
+sktime/classification/feature_based/_signature_classifier.py @jambo6 @TonyBagnall
 sktime/classification/hybrid/ @MatthewMiddlehurst @TonyBagnall
 sktime/classification/interval_based/ @MatthewMiddlehurst @TonyBagnall
 sktime/classification/kernel_based/ @MatthewMiddlehurst @TonyBagnall
-sktime/classification/shapelet_based/ @jasonlines @ABostrom @TonyBagnall
-sktime/classification/shapelet_based/_stc.py @jasonlines @ABostrom @MatthewMiddlehurst @TonyBagnall
+sktime/classification/plotting/temporal_importance_diagram.py
+sktime/classification/shapelet_based/ @jasonlines @TonyBagnall
+sktime/classification/shapelet_based/_stc.py @jasonlines @MatthewMiddlehurst @TonyBagnall
+sktime/classification/sklearn @MatthewMiddlehurst @TonyBagnall
 
-sktime/transformations/panel/dictionary_based/ @patrickzib @MatthewMiddlehurst
-sktime/transformations/panel/catch22.py @MatthewMiddlehurst
-sktime/transformations/panel/shapelet_transform.py @MatthewMiddlehurst @TonyBagnall
-sktime/transformations/panel/shapelets.py @jasonlines @ABostrom @TonyBagnall
-sktime/transformations/panel/rocket/ @angus924
-sktime/transformations/panel/rocket/_multirocket.py @ChangWeiTan @fstinner @angus924
-sktime/transformations/panel/rocket/_multirocket_multivariate.py @ChangWeiTan @fstinner @angus924
-sktime/transformations/series/impute.py @aiwalter
-sktime/transformations/series/outlier_detection.py @aiwalter
-sktime/transformations/series/compose.py @aiwalter
-sktime/transformations/series/feature_selection.py @aiwalter
-sktime/transformations/panel/signature_based/ @jambo6
-sktime/transformations/series/theta.py @GuzalBulatova
-sktime/transformations/series/difference.py @rnkuhns
-sktime/transformations/series/exponent.py @rnkuhns
-sktime/transformations/series/scaledlogit.py @ltsaprounis
-sktime/transformations/series/kalman_filter.py @NoaBenAmi
-sktime/transformations/panel/augmenter.py @MrPr3ntice @iljamaurer
-sktime/transformations/multiplex.py @miraep8
-sktime/transformations/tests/test_multiplexer.py @miraep8
-sktime/transformations/panel/channel_selection.py @haskarb @a-pasos-ruiz @TonyBagnall
+sktime/clustering/ @chrisholder @TonyBagnall
+sktime/datasets/ @TonyBagnall
+sktime/datatypes/
+sktime/distances/ @chrisholder @TonyBagnall
+sktime/dists_kernels/
 
 sktime/forecasting/base/ @fkiraly @mloning @aiwalter
 sktime/forecasting/base/adapters/_statsforecast.py @FedericoGarza
@@ -57,14 +59,45 @@ sktime/forecasting/compose/_ensemble.py @aiwalter
 sktime/forecasting/online_learning/ @magittan
 sktime/forecasting/sarimax.py @TNTran92
 
+sktime/networks/
+
+sktime/param_est/
+
 sktime/performance_metrics/forecasting/_functions.py @aiwalter @rnkuhns
 sktime/performance_metrics/forecasting/_classes.py @rnkuhns
 sktime/performance_metrics/annotation @lmmentel
 
-sktime/annotation/clasp.py @patrickzib @ermshaua
-sktime/annotation/igts.py @lmmentel
-sktime/annotation/ggs.py @lmmentel
-sktime/annotation/datagen.py @lmmentel
+sktime/pipeline
+
+sktime/registry
+
+sktime/regression
+
+sktime/series_as_features
+
+sktime/tests
+
 sktime/transformations/series/clasp.py @patrickzib @ermshaua
+sktime/transformations/panel/dictionary_based/ @patrickzib @MatthewMiddlehurst
+sktime/transformations/panel/catch22.py @MatthewMiddlehurst
+sktime/transformations/panel/shapelet_transform.py @MatthewMiddlehurst @TonyBagnall
+sktime/transformations/panel/shapelets.py @jasonlines @TonyBagnall
+sktime/transformations/panel/rocket/ @angus924
+sktime/transformations/panel/rocket/_multirocket.py @ChangWeiTan @fstinner @angus924
+sktime/transformations/panel/rocket/_multirocket_multivariate.py @ChangWeiTan @fstinner @angus924
+sktime/transformations/series/impute.py @aiwalter
+sktime/transformations/series/outlier_detection.py @aiwalter
+sktime/transformations/series/compose.py @aiwalter
+sktime/transformations/series/feature_selection.py @aiwalter
+sktime/transformations/panel/signature_based/ @jambo6
+sktime/transformations/series/theta.py @GuzalBulatova
+sktime/transformations/series/difference.py @rnkuhns
+sktime/transformations/series/exponent.py @rnkuhns
+sktime/transformations/series/scaledlogit.py @ltsaprounis
+sktime/transformations/series/kalman_filter.py @NoaBenAmi
+sktime/transformations/panel/augmenter.py @MrPr3ntice @iljamaurer
+sktime/transformations/multiplex.py @miraep8
+sktime/transformations/tests/test_multiplexer.py @miraep8
+sktime/transformations/panel/channel_selection.py @haskarb @a-pasos-ruiz @TonyBagnall
 
 .github/workflows/* @lmmentel @freddyaboulton

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # The file lists sktime's algorithm maintainers as specified in GOVERNANCE.md.
 # Each line is a file pattern followed by one or more owners.
 
-* @fkiraly @aiwalter
+* @fkiraly @aiwalter @GuzalBulatova
 
 sktime/alignment/
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,7 +20,7 @@ sktime/classification/deep_learning/fcn
 sktime/classification/deep_learning/mlp
 sktime/classification/deep_learning/tapnet
 sktime/classification/dictionary_based/ @patrickzib @MatthewMiddlehurst @TonyBagnall
-sktime/classification/distance_based/ @jasonlines @goaster @TonyBagnall
+sktime/classification/distance_based/ @TonyBagnall
 sktime/classification/dummy/ @ZiyaoWei
 sktime/classification/early_classification/ @MatthewMiddlehurst @TonyBagnall
 sktime/classification/early_classification/_teaser.py @patrickzib @MatthewMiddlehurst @TonyBagnall
@@ -30,8 +30,8 @@ sktime/classification/hybrid/ @MatthewMiddlehurst @TonyBagnall
 sktime/classification/interval_based/ @MatthewMiddlehurst @TonyBagnall
 sktime/classification/kernel_based/ @MatthewMiddlehurst @TonyBagnall
 sktime/classification/plotting/temporal_importance_diagram.py
-sktime/classification/shapelet_based/ @jasonlines @TonyBagnall
-sktime/classification/shapelet_based/_stc.py @jasonlines @MatthewMiddlehurst @TonyBagnall
+sktime/classification/shapelet_based/ @MatthewMiddlehurst @TonyBagnall
+sktime/classification/shapelet_based/_stc.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/sklearn @MatthewMiddlehurst @TonyBagnall
 
 sktime/clustering/ @chrisholder @TonyBagnall
@@ -81,7 +81,6 @@ sktime/transformations/series/clasp.py @patrickzib @ermshaua
 sktime/transformations/panel/dictionary_based/ @patrickzib @MatthewMiddlehurst
 sktime/transformations/panel/catch22.py @MatthewMiddlehurst
 sktime/transformations/panel/shapelet_transform.py @MatthewMiddlehurst @TonyBagnall
-sktime/transformations/panel/shapelets.py @jasonlines @TonyBagnall
 sktime/transformations/panel/rocket/ @angus924
 sktime/transformations/panel/rocket/_multirocket.py @ChangWeiTan @fstinner @angus924
 sktime/transformations/panel/rocket/_multirocket_multivariate.py @ChangWeiTan @fstinner @angus924

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,24 +19,23 @@ sktime/classification/deep_learning/cnn @TonyBagnall
 sktime/classification/deep_learning/fcn
 sktime/classification/deep_learning/mlp
 sktime/classification/deep_learning/tapnet
-sktime/classification/dictionary_based/ @patrickzib @MatthewMiddlehurst @TonyBagnall
-sktime/classification/distance_based/ @TonyBagnall
+sktime/classification/dictionary_based/ @patrickzib @MatthewMiddlehurst
+sktime/classification/distance_based/
 sktime/classification/dummy/ @ZiyaoWei
-sktime/classification/early_classification/ @MatthewMiddlehurst @TonyBagnall
-sktime/classification/early_classification/_teaser.py @patrickzib @MatthewMiddlehurst @TonyBagnall
+sktime/classification/early_classification/ @MatthewMiddlehurst
+sktime/classification/early_classification/_teaser.py @patrickzib @MatthewMiddlehurst
 sktime/classification/feature_based/ @MatthewMiddlehurst @TonyBagnall
-sktime/classification/feature_based/_signature_classifier.py @jambo6 @TonyBagnall
+sktime/classification/feature_based/_signature_classifier.py @jambo6
 sktime/classification/hybrid/ @MatthewMiddlehurst @TonyBagnall
 sktime/classification/interval_based/ @MatthewMiddlehurst @TonyBagnall
 sktime/classification/kernel_based/ @MatthewMiddlehurst @TonyBagnall
 sktime/classification/plotting/temporal_importance_diagram.py
 sktime/classification/shapelet_based/ @MatthewMiddlehurst @TonyBagnall
-sktime/classification/shapelet_based/_stc.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/sklearn @MatthewMiddlehurst @TonyBagnall
 
 sktime/clustering/ @chrisholder @TonyBagnall
 
-sktime/datasets/ @TonyBagnall
+sktime/datasets/
 
 sktime/datatypes/
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,9 +35,13 @@ sktime/classification/shapelet_based/_stc.py @jasonlines @MatthewMiddlehurst @To
 sktime/classification/sklearn @MatthewMiddlehurst @TonyBagnall
 
 sktime/clustering/ @chrisholder @TonyBagnall
+
 sktime/datasets/ @TonyBagnall
+
 sktime/datatypes/
+
 sktime/distances/ @chrisholder @TonyBagnall
+
 sktime/dists_kernels/
 
 sktime/forecasting/base/ @fkiraly @mloning @aiwalter
@@ -69,13 +73,9 @@ sktime/performance_metrics/annotation @lmmentel
 
 sktime/pipeline
 
-sktime/registry
-
 sktime/regression
 
 sktime/series_as_features
-
-sktime/tests
 
 sktime/transformations/series/clasp.py @patrickzib @ermshaua
 sktime/transformations/panel/dictionary_based/ @patrickzib @MatthewMiddlehurst


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Initially my intention was to remove inactive core devs who no longer want to be listed as code owners. However, I notice that a lot of code does not have code owners listed. I have put place holders for these. I'm not sure if this wanted though. I am not aiming for any controversy, I simply think it a good idea to update this and have a complete list of packages. For example, I wasnt sure if anyone should "own" tests or datatypes. Anyone feel free to update this PR, remove/add owners remove/add packages not "owned".  

Is @GuzalBulatova meant to be listed at the top of this file?

* @fkiraly @aiwalter



