### PR TITLE
[MNT] replace author names by GitHub ID in author fields, linting

### DIFF
--- a/build_tools/make_release.py
+++ b/build_tools/make_release.py
@@ -13,7 +13,7 @@ The script is adapted from:
 /make_release.py
 """
 
-__author__ = ["mloning"]
+__author__ = ["Markus Löning"]
 
 import codecs
 import os

--- a/build_tools/make_release.py
+++ b/build_tools/make_release.py
@@ -13,7 +13,7 @@ The script is adapted from:
 /make_release.py
 """
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 
 import codecs
 import os

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Install script for sktime."""
 
-__author__ = ["Markus Löning", "lmmentel"]
+__author__ = ["mloning", "lmmentel"]
 
 import codecs
 

--- a/sktime/benchmarking/base.py
+++ b/sktime/benchmarking/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__author__ = ["Markus Löning", "Viktor Kazakov"]
+__author__ = ["mloning", "viktorkaz"]
 __all__ = ["BaseDataset", "HDDBaseDataset", "BaseResults", "HDDBaseResults"]
 
 import os

--- a/sktime/benchmarking/base.py
+++ b/sktime/benchmarking/base.py
@@ -1,51 +1,61 @@
 # -*- coding: utf-8 -*-
+"""Benchmarking base module."""
+
 __author__ = ["mloning", "viktorkaz"]
 __all__ = ["BaseDataset", "HDDBaseDataset", "BaseResults", "HDDBaseResults"]
 
 import os
-from abc import ABC
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from warnings import warn
 
 import numpy as np
-from joblib import dump
-from joblib import load
+from joblib import dump, load
 
 
 class BaseDataset:
+    """Base dataset class."""
+
     def __init__(self, name):
         self._name = name
 
     def __repr__(self):
+        """Repr dunder."""
         class_name = self.__class__.__name__
         return f"{class_name}(name={self.name})"
 
     def load(self):
+        """Load dataset."""
         raise NotImplementedError()
 
     @property
     def name(self):
+        """Name of dataset."""
         return self._name
 
 
 class HDDBaseDataset(BaseDataset):
+    """HDD dataset."""
+
     def __init__(self, path, name):
         self._path = path
         super(HDDBaseDataset, self).__init__(name=name)
 
     @property
     def path(self):
+        """Path to dataset."""
         return self._path
 
     @staticmethod
     def _validate_path(path):
-        """Helper function to validate paths"""
+        """Validate paths."""
         # check if path already exists
         if not os.path.exists(path):
             raise ValueError(f"No dataset found at path: {path}")
 
 
 class BaseResults:
+    """Base results class."""
+
     def __init__(self):
         # assigned during fitting of orchestration
         self.strategy_names = []
@@ -63,29 +73,31 @@ class BaseResults:
         cv_fold,
         train_or_test,
     ):
+        """Save predictions."""
         raise NotImplementedError()
 
     def load_predictions(self, cv_fold, train_or_test):
-        """Loads predictions for all datasets and strategies iteratively"""
+        """Load predictions for all datasets and strategies iteratively."""
         raise NotImplementedError()
 
     def check_predictions_exist(self, strategy, dataset_name, cv_fold, train_or_test):
+        """Check that predictions exist."""
         raise NotImplementedError()
 
     def save_fitted_strategy(self, strategy, dataset_name, cv_fold):
+        """Save fitted strategy."""
         raise NotImplementedError()
 
     def load_fitted_strategy(self, strategy_name, dataset_name, cv_fold):
-        """Load fitted strategies for all datasets and strategies
-        iteratively"""
+        """Load fitted strategies for all datasets and strategies iteratively."""
         raise NotImplementedError()
 
     def check_fitted_strategy_exists(self, strategy, dataset_name, cv_fold):
+        """Check that fitted strategy exists."""
         raise NotImplementedError()
 
     def _append_key(self, strategy_name, dataset_name):
-        """Append names of datasets and strategies to results objects during
-        orchestration"""
+        """Append names of datasets, strategies to results objects."""
         if strategy_name not in self.strategy_names:
             self.strategy_names.append(strategy_name)
 
@@ -96,6 +108,7 @@ class BaseResults:
         raise NotImplementedError()
 
     def __repr__(self):
+        """Representation dunder."""
         class_name = self.__class__.__name__
         return (
             f"{class_name}(strategies={self.strategy_names}, datasets="
@@ -104,17 +117,19 @@ class BaseResults:
         )
 
     def save(self):
-        """Save results object as master file"""
+        """Save results object as master file."""
         NotImplementedError()
 
     def _iter(self):
-        """Iterate over registry of results object"""
+        """Iterate over registry of results object."""
         for strategy_name in self.strategy_names:
             for dataset_name in self.dataset_names:
                 yield strategy_name, dataset_name
 
 
 class HDDBaseResults(BaseResults):
+    """HDD results."""
+
     def __init__(self, path):
         # validate paths
         self._validate_path(path)
@@ -126,10 +141,11 @@ class HDDBaseResults(BaseResults):
 
     @property
     def path(self):
+        """Path for results on HDD."""
         return self._path
 
     def save(self):
-        """Save results object as master file"""
+        """Save results object as master file."""
         file = os.path.join(self.path, "results.pickle")
 
         # if file does not exist already, create a new one
@@ -148,7 +164,7 @@ class HDDBaseResults(BaseResults):
 
     @staticmethod
     def _validate_path(path):
-        """Helper function to validate paths"""
+        """Validate paths."""
         # check if path already exists
         if os.path.exists(path):
             if not os.path.isdir(path):
@@ -167,8 +183,7 @@ class HDDBaseResults(BaseResults):
 
 
 class _PredictionsWrapper:
-    """Single result class to ensure consistency for return object when
-    loading results"""
+    """Single result class for consistency of return object when loading results."""
 
     def __init__(
         self,
@@ -214,4 +229,4 @@ class BaseMetric(ABC):
 
     @abstractmethod
     def compute(self, y_true, y_pred):
-        """Compute mean and standard error of metric"""
+        """Compute mean and standard error of metric."""

--- a/sktime/benchmarking/data.py
+++ b/sktime/benchmarking/data.py
@@ -2,7 +2,7 @@
 """Data storage for benchmarking."""
 
 __all__ = ["UEADataset", "RAMDataset", "make_datasets"]
-__author__ = ["Viktor Kazakov", "mloning"]
+__author__ = ["viktorkaz", "mloning"]
 
 import os
 

--- a/sktime/benchmarking/evaluation.py
+++ b/sktime/benchmarking/evaluation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Evaluator class for analyzing results of a machine learning experiment."""
-__author__ = ["Viktor Kazakov", "Markus Löning", "Aaron Bostrom"]
+__author__ = ["viktorkaz", "mloning", "Aaron Bostrom"]
 __all__ = ["Evaluator"]
 
 import itertools

