### PR TITLE
[BUG] Fix handling of `missing_values` in `Imputer`

### DIFF
--- a/sktime/transformations/series/tests/test_imputer.py
+++ b/sktime/transformations/series/tests/test_imputer.py
@@ -20,12 +20,23 @@ X.iloc[3, 1] = np.nan
 X.iloc[0, 1] = np.nan
 X.iloc[-1, 1] = np.nan
 
+X_inf = X.copy()
+X_inf.iloc[3, 0] = np.inf
+X_inf.iloc[0, 1] = np.inf
+
 y.iloc[3] = np.nan
 y.iloc[0] = np.nan
 y.iloc[-1] = np.nan
 
 
-@pytest.mark.parametrize("Z", [y, X])
+@pytest.mark.parametrize(
+    "X,missing_values",
+    [
+        (y, None),
+        (X, None),
+        (X_inf, [np.inf]),
+    ],
+)
 @pytest.mark.parametrize(
     "method",
     [
@@ -41,10 +52,12 @@ y.iloc[-1] = np.nan
         "forecaster",
     ],
 )
-def test_imputer(method, Z):
+def test_imputer(method, X, missing_values):
     """Test univariate and multivariate Imputer with all methods."""
     forecaster = ExponentialSmoothing() if method == "forecaster" else None
     value = 3 if method == "constant" else None
-    t = Imputer(method=method, forecaster=forecaster, value=value)
-    y_hat = t.fit_transform(Z)
+    t = Imputer(
+        method=method, forecaster=forecaster, value=value, missing_values=missing_values
+    )
+    y_hat = t.fit_transform(X)
     assert not y_hat.isnull().to_numpy().any()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #3655. This PR solves a bug in `sktime.transformations.series.impute.Imputer`. The problem is that abnormal values such as `np.inf` that are passed to the `Imputer` are not handled before calculating metrics such as `std` or fitting forecasters. This leads to an error.


#### What does this implement/fix? Explain your changes.

The values that are specified in `missing_values` are imputed with `np.nan` at three different locations for different reasons:
* `_fit` -> Prevent errors when calculating `mean` or `median` with `np.inf` as an input.
* `_get_random` -> Prevent errors when sampling from uniform distribution with `np.inf` as an input.
* `_impute_with_forecaster` -> Prevent errors when `np.inf` is passed to underlying forecasters.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
