### PR TITLE
[MNT] isolate `statsmodels`, part 4: isolating `statsmodels` in non-suite tests

### DIFF
--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -1050,7 +1050,7 @@ def load_macroeconomic():
     Examples
     --------
     >>> from sktime.datasets import load_macroeconomic
-    >>> y = load_macroeconomic()
+    >>> y = load_macroeconomic()  # doctest: +SKIP
 
     Notes
     -----

--- a/sktime/datasets/tests/test_loaders.py
+++ b/sktime/datasets/tests/test_loaders.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""Test functions for loose loaers."""
+
+__author__ = ["fkiraly"]
+
+__all__ = []
+
+
+import pytest
+
+from sktime.utils.validation._dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_load_macroeconomic():
+    """Test that load_macroeconomic runs."""
+    from sktime.datasets import load_macroeconomic
+    load_macroeconomic()

--- a/sktime/datasets/tests/test_loaders.py
+++ b/sktime/datasets/tests/test_loaders.py
@@ -18,4 +18,5 @@ from sktime.utils.validation._dependencies import _check_soft_dependencies
 def test_load_macroeconomic():
     """Test that load_macroeconomic runs."""
     from sktime.datasets import load_macroeconomic
+
     load_macroeconomic()

--- a/sktime/forecasting/ardl.py
+++ b/sktime/forecasting/ardl.py
@@ -179,17 +179,18 @@ class ARDL(_StatsModelsAdapter):
     >>> from sktime.datasets import load_macroeconomic
     >>> from sktime.forecasting.ardl import ARDL
     >>> from sktime.forecasting.base import ForecastingHorizon
-    >>> data = load_macroeconomic()
-    >>> oos = data.iloc[-5:, :]
-    >>> data = data.iloc[:-5, :]
-    >>> y = data.realgdp
-    >>> X = data[["realcons", "realinv"]]
-    >>> X_oos = oos[["realcons", "realinv"]]
-    >>> ardl = ARDL(lags=2, order={"realcons": 1, "realinv": 2}, trend="c")
-    >>> ardl.fit(y=y, X=X)
+    >>> data = load_macroeconomic()  # doctest: +SKIP
+    >>> oos = data.iloc[-5:, :]  # doctest: +SKIP
+    >>> data = data.iloc[:-5, :]  # doctest: +SKIP
+    >>> y = data.realgdp  # doctest: +SKIP
+    >>> X = data[["realcons", "realinv"]]  # doctest: +SKIP
+    >>> X_oos = oos[["realcons", "realinv"]]  # doctest: +SKIP
+    >>> ardl = ARDL(lags=2, order={"realcons": 1, "realinv": 2}, trend="c")\
+    # doctest: +SKIP
+    >>> ardl.fit(y=y, X=X)  # doctest: +SKIP
     ARDL(lags=2, order={'realcons': 1, 'realinv': 2})
-    >>> fh = ForecastingHorizon([1, 2, 3])
-    >>> y_pred = ardl.predict(fh=fh, X=X_oos)
+    >>> fh = ForecastingHorizon([1, 2, 3])  # doctest: +SKIP
+    >>> y_pred = ardl.predict(fh=fh, X=X_oos)  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -274,6 +274,10 @@ def test_vectorization_multivariate(mtype, exogeneous):
     assert y_pred_equal_length, msg
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_dynamic_tags_reset_properly():
     """Test that dynamic tags are being reset properly."""
     from sktime.forecasting.compose import MultiplexForecaster
@@ -290,6 +294,10 @@ def test_dynamic_tags_reset_properly():
     f.fit(X_multivariate)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_predict_residuals():
     """Test that predict_residuals has no side-effect."""
     from sktime.forecasting.base import ForecastingHorizon

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -435,6 +435,10 @@ def test_to_absolute_int_fh_with_freq(idx: int, freq: str):
     assert_array_equal(fh + idx, absolute_int)
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(AutoETS, severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
 @pytest.mark.parametrize("freqstr", ["W-WED", "W-SUN", "W-SAT"])
 def test_estimator_fh(freqstr):
     """Test model fitting with anchored frequency."""

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -475,6 +475,10 @@ def test_frequency_setter(freqstr):
 
 
 # TODO: Replace this long running test with fast unit test
+@pytest.mark.skipif(
+    not _check_estimator_deps(AutoETS, severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
 def test_auto_ets():
     """Fix bug in 1435.
 
@@ -495,6 +499,10 @@ def test_auto_ets():
 
 
 # TODO: Replace this long running test with fast unit test
+@pytest.mark.skipif(
+    not _check_estimator_deps(ExponentialSmoothing, severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
 def test_exponential_smoothing():
     """Test bug in 1876.
 

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -480,7 +480,7 @@ def test_frequency_setter(freqstr):
     reason="skip test if required soft dependency for hmmlearn not available",
 )
 def test_auto_ets():
-    """Fix bug in 1435.
+    """Test failure case from #1435.
 
     https://github.com/sktime/sktime/issues/1435#issue-1000175469
     """
@@ -504,7 +504,7 @@ def test_auto_ets():
     reason="skip test if required soft dependency for hmmlearn not available",
 )
 def test_exponential_smoothing():
-    """Test bug in 1876.
+    """Test failure case from #1876.
 
     https://github.com/sktime/sktime/issues/1876#issue-1103752402.
     """
@@ -533,7 +533,7 @@ def test_exponential_smoothing():
     reason="skip test if required soft dependencies not available",
 )
 def test_auto_arima():
-    """Test bug in 805.
+    """Test failure case from #805.
 
     https://github.com/sktime/sktime/issues/805#issuecomment-891848228.
     """

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -82,10 +82,10 @@ class BaggingForecaster(BaseForecaster):
     >>> y = load_airline()
     >>> forecaster = BaggingForecaster(
     ...     STLBootstrapTransformer(sp=12), NaiveForecaster(sp=12)
-    ... )
-    >>> forecaster.fit(y)
+    ... )  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
     BaggingForecaster(...)
-    >>> y_hat = forecaster.predict([1,2,3])
+    >>> y_hat = forecaster.predict([1,2,3])  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -47,10 +47,10 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
     >>> from sktime.forecasting.compose import ColumnEnsembleForecaster
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.forecasting.trend import PolynomialTrendForecaster
-    >>> from sktime.datasets import load_macroeconomic
+    >>> from sktime.datasets import load_longley
 
-    Using integers (column iloc refernces= for indexing:
-    >>> y = load_macroeconomic()[["realgdp", "realcons"]]
+    Using integers (column iloc references) for indexing:
+    >>> y = load_longley()[["GNP", "UNEMP"]]
     >>> forecasters = [
     ...     ("trend", PolynomialTrendForecaster(), 0),
     ...     ("naive", NaiveForecaster(), 1),

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -45,7 +45,6 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
     Examples
     --------
     >>> from sktime.forecasting.compose import ColumnEnsembleForecaster
-    >>> from sktime.forecasting.exp_smoothing import ExponentialSmoothing
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.forecasting.trend import PolynomialTrendForecaster
     >>> from sktime.datasets import load_macroeconomic
@@ -54,7 +53,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
     >>> y = load_macroeconomic()[["realgdp", "realcons"]]
     >>> forecasters = [
     ...     ("trend", PolynomialTrendForecaster(), 0),
-    ...     ("ses", ExponentialSmoothing(trend='add'), 1),
+    ...     ("naive", NaiveForecaster(), 1),
     ... ]
     >>> forecaster = ColumnEnsembleForecaster(forecasters=forecasters)
     >>> forecaster.fit(y, fh=[1, 2, 3])

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -50,7 +50,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
     >>> from sktime.datasets import load_longley
 
     Using integers (column iloc references) for indexing:
-    >>> y = load_longley()[["GNP", "UNEMP"]]
+    >>> y = load_longley()[1][["GNP", "UNEMP"]]
     >>> forecasters = [
     ...     ("trend", PolynomialTrendForecaster(), 0),
     ...     ("naive", NaiveForecaster(), 1),

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -68,15 +68,15 @@ class MultiplexForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     >>> forecaster = MultiplexForecaster(forecasters=[
     ...     ("ets", AutoETS()),
     ...     ("theta", ThetaForecaster()),
-    ...     ("naive", NaiveForecaster())])
+    ...     ("naive", NaiveForecaster())])  # doctest: +SKIP
     >>> cv = ExpandingWindowSplitter(
     ...     start_with_window=True,
-    ...     step_length=12)
+    ...     step_length=12)  # doctest: +SKIP
     >>> gscv = ForecastingGridSearchCV(
     ...     cv=cv,
     ...     param_grid={"selected_forecaster":["ets", "theta", "naive"]},
-    ...     forecaster=forecaster)
-    >>> gscv.fit(y)
+    ...     forecaster=forecaster)  # doctest: +SKIP
+    >>> gscv.fit(y)  # doctest: +SKIP
     ForecastingGridSearchCV(...)
     """
 

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -665,14 +665,14 @@ class TransformedTargetForecaster(_Pipeline):
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.forecasting.compose import TransformedTargetForecaster
     >>> from sktime.transformations.series.impute import Imputer
-    >>> from sktime.transformations.series.detrend import Deseasonalizer
+    >>> from sktime.transformations.series.detrend import Detrender
     >>> from sktime.transformations.series.exponent import ExponentTransformer
     >>> y = load_airline()
 
         Example 1: string/estimator pairs
     >>> pipe = TransformedTargetForecaster(steps=[
     ...     ("imputer", Imputer(method="mean")),
-    ...     ("detrender", Deseasonalizer()),
+    ...     ("detrender", Detrender()),
     ...     ("forecaster", NaiveForecaster(strategy="drift")),
     ... ])
     >>> pipe.fit(y)
@@ -682,7 +682,7 @@ class TransformedTargetForecaster(_Pipeline):
         Example 2: without strings
     >>> pipe = TransformedTargetForecaster([
     ...     Imputer(method="mean"),
-    ...     Deseasonalizer(),
+    ...     Detrender(),
     ...     NaiveForecaster(strategy="drift"),
     ...     ExponentTransformer(),
     ... ])
@@ -690,7 +690,7 @@ class TransformedTargetForecaster(_Pipeline):
         Example 3: using the dunder method
     >>> forecaster = NaiveForecaster(strategy="drift")
     >>> imputer = Imputer(method="mean")
-    >>> pipe = imputer * Deseasonalizer() * forecaster * ExponentTransformer()
+    >>> pipe = imputer * Detrender() * forecaster * ExponentTransformer()
     """
 
     _tags = {

--- a/sktime/forecasting/compose/tests/test_bagging.py
+++ b/sktime/forecasting/compose/tests/test_bagging.py
@@ -17,6 +17,10 @@ from sktime.utils.validation._dependencies import _check_soft_dependencies
 y = load_airline()
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
 @pytest.mark.parametrize("transformer", [LogTransformer, NaiveForecaster])
 def test_bagging_forecaster_transformer_type_error(transformer):
     """Test that the right exception is raised for invalid transformer."""

--- a/sktime/forecasting/compose/tests/test_bagging.py
+++ b/sktime/forecasting/compose/tests/test_bagging.py
@@ -12,6 +12,7 @@ from sktime.forecasting.compose._bagging import _calculate_data_quantiles
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.transformations.bootstrap import STLBootstrapTransformer
 from sktime.transformations.series.boxcox import LogTransformer
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 y = load_airline()
 
@@ -31,6 +32,10 @@ def test_bagging_forecaster_transformer_type_error(transformer):
         assert msg == ex.value
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
 @pytest.mark.parametrize("forecaster", [LogTransformer])
 def test_bagging_forecaster_forecaster_type_error(forecaster):
     """Test that the right exception is raised for invalid forecaster."""

--- a/sktime/forecasting/compose/tests/test_column_ensemble.py
+++ b/sktime/forecasting/compose/tests/test_column_ensemble.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pytest
 
 from sktime.forecasting.compose import ColumnEnsembleForecaster
-from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.utils.validation._dependencies import _check_soft_dependencies
@@ -22,7 +21,7 @@ from sktime.utils.validation._dependencies import _check_soft_dependencies
         [
             ("trend", PolynomialTrendForecaster(), 0),
             ("naive", NaiveForecaster(), 1),
-            ("ses", ExponentialSmoothing(), 2),
+            ("ses", NaiveForecaster(strategy="mean"), 2),
         ]
     ],
 )

