### PR TITLE
[ENH] better error message on transform output check fail

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1021,11 +1021,17 @@ class BaseTransformer(BaseEstimator):
             #   we cannot convert back to pd.Series, do pd.DataFrame instead then
             #   this happens only for Series, not Panel
             if X_input_scitype == "Series":
-                _, _, metadata = check_is_mtype(
+                valid, msg, metadata = check_is_mtype(
                     Xt,
                     ["pd.DataFrame", "pd.Series", "np.ndarray"],
                     return_metadata=True,
                 )
+                if not valid:
+                    raise TypeError(
+                        f"_transform output of {type(self)} does not comply "
+                        "with sktime mtype specifications. Returned error message:"
+                        f" {msg} Returned object: {Xt}"
+                    )
                 if not metadata["is_univariate"] and X_input_mtype == "pd.Series":
                     X_output_mtype = "pd.DataFrame"
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1029,8 +1029,9 @@ class BaseTransformer(BaseEstimator):
                 if not valid:
                     raise TypeError(
                         f"_transform output of {type(self)} does not comply "
-                        "with sktime mtype specifications. Returned error message:"
-                        f" {msg} Returned object: {Xt}"
+                        "with sktime mtype specifications. See datatypes.MTYPE_REGISTER"
+                        " for mtype specifications. Returned error message:"
+                        f" {msg}. Returned object: {Xt}"
                     )
                 if not metadata["is_univariate"] and X_input_mtype == "pd.Series":
                     X_output_mtype = "pd.DataFrame"


### PR DESCRIPTION
This PR improves the error message if the transform output check fails, by pointing to the estimator type and printing the output.