### PR TITLE
[BUG] in `DummyClassifier`, fix incorrectly set `capability:multivariate` tag

### DIFF
--- a/sktime/classification/dummy/_dummy.py
+++ b/sktime/classification/dummy/_dummy.py
@@ -64,6 +64,7 @@ class DummyClassifier(BaseClassifier):
         "X_inner_mtype": "nested_univ",
         "capability:missing_values": True,
         "capability:unequal_length": True,
+        "capability:multivariate": True,
     }
 
     def __init__(self, strategy="prior", random_state=None, constant=None):


### PR DESCRIPTION
In `DummyClassifier`, the `capability:multivariate` tag was incorrectly set to `False`.

This has been changed to `True`.

Reason: `DummyClassifier` ignores `X` (besides its length), so it is unimportant whether it was multivariate or not.