### PR TITLE
[ENH] Add `is_weekend` option to `DateTimeFeatures` trafo

### DIFF
--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -75,7 +75,7 @@ test_types = pipe.transform(y_train).select_dtypes(include=["int64"]).columns.to
 # Test `is_weekend` works in manual selection
 @pytest.fixture
 def df_datetime_daily_idx():
-    """Create timeseries with Datetime index, month start frequency."""
+    """Create timeseries with Datetime index, daily frequency."""
     return pd.DataFrame(
         data={"y": [1, 1, 1, 1, 1, 1, 1]},
         index=pd.date_range(start="2000-01-01", freq="D", periods=7),

--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -178,7 +178,7 @@ def test_eval(test_input, expected):
 
 
 def test_manual_selection_is_weekend(df_datetime_daily_idx):
-    """Tests that "weekend" returns correct result in `manual_selection`."""
+    """Tests that "is_weekend" returns correct result in `manual_selection`."""
     transformer = DateTimeFeatures(manual_selection=["is_weekend"])
 
     Xt = transformer.fit_transform(df_datetime_daily_idx)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->
#### What does this implement/fix? Explain your changes.
This PR adds `is_weekend` as an option to the `manual_selection` argument in the `DateTimeFeatures` transformer. I have also added more examples to the docstring.

Example usage:
```Python
import pandas as pd
from sktime.transformations.series.date import DateTimeFeatures

df = pd.DataFrame(
        data={"y": [1, 1, 1, 1, 1, 1, 1]},
        index=pd.date_range(start="2000-01-01", freq="D", periods=7),
    )

result = DateTimeFeatures(manual_selection=["is_weekend"]).fit_transform(df)

```

#### What should a reviewer concentrate their feedback on?
The changes made to `_RAW_DUMMIES` on line 32. I'm forced to create a child/parent relationship so I made the child `day` and parent `week`. I'm unsure whether this could have unintended consequences. None were picked up in testing.

The setting of the `fourier` column in the `DUMMIES` dataframe on line 324. I am unsure whether this is the correct value to set for the `fourier` column and what impact this might have?

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.



<!--
Thanks for contributing!
-->