--- a/sktime/benchmarking/metrics.py
+++ b/sktime/benchmarking/metrics.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Implements metrics for pairwise and aggregate comparison."""
 __all__ = ["PairwiseMetric", "AggregateMetric"]
-__author__ = ["Viktor Kazakov", "Markus Löning"]
+__author__ = ["viktorkaz", "mloning"]
 
 import numpy as np
 

--- a/sktime/benchmarking/results.py
+++ b/sktime/benchmarking/results.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+"""Benchmark results classes."""
+
 __all__ = ["HDDResults", "RAMResults"]
 __author__ = ["viktorkaz", "mloning"]
 
@@ -7,12 +9,13 @@ import os
 import numpy as np
 import pandas as pd
 from joblib import load
-from sktime.benchmarking.base import BaseResults
-from sktime.benchmarking.base import HDDBaseResults
-from sktime.benchmarking.base import _PredictionsWrapper
+
+from sktime.benchmarking.base import BaseResults, HDDBaseResults, _PredictionsWrapper
 
 
 class RAMResults(BaseResults):
+    """In-memory results."""
+
     def __init__(self):
         self.results = {}
         super(RAMResults, self).__init__()
@@ -32,8 +35,7 @@ class RAMResults(BaseResults):
         predict_estimator_start_time=None,
         predict_estimator_end_time=None,
     ):
-        """
-        Saves the predictions of trained estimators.
+        """Save the predictions of trained estimators.
 
         Parameters
         ----------
@@ -79,7 +81,7 @@ class RAMResults(BaseResults):
         self._append_key(strategy_name, dataset_name)
 
     def load_predictions(self, cv_fold, train_or_test):
-        """Loads predictions for all datasets and strategies iteratively"""
+        """Load predictions for all datasets and strategies iteratively."""
         for strategy_name, dataset_name in self._iter():
             key = self._generate_key(
                 strategy_name, dataset_name, cv_fold, train_or_test
@@ -87,30 +89,36 @@ class RAMResults(BaseResults):
             yield self.results[key]
 
     def check_predictions_exist(self, strategy, dataset_name, cv_fold, train_or_test):
+        """Check that predictions exist."""
         # for in-memory results, always false, results are always overwritten
         return False
 
     def save_fitted_strategy(self, strategy, dataset_name, cv_fold):
+        """Save fitted strategy."""
         raise NotImplementedError()
 
     def load_fitted_strategy(self, strategy_name, dataset_name, cv_fold):
+        """Load fitted strategy."""
         raise NotImplementedError()
 
     def check_fitted_strategy_exists(self, strategy, dataset_name, cv_fold):
+        """Check that fitted strategy exists."""
         # for in-memory results, always false, results are always overwritten
         return False
 
     def save(self):
+        """Save self. Method present for interface consistency."""
         # in-memory results are currently not persisted (i.e saved to the disk)
         pass
 
     def _generate_key(self, strategy_name, dataset_name, cv_fold, train_or_test):
-        """Function to get paths for files, this basically encapsulate the
-        storage logic of the class"""
+        """Get paths for files, encapsulates the storage logic of the class."""
         return f"{strategy_name}_{dataset_name}_{train_or_test}_{str(cv_fold)}"
 
 
 class HDDResults(HDDBaseResults):
+    """HDD results."""
+
     def save_predictions(
         self,
         strategy_name,
@@ -126,8 +134,7 @@ class HDDResults(HDDBaseResults):
         predict_estimator_start_time=None,
         predict_estimator_end_time=None,
     ):
-        """
-        Saves the predictions of trained estimators.
+        """Save the predictions of trained estimators.
 
         Parameters
         ----------
@@ -173,8 +180,7 @@ class HDDResults(HDDBaseResults):
         self._append_key(strategy_name, dataset_name)
 
     def load_predictions(self, cv_fold, train_or_test):
-        """Load saved predictions"""
-
+        """Load saved predictions."""
         for strategy_name, dataset_name in self._iter():
             key = (
                 self._generate_key(
@@ -205,7 +211,7 @@ class HDDResults(HDDBaseResults):
             )
 
     def save_fitted_strategy(self, strategy, dataset_name, cv_fold):
-        """Save fitted strategy"""
+        """Save fitted strategy."""
         path = (
             self._generate_key(
                 strategy.name, dataset_name, cv_fold, train_or_test="train"
@@ -216,7 +222,7 @@ class HDDResults(HDDBaseResults):
         self._append_key(strategy.name, dataset_name)
 
     def load_fitted_strategy(self, strategy_name, dataset_name, cv_fold):
-        """Load saved (fitted) strategy"""
+        """Load saved (fitted) strategy."""
         for strategy_name, dataset_name in self._iter():
             key = (
                 self._generate_key(
@@ -229,6 +235,7 @@ class HDDResults(HDDBaseResults):
             return load(key)
 
     def check_fitted_strategy_exists(self, strategy_name, dataset_name, cv_fold):
+        """Check that fitted strategy exists."""
         path = (
             self._generate_key(
                 strategy_name, dataset_name, cv_fold, train_or_test="train"
@@ -243,6 +250,7 @@ class HDDResults(HDDBaseResults):
     def check_predictions_exist(
         self, strategy_name, dataset_name, cv_fold, train_or_test
     ):
+        """Check that predictions exist."""
         path = (
             self._generate_key(strategy_name, dataset_name, cv_fold, train_or_test)
             + ".csv"
@@ -253,8 +261,7 @@ class HDDResults(HDDBaseResults):
             return False
 
     def _generate_key(self, strategy_name, dataset_name, cv_fold, train_or_test):
-        """Function to get paths for files, this basically encapsulate
-        the storage logic of the class"""
+        """Get paths for files, encapsulates the storage logic of the class."""
         filepath = os.path.join(self.path, strategy_name, dataset_name)
         if not os.path.exists(filepath):
             # recursively create directory including intermediate-level folders

--- a/sktime/benchmarking/results.py
+++ b/sktime/benchmarking/results.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 __all__ = ["HDDResults", "RAMResults"]
-__author__ = ["Viktor Kazakov", "Markus Löning"]
+__author__ = ["viktorkaz", "mloning"]
 
 import os
 

--- a/sktime/benchmarking/tests/test_orchestration.py
+++ b/sktime/benchmarking/tests/test_orchestration.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Test orchestration."""
-__author__ = ["Viktor Kazakov", "mloning"]
+__author__ = ["viktorkaz", "mloning"]
 
 import os
 

