### PR TITLE
[ENH] equality dunder for `BaseObject` to compare blueprint

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -76,6 +76,24 @@ class BaseObject(_BaseEstimator):
         self._tags_dynamic = dict()
         super(BaseObject, self).__init__()
 
+    def __eq__(self, other):
+        """Equality dunder. Checks equal class and parameters.
+
+        Returns True iff result of get_params(deep=False)
+        results in equal parameter sets.
+
+        Nested BaseObject descendants from get_params are compared via __eq__ as well.
+        """
+        from sktime.utils._testing.deep_equals import deep_equals
+
+        if not isinstance(other, BaseObject):
+            return False
+
+        self_params = self.get_params(deep=False)
+        other_params = other.get_params(deep=False)
+
+        return deep_equals(self_params, other_params)
+
     def reset(self):
         """Reset the object to a clean post-init state.
 

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -281,8 +281,8 @@ def test_components():
 
     assert isinstance(comp_comps, dict)
     assert set(comp_comps.keys()) == set(["foo_"])
-    assert comp_comps["foo_"] == composite.foo_
-    assert comp_comps["foo_"] != composite.foo
+    assert comp_comps["foo_"] is composite.foo_
+    assert comp_comps["foo_"] is not composite.foo
 
 
 class FittableCompositionDummy(BaseEstimator):
@@ -322,8 +322,8 @@ def test_get_fitted_params():
 
     assert isinstance(comp_f_params, dict)
     assert set(comp_f_params) == set(["foo", "foo__foo"])
-    assert comp_f_params["foo"] == composite.foo_
-    assert comp_f_params["foo"] != composite.foo
+    assert comp_f_params["foo"] is composite.foo_
+    assert comp_f_params["foo"] is not composite.foo
 
 
 def test_eq_dunder():

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -16,6 +16,8 @@ tests in this module:
 
     test_components         - tests retrieval of list of components via _components
     test_get_fitted_params  - tests get_fitted_params logic, nested and non-nested
+
+    test_eq_dunder       - tests __eq__ dunder to compare parameter definition
 """
 
 __author__ = ["fkiraly"]
@@ -28,6 +30,9 @@ __all__ = [
     "test_set_tags",
     "test_reset",
     "test_reset_composite",
+    "test_components",
+    "test_get_fitted_params",
+    "test_eq_dunder",
 ]
 
 from copy import deepcopy
@@ -319,3 +324,46 @@ def test_get_fitted_params():
     assert set(comp_f_params) == set(["foo", "foo__foo"])
     assert comp_f_params["foo"] == composite.foo_
     assert comp_f_params["foo"] != composite.foo
+
+
+def test_eq_dunder():
+    """Tests equality dunder for BaseObject descendants.
+
+    Equality should be determined only by get_params results.
+
+    Raises
+    ------
+    AssertionError if logic behind __eq__ is incorrect, logic tested:
+        equality of non-composites depends only on params, not on identity
+        equality of composites depends only on params, not on identity
+        result is not affected by fitting the estimator
+    """
+    non_composite = FittableCompositionDummy(foo=42)
+    non_composite_2 = FittableCompositionDummy(foo=42)
+    non_composite_3 = FittableCompositionDummy(foo=84)
+
+    composite = FittableCompositionDummy(foo=non_composite)
+    composite_2 = FittableCompositionDummy(foo=non_composite_2)
+    composite_3 = FittableCompositionDummy(foo=non_composite_3)
+
+    assert non_composite == non_composite
+    assert composite == composite
+    assert non_composite == non_composite_2
+    assert non_composite != non_composite_3
+    assert non_composite_2 != non_composite_3
+    assert composite == composite_2
+    assert composite != composite_3
+    assert composite_2 != composite_3
+
+    # equality should not be affected by fitting
+    composite.fit()
+    non_composite_2.fit()
+
+    assert non_composite == non_composite
+    assert composite == composite
+    assert non_composite == non_composite_2
+    assert non_composite != non_composite_3
+    assert non_composite_2 != non_composite_3
+    assert composite == composite_2
+    assert composite != composite_3
+    assert composite_2 != composite_3


### PR DESCRIPTION
This adds an equality dunder to `BaseObject` descendants.

Two `BaseObject` descendants are considered equal if they define the same estimator blueprint, i.e., nested `get_params` result in value-identical dictionaries (with nested call to `__eq__` should those dictionaries contain `BaseObject` descendants).

Includes a test for expected properties of the dunder.

This is prompted by issues of equality testing in tests such as in the failure relevant for https://github.com/sktime/sktime/pull/3857, where equality currently means object identity rather than parameter identity.

FYI @RNKuhns, this could/should be an `skbase` feature, so would appreciate opinion on whether it interacts with any of the other tests or properties.