### PR TITLE
[BUG] `ClearSky` doesn't raise error for range indexes and when `X` has no set frequency

### DIFF
--- a/sktime/transformations/series/clear_sky.py
+++ b/sktime/transformations/series/clear_sky.py
@@ -357,12 +357,12 @@ def _check_index(X):
 
     tod = pd.timedelta_range(start="0T", end="1D", freq=freq_ind)
     # checck frequency of tod
-    if (tod.freq >= pd.offsets.Day(1)) | (tod.freq < pd.offsets.Second(1)):
+    if (tod.freq > pd.offsets.Day(1)) | (tod.freq < pd.offsets.Second(1)):
         raise ValueError(
             """
             Transformer intended to be used with input frequency of greater than
-            one day and with a frequency of less or equal to than 1 second.
-            Contributions welcome on adapting for these use cases.
+            or equal to one day and with a frequency of less or equal to than
+            1 second. Contributions welcome on adapting for these use cases.
             """
         )
     return freq_ind

--- a/sktime/transformations/series/clear_sky.py
+++ b/sktime/transformations/series/clear_sky.py
@@ -87,7 +87,8 @@ class ClearSky(BaseTransformer):
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
         "requires_y": False,  # does y need to be passed in fit?
         "enforce_index_type": [
-            pd.DatetimeIndex
+            pd.DatetimeIndex,
+            pd.PeriodIndex,
         ],  # index type that needs to be enforced in X/y
         "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
         "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
@@ -135,12 +136,15 @@ class ClearSky(BaseTransformer):
         -------
         self: reference to self
         """
+        # check that the data is formatted correctly etc
+        self.freq = _check_index(X)
+        # now get grid of model
         df = pd.DataFrame(index=X.index)
         df["yday"] = df.index.dayofyear
         df["tod"] = df.index.hour + df.index.minute / 60 + df.index.second / 60
 
         # set up smoothing grid
-        tod = pd.timedelta_range(start="0T", end="1D", freq=df.index.freq)[:-1]
+        tod = pd.timedelta_range(start="0T", end="1D", freq=self.freq)[:-1]
         tod = [(x.total_seconds() / (60 * 60)) for x in tod.to_pytimedelta()]
         yday = pd.RangeIndex(start=1, stop=367)
         indx = pd.MultiIndex.from_product([yday, tod], names=["yday", "tod"])
@@ -184,6 +188,14 @@ class ClearSky(BaseTransformer):
         -------
         X_trafo : transformed version of X
         """
+        _freq_ind = _check_index(X)
+        if self.freq != _freq_ind:
+            raise ValueError(
+                """
+                Change in frequency detected from original input. Make sure
+                X is the same frequency as used in .fit().
+                """
+            )
         # get required seasonal index
         yday = X.index.dayofyear
         tod = X.index.hour + X.index.minute / 60 + X.index.second / 60