--- a/sktime/benchmarking/tests/test_tasks.py
+++ b/sktime/benchmarking/tests/test_tasks.py
@@ -1,4 +1,4 @@
-__author__ = "Markus Löning"
+__author__ = "mloning"
 
 import pytest
 from pytest import raises

--- a/sktime/benchmarking/tests/test_tasks.py
+++ b/sktime/benchmarking/tests/test_tasks.py
@@ -6,11 +6,9 @@ __author__ = "mloning"
 
 import pytest
 from pytest import raises
-from sktime.benchmarking.tasks import BaseTask
-from sktime.benchmarking.tasks import TSCTask
-from sktime.benchmarking.tasks import TSRTask
-from sktime.datasets import load_gunpoint
-from sktime.datasets import load_shampoo_sales
+
+from sktime.benchmarking.tasks import BaseTask, TSCTask, TSRTask
+from sktime.datasets import load_gunpoint, load_shampoo_sales
 
 TASKS = (TSCTask, TSRTask)
 

--- a/sktime/benchmarking/tests/test_tasks.py
+++ b/sktime/benchmarking/tests/test_tasks.py
@@ -1,3 +1,7 @@
+#! /usr/bin/env python
+"""Tests for benchmarking tasks."""
+# -*- coding: utf-8 -*-
+
 __author__ = "mloning"
 
 import pytest
