### PR TITLE
[ENH] ExpandingWindowSplittter fix for initial_window=0 and depreciating "start_with_window" 

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1823,8 +1823,8 @@
     {
       "login": "chillerobscuro",
       "name": "Logan Duffy",
-      "avatar_url": "https://avatars.githubusercontent.com/u/16029092?v=4",
-      "profile": "https://github.com/arampuria19",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5232872?v=4",
+      "profile": "https://github.com/chillerobscuro",
       "contributions": [
         "code",
         "doc",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1819,6 +1819,19 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "chillerobscuro",
+      "name": "Logan Duffy",
+      "avatar_url": "https://avatars.githubusercontent.com/u/16029092?v=4",
+      "profile": "https://github.com/arampuria19",
+      "contributions": [
+        "code",
+        "doc",
+        "test",
+        "bug",
+        "ideas"
+      ]
     }
   ]
 }

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -13,6 +13,7 @@ __all__ = [
 __author__ = ["mloning", "kkoralturk", "khrapovs"]
 
 from typing import Iterator, Optional, Tuple, Union
+from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -986,7 +987,7 @@ class BaseWindowSplitter(BaseSplitter):
         # length.
         if hasattr(self, "start_with_window") and self.start_with_window:
 
-            if self._initial_window is not None:
+            if self._initial_window not in [None, 0]:
 
                 if is_timedelta_or_date_offset(x=self._initial_window):
                     start = y.get_loc(
@@ -1199,7 +1200,7 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
         fh: FORECASTING_HORIZON_TYPES = DEFAULT_FH,
         initial_window: ACCEPTED_WINDOW_LENGTH_TYPES = DEFAULT_WINDOW_LENGTH,
         step_length: NON_FLOAT_WINDOW_LENGTH_TYPES = DEFAULT_STEP_LENGTH,
-        start_with_window: bool = True,
+        start_with_window: bool = True,  # TODO: remove 0.15.0
     ) -> None:
         # Note that we pass the initial window as the window_length below. This
         # allows us to use the common logic from the parent class, while at the same
@@ -1209,8 +1210,14 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
             window_length=initial_window,
             initial_window=None,
             step_length=step_length,
-            start_with_window=start_with_window,
+            start_with_window=start_with_window,  # TODO: remove 0.15.0
         )
+
+        if not start_with_window:  # TODO: remove 0.15.0
+            warn(
+                '"start_with_window" will be depreciated in 0.15.0, '
+                "use initial_window=0 instead"
+            )
 
         # initial_window needs to be written to self for sklearn compatibility
         self.initial_window = initial_window
@@ -1345,7 +1352,7 @@ class SingleWindowSplitter(BaseSplitter):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        params = {"fh": 3}
+        params = {"fh": 3, "initial_window": 0}
         return params
 
 

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -10,7 +10,7 @@ __all__ = [
     "SingleWindowSplitter",
     "temporal_train_test_split",
 ]
-__author__ = ["mloning", "kkoralturk", "khrapovs"]
+__author__ = ["mloning", "kkoralturk", "khrapovs", "chillerobscuro"]
 
 from typing import Iterator, Optional, Tuple, Union
 from warnings import warn

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1352,7 +1352,7 @@ class SingleWindowSplitter(BaseSplitter):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        params = {"fh": 3, "initial_window": 0}
+        params = {"fh": 3}
         return params
 
 

--- a/sktime/forecasting/model_selection/tests/test_split.py
+++ b/sktime/forecasting/model_selection/tests/test_split.py
@@ -345,7 +345,9 @@ def test_expanding_window_splitter_start_with_initial_window_zero(y, fh, step_le
     else:
         match = "Unsupported combination of types"
         with pytest.raises(TypeError, match=match):
-            ExpandingWindowSplitter(fh=fh, initial_window=0, step_length=step_length)
+            ExpandingWindowSplitter(
+                fh=fh, initial_window=initial_window, step_length=step_length
+            )
 
 
 def test_sliding_window_splitter_initial_window_start_with_empty_window_raises_error():

--- a/sktime/forecasting/model_selection/tests/test_split.py
+++ b/sktime/forecasting/model_selection/tests/test_split.py
@@ -330,11 +330,12 @@ def test_sliding_window_splitter_start_with_empty_window(
 @pytest.mark.parametrize("step_length", TEST_STEP_LENGTHS)
 def test_expanding_window_splitter_start_with_initial_window_zero(y, fh, step_length):
     """Test ExpandingWindowSplitter."""
-    if _inputs_are_supported([fh, step_length, 0]):
+    initial_window = 0
+    if _inputs_are_supported([fh, step_length, initial_window]):
         cv = ExpandingWindowSplitter(
             fh=fh,
             step_length=step_length,
-            initial_window=0,
+            initial_window=initial_window,
         )
         train_windows, test_windows, _, n_splits = _check_cv(
             cv, y, allow_empty_window=True

--- a/sktime/forecasting/model_selection/tests/test_split.py
+++ b/sktime/forecasting/model_selection/tests/test_split.py
@@ -325,6 +325,28 @@ def test_sliding_window_splitter_start_with_empty_window(
             )
 
 
+@pytest.mark.parametrize("y", TEST_YS)
+@pytest.mark.parametrize("fh", [*TEST_FHS, *TEST_FHS_TIMEDELTA])
+@pytest.mark.parametrize("step_length", TEST_STEP_LENGTHS)
+def test_expanding_window_splitter_start_with_initial_window_zero(y, fh, step_length):
+    """Test ExpandingWindowSplitter."""
+    if _inputs_are_supported([fh, step_length, 0]):
+        cv = ExpandingWindowSplitter(
+            fh=fh,
+            step_length=step_length,
+            initial_window=0,
+        )
+        train_windows, test_windows, _, n_splits = _check_cv(
+            cv, y, allow_empty_window=True
+        )
+
+        assert np.vstack(test_windows).shape == (n_splits, len(check_fh(fh)))
+    else:
+        match = "Unsupported combination of types"
+        with pytest.raises(TypeError, match=match):
+            ExpandingWindowSplitter(fh=fh, initial_window=0, step_length=step_length)
+
+
 def test_sliding_window_splitter_initial_window_start_with_empty_window_raises_error():
     """Test SlidingWindowSplitter."""
     y = _make_series()

--- a/sktime/utils/validation/__init__.py
+++ b/sktime/utils/validation/__init__.py
@@ -178,7 +178,7 @@ def check_window_length(
     if window_length is None:
         return window_length
 
-    elif is_int(window_length) and window_length >= 1:
+    elif is_int(window_length) and window_length >= 0:
         return window_length
 
     elif is_float(window_length) and 0 < window_length < 1:
@@ -202,6 +202,6 @@ def check_window_length(
 
     else:
         raise ValueError(
-            f"`{name}` must be a positive integer >= 1, or"
+            f"`{name}` must be a positive integer >= 0, or "
             f"float in (0, 1) or None, but found: {window_length}."
         )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #2678 - second attempt after PR 3685 got messy.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
`ExpandingWindowSplitter` now has consistent behavior when `start_with_window=False` or `initial_window=0`. In the case of the former, a warning is raised that `start_with_window` will be depreciated in version 0.15.0.

Also includes a test case for when `initial_window=0` with `ExpandingWindowSplitter`. 

Unlike the last PR, the scope does not affect behavior of `SlidingWindowSplitter`. 

#### Does your contribution introduce a new dependency? If yes, which one?

I imported `warn` but no real deps.