### PR TITLE
[ENH] default `get_params`/`set_params` for `_HeterogenousMetaEstimator` & [BUG] fix infinite loop in `get_params` for `FeatureUnion`, with hoesler

### DIFF
--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -11,7 +11,7 @@ from inspect import isclass
 from sktime.base import BaseEstimator
 
 
-class _HeterogenousMetaEstimator(BaseEstimator):
+class _HeterogenousMetaEstimator:
     """Handles parameter management for estimators composed of named estimators.
 
     Partly adapted from sklearn utils.metaestimator.py.

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -17,13 +17,41 @@ class _HeterogenousMetaEstimator(BaseEstimator):
     Partly adapted from sklearn utils.metaestimator.py.
     """
 
-    def get_params(self, deep=True):
-        """Return estimator parameters."""
-        raise NotImplementedError("abstract method")
+    # for default get_params/set_params
+    # _steps_attr points to the attribute of self
+    # which contains the heterogeneous set of estimators
+    # this must be an iterable of (name: str, estimator) pairs for the default
+    _steps_attr = "steps_"
 
-    def set_params(self, **params):
-        """Set estimator parameters."""
-        raise NotImplementedError("abstract method")
+    def get_params(self, deep=True):
+        """Get parameters of estimator in `_forecasters`.
+
+        Parameters
+        ----------
+        deep : boolean, optional
+            If True, will return the parameters for this estimator and
+            contained sub-objects that are estimators.
+
+        Returns
+        -------
+        params : mapping of string to any
+            Parameter names mapped to their values.
+        """
+        steps = getattr(self, self._steps_attr)
+        return self._get_params(steps, deep=deep)
+
+    def set_params(self, **kwargs):
+        """Set the parameters of estimator in `_forecasters`.
+
+        Valid parameter keys can be listed with ``get_params()``.
+
+        Returns
+        -------
+        self : returns an instance of self.
+        """
+        steps_attr = getattr(self, self._steps_attr)
+        self._set_params(steps_attr, **kwargs)
+        return self
 
     def is_composite(self):
         """Check if the object is composite.

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -17,11 +17,11 @@ class _HeterogenousMetaEstimator(BaseEstimator):
     Partly adapted from sklearn utils.metaestimator.py.
     """
 
-    # for default get_params/set_params
+    # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
     # this must be an iterable of (name: str, estimator) pairs for the default
-    _steps_attr = "steps_"
+    _steps_attr = "_steps"
 
     def get_params(self, deep=True):
         """Get parameters of estimator in `_forecasters`.

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -37,7 +37,7 @@ class _HeterogenousMetaEstimator:
         params : mapping of string to any
             Parameter names mapped to their values.
         """
-        steps = getattr(self, self._steps_attr)
+        steps = self._steps_attr
         return self._get_params(steps, deep=deep)
 
     def set_params(self, **kwargs):
@@ -49,7 +49,7 @@ class _HeterogenousMetaEstimator:
         -------
         self : returns an instance of self.
         """
-        steps_attr = getattr(self, self._steps_attr)
+        steps_attr = self._steps_attr
         self._set_params(steps_attr, **kwargs)
         return self
 

--- a/sktime/classification/_delegate.py
+++ b/sktime/classification/_delegate.py
@@ -30,6 +30,9 @@ class _DelegatedClassifier(BaseClassifier):
     Does NOT delegate or copy tags, this should be done in a child class if required.
     """
 
+    # attribute for _Delegatedclassifier, which then delegates
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
+    #     see further details in _DelegatedClassifier docstring
     _delegate_name = "estimator_"
 
     def _get_delegate(self):

--- a/sktime/classification/compose/_column_ensemble.py
+++ b/sktime/classification/compose/_column_ensemble.py
@@ -17,7 +17,7 @@ from sktime.base import _HeterogenousMetaEstimator
 from sktime.classification.base import BaseClassifier
 
 