--- a/sktime/forecasting/compose/tests/test_ensemble.py
+++ b/sktime/forecasting/compose/tests/test_ensemble.py
@@ -12,7 +12,6 @@ import pytest
 
 from sktime.forecasting.compose import EnsembleForecaster
 from sktime.forecasting.compose._ensemble import VALID_AGG_FUNCS
-from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.forecasting.var import VAR
@@ -23,7 +22,7 @@ from sktime.utils._testing.forecasting import make_forecasting_problem
     "forecasters",
     [
         [("trend", PolynomialTrendForecaster()), ("naive", NaiveForecaster())],
-        [("trend", PolynomialTrendForecaster()), ("ses", ExponentialSmoothing())],
+        [("trend", PolynomialTrendForecaster(degree=2)), ("naive", NaiveForecaster())],
     ],
 )
 def test_avg_mean(forecasters):
@@ -49,7 +48,7 @@ def test_avg_mean(forecasters):
             pd.DataFrame(make_forecasting_problem()),
         ),
         (
-            [("var", VAR()), ("naive", NaiveForecaster())],
+            [("var", NaiveForecaster(strategy="drift")), ("naive", NaiveForecaster())],
             make_forecasting_problem(n_columns=3),
         ),
     ],

--- a/sktime/forecasting/compose/tests/test_ensemble.py
+++ b/sktime/forecasting/compose/tests/test_ensemble.py
@@ -14,7 +14,6 @@ from sktime.forecasting.compose import EnsembleForecaster
 from sktime.forecasting.compose._ensemble import VALID_AGG_FUNCS
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.forecasting.trend import PolynomialTrendForecaster
-from sktime.forecasting.var import VAR
 from sktime.utils._testing.forecasting import make_forecasting_problem
 
 
@@ -90,7 +89,7 @@ def test_aggregation_unweighted(forecasters, y, aggfunc):
             pd.DataFrame(make_forecasting_problem()),
         ),
         (
-            [("var", VAR()), ("naive", NaiveForecaster())],
+            [("var", NaiveForecaster(strategy="drift")), ("naive", NaiveForecaster())],
             make_forecasting_problem(n_columns=3),
         ),
     ],

--- a/sktime/forecasting/compose/tests/test_multiplex.py
+++ b/sktime/forecasting/compose/tests/test_multiplex.py
@@ -37,6 +37,10 @@ def _score_forecasters(forecasters, cv, y):
     return best_name
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(ThetaForecaster, severity="none"),
+    reason="skip test if required soft dependency is not available",
+)
 def test_multiplex_forecaster_alone():
     """Test results of MultiplexForecaster.
 
@@ -81,8 +85,8 @@ def test_multiplex_with_grid_search():
     """
     y = load_shampoo_sales()
     forecasters = [
-        ("ets", AutoETS()),
-        ("naive", NaiveForecaster()),
+        ("naive1", NaiveForecaster()),
+        ("naive2", NaiveForecaster(strategy="mean")),
     ]
     multiplex_forecaster = MultiplexForecaster(forecasters=forecasters)
     forecaster_names = [name for name, _ in forecasters]

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -100,6 +100,10 @@ def test_skip_inverse_transform():
     assert isinstance(y_pred, pd.Series)
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(AutoETS, severity="none"),
+    reason="skip test if required soft dependency is not available",
+)
 def test_nesting_pipelines():
     """Test that nesting of pipelines works."""
     from sktime.forecasting.ets import AutoETS

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -8,6 +8,7 @@ __all__ = []
 
 import numpy as np
 import pandas as pd
+import pytest
 from sklearn.preprocessing import MinMaxScaler, StandardScaler
 from sklearn.svm import SVR
 
@@ -39,6 +40,7 @@ from sktime.transformations.series.outlier_detection import HampelFilter
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 from sktime.utils._testing.series import _make_series
 from sktime.utils.estimators import MockForecaster
+from sktime.utils.validation._dependencies import _check_estimator_deps
 
 
 def test_pipeline():
@@ -210,6 +212,10 @@ def test_pipeline_with_dimension_changing_transformer():
     gscv.fit(train_model, X=X_train)
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(SARIMAX, severity="none"),
+    reason="skip test if required soft dependency is not available",
+)
 def test_nested_pipeline_with_index_creation_y_before_X():
     """Tests a nested pipeline where y indices are created before X indices.
 
@@ -235,6 +241,10 @@ def test_nested_pipeline_with_index_creation_y_before_X():
     assert len(y_pred) == 9
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(SARIMAX, severity="none"),
+    reason="skip test if required soft dependency is not available",
+)
 def test_nested_pipeline_with_index_creation_X_before_y():
     """Tests a nested pipeline where X indices are created before y indices.
 
@@ -296,6 +306,10 @@ def test_forecasting_pipeline_dunder_endog():
     np.testing.assert_array_equal(actual, expected)
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(SARIMAX, severity="none"),
+    reason="skip test if required soft dependency is not available",
+)
 def test_forecasting_pipeline_dunder_exog():
     """Test forecasting pipeline dunder for exogeneous transformation."""
     y = _make_series()
@@ -372,6 +386,10 @@ def test_tag_handles_missing_data():
     X_pipe.fit(y)
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(SARIMAX, severity="none"),
+    reason="skip test if required soft dependency is not available",
+)
 def test_subset_getitem():
     """Test subsetting using the [ ] dunder, __getitem__."""
     y = _make_series(n_columns=3)

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -40,7 +40,10 @@ from sktime.transformations.series.outlier_detection import HampelFilter
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 from sktime.utils._testing.series import _make_series
 from sktime.utils.estimators import MockForecaster
-from sktime.utils.validation._dependencies import _check_estimator_deps
+from sktime.utils.validation._dependencies import (
+    _check_estimator_deps,
+    _check_soft_dependencies,
+)
 
 
 def test_pipeline():
@@ -101,7 +104,7 @@ def test_skip_inverse_transform():
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(AutoETS, severity="none"),
+    not _check_soft_dependencies("statsmodels", severity="none"),
     reason="skip test if required soft dependency is not available",
 )
 def test_nesting_pipelines():

--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -118,10 +118,10 @@ class DynamicFactor(_StatsModelsAdapter):
     >>> from sktime.utils._testing.series import _make_series
     >>> from sktime.forecasting.dynamic_factor import DynamicFactor
     >>> y = _make_series(n_columns=4)
-    >>> forecaster = DynamicFactor()
-    >>> forecaster.fit(y)
+    >>> forecaster = DynamicFactor()  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
     DynamicFactor(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])
+    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -160,10 +160,10 @@ class AutoETS(_StatsModelsAdapter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.ets import AutoETS
     >>> y = load_airline()
-    >>> forecaster = AutoETS(auto=True, n_jobs=-1, sp=12)
-    >>> forecaster.fit(y)
+    >>> forecaster = AutoETS(auto=True, n_jobs=-1, sp=12)  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
     AutoETS(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])