@@ -19,7 +23,8 @@ BASE_READONLY_ATTRS = ("target", "features", "metadata")
 # Test read-only attributes of base task
 @pytest.mark.parametrize("attr", BASE_READONLY_ATTRS)
 def test_readonly_attributes(attr):
-    task = BaseTask(target='class_val', metadata=gunpoint)
+    """Test read-only attributes."""
+    task = BaseTask(target="class_val", metadata=gunpoint)
     with raises(AttributeError):
         task.__setattr__(attr, "val")
 
@@ -27,13 +32,15 @@ def test_readonly_attributes(attr):
 # Test data compatibility checks
 @pytest.mark.parametrize("task", TASKS)
 def test_check_data_compatibility(task):
-    task = task(target='target')
+    """Check data compatibility."""
+    task = task(target="target")
     with raises(ValueError):
         task.set_metadata(gunpoint)
 
 
 # Test setting of metadata
 def check_set_metadata(task, target, metadata):
+    """Check set_metadata."""
     task = task(target=target)
     assert task.metadata is None
 
@@ -47,4 +54,5 @@ def check_set_metadata(task, target, metadata):
 
 @pytest.mark.parametrize("task", [TSRTask, TSCTask])
 def test_set_metadata_supervised(task):
-    check_set_metadata(task, 'class_val', gunpoint)
+    """Test check_set_metadata."""
+    check_set_metadata(task, "class_val", gunpoint)

--- a/sktime/benchmarking/tests/test_tasks.py
+++ b/sktime/benchmarking/tests/test_tasks.py
@@ -1,6 +1,5 @@
-#! /usr/bin/env python
-"""Tests for benchmarking tasks."""
 # -*- coding: utf-8 -*-
+"""Tests for benchmarking tasks."""
 
 __author__ = "mloning"
 

--- a/sktime/datasets/setup.py
+++ b/sktime/datasets/setup.py
@@ -3,7 +3,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Set up the datasets included in sktime."""
 
-__author__ = "Markus Löning"
+__author__ = "mloning"
 
 # The file is adapted from:
 # https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/datasets/setup.py

--- a/sktime/exceptions.py
+++ b/sktime/exceptions.py
@@ -3,7 +3,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Custom exceptions and warnings."""
 
-__author__ = "Markus Löning"
+__author__ = "mloning"
 __all__ = ["NotEvaluatedError", "NotFittedError", "FitFailedWarning"]
 
 

--- a/sktime/forecasting/base/adapters/__init__.py
+++ b/sktime/forecasting/base/adapters/__init__.py
@@ -3,7 +3,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements base classes for adapting other forecasters to sktime framework."""
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = [
     "_ProphetAdapter",
     "_StatsModelsAdapter",

--- a/sktime/forecasting/base/adapters/__init__.py
+++ b/sktime/forecasting/base/adapters/__init__.py
@@ -1,17 +1,17 @@
-# -*- coding: utf-8 -*-
 # !/usr/bin/env python3 -u
+"""Base classes for adapting other forecasters to sktime framework."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Implements base classes for adapting other forecasters to sktime framework."""
 
