### PR TITLE
[MNT] temporary skip of new failure `test_deep_estimator_full[keras-adamax]`

### DIFF
--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -469,6 +469,7 @@ def test_deep_estimator_empty():
     assert empty_dummy.__dict__ == deserialized_empty.__dict__
 
 
+@pytest.mark.xfail(reason="known failure of unknown cause, see #3816")
 @pytest.mark.parametrize("optimizer", [None, "adam", "keras-adamax"])
 def test_deep_estimator_full(optimizer):
     """Check if serialization works for full dummy."""


### PR DESCRIPTION
This PR temporarily skips the new failure `test_deep_estimator_full[keras-adamax]`, possibly coming from an update in the dependencies.

See here for the failure: https://github.com/sktime/sktime/issues/3816