### PR TITLE
[ENH] slightly speed up the tests for ComposableTimeSeriesForestClassifier 

### DIFF
--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -621,13 +621,13 @@ class WeightedEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
 
     Examples
     --------
-    >>> from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
+    >>> from sktime.classification.dummy import DummyClassifier
     >>> from sktime.classification.kernel_based import RocketClassifier
     >>> from sktime.datasets import load_unit_test
-    >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
     >>> clf = WeightedEnsembleClassifier(
-    ...     [KNeighborsTimeSeriesClassifier(), RocketClassifier()],
+    ...     [DummyClassifier(), RocketClassifier()],
     ...     weights=2,
     ... )
     >>> clf.fit(X_train, y_train)

--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -627,7 +627,7 @@ class WeightedEnsembleClassifier(BaseClassifier, _HeterogenousMetaEstimator):
     >>> X_train, y_train = load_unit_test(split="train")
     >>> X_test, y_test = load_unit_test(split="test")
     >>> clf = WeightedEnsembleClassifier(
-    ...     [DummyClassifier(), RocketClassifier()],
+    ...     [DummyClassifier(), RocketClassifier(num_kernels=100)],
     ...     weights=2,
     ... )
     >>> clf.fit(X_train, y_train)

--- a/sktime/classification/compose/tests/test_ensemble.py
+++ b/sktime/classification/compose/tests/test_ensemble.py
@@ -95,8 +95,7 @@ def test_equivalent_model_specifications(n_intervals, n_estimators):
     np.array_equal(a, b)
 
 
-# Compare TimeSeriesForest ensemble predictions using pipeline as
-# estimator
+# Compare TimeSeriesForest ensemble predictions using pipeline as estimator
 @pytest.mark.parametrize("n_intervals", ["sqrt", 1])
 @pytest.mark.parametrize("n_estimators", [1, 3])
 def test_tsf_predictions(n_estimators, n_intervals):

--- a/sktime/classification/compose/tests/test_ensemble.py
+++ b/sktime/classification/compose/tests/test_ensemble.py
@@ -72,7 +72,7 @@ def test_equivalent_model_specifications(n_intervals, n_estimators):
             "transform",
             FeatureUnion([("mean", mean_transformer), ("std", std_transformer)]),
         ),
-        ("clf", DecisionTreeClassifier(random_state=random_state)),
+        ("clf", DecisionTreeClassifier(random_state=random_state, max_depth=2)),
     ]
     clf1 = Pipeline(steps)
     clf1.fit(X_train, y_train)
@@ -87,7 +87,7 @@ def test_equivalent_model_specifications(n_intervals, n_estimators):
                 random_state=random_state,
             ),
         ),
-        ("clf", DecisionTreeClassifier(random_state=random_state)),
+        ("clf", DecisionTreeClassifier(random_state=random_state, max_depth=2)),
     ]
     clf2 = Pipeline(steps)
     clf2.fit(X_train, y_train)
@@ -97,7 +97,7 @@ def test_equivalent_model_specifications(n_intervals, n_estimators):
 
 # Compare TimeSeriesForest ensemble predictions using pipeline as
 # estimator
-@pytest.mark.parametrize("n_intervals", ["sqrt", 1, 3])
+@pytest.mark.parametrize("n_intervals", ["sqrt", 1])
 @pytest.mark.parametrize("n_estimators", [1, 3])
 def test_tsf_predictions(n_estimators, n_intervals):
     """Test TSF predictions."""
@@ -113,7 +113,7 @@ def test_tsf_predictions(n_estimators, n_intervals):
                 random_state=random_state, features=features
             ),
         ),
-        ("clf", DecisionTreeClassifier()),
+        ("clf", DecisionTreeClassifier(random_state=random_state, max_depth=2)),
     ]
     estimator = Pipeline(steps)
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
minimally reconfigures the test for ComposableTimeSeriesForestClassifier to speed them up. 

The testing contains this line
@pytest.mark.xfail(reason="SeriesToPrimitivesTransformer will be deprecated, see 2179")

not sure if this has been resolved. There is no code owner for ComposableTimeSeriesForestClassifier and I do not want to change the algorithm at all, so I am leaving this as is. 

