### PR TITLE
[BUG] exclude TapNet from tests

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -29,6 +29,9 @@ EXCLUDE_ESTIMATORS = [
     "RandomIntervalClassifier",
     "MiniRocket",
     "MatrixProfileTransformer",
+    # TapNet excluded to test CI
+    "TapNetRegressor",
+    "TapNetClassifier",
 ]
 
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -29,7 +29,7 @@ EXCLUDE_ESTIMATORS = [
     "RandomIntervalClassifier",
     "MiniRocket",
     "MatrixProfileTransformer",
-    # TapNet excluded to test CI
+    # tapnet based estimators fail stochastically for unknown reasons, see #3525
     "TapNetRegressor",
     "TapNetClassifier",
 ]


### PR DESCRIPTION
Tests are failing for strange reasons, see for example
https://github.com/sktime/sktime/actions/runs/3492869189/jobs/5847895424
I cannot reproduce locally. TapNet was excluded but recently put back in. This PR is just to test to see if it is the root of the problem