### PR TITLE
[BUG] decouple forecasting pipeline module from registry

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from sktime.base import _HeterogenousMetaEstimator
 from sktime.forecasting.base._base import BaseForecaster
-from sktime.registry import scitype
+from sktime.transformations.base import BaseTransformer
 from sktime.utils.validation.series import check_series
 
 
@@ -21,7 +21,17 @@ class _Pipeline(
 
     def _get_pipeline_scitypes(self, estimators):
         """Get list of scityes (str) from names/estimator list."""
-        return [scitype(x[1]) for x in estimators]
+
+        def est_scitype(tpl):
+            est = tpl[1]
+            if isinstance(est, BaseForecaster):
+                return "forecaster"
+            elif isinstance(est, BaseTransformer):
+                return "transformer"
+            else:
+                return "other"
+
+        return [est_scitype(x) for x in estimators]
 
     def _get_forecaster_index(self, estimators):
         """Get the index of the first forecaster in the list."""


### PR DESCRIPTION
This PR decouples the forecasting pipeline module `forecasting.compose._pipeline` from the `registry` module, fixing some of the import coupling and `numba` related issues in https://github.com/sktime/sktime/issues/3660.

With this, only test modules, the `all` modules and utils should import from the `registry`, and no estimators.