### PR TITLE
Revert "[GOV] Lazy consensus on GOV PRs"

### DIFF
--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -466,7 +466,7 @@ corresponding decision making process is described in more detail below.
    * - Changes to the API design, hard dependencies, or supported versions
      - Lazy consensus, requires a :ref:`steps`
    * - Changes to sktime's governance (this document and the CoC)
-     - No lazy consensus, requires at least two approvals by core-developers
+     - Lazy consensus, requires a :ref:`steps`
    * - Appointment
      - Directly starts with voting (stage 2)
 


### PR DESCRIPTION
Reverts sktime/sktime#3684

Sorry, did not see this - it was merged within a very short time of the PR being opened.

I disagree with the change.

I agree that governance documents need to be approved, so I agree with removing the lazy consensus condition.

However, I do not agree removing the requirement for a STEP, which means the change must be made public.

Here's the change I would want:
* there must be at least one presentation of proposed GOV changes in teh CC meeting before they can be merged
* it requires approval by at least one CC member (if gov doc) or CoC committee member (if CoC doc)