### PR TITLE
[MNT] Update sklearn compatibility to `1.2.x`, version bound to `<1.3`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "numba>=0.55",
     "numpy>=1.21.0,<1.23",
     "pandas>=1.1.0,<1.6.0",
-    "scikit-learn>=0.24.0,<1.2.0",
+    "scikit-learn>=0.24.0,<1.3.0",
     "statsmodels>=0.12.1",
     "scipy<2.0.0",
 ]

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -24,7 +24,6 @@ from inspect import signature
 
 import numpy as np
 from sklearn.neighbors import KNeighborsClassifier
-from sklearn.neighbors._base import _check_weights
 
 from sktime.classification.base import BaseClassifier
 from sktime.datatypes import check_is_mtype
@@ -139,7 +138,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         n_jobs=None,
     ):
         self.n_neighbors = n_neighbors
-        self.weights = _check_weights(weights)
+        self.weights = weights
         self.algorithm = algorithm
         self.distance = distance
         self.distance_params = distance_params

--- a/sktime/regression/distance_based/_time_series_neighbors.py
+++ b/sktime/regression/distance_based/_time_series_neighbors.py
@@ -13,7 +13,6 @@ __author__ = ["fkiraly"]
 __all__ = ["KNeighborsTimeSeriesRegressor"]
 
 from sklearn.neighbors import KNeighborsRegressor
-from sklearn.neighbors._base import _check_weights
 
 from sktime.distances import pairwise_distance
 from sktime.regression.base import BaseRegressor
@@ -132,7 +131,7 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
             leaf_size=leaf_size,
             n_jobs=n_jobs,
         )
-        self.weights = _check_weights(weights)
+        self.weights = weights
 
         super(KNeighborsTimeSeriesRegressor, self).__init__()
 

--- a/sktime/series_as_features/base/estimators/interval_based/_tsf.py
+++ b/sktime/series_as_features/base/estimators/interval_based/_tsf.py
@@ -39,7 +39,7 @@ class BaseTimeSeriesForest:
         random_state=None,
     ):
         super(BaseTimeSeriesForest, self).__init__(
-            base_estimator=self._base_estimator,
+            self._base_estimator,
             n_estimators=n_estimators,
         )
 


### PR DESCRIPTION
(@fkiraly update:) This PR updates the `sklearn` version bound to `<1.3`.

Includes fixes for `sklearn 1.2` compatibility:

* https://github.com/sktime/sktime/pull/3918
* https://github.com/sktime/sktime/pull/3919