### PR TITLE
[BUG] Small classification bugfixes

### DIFF
--- a/sktime/classification/interval_based/_drcif.py
+++ b/sktime/classification/interval_based/_drcif.py
@@ -515,7 +515,7 @@ class DrCIF(BaseClassifier):
         tree = _clone_estimator(self._base_estimator, random_state=rs)
         transformed_x = transformed_x.T
         transformed_x = transformed_x.round(8)
-        if self.base_estimator == "CIT":
+        if isinstance(self._base_estimator, ContinuousIntervalTree):
             transformed_x = np.nan_to_num(
                 transformed_x, False, posinf=np.nan, neginf=np.nan
             )

--- a/sktime/classification/sklearn/_continuous_interval_tree.py
+++ b/sktime/classification/sklearn/_continuous_interval_tree.py
@@ -19,7 +19,6 @@ from sklearn.utils import check_random_state
 
 from sktime.exceptions import NotFittedError
 from sktime.utils.numba.stats import iqr, mean, numba_max, numba_min, slope, std
-from sktime.utils.validation.panel import check_X
 
 
 class ContinuousIntervalTree(BaseEstimator):
@@ -117,7 +116,9 @@ class ContinuousIntervalTree(BaseEstimator):
                 "A valid sklearn input such as a 2d numpy array is required."
                 "Sparse input formats are currently not supported."
             )
-        X, y = self._validate_data(X=X, y=y, ensure_min_samples=2)
+        X, y = self._validate_data(
+            X=X, y=y, ensure_min_samples=2, force_all_finite="allow-nan"
+        )
 
         self.n_instances_, self.n_atts_ = X.shape
         self.classes_ = np.unique(y)
@@ -201,8 +202,7 @@ class ContinuousIntervalTree(BaseEstimator):
 
         # treat case of single class seen in fit
         if self.n_classes_ == 1:
-            n_instances = len(X)
-            return np.repeat([[1]], n_instances, axis=0)
+            return np.full(X.shape[0], self.classes_[0])
 
         if isinstance(X, np.ndarray) and len(X.shape) == 3 and X.shape[1] == 1:
             X = np.reshape(X, (X.shape[0], -1))
@@ -212,7 +212,7 @@ class ContinuousIntervalTree(BaseEstimator):
                 "A valid sklearn input such as a 2d numpy array is required."
                 "Sparse input formats are currently not supported."
             )
-        X = self._validate_data(X=X, reset=False)
+        X = self._validate_data(X=X, reset=False, force_all_finite="allow-nan")
 
         dists = np.zeros((X.shape[0], self.n_classes_))
         for i in range(X.shape[0]):
@@ -226,7 +226,6 @@ class ContinuousIntervalTree(BaseEstimator):
                 f"This instance of {self.__class__.__name__} has not "
                 f"been fitted yet; please call `fit` first."
             )
-        X = check_X(X, coerce_to_numpy=True)
         n_instances, n_dims, series_length = X.shape
 
         dists = np.zeros((n_instances, self.n_classes_))
@@ -250,7 +249,6 @@ class ContinuousIntervalTree(BaseEstimator):
                 f"This instance of {self.__class__.__name__} has not "
                 f"been fitted yet; please call `fit` first."
             )
-        X = check_X(X, coerce_to_numpy=True)
         n_instances, n_dims, series_length = X.shape
 
         dists = np.zeros((n_instances, self.n_classes_))

--- a/sktime/classification/sklearn/_continuous_interval_tree.py
+++ b/sktime/classification/sklearn/_continuous_interval_tree.py
@@ -202,7 +202,7 @@ class ContinuousIntervalTree(BaseEstimator):
 
         # treat case of single class seen in fit
         if self.n_classes_ == 1:
-            return np.full(X.shape[0], self.classes_[0])
+            return np.repeat([[1]], X.shape[0], axis=0)
 
         if isinstance(X, np.ndarray) and len(X.shape) == 3 and X.shape[1] == 1:
             X = np.reshape(X, (X.shape[0], -1))

--- a/sktime/classification/sklearn/_rotation_forest.py
+++ b/sktime/classification/sklearn/_rotation_forest.py
@@ -284,8 +284,7 @@ class RotationForest(BaseEstimator):
 
         # treat case of single class seen in fit
         if self.n_classes_ == 1:
