### PR TITLE
[BUG] fix soft dependency check in `plotting.plot_correlations`

### DIFF
--- a/sktime/utils/plotting.py
+++ b/sktime/utils/plotting.py
@@ -307,7 +307,7 @@ def plot_correlations(
     >>> y = load_airline()
     >>> fig, ax = plot_correlations(y)  # doctest: +SKIP
     """
-    _check_soft_dependencies(("matplotlib", "statsmodels"))
+    _check_soft_dependencies("matplotlib", "statsmodels")
     import matplotlib.pyplot as plt
     from statsmodels.graphics.tsaplots import plot_acf, plot_pacf
 


### PR DESCRIPTION
packages must be str or a tuple of str. So, removing additional parenthesis.
