### PR TITLE
by matthewmiddlehurst [DOC] Add missing estimators to classification API page

### DIFF
--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -5,33 +5,6 @@ Time series classification
 
 The :mod:`sktime.classification` module contains algorithms and composition tools for time series classification.
 
-Base
-----
-
-.. currentmodule:: sktime.classification
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    BaseClassifier
-
-.. currentmodule:: sktime.classification.deep_learning.base
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    BaseDeepClassifier
-
-.. currentmodule:: sktime.classification.early_classification.base
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    BaseEarlyClassifier
-
 Composition
 -----------
 
@@ -194,3 +167,30 @@ sklearn
 
     ContinuousIntervalTree
     RotationForest
+
+Base
+----
+
+.. currentmodule:: sktime.classification
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    BaseClassifier
+
+.. currentmodule:: sktime.classification.deep_learning.base
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    BaseDeepClassifier
+
+.. currentmodule:: sktime.classification.early_classification.base
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    BaseEarlyClassifier

--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -5,6 +5,33 @@ Time series classification
 
 The :mod:`sktime.classification` module contains algorithms and composition tools for time series classification.
 
+Base
+----
+
+.. currentmodule:: sktime.classification
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    BaseClassifier
+
+.. currentmodule:: sktime.classification.deep_learning.base
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    BaseDeepClassifier
+
+.. currentmodule:: sktime.classification.early_classification.base
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    BaseEarlyClassifier
+
 Composition
 -----------
 
@@ -14,10 +41,24 @@ Composition
     :toctree: auto_generated/
     :template: class.rst
 
+    ClassifierPipeline
     ColumnEnsembleClassifier
     ComposableTimeSeriesForestClassifier
-    ClassifierPipeline
     SklearnClassifierPipeline
+
+Dictionary-based
+----------------
+
+.. currentmodule:: sktime.classification.deep_learning
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    CNNClassifier
+    FCNClassifier
+    MLPClassifier
+    TapNetClassifier
 
 Dictionary-based
 ----------------
@@ -29,11 +70,11 @@ Dictionary-based
     :template: class.rst
 
     BOSSEnsemble
-    IndividualBOSS
     ContractableBOSS
+    IndividualBOSS
+    IndividualTDE
     MUSE
     TemporalDictionaryEnsemble
-    IndividualTDE
     WEASEL
 
 Distance-based
@@ -46,11 +87,11 @@ Distance-based
     :template: class.rst
 
     ElasticEnsemble
-    ProximityForest
-    ProximityTree
-    ProximityStump
-    ShapeDTW
     KNeighborsTimeSeriesClassifier
+    ProximityForest
+    ProximityStump
+    ProximityTree
+    ShapeDTW
 
 Dummy
 -----
@@ -128,8 +169,8 @@ Kernel-based
     :toctree: auto_generated/
     :template: class.rst
 
-    RocketClassifier
     Arsenal
+    RocketClassifier
 
 Shapelet-based
 --------------
@@ -153,22 +194,3 @@ sklearn
 
     ContinuousIntervalTree
     RotationForest
-
-Base
-----
-
-.. currentmodule:: sktime.classification
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    BaseClassifier
-
-.. currentmodule:: sktime.classification.early_classification
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    BaseEarlyClassifier

--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -15,6 +15,9 @@ Composition
     :template: class.rst
 
     ColumnEnsembleClassifier
+    ComposableTimeSeriesForestClassifier
+    ClassifierPipeline
+    SklearnClassifierPipeline
 
 Dictionary-based
 ----------------
@@ -25,13 +28,13 @@ Dictionary-based
     :toctree: auto_generated/
     :template: class.rst
 
-    IndividualBOSS
     BOSSEnsemble
+    IndividualBOSS
     ContractableBOSS
-    WEASEL
     MUSE
-    IndividualTDE
     TemporalDictionaryEnsemble
+    IndividualTDE
+    WEASEL
 
 Distance-based
 --------------
@@ -42,11 +45,12 @@ Distance-based
     :toctree: auto_generated/
     :template: class.rst
 
-    KNeighborsTimeSeriesClassifier
     ElasticEnsemble
     ProximityForest
     ProximityTree
     ProximityStump
+    ShapeDTW
+    KNeighborsTimeSeriesClassifier
 
 Dummy
 -----
@@ -58,6 +62,35 @@ Dummy
     :template: class.rst
 
     DummyClassifier
+
+Early classification
+--------------------
+
+.. currentmodule:: sktime.classification.early_classification
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ProbabilityThresholdEarlyClassifier
+    TEASER
+
+Feature-based
+-------------
+
+.. currentmodule:: sktime.classification.feature_based
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    Catch22Classifier
+    FreshPRINCE
+    MatrixProfileClassifier
+    RandomIntervalClassifier
+    SignatureClassifier
+    SummaryClassifier
+    TSFreshClassifier
 
 Hybrid
 ------
@@ -80,23 +113,11 @@ Interval-based
     :toctree: auto_generated/
     :template: class.rst
 
-    TimeSeriesForestClassifier
-    SupervisedTimeSeriesForest
     CanonicalIntervalForest
     DrCIF
     RandomIntervalSpectralEnsemble
-
-
-Shapelet-based
---------------
-
-.. currentmodule:: sktime.classification.shapelet_based
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    ShapeletTransformClassifier
+    SupervisedTimeSeriesForest
+    TimeSeriesForestClassifier
 
 Kernel-based
 ------------
@@ -110,19 +131,44 @@ Kernel-based
     RocketClassifier
     Arsenal
 
-Feature-based
--------------
+Shapelet-based
+--------------
 
-.. currentmodule:: sktime.classification.feature_based
+.. currentmodule:: sktime.classification.shapelet_based
 
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
-    Catch22Classifier
-    MatrixProfileClassifier
-    TSFreshClassifier
-    SignatureClassifier
-    FreshPRINCE
-    SummaryClassifier
-    RandomIntervalClassifier
+    ShapeletTransformClassifier
+
+sklearn
+-------
+
+.. currentmodule:: sktime.classification.sklearn
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ContinuousIntervalTree
+    RotationForest
+
+Base
+----
+
+.. currentmodule:: sktime.classification
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    BaseClassifier
+
+.. currentmodule:: sktime.classification.early_classification
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    BaseEarlyClassifier

--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -47,7 +47,7 @@ Composition
     SklearnClassifierPipeline
 
 Deep learning
-----------------
+-------------
 
 .. currentmodule:: sktime.classification.deep_learning
 

--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -46,7 +46,7 @@ Composition
     ComposableTimeSeriesForestClassifier
     SklearnClassifierPipeline
 
-Dictionary-based
+Deep learning
 ----------------
 
 .. currentmodule:: sktime.classification.deep_learning


### PR DESCRIPTION
Restored reverted #3735 by @MatthewMiddlehurst since I have a change request.

My change request:

Agreed with the addition of missing classifiers.

Disagree with the change in section sequence and overall sequence, this makes more obscure classifiers more prominent.

First listed should be more well-known classifiers or those that people would like to find, generalizations of common tabular classifiers, and/or sensible baselines.

Re categories, the first ones should be

* composition
* dummy
* feature-based
* distance-based

Inside categories, common classifiers or generalizations of well-known classifiers from sklearn should be first.

* in distance-based, should be KNN
* in interval-based, it should be the forests

Early classification and tabular classification should be separate rubrics.