### PR TITLE
[ENH] `TimeBinner` transformation for temporal bin aggregation

### DIFF
--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -100,6 +100,7 @@ Sklearn and pandas adapters
     :template: class.rst
 
     Tabularizer
+    TimeBinner
 
 .. currentmodule:: sktime.transformations.series.adapt
 

--- a/sktime/transformations/panel/reduce.py
+++ b/sktime/transformations/panel/reduce.py
@@ -89,29 +89,10 @@ class TimeBinner(BaseTransformer):
     idx : pd.IntervalIndex
         IntervalIndex defining intervals considered by aggfunc
     aggfunc : callable
-        Function used to aggregate the values in intervals
+        Function used to aggregate the values in intervals.
+        Should have signature 1D iterable -> float
     """
 
-    # todo: fill out estimator tags here
-    #  tags are inherited from parent class if they are not set
-    #
-    # todo: define the transformer scitype by setting the tags
-    #   scitype:transform-input - the expected input scitype of X
-    #   scitype:transform-output - the output scitype that transform produces
-    #   scitype:transform-labels - whether y is used and if yes which scitype
-    #   scitype:instancewise - whether transform uses all samples or acts by instance
-    #
-    # todo: define internal types for X, y in _fit/_transform by setting the tags
-    #   X_inner_mtype - the internal mtype used for X in _fit and _transform
-    #   y_inner_mtype - if y is used, the internal mtype used for y; usually "None"
-    #   setting this guarantees that X, y passed to _fit, _transform are of above types
-    #   for possible mtypes see datatypes.MTYPE_REGISTER, or the datatypes tutorial
-    #
-    #  when scitype:transform-input is set to Panel:
-    #   X_inner_mtype must be changed to one or a list of sktime Panel mtypes
-    #  when scitype:transform-labels is set to Series or Panel:
-    #   y_inner_mtype must be changed to one or a list of compatible sktime mtypes
-    #  the other tags are "safe defaults" which can usually be left as-is
     _tags = {
         "fit_is_empty": True,
         "univariate-only": False,
@@ -125,18 +106,13 @@ class TimeBinner(BaseTransformer):
         "y_inner_mtype": "None",  # and for y?
     }
 
-    # todo: add any hyper-parameters and components to constructor
     def __init__(self, idx, aggfunc):
-        # estimators should precede parameters
-        #  if estimators have default values, set None and initalize below
 
-        # todo: write any hyper-parameters and components to self
         self.idx = idx
         self.aggfunc = aggfunc
 
         super(TimeBinner, self).__init__()
 
-        # todo: optional, parameter checking logic (if applicable) should happen here
         assert isinstance(
             self.idx, pd.IntervalIndex
         ), "idx should be of type pd.IntervalIndex"
@@ -144,7 +120,6 @@ class TimeBinner(BaseTransformer):
         # if writes derived values to self, should *not* overwrite self.parama etc
         # instead, write to self._parama, self._newparam (starting with _)
 
-    # todo: implement this, mandatory
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.
 
@@ -162,31 +137,11 @@ class TimeBinner(BaseTransformer):
         -------
         transformed version of X
         """
-        # implement here
-        # X, y passed to this function are always of X_inner_mtype, y_inner_mtype
-        # IMPORTANT: avoid side effects to X, y
-        #
-        # if transform-output is "Primitives":
-        #  return should be pd.DataFrame, with as many rows as instances in input
-        #  if input is a single series, return should be single-row pd.DataFrame
-        # if transform-output is "Series":
-        #  return should be of same mtype as input, X_inner_mtype
-        #  if multiple X_inner_mtype are supported, ensure same input/output
-        # if transform-output is "Panel":
-        #  return a multi-indexed pd.DataFrame of Panel mtype pd_multiindex
-        #
-        # todo: add the return mtype/scitype to the docstring, e.g.,
-        #  Returns
-        #  -------
-        #  X_transformed : Series of mtype pd.DataFrame
-        #       transformed version of X
         idx = pd.cut(X.iloc[0, 0].index, bins=self.idx, include_lowest=True)
         Xt = X.applymap(lambda x: x.groupby(idx).aggregate(self.aggfunc))
         Xt = convert_to(Xt, to_type="numpyflat", as_scitype="Panel")
         return Xt
 