-            n_instances = len(X)
-            return np.repeat([[1]], n_instances, axis=0)
+            return np.full(X.shape[0], self.classes_[0])
 
         if isinstance(X, np.ndarray) and len(X.shape) == 3 and X.shape[1] == 1:
             X = np.reshape(X, (X.shape[0], -1))
@@ -432,6 +431,7 @@ class RotationForest(BaseEstimator):
         X_t = np.concatenate(
             [pcas[i].transform(X[:, group]) for i, group in enumerate(groups)], axis=1
         )
+        X_t = np.nan_to_num(X_t, False, 0, 0, 0)
         tree = _clone_estimator(self._base_estimator, random_state=rs)
         tree.fit(X_t, y)
 
@@ -441,6 +441,7 @@ class RotationForest(BaseEstimator):
         X_t = np.concatenate(
             [pcas[i].transform(X[:, group]) for i, group in enumerate(groups)], axis=1
         )
+        X_t = np.nan_to_num(X_t, False, 0, 0, 0)
         probas = clf.predict_proba(X_t)
 
         if probas.shape[1] != self.n_classes_:

--- a/sktime/classification/sklearn/_rotation_forest.py
+++ b/sktime/classification/sklearn/_rotation_forest.py
@@ -284,7 +284,7 @@ class RotationForest(BaseEstimator):
 
         # treat case of single class seen in fit
         if self.n_classes_ == 1:
-            return np.full(X.shape[0], self.classes_[0])
+            return np.repeat([[1]], X.shape[0], axis=0)
 
         if isinstance(X, np.ndarray) and len(X.shape) == 3 and X.shape[1] == 1:
             X = np.reshape(X, (X.shape[0], -1))

--- a/sktime/classification/sklearn/tests/test_all_classifiers.py
+++ b/sktime/classification/sklearn/tests/test_all_classifiers.py
@@ -15,8 +15,7 @@ def test_sklearn_compatible_estimator(estimator, check):
         check(estimator)
     except AssertionError as error:
         # ContinuousIntervalTree can handle NaN values
-        if (
-            str(error)
-            != "Estimator ContinuousIntervalTree doesn't check for NaN and inf in fit."
-        ):
+        if not isinstance(
+            estimator, ContinuousIntervalTree
+        ) or "check for NaN and inf" not in str(error):
             raise error

--- a/sktime/classification/sklearn/tests/test_all_classifiers.py
+++ b/sktime/classification/sklearn/tests/test_all_classifiers.py
@@ -11,4 +11,12 @@ from sktime.classification.sklearn import ContinuousIntervalTree, RotationForest
 @parametrize_with_checks([RotationForest(n_estimators=3), ContinuousIntervalTree()])
 def test_sklearn_compatible_estimator(estimator, check):
     """Test that sklearn estimators adhere to sklearn conventions."""
-    check(estimator)
+    try:
+        check(estimator)
+    except AssertionError as error:
+        # ContinuousIntervalTree can handle NaN values
+        if (
+            str(error)
+            != "Estimator ContinuousIntervalTree doesn't check for NaN and inf in fit."
+        ):
+            raise error

