### PR TITLE
[ENH] _fit_transform

### DIFF
--- a/sktime/transformations/panel/supervised_intervals.py
+++ b/sktime/transformations/panel/supervised_intervals.py
@@ -146,7 +146,7 @@ class SupervisedIntervals(BaseTransformer):
 
         super(SupervisedIntervals, self).__init__()
 
-    def fit_transform(self, X, y=None):
+    def _fit_transform(self, X, y=None):
         """Fit to data, then transform it.
 
         Fits the transformer to X and y and returns a transformed version of X.
@@ -202,11 +202,6 @@ class SupervisedIntervals(BaseTransformer):
                 then the return is a `Panel` object of type `pd-multiindex`
                 Example: i-th instance of the output is the i-th window running over `X`
         """
-        self.reset()
-        if y is None:
-            raise ValueError("SupervisedIntervals requires `y` in `fit`.")
-        X, y, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
-
         y = self._fit_setup(X, y)
         X_norm = z_normalise_series_3d(X)
 
@@ -238,13 +233,7 @@ class SupervisedIntervals(BaseTransformer):
         for i in range(1, self.n_intervals):
             Xt = np.hstack((Xt, transformed_intervals[i]))
 
-        self._is_fitted = True
-
-        if not hasattr(self, "_output_convert") or self._output_convert == "auto":
-            X_out = self._convert_output(Xt, metadata=metadata)
-        else:
-            X_out = Xt
-        return X_out
+        return Xt
 
     def _fit(self, X, y=None):
         y = self._fit_setup(X, y)

--- a/sktime/transformations/panel/tsfresh.py
+++ b/sktime/transformations/panel/tsfresh.py
@@ -560,7 +560,7 @@ class TSFreshRelevantFeatureExtractor(_TSFreshFeatureExtractor):
 
         return selection_params
 
-    def fit_transform(self, X, y=None):
+    def _fit_transform(self, X, y=None):
         """Fit to data, then transform it.
 
         Fits the transformer to X and y and returns a transformed version of X.
@@ -616,9 +616,6 @@ class TSFreshRelevantFeatureExtractor(_TSFreshFeatureExtractor):
                 then the return is a `Panel` object of type `pd-multiindex`
                 Example: i-th instance of the output is the i-th window running over `X`
         """
-        self.reset()
-        if y is None:
-            raise ValueError("SupervisedIntervals requires `y` in `fit`.")
         X, y, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
 
         # lazy imports to avoid hard dependency
@@ -647,13 +644,7 @@ class TSFreshRelevantFeatureExtractor(_TSFreshFeatureExtractor):
         Xt = self.selector_.fit_transform(Xt, y)
         Xt = Xt.reindex(X.index)
 
-        self._is_fitted = True
-
-        if not hasattr(self, "_output_convert") or self._output_convert == "auto":
-            X_out = self._convert_output(Xt, metadata=metadata)
-        else:
-            X_out = Xt
-        return X_out
+        return Xt
 
     def _fit(self, X, y=None):
         """Fit.


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3823 

#### What does this implement/fix? Explain your changes.

Implements a `_fit_transform` method in `BaseTransformer`. `fit_transform` now calls the private method, and contains a set of checks merged from `fit` and `transform`.

This PR also replaces the current `fit_transform` overrides in `SupervisedIntervals` and `TSFreshRelevantFeatureExtractor` with the private method.

Alongside allowing for easier implementation of efficient `fit_transform` methods, the change reduces the repetition of some checks when the method is called.

#### Any other comments?

Happy to make changes or add additional checks if people think they are necessary. As it is, this is essentially a merge of the current `fit` and `transform` methods with some repetition removed.
