### PR TITLE
[ENH] fix return index for transformers' `Primitives` output in row vectorization case

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1044,14 +1044,21 @@ class BaseTransformer(BaseEstimator):
                 store_behaviour="freeze",
             )
         elif output_scitype == "Primitives":
-            # we "abuse" the Series converter to ensure df output
-            # & reset index to have integers for instances
+            # we ensure the output is pd_DataFrame_Table
+            # & ensure the returned index is sensible
+            # for return index, we need to deal with last level, constant 0
             if isinstance(Xt, (pd.DataFrame, pd.Series)):
-                Xt = Xt.reset_index(drop=True)
+                # if index is multiindex, last level is constant 0
+                # and other levels are hierarchy
+                if isinstance(Xt.index, pd.MultiIndex):
+                    Xt.index = Xt.index.droplevel(-1)
+                # else this is only zeros and should be reset to RangeIndex
+                else:
+                    Xt = Xt.reset_index(drop=True)
             Xt = convert_to(
                 Xt,
-                to_type="pd.DataFrame",
-                as_scitype="Series",
+                to_type="pd_DataFrame_Table",
+                as_scitype="Table",
                 # no converter store since this is not a "1:1 back-conversion"
             )
         # else output_scitype is "Panel" and no need for conversion

--- a/sktime/transformations/tests/test_base.py
+++ b/sktime/transformations/tests/test_base.py
@@ -630,3 +630,31 @@ def test_vectorize_reconstruct_unique_columns():
     t = Detrender.create_test_instance()
     Xt = t.fit_transform(X)
     assert set(Xt.columns) == set([0, 1])
+
+
+def test_vectorize_reconstruct_correct_hierarchy():
+    """Tests correct transform return index in hierarchical case for primitives output.
+
+    Tests that the row index is as expected if rows are vectorized over,
+    by a transform that returns Primitives.
+    The row index of transform return should be identical to the input,
+    with temporal index level removed
+
+    Raises
+    ------
+    AssertionError if output index is not as expected.
+    """
+    from sktime.transformations.series.summarize import SummaryTransformer
+    from sktime.utils._testing.hierarchical import _make_hierarchical
+
+    # hierarchical data with 2 variables and 2 levels
+    X = _make_hierarchical(n_columns=2)
+
+    summary_trafo = SummaryTransformer()
+
+    # this produces a pandas DataFrame with more rows and columns
+    # rows should correspond to different instances in X
+    Xt = summary_trafo.fit_transform(X)
+
+    # check that Xt.index is the same as X.index with time level dropped and made unique
+    assert (X.index.droplevel(-1).unique() == Xt.index).all()

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -160,7 +160,7 @@ def test_sklearn_after_primitives():
     X_out = t.fit_transform(X)
     X_summary = SummaryTransformer().fit_transform(X)
 
-    assert deep_equals(X_out.index, X_summary.index)
+    assert (X_out.index == X_summary.index).all()
     assert deep_equals(X_out.columns, X_summary.columns)
     # var_0 is the same for all three instances
     # so summary statistics are all the same, thus StandardScaler transforms to 0


### PR DESCRIPTION
Transformers with `Primitives` output would return unexpected indices in case of vectorization: this would always reset to a `RangeIndex`, but the expectation is that the hierarchy/instance index is preserved, if there is at least one hierarchy level.

Fixed the bug and added a test.

Other changes:
* replaced the "abuse" of `Series` converter in the same location with the `Table` converter (this was introduced after the original code was written, and is the correct type check).
* the test `test_sklearn_after_primitives` needed to be slightly relaxed, as the above changes lead to indices with same elements but different type in `Table` typed returns, i.e., `Int64Index` being preserved from the instance index level, instead of being reset to `RangeIndex`. This happens in the panel data example used in the test where the instances index level is integer valued.