### PR TITLE
[GOV] proposed lazy consensus policy

### DIFF
--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -387,10 +387,10 @@ core developers.
    Some changes also require a worked out :ref:`steps`. This depends on the type of change, see
    `decision making process <#Decision-making>`__ above.
 -  For a proposed change to be approved via lazy consensus, it needs to
-   approval by at least one core developer (lazy consensus) and no rejection by a core developer (veto right).
-   The approval required for this condition must be by a core developer different from a proposer.
+   approval by at least one core developer (lazy consensus), no rejection by a core developer (veto right),
+   or be authored by a core developer.
 -  For a proposed change to be rejected via lazy consensus, it needs to receive a
-   rejection by at least one core developer, and no acceptance by a core developer.
+   rejection by at least one core developer, and no acceptance or authorship by a core developer.
 -  Approvals must be in the form of a GitHub PR approval of the PR in question.
    Rejections can be expressed as -1 comments, or any written comments
    containing "I formally reject" in the PR, in reference to it.
@@ -400,9 +400,11 @@ core developers.
    Ten working days excluding week-ends constitute "reasonable time" in the above sense.
    The period resets at every new change made to the PR.
    It starts only when all GitHub checks pass.
--  During this period, the PR can be merged if it has an approval and no rejection, but should be
-   reverted if it receives a rejection in addition.
--  If the "reasonable time" period elapses and no approval or rejection has been expressed on a PR,
+-  During this period, the PR can be merged if it has an approval and no rejection after two working days excluding week-ends,
+   or if five working days excluding week-ends have passed (without any additional condition).
+   Such a merge should be reverted if the merged PR receives a rejection.
+-  If the "reasonable time" period elapses for a PR not authored by a core developer,
+   and no approval or rejection has been expressed on a PR,
    the PR is scheduled at the top of agenda for the next developer meetup.
    In that meeting, a core developer is assigned to review the PR and either approve or reject within five days of the meeting excluding weekends.
 


### PR DESCRIPTION
This document updates the lazy consensus policy to the de-facto rules.

How the de-facto rules came into being:

* with pydata conferences in Berlin and London approaching in Apr, a lot of PR were stalled due to lack of review
* CC then accepted a standing policy of letting PR by core devs to be merged after 5 WD without review, and 3 WD in the week before the conference was 
* this was enacted twice, since there were two conferences (Berlin, London)
* afterwards it was agreed to keep the 5 WD rule as a standing policy, to prevent PR stalling

in summary, we have been working like this since the lead-up to pydata Berlin.
@MatthewMiddlehurst therefore made the valid point that we need to adapt the governance document and perhaps have a discussion of what the rule should be.

This PR changes the rules to the current "status quo", i.e., moving the standing policy into the gov docs.