-__author__ = ["mloning"]
 __all__ = [
     "_ProphetAdapter",
     "_StatsModelsAdapter",
     "_TbatsAdapter",
     "_PmdArimaAdapter",
+    "_StatsForecastAdapter",
 ]
 
 from sktime.forecasting.base.adapters._fbprophet import _ProphetAdapter
 from sktime.forecasting.base.adapters._statsmodels import _StatsModelsAdapter
 from sktime.forecasting.base.adapters._tbats import _TbatsAdapter
 from sktime.forecasting.base.adapters._pmdarima import _PmdArimaAdapter
+from sktime.forecasting.base.adapters._statsforecast import _StatsForecastAdapter

--- a/sktime/forecasting/base/adapters/__init__.py
+++ b/sktime/forecasting/base/adapters/__init__.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python3 -u
+# -*- coding: utf-8 -*-
 """Base classes for adapting other forecasters to sktime framework."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
@@ -11,7 +11,7 @@ __all__ = [
 ]
 
 from sktime.forecasting.base.adapters._fbprophet import _ProphetAdapter
-from sktime.forecasting.base.adapters._statsmodels import _StatsModelsAdapter
-from sktime.forecasting.base.adapters._tbats import _TbatsAdapter
 from sktime.forecasting.base.adapters._pmdarima import _PmdArimaAdapter
 from sktime.forecasting.base.adapters._statsforecast import _StatsForecastAdapter
+from sktime.forecasting.base.adapters._statsmodels import _StatsModelsAdapter
+from sktime.forecasting.base.adapters._tbats import _TbatsAdapter

--- a/sktime/forecasting/base/tests/__init__.py
+++ b/sktime/forecasting/base/tests/__init__.py
@@ -2,5 +2,5 @@
 # coding: utf-8
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = []

--- a/sktime/forecasting/base/tests/__init__.py
+++ b/sktime/forecasting/base/tests/__init__.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python3 -u
-# coding: utf-8
+# -*- coding: utf-8 -*-
+"""Tests for the forecaster base module."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 __author__ = ["mloning"]

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -4,7 +4,7 @@
 
 """Test reduce."""
 
-__author__ = ["Lovkush Agarwal", "Markus Löning", "Luis Zugasti", "AyushmaanSeth"]
+__author__ = ["Lovkush Agarwal", "mloning", "Luis Zugasti", "AyushmaanSeth"]
 
 import numpy as np
 import pandas as pd

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -14,10 +14,14 @@ __all__ = [
     "ForecastingRandomizedSearchCV",
 ]
 
-from sktime.forecasting.model_selection._split import ExpandingWindowSplitter
-from sktime.forecasting.model_selection._split import CutoffSplitter
-from sktime.forecasting.model_selection._split import SingleWindowSplitter
-from sktime.forecasting.model_selection._split import SlidingWindowSplitter
-from sktime.forecasting.model_selection._split import temporal_train_test_split
-from sktime.forecasting.model_selection._tune import ForecastingGridSearchCV
-from sktime.forecasting.model_selection._tune import ForecastingRandomizedSearchCV
+from sktime.forecasting.model_selection._split import (
+    CutoffSplitter,
+    ExpandingWindowSplitter,
+    SingleWindowSplitter,
+    SlidingWindowSplitter,
+    temporal_train_test_split,
+)
+from sktime.forecasting.model_selection._tune import (
+    ForecastingGridSearchCV,
+    ForecastingRandomizedSearchCV,
+)

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -3,7 +3,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements functionality for selecting forecasting models."""
 
-__author__ = ["Markus Löning", "Kutay Koralturk"]
+__author__ = ["mloning", "kkoralturk"]
 __all__ = [
     "CutoffSplitter",
     "SingleWindowSplitter",

--- a/sktime/forecasting/tests/_config.py
+++ b/sktime/forecasting/tests/_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = [
     "TEST_YS",
     "TEST_SPS",

--- a/sktime/forecasting/tests/test_exp_smoothing.py
+++ b/sktime/forecasting/tests/test_exp_smoothing.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+"""Test exponential smoothing forecasters."""
+
 __author__ = ["mloning", "@big-o"]
 __all__ = ["test_set_params"]
 
@@ -16,6 +18,7 @@ y_train, y_test = temporal_train_test_split(y, train_size=0.75)
 
 @pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_set_params():
+    """Test set_params."""
     params = {"trend": "additive"}
 
     f = ExponentialSmoothing(**params)

--- a/sktime/forecasting/tests/test_exp_smoothing.py
+++ b/sktime/forecasting/tests/test_exp_smoothing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__author__ = ["Markus Löning", "@big-o"]
+__author__ = ["mloning", "@big-o"]
 __all__ = ["test_set_params"]
 
 import pytest

--- a/sktime/forecasting/tests/test_trend.py
+++ b/sktime/forecasting/tests/test_trend.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
+"""Test trend forecasters."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 __author__ = ["mloning"]
@@ -14,8 +14,7 @@ from sktime.utils._testing.forecasting import make_forecasting_problem
 
 
 def get_expected_polynomial_coefs(y, degree, with_intercept=True):