--- a/sktime/classification/sklearn/tests/test_continuous_interval_tree.py
+++ b/sktime/classification/sklearn/tests/test_continuous_interval_tree.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""ContinuousIntervalTree test code."""
+import numpy as np
+import pytest
+
+from sktime.classification.sklearn import ContinuousIntervalTree
+
+
+def test_nan_values():
+    """Test that ContinuousIntervalTree can handle NaN values."""
+    rng = np.random.RandomState(0)
+    X = rng.uniform(size=(10, 3))
+    X[0:3, 0] = np.nan
+    y = np.zeros(10)
+    y[:5] = 1
+
+    clf = ContinuousIntervalTree()
+    clf.fit(X, y)
+    clf.predict(X)
+
+    # check inf values still raise an error
+    X[0:3, 0] = np.inf
+    with pytest.raises(ValueError):
+        clf.fit(X, y)

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -95,7 +95,7 @@ EXCLUDED_TESTS = {
     "SeriesToSeriesRowTransformer": ["test_methods_do_not_change_state"],
     # ColumnTransformer still needs to be refactored, see #2537
     "ColumnTransformer": ["test_methods_do_not_change_state"],
-    # Early classifiers intentionally retain information from pervious predict calls
+    # Early classifiers intentionally retain information from previous predict calls
     #   for #1.
     # #2 amd #3 are due to predict/predict_proba returning two items and that breaking
     #   assert_array_equal

--- a/sktime/transformations/panel/dictionary_based/_sfa_fast.py
+++ b/sktime/transformations/panel/dictionary_based/_sfa_fast.py
@@ -241,7 +241,7 @@ class SFAFast(BaseTransformer):
 
         if self.variance and self.anova:
             raise ValueError(
-                "Please set either variance or anova Fourier coefficient" " selection"
+                "Please set either variance or anova Fourier coefficient selection"
             )
 
         if self.binning_method not in binning_methods:

--- a/sktime/transformations/panel/rocket/tests/test_MiniRocket.py
+++ b/sktime/transformations/panel/rocket/tests/test_MiniRocket.py
@@ -16,7 +16,7 @@ def test_minirocket_on_gunpoint():
     X_training, Y_training = load_gunpoint(split="train", return_X_y=True)
 
     # 'fit' MINIROCKET -> infer data dimensions, generate random kernels
-    minirocket = MiniRocket()
+    minirocket = MiniRocket(random_state=0)
     minirocket.fit(X_training)
 
     # transform training data

--- a/sktime/transformations/panel/rocket/tests/test_MiniRocketMultivariate.py
+++ b/sktime/transformations/panel/rocket/tests/test_MiniRocketMultivariate.py
@@ -16,7 +16,7 @@ def test_minirocket_multivariate_on_basic_motions():
     X_training, Y_training = load_basic_motions(split="train", return_X_y=True)
 
     # 'fit' MINIROCKET -> infer data dimensions, generate random kernels
-    minirocket = MiniRocketMultivariate()
+    minirocket = MiniRocketMultivariate(random_state=0)
     minirocket.fit(X_training)
 
     # transform training data

--- a/sktime/transformations/panel/rocket/tests/test_MultiRocket.py
+++ b/sktime/transformations/panel/rocket/tests/test_MultiRocket.py
@@ -16,7 +16,7 @@ def test_multirocket_on_gunpoint():
     X_training, Y_training = load_gunpoint(split="train", return_X_y=True)
 
     # 'fit' MultiRocket -> infer data dimensions, generate random kernels
-    multirocket = MultiRocket()
+    multirocket = MultiRocket(random_state=0)
     multirocket.fit(X_training)
 
     # transform training data

--- a/sktime/transformations/panel/rocket/tests/test_MultiRocketMultivariate.py
+++ b/sktime/transformations/panel/rocket/tests/test_MultiRocketMultivariate.py
@@ -16,7 +16,7 @@ def test_multirocket_multivariate_on_basic_motions():
     X_training, Y_training = load_basic_motions(split="train", return_X_y=True)
 
     # 'fit' MultiRocket -> infer data dimensions, generate random kernels
-    multirocket = MultiRocketMultivariate()
+    multirocket = MultiRocketMultivariate(random_state=0)
     multirocket.fit(X_training)
 
     # transform training data

--- a/sktime/transformations/panel/rocket/tests/test_Rocket.py
+++ b/sktime/transformations/panel/rocket/tests/test_Rocket.py
@@ -16,7 +16,7 @@ def test_rocket_on_gunpoint():
     X_training, Y_training = load_gunpoint(split="train", return_X_y=True)
 
     # 'fit' ROCKET -> infer data dimensions, generate random kernels
-    ROCKET = Rocket(num_kernels=10_000)
+    ROCKET = Rocket(num_kernels=10_000, random_state=0)
     ROCKET.fit(X_training)
 
     # transform training data


### PR DESCRIPTION
Fixes some small classification bugs and typos.

- `TSFreshClassifier` returns the majority class if all attributes are removed in feature selection
- `ContinuousIntervalTree` allow NaNs in its input (includes test for NaN input)
- `RotationForest` replaces PCA NaNs with 0s
- Fixes #3694 by setting a random state for ROCKET tests