### PR TITLE
[ENH] getitem / square brackets dunder for forecasting

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -231,6 +231,52 @@ class BaseForecaster(BaseEstimator):
         else:
             return NotImplemented
 
+    def __getitem__(self, key):
+        """Magic [...] method, return forecaster with subsetted data.
+
+        First index does subsetting of exogeneous input data.
+        Second index does subsetting of the forecast (but not of endogeneous data).
+
+        Keys must be valid inputs for `columns` in `ColumnSubset`.
+
+        Parameters
+        ----------
+        key: valid input for `columns` in `ColumnSubset`, or pair thereof
+            keys can also be a :-slice, in which case it is considered as not passed
+
+        Returns
+        -------
+        the following composite pipeline object:
+            ColumnSubset(columns1) ** self * ColumnSubset(columns2)
+            where `columns1` is first or only item in `key`, and `columns2` is the last
+            if only one item is passed in `key`, only `columns1` is applied to input
+        """
+        from sktime.transformations.series.subset import ColumnSelect
+
+        def is_noneslice(obj):
+            res = isinstance(obj, slice)
+            res = res and obj.start is None and obj.stop is None and obj.step is None
+            return res
+
+        if isinstance(key, tuple):
+            if not len(key) == 2:
+                raise ValueError(
+                    "there should be one or two keys when calling [] or getitem, "
+                    "e.g., mytrafo[key], or mytrafo[key1, key2]"
+                )
+            columns1 = key[0]
+            columns2 = key[1]
+            if is_noneslice(columns1) and is_noneslice(columns2):
+                return self
+            elif is_noneslice(columns2):
+                return ColumnSelect(columns1) ** self
+            elif is_noneslice(columns1):
+                return self * ColumnSelect(columns2)
+            else:
+                return ColumnSelect(columns1) ** self * ColumnSelect(columns2)
+        else:
+            return ColumnSelect(key) ** self
+
     def fit(self, y, X=None, fh=None):
         """Fit forecaster to training data.
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -309,7 +309,7 @@ class BaseTransformer(BaseEstimator):
     def __getitem__(self, key):
         """Magic [...] method, return column subsetted transformer.
 
-        First index does output subsetting, second index does input subsetting.
+        First index does intput subsetting, second index does output subsetting.
 
         Keys must be valid inputs for `columns` in `ColumnSubset`.
 


### PR DESCRIPTION
This PR adds a square brackets / `__getitem__` dunder for forecasting.

This mirrors the same dunder for transformers:

* first bracket element subsets the exogeneous input data
* second bracket element subsets the forecast

See docstring of the new dunder.

The choice for subsetting the exogeneous and not endogeneous input data is due to that being a more frequent use case (I think).

Tests are also added for the new dunder.

Other minor content:

* docstring fix for the transformer square bracket dunder