### PR TITLE
[ENH] Add `prefer="threads"` to classification `Parallel` usage

### DIFF
--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -721,7 +721,7 @@ def pairwise_distances(X, Y=None, use_boss_distance=False, n_jobs=1):
         distance_matrix = np.zeros((X.shape[0], Y.shape[0]))
 
         if effective_n_jobs(n_jobs) > 1:
-            Parallel(n_jobs=n_jobs, backend="threading")(
+            Parallel(n_jobs=n_jobs, prefer="threads")(
                 delayed(_dist_wrapper)(distance_matrix, X, Y, s, XX_row_norms, XY)
                 for s in gen_even_slices(_num_samples(X), effective_n_jobs(n_jobs))
             )

--- a/sktime/classification/dictionary_based/_muse.py
+++ b/sktime/classification/dictionary_based/_muse.py
@@ -206,7 +206,7 @@ class MUSE(BaseClassifier):
         if self.variance and self.anova:
             raise ValueError("MUSE Warning: Please set either variance or anova.")
 
-        parallel_res = Parallel(n_jobs=self.n_jobs, backend="threading")(
+        parallel_res = Parallel(n_jobs=self.n_jobs, prefer="threads")(
             delayed(_parallel_fit)(
                 X,
                 y.copy(),  # no clue why, but this copy is required.
@@ -308,7 +308,7 @@ class MUSE(BaseClassifier):
         if self.use_first_order_differences:
             X = self._add_first_order_differences(X)
 
-        parallel_res = Parallel(n_jobs=self._threads_to_use, backend="threading")(
+        parallel_res = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
             delayed(_parallel_transform_words)(
                 X, self.window_sizes, self.SFA_transformers, ind
             )

--- a/sktime/classification/dictionary_based/_weasel.py
+++ b/sktime/classification/dictionary_based/_weasel.py
@@ -223,7 +223,7 @@ class WEASEL(BaseClassifier):
         self.window_sizes = list(range(self.min_window, self.max_window, win_inc))
         self.highest_bit = (math.ceil(math.log2(self.max_window))) + 1
 
-        parallel_res = Parallel(n_jobs=self.n_jobs, backend="threading")(
+        parallel_res = Parallel(n_jobs=self.n_jobs, prefer="threads")(
             delayed(_parallel_fit)(
                 X,
                 y,
@@ -305,7 +305,7 @@ class WEASEL(BaseClassifier):
             )
 
     def _transform_words(self, X):
-        parallel_res = Parallel(n_jobs=self._threads_to_use, backend="threading")(
+        parallel_res = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
             delayed(transformer.transform)(X) for transformer in self.SFA_transformers
         )
         all_words = []

--- a/sktime/classification/early_classification/_teaser.py
+++ b/sktime/classification/early_classification/_teaser.py
@@ -172,7 +172,7 @@ class TEASER(BaseEarlyClassifier):
         m = getattr(self.estimator, "n_jobs", None)
         threads = self._threads_to_use if m is None else 1
 
-        fit = Parallel(n_jobs=threads)(
+        fit = Parallel(n_jobs=threads, prefer="threads")(
             delayed(self._fit_estimator)(
                 X,
                 y,
@@ -231,7 +231,7 @@ class TEASER(BaseEarlyClassifier):
         threads = self._threads_to_use if m is None else 1
 
         # compute all new updates since then
-        out = Parallel(n_jobs=threads)(
+        out = Parallel(n_jobs=threads, prefer="threads")(
             delayed(self._predict_proba_for_estimator)(
                 X,
                 i,
@@ -304,7 +304,7 @@ class TEASER(BaseEarlyClassifier):
         threads = self._threads_to_use if m is None else 1
 
         # compute all new updates since then
-        out = Parallel(n_jobs=threads)(
+        out = Parallel(n_jobs=threads, prefer="threads")(
             delayed(self._predict_proba_for_estimator)(
                 X,
                 i,

--- a/sktime/classification/interval_based/_cif.py
+++ b/sktime/classification/interval_based/_cif.py
@@ -194,7 +194,7 @@ class CanonicalIntervalForest(BaseClassifier):
         if self._max_interval < self._min_interval:
             self._max_interval = self._min_interval
 
-        fit = Parallel(n_jobs=self._threads_to_use)(
+        fit = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
             delayed(self._fit_estimator)(
                 X,
                 y,
@@ -224,7 +224,7 @@ class CanonicalIntervalForest(BaseClassifier):
                 "that in the test data"
             )
 
-        y_probas = Parallel(n_jobs=self._threads_to_use)(
+        y_probas = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
             delayed(self._predict_proba_for_estimator)(
                 X,
                 self.estimators_[i],

--- a/sktime/classification/interval_based/_drcif.py
+++ b/sktime/classification/interval_based/_drcif.py
@@ -300,7 +300,7 @@ class DrCIF(BaseClassifier):
                 train_time < time_limit
                 and self._n_estimators < self.contract_max_n_estimators
             ):
-                fit = Parallel(n_jobs=self._threads_to_use)(
+                fit = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
                     delayed(self._fit_estimator)(
                         X,
                         X_p,
@@ -328,7 +328,7 @@ class DrCIF(BaseClassifier):
                 self._n_estimators += self._threads_to_use
                 train_time = time.time() - start_time
         else:
-            fit = Parallel(n_jobs=self._threads_to_use)(
+            fit = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
                 delayed(self._fit_estimator)(
                     X,
                     X_p,
@@ -381,7 +381,7 @@ class DrCIF(BaseClassifier):
 
         X_d = np.diff(X, 1)
 
-        y_probas = Parallel(n_jobs=self._threads_to_use)(
+        y_probas = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
             delayed(self._predict_proba_for_estimator)(
                 X,
                 X_p,
@@ -423,7 +423,7 @@ class DrCIF(BaseClassifier):
         if not self.save_transformed_data:
             raise ValueError("Currently only works with saved transform data from fit.")
 
-        p = Parallel(n_jobs=self._threads_to_use)(
+        p = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
             delayed(self._train_probas_for_estimator)(
                 y,
                 i,

--- a/sktime/classification/interval_based/_rise.py
+++ b/sktime/classification/interval_based/_rise.py
@@ -273,7 +273,7 @@ class RandomIntervalSpectralEnsemble(BaseClassifier):
         ]
 
         # Parallel loop
-        worker_rets = Parallel(n_jobs=self._threads_to_use)(
+        worker_rets = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
             delayed(_parallel_build_trees)(
                 X,
                 y,
@@ -348,7 +348,7 @@ class RandomIntervalSpectralEnsemble(BaseClassifier):
         n_jobs, _, _ = _partition_estimators(self.n_estimators, self._threads_to_use)
 
         # Parallel loop
-        all_proba = Parallel(n_jobs=n_jobs)(
+        all_proba = Parallel(n_jobs=n_jobs, prefer="threads")(
             delayed(_predict_proba_for_estimator)(
                 X,
                 self.estimators_[i],

--- a/sktime/classification/interval_based/_stsf.py
+++ b/sktime/classification/interval_based/_stsf.py
@@ -151,7 +151,7 @@ class SupervisedTimeSeriesForest(BaseClassifier):
                     (rng.choice(cls_idx, size=average - class_counts[i]), balance_cases)
                 )
 
-        fit = Parallel(n_jobs=self._threads_to_use)(
+        fit = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
             delayed(self._fit_estimator)(
                 X,
                 X_p,
@@ -213,7 +213,7 @@ class SupervisedTimeSeriesForest(BaseClassifier):
         _, X_p = signal.periodogram(X)
         X_d = np.diff(X, 1)
 
-        y_probas = Parallel(n_jobs=self._threads_to_use)(
+        y_probas = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
             delayed(self._predict_proba_for_estimator)(
                 X,
                 X_p,

--- a/sktime/classification/interval_based/_tsf.py
+++ b/sktime/classification/interval_based/_tsf.py
@@ -158,7 +158,7 @@ class TimeSeriesForestClassifier(
             Predicted probabilities
         """
         X = X.squeeze(1)
-        y_probas = Parallel(n_jobs=self.n_jobs)(
+        y_probas = Parallel(n_jobs=self.n_jobs, prefer="threads")(
             delayed(_predict_single_classifier_proba)(
                 X, self.estimators_[i], self.intervals_[i]
             )

--- a/sktime/classification/kernel_based/_arsenal.py
+++ b/sktime/classification/kernel_based/_arsenal.py
@@ -219,7 +219,7 @@ class Arsenal(BaseClassifier):
                 train_time < time_limit
                 and self.n_estimators < self.contract_max_n_estimators
             ):
-                fit = Parallel(n_jobs=self._threads_to_use)(
+                fit = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
                     delayed(self._fit_estimator)(
                         _clone_estimator(
                             base_rocket,
@@ -243,7 +243,7 @@ class Arsenal(BaseClassifier):
                 self.n_estimators += self._threads_to_use
                 train_time = time.time() - start_time
         else:
-            fit = Parallel(n_jobs=self._threads_to_use)(
+            fit = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
                 delayed(self._fit_estimator)(
                     _clone_estimator(
                         base_rocket,
@@ -304,7 +304,7 @@ class Arsenal(BaseClassifier):
         y : array-like, shape = [n_instances, n_classes_]
             Predicted probabilities using the ordering in classes_.
         """
-        y_probas = Parallel(n_jobs=self._threads_to_use)(
+        y_probas = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
             delayed(self._predict_proba_for_estimator)(
                 X,
                 self.estimators_[i],
@@ -341,7 +341,7 @@ class Arsenal(BaseClassifier):
         if not self.save_transformed_data:
             raise ValueError("Currently only works with saved transform data from fit.")
 
-        p = Parallel(n_jobs=self._threads_to_use)(
+        p = Parallel(n_jobs=self._threads_to_use, prefer="threads")(
             delayed(self._train_probas_for_estimator)(
                 y,
                 i,

--- a/sktime/classification/sklearn/_rotation_forest.py
+++ b/sktime/classification/sklearn/_rotation_forest.py
@@ -217,7 +217,7 @@ class RotationForest(BaseEstimator):
                 train_time < time_limit
                 and self._n_estimators < self.contract_max_n_estimators
             ):
-                fit = Parallel(n_jobs=self._n_jobs)(
+                fit = Parallel(n_jobs=self._n_jobs, prefer="threads")(
                     delayed(self._fit_estimator)(
                         X,
                         X_cls_split,
@@ -239,7 +239,7 @@ class RotationForest(BaseEstimator):
         else:
             self._n_estimators = self.n_estimators
 
-            fit = Parallel(n_jobs=self._n_jobs)(
+            fit = Parallel(n_jobs=self._n_jobs, prefer="threads")(
                 delayed(self._fit_estimator)(
                     X,
                     X_cls_split,
@@ -318,7 +318,7 @@ class RotationForest(BaseEstimator):
         # normalise the data.
         X = (X - self._min) / self._ptp
 
-        y_probas = Parallel(n_jobs=self._n_jobs)(
+        y_probas = Parallel(n_jobs=self._n_jobs, prefer="threads")(
             delayed(self._predict_proba_for_estimator)(
                 X,
                 self.estimators_[i],
@@ -366,7 +366,7 @@ class RotationForest(BaseEstimator):
         if not self.save_transformed_data:
             raise ValueError("Currently only works with saved transform data from fit.")
 
-        p = Parallel(n_jobs=self._n_jobs)(
+        p = Parallel(n_jobs=self._n_jobs, prefer="threads")(
             delayed(self._train_probas_for_estimator)(
                 y,
                 i,

--- a/sktime/transformations/panel/catch22.py
+++ b/sktime/transformations/panel/catch22.py
@@ -175,7 +175,7 @@ class Catch22(BaseTransformer):
                 "current 1 CPU core."
             )
 
-        c22_list = Parallel(n_jobs=threads_to_use)(
+        c22_list = Parallel(n_jobs=threads_to_use, prefer="threads")(
             delayed(self._transform_case)(
                 X.iloc[i],
                 f_idx,
@@ -367,7 +367,7 @@ class Catch22(BaseTransformer):
                 "current 1 CPU core."
             )
 
-        c22_list = Parallel(n_jobs=threads_to_use)(
+        c22_list = Parallel(n_jobs=threads_to_use, prefer="threads")(
             delayed(self._transform_case_single)(
                 X[i],
                 feature,

--- a/sktime/transformations/panel/catch22wrapper.py
+++ b/sktime/transformations/panel/catch22wrapper.py
@@ -169,7 +169,7 @@ class Catch22Wrapper(BaseTransformer):
 
         threads_to_use = check_n_jobs(self.n_jobs)
 
-        c22_list = Parallel(n_jobs=threads_to_use)(
+        c22_list = Parallel(n_jobs=threads_to_use, prefer="threads")(
             delayed(self._transform_case)(
                 X.iloc[i],
                 f_idx,

--- a/sktime/transformations/panel/dictionary_based/_sfa.py
+++ b/sktime/transformations/panel/dictionary_based/_sfa.py
@@ -271,7 +271,7 @@ class SFA(BaseTransformer):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=NumbaTypeSafetyWarning)
-            transform = Parallel(n_jobs=self.n_jobs)(
+            transform = Parallel(n_jobs=self.n_jobs, prefer="threads")(
                 delayed(self._transform_case)(
                     X[i, :],
                     supplied_dft=self.binning_dft[i] if self.keep_binning_dft else None,
@@ -713,7 +713,7 @@ class SFA(BaseTransformer):
         if self.typed_dict:
             warnings.simplefilter("ignore", category=NumbaTypeSafetyWarning)
 
-        dim = Parallel(n_jobs=self.n_jobs)(
+        dim = Parallel(n_jobs=self.n_jobs, prefer="threads")(
             delayed(self._shorten_case)(word_len, i) for i in range(len(self.words))
         )
 


### PR DESCRIPTION
Some classifiers have had issues with the current default backend (#3788), and "threads" seems to be a more sensible default for data science applications (discussion in #3652).