+    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
     """
 
     _fitted_param_names = ("aic", "aicc", "bic", "hqic")

--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -103,8 +103,9 @@ class ExponentialSmoothing(_StatsModelsAdapter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.exp_smoothing import ExponentialSmoothing
     >>> y = load_airline()
-    >>> forecaster = ExponentialSmoothing(trend='add', seasonal='multiplicative', sp=12)
-    # doctest: +SKIP
+    >>> forecaster = ExponentialSmoothing(
+    ...     trend='add', seasonal='multiplicative', sp=12
+    ... )  # doctest: +SKIP
     >>> forecaster.fit(y)  # doctest: +SKIP
     ExponentialSmoothing(...)
     >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP

--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -104,9 +104,10 @@ class ExponentialSmoothing(_StatsModelsAdapter):
     >>> from sktime.forecasting.exp_smoothing import ExponentialSmoothing
     >>> y = load_airline()
     >>> forecaster = ExponentialSmoothing(trend='add', seasonal='multiplicative', sp=12)
-    >>> forecaster.fit(y)
+    # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
     ExponentialSmoothing(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])
+    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
     """
 
     _fitted_param_names = (

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -224,7 +224,8 @@ class BaseGridSearch(_DelegatedForecaster):
         # Raise error if all fits in evaluate failed because all score values are NaN.
         if self.best_index_ == -1:
             raise NotFittedError(
-                f"""All fits of forecaster failed, set error_score='raise' to see the exceptions.
+                f"""All fits of forecaster failed,
+                set error_score='raise' to see the exceptions.
                 Failed forecaster: {self.forecaster}"""
             )
         self.best_score_ = results.loc[self.best_index_, f"mean_{scoring_name}"]
@@ -437,10 +438,10 @@ class ForecastingGridSearchCV(BaseGridSearch):
     ...     },
     ...     ],
     ...     cv=cv,
-    ...     n_jobs=-1)
-    >>> gscv.fit(y)
+    ...     n_jobs=-1)  # doctest: +SKIP
+    >>> gscv.fit(y)  # doctest: +SKIP
     ForecastingGridSearchCV(...)
-    >>> y_pred = gscv.predict(fh=[1,2,3])
+    >>> y_pred = gscv.predict(fh=[1,2,3])  # doctest: +SKIP
     """
 
     def __init__(

--- a/sktime/forecasting/online_learning/tests/test_online_learning.py
+++ b/sktime/forecasting/online_learning/tests/test_online_learning.py
@@ -6,6 +6,7 @@
 __author__ = ["magittan"]
 
 import numpy as np
+import pytest
 from sklearn.metrics import mean_squared_error
 
 from sktime.datasets import load_airline
@@ -20,10 +21,15 @@ from sktime.forecasting.online_learning._prediction_weighted_ensembler import (
     NNLSEnsemble,
     NormalHedgeEnsemble,
 )
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 cv = SlidingWindowSplitter(start_with_window=True, window_length=1, fh=1)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
 def test_weights_for_airline_averaging():
     """Test weights."""
     y = load_airline()

--- a/sktime/forecasting/reconcile.py
+++ b/sktime/forecasting/reconcile.py
@@ -75,7 +75,7 @@ class ReconcilerForecaster(BaseForecaster):
     ...     random_seed=123,
     ... )
     >>> y = agg.fit_transform(y)
-    >>> forecaster = NaiveForecaster(strategy="drift)
+    >>> forecaster = NaiveForecaster(strategy="drift")
     >>> reconciler = ReconcilerForecaster(forecaster, method="mint_shrink")
     >>> reconciler.fit(y)
     ReconcilerForecaster(...)

--- a/sktime/forecasting/reconcile.py
+++ b/sktime/forecasting/reconcile.py
@@ -64,7 +64,7 @@ class ReconcilerForecaster(BaseForecaster):
 
     Examples
     --------
-    >>> from sktime.forecasting.exp_smoothing import ExponentialSmoothing
+    >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.forecasting.reconcile import ReconcilerForecaster
     >>> from sktime.transformations.hierarchical.aggregate import Aggregator
     >>> from sktime.utils._testing.hierarchical import _bottom_hier_datagen
@@ -75,7 +75,7 @@ class ReconcilerForecaster(BaseForecaster):
     ...     random_seed=123,
     ... )
     >>> y = agg.fit_transform(y)
-    >>> forecaster = ExponentialSmoothing()
+    >>> forecaster = NaiveForecaster(strategy="drift)
     >>> reconciler = ReconcilerForecaster(forecaster, method="mint_shrink")
     >>> reconciler.fit(y)
     ReconcilerForecaster(...)

--- a/sktime/forecasting/sarimax.py
+++ b/sktime/forecasting/sarimax.py
@@ -106,10 +106,12 @@ class SARIMAX(_StatsModelsAdapter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.sarimax import SARIMAX
     >>> y = load_airline()
-    >>> forecaster = SARIMAX(order=(1, 0, 0), trend="t", seasonal_order=(1, 0, 0, 6))
-    >>> forecaster.fit(y)
+    >>> forecaster = SARIMAX(
+    ...     order=(1, 0, 0), trend="t", seasonal_order=(1, 0, 0, 6))  # doctest: +SKIP
+    ... )
+    >>> forecaster.fit(y)  # doctest: +SKIP
     SARIMAX(...)
-    >>> y_pred = forecaster.predict(fh=y.index)
+    >>> y_pred = forecaster.predict(fh=y.index)  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/forecasting/squaring_residuals.py
+++ b/sktime/forecasting/squaring_residuals.py
@@ -74,8 +74,8 @@ class SquaringResiduals(BaseForecaster):
     >>> fc = NaiveForecaster()
     >>> var_fc = ThetaForecaster()  # doctest: +SKIP
     >>> y = load_macroeconomic().realgdp  # doctest: +SKIP
-    >>> sqr = SquaringResiduals(forecaster=fc, residual_forecaster=var_fc)\
-        # doctest: +SKIP
+    >>> sqr = SquaringResiduals(forecaster=fc, residual_forecaster=var_fc)
+    ... # doctest: +SKIP
     >>> fh = ForecastingHorizon(values=[1, 2, 3])  # doctest: +SKIP
     >>> sqr = sqr.fit(y, fh=fh)  # doctest: +SKIP
     >>> pred_interval = sqr.predict_interval(coverage=0.95)  # doctest: +SKIP

--- a/sktime/forecasting/squaring_residuals.py
+++ b/sktime/forecasting/squaring_residuals.py
@@ -72,12 +72,13 @@ class SquaringResiduals(BaseForecaster):
     >>> from sktime.forecasting.theta import ThetaForecaster
     >>> from sktime.forecasting.squaring_residuals import SquaringResiduals
     >>> fc = NaiveForecaster()
-    >>> var_fc = ThetaForecaster()
-    >>> y = load_macroeconomic().realgdp
-    >>> sqr = SquaringResiduals(forecaster=fc, residual_forecaster=var_fc)
-    >>> fh = ForecastingHorizon(values=[1, 2, 3])
-    >>> sqr = sqr.fit(y, fh=fh)
-    >>> pred_interval = sqr.predict_interval(coverage=0.95)
+    >>> var_fc = ThetaForecaster()  # doctest: +SKIP
+    >>> y = load_macroeconomic().realgdp  # doctest: +SKIP
+    >>> sqr = SquaringResiduals(forecaster=fc, residual_forecaster=var_fc)\
+    # doctest: +SKIP
+    >>> fh = ForecastingHorizon(values=[1, 2, 3])  # doctest: +SKIP
+    >>> sqr = sqr.fit(y, fh=fh)  # doctest: +SKIP
+    >>> pred_interval = sqr.predict_interval(coverage=0.95)  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/forecasting/squaring_residuals.py
+++ b/sktime/forecasting/squaring_residuals.py
@@ -75,7 +75,7 @@ class SquaringResiduals(BaseForecaster):
     >>> var_fc = ThetaForecaster()  # doctest: +SKIP
     >>> y = load_macroeconomic().realgdp  # doctest: +SKIP
     >>> sqr = SquaringResiduals(forecaster=fc, residual_forecaster=var_fc)\
-    # doctest: +SKIP
+        # doctest: +SKIP
     >>> fh = ForecastingHorizon(values=[1, 2, 3])  # doctest: +SKIP
     >>> sqr = sqr.fit(y, fh=fh)  # doctest: +SKIP
     >>> pred_interval = sqr.predict_interval(coverage=0.95)  # doctest: +SKIP

--- a/sktime/forecasting/structural.py
+++ b/sktime/forecasting/structural.py
@@ -192,10 +192,10 @@ class UnobservedComponents(_StatsModelsAdapter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.structural import UnobservedComponents
     >>> y = load_airline()
-    >>> forecaster = UnobservedComponents(level='local linear trend')
-    >>> forecaster.fit(y)
+    >>> forecaster = UnobservedComponents(level='local linear trend')  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
     UnobservedComponents(...)
-    >>> y_pred = forecaster.predict(fh=[1, 2, 3])
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/forecasting/tests/test_ets.py
+++ b/sktime/forecasting/tests/test_ets.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_array_equal
 
 from sktime.datasets import load_airline
 from sktime.forecasting.ets import AutoETS
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 # test results against R implementation on airline dataset
 y = load_airline()
@@ -21,6 +22,10 @@ inf_ic_ts = pd.Series(
 )
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_airline_default():
     """
     Default condition.
@@ -43,6 +48,10 @@ def test_airline_default():
     assert_array_equal(fit_result_R, fit_result)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 @pytest.mark.xfail(reason="flaky results on linux")
 def test_airline_allow_multiplicative_trend():
     """
@@ -68,6 +77,10 @@ def test_airline_allow_multiplicative_trend():
     assert_array_equal(fit_result_R, fit_result)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_inf_ic_true():
     """Ignore infinite IC models when ignore_inf_ic is `True`."""
     forecaster = AutoETS(auto=True, sp=52, n_jobs=-1, ignore_inf_ic=True)
@@ -81,6 +94,10 @@ def test_inf_ic_true():
     )
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 @pytest.mark.xfail
 def test_inf_ic_false():
     """Don't ignore infinite IC models when ignore_inf_ic is False."""

--- a/sktime/forecasting/tests/test_reconcile.py
+++ b/sktime/forecasting/tests/test_reconcile.py
@@ -14,6 +14,7 @@ from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.reconcile import ReconcilerForecaster
 from sktime.transformations.hierarchical.aggregate import Aggregator
 from sktime.utils._testing.hierarchical import _bottom_hier_datagen
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 # get all the methods
 METHOD_LIST = ReconcilerForecaster.METHOD_LIST
@@ -22,6 +23,10 @@ METHOD_LIST = ReconcilerForecaster.METHOD_LIST
 # test the reconciled predictions are actually hierarchical
 # test the index/columns on the g and s matrices match
 # test it works for named and unnamed indexes
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 @pytest.mark.parametrize("method", METHOD_LIST)
 def test_reconciler_fit_predict(method):
     """Tests fit_predict and output of ReconcilerForecaster.

--- a/sktime/forecasting/tests/test_theta.py
+++ b/sktime/forecasting/tests/test_theta.py
@@ -13,9 +13,14 @@ from sktime.datasets import load_airline
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.forecasting.tests._config import TEST_OOS_FHS
 from sktime.forecasting.theta import ThetaForecaster, ThetaModularForecaster
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 from sktime.utils.validation.forecasting import check_fh
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_predictive_performance_on_airline():
     """Check prediction performance on airline dataset.
 
@@ -36,6 +41,10 @@ def test_predictive_performance_on_airline():
     np.testing.assert_allclose(y_pred, y_test, rtol=0.05)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
 def test_pred_errors_against_y_test(fh):
     """Check prediction performance on airline dataset.
@@ -66,6 +75,10 @@ def test_pred_errors_against_y_test(fh):
     assert np.all(y_test < intervals[("Coverage", 0.9, "upper")].values)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_forecaster_with_initial_level():
     """Check prediction performance on airline dataset.
 
@@ -86,6 +99,10 @@ def test_forecaster_with_initial_level():
     np.testing.assert_allclose(y_pred, y_test, rtol=0.05)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_theta_and_thetamodular():
     """Check predictions ThetaForecaster and ThetaModularForecaster align.
 

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -20,6 +20,7 @@ from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.transformations.series.detrend import Deseasonalizer
 from sktime.transformations.series.theta import ThetaLinesTransformer
 from sktime.utils.slope_and_trend import _fit_trend
+from sktime.utils.validation._dependencies import _check_estimator_deps
 from sktime.utils.validation.forecasting import check_sp
 
 
@@ -380,9 +381,16 @@ class ThetaModularForecaster(BaseForecaster):
                 if theta == 0:
                     name = f"trend{str(i)}"
                     forecaster = (name, PolynomialTrendForecaster(), i)
-                else:
+                elif _check_estimator_deps(ExponentialSmoothing, severity="none"):
                     name = f"ses{str(i)}"
                     forecaster = name, ExponentialSmoothing(), i
+                else:
+                    raise RuntimeError(
+                        "Constructing ThetaModularForecaster without forecasters "
+                        "results in using ExponentialSmoothing for non-zero theta "
+                        "components. Ensure that statsmodels package is available "
+                        "when constructing ThetaModularForecaster with this default."
+                    )
                 _forecasters.append(forecaster)
         elif len(forecasters) != len(self.theta_values):
             raise ValueError(

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -447,4 +447,11 @@ class ThetaModularForecaster(BaseForecaster):
         }
         params1 = {"theta_values": (0, 3)}
         params2 = {"weights": [1.0, 0.8]}
-        return [params0, params1, params2]
+
+        # params1 and params2 invoke ExpoentialSmoothing which requires statsmodels
+        if _check_estimator_deps(ExponentialSmoothing, severity="none"):
+            params = [params0, params1, params2]
+        else:
+            params = params0
+
+        return params

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -82,10 +82,10 @@ class ThetaForecaster(ExponentialSmoothing):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.theta import ThetaForecaster
     >>> y = load_airline()
-    >>> forecaster = ThetaForecaster(sp=12)
-    >>> forecaster.fit(y)
+    >>> forecaster = ThetaForecaster(sp=12)  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
     ThetaForecaster(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])
+    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
     """
 
     _fitted_param_names = ("initial_level", "smoothing_level")

--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -304,10 +304,10 @@ class STLForecaster(BaseForecaster):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.trend import STLForecaster
     >>> y = load_airline()
-    >>> forecaster = STLForecaster(sp=12)
-    >>> forecaster.fit(y)
+    >>> forecaster = STLForecaster(sp=12)  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
     STLForecaster(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])
+    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
 
     See Also
     --------

--- a/sktime/forecasting/var.py
+++ b/sktime/forecasting/var.py
@@ -65,10 +65,10 @@ class VAR(_StatsModelsAdapter):
     >>> from sktime.forecasting.var import VAR
     >>> from sktime.datasets import load_longley
     >>> _, y = load_longley()
-    >>> forecaster = VAR()
-    >>> forecaster.fit(y)
+    >>> forecaster = VAR()  # doctest: +SKIP
+    >>> forecaster.fit(y)  # doctest: +SKIP
     VAR(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])
+    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
     """
 
     _fitted_param_names = ("aic", "fpe", "hqic", "bic")

--- a/sktime/forecasting/varmax.py
+++ b/sktime/forecasting/varmax.py
@@ -199,11 +199,11 @@ class VARMAX(_StatsModelsAdapter):
     >>> from sktime.forecasting.varmax import VARMAX
     >>> from sktime.datasets import load_macroeconomic
     >>> from sktime.forecasting.model_selection import temporal_train_test_split
-    >>> y = load_macroeconomic()
-    >>> forecaster = VARMAX(suppress_warnings=True)
-    >>> forecaster.fit(y[['realgdp', 'unemp']])
+    >>> y = load_macroeconomic()  # doctest: +SKIP
+    >>> forecaster = VARMAX(suppress_warnings=True)  # doctest: +SKIP
+    >>> forecaster.fit(y[['realgdp', 'unemp']])  # doctest: +SKIP
     VARMAX(...)
-    >>> y_pred = forecaster.predict(fh=[1,4,12])
+    >>> y_pred = forecaster.predict(fh=[1,4,12])  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -71,10 +71,10 @@ class VECM(_StatsModelsAdapter):
     ... columns=list("AB"),
     ... index=pd.PeriodIndex(index))
     >>> train, test = temporal_train_test_split(df)
-    >>> sktime_model = VECM()
+    >>> sktime_model = VECM()  # doctest: +SKIP
     >>> fh = ForecastingHorizon([1, 3, 4, 5, 7, 9])
-    >>> _ = sktime_model.fit(train, fh=fh)
-    >>> fc2 = sktime_model.predict(fh=fh)
+    >>> _ = sktime_model.fit(train, fh=fh)  # doctest: +SKIP
+    >>> fc2 = sktime_model.predict(fh=fh)  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/param_est/compose.py
+++ b/sktime/param_est/compose.py
@@ -75,14 +75,14 @@ class ParamFitterPipeline(_HeterogenousMetaEstimator, BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>>
     >>> X = load_airline()
-    >>> pipeline = ParamFitterPipeline(SeasonalityACF(), [Differencer()])
-    >>> pipeline.fit(X)
+    >>> pipe = ParamFitterPipeline(SeasonalityACF(), [Differencer()])  # doctest: +SKIP
+    >>> pipe.fit(X)  # doctest: +SKIP
     ParamFitterPipeline(...)
-    >>> pipeline.get_fitted_params()["sp"]
+    >>> pipe.get_fitted_params()["sp"]  # doctest: +SKIP
     12
 
     Alternative construction via dunder method:
-    >>> pipeline = Differencer() * SeasonalityACF()
+    >>> pipe = Differencer() * SeasonalityACF()  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/param_est/fixed.py
+++ b/sktime/param_est/fixed.py
@@ -23,35 +23,6 @@ class FixedParams(BaseParamFitter):
     ----------
     param_dict : dict
         fixed parameter values written to `self`
-
-    Examples
-    --------
-    >>> from sktime.datasets import load_airline
-    >>> from sktime.param_est.seasonality import SeasonalityACF
-    >>>
-    >>> X = load_airline().diff()[1:]
-    >>> sp_est = SeasonalityACF()
-    >>> sp_est.fit(X)
-    SeasonalityACF(...)
-    >>> sp_est.get_fitted_params()["sp"]
-    12
-    >>> sp_est.get_fitted_params()["sp_significant"]
-    array([12, 11])
-
-    Series should be stationary before applying ACF.
-    To pipeline SeasonalityACF with the Differencer, use the ParamFitterPipeline:
-    >>> from sktime.datasets import load_airline
-    >>> from sktime.param_est.seasonality import SeasonalityACF
-    >>> from sktime.transformations.series.difference import Differencer
-    >>>
-    >>> X = load_airline()
-    >>> sp_est = Differencer() * SeasonalityACF()
-    >>> sp_est.fit(X)
-    ParamFitterPipeline(...)
-    >>> sp_est.get_fitted_params()["sp"]
-    12
-    >>> sp_est.get_fitted_params()["sp_significant"]
-    array([12, 11])
     """
 
     _tags = {

--- a/sktime/param_est/plugin.py
+++ b/sktime/param_est/plugin.py
@@ -51,21 +51,21 @@ class PluginParamsForecaster(_DelegatedForecaster):
     >>> from sktime.param_est.seasonality import SeasonalityACF
     >>> from sktime.transformations.series.difference import Differencer
     >>>
-    >>> y = load_airline()
-    >>> sp_est = Differencer() * SeasonalityACF()
-    >>> fcst = NaiveForecaster()
-    >>> sp_auto = PluginParamsForecaster(sp_est, fcst)
-    >>> sp_auto.fit(y, fh=[1, 2, 3])
+    >>> y = load_airline()  # doctest: +SKIP
+    >>> sp_est = Differencer() * SeasonalityACF()  # doctest: +SKIP
+    >>> fcst = NaiveForecaster()  # doctest: +SKIP
+    >>> sp_auto = PluginParamsForecaster(sp_est, fcst)  # doctest: +SKIP
+    >>> sp_auto.fit(y, fh=[1, 2, 3])  # doctest: +SKIP
     PluginParamsForecaster(...)
-    >>> y_pred = sp_auto.predict()
-    >>> sp_auto.forecaster_.get_params()["sp"]
+    >>> y_pred = sp_auto.predict()  # doctest: +SKIP
+    >>> sp_auto.forecaster_.get_params()["sp"]  # doctest: +SKIP
     12
 
     using dictionary to plug "foo" parameter into "sp"
     >>> from sktime.param_est.fixed import FixedParams
     >>> sp_plugin = PluginParamsForecaster(
     ...     FixedParams({"foo": 12}), NaiveForecaster(), params={"foo": "sp"}
-    ... )
+    ... )  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -60,13 +60,13 @@ class SeasonalityACF(BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.seasonality import SeasonalityACF
     >>>
-    >>> X = load_airline().diff()[1:]
-    >>> sp_est = SeasonalityACF()
-    >>> sp_est.fit(X)
+    >>> X = load_airline().diff()[1:]  # doctest: +SKIP
+    >>> sp_est = SeasonalityACF()  # doctest: +SKIP
+    >>> sp_est.fit(X)  # doctest: +SKIP
     SeasonalityACF(...)
-    >>> sp_est.get_fitted_params()["sp"]
+    >>> sp_est.get_fitted_params()["sp"]  # doctest: +SKIP
     12
-    >>> sp_est.get_fitted_params()["sp_significant"]
+    >>> sp_est.get_fitted_params()["sp_significant"]  # doctest: +SKIP
     array([12, 11])
 
     Series should be stationary before applying ACF.
@@ -75,13 +75,13 @@ class SeasonalityACF(BaseParamFitter):
     >>> from sktime.param_est.seasonality import SeasonalityACF
     >>> from sktime.transformations.series.difference import Differencer
     >>>
-    >>> X = load_airline()
-    >>> sp_est = Differencer() * SeasonalityACF()
-    >>> sp_est.fit(X)
+    >>> X = load_airline()  # doctest: +SKIP
+    >>> sp_est = Differencer() * SeasonalityACF()  # doctest: +SKIP
+    >>> sp_est.fit(X)  # doctest: +SKIP
     ParamFitterPipeline(...)
-    >>> sp_est.get_fitted_params()["sp"]
+    >>> sp_est.get_fitted_params()["sp"]  # doctest: +SKIP
     12
-    >>> sp_est.get_fitted_params()["sp_significant"]
+    >>> sp_est.get_fitted_params()["sp_significant"]  # doctest: +SKIP
     array([12, 11])
     """
 
@@ -260,10 +260,10 @@ class SeasonalityACFqstat(BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.seasonality import SeasonalityACFqstat
     >>> X = load_airline().diff()[1:]
-    >>> sp_est = SeasonalityACFqstat(candidate_sp=[3, 7, 12])
-    >>> sp_est.fit(X)
+    >>> sp_est = SeasonalityACFqstat(candidate_sp=[3, 7, 12])  # doctest: +SKIP
+    >>> sp_est.fit(X)  # doctest: +SKIP
     SeasonalityACFqstat(...)
-    >>> sp_est.get_fitted_params()["sp_significant"]
+    >>> sp_est.get_fitted_params()["sp_significant"]  # doctest: +SKIP
     array([12,  7,  3])
     """
 

--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -272,6 +272,7 @@ class SeasonalityACFqstat(BaseParamFitter):
         "scitype:X": "Series",  # which X scitypes are supported natively?
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:multivariate": False,  # can estimator handle multivariate data?
+        "python_dependencies": "statsmodels",
     }
 
     def __init__(

--- a/sktime/param_est/tests/test_plugin.py
+++ b/sktime/param_est/tests/test_plugin.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for parameter plugin transformers."""
+
+__author__ = ["fkiraly"]
+
+import pytest
+
+from sktime.datasets import load_airline
+from sktime.forecasting.naive import NaiveForecaster
+from sktime.param_est.fixed import FixedParams
+from sktime.param_est.plugin import PluginParamsForecaster
+from sktime.param_est.seasonality import SeasonalityACF
+from sktime.transformations.series.difference import Differencer
+from sktime.utils.validation._dependencies import _check_estimator_deps
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(SeasonalityACF, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+def test_seasonality_acf():
+    """Test PluginParamsForecaster on airline data. Same as docstring example."""
+    y = load_airline()
+
+    sp_est = Differencer() * SeasonalityACF()
+    fcst = NaiveForecaster()
+    sp_auto = PluginParamsForecaster(sp_est, fcst)
+    sp_auto.fit(y, fh=[1, 2, 3])
+    assert sp_auto.forecaster_.get_params()["sp"] == 12
+
+    PluginParamsForecaster(
+        FixedParams({"foo": 12}), NaiveForecaster(), params={"foo": "sp"}
+    )

--- a/sktime/param_est/tests/test_seasonality.py
+++ b/sktime/param_est/tests/test_seasonality.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for seasonality tansformers."""
+
+__author__ = ["fkiraly"]
+
+import numpy as np
+import pytest
+
+from sktime.datasets import load_airline
+from sktime.param_est.seasonality import SeasonalityACF, SeasonalityACFqstat
+from sktime.utils.validation._dependencies import _check_estimator_deps
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(SeasonalityACF, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+def test_seasonality_acf():
+    """Test SeasonalityACF on airline data."""
+    X = load_airline().diff()[1:]
+    sp_est = SeasonalityACF()
+    sp_est.fit(X)
+
+    assert sp_est.get_fitted_params()["sp"] == 12
+    actual = sp_est.get_fitted_params()["sp_significant"]
+    expected = np.array([12, 11])
+    np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(SeasonalityACF, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+def test_seasonality_acf_pipeline():
+    """Test SeasonalityACF pipeline on airline data."""
+    from sktime.transformations.series.difference import Differencer
+
+    X = load_airline()
+    sp_est = Differencer() * SeasonalityACF()
+    sp_est.fit(X)
+    assert sp_est.get_fitted_params()["sp"] == 12
+    actual = sp_est.get_fitted_params()["sp_significant"]
+    expected = np.array([12, 11])
+    np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(SeasonalityACFqstat, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+def test_seasonality_acf_qstat():
+    """Test SeasonalityACFqstat on airline data."""
+    X = load_airline().diff()[1:]
+    sp_est = SeasonalityACFqstat(candidate_sp=[3, 7, 12])
+    sp_est.fit(X)
+
+    actual = sp_est.get_fitted_params()["sp_significant"]
+    expected = np.array([12, 7, 3])
+    np.testing.assert_array_equal(actual, expected)

--- a/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
@@ -6,9 +6,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from sktime.forecasting.compose import ColumnEnsembleForecaster
 from sktime.forecasting.model_selection import temporal_train_test_split
-from sktime.forecasting.theta import ThetaForecaster
+from sktime.forecasting.naive import NaiveForecaster, NaiveVariance
 from sktime.performance_metrics.forecasting.probabilistic import (
     ConstraintViolation,
     EmpiricalCoverage,
@@ -29,16 +28,17 @@ interval_metrics = [
 
 all_metrics = quantile_metrics + interval_metrics
 
+
 y_uni = _make_series(n_columns=1)
 y_train_uni, y_test_uni = temporal_train_test_split(y_uni)
 fh_uni = np.arange(len(y_test_uni)) + 1
-f_uni = ColumnEnsembleForecaster(ThetaForecaster(sp=12))
+f_uni = NaiveVariance(NaiveForecaster())
 f_uni.fit(y_train_uni)
 
 y_multi = _make_series(n_columns=3)
 y_train_multi, y_test_multi = temporal_train_test_split(y_multi)
 fh_multi = np.arange(len(y_test_multi)) + 1
-f_multi = ColumnEnsembleForecaster(ThetaForecaster(sp=12))
+f_multi = NaiveVariance(NaiveForecaster())
 f_multi.fit(y_train_multi)
 """
 Cases we need to test

--- a/sktime/pipeline/_make_pipeline.py
+++ b/sktime/pipeline/_make_pipeline.py
@@ -26,11 +26,11 @@ def make_pipeline(*steps):
 
     Example 1: forecaster pipeline
     >>> from sktime.datasets import load_airline
-    >>> from sktime.forecasting.theta import ThetaForecaster
+    >>> from sktime.forecasting.trend import PolynomialTrendForecaster
     >>> from sktime.pipeline import make_pipeline
     >>> from sktime.transformations.series.exponent import ExponentTransformer
     >>> y = load_airline()
-    >>> pipe = make_pipeline(ExponentTransformer(), ThetaForecaster())
+    >>> pipe = make_pipeline(ExponentTransformer(), PolynomialTrendForecaster())
     >>> type(pipe).__name__
     'TransformedTargetForecaster'
 

--- a/sktime/transformations/bootstrap/_mbb.py
+++ b/sktime/transformations/bootstrap/_mbb.py
@@ -144,18 +144,18 @@ class STLBootstrapTransformer(BaseTransformer):
     >>> from sktime.transformations.bootstrap import STLBootstrapTransformer
     >>> from sktime.datasets import load_airline
     >>> from sktime.utils.plotting import plot_series  # doctest: +SKIP
-    >>> y = load_airline()
-    >>> transformer = STLBootstrapTransformer(10)
-    >>> y_hat = transformer.fit_transform(y)
-    >>> series_list = []
-    >>> names = []
+    >>> y = load_airline()  # doctest: +SKIP
+    >>> transformer = STLBootstrapTransformer(10)  # doctest: +SKIP
+    >>> y_hat = transformer.fit_transform(y)  # doctest: +SKIP
+    >>> series_list = []  # doctest: +SKIP
+    >>> names = []  # doctest: +SKIP
     >>> for group, series in y_hat.groupby(level=[0], as_index=False):
     ...     series.index = series.index.droplevel(0)
     ...     series_list.append(series)
-    ...     names.append(group)
+    ...     names.append(group)  # doctest: +SKIP
     >>> plot_series(*series_list, labels=names)  # doctest: +SKIP
     (...)
-    >>> print(y_hat.head()) # doctest: +NORMALIZE_WHITESPACE
+    >>> print(y_hat.head())  # doctest: +SKIP
                           Number of airline passengers
     series_id time_index
     actual    1949-01                            112.0

--- a/sktime/transformations/bootstrap/tests/test_mbb.py
+++ b/sktime/transformations/bootstrap/tests/test_mbb.py
@@ -19,7 +19,6 @@ from sktime.transformations.bootstrap._mbb import (
 )
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-
 y = load_airline()
 y_index = y.index
 

--- a/sktime/transformations/bootstrap/tests/test_mbb.py
+++ b/sktime/transformations/bootstrap/tests/test_mbb.py
@@ -17,11 +17,17 @@ from sktime.transformations.bootstrap._mbb import (
     _get_series_name,
     _moving_block_bootstrap,
 )
+from sktime.utils.validation._dependencies import _check_soft_dependencies
+
 
 y = load_airline()
 y_index = y.index
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
 def test_bootstrapping_transformer_no_seasonal_period():
     """Tests that an exception is raised if sp<2."""
     with pytest.raises(NotImplementedError) as ex:
@@ -31,6 +37,10 @@ def test_bootstrapping_transformer_no_seasonal_period():
         assert "STLBootstrapTransformer does not support non-seasonal data" == ex.value
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
 def test_bootstrapping_transformer_series_shorter_than_sp():
     """Tests that an exception is raised if sp>len(y)."""
     with pytest.raises(ValueError) as ex:
@@ -42,6 +52,10 @@ def test_bootstrapping_transformer_series_shorter_than_sp():
         assert msg == ex.value
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
 @pytest.mark.parametrize(
     "transformer_class", [STLBootstrapTransformer, MovingBlockBootstrapTransformer]
 )
@@ -66,6 +80,10 @@ index_return_actual_false = pd.MultiIndex.from_product(
 )
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
 @pytest.mark.parametrize(
     "transformer_class, return_actual, expected_index",
     [

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -662,7 +662,7 @@ class FeatureUnion(_HeterogenousMetaEstimator, BaseTransformer):
 
 
 class FitInTransform(BaseTransformer):
-    """Transformer composition to always fit a given transformer on the transform data only.
+    """Transformer wrapper to delay fit to the transform phase.
 
     In panel settings, e.g., time series classification, it can be preferable
     (or, necessary) to fit and transform on the test set, e.g., interpolate within the

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -1296,24 +1296,24 @@ class OptionalPassthrough(_DelegatedTransformer):
     >>> pipe = TransformedTargetForecaster(steps=[
     ...     ("deseasonalizer", OptionalPassthrough(Deseasonalizer())),
     ...     ("scaler", OptionalPassthrough(TabularToSeriesAdaptor(StandardScaler()))),
-    ...     ("forecaster", NaiveForecaster())])
+    ...     ("forecaster", NaiveForecaster())])  # doctest: +SKIP
     >>> # putting it all together in a grid search
     >>> cv = SlidingWindowSplitter(
     ...     initial_window=60,
     ...     window_length=24,
     ...     start_with_window=True,
-    ...     step_length=48)
+    ...     step_length=48)  # doctest: +SKIP
     >>> param_grid = {
     ...     "deseasonalizer__passthrough" : [True, False],
     ...     "scaler__transformer__transformer__with_mean": [True, False],
     ...     "scaler__passthrough" : [True, False],
-    ...     "forecaster__strategy": ["drift", "mean", "last"]}
+    ...     "forecaster__strategy": ["drift", "mean", "last"]}  # doctest: +SKIP
     >>> gscv = ForecastingGridSearchCV(
     ...     forecaster=pipe,
     ...     param_grid=param_grid,
     ...     cv=cv,
-    ...     n_jobs=-1)
-    >>> gscv_fitted = gscv.fit(load_airline())
+    ...     n_jobs=-1)  # doctest: +SKIP
+    >>> gscv_fitted = gscv.fit(load_airline())  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/transformations/hierarchical/reconcile.py
+++ b/sktime/transformations/hierarchical/reconcile.py
@@ -54,7 +54,7 @@ class Reconciler(BaseTransformer):
 
     Examples
     --------
-    >>> from sktime.forecasting.exp_smoothing import ExponentialSmoothing
+    >>> from sktime.forecasting.trend import PolynomialTrendForecaster
     >>> from sktime.transformations.hierarchical.reconcile import Reconciler
     >>> from sktime.transformations.hierarchical.aggregate import Aggregator
     >>> from sktime.utils._testing.hierarchical import _bottom_hier_datagen
@@ -65,9 +65,9 @@ class Reconciler(BaseTransformer):
     ...     random_seed=123,
     ... )
     >>> y = agg.fit_transform(y)
-    >>> forecaster = ExponentialSmoothing()
+    >>> forecaster = PolynomialTrendForecaster()
     >>> forecaster.fit(y)
-    ExponentialSmoothing(...)
+    PolynomialTrendForecaster(...)
     >>> prds = forecaster.predict(fh=[1])
     >>> # reconcile forecasts
     >>> reconciler = Reconciler(method="ols")

--- a/sktime/transformations/hierarchical/tests/test_reconcile.py
+++ b/sktime/transformations/hierarchical/tests/test_reconcile.py
@@ -14,6 +14,7 @@ from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.transformations.hierarchical.aggregate import Aggregator
 from sktime.transformations.hierarchical.reconcile import Reconciler
 from sktime.utils._testing.hierarchical import _bottom_hier_datagen
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 # get all the methods
 METHOD_LIST = Reconciler.METHOD_LIST
@@ -22,6 +23,10 @@ METHOD_LIST = Reconciler.METHOD_LIST
 # test the reconciled predictions are actually hierarchical
 # test the index/columns on the g and s matrices match
 # test it works for named and unnamed indexes
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 @pytest.mark.parametrize("method", METHOD_LIST)
 def test_reconciler_fit_transform(method):
     """Tests fit_trasnform and output of reconciler.

--- a/sktime/transformations/panel/summarize/tests/test_FittedParamExtractor.py
+++ b/sktime/transformations/panel/summarize/tests/test_FittedParamExtractor.py
@@ -10,10 +10,15 @@ import pytest
 from sktime.datasets import load_gunpoint
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.transformations.panel.summarize import FittedParamExtractor
+from sktime.utils.validation._dependencies import _check_estimator_deps
 
 X_train, y_train = load_gunpoint("train", return_X_y=True)
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(ExponentialSmoothing, severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
 @pytest.mark.parametrize("param_names", ["initial_level"])
 def test_FittedParamExtractor(param_names):
     forecaster = ExponentialSmoothing()

--- a/sktime/transformations/series/acf.py
+++ b/sktime/transformations/series/acf.py
@@ -62,9 +62,9 @@ class AutoCorrelationTransformer(BaseTransformer):
     --------
     >>> from sktime.transformations.series.acf import AutoCorrelationTransformer
     >>> from sktime.datasets import load_airline
-    >>> y = load_airline()
-    >>> transformer = AutoCorrelationTransformer(n_lags=12)
-    >>> y_hat = transformer.fit_transform(y)
+    >>> y = load_airline()  # doctest: +SKIP
+    >>> transformer = AutoCorrelationTransformer(n_lags=12)  # doctest: +SKIP
+    >>> y_hat = transformer.fit_transform(y)  # doctest: +SKIP
     """
 
     _tags = {
@@ -143,7 +143,7 @@ class AutoCorrelationTransformer(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        return {"n_lags": 1}
+        return [{}, {"n_lags": 1}]
 
 
 class PartialAutoCorrelationTransformer(BaseTransformer):
@@ -194,9 +194,9 @@ class PartialAutoCorrelationTransformer(BaseTransformer):
     --------
     >>> from sktime.transformations.series.acf import PartialAutoCorrelationTransformer
     >>> from sktime.datasets import load_airline
-    >>> y = load_airline()
-    >>> transformer = PartialAutoCorrelationTransformer(n_lags=12)
-    >>> y_hat = transformer.fit_transform(y)
+    >>> y = load_airline()  # doctest: +SKIP
+    >>> transformer = PartialAutoCorrelationTransformer(n_lags=12)  # doctest: +SKIP
+    >>> y_hat = transformer.fit_transform(y)  # doctest: +SKIP
     """
 
     _tags = {
@@ -263,4 +263,4 @@ class PartialAutoCorrelationTransformer(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        return {"n_lags": 1}
+        return [{}, {"n_lags": 1}]

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -59,8 +59,8 @@ class Deseasonalizer(BaseTransformer):
     >>> from sktime.transformations.series.detrend import Deseasonalizer
     >>> from sktime.datasets import load_airline
     >>> y = load_airline()
-    >>> transformer = Deseasonalizer()
-    >>> y_hat = transformer.fit_transform(y)
+    >>> transformer = Deseasonalizer()  # doctest: +SKIP
+    >>> y_hat = transformer.fit_transform(y)  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -230,7 +230,7 @@ class Deseasonalizer(BaseTransformer):
         """
         params = {}
 
-        params2 = {"sp": 12}
+        params2 = {"sp": 2}
 
         return [params, params2]
 

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -58,7 +58,7 @@ class Deseasonalizer(BaseTransformer):
     --------
     >>> from sktime.transformations.series.detrend import Deseasonalizer
     >>> from sktime.datasets import load_airline
-    >>> y = load_airline()
+    >>> y = load_airline()  # doctest: +SKIP
     >>> transformer = Deseasonalizer()  # doctest: +SKIP
     >>> y_hat = transformer.fit_transform(y)  # doctest: +SKIP
     """
@@ -209,6 +209,31 @@ class Deseasonalizer(BaseTransformer):
             self._fit(X_full, update_params=update_params)
         return self
 
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for transformers.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params = {}
+
+        params2 = {"sp": 12}
+
+        return [params, params2]
+
 
 class ConditionalDeseasonalizer(Deseasonalizer):
     """Remove seasonal components from time series, conditional on seasonality test.
@@ -262,9 +287,9 @@ class ConditionalDeseasonalizer(Deseasonalizer):
     --------
     >>> from sktime.transformations.series.detrend import ConditionalDeseasonalizer
     >>> from sktime.datasets import load_airline
-    >>> y = load_airline()
-    >>> transformer = ConditionalDeseasonalizer(sp=12)
-    >>> y_hat = transformer.fit_transform(y)
+    >>> y = load_airline()  # doctest: +SKIP
+    >>> transformer = ConditionalDeseasonalizer(sp=12)  # doctest: +SKIP
+    >>> y_hat = transformer.fit_transform(y)  # doctest: +SKIP
     """
 
     def __init__(self, seasonality_test=None, sp=1, model="additive"):
@@ -421,9 +446,9 @@ class STLTransformer(BaseTransformer):
     --------
     >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.detrend import STLTransformer
-    >>> X = load_airline()
-    >>> transformer = STLTransformer(sp=12)
-    >>> Xt = transformer.fit_transform(X)
+    >>> X = load_airline()  # doctest: +SKIP
+    >>> transformer = STLTransformer(sp=12)  # doctest: +SKIP
+    >>> Xt = transformer.fit_transform(X)  # doctest: +SKIP
     """
 
     _tags = {
@@ -599,4 +624,7 @@ class STLTransformer(BaseTransformer):
         # test case 2: return all components
         params2 = {"return_components": True}
 
-        return [params1, params2]
+        # test case 3: seasonality parameter set, from the skipped doctest
+        params3 = {"sp": 12}
+
+        return [params1, params2, params3]

--- a/sktime/transformations/series/detrend/tests/test_deseasonalise.py
+++ b/sktime/transformations/series/detrend/tests/test_deseasonalise.py
@@ -37,6 +37,10 @@ def test_deseasonalised_values(sp):
     np.testing.assert_array_equal(actual, expected)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 @pytest.mark.parametrize("sp", TEST_SPS)
 @pytest.mark.parametrize("model", MODELS)
 def test_transform_time_index(sp, model):
@@ -46,6 +50,10 @@ def test_transform_time_index(sp, model):
     np.testing.assert_array_equal(yt.index, y_test.index)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 @pytest.mark.parametrize("sp", TEST_SPS)
 @pytest.mark.parametrize("model", MODELS)
 def test_inverse_transform_time_index(sp, model):
@@ -55,6 +63,10 @@ def test_inverse_transform_time_index(sp, model):
     np.testing.assert_array_equal(yit.index, y_test.index)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 @pytest.mark.parametrize("sp", TEST_SPS)
 @pytest.mark.parametrize("model", MODELS)
 def test_transform_inverse_transform_equivalence(sp, model):
@@ -65,6 +77,10 @@ def test_transform_inverse_transform_equivalence(sp, model):
     np.testing.assert_array_almost_equal(y_train, yit)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_deseasonalizer_in_pipeline():
     """Test deseasonalizer in pipeline, see issue #3267."""
     from sktime.datasets import load_airline

--- a/sktime/transformations/series/scaledlogit.py
+++ b/sktime/transformations/series/scaledlogit.py
@@ -69,19 +69,17 @@ class ScaledLogitTransformer(BaseTransformer):
         practice, 3rd edition, OTexts: Melbourne, Australia. OTexts.com/fpp3.
         Accessed on January 24th 2022.
 
-
-
     Examples
     --------
     >>> import numpy as np
     >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.scaledlogit import ScaledLogitTransformer
-    >>> from sktime.forecasting.ets import AutoETS
+    >>> from sktime.forecasting.trend import PolynomialForecaster
     >>> from sktime.forecasting.compose import TransformedTargetForecaster
     >>> y = load_airline()
     >>> fcaster = TransformedTargetForecaster([
     ...     ("scaled_logit", ScaledLogitTransformer(0, 650)),
-    ...     ("ets", AutoETS(sp=12, auto=True))
+    ...     ("poly", PolynomialForecaster(2))
     ... ])
     >>> fcaster.fit(y)
     TransformedTargetForecaster(...)

--- a/sktime/transformations/series/scaledlogit.py
+++ b/sktime/transformations/series/scaledlogit.py
@@ -74,12 +74,12 @@ class ScaledLogitTransformer(BaseTransformer):
     >>> import numpy as np
     >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.scaledlogit import ScaledLogitTransformer
-    >>> from sktime.forecasting.trend import PolynomialForecaster
+    >>> from sktime.forecasting.trend import PolynomialTrendForecaster
     >>> from sktime.forecasting.compose import TransformedTargetForecaster
     >>> y = load_airline()
     >>> fcaster = TransformedTargetForecaster([
     ...     ("scaled_logit", ScaledLogitTransformer(0, 650)),
-    ...     ("poly", PolynomialForecaster(2))
+    ...     ("poly", PolynomialTrendForecaster(2))
     ... ])
     >>> fcaster.fit(y)
     TransformedTargetForecaster(...)

--- a/sktime/transformations/series/scaledlogit.py
+++ b/sktime/transformations/series/scaledlogit.py
@@ -79,7 +79,7 @@ class ScaledLogitTransformer(BaseTransformer):
     >>> y = load_airline()
     >>> fcaster = TransformedTargetForecaster([
     ...     ("scaled_logit", ScaledLogitTransformer(0, 650)),
-    ...     ("poly", PolynomialTrendForecaster(2))
+    ...     ("poly", PolynomialTrendForecaster(degree=2))
     ... ])
     >>> fcaster.fit(y)
     TransformedTargetForecaster(...)

--- a/sktime/transformations/series/tests/test_clear_sky.py
+++ b/sktime/transformations/series/tests/test_clear_sky.py
@@ -65,7 +65,7 @@ output_chk = [
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("hmmlearn", severity="none"),
+    not _check_soft_dependencies("statsmodels", severity="none"),
     reason="skip test if required soft dependency for hmmlearn not available",
 )
 def test_clearsky_trafo_vals():

--- a/sktime/transformations/series/tests/test_clear_sky.py
+++ b/sktime/transformations/series/tests/test_clear_sky.py
@@ -6,9 +6,11 @@
 __author__ = ["ciaran-g"]
 
 import numpy as np
+import pytest
 
 from sktime.datasets import load_solar
 from sktime.transformations.series.clear_sky import ClearSky
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 output_chk = [
     0.0,
@@ -62,6 +64,10 @@ output_chk = [
 ]
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("hmmlearn", severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
 def test_clearsky_trafo_vals():
     """Tests clear sky trafo with and without missing values."""
     y = load_solar(api_version=None)

--- a/sktime/transformations/series/tests/test_imputer.py
+++ b/sktime/transformations/series/tests/test_imputer.py
@@ -9,7 +9,7 @@ __all__ = []
 import numpy as np
 import pytest
 
-from sktime.forecasting.exp_smoothing import ExponentialSmoothing
+from sktime.forecasting.naive import NaiveForecaster
 from sktime.transformations.series.impute import Imputer
 from sktime.utils._testing.forecasting import make_forecasting_problem
 
@@ -43,7 +43,7 @@ y.iloc[-1] = np.nan
 )
 def test_imputer(method, Z):
     """Test univariate and multivariate Imputer with all methods."""
-    forecaster = ExponentialSmoothing() if method == "forecaster" else None
+    forecaster = NaiveForecaster() if method == "forecaster" else None
     value = 3 if method == "constant" else None
     t = Imputer(method=method, forecaster=forecaster, value=value)
     y_hat = t.fit_transform(Z)

--- a/sktime/transformations/tests/test_optionalpassthrough.py
+++ b/sktime/transformations/tests/test_optionalpassthrough.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""Tests for using OptionalPassthrough."""
+
+import pytest
+
+from sktime.utils.validation._dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency is not available",
+)
+def test_optionalpassthrough():
+    """Test for OptionalPassthrough used within grid search and with pipeline."""
+    from sklearn.preprocessing import StandardScaler
+
+    from sktime.datasets import load_airline
+    from sktime.forecasting.compose import TransformedTargetForecaster
+    from sktime.forecasting.model_selection import (
+        ForecastingGridSearchCV,
+        SlidingWindowSplitter)
+    from sktime.forecasting.naive import NaiveForecaster
+    from sktime.transformations.series.adapt import TabularToSeriesAdaptor
+    from sktime.transformations.series.compose import OptionalPassthrough
+    from sktime.transformations.series.detrend import Deseasonalizer
+
+    # create pipeline
+    pipe = TransformedTargetForecaster(steps=[
+        ("deseasonalizer", OptionalPassthrough(Deseasonalizer())),
+        ("scaler", OptionalPassthrough(TabularToSeriesAdaptor(StandardScaler()))),
+        ("forecaster", NaiveForecaster())])
+    # putting it all together in a grid search
+    cv = SlidingWindowSplitter(
+        initial_window=60,
+        window_length=24,
+        start_with_window=True,
+        step_length=48)
+    param_grid = {
+        "deseasonalizer__passthrough" : [True, False],
+        "scaler__transformer__transformer__with_mean": [True, False],
+        "scaler__passthrough" : [True, False],
+        "forecaster__strategy": ["drift", "mean", "last"]}
+    gscv = ForecastingGridSearchCV(
+        forecaster=pipe,
+        param_grid=param_grid,
+        cv=cv,
+        n_jobs=-1)
+    gscv.fit(load_airline())

--- a/sktime/transformations/tests/test_optionalpassthrough.py
+++ b/sktime/transformations/tests/test_optionalpassthrough.py
@@ -18,31 +18,32 @@ def test_optionalpassthrough():
     from sktime.forecasting.compose import TransformedTargetForecaster
     from sktime.forecasting.model_selection import (
         ForecastingGridSearchCV,
-        SlidingWindowSplitter)
+        SlidingWindowSplitter,
+    )
     from sktime.forecasting.naive import NaiveForecaster
     from sktime.transformations.series.adapt import TabularToSeriesAdaptor
     from sktime.transformations.series.compose import OptionalPassthrough
     from sktime.transformations.series.detrend import Deseasonalizer
 
     # create pipeline
-    pipe = TransformedTargetForecaster(steps=[
-        ("deseasonalizer", OptionalPassthrough(Deseasonalizer())),
-        ("scaler", OptionalPassthrough(TabularToSeriesAdaptor(StandardScaler()))),
-        ("forecaster", NaiveForecaster())])
+    pipe = TransformedTargetForecaster(
+        steps=[
+            ("deseasonalizer", OptionalPassthrough(Deseasonalizer())),
+            ("scaler", OptionalPassthrough(TabularToSeriesAdaptor(StandardScaler()))),
+            ("forecaster", NaiveForecaster()),
+        ]
+    )
     # putting it all together in a grid search
     cv = SlidingWindowSplitter(
-        initial_window=60,
-        window_length=24,
-        start_with_window=True,
-        step_length=48)
+        initial_window=60, window_length=24, start_with_window=True, step_length=48
+    )
     param_grid = {
-        "deseasonalizer__passthrough" : [True, False],
+        "deseasonalizer__passthrough": [True, False],
         "scaler__transformer__transformer__with_mean": [True, False],
-        "scaler__passthrough" : [True, False],
-        "forecaster__strategy": ["drift", "mean", "last"]}
+        "scaler__passthrough": [True, False],
+        "forecaster__strategy": ["drift", "mean", "last"],
+    }
     gscv = ForecastingGridSearchCV(
-        forecaster=pipe,
-        param_grid=param_grid,
-        cv=cv,
-        n_jobs=-1)
+        forecaster=pipe, param_grid=param_grid, cv=cv, n_jobs=-1
+    )
     gscv.fit(load_airline())

--- a/sktime/transformations/tests/test_optionalpassthrough.py
+++ b/sktime/transformations/tests/test_optionalpassthrough.py
@@ -11,7 +11,10 @@ from sktime.utils.validation._dependencies import _check_soft_dependencies
     reason="skip test if required soft dependency is not available",
 )
 def test_optionalpassthrough():
-    """Test for OptionalPassthrough used within grid search and with pipeline."""
+    """Test for OptionalPassthrough used within grid search and with pipeline.
+
+    Same as docstring example of OptionalPassthrough.
+    """
     from sklearn.preprocessing import StandardScaler
 
     from sktime.datasets import load_airline

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -75,8 +75,9 @@ def check_estimator(
     All tests PASSED!
 
     Running specific test (all fixtures) for ExponentTransformer
-    >>> check_estimator(ExponentTransformer, tests_to_run="test_clone")
+    >>> results = check_estimator(ExponentTransformer, tests_to_run="test_clone")
     All tests PASSED!
+
     {'test_clone[ExponentTransformer-0]': 'PASSED',
     'test_clone[ExponentTransformer-1]': 'PASSED'}
 

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -86,7 +86,7 @@ def check_estimator(
     ...    ExponentTransformer, fixtures_to_run="test_clone[ExponentTransformer-1]"
     ... )
     All tests PASSED!
-    {'test_score['test_clone[ExponentTransformer-1]']': 'PASSED'}
+    {'test_clone[ExponentTransformer-1]': 'PASSED'}
     """
     from sktime.base import BaseEstimator
     from sktime.classification.early_classification.tests.test_all_early_classifiers import (  # noqa E501

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -61,15 +61,30 @@ def check_estimator(
 
     Examples
     --------
-    >>> from sktime.forecasting.naive import NaiveForecaster
+    >>> from sktime.transformations.series.exponent import ExponentTransformer
     >>> from sktime.utils.estimator_checks import check_estimator
-    >>> results = check_estimator(NaiveForecaster, tests_to_run="test_pred_int_tag")
+
+    Running all tests for ExponentTransformer class,
+    this uses all instances from get_test_params and compatible scenarios
+    >>> results = check_estimator(ExponentTransformer)
     All tests PASSED!
+
+    Running all tests for a specific ExponentTransformer
+    this uses the instance that is passed and compatible scenarios
+    >>> results = check_estimator(ExponentTransformer(42))
+
+    Running specific test (all fixtures) for ExponentTransformer
+    >>> check_estimator(ExponentTransformer, tests_to_run="test_clone")
+    All tests PASSED!
+    {'test_clone[ExponentTransformer-0]': 'PASSED',
+    'test_clone[ExponentTransformer-1]': 'PASSED'}
+
+    Running one specific test-fixture-combination for ExponentTransformer
     >>> check_estimator(
-    ...    NaiveForecaster, fixtures_to_run="test_score[NaiveForecaster-y:1cols-fh=1]"
+    ...    ExponentTransformer, fixtures_to_run="test_clone[ExponentTransformer-1]"
     ... )
     All tests PASSED!
-    {'test_score[NaiveForecaster-y:1cols-fh=1]': 'PASSED'}
+    {'test_score['test_clone[ExponentTransformer-1]']': 'PASSED'}
     """
     from sktime.base import BaseEstimator
     from sktime.classification.early_classification.tests.test_all_early_classifiers import (  # noqa E501

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -61,15 +61,15 @@ def check_estimator(
 
     Examples
     --------
-    >>> from sktime.forecasting.theta import ThetaForecaster
+    >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.utils.estimator_checks import check_estimator
-    >>> results = check_estimator(ThetaForecaster, tests_to_run="test_pred_int_tag")
+    >>> results = check_estimator(NaiveForecaster, tests_to_run="test_pred_int_tag")
     All tests PASSED!
     >>> check_estimator(
-    ...    ThetaForecaster, fixtures_to_run="test_score[ThetaForecaster-y:1cols-fh=1]"
+    ...    NaiveForecaster, fixtures_to_run="test_score[NaiveForecaster-y:1cols-fh=1]"
     ... )
     All tests PASSED!
-    {'test_score[ThetaForecaster-y:1cols-fh=1]': 'PASSED'}
+    {'test_score[NaiveForecaster-y:1cols-fh=1]': 'PASSED'}
     """
     from sktime.base import BaseEstimator
     from sktime.classification.early_classification.tests.test_all_early_classifiers import (  # noqa E501

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -72,6 +72,7 @@ def check_estimator(
     Running all tests for a specific ExponentTransformer
     this uses the instance that is passed and compatible scenarios
     >>> results = check_estimator(ExponentTransformer(42))
+    All tests PASSED!
 
     Running specific test (all fixtures) for ExponentTransformer
     >>> check_estimator(ExponentTransformer, tests_to_run="test_clone")


### PR DESCRIPTION
This PR isolates the remaining occurrences of `statsmodels` in non-suite tests as follows:

* `pytest` tests are isolated via `pytest.skipif` depending on the availability of the package
* `doctest` tests are removed via `doctest` skip if rendundant with suite tests, otherwise moved into `pytest` tests that are isolated as above
* in some cases where estimators are used inside integration tests or doctests, they are instead replaced by suitable similar estimators that are `sktime` native