### PR TITLE
[DOC] Tidy Rocket docstrings

### DIFF
--- a/sktime/transformations/panel/rocket/_minirocket.py
+++ b/sktime/transformations/panel/rocket/_minirocket.py
@@ -14,51 +14,48 @@ from sktime.transformations.base import BaseTransformer
 
 
 class MiniRocket(BaseTransformer):
-    """MINIROCKET.
+    """MINImally RandOm Convolutional KErnel Transform (MiniRocket).
 
-    MINImally RandOm Convolutional KErnel Transform
-
-    **Univariate** and **equal length**
-
-    Unviariate input only.  Use class MiniRocketMultivariate for multivariate
-    input, or MiniRocketMultivariate for unequal length time-series . [1]_
-
+    MiniRocket [1]_ is an almost deterministic version of Rocket. If creates
+    convolutions of length of 9 with weights restricted to two values, and uses 84 fixed
+    convolutions with six of one weight, three of the second weight to seed dilations.
+    MiniRocket is for unviariate time series only.  Use class MiniRocketMultivariate
+    for multivariate time series.
 
     Parameters
     ----------
-    num_kernels              : int, (default=10,000)
-                                number of random convolutional kernels
-    max_dilations_per_kernel : int, (default=32)
-                                maximum number of dilations per kernel
-    n_jobs                   : int, (default=1)
-                                The number of jobs to run in parallel
-                                for `transform`. ``-1`` means using all processors.
-    random_state             : int or None, (default=None)
-                                random seed, not set by default
-
-    References
-    ----------
-    .. [1] Angus Dempster, Daniel F Schmidt, Geoffrey I Webb
-        MINIROCKET: A Very Fast (Almost) Deterministic Transform for
-        Time Series Classification, 2020, arXiv:2012.08791
+    num_kernels : int, default=10,000
+       number of random convolutional kernels.
+    max_dilations_per_kernel : int, default=32
+        maximum number of dilations per kernel.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel for `transform`. ``-1`` means using all
+        processors.
+    random_state : None or int, default = None
 
     See Also
     --------
-    MultiRocket, MiniRocketMultivariate, MiniRocketMultivariateVariable, Rocket
+    MultiRocketMultivariate, MiniRocket, MiniRocketMultivariate, Rocket
+
+    References
+    ----------
+    .. [1] Dempster, Angus and Schmidt, Daniel F and Webb, Geoffrey I,
+        "MINIROCKET: A Very Fast (Almost) Deterministic Transform for Time Series
+        Classification",2020,
+        https://dl.acm.org/doi/abs/10.1145/3447548.3467231,
+        https://arxiv.org/abs/2012.08791
 
     Examples
     --------