-    """Helper function to compute expected coefficients from polynomial
-    regression"""
+    """Compute expected coefficients from polynomial regression."""
     poly_matrix = np.vander(np.arange(len(y)), degree + 1)
     if not with_intercept:
         poly_matrix = poly_matrix[:, :-1]
@@ -23,7 +22,7 @@ def get_expected_polynomial_coefs(y, degree, with_intercept=True):
 
 
 def _test_trend(degree, with_intercept):
-    """Helper function to check trend"""
+    """Check trend, helper function."""
     y = make_forecasting_problem()
     forecaster = PolynomialTrendForecaster(degree=degree, with_intercept=with_intercept)
     forecaster.fit(y)

--- a/sktime/forecasting/tests/test_trend.py
+++ b/sktime/forecasting/tests/test_trend.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = ["get_expected_polynomial_coefs"]
 
 import numpy as np

--- a/sktime/regression/all/__init__.py
+++ b/sktime/regression/all/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Import all time series regression functionality available in sktime."""
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = [
     "np",
     "pd",

--- a/sktime/regression/compose/_ensemble.py
+++ b/sktime/regression/compose/_ensemble.py
@@ -3,7 +3,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements a composite Time series Forest Regressor that accepts a pipeline."""
 
-__author__ = ["Markus Löning", "AyushmaanSeth"]
+__author__ = ["mloning", "AyushmaanSeth"]
 __all__ = ["ComposableTimeSeriesForestRegressor"]
 
 import numbers

--- a/sktime/regression/interval_based/__init__.py
+++ b/sktime/regression/interval_based/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Implement interval based time series regression estimators."""
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = ["TimeSeriesForestRegressor"]
 
 from sktime.regression.interval_based._tsf import TimeSeriesForestRegressor

--- a/sktime/regression/interval_based/_tsf.py
+++ b/sktime/regression/interval_based/_tsf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Time Series Forest Regressor (TSF)."""
 
-__author__ = ["Tony Bagnall", "kkoziara", "luiszugasti", "kanand77", "Markus Löning"]
+__author__ = ["Tony Bagnall", "kkoziara", "luiszugasti", "kanand77", "mloning"]
 __all__ = ["TimeSeriesForestRegressor"]
 
 import numpy as np

--- a/sktime/series_as_features/__init__.py
+++ b/sktime/series_as_features/__init__.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
+"""Series-as-features estimators."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 __author__ = ["mloning"]

--- a/sktime/series_as_features/__init__.py
+++ b/sktime/series_as_features/__init__.py
@@ -2,5 +2,5 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = []

--- a/sktime/series_as_features/base/estimators/interval_based/_tsf.py
+++ b/sktime/series_as_features/base/estimators/interval_based/_tsf.py
@@ -6,7 +6,7 @@ __author__ = [
     "kkoziara",
     "luiszugasti",
     "kanand77",
-    "Markus Löning",
+    "mloning",
     "Oleksii Kachaiev",
 ]
 __all__ = [

--- a/sktime/series_as_features/model_selection/__init__.py
+++ b/sktime/series_as_features/model_selection/__init__.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
+"""Model selection module."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 __author__ = ["mloning"]
@@ -8,5 +8,7 @@ __all__ = [
     "PresplitFilesCV",
 ]
 
-from sktime.series_as_features.model_selection._split import PresplitFilesCV
-from sktime.series_as_features.model_selection._split import SingleSplit
+from sktime.series_as_features.model_selection._split import (
+    PresplitFilesCV,
+    SingleSplit,
+)

