### PR TITLE
[GOV] transparent fiscal reporting requirements on core developers

### DIFF
--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -212,6 +212,19 @@ Rights and responsibilities
      - They can participate in the decision making process by vetoing changes and casting votes.
    * - Nomination
      - They can nominate new core developers, CoC committee members and CC members.
+   * - Fiscal reporting
+     - Core developers are expected to conform to public fiscal reporting requirements as below.
+
+Fiscal reporting requirements:
+
+* at the start of every calendar quarter, core developers must report openly and publicly whether
+  they have been administering funds on behalf of ``sktime`` in the past calendar quarter.
+* if the answer to the above is "yes", they must further provide a public description of
+  scope, purpose, and source of funds. They also must publish monthly budget reports on
+  the funds administered.
+* Publication of materials above happens in a location prescribed by the ``sktime`` community.
+  Monthly budget reports must be published no longer than three calendar months
+  after the end of the reported month.
 
 Eligibility
 ^^^^^^^^^^^
@@ -255,6 +268,11 @@ Becoming active (after becoming inactive) in the above sense requires one of:
 
 * an approved pull request authored by the core developer
 * a contribution to the community that is minuted in one of the regular meetings
+
+Core developers found in breach of fiscal reporting requirements are removed from their role,
+and they must transfer control of funds administered to the ``sktime`` project.
+Removal through this rule does not void any reporting requirements
+for funds administered on behalf of ``sktime``.
 
 .. _coc-committee-members:
 


### PR DESCRIPTION
This PR makes explicit expectations on public fiscal reporting by core developers.

In summary, core developers must publicly report whether they are administering funds on behalf of `sktime`, and a high-level budget. Funds administered not on behalf of `sktime` are not subject to this rule. This also proposes to make violation of public reporting rules to trigger removal.

Example situations this is meant to address:

* "hard embezzlement" - e.g., core dev A handling donations from company/person B, claiming towards B that it is on behalf of `sktime`, but not reporting it to `sktime` and instead using the donations on their own.
* "soft embezzlement" ß e.g., core dev A handling donations or public taxpayer money, claiming towards the donor or public funder to do this on behalf of `sktime`, but handling the money outside of `sktime` decision making mechanisms, e.g., through a charity separate from `sktime`/`numfocus` where core dev A is the sole person in control
* violation of conflict of interest or anti-bribery/anti-corruption/anti-trust reporting requirements at a public sector entity or company. E.g., core dev A working at government entity or company B which requires internal reporting of funds administered externally under certain conditions. Core dev A declaring towards company B that they are not administering funds, but in fact are administering `sktime` funds.