-    >>> from sktime.transformations.panel.rocket import MiniRocket
-    >>> from sktime.datasets import load_gunpoint
-    >>> # load univariate dataset
-    >>> X_train, _ = load_gunpoint(split="train", return_X_y=True)
-    >>> X_test, _ = load_gunpoint(split="test", return_X_y=True)
-    >>> pre_clf = MiniRocket()
-    >>> pre_clf.fit(X_train, y=None)
-    MiniRocket(...)
-    >>> X_transformed = pre_clf.transform(X_test)
-    >>> X_transformed.shape
-    (150, 9996)
+     >>> from sktime.transformations.panel.rocket import Rocket
+     >>> from sktime.datasets import load_unit_test
+     >>> X_train, y_train = load_unit_test(split="train")
+     >>> X_test, y_test = load_unit_test(split="test")
+     >>> trf = MiniRocket(num_kernels=512)
+     >>> trf.fit(X_train)
+     MiniRocket(...)
+     >>> X_train = trf.transform(X_train)
+     >>> X_test = trf.transform(X_test)
     """
 
     _tags = {

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate.py
@@ -14,50 +14,47 @@ from sktime.transformations.base import BaseTransformer
 
 
 class MiniRocketMultivariate(BaseTransformer):
-    """MINIROCKET (Multivariate).
+    """MINImally RandOm Convolutional KErnel Transform (MiniRocket) multivariate.
 
-    MINImally RandOm Convolutional KErnel Transform
-
-    **Multivariate** and **equal length**
-
-    A provisional and naive extension of MINIROCKET to multivariate input.  Use
-    class MiniRocket for univariate input. [1]_
+    MiniRocketMultivariate [1]_ is an almost deterministic version of Rocket. If creates
+    convolutions of length of 9 with weights restricted to two values, and uses 84 fixed
+    convolutions with six of one weight, three of the second weight to seed dilations.
+    MiniRocketMultivariate works with univariate and multivariate time series.
 
     Parameters
     ----------
-    num_kernels              : int, (default=10,000)
-                                number of random convolutional kernels
-    max_dilations_per_kernel : int, (default=32)
-                                maximum number of dilations per kernel
-    n_jobs                   : int, (default=1)
-                                The number of jobs to run in parallel
-                                 for `transform`. ``-1`` means using all processors.
-    random_state             : int or None, (default=None)
-                                random seed, not set by default
-
-    References
-    ----------
-    .. [1] Angus Dempster, Daniel F Schmidt, Geoffrey I Webb
-        MINIROCKET: A Very Fast (Almost) Deterministic Transform for
-        Time Series Classification, 2020, arXiv:2012.08791
+    num_kernels : int, default=10,000
+       number of random convolutional kernels.
+    max_dilations_per_kernel : int, default=32
+        maximum number of dilations per kernel.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel for `transform`. ``-1`` means using all
+        processors.
+    random_state : None or int, default = None
 
     See Also
     --------
-    MultiRocket, MiniRocket, MiniRocketMultivariateVariable, Rocket
+    MultiRocketMultivariate, MiniRocket, MiniRocketMultivariate, Rocket
+
+    References
+    ----------
+    .. [1] Dempster, Angus and Schmidt, Daniel F and Webb, Geoffrey I,
+        "MINIROCKET: A Very Fast (Almost) Deterministic Transform for Time Series
+        Classification",2020,
+        https://dl.acm.org/doi/abs/10.1145/3447548.3467231,
+        https://arxiv.org/abs/2012.08791
 
     Examples
     --------
-    >>> from sktime.transformations.panel.rocket import MiniRocketMultivariate
-    >>> from sktime.datasets import load_basic_motions
-    >>> # load multivariate and equal length dataset
-    >>> X_train, _ = load_basic_motions(split="train", return_X_y=True)
-    >>> X_test, _ = load_basic_motions(split="test", return_X_y=True)
-    >>> pre_clf = MiniRocketMultivariate()
-    >>> pre_clf.fit(X_train, y=None)
-    MiniRocketMultivariate(...)
-    >>> X_transformed = pre_clf.transform(X_test)
-    >>> X_transformed.shape
-    (40, 9996)
+     >>> from sktime.transformations.panel.rocket import Rocket
+     >>> from sktime.datasets import load_basic_motions
+     >>> X_train, y_train = load_basic_motions(split="train")
+     >>> X_test, y_test = load_basic_motions(split="test")
+     >>> trf = MiniRocketMultivariate(num_kernels=512)
+     >>> trf.fit(X_train)
+     MiniRocketMultivariate(...)
+     >>> X_train = trf.transform(X_train)
+     >>> X_test = trf.transform(X_test)
     """
 
     _tags = {

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
@@ -52,10 +52,11 @@ class MiniRocketMultivariateVariable(BaseTransformer):
     >>> # load multivariate and unequal length dataset
     >>> X_train, _ = load_japanese_vowels(split="train", return_X_y=True)
     >>> X_test, _ = load_japanese_vowels(split="test", return_X_y=True)
-    >>> pre_clf = MiniRocketMultivariateVariable(num_kernels=512)
+    >>> pre_clf = MiniRocketMultivariateVariable(pad_value_short_series=0.0)
     >>> pre_clf.fit(X_train, y=None)
     MiniRocketMultivariateVariable(...)
     >>> X_transformed = pre_clf.transform(X_test)
+    >>> X_transformed.shape
 
     Raises
     ------

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
@@ -29,23 +29,21 @@ class MiniRocketMultivariateVariable(BaseTransformer):
 
     Parameters
     ----------
-    num_kernels              : int, (default=10_000)
-                                number of random convolutional kernels.
-                                Reduced to the closest multiple of 84.
-    max_dilations_per_kernel : int, (default=32)
-                                maximum number of dilations per kernel
-    reference_length         : int or str, (default `'max'`)
-                                series-length of reference, str defines
-                                how to infer from X during 'fit'.
-                                options are `'max'`, `'mean'`, `'median'`, `'min'`
-    n_jobs                   : int, (default=1)
-                                The number of jobs to run in parallel
-                                for `transform`. ``-1`` means using all processors.
-    pad_value_short_series   : float or None, (default=None)
-                                if padding series with len<9 to value.
-                                if None, not padding is performed.
-    random_state             : int, (default=None)
-                                random seed, not set by default
+    num_kernels : int, default=10,000
+       number of random convolutional kernels. The calculated number of features is the
+       nearest multiple of n_features_per_kernel(default 4)*84=336 < 50,000
+       (2*n_features_per_kernel(default 4)*num_kernels(default 10,000)).
+    max_dilations_per_kernel : int, default=32
+        maximum number of dilations per kernel.
+    reference_length : int or str, default = `'max'`
+        series-length of reference, str defines how to infer from X during 'fit'.
+        options are `'max'`, `'mean'`, `'median'`, `'min'`.
+    pad_value_short_series : float or None, default=None
+        if padding series with len<9 to value. if None, not padding is performed.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel for `transform`. ``-1`` means using all
+        processors.
+    random_state : None or int, default = None
 
     Examples
     --------
@@ -54,12 +52,10 @@ class MiniRocketMultivariateVariable(BaseTransformer):
     >>> # load multivariate and unequal length dataset
     >>> X_train, _ = load_japanese_vowels(split="train", return_X_y=True)
     >>> X_test, _ = load_japanese_vowels(split="test", return_X_y=True)
-    >>> pre_clf = MiniRocketMultivariateVariable(pad_value_short_series=0.0)
+    >>> pre_clf = MiniRocketMultivariateVariable(num_kernels=512)
     >>> pre_clf.fit(X_train, y=None)
     MiniRocketMultivariateVariable(...)
     >>> X_transformed = pre_clf.transform(X_test)
-    >>> X_transformed.shape
-    (370, 9996)
 
     Raises
     ------

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
@@ -57,6 +57,7 @@ class MiniRocketMultivariateVariable(BaseTransformer):
     MiniRocketMultivariateVariable(...)
     >>> X_transformed = pre_clf.transform(X_test)
     >>> X_transformed.shape
+    (370, 9996)
 
     Raises
     ------

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
@@ -155,7 +155,7 @@ class MiniRocketMultivariateVariable(BaseTransformer):
             If any multivariate series_length in X is < 9 and
             pad_value_short_series is set to None
         """
-        X_2d_t, lenghts_1darray = _nested_dataframe_to_transposed2D_array_and_len_list(
+        X_2d_t, lengths_1darray = _nested_dataframe_to_transposed2D_array_and_len_list(
             X, pad=self.pad_value_short_series
         )
 
@@ -163,7 +163,7 @@ class MiniRocketMultivariateVariable(BaseTransformer):
             _reference_length = self.reference_length
         elif self.reference_length in self._reference_modes:
             # np.mean, np.max, np.median, np.min ..
-            _reference_length = getattr(np, self.reference_length)(lenghts_1darray)
+            _reference_length = getattr(np, self.reference_length)(lengths_1darray)
         else:
             raise ValueError(
                 "reference_length in MiniRocketMultivariateVariable must be int>=9 or "
@@ -172,17 +172,17 @@ class MiniRocketMultivariateVariable(BaseTransformer):
             )
         self._fitted_reference_length = int(max(9, _reference_length))
 
-        if lenghts_1darray.min() < 9:
-            failed_index = np.where(lenghts_1darray < 9)[0]
+        if lengths_1darray.min() < 9:
+            failed_index = np.where(lengths_1darray < 9)[0]
             raise ValueError(
                 (
                     f"X must be >= 9 for all samples, but found miniumum to be "
-                    f"{lenghts_1darray.min()}; at index {failed_index}, pad shorter "
+                    f"{lengths_1darray.min()}; at index {failed_index}, pad shorter "
                     "series so that n_timepoints >= 9 for all samples."
                 )
             )
 
-        if lenghts_1darray.min() == lenghts_1darray.max():
+        if lengths_1darray.min() == lengths_1darray.max():
             warnings.warn(
                 "X is of equal length, consider using MiniRocketMultivariate for "
                 "speedup and stability instead."
@@ -195,7 +195,7 @@ class MiniRocketMultivariateVariable(BaseTransformer):
 
         self.parameters = _fit_multi_var(
             X_2d_t,
-            L=lenghts_1darray,
+            L=lengths_1darray,
             reference_length=self._fitted_reference_length,
             num_features=self.num_kernels,
             max_dilations_per_kernel=self.max_dilations_per_kernel,

--- a/sktime/transformations/panel/rocket/_multirocket.py
+++ b/sktime/transformations/panel/rocket/_multirocket.py
@@ -10,38 +10,31 @@ from sktime.transformations.base import BaseTransformer
 
 
 class MultiRocket(BaseTransformer):
-    """
-    MultiRocket univariate version.
+    """Multi RandOm Convolutional KErnel Transform (MultiRocket).
 
-    Multi RandOm Convolutional KErnel Transform
-
-    **Univariate**
-
-    Univariate input only.  Use class MultiRocketMultivariate for multivariate
-    input.
-
-    @article{Tan2021MultiRocket,
-    title={{MultiRocket}: Multiple pooling operators and transformations
-    for fast and effective time series classification},
-    author={Tan, Chang Wei and Dempster, Angus and Bergmeir, Christoph and
-    Webb, Geoffrey I},
-    year={2021},
-    journal={arxiv:2102.00457v3}
-    }
+    MultiRocket [1]_ is uses the same set of kernels as MiniRocket on both the raw
+    series and the first order differenced series representation. It uses a different
+    set of dilations and used for each representation. In addition to percentage of
+    positive values (PPV) MultiRocket adds 3 pooling operators: Mean of Positive
+    Values (MPV); Mean of Indices of Positive Values (MIPV); and Longest Stretch of
+    Positive Values (LSPV). This version is for univariate time series only. Use class
+    MultiRocketMultivariate for multivariate input.
 
     Parameters
     ----------
-    num_kernels              : int, number of random convolutional kernels
-    (default 6,250)
-    calculated number of features is the nearest multiple of
-    n_features_per_kernel(default 4)*84=336 < 50,000
-    (2*n_features_per_kernel(default 4)*num_kernels(default 6,250))
-    max_dilations_per_kernel : int, maximum number of dilations per kernel (default 32)
-    n_features_per_kernel    : int, number of features per kernel (default 4)
-    normalise                : int, normalise the data (default False)
-    n_jobs                   : int, optional (default=1) The number of jobs to run in
-    parallel for `transform`. ``-1`` means using all processors.
-    random_state             : int, random seed (optional, default None)
+    num_kernels : int, default = 6,250
+       number of random convolutional kernels. The calculated number of features is the
+       nearest multiple of n_features_per_kernel(default 4)*84=336 < 50,000
+       (2*n_features_per_kernel(default 4)*num_kernels(default 6,250)).
+    max_dilations_per_kernel : int, default = 32
+        maximum number of dilations per kernel.
+    n_features_per_kernel : int, default = 4
+        number of features per kernel.
+    normalise : bool, default False
+    n_jobs : int, default=1
+        The number of jobs to run in parallel for `transform`. ``-1`` means using all
+        processors.
+    random_state : None or int, default = None
 
     Attributes
     ----------
@@ -52,29 +45,30 @@ class MultiRocket(BaseTransformer):
         parameter (dilations, num_features_per_dilation, biases) for
         transformation of input X1 = np.diff(X, 1)
 
+
     See Also
     --------
     MultiRocketMultivariate, MiniRocket, MiniRocketMultivariate, Rocket
 
     References
     ----------
-    .. [1] Tan, Chang Wei and Dempster, Angus and Bergmeir, Christoph
-        and Webb, Geoffrey I,
-        "MultiRocket: Multiple pooling operators and transformations
-        for fast and effective time series classification",
-        2021, https://arxiv.org/abs/2102.00457v3
+    .. [1] Tan, Chang Wei and Dempster, Angus and Bergmeir, Christoph and
+    Webb, Geoffrey I, "MultiRocket: Multiple pooling operators and transformations
+    for fast and effective time series classification",2022,
+    https://link.springer.com/article/10.1007/s10618-022-00844-1
+    https://arxiv.org/abs/2102.00457
 
     Examples
     --------
-    >>> from sktime.transformations.panel.rocket._multirocket import MultiRocket
-    >>> from sktime.datasets import load_unit_test
-    >>> X_train, y_train = load_unit_test(split="train")
-    >>> X_test, y_test = load_unit_test(split="test")
-    >>> trf = MultiRocket(num_kernels=512)
-    >>> trf.fit(X_train)
-    MultiRocket(...)
-    >>> X_train = trf.transform(X_train)
-    >>> X_test = trf.transform(X_test)
+     >>> from sktime.transformations.panel.rocket import Rocket
+     >>> from sktime.datasets import load_unit_test
+     >>> X_train, y_train = load_unit_test(split="train")
+     >>> X_test, y_test = load_unit_test(split="test")
+     >>> trf = MultiRocket(num_kernels=512)
+     >>> trf.fit(X_train)
+     MultiRocket(...)
+     >>> X_train = trf.transform(X_train)
+     >>> X_test = trf.transform(X_test)
     """
 
     _tags = {

--- a/sktime/transformations/panel/rocket/_multirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_multirocket_multivariate.py
@@ -9,44 +9,30 @@ from sktime.transformations.base import BaseTransformer
 
 
 class MultiRocketMultivariate(BaseTransformer):
-    """
-    MultiRocket multivariate version.
+    """Multi RandOm Convolutional KErnel Transform (MultiRocket).
 
-    Multi RandOm Convolutional KErnel Transform
-
-    **Multivariate**
-
-    A provisional and naive extension of MultiRocket to multivariate input.  Use
-    class MultiRocket for univariate input.
-
-    @article{Tan2021MultiRocket,
-    title={{MultiRocket}: Multiple pooling operators and transformations
-    for fast and effective time series classification},
-    author={Tan, Chang Wei and Dempster, Angus and Bergmeir, Christoph and
-    Webb, Geoffrey I},
-    year={2021},
-    journal={arxiv:2102.00457v3}
-    }
+    MultiRocket [1]_ is uses the same set of kernels as MiniRocket on both the raw
+    series and the first order differenced series representation. It uses a different
+    set of dilations and used for each representation. In addition to percentage of
+    positive values (PPV) MultiRocket adds 3 pooling operators: Mean of Positive
+    Values (MPV); Mean of Indices of Positive Values (MIPV); and Longest Stretch of
+    Positive Values (LSPV). This version is the multivariate version.
 
     Parameters
     ----------
-    num_kernels              : int, (default=6,250)
-                                number of random convolutional kernels
-                                calculated number of features is the nearest multiple of
-                                n_features_per_kernel
-                                (default is 4)*84=336 < 50,000
-                                (2*n_features_per_kernel*num_kernels)
-    max_dilations_per_kernel : int, (default=32)
-                                maximum number of dilations per kernel
-    n_features_per_kernel    : int, (default=4)
-                                number of features per kernel
-    normalise                : int, (default=False)
-                                normalise the data
-    n_jobs                   : int, (default=1)
-                                The number of jobs to run in parallel
-                                for `transform`. ``-1`` means using all processors.
-    random_state             : int, (default=None)
-                                random seed
+    num_kernels : int, default=6,250
+       number of random convolutional kernels. The calculated number of features is the
+       nearest multiple of n_features_per_kernel(default 4)*84=336 < 50,000
+       (2*n_features_per_kernel(default 4)*num_kernels(default 6,250)).
+    max_dilations_per_kernel : int, default=32
+        maximum number of dilations per kernel.
+    n_features_per_kernel : int, default =4
+        number of features per kernel.
+    normalise : bool, default False
+    n_jobs : int, default=1
+        The number of jobs to run in parallel for `transform`. ``-1`` means using all
+        processors.
+    random_state : None or int, default = None
 
     Attributes
     ----------
@@ -57,29 +43,30 @@ class MultiRocketMultivariate(BaseTransformer):
         parameter (dilations, num_features_per_dilation, biases) for
         transformation of input X1 = np.diff(X, 1)
 
+
     See Also
     --------
-    MultiRocket, MiniRocket, MiniRocketMultivariateVariable, Rocket
+    MultiRocketMultivariate, MiniRocket, MiniRocketMultivariate, Rocket
 
     References
     ----------
-    .. [1] Tan, Chang Wei and Dempster, Angus and Bergmeir, Christoph
-        and Webb, Geoffrey I,
-        "MultiRocket: Multiple pooling operators and transformations
-        for fast and effective time series classification",
-        2021, https://arxiv.org/abs/2102.00457v3
+    .. [1] Tan, Chang Wei and Dempster, Angus and Bergmeir, Christoph and
+    Webb, Geoffrey I, "MultiRocket: Multiple pooling operators and transformations
+    for fast and effective time series classification",2022,
+    https://link.springer.com/article/10.1007/s10618-022-00844-1
+    https://arxiv.org/abs/2102.00457
 
     Examples
     --------
-    >>> from sktime.transformations.panel.rocket._multirocket import MultiRocket
-    >>> from sktime.datasets import load_basic_motions
-    >>> X_train, y_train = load_basic_motions(split="train")
-    >>> X_test, y_test = load_basic_motions(split="test")
-    >>> trf = MultiRocket(num_kernels=512)
-    >>> trf.fit(X_train)
-    MultiRocket(...)
-    >>> X_train = trf.transform(X_train)
-    >>> X_test = trf.transform(X_test)
+     >>> from sktime.transformations.panel.rocket import Rocket
+     >>> from sktime.datasets import load_basic_motions
+     >>> X_train, y_train = load_basic_motions(split="train")
+     >>> X_test, y_test = load_basic_motions(split="test")
+     >>> trf = MultiRocketMultivariate(num_kernels=512)
+     >>> trf.fit(X_train)
+     MultiRocketMultivariate(...)
+     >>> X_train = trf.transform(X_train)
+     >>> X_test = trf.transform(X_test)
     """
 
     _tags = {

--- a/sktime/transformations/panel/rocket/_rocket.py
+++ b/sktime/transformations/panel/rocket/_rocket.py
@@ -14,44 +14,48 @@ from sktime.transformations.base import BaseTransformer
 
 
 class Rocket(BaseTransformer):
-    """ROCKET.
+    """RandOm Convolutional KErnel Transform (ROCKET).
 
-    RandOm Convolutional KErnel Transform
+    ROCKET [1]_ generates random convolutional kernels, including random length and
+    dilation. It transforms the time series with two features per kernel. The first
+    feature is global max pooling and the second is proportion of positive values.
+
 
     Parameters
     ----------
-    num_kernels              : int, (default=10,000)
-                                number of random convolutional kernels
-    normalise                : boolean, (default=True)
-                                whether or not to normalise the input time
-                                series per instance
-    n_jobs                   : int, (default=1)
-                                The number of jobs to run in parallel
-                                for `transform`. ``-1`` means using all processors.
-    random_state             : int or None, (default=None)
-                                random seed, not set by default
+    num_kernels : int, default=10,000
+       number of random convolutional kernels.
+    normalise : boolean, default True
+       whether or not to normalise the input time series per instance.
+    n_jobs : int, default=1
+       The number of jobs to run in parallel for `transform`. ``-1`` means use all
+       processors.
+    random_state : None or int, optional, default = None
+
+    See Also
+    --------
+    MultiRocketMultivariate, MiniRocket, MiniRocketMultivariate, Rocket
 
     References
     ----------
-    .. [1] Dempster, Angus and Petitjean, Francois and Webb, Geoffrey I
-        ROCKET: Exceptionally fast and accurate time series
-        classification using random convolutional kernels,
-        2019, arXiv:1910.13051
-
+    .. [1] Tan, Chang Wei and Dempster, Angus and Bergmeir, Christoph
+        and Webb, Geoffrey I,
+        "ROCKET: Exceptionally fast and accurate time series
+      classification using random convolutional kernels",2020,
+      https://link.springer.com/article/10.1007/s10618-020-00701-z,
+      https://arxiv.org/abs/1910.13051
 
     Examples
     --------
     >>> from sktime.transformations.panel.rocket import Rocket
-    >>> from sktime.datasets import load_gunpoint
-    >>> # load univariate dataset
-    >>> X_train, _ = load_gunpoint(split="train", return_X_y=True)
-    >>> X_test, _ = load_gunpoint(split="test", return_X_y=True)
-    >>> pre_clf = Rocket()
-    >>> pre_clf.fit(X_train, y=None)
+    >>> from sktime.datasets import load_unit_test
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
+    >>> trf = Rocket(num_kernels=512)
+    >>> trf.fit(X_train)
     Rocket(...)
-    >>> X_transformed = pre_clf.transform(X_test)
-    >>> X_transformed.shape
-    (150, 20000)
+    >>> X_train = trf.transform(X_train)
+    >>> X_test = trf.transform(X_test)
     """
 
     _tags = {


### PR DESCRIPTION
This PR 
1) reduces the number of kernels in the examples to speed up testing and
2) standardises the format and expands descriptions of the docstrings 

this is an interim measure, there is duplication of code here, see https://github.com/sktime/sktime/pull/3786, its not fixing this, its a minor tidy up