-    # todo: return default parameters, so that a test instance can be created
-    #   required for automated unit and integration testing of estimator
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
@@ -206,41 +161,6 @@ class TimeBinner(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-
-        # todo: set the testing parameters for the estimators
-        # Testing parameters can be dictionary or list of dictionaries
-        # Testing parameter choice should cover internal cases well.
-        #
-        # this method can, if required, use:
-        #   class properties (e.g., inherited); parent class test case
-        #   imported objects such as estimators from sktime or sklearn
-        # important: all such imports should be *inside get_test_params*, not at the top
-        #            since imports are used only at testing time
-        #
-        # The parameter_set argument is not used for automated, module level tests.
-        #   It can be used in custom, estimator specific tests, for "special" settings.
-        # A parameter dictionary must be returned *for all values* of parameter_set,
-        #   i.e., "parameter_set not available" errors should never be raised.
-        #
-        # example 1: specify params as dictionary
-        # any number of params can be specified
-        # params = {"est": value0, "parama": value1, "paramb": value2}
-        #
-        # example 2: specify params as list of dictionary
-        # note: Only first dictionary will be used by create_test_instance
-        # params = [{"est": value1, "parama": value2},
-        #           {"est": value3, "parama": value4}]
-        # return params
-        #
-        # example 3: parameter set depending on param_set value
-        #   note: only needed if a separate parameter set is needed in tests
-        # if parameter_set == "special_param_set":
-        #     params = {"est": value1, "parama": value2}
-        #     return params
-        #
-        # # "default" params - always returned except for "special_param_set" value
-        # params = {"est": value3, "parama": value4}
-        # return params
         import pandas as pd
 
         idx = pd.interval_range(start=0, end=100, freq=10, closed="left")

--- a/sktime/transformations/panel/reduce.py
+++ b/sktime/transformations/panel/reduce.py
@@ -108,10 +108,11 @@ class TimeBinner(BaseTransformer):
 
     def __init__(self, idx, aggfunc="sum"):
 
+        self.idx = idx
         assert isinstance(
             self.idx, pd.IntervalIndex
         ), "idx should be of type pd.IntervalIndex"
-        self.idx = idx
+
         assert aggfunc in ["sum", "min", "max", "median", "std"]
         self.aggfunc = aggfunc
         super(TimeBinner, self).__init__()

--- a/sktime/transformations/panel/reduce.py
+++ b/sktime/transformations/panel/reduce.py
@@ -5,6 +5,8 @@
 __author__ = ["mloning", "fkiraly"]
 __all__ = ["Tabularizer"]
 
+import pandas as pd
+
 from sktime.datatypes import convert, convert_to
 from sktime.transformations.base import BaseTransformer
 
@@ -67,3 +69,184 @@ class Tabularizer(BaseTransformer):
         """
         Xt = convert(X, from_type="numpyflat", to_type="numpy3D", as_scitype="Panel")
         return Xt
+
+
+class TimeBinner(BaseTransformer):
+    """A transformer that turns time series/panel data into tabular data.
+
+    This estimator converts nested pandas dataframe containing
+    time-series/panel data with numpy arrays or pandas Series in
+    dataframe cells into a tabular pandas dataframe with only primitives in
+    cells. The primitives are calculated based on Intervals defined
+    by the IntervalIndex and aggregated by aggfunc.
+
+    This is useful for transforming time-series/panel data
+    into a format that is accepted by standard validation learning
+    algorithms (as in sklearn).
+
+    Parameters
+    ----------
+    idx : pd.IntervalIndex
+        IntervalIndex defining intervals considered by aggfunc
+    aggfunc : callable
+        Function used to aggregate the values in intervals
+    """
+
+    # todo: fill out estimator tags here
+    #  tags are inherited from parent class if they are not set
+    #
+    # todo: define the transformer scitype by setting the tags
+    #   scitype:transform-input - the expected input scitype of X
+    #   scitype:transform-output - the output scitype that transform produces
+    #   scitype:transform-labels - whether y is used and if yes which scitype
+    #   scitype:instancewise - whether transform uses all samples or acts by instance
+    #
+    # todo: define internal types for X, y in _fit/_transform by setting the tags
+    #   X_inner_mtype - the internal mtype used for X in _fit and _transform
+    #   y_inner_mtype - if y is used, the internal mtype used for y; usually "None"
+    #   setting this guarantees that X, y passed to _fit, _transform are of above types
+    #   for possible mtypes see datatypes.MTYPE_REGISTER, or the datatypes tutorial
+    #
+    #  when scitype:transform-input is set to Panel:
+    #   X_inner_mtype must be changed to one or a list of sktime Panel mtypes
+    #  when scitype:transform-labels is set to Series or Panel:
+    #   y_inner_mtype must be changed to one or a list of compatible sktime mtypes
+    #  the other tags are "safe defaults" which can usually be left as-is
+    _tags = {
+        "fit_is_empty": True,
+        "univariate-only": False,
+        "scitype:transform-input": "Series",
+        # what is the scitype of X: Series, or Panel
+        "scitype:transform-output": "Primitives",
+        # what is the scitype of y: None (not needed), Primitives, Series, Panel
+        "scitype:instancewise": True,  # is this an instance-wise transform?
+        "X_inner_mtype": ["nested_univ", "numpy3D"],
+        # which mtypes do _fit/_predict support for X?
+        "y_inner_mtype": "None",  # and for y?
+    }
+
+    # todo: add any hyper-parameters and components to constructor
+    def __init__(self, idx, aggfunc):
+        # estimators should precede parameters
+        #  if estimators have default values, set None and initalize below
+
+        # todo: write any hyper-parameters and components to self
+        self.idx = idx
+        self.aggfunc = aggfunc
+
+        super(TimeBinner, self).__init__()
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        assert isinstance(
+            self.idx, pd.IntervalIndex
+        ), "idx should be of type pd.IntervalIndex"
+        assert callable(self.aggfunc), "aggfunc should be a function"
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
+
+    # todo: implement this, mandatory
+    def _transform(self, X, y=None):
+        """Transform X and return a transformed version.
+
+        private _transform containing core logic, called from transform
+
+        Parameters
+        ----------
+        X : Series or Panel of mtype X_inner_mtype
+            if X_inner_mtype is list, _transform must support all types in it
+            Data to be transformed
+        y : Series or Panel of mtype y_inner_mtype, default=None
+            Additional data, e.g., labels for transformation
+
+        Returns
+        -------
+        transformed version of X
+        """
+        # implement here
+        # X, y passed to this function are always of X_inner_mtype, y_inner_mtype
+        # IMPORTANT: avoid side effects to X, y
+        #
+        # if transform-output is "Primitives":
+        #  return should be pd.DataFrame, with as many rows as instances in input
+        #  if input is a single series, return should be single-row pd.DataFrame
+        # if transform-output is "Series":
+        #  return should be of same mtype as input, X_inner_mtype
+        #  if multiple X_inner_mtype are supported, ensure same input/output
+        # if transform-output is "Panel":
+        #  return a multi-indexed pd.DataFrame of Panel mtype pd_multiindex
+        #
+        # todo: add the return mtype/scitype to the docstring, e.g.,
+        #  Returns
+        #  -------
+        #  X_transformed : Series of mtype pd.DataFrame
+        #       transformed version of X
+        idx = pd.cut(X.iloc[0, 0].index, bins=self.idx, include_lowest=True)
+        Xt = X.applymap(lambda x: x.groupby(idx).aggregate(self.aggfunc))
+        Xt = convert_to(Xt, to_type="numpyflat", as_scitype="Panel")
+        return Xt
+
+    # todo: return default parameters, so that a test instance can be created
+    #   required for automated unit and integration testing of estimator
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for transformers.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+
+        # todo: set the testing parameters for the estimators
+        # Testing parameters can be dictionary or list of dictionaries
+        # Testing parameter choice should cover internal cases well.
+        #
+        # this method can, if required, use:
+        #   class properties (e.g., inherited); parent class test case
+        #   imported objects such as estimators from sktime or sklearn
+        # important: all such imports should be *inside get_test_params*, not at the top
+        #            since imports are used only at testing time
+        #
+        # The parameter_set argument is not used for automated, module level tests.
+        #   It can be used in custom, estimator specific tests, for "special" settings.
+        # A parameter dictionary must be returned *for all values* of parameter_set,
+        #   i.e., "parameter_set not available" errors should never be raised.
+        #
+        # example 1: specify params as dictionary
+        # any number of params can be specified
+        # params = {"est": value0, "parama": value1, "paramb": value2}
+        #
+        # example 2: specify params as list of dictionary
+        # note: Only first dictionary will be used by create_test_instance
+        # params = [{"est": value1, "parama": value2},
+        #           {"est": value3, "parama": value4}]
+        # return params
+        #
+        # example 3: parameter set depending on param_set value
+        #   note: only needed if a separate parameter set is needed in tests
+        # if parameter_set == "special_param_set":
+        #     params = {"est": value1, "parama": value2}
+        #     return params
+        #
+        # # "default" params - always returned except for "special_param_set" value
+        # params = {"est": value3, "parama": value4}
+        # return params
+        import pandas as pd
+
+        idx = pd.interval_range(start=0, end=100, freq=10, closed="left")
+
+        def aggfunc(x):
+            return sum(x)
+
+        params = {"idx": idx, "aggfunc": aggfunc}
+        return params

--- a/sktime/transformations/panel/reduce.py
+++ b/sktime/transformations/panel/reduce.py
@@ -75,7 +75,7 @@ class Tabularizer(BaseTransformer):
 
 
 class TimeBinner(BaseTransformer):
-    """A transformer that turns time series/panel data into tabular data.
+    """Turns time series/panel data into tabular data based on intervals.
 
     This estimator converts nested pandas dataframe containing
     time-series/panel data with numpy arrays or pandas Series in

--- a/sktime/transformations/panel/tests/test_timebinner.py
+++ b/sktime/transformations/panel/tests/test_timebinner.py
@@ -29,15 +29,17 @@ def test_timebinner2():
     X, y = load_basic_motions(return_X_y=True)
 
     def aggfunc(x):
-        return min(x)
+        return sum(x)
 
     freq = 10
-    idx = pd.interval_range(start=0, end=100, freq=freq, closed="left")
+    idx = pd.interval_range(start=0, end=100, freq=freq, closed="right")
     tb = TimeBinner(idx=idx, aggfunc=aggfunc)
     tb.fit(X)
     row = 3
     Xtb = tb.transform(X)
-    assert np.isclose(np.sum(X.iloc[row, 5][8 * 10 : 9 * 10]), Xtb.iloc[row, 58])
+    assert np.isclose(
+        np.sum(X.iloc[row, 5][8 * 10 + 1 : 9 * 10 + 1]), Xtb.iloc[row, 58]
+    )
 
 
 def test_timebinner3():
@@ -45,7 +47,7 @@ def test_timebinner3():
     X, y = load_basic_motions(return_X_y=True)
 
     def aggfunc(x):
-        return sum(x)
+        return max(x)
 
     freq = 5
     idx = pd.interval_range(start=0, end=100, freq=freq, closed="right")
@@ -55,6 +57,6 @@ def test_timebinner3():
     tb.fit(X)
     Xtb = tb.transform(X)
     assert np.isclose(
-        np.sum(X.iloc[row, 0][col * freq + 1 : ((col + 1) * freq) + 1]),
+        np.max(X.iloc[row, 0][col * freq + 1 : ((col + 1) * freq) + 1]),
         Xtb.iloc[row, col],
     )

--- a/sktime/transformations/panel/tests/test_timebinner.py
+++ b/sktime/transformations/panel/tests/test_timebinner.py
@@ -19,8 +19,9 @@ def test_timebinner():
     idx = pd.interval_range(start=0, end=100, freq=freq, closed="left")
     tb = TimeBinner(idx=idx, aggfunc=aggfunc)
     tb.fit(X)
+    row = 1
     Xtb = tb.transform(X)
-    assert np.isclose(np.sum(X.iloc[0, 0][freq : (2 * freq)]), Xtb.iloc[1, 1])
+    assert np.isclose(np.sum(X.iloc[row, 0][freq : (2 * freq)]), Xtb.iloc[row, 1])
 
 
 def test_timebinner2():
@@ -34,8 +35,9 @@ def test_timebinner2():
     idx = pd.interval_range(start=0, end=100, freq=freq, closed="left")
     tb = TimeBinner(idx=idx, aggfunc=aggfunc)
     tb.fit(X)
+    row = 3
     Xtb = tb.transform(X)
-    assert np.isclose(np.sum(X.iloc[3, 5][8 * 10 : 9 * 10]), Xtb.iloc[3, 58])
+    assert np.isclose(np.sum(X.iloc[row, 5][8 * 10 : 9 * 10]), Xtb.iloc[row, 58])
 
 
 def test_timebinner3():

--- a/sktime/transformations/panel/tests/test_timebinner.py
+++ b/sktime/transformations/panel/tests/test_timebinner.py
@@ -12,7 +12,7 @@ def test_timebinner():
     """Test TimeBinner."""
     X, y = load_basic_motions(return_X_y=True)
 
-    aggfunc = "sum"
+    aggfunc = np.sum
     freq = 8
     idx = pd.interval_range(start=0, end=100, freq=freq, closed="left")
     tb = TimeBinner(idx=idx, aggfunc=aggfunc)
@@ -26,7 +26,7 @@ def test_timebinner2():
     """Test TimeBinner."""
     X, y = load_basic_motions(return_X_y=True)
 
-    aggfunc = "sum"
+    aggfunc = np.max
     freq = 10
     idx = pd.interval_range(start=0, end=100, freq=freq, closed="right")
     tb = TimeBinner(idx=idx, aggfunc=aggfunc)
@@ -34,7 +34,7 @@ def test_timebinner2():
     row = 3
     Xtb = tb.transform(X)
     assert np.isclose(
-        np.sum(X.iloc[row, 5][8 * 10 + 1 : 9 * 10 + 1]), Xtb.iloc[row, 58]
+        np.max(X.iloc[row, 5][8 * 10 + 1 : 9 * 10 + 1]), Xtb.iloc[row, 58]
     )
 
 
@@ -42,7 +42,9 @@ def test_timebinner3():
     """Test TimeBinner."""
     X, y = load_basic_motions(return_X_y=True)
 
-    aggfunc = "max"
+    def aggfunc(ser):
+        return np.quantile(ser, q=0.25)
+
     freq = 5
     idx = pd.interval_range(start=0, end=100, freq=freq, closed="right")
     tb = TimeBinner(idx=idx, aggfunc=aggfunc)
@@ -51,6 +53,6 @@ def test_timebinner3():
     tb.fit(X)
     Xtb = tb.transform(X)
     assert np.isclose(
-        np.max(X.iloc[row, 0][col * freq + 1 : ((col + 1) * freq) + 1]),
+        np.quantile(X.iloc[row, 0][col * freq + 1 : ((col + 1) * freq) + 1], q=0.25),
         Xtb.iloc[row, col],
     )

--- a/sktime/transformations/panel/tests/test_timebinner.py
+++ b/sktime/transformations/panel/tests/test_timebinner.py
@@ -9,7 +9,7 @@ from sktime.transformations.panel.reduce import TimeBinner
 
 
 def test_timebinner():
-    """ "Test TimeBinner."""
+    """Test TimeBinner."""
     X, y = load_basic_motions(return_X_y=True)
 
     def aggfunc(x):
@@ -24,7 +24,7 @@ def test_timebinner():
 
 
 def test_timebinner2():
-    """ "Test TimeBinner."""
+    """Test TimeBinner."""
     X, y = load_basic_motions(return_X_y=True)
 
     def aggfunc(x):
@@ -36,3 +36,23 @@ def test_timebinner2():
     tb.fit(X)
     Xtb = tb.transform(X)
     assert np.isclose(np.sum(X.iloc[3, 5][8 * 10 : 9 * 10]), Xtb.iloc[3, 58])
+
+
+def test_timebinner3():
+    """Test TimeBinner."""
+    X, y = load_basic_motions(return_X_y=True)
+
+    def aggfunc(x):
+        return sum(x)
+
+    freq = 5
+    idx = pd.interval_range(start=0, end=100, freq=freq, closed="right")
+    tb = TimeBinner(idx=idx, aggfunc=aggfunc)
+    row = 1
+    col = 3
+    tb.fit(X)
+    Xtb = tb.transform(X)
+    assert np.isclose(
+        np.sum(X.iloc[row, 0][col * freq + 1 : ((col + 1) * freq) + 1]),
+        Xtb.iloc[row, col],
+    )

--- a/sktime/transformations/panel/tests/test_timebinner.py
+++ b/sktime/transformations/panel/tests/test_timebinner.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""Tests for TimeBinner."""
+
+import numpy as np
+import pandas as pd
+
+from sktime.datasets import load_basic_motions
+from sktime.transformations.panel.reduce import TimeBinner
+
+
+def test_timebinner():
+    """ "Test TimeBinner."""
+    X, y = load_basic_motions(return_X_y=True)
+
+    def aggfunc(x):
+        return sum(x)
+
+    freq = 8
+    idx = pd.interval_range(start=0, end=100, freq=freq, closed="left")
+    tb = TimeBinner(idx=idx, aggfunc=aggfunc)
+    tb.fit(X)
+    Xtb = tb.transform(X)
+    assert np.isclose(np.sum(X.iloc[0, 0][freq : (2 * freq)]), Xtb.iloc[1, 1])
+
+
+def test_timebinner2():
+    """ "Test TimeBinner."""
+    X, y = load_basic_motions(return_X_y=True)
+
+    def aggfunc(x):
+        return min(x)
+
+    freq = 10
+    idx = pd.interval_range(start=0, end=100, freq=freq, closed="left")
+    tb = TimeBinner(idx=idx, aggfunc=aggfunc)
+    tb.fit(X)
+    Xtb = tb.transform(X)
+    assert np.isclose(np.sum(X.iloc[3, 5][8 * 10 : 9 * 10]), Xtb.iloc[3, 58])

--- a/sktime/transformations/panel/tests/test_timebinner.py
+++ b/sktime/transformations/panel/tests/test_timebinner.py
@@ -12,9 +12,7 @@ def test_timebinner():
     """Test TimeBinner."""
     X, y = load_basic_motions(return_X_y=True)
 
-    def aggfunc(x):
-        return sum(x)
-
+    aggfunc = "sum"
     freq = 8
     idx = pd.interval_range(start=0, end=100, freq=freq, closed="left")
     tb = TimeBinner(idx=idx, aggfunc=aggfunc)
@@ -28,9 +26,7 @@ def test_timebinner2():
     """Test TimeBinner."""
     X, y = load_basic_motions(return_X_y=True)
 
-    def aggfunc(x):
-        return sum(x)
-
+    aggfunc = "sum"
     freq = 10
     idx = pd.interval_range(start=0, end=100, freq=freq, closed="right")
     tb = TimeBinner(idx=idx, aggfunc=aggfunc)
@@ -46,9 +42,7 @@ def test_timebinner3():
     """Test TimeBinner."""
     X, y = load_basic_motions(return_X_y=True)
 
-    def aggfunc(x):
-        return max(x)
-
+    aggfunc = "max"
     freq = 5
     idx = pd.interval_range(start=0, end=100, freq=freq, closed="right")
     tb = TimeBinner(idx=idx, aggfunc=aggfunc)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Implements `TimeBinner` transformer as requested in #242 


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Adds the option to specify custom intervals which to use for aggregating time series/panel data. In that sense, it generalizes `Tabularizer`

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No



#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
- [ ] Check for functionality on panel data other than `basic_motions` dataset
- [ ] Implement alternatives to passing a `pd.IntervalIndex`

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.



<!--
Thanks for contributing!
-->
