### PR TITLE
[BUG] fix unreported `set_params` bug in `ClassifierPipeline` and `RegressorPipeline`

### DIFF
--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -120,10 +120,41 @@ class _HeterogenousMetaEstimator:
                 "{0!r}".format(invalid_names)
             )
 
-    def _subset_dict_keys(self, dict_to_subset, keys):
-        """Subset dictionary d to keys in keys."""
+    def _subset_dict_keys(self, dict_to_subset, keys, prefix=None):
+        """Subset dictionary d to keys in keys.
+
+        Subsets `dict_to_subset` to keys in iterable `keys`.
+
+        If `prefix` is passed, subsets to `f"{prefix}__{key}"` for all `key` in `keys`.
+        The prefix is then removed from the keys of the return dict, i.e.,
+        return has keys `{key}` where `f"{prefix}__{key}"` was key in `dict_to_subset`.
+        Note that passing `prefix` will turn non-str keys into str keys.
+
+        Parameters
+        ----------
+        dict_to_subset : dict
+            dictionary to subset by keys
+        keys : iterable
+        prefix : str or None, optional
+
+        Returns
+        -------
+        `subsetted_dict` : dict
+            `dict_to_subset` subset to keys in `keys` described as above
+        """
+        def rem_prefix(x):
+            if prefix is None:
+                return x
+            prefix__ = f"{prefix}__"
+            if x.startswith(prefix__):
+                return x[len(prefix__):]
+            else:
+                return x
+
+        if prefix is not None:
+            keys = [f"{prefix}__{key}" for key in keys]
         keys_in_both = set(keys).intersection(dict_to_subset.keys())
-        subsetted_dict = dict((k, dict_to_subset[k]) for k in keys_in_both)
+        subsetted_dict = dict((rem_prefix(k), dict_to_subset[k]) for k in keys_in_both)
         return subsetted_dict
 
     @staticmethod

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -142,12 +142,13 @@ class _HeterogenousMetaEstimator:
         `subsetted_dict` : dict
             `dict_to_subset` subset to keys in `keys` described as above
         """
+
         def rem_prefix(x):
             if prefix is None:
                 return x
             prefix__ = f"{prefix}__"
             if x.startswith(prefix__):
-                return x[len(prefix__):]
+                return x[len(prefix__) :]
             else:
                 return x
 

--- a/sktime/classification/compose/_pipeline.py
+++ b/sktime/classification/compose/_pipeline.py
@@ -264,9 +264,6 @@ class ClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
         -------
         self : returns an instance of self.
         """
-        kwargs = kwargs.copy()
-        current_params = self.get_params(deep=False)
-        kwargs.update(current_params)
         if "classifier" in kwargs.keys():
             if not isinstance(kwargs["classifier"], BaseClassifier):
                 raise TypeError('"classifier" arg must be an sktime classifier')

--- a/sktime/classification/compose/_pipeline.py
+++ b/sktime/classification/compose/_pipeline.py
@@ -422,7 +422,7 @@ class SklearnClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
         self.transformers = transformers
         self.transformers_ = TransformerPipeline(transformers)
 
-        super(ClassifierPipeline, self).__init__()
+        super(SklearnClassifierPipeline, self).__init__()
 
         # can handle multivariate iff all transformers can
         # sklearn transformers always support multivariate

--- a/sktime/classification/compose/_pipeline.py
+++ b/sktime/classification/compose/_pipeline.py
@@ -264,6 +264,9 @@ class ClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
         -------
         self : returns an instance of self.
         """
+        kwargs = kwargs.copy()
+        current_params = self.get_params(deep=False)
+        kwargs.update(current_params)
         if "classifier" in kwargs.keys():
             if not isinstance(kwargs["classifier"], BaseClassifier):
                 raise TypeError('"classifier" arg must be an sktime classifier')
@@ -301,14 +304,19 @@ class ClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
         """
         # imports
         from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
+        from sktime.classification.dummy import DummyClassifier
         from sktime.transformations.series.exponent import ExponentTransformer
 
         t1 = ExponentTransformer(power=2)
         t2 = ExponentTransformer(power=0.5)
         c = KNeighborsTimeSeriesClassifier()
 
-        # construct without names
-        return {"transformers": [t1, t2], "classifier": c}
+        another_c = DummyClassifier()
+
+        params1 = {"transformers": [t1, t2], "classifier": c}
+        params2 = {"transformers": [t1], "classifier": another_c}
+
+        return [params1, params2]
 
 
 class SklearnClassifierPipeline(ClassifierPipeline):

--- a/sktime/classification/dummy/_dummy.py
+++ b/sktime/classification/dummy/_dummy.py
@@ -64,6 +64,7 @@ class DummyClassifier(BaseClassifier):
         "X_inner_mtype": "nested_univ",
         "capability:missing_values": True,
         "capability:unequal_length": True,
