### PR TITLE
[MNT] update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,7 +25,7 @@ sktime/classification/interval_based/_cif.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/interval_based/_drcif.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/interval_based/_rise.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/interval_based/_stsf.py @MatthewMiddlehurst @TonyBagnall
-sktime/classification/interval_based/_tsf.py @TonyBagnall
+sktime/classification/interval_based/_tsf.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/kernel_based/_arsenal.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/kernel_based/_rocket_classifier.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/shapelet_based/_stc.py @jasonlines @ABostrom @MatthewMiddlehurst @TonyBagnall

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,8 +10,8 @@ sktime/classification/dictionary_based/_tde.py @patrickzib @MatthewMiddlehurst @
 sktime/classification/dictionary_based/_weasel.py @patrickzib @MatthewMiddlehurst @TonyBagnall
 sktime/classification/distance_based/ @jasonlines @goaster @TonyBagnall
 sktime/classification/dummy/ @ZiyaoWei
-sktime/classification/early_classification/_probability_threshold.py @MatthewMiddlehurst @TonyBagnall
-sktime/classification/early_classification/_teaser.py @patrickzib @MatthewMiddlehurst @TonyBagnall
+sktime/classification/early_classification/_probability_threshold.py @MatthewMiddlehurst
+sktime/classification/early_classification/_teaser.py @patrickzib @MatthewMiddlehurst
 sktime/classification/feature_based/_catch22_classifier.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/feature_based/_fresh_prince.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/feature_based/_matrix_profile_classifier.py @MatthewMiddlehurst @TonyBagnall

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,23 +3,43 @@
 
 * @fkiraly @aiwalter @guzalbulatova
 
-sktime/classification/dummy/ @ZiyaoWei
-sktime/classification/dictionary_based/ @patrickzib @MatthewMiddlehurst @TonyBagnall
+sktime/classification/dictionary_based/_boss.py @patrickzib @MatthewMiddlehurst @TonyBagnall
+sktime/classification/dictionary_based/_cboss.py @patrickzib @MatthewMiddlehurst @TonyBagnall
+sktime/classification/dictionary_based/_muse.py @patrickzib @MatthewMiddlehurst @TonyBagnall
+sktime/classification/dictionary_based/_tde.py @patrickzib @MatthewMiddlehurst @TonyBagnall
+sktime/classification/dictionary_based/_weasel.py @patrickzib @MatthewMiddlehurst @TonyBagnall
 sktime/classification/distance_based/ @jasonlines @goaster @TonyBagnall
-sktime/classification/early_classification/ @MatthewMiddlehurst @TonyBagnall
+sktime/classification/dummy/ @ZiyaoWei
+sktime/classification/early_classification/_probability_threshold.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/early_classification/_teaser.py @patrickzib @MatthewMiddlehurst @TonyBagnall
-sktime/classification/feature_based/ @MatthewMiddlehurst @TonyBagnall
+sktime/classification/feature_based/_catch22_classifier.py @MatthewMiddlehurst @TonyBagnall
+sktime/classification/feature_based/_fresh_prince.py @MatthewMiddlehurst @TonyBagnall
+sktime/classification/feature_based/_matrix_profile_classifier.py @MatthewMiddlehurst @TonyBagnall
+sktime/classification/feature_based/_random_interval_classifier.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/feature_based/_signature_classifier.py @jambo6
-sktime/classification/hybrid/ @MatthewMiddlehurst @TonyBagnall
-sktime/classification/interval_based/ @MatthewMiddlehurst @TonyBagnall
-sktime/classification/kernel_based/ @MatthewMiddlehurst @TonyBagnall
-sktime/classification/shapelet_based/ @jasonlines @ABostrom @TonyBagnall
+sktime/classification/feature_based/_summary_classifier.py @MatthewMiddlehurst @TonyBagnall
+sktime/classification/feature_based/_tsfresh_classifier.py @MatthewMiddlehurst @TonyBagnall
+sktime/classification/hybrid/_hivecote_v1.py @MatthewMiddlehurst @TonyBagnall
+sktime/classification/hybrid/_hivecote_v2.py @MatthewMiddlehurst @TonyBagnall
+sktime/classification/interval_based/_cif.py @MatthewMiddlehurst @TonyBagnall
+sktime/classification/interval_based/_drcif.py @MatthewMiddlehurst @TonyBagnall
+sktime/classification/interval_based/_rise.py @TonyBagnall
+sktime/classification/interval_based/_stsf.py @MatthewMiddlehurst @TonyBagnall
+sktime/classification/interval_based/_tsf.py @TonyBagnall
+sktime/classification/kernel_based/_arsenal.py @MatthewMiddlehurst @TonyBagnall
+sktime/classification/kernel_based/_rocket_classifier.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/shapelet_based/_stc.py @jasonlines @ABostrom @MatthewMiddlehurst @TonyBagnall
+sktime/classification/sklearn/_continuous_interval_tree.py @MatthewMiddlehurst
+sktime/classification/sklearn/_rotation_forest.py @MatthewMiddlehurst
 