-class BaseColumnEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
+class BaseColumnEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
     """Base Class for column ensemble."""
 
     _tags = {

--- a/sktime/classification/compose/_column_ensemble.py
+++ b/sktime/classification/compose/_column_ensemble.py
@@ -244,37 +244,15 @@ class ColumnEnsembleClassifier(BaseColumnEnsembleClassifier):
     >>> y_pred = col_ens.predict(X_test)
     """
 
+    # for default get_params/set_params from _HeterogenousMetaEstimator
+    # _steps_attr points to the attribute of self
+    # which contains the heterogeneous set of estimators
+    # this must be an iterable of (name: str, estimator) pairs for the default
+    _steps_attr = "_estimators"
+
     def __init__(self, estimators, remainder="drop", verbose=False):
         self.remainder = remainder
         super(ColumnEnsembleClassifier, self).__init__(estimators, verbose=verbose)
-
-    def get_params(self, deep=True):
-        """Get parameters for this estimator.
-
-        Parameters
-        ----------
-        deep : boolean, optional, default=True
-            If True, will return the parameters for this estimator and
-            contained subobjects that are estimators.
-
-        Returns
-        -------
-        params : mapping of string to any
-            Parameter names mapped to their values.
-        """
-        return self._get_params("_estimators", deep=deep)
-
-    def set_params(self, **kwargs):
-        """Set the parameters of this estimator.
-
-        Valid parameter keys can be listed with ``get_params()``.
-
-        Returns
-        -------
-        self
-        """
-        self._set_params("_estimators", **kwargs)
-        return self
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -646,6 +646,12 @@ class WeightedEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
         ],
     }
 
+    # for default get_params/set_params from _HeterogenousMetaEstimator
+    # _steps_attr points to the attribute of self
+    # which contains the heterogeneous set of estimators
+    # this must be an iterable of (name: str, estimator) pairs for the default
+    _steps_attr = "_classifiers"
+
     def __init__(
         self,
         classifiers,
@@ -701,34 +707,6 @@ class WeightedEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
     @_classifiers.setter
     def _classifiers(self, value):
         self.classifiers = value
-
-    def get_params(self, deep=True):
-        """Get parameters of estimator in `classifiers`.
-
-        Parameters
-        ----------
-        deep : boolean, optional, default=True
-            If True, will return the parameters for this estimator and
-            contained sub-objects that are estimators.
-
-        Returns
-        -------
-        params : mapping of string to any
-            Parameter names mapped to their values.
-        """
-        return self._get_params("_classifiers", deep=deep)
-
-    def set_params(self, **kwargs):
-        """Set the parameters of estimator in `classifiers`.
-
-        Valid parameter keys can be listed with ``get_params()``.
-
-        Returns
-        -------
-        self : returns an instance of self.
-        """
-        self._set_params("_classifiers", **kwargs)
-        return self
 
     def _fit(self, X, y):
         """Fit time series classifier to training data.

--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -561,7 +561,7 @@ class ComposableTimeSeriesForestClassifier(BaseTimeSeriesForest, BaseClassifier)
         return {"n_estimators": 2}
 
 
-class WeightedEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
+class WeightedEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
     """Weighted ensemble of classifiers with fittable ensemble weight.
 
     Produces a probabilistic prediction which is the weighted average of

--- a/sktime/classification/compose/_pipeline.py
+++ b/sktime/classification/compose/_pipeline.py
@@ -14,7 +14,7 @@ __author__ = ["fkiraly"]
 __all__ = ["ClassifierPipeline", "SklearnClassifierPipeline"]
 
 
-class ClassifierPipeline(BaseClassifier, _HeterogenousMetaEstimator):
+class ClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
     """Pipeline of transformers and a classifier.
 
     The `ClassifierPipeline` compositor chains transformers and a single classifier.

--- a/sktime/dists_kernels/algebra.py
+++ b/sktime/dists_kernels/algebra.py
@@ -11,7 +11,7 @@ from sktime.dists_kernels._base import BasePairwiseTransformerPanel
 SUPPORTED_MTYPES = ["pd-multiindex", "nested_univ", "df-list", "numpy3D"]
 
 
-class CombinedDistance(BasePairwiseTransformerPanel, _HeterogenousMetaEstimator):
+class CombinedDistance(_HeterogenousMetaEstimator, BasePairwiseTransformerPanel):
     """Distances combined via arithmetic operation, e.g., addition, multiplication.
 
     `CombinedDistance` creates a pairwise trafo from multiple other pairwise trafos,

--- a/sktime/dists_kernels/algebra.py
+++ b/sktime/dists_kernels/algebra.py
@@ -55,6 +55,12 @@ class CombinedDistance(BasePairwiseTransformerPanel, _HeterogenousMetaEstimator)
         "capability:unequal_length": True,  # can dist handle unequal length panels?
     }
 
+    # for default get_params/set_params from _HeterogenousMetaEstimator
+    # _steps_attr points to the attribute of self
+    # which contains the heterogeneous set of estimators
+    # this must be an iterable of (name: str, estimator) pairs for the default
+    _steps_attr = "_pw_trafos"
+
     def __init__(self, pw_trafos, operation=None):
 
         self.pw_trafos = pw_trafos
@@ -130,34 +136,6 @@ class CombinedDistance(BasePairwiseTransformerPanel, _HeterogenousMetaEstimator)
             distmat = distmat.squeeze(axis=0)
 
         return distmat
-
-    def get_params(self, deep=True):
-        """Get parameters of estimator in `steps`.
-
-        Parameters
-        ----------
-        deep : boolean, optional, default=True
-            If True, will return the parameters for this estimator and
-            contained sub-objects that are estimators.
-
-        Returns
-        -------
-        params : mapping of string to any
-            Parameter names mapped to their values.
-        """
-        return self._get_params("_pw_trafos", deep=deep)
-
-    def set_params(self, **kwargs):
-        """Set the parameters of estimator in `steps`.
-
-        Valid parameter keys can be listed with ``get_params()``.
-
-        Returns
-        -------
-        self : returns an instance of self.
-        """
-        self._set_params("_pw_trafos", **kwargs)
-        return self
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/dists_kernels/compose.py
+++ b/sktime/dists_kernels/compose.py
@@ -11,7 +11,7 @@ from sktime.transformations.compose import TransformerPipeline
 SUPPORTED_MTYPES = ["pd-multiindex", "nested_univ", "df-list", "numpy3D"]
 
 
-class PwTrafoPanelPipeline(BasePairwiseTransformerPanel, _HeterogenousMetaEstimator):
+class PwTrafoPanelPipeline(_HeterogenousMetaEstimator, BasePairwiseTransformerPanel):
     """Pipeline of transformers and a pairwise panel transformer.
 
     `PwTrafoPanelPipeline` chains transformers and a pairwise transformer at the end.

--- a/sktime/forecasting/base/_delegate.py
+++ b/sktime/forecasting/base/_delegate.py
@@ -31,6 +31,9 @@ class _DelegatedForecaster(BaseForecaster):
     Does NOT delegate or copy tags, this should be done in a child class if required.
     """
 
+    # attribute for _DelegatedForecaster, which then delegates
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
+    #     see further details in _DelegatedForecaster docstring
     _delegate_name = "estimator_"
 
     def _get_delegate(self):

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -13,7 +13,7 @@ from sktime.base import _HeterogenousMetaEstimator
 from sktime.forecasting.base._base import BaseForecaster
 
 
-class _HeterogenousEnsembleForecaster(BaseForecaster, _HeterogenousMetaEstimator):
+class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster):
     """Base class for heterogeneous ensemble forecasters."""
 
     # for default get_params/set_params from _HeterogenousMetaEstimator

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -16,6 +16,12 @@ from sktime.forecasting.base._base import BaseForecaster
 class _HeterogenousEnsembleForecaster(BaseForecaster, _HeterogenousMetaEstimator):
     """Base class for heterogeneous ensemble forecasters."""
 
+    # for default get_params/set_params from _HeterogenousMetaEstimator
+    # _steps_attr points to the attribute of self
+    # which contains the heterogeneous set of estimators
+    # this must be an iterable of (name: str, estimator) pairs for the default
+    _steps_attr = "forecasters"
+
     def __init__(self, forecasters, n_jobs=None):
         self.forecasters = forecasters
         self.forecasters_ = None
@@ -84,32 +90,4 @@ class _HeterogenousEnsembleForecaster(BaseForecaster, _HeterogenousMetaEstimator
         """
         for forecaster in self.forecasters_:
             forecaster.update(y, X, update_params=update_params)
-        return self
-
-    def get_params(self, deep=True):
-        """Get parameters for this estimator.
-
-        Parameters
-        ----------
-        deep : boolean, optional, default=True
-            If True, will return the parameters for this estimator and
-            contained sub-objects that are estimators.
-
-        Returns
-        -------
-        params : mapping of string to any
-            Parameter names mapped to their values.
-        """
-        return self._get_params("forecasters", deep=deep)
-
-    def set_params(self, **params):
-        """Set the parameters of this estimator.
-
-        Valid parameter keys can be listed with ``get_params()``.
-
-        Returns
-        -------
-        self
-        """
-        self._set_params("forecasters", **params)
         return self

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -85,6 +85,12 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
         "capability:pred_int": True,
     }
 