+        "capability:multivariate": True,
     }
 
     def __init__(self, strategy="prior", random_state=None, constant=None):

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -546,7 +546,6 @@ class SklearnRegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
         """
         if "regressor" in kwargs.keys():
             if not is_sklearn_regressor(kwargs["regressor"]):
-                print(kwargs["regressor"])
                 raise TypeError('"regressor" arg must be an sklearn regressor')
         trafo_keys = self._get_params("_transformers", deep=True).keys()
         regr_keys = self.regressor.get_params(deep=True).keys()

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -279,16 +279,26 @@ class RegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
-        from sklearn.dummy import DummyRegressor
-        
         from sktime.transformations.series.exponent import ExponentTransformer
+        from sktime.utils.validation._dependencies import _check_soft_dependencies
 
         t1 = ExponentTransformer(power=2)
         t2 = ExponentTransformer(power=0.5)
-        c = KNeighborsTimeSeriesRegressor()
 
-        # construct without names
-        return {"transformers": [t1, t2], "regressor": c}
+        r = SklearnRegressorPipeline.create_test_instance()
+
+        params1 = {"transformers": [t1, t2], "regressor": r}
+
+        if _check_soft_dependencies("numba", severity="none"):
+            from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor
+
+            c = KNeighborsTimeSeriesRegressor()
+
+            # construct without names
+            params2 = {"transformers": [t1, t2], "regressor": c}
+            return [params1, params2]
+        else:
+            return params1
 
 
 class SklearnRegressorPipeline(RegressorPipeline):

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -279,8 +279,8 @@ class RegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
-        # imports
-        from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor
+        from sklearn.dummy import DummyRegressor
+        
         from sktime.transformations.series.exponent import ExponentTransformer
 
         t1 = ExponentTransformer(power=2)
@@ -512,6 +512,9 @@ class SklearnRegressorPipeline(RegressorPipeline):
         -------
         self : returns an instance of self.
         """
+        kwargs = kwargs.copy()
+        current_params = self.get_params(deep=False)
+        kwargs.update(current_params)
         if "regressor" in kwargs.keys():
             if not is_sklearn_regressor(kwargs["regressor"]):
                 raise TypeError('"regressor" arg must be an sklearn regressor')

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -522,9 +522,6 @@ class SklearnRegressorPipeline(RegressorPipeline):
         -------
         self : returns an instance of self.
         """
-        kwargs = kwargs.copy()
-        current_params = self.get_params(deep=False)
-        kwargs.update(current_params)
         if "regressor" in kwargs.keys():
             if not is_sklearn_regressor(kwargs["regressor"]):
                 raise TypeError('"regressor" arg must be an sklearn regressor')

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -119,11 +119,6 @@ def deep_equals(x, y, return_msg=False):
         )
     elif isclass(x):
         return ret(x == y, f".class, x={x.__name__} != y={y.__name__}")
-    elif hasattr(x, "get_params") and hasattr(y, "get_params"):
-        res, msg = deep_equals(
-            x.get_params(deep=False), y.get_params(deep=False), return_msg=True
-        )
-        return ret(res, f"params, {msg}")
     elif type(x).__name__ == "ForecastingHorizon":
         return ret(*_fh_equals(x, y, return_msg=True))
     elif isinstance(x != y, bool) and x != y:

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -11,6 +11,7 @@ __author__ = ["fkiraly"]
 
 __all__ = ["deep_equals"]
 
+from inspect import isclass
 
 import numpy as np
 import pandas as pd
@@ -116,6 +117,8 @@ def deep_equals(x, y, return_msg=False):
         return ret(
             isinstance(y, type(np.nan)), f"type(x)={type(x)} != type(y)={type(y)}"
         )
+    elif isclass(x) or isclass(y):
+        return ret(x != y, f"type(x)={type(x)} != type(y)={type(y)}")
     elif hasattr(x, "get_params") and hasattr(y, "get_params"):
         res, msg = deep_equals(
             x.get_params(deep=False), y.get_params(deep=False), return_msg=True

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -117,8 +117,8 @@ def deep_equals(x, y, return_msg=False):
         return ret(
             isinstance(y, type(np.nan)), f"type(x)={type(x)} != type(y)={type(y)}"
         )
-    elif isclass(x) or isclass(y):
-        return ret(x != y, f"type(x)={type(x)} != type(y)={type(y)}")
+    elif isclass(x):
+        return ret(x == y, f".class, x={x.__name__} != y={y.__name__}")
     elif hasattr(x, "get_params") and hasattr(y, "get_params"):
         res, msg = deep_equals(
             x.get_params(deep=False), y.get_params(deep=False), return_msg=True

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -116,6 +116,11 @@ def deep_equals(x, y, return_msg=False):
         return ret(
             isinstance(y, type(np.nan)), f"type(x)={type(x)} != type(y)={type(y)}"
         )
+    elif hasattr(x, "get_params") and hasattr(y, "get_params"):
+        res, msg = deep_equals(
+            x.get_params(deep=False), y.get_params(deep=False), return_msg=True
+        )
+        return ret(res, f"params, {msg}")
     elif type(x).__name__ == "ForecastingHorizon":
         return ret(*_fh_equals(x, y, return_msg=True))
     elif isinstance(x != y, bool) and x != y:


### PR DESCRIPTION
`set_params` bug in `ClassifierPipeline` and `RegressorPipeline` was broken, it would not correctly update parameters.

The failure to detect this is an instance of the known problem https://github.com/sktime/sktime/issues/3429

The bug has been fixed, and is now covered by appropriate tests (addition of a second parameter set).

The fix is as follow:

* the issue was in `set_params` which accidentally had one too many layer of nesting in the param dict indexing, e.g., `classifier__` etc. This would materialize only for doubly nested estimators.
* this was fixed, with a concomitant extension of the dict subset utility in the `_HetereogenousMetaEstimator`.

Depends on https://github.com/sktime/sktime/pull/3858 as the `DummyClassifier` is used as one of two param sets.