--- a/sktime/series_as_features/model_selection/__init__.py
+++ b/sktime/series_as_features/model_selection/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = [
     "SingleSplit",
     "PresplitFilesCV",

--- a/sktime/transformations/panel/summarize/__init__.py
+++ b/sktime/transformations/panel/summarize/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = [
     "DerivativeSlopeTransformer",
     "PlateauFinder",

--- a/sktime/transformations/panel/summarize/__init__.py
+++ b/sktime/transformations/panel/summarize/__init__.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
+"""Module for summarization transformers."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 __author__ = ["mloning"]
@@ -10,7 +10,9 @@ __all__ = [
     "FittedParamExtractor",
 ]
 
-from ._extract import DerivativeSlopeTransformer
-from ._extract import FittedParamExtractor
-from ._extract import PlateauFinder
-from ._extract import RandomIntervalFeatureExtractor
+from ._extract import (
+    DerivativeSlopeTransformer,
+    FittedParamExtractor,
+    PlateauFinder,
+    RandomIntervalFeatureExtractor,
+)

--- a/sktime/transformations/panel/summarize/tests/test_FittedParamExtractor.py
+++ b/sktime/transformations/panel/summarize/tests/test_FittedParamExtractor.py
@@ -1,11 +1,12 @@
-#!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
+"""Tests for FittedParamExtractor."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 __author__ = ["mloning"]
 __all__ = []
 
 import pytest
+
 from sktime.datasets import load_gunpoint
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.transformations.panel.summarize import FittedParamExtractor

--- a/sktime/transformations/panel/summarize/tests/test_FittedParamExtractor.py
+++ b/sktime/transformations/panel/summarize/tests/test_FittedParamExtractor.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = []
 
 import pytest

--- a/sktime/transformations/panel/tsfresh.py
+++ b/sktime/transformations/panel/tsfresh.py
@@ -2,7 +2,7 @@
 """tsfresh interface class."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = ["AyushmaanSeth", "Markus Löning", "Alwin Wang"]
+__author__ = ["AyushmaanSeth", "mloning", "Alwin Wang"]
 __all__ = ["TSFreshFeatureExtractor", "TSFreshRelevantFeatureExtractor"]
 
 from warnings import warn

--- a/sktime/transformations/series/detrend/tests/__init__.py
+++ b/sktime/transformations/series/detrend/tests/__init__.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
+"""Tests for detrenders."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 __author__ = "mloning"

--- a/sktime/transformations/series/detrend/tests/__init__.py
+++ b/sktime/transformations/series/detrend/tests/__init__.py
@@ -2,4 +2,4 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = "Markus Löning"
+__author__ = "mloning"

--- a/sktime/transformations/series/detrend/tests/test_detrend.py
+++ b/sktime/transformations/series/detrend/tests/test_detrend.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
+"""Test detrenders."""
 
 __author__ = ["mloning"]
 __all__ = []

--- a/sktime/transformations/series/detrend/tests/test_detrend.py
+++ b/sktime/transformations/series/detrend/tests/test_detrend.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = []
 
 

--- a/sktime/transformations/series/tests/test_boxcox.py
+++ b/sktime/transformations/series/tests/test_boxcox.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = []
 
 import numpy as np

--- a/sktime/transformations/series/tests/test_boxcox.py
+++ b/sktime/transformations/series/tests/test_boxcox.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
+"""Tests for BoxCoxTransformer."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 __author__ = ["mloning"]
@@ -45,7 +45,8 @@ def test_lambda_bounds(bounds, method, sp):
     ],
 )
 def test_guerrero_against_r_implementation(bounds, r_lambda):
-    """
+    """Test BoxCoxTransformer against forecast guerrero method.
+
     Testing lambda values estimated by the R implementation of the Guerrero method
     https://github.com/robjhyndman/forecast/blob/master/R/guerrero.R
     against the guerrero method in BoxCoxTransformer.

--- a/sktime/transformations/series/tests/test_boxcox.py
+++ b/sktime/transformations/series/tests/test_boxcox.py
@@ -8,6 +8,7 @@ __all__ = []
 import numpy as np
 import pytest
 from scipy.stats import boxcox
+
 from sktime.datasets import load_airline
 from sktime.transformations.series.boxcox import BoxCoxTransformer
 

--- a/sktime/transformations/series/tests/test_sklearn_adaptor.py
+++ b/sktime/transformations/series/tests/test_sklearn_adaptor.py
@@ -7,6 +7,7 @@ __author__ = ["mloning"]
 import numpy as np
 from scipy.stats import boxcox
 from sklearn.preprocessing import PowerTransformer
+
 from sktime.datasets import load_airline
 from sktime.transformations.series.adapt import TabularToSeriesAdaptor
 

--- a/sktime/transformations/series/tests/test_sklearn_adaptor.py
+++ b/sktime/transformations/series/tests/test_sklearn_adaptor.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 
 import numpy as np
 from scipy.stats import boxcox

--- a/sktime/transformations/series/tests/test_sklearn_adaptor.py
+++ b/sktime/transformations/series/tests/test_sklearn_adaptor.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
+"""Tests for TabularToSeriesAdaptor."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 __author__ = ["mloning"]
@@ -13,6 +13,7 @@ from sktime.transformations.series.adapt import TabularToSeriesAdaptor
 
 
 def test_boxcox_transform():
+    """Test whether adaptor based transformer behaves like the raw wrapped method."""
     y = load_airline()
     t = TabularToSeriesAdaptor(PowerTransformer(method="box-cox", standardize=False))
     actual = t.fit_transform(y)

--- a/sktime/utils/_maint/_show_versions.py
+++ b/sktime/utils/_maint/_show_versions.py
@@ -84,10 +84,10 @@ def show_versions():
     sys_info = _get_sys_info()
     deps_info = _get_deps_info()
 
-    print("\nSystem:")  # noqa: T001
+    print("\nSystem:")  # noqa: T001, T201
     for k, stat in sys_info.items():
-        print("{k:>10}: {stat}".format(k=k, stat=stat))  # noqa: T001
+        print("{k:>10}: {stat}".format(k=k, stat=stat))  # noqa: T001, T201
 
-    print("\nPython dependencies:")  # noqa: T001
+    print("\nPython dependencies:")  # noqa: T001, T201
     for k, stat in deps_info.items():
-        print("{k:>13}: {stat}".format(k=k, stat=stat))  # noqa: T001
+        print("{k:>13}: {stat}".format(k=k, stat=stat))  # noqa: T001, T201

--- a/sktime/utils/_maint/_show_versions.py
+++ b/sktime/utils/_maint/_show_versions.py
@@ -7,7 +7,7 @@
 adapted from :func:`sklearn.show_versions`
 """
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = ["show_versions"]
 
 import importlib

--- a/sktime/utils/_testing/forecasting.py
+++ b/sktime/utils/_testing/forecasting.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = [
     "_get_expected_index_for_update_predict",
     "_generate_polynomial_series",

--- a/sktime/utils/_testing/series.py
+++ b/sktime/utils/_testing/series.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = []
 
 import numpy as np

--- a/sktime/utils/_testing/tests/__init__.py
+++ b/sktime/utils/_testing/tests/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = []

--- a/sktime/utils/_testing/tests/test_forecasting.py
+++ b/sktime/utils/_testing/tests/test_forecasting.py
@@ -4,8 +4,9 @@
 __author__ = ["mloning"]
 __all__ = []
 
-import pytest
 import pandas as pd
+import pytest
+
 from sktime.utils._testing.forecasting import make_forecasting_problem
 
 

--- a/sktime/utils/_testing/tests/test_forecasting.py
+++ b/sktime/utils/_testing/tests/test_forecasting.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 __all__ = []
 
 import pytest

--- a/sktime/utils/slope_and_trend.py
+++ b/sktime/utils/slope_and_trend.py
@@ -81,5 +81,5 @@ def _slope(y, axis=0):
 
     # Compute slope along given axis
     return (np.mean(y * x, axis=axis) - x_mean * np.mean(y, axis=axis)) / (
-        (x * x).mean() - x_mean ** 2
+        (x * x).mean() - x_mean**2
     )

--- a/sktime/utils/slope_and_trend.py
+++ b/sktime/utils/slope_and_trend.py
@@ -4,7 +4,7 @@ __all__ = [
     "_slope",
     "_fit_trend",
 ]
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 
 import numpy as np
 from sklearn.utils import check_array

--- a/sktime/utils/validation/__init__.py
+++ b/sktime/utils/validation/__init__.py
@@ -12,7 +12,7 @@ __all__ = [
     "check_n_jobs",
     "check_window_length",
 ]
-__author__ = ["Markus Löning", "Taiwo Owoseni", "khrapovs"]
+__author__ = ["mloning", "Taiwo Owoseni", "khrapovs"]
 
 import os
 from datetime import timedelta

--- a/sktime/utils/validation/series.py
+++ b/sktime/utils/validation/series.py
@@ -3,7 +3,7 @@
 
 """Functions for checking input data."""
 
-__author__ = ["Markus Löning", "Drishti Bhasin", "khrapovs"]
+__author__ = ["mloning", "Drishti Bhasin", "khrapovs"]
 __all__ = [
     "check_series",
     "check_time_index",


### PR DESCRIPTION
This PR replaces some author names by GitHub IDs in author fields.

This is the convention, and full names are still linked via the contributor register.

Also lints all the affected files - no content is changed.