-sktime/transformations/panel/dictionary_based/ @patrickzib @MatthewMiddlehurst
+sktime/transformations/panel/dictionary_based/_paa.py @patrickzib @MatthewMiddlehurst
+sktime/transformations/panel/dictionary_based/_sax.py @patrickzib @MatthewMiddlehurst
+sktime/transformations/panel/dictionary_based/_sfa.py @patrickzib @MatthewMiddlehurst
+sktime/transformations/panel/dictionary_based/_sfa_fast.py @patrickzib @MatthewMiddlehurst
 sktime/transformations/panel/catch22.py @MatthewMiddlehurst
-sktime/transformations/panel/shapelet_transform.py @MatthewMiddlehurst @TonyBagnall
-sktime/transformations/panel/shapelets.py @jasonlines @ABostrom @TonyBagnall
+sktime/transformations/panel/random_intervals.py @MatthewMiddlehurst
+sktime/transformations/panel/shapelet_transform.py @MatthewMiddlehurst @TonyBagnall @jasonlines @ABostrom
+sktime/transformations/panel/supervised_intervals.py @MatthewMiddlehurst
 sktime/transformations/panel/rocket/ @angus924
 sktime/transformations/panel/rocket/_multirocket.py @ChangWeiTan @fstinner @angus924
 sktime/transformations/panel/rocket/_multirocket_multivariate.py @ChangWeiTan @fstinner @angus924

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,7 +23,7 @@ sktime/classification/hybrid/_hivecote_v1.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/hybrid/_hivecote_v2.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/interval_based/_cif.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/interval_based/_drcif.py @MatthewMiddlehurst @TonyBagnall
-sktime/classification/interval_based/_rise.py @TonyBagnall
+sktime/classification/interval_based/_rise.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/interval_based/_stsf.py @MatthewMiddlehurst @TonyBagnall
 sktime/classification/interval_based/_tsf.py @TonyBagnall
 sktime/classification/kernel_based/_arsenal.py @MatthewMiddlehurst @TonyBagnall
@@ -38,7 +38,7 @@ sktime/transformations/panel/dictionary_based/_sfa.py @patrickzib @MatthewMiddle
 sktime/transformations/panel/dictionary_based/_sfa_fast.py @patrickzib @MatthewMiddlehurst
 sktime/transformations/panel/catch22.py @MatthewMiddlehurst
 sktime/transformations/panel/random_intervals.py @MatthewMiddlehurst
-sktime/transformations/panel/shapelet_transform.py @MatthewMiddlehurst @TonyBagnall @jasonlines @ABostrom
+sktime/transformations/panel/shapelet_transform.py @jasonlines @ABostrom @MatthewMiddlehurst @TonyBagnall
 sktime/transformations/panel/supervised_intervals.py @MatthewMiddlehurst
 sktime/transformations/panel/rocket/ @angus924
 sktime/transformations/panel/rocket/_multirocket.py @ChangWeiTan @fstinner @angus924


### PR DESCRIPTION
Removes owners of classification sub-packages and replaces them with owners for individual files. This impacts @TonyBagnall and @patrickzib, let me know if you are fine with these changes or if you want any other changes to ownership.

Adds myself as owner to `sktime/transformations/panel/random_intervals.py`, `sktime/transformations/panel/supervised_intervals.py`, `sktime/classification/sklearn/_continuous_interval_tree.py`, `sktime/classification/sklearn/_rotation_forest.py`.

Moved the owners of `sktime/transformations/panel/shapelets.py` to the correct file (`shapelets.py` does not exist).