+    # for default get_params/set_params
+    # _steps_attr points to the attribute of self
+    # which contains the heterogeneous set of estimators
+    # this must be an iterable of (name: str, estimator) pairs for the default
+    _steps_attr = "_forecasters"
+
     def __init__(self, forecasters):
         self.forecasters = forecasters
         super(ColumnEnsembleForecaster, self).__init__(forecasters=forecasters)
@@ -375,34 +381,6 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
                     covariance between time index in row and col.
         """
         return self._by_column("predict_var", fh=fh, X=X, cov=cov, col_multiindex=True)
-
-    def get_params(self, deep=True):
-        """Get parameters of estimator in `_forecasters`.
-
-        Parameters
-        ----------
-        deep : boolean, optional
-            If True, will return the parameters for this estimator and
-            contained sub-objects that are estimators.
-
-        Returns
-        -------
-        params : mapping of string to any
-            Parameter names mapped to their values.
-        """
-        return self._get_params("_forecasters", deep=deep)
-
-    def set_params(self, **kwargs):
-        """Set the parameters of estimator in `_forecasters`.
-
-        Valid parameter keys can be listed with ``get_params()``.
-
-        Returns
-        -------
-        self : returns an instance of self.
-        """
-        self._set_params("_forecasters", **kwargs)
-        return self
 
     def _get_indices(self, y, idx):
         """Convert integer indices if necessary."""

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -63,7 +63,7 @@ class ForecastByLevel(_DelegatedForecaster):
     }
 
     # attribute for _DelegatedForecaster, which then delegates
-    #     all non-overridden methods to those of same name in self.forecaster_
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
     #     see further details in _DelegatedForecaster docstring
     _delegate_name = "forecaster_"
 

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -94,6 +94,12 @@ class MultiplexForecaster(_DelegatedForecaster, _HeterogenousMetaEstimator):
     #     see further details in _DelegatedForecaster docstring
     _delegate_name = "forecaster_"
 
+    # for default get_params/set_params from _HeterogenousMetaEstimator
+    # _steps_attr points to the attribute of self
+    # which contains the heterogeneous set of estimators
+    # this must be an iterable of (name: str, estimator) pairs for the default
+    _steps_attr = "_forecasters"
+
     def __init__(
         self,
         forecasters: list,
@@ -196,34 +202,6 @@ class MultiplexForecaster(_DelegatedForecaster, _HeterogenousMetaEstimator):
         else:
             # if None, simply clone the first forecaster to self.forecaster_
             self.forecaster_ = self._get_estimator_list(self.forecasters)[0].clone()
-
-    def get_params(self, deep=True):
-        """Get parameters for this estimator.
-
-        Parameters
-        ----------
-        deep : boolean, optional, default=True
-            If True, will return the parameters for this estimator and
-            contained subobjects that are estimators.
-
-        Returns
-        -------
-        params : mapping of string to any
-            Parameter names mapped to their values.
-        """
-        return self._get_params("_forecasters", deep=deep)
-
-    def set_params(self, **kwargs):
-        """Set the parameters of this estimator.
-
-        Valid parameter keys can be listed with ``get_params()``.
-
-        Returns
-        -------
-        self
-        """
-        self._set_params("_forecasters", **kwargs)
-        return self
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -12,7 +12,7 @@ __author__ = ["kkoralturk", "aiwalter", "fkiraly", "miraep8"]
 __all__ = ["MultiplexForecaster"]
 
 
-class MultiplexForecaster(_DelegatedForecaster, _HeterogenousMetaEstimator):
+class MultiplexForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     """MultiplexForecaster for selecting among different models.
 
     MultiplexForecaster facilitates a framework for performing

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -13,10 +13,7 @@ from sktime.registry import scitype
 from sktime.utils.validation.series import check_series
 
 
