### PR TITLE
[MNT] addressing failed v0.14.0 pypi upload

### DIFF
--- a/docs/source/developer_guide/release.rst
+++ b/docs/source/developer_guide/release.rst
@@ -88,7 +88,7 @@ The release process is as follows, on high-level:
      guidelines related to maintaining conda feedstcok packages see `conda-forge package<https://conda-forge.org/docs/maintainer/updating_pkgs.html>`_.
 
      After forking and cloning the repo, edit the ``meta.yml`` file and
-     
+
      - increment the version in the line that contains ``{% set version = "0.X.Y" %}``
      - paste the sha256 sum of the source archive from github in the ``source/sha256`` section
      - submit PR and ask for review

--- a/docs/source/developer_guide/release.rst
+++ b/docs/source/developer_guide/release.rst
@@ -74,6 +74,8 @@ The release process is as follows, on high-level:
   If the install does not succeed or wheels have not been uploaded, urgent action to diagnose and remedy must be taken.
   All core developers should be urgently informed of such a situation through mail-all in the core developer channel on slack.
   In the most common case, the install instructions need to be updated.
+  If wheel upload has failed, the tag in 5. needs to be deleted and recreated.
+  The tag can be deleted using the ``git`` command ``git push --delete origin tagname`` from a local repo.
 
 ``conda`` release and release validation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,13 @@ name = "sktime"
 version = "0.14.0"
 description = "A unified framework for machine learning with time series"
 authors = [
-    {name = "Franz Király", email = "f.kiraly@ucl.ac.uk"},
-    {name = "Tony Bagnall", email = "ajb@uea.ac.uk"},
+    {name = "Franz Király"},
+    {name = "Tony Bagnall"},
     {name = "Markus Löning"},
     {name = "Martin Walter"},
 ]
 maintainers = [
-    {name = "Franz Király", email = "f.kiraly@ucl.ac.uk"},
+    {name = "Franz Király"},
     {name = "Guzal Bulatova"},
     {name = "Martin Walter"},
 ]

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def setup_package():
     """Set up package."""
     projectname = pyproject["project"]["name"]
     setup(
-        author_email="info@sktime.com",
+        author_email="info@sktime.org",
         author=f"{projectname} developers",
         classifiers=pyproject["project"]["classifiers"],
         description=pyproject["project"]["description"],
@@ -40,7 +40,7 @@ def setup_package():
         keywords=pyproject["project"]["keywords"],
         license=pyproject["project"]["license"],
         long_description=long_description(),
-        maintainer_email="info@sktime.com",
+        maintainer_email="info@sktime.org",
         maintainer=f"{projectname} developers",
         name=projectname,
         package_data={

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,10 @@ pyproject = toml.load("pyproject.toml")
 
 def setup_package():
     """Set up package."""
+    projectname = pyproject["project"]["name"]
     setup(
-        author_email=pyproject["project"]["authors"][0]["email"],
-        author=pyproject["project"]["authors"][0]["name"],
+        author_email="info@sktime.com",
+        author=f"{projectname} developers",
         classifiers=pyproject["project"]["classifiers"],
         description=pyproject["project"]["description"],
         download_url=pyproject["project"]["urls"]["download"],
@@ -39,9 +40,9 @@ def setup_package():
         keywords=pyproject["project"]["keywords"],
         license=pyproject["project"]["license"],
         long_description=long_description(),
-        maintainer_email=pyproject["project"]["maintainers"][0]["email"],
-        maintainer=pyproject["project"]["maintainers"][0]["name"],
-        name=pyproject["project"]["name"],
+        maintainer_email="info@sktime.com",
+        maintainer=f"{projectname} developers",
+        name=projectname,
         package_data={
             "sktime": [
                 "*.csv",


### PR DESCRIPTION
This PR attempts to address the failed pypi upload for v0.14.0, fixes https://github.com/sktime/sktime/issues/3715.

My suspicion is that there is an interaction between `setup.py` and `pyproject.toml` in the email address fields.

* this PR removes personal email addresses from `pyproject.toml`
* in `setup.py`, replaces names of one author with "project developers", and emails with a hardcoded string `"info@sktime.org"`

Also adds instructions to the release process docs how to re-release in a case where the wheel upload fails.