### PR TITLE
[BUG] Add missing submodules in classification.rst and regression.rst

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1835,6 +1835,15 @@
         "bug",
         "ideas"
       ]
+    },
+    {
+      "login": "GigaMoksh",
+      "name": "Mokshit Surana",
+      "avatar_url": "https://avatars.githubusercontent.com/u/72140092?v=4",
+      "profile": "https://github.com/GigaMoksh",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -16,6 +16,20 @@ Composition
 
     ColumnEnsembleClassifier
 
+Deep-Learning
+-------------
+
+.. current-module:: sktime.classification.deep_learning
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    CNNClassifier
+    FCNClassifier
+    MLPClassifier
+    TapNetClassifier
+
 Dictionary-based
 ----------------
 
@@ -58,6 +72,35 @@ Dummy
     :template: class.rst
 
     DummyClassifier
+
+Early-Classification
+--------------------
+
+.. currentmodule:: sktime.classification.early_classification
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ProbabilityThresholdEarlyClassifier
+    TEASER
+
+Feature-based
+-------------
+
+.. currentmodule:: sktime.classification.feature_based
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    Catch22Classifier
+    MatrixProfileClassifier
+    TSFreshClassifier
+    SignatureClassifier
+    FreshPRINCE
+    SummaryClassifier
+    RandomIntervalClassifier
 
 Hybrid
 ------
@@ -110,19 +153,3 @@ Kernel-based
     RocketClassifier
     Arsenal
 
-Feature-based
--------------
-
-.. currentmodule:: sktime.classification.feature_based
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    Catch22Classifier
-    MatrixProfileClassifier
-    TSFreshClassifier
-    SignatureClassifier
-    FreshPRINCE
-    SummaryClassifier
-    RandomIntervalClassifier

--- a/docs/source/api_reference/regression.rst
+++ b/docs/source/api_reference/regression.rst
@@ -20,6 +20,29 @@ Composition
 
     ComposableTimeSeriesForestRegressor
 
+Deep-Learning
+-------------
+
+.. currentmodule:: sktime.regression.deep_learning
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    CNNRegressor
+    TapNetRegressor
+
+Distance-based
+--------------
+
+.. currentmodule:: sktime.regression.distance_based
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    KNeighborsTimeSeriesRegressor
+
 Interval-based
 --------------
 
@@ -30,3 +53,14 @@ Interval-based
     :template: class.rst
 
     TimeSeriesForestRegressor
+
+Kernel-based
+------------
+
+.. currentmodule:: sktime.regression.kernel_based
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    RocketRegressor


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #3314

#### What does this implement/fix? Explain your changes.
Added submodules `deep_learning`, `distance_based` and `kernel_based` in `regression.rst` and submodules `early_classification` and `deep_learning` in `classification.rst`

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
To check if all submodules in `regression.rst` and `classification.rst` are added

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

