### PR TITLE
[BUG] Fix ContinuousIntervalTree and RandomShapeletTransform deprecation warnings

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,6 +37,7 @@ sktime/transformations/panel/dictionary_based/_sax.py @patrickzib @MatthewMiddle
 sktime/transformations/panel/dictionary_based/_sfa.py @patrickzib @MatthewMiddlehurst
 sktime/transformations/panel/dictionary_based/_sfa_fast.py @patrickzib @MatthewMiddlehurst
 sktime/transformations/panel/catch22.py @MatthewMiddlehurst
+sktime/transformations/panel/catch22wrapper.py @MatthewMiddlehurst
 sktime/transformations/panel/random_intervals.py @MatthewMiddlehurst
 sktime/transformations/panel/shapelet_transform.py @jasonlines @ABostrom @MatthewMiddlehurst @TonyBagnall
 sktime/transformations/panel/supervised_intervals.py @MatthewMiddlehurst

--- a/sktime/classification/sklearn/_continuous_interval_tree.py
+++ b/sktime/classification/sklearn/_continuous_interval_tree.py
@@ -669,7 +669,7 @@ def _drcif_feature(X, interval, dim, att, c22, case_id=None):
     if att > 21:
         return _summary_stat(X[:, dim, interval[0] : interval[1]], att)
     else:
-        return c22.transform_single_feature(
+        return c22._transform_single_feature(
             X[:, dim, interval[0] : interval[1]], att, case_id=case_id
         )
 

--- a/sktime/transformations/panel/catch22.py
+++ b/sktime/transformations/panel/catch22.py
@@ -302,6 +302,9 @@ class Catch22(BaseTransformer):
         -------
         Numpy array containing a catch22 feature for each input series.
         """
+        self._transform_single_feature(X, feature, case_id)
+
+    def _transform_single_feature(self, X, feature, case_id=None):
         if isinstance(feature, (int, np.integer)) or isinstance(
             feature, (float, float)
         ):


### PR DESCRIPTION
Solves the deprecation part of #3788 by changing the catch22 function used in `ContinuousIntervalTree` and integrating `numba` typed-lists into `RandomShapeletTransform`.

Additionally:
- Adds myself as the CODEOWNER of `catch22wrapper.py` (missed from the PR adding it)
- Adds a `parallel_backend` parameter to RandomShapeletTransform and sets the preferred default to "threads"