@@ -215,6 +227,14 @@ class ClearSky(BaseTransformer):
         -------
         X_trafo : inverse transformed version of X
         """
+        _freq_ind = _check_index(X)
+        if self.freq != _freq_ind:
+            raise ValueError(
+                """
+                Change in frequency detected from original input. Make sure
+                X is the same frequency as used in .fit().
+                """
+            )
         yday = X.index.dayofyear
         tod = X.index.hour + X.index.minute / 60 + X.index.second / 60
         indx_seasonal = pd.MultiIndex.from_arrays([yday, tod], names=["yday", "tod"])
@@ -300,3 +320,49 @@ def _clearskypower(y, q, tod_i, doy_i, tod_vec, doy_vec, bw_tod, bw_doy):
     csp = DescrStatsW(y, weights=wts).quantile(probs=q).values[0]
 
     return csp
+
+
+def _check_index(X):
+    """Check input value frequency is set and we have the correct index.
+
+    Parameters
+    ----------
+    X : Series or pd.DataFrame
+        Data used to be inversed transformed.
+
+    Raises
+    ------
+    ValueError : Input index must be class pd.DatetimeIndex or pd.PeriodIndex.
+    ValueError : Input index frequency cannot be inferred and is not set.
+    ValueError : Frequency of data not suitable for transformer as is.
+
+    Returns
+    -------
+    freq_ind : str or None
+        Frequency of data in string format
+
+    """
+    if not (isinstance(X.index, pd.DatetimeIndex)) | (
+        isinstance(X.index, pd.PeriodIndex)
+    ):
+        raise ValueError(
+            "Input index must be class pd.DatetimeIndex or pd.PeriodIndex."
+        )
+    # check that it has a frequency, if not infer
+    freq_ind = X.index.freq
+    if freq_ind is None:
+        freq_ind = pd.infer_freq(X.index)
+        if freq_ind is None:
+            raise ValueError("Input index frequency cannot be inferred and is not set.")
+
+    tod = pd.timedelta_range(start="0T", end="1D", freq=freq_ind)
+    # checck frequency of tod
+    if (tod.freq >= pd.offsets.Day(1)) | (tod.freq < pd.offsets.Second(1)):
+        raise ValueError(
+            """
+            Transformer intended to be used with input frequency of greater than
+            one day and with a frequency of less or equal to than 1 second.
+            Contributions welcome on adapting for these use cases.
+            """
+        )
+    return freq_ind

--- a/sktime/transformations/series/tests/test_clear_sky.py
+++ b/sktime/transformations/series/tests/test_clear_sky.py
@@ -6,6 +6,7 @@
 __author__ = ["ciaran-g"]
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from sktime.datasets import load_solar
@@ -69,7 +70,7 @@ output_chk = [
     reason="skip test if required soft dependency for hmmlearn not available",
 )
 def test_clearsky_trafo_vals():
-    """Tests clear sky trafo with and without missing values."""
+    """Tests clear sky trafo with and without missing values and period intex."""
     y = load_solar(api_version=None)
     cs_model = ClearSky()
     y_trafo = cs_model.fit_transform(y)
@@ -85,3 +86,56 @@ def test_clearsky_trafo_vals():
     msg = "ClearSky transformer not returning correct number of values."
     assert y.count() == y_trafo.count(), msg
     assert y_missing.count() == y_trafo_missing.count(), msg
+
+    y_period = y.copy()
+    y_period.index = y_period.index.to_period()
+    cs_model_period = ClearSky()
+    y_trafo_period = cs_model_period.fit_transform(y_period)
+
+    msg = "PeriodIndex and DatetimeIndex returning different values"
+    assert np.all(y_trafo_period.values == y_trafo.values), msg
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
+def test_clearsky_trafo_range_exception():
+    """Tests clear sky trafo exception with range index."""
+    y = load_solar(api_version=None)
+
+    # range index should not work
+    y = y.reset_index(drop=True)
+    cs_model = ClearSky()
+    with pytest.raises(ValueError):
+        cs_model.fit_transform(y)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
+def test_clearsky_trafo_nofreq_exception():
+    """Tests clear sky trafo exception with no set/inferrable freq in index."""
+    y = load_solar(api_version=None)
+
+    # no set or inferrable frequency should not work
+    y = y.drop(pd.to_datetime("2021-05-01 00:30:00", utc=True))
+    cs_model = ClearSky()
+    with pytest.raises(ValueError):
+        cs_model.fit_transform(y)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency for hmmlearn not available",
+)
+def test_clearsky_trafo_daily_exception():
+    """Tests clear sky trafo exception with geq daily freq in index."""
+    y = load_solar(api_version=None)
+
+    # geq daily frequency should not work
+    y = y.asfreq("1D")
+    cs_model = ClearSky()
+    with pytest.raises(ValueError):
+        cs_model.fit_transform(y)

--- a/sktime/transformations/series/tests/test_clear_sky.py
+++ b/sktime/transformations/series/tests/test_clear_sky.py
@@ -13,73 +13,26 @@ from sktime.datasets import load_solar
 from sktime.transformations.series.clear_sky import ClearSky
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-output_chk = [
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.052,
-    0.256,
-    0.469,
-    0.585,
-    0.686,
-    0.764,
-    0.784,
-    0.783,
-    0.844,
-    0.873,
-    0.833,
-    0.757,
-    0.725,
-    0.737,
-    0.739,
-    0.836,
-    0.819,
-    0.799,
-    0.795,
-    0.758,
-    0.701,
-    0.641,
-    0.618,
-    0.635,
-    0.696,
-    0.621,
-    0.557,
-    0.477,
-    0.283,
-    0.072,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-]
+output_chk = [0.0, 0.0, 0.901, 0.739, 0.618, 0.0]
 
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
-    reason="skip test if required soft dependency for hmmlearn not available",
+    reason="skip test if required soft dependency for statsmodels not available",
 )
 def test_clearsky_trafo_vals():
-    """Tests clear sky trafo with and without missing values and period intex."""
+    """Tests clear sky trafo with and without missing values and period index."""
     y = load_solar(api_version=None)
+    # only take every 4H for quickness
+    y = y.asfreq("4H")
     cs_model = ClearSky()
     y_trafo = cs_model.fit_transform(y)
 
     msg = "ClearSky not transforming values consistently with stored values."
-    assert np.all(output_chk == y_trafo[0:48].round(3).tolist()), msg
+    assert np.all(output_chk == y_trafo[0:6].round(3).tolist()), msg
 
     y_missing = y.copy()
-    y_missing.iloc[48:96] = np.nan
+    y_missing.iloc[6:12] = np.nan
     cs_model_missing = ClearSky()
     y_trafo_missing = cs_model_missing.fit_transform(y_missing)
 
@@ -98,7 +51,7 @@ def test_clearsky_trafo_vals():
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
-    reason="skip test if required soft dependency for hmmlearn not available",
+    reason="skip test if required soft dependency for statsmodels not available",
 )
 def test_clearsky_trafo_range_exception():
     """Tests clear sky trafo exception with range index."""
@@ -113,7 +66,7 @@ def test_clearsky_trafo_range_exception():
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
-    reason="skip test if required soft dependency for hmmlearn not available",
+    reason="skip test if required soft dependency for statsmodels not available",
 )
 def test_clearsky_trafo_nofreq_exception():
     """Tests clear sky trafo exception with no set/inferrable freq in index."""
@@ -128,14 +81,14 @@ def test_clearsky_trafo_nofreq_exception():
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
-    reason="skip test if required soft dependency for hmmlearn not available",
+    reason="skip test if required soft dependency for statsmodels not available",
 )
-def test_clearsky_trafo_daily_exception():
-    """Tests clear sky trafo exception with geq daily freq in index."""
+def test_clearsky_trafo_grdaily_exception():
+    """Tests clear sky trafo exception with greater than daily freq in index."""
     y = load_solar(api_version=None)
 
-    # geq daily frequency should not work
-    y = y.asfreq("1D")
+    # gr daily frequency should not work
+    y = y.asfreq("2D")
     cs_model = ClearSky()
     with pytest.raises(ValueError):
         cs_model.fit_transform(y)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
No open issue


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Added some bug fixes which were highlighted by @robertmcleod2 - cheers!

The bugs were

* The `ClearSky` transformer relies on the datetime index to get the time of day. I thought the `enforce_index_type` tag would deal with removing range indexes, but it doesn't at the moment. Added a check for this
* The frequency of the data should be set and there was no check for this. I added one along with a function to infer it if possible. 
* The frequency should be within a range to be suitable for the transformer, so added a check for this as well.

Added tests for these bugs as well. 

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

No