-class _Pipeline(
-    BaseForecaster,
-    _HeterogenousMetaEstimator,
-):
+class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
     """Abstract class for forecasting pipelines."""
 
     # for default get_params/set_params from _HeterogenousMetaEstimator

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -19,6 +19,12 @@ class _Pipeline(
 ):
     """Abstract class for forecasting pipelines."""
 
+    # for default get_params/set_params from _HeterogenousMetaEstimator
+    # _steps_attr points to the attribute of self
+    # which contains the heterogeneous set of estimators
+    # this must be an iterable of (name: str, estimator) pairs for the default
+    _steps_attr = "_steps"
+
     def _get_pipeline_scitypes(self, estimators):
         """Get list of scityes (str) from names/estimator list."""
         return [scitype(x[1]) for x in estimators]
@@ -161,34 +167,6 @@ class _Pipeline(
     @_steps.setter
     def _steps(self, value):
         self.steps = value
-
-    def get_params(self, deep=True):
-        """Get parameters for this estimator.
-
-        Parameters
-        ----------
-        deep : boolean, optional, default=True
-            If True, will return the parameters for this estimator and
-            contained subobjects that are estimators.
-
-        Returns
-        -------
-        params : mapping of string to any
-            Parameter names mapped to their values.
-        """
-        return self._get_params("_steps", deep=deep)
-
-    def set_params(self, **kwargs):
-        """Set the parameters of this estimator.
-
-        Valid parameter keys can be listed with ``get_params()``.
-
-        Returns
-        -------
-        self
-        """
-        self._set_params("_steps", **kwargs)
-        return self
 
     # both children use the same step params for testing, so putting it here
     @classmethod

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -74,6 +74,9 @@ class BaseGridSearch(_DelegatedForecaster):
         self._extend_to_all_scitypes("y_inner_mtype")
         self._extend_to_all_scitypes("X_inner_mtype")
 
+    # attribute for _DelegatedForecaster, which then delegates
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
+    #     see further details in _DelegatedForecaster docstring
     _delegate_name = "best_forecaster_"
 
     def _extend_to_all_scitypes(self, tagname):

--- a/sktime/forecasting/stream/_update.py
+++ b/sktime/forecasting/stream/_update.py
@@ -45,6 +45,9 @@ class UpdateRefitsEvery(_DelegatedForecaster):
         default = 0, i.e., refit window ends with and includes cutoff
     """
 
+    # attribute for _DelegatedForecaster, which then delegates
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
+    #     see further details in _DelegatedForecaster docstring
     _delegate_name = "forecaster_"
 
     _tags = {
@@ -227,6 +230,9 @@ class UpdateEvery(_DelegatedForecaster):
             if int, will be interpreted as number of time stamps seen since last update
     """
 
+    # attribute for _DelegatedForecaster, which then delegates
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
+    #     see further details in _DelegatedForecaster docstring
     _delegate_name = "forecaster_"
 
     _tags = {
@@ -389,6 +395,9 @@ class DontUpdate(_DelegatedForecaster):
         default = 0, i.e., refit window ends with and includes cutoff
     """
 
+    # attribute for _DelegatedForecaster, which then delegates
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
+    #     see further details in _DelegatedForecaster docstring
     _delegate_name = "forecaster_"
 
     _tags = {

--- a/sktime/param_est/compose.py
+++ b/sktime/param_est/compose.py
@@ -14,7 +14,7 @@ __all__ = ["ParamFitterPipeline"]
 SUPPORTED_MTYPES = ["pd.DataFrame", "pd.Series", "pd-multiindex", "pd_multiindex_hier"]
 
 
-class ParamFitterPipeline(BaseParamFitter, _HeterogenousMetaEstimator):
+class ParamFitterPipeline(_HeterogenousMetaEstimator, BaseParamFitter):
     """Pipeline of transformers and a parameter estimator.
 
     The `ParamFitterPipeline` compositor chains transformers and a single estimator.

--- a/sktime/regression/_delegate.py
+++ b/sktime/regression/_delegate.py
@@ -30,6 +30,9 @@ class _DelegatedRegressor(BaseRegressor):
     Does NOT delegate or copy tags, this should be done in a child class if required.
     """
 
+    # attribute for _DelegatedRegressor, which then delegates
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
+    #     see further details in _DelegatedRegressor docstring
     _delegate_name = "estimator_"
 
     def _get_delegate(self):

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -14,7 +14,7 @@ __author__ = ["fkiraly"]
 __all__ = ["RegressorPipeline", "SklearnRegressorPipeline"]
 
 
-class RegressorPipeline(BaseRegressor, _HeterogenousMetaEstimator):
+class RegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
     """Pipeline of transformers and a regressor.
 
     The `RegressorPipeline` compositor chains transformers and a single regressor.

--- a/sktime/transformations/_delegate.py
+++ b/sktime/transformations/_delegate.py
@@ -30,6 +30,9 @@ class _DelegatedTransformer(BaseTransformer):
     Does NOT delegate or copy tags, this should be done in a child class if required.
     """
 
+    # attribute for _DelegatedTransformer, which then delegates
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
+    #     see further details in _DelegatedTransformer docstring
     _delegate_name = "estimator_"
 
     def _get_delegate(self):

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -163,6 +163,12 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
 
     # no further default tag values - these are set dynamically below
 
+    # for default get_params/set_params from _HeterogenousMetaEstimator
+    # _steps_attr points to the attribute of self
+    # which contains the heterogeneous set of estimators
+    # this must be an iterable of (name: str, estimator) pairs for the default
+    _steps_attr = "_steps"
+
     def __init__(self, steps):
 
         self.steps = steps
@@ -385,34 +391,6 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
 
         return self
 
-    def get_params(self, deep=True):
-        """Get parameters of estimator in `steps`.
-
-        Parameters
-        ----------
-        deep : boolean, optional, default=True
-            If True, will return the parameters for this estimator and
-            contained sub-objects that are estimators.
-
-        Returns
-        -------
-        params : mapping of string to any
-            Parameter names mapped to their values.
-        """
-        return self._get_params("_steps", deep=deep)
-
-    def set_params(self, **kwargs):
-        """Set the parameters of estimator in `steps`.
-
-        Valid parameter keys can be listed with ``get_params()``.
-
-        Returns
-        -------
-        self : returns an instance of self.
-        """
-        self._set_params("_steps", **kwargs)
-        return self
-
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
@@ -498,6 +476,12 @@ class FeatureUnion(BaseTransformer, _HeterogenousMetaEstimator):
         # unclear what inverse transform should be, since multiple inverse_transform
         #   would have to inverse transform to one
     }
+
+    # for default get_params/set_params from _HeterogenousMetaEstimator
+    # _steps_attr points to the attribute of self
+    # which contains the heterogeneous set of estimators
+    # this must be an iterable of (name: str, estimator) pairs for the default
+    _steps_attr = "transformer_list"
 
     def __init__(
         self,
@@ -651,34 +635,6 @@ class FeatureUnion(BaseTransformer, _HeterogenousMetaEstimator):
             Xt.columns = flatten_multiindex(Xt.columns)
 
         return Xt
-
-    def get_params(self, deep=True):
-        """Get parameters of estimator in `_forecasters`.
-
-        Parameters
-        ----------
-        deep : boolean, optional, default=True
-            If True, will return the parameters for this estimator and
-            contained sub-objects that are estimators.
-
-        Returns
-        -------
-        params : mapping of string to any
-            Parameter names mapped to their values.
-        """
-        return self._get_params("transformer_list", deep=deep)
-
-    def set_params(self, **kwargs):
-        """Set the parameters of estimator in `_forecasters`.
-
-        Valid parameter keys can be listed with ``get_params()``.
-
-        Returns
-        -------
-        self : returns an instance of self.
-        """
-        self._set_params("transformer_list", **kwargs)
-        return self
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -915,7 +871,16 @@ class MultiplexTransformer(_DelegatedTransformer, _HeterogenousMetaEstimator):
         "X_inner_mtype": ALL_TIME_SERIES_MTYPES,
     }
 
+    # attribute for _DelegatedTransformer, which then delegates
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
+    #     see further details in _DelegatedTransformer docstring
     _delegate_name = "transformer_"
+
+    # for default get_params/set_params from _HeterogenousMetaEstimator
+    # _steps_attr points to the attribute of self
+    # which contains the heterogeneous set of estimators
+    # this must be an iterable of (name: str, estimator) pairs for the default
+    _steps_attr = "_transformers"
 
     def __init__(
         self,
@@ -969,34 +934,6 @@ class MultiplexTransformer(_DelegatedTransformer, _HeterogenousMetaEstimator):
         else:
             # if None, simply clone the first transformer to self.transformer_
             self.transformer_ = self._get_estimator_list(self.transformers)[0].clone()
-
-    def get_params(self, deep=True):
-        """Get parameters for this estimator.
-
-        Parameters
-        ----------
-        deep : boolean, optional
-            If True, will return the parameters for this estimator and
-            contained subobjects that are estimators.
-
-        Returns
-        -------
-        params : mapping of string to any
-            Parameter names mapped to their values.
-        """
-        return self._get_params("_transformers", deep=deep)
-
-    def set_params(self, **kwargs):
-        """Set the parameters of this estimator.
-
-        Valid parameter keys can be listed with ``get_params()``.
-
-        Returns
-        -------
-        self
-        """
-        self._set_params("_transformers", **kwargs)
-        return self
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -1163,6 +1100,9 @@ class InvertTransform(_DelegatedTransformer):
                 " this transformer will likely crash on input."
             )
 
+    # attribute for _DelegatedTransformer, which then delegates
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
+    #     see further details in _DelegatedTransformer docstring
     _delegate_name = "transformer_"
 
     def _transform(self, X, y=None):
@@ -1405,6 +1345,9 @@ class OptionalPassthrough(_DelegatedTransformer):
         else:
             self.transformer_ = transformer.clone()
 
+    # attribute for _DelegatedTransformer, which then delegates
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
+    #     see further details in _DelegatedTransformer docstring
     _delegate_name = "transformer_"
 
     @classmethod

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -481,7 +481,7 @@ class FeatureUnion(_HeterogenousMetaEstimator, BaseTransformer):
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
     # this must be an iterable of (name: str, estimator) pairs for the default
-    _steps_attr = "transformer_list"
+    _steps_attr = "_transformer_list"
 
     def __init__(
         self,

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -59,7 +59,7 @@ def _coerce_to_sktime(other):
     return other
 
 
-class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
+class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
     """Pipeline of transformers compositor.
 
     The `TransformerPipeline` compositor allows to chain transformers.
@@ -428,7 +428,7 @@ class TransformerPipeline(BaseTransformer, _HeterogenousMetaEstimator):
         return [params1, params2, params3]
 
 
-class FeatureUnion(BaseTransformer, _HeterogenousMetaEstimator):
+class FeatureUnion(_HeterogenousMetaEstimator, BaseTransformer):
     """Concatenates results of multiple transformer objects.
 
     This estimator applies a list of transformer objects in parallel to the
@@ -785,7 +785,7 @@ class FitInTransform(BaseTransformer):
         return params
 
 
-class MultiplexTransformer(_DelegatedTransformer, _HeterogenousMetaEstimator):
+class MultiplexTransformer(_HeterogenousMetaEstimator, _DelegatedTransformer):
     """Facilitate an AutoML based selection of the best transformer.
 
     When used in combination with either TransformedTargetForecaster or


### PR DESCRIPTION
This PR adds a default `get_params`/`set_params` for the `_HeterogenousMetaEstimator` with varying part based on a private attribute, which can replace many of the copy/pasted `get_params`/`set_params` for concrete heterogeneous estimators.

This replaces abstract methods of the same name that raise an error if called.

For this to work as a replacement of copy-pasted methods in descendants, two changes are made:

* `_HeterogenousMetaEstimator` no longer inherits from `BaseEstimator`, so is turned back into a mixin from a base class
* descendants now must inherit from `_HeterogenousMetaEstimator` *before* a base class

A full refactor is carried out to replace duplicated `get_params`/`set_params` with the default from `_HeterogenousMetaEstimator`.

No deprecation is necessary since the class is private, and the public interfaces do not change.

Testing is via the main test suite's existing tests for the params interface points.

Also includes a bugfix to #3789, as pointed out by @hoesler, with the attribute accessed in `FeatureUnion` changed from `transformer_list` to `_transformer_list`.

The bugfix is certified by the test in https://github.com/sktime/sktime/pull/3792.