### PR TITLE
& fkiraly [MNT] bump numpy version bound to <1.25 and fix compatibility issues #3907

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ requires-python = ">=3.7,<3.11"
 dependencies = [
     "deprecated>=1.2.13",
     "numba>=0.55",
-    "numpy>=1.21.0,<1.23",
+    "numpy>=1.21.0,<1.24",
     "pandas>=1.1.0,<1.6.0",
     "scikit-learn>=0.24.0,<1.2.0",
     "statsmodels>=0.12.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ requires-python = ">=3.7,<3.11"
 dependencies = [
     "deprecated>=1.2.13",
     "numba>=0.55",
-    "numpy>=1.21.0,<1.24",
+    "numpy>=1.21.0,<1.25",
     "pandas>=1.1.0,<1.6.0",
     "scikit-learn>=0.24.0,<1.2.0",
     "statsmodels>=0.12.1",

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -2204,27 +2204,27 @@ class MeanLinexError(BaseForecastingErrorMetricFunc):
     >>> linex_error = MeanLinexError()
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
-    >>> linex_error(y_true, y_pred)
+    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
     0.19802627763937575
     >>> linex_error = MeanLinexError(b=2)
-    >>> linex_error(y_true, y_pred)
+    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
     0.3960525552787515
     >>> linex_error = MeanLinexError(a=-1)
-    >>> linex_error(y_true, y_pred)
+    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
     0.2391800623225643
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> linex_error = MeanLinexError()
-    >>> linex_error(y_true, y_pred)
+    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
     0.2700398392309829
     >>> linex_error = MeanLinexError(a=-1)
-    >>> linex_error(y_true, y_pred)
+    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
     0.49660966225813563
     >>> linex_error = MeanLinexError(multioutput='raw_values')
-    >>> linex_error(y_true, y_pred)
+    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
     array([0.17220024, 0.36787944])
     >>> linex_error = MeanLinexError(multioutput=[0.3, 0.7])
-    >>> linex_error(y_true, y_pred)
+    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
     0.30917568000716666
     """
 

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1367,30 +1367,30 @@ class GeometricMeanSquaredError(BaseForecastingErrorMetricFunc):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> gmse = GeometricMeanSquaredError()
-    >>> gmse(y_true, y_pred)
+    >>> gmse(y_true, y_pred)  # doctest: +SKIP
     2.80399089461488e-07
     >>> rgmse = GeometricMeanSquaredError(square_root=True)
-    >>> rgmse(y_true, y_pred)
+    >>> rgmse(y_true, y_pred)  # doctest: +SKIP
     0.000529527232030127
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> gmse = GeometricMeanSquaredError()
-    >>> gmse(y_true, y_pred)
+    >>> gmse(y_true, y_pred)  # doctest: +SKIP
     0.5000000000115499
     >>> rgmse = GeometricMeanSquaredError(square_root=True)
-    >>> rgmse(y_true, y_pred)
+    >>> rgmse(y_true, y_pred)  # doctest: +SKIP
     0.5000024031086919
     >>> gmse = GeometricMeanSquaredError(multioutput='raw_values')
-    >>> gmse(y_true, y_pred)
+    >>> gmse(y_true, y_pred)  # doctest: +SKIP
     array([2.30997255e-11, 1.00000000e+00])
     >>> rgmse = GeometricMeanSquaredError(multioutput='raw_values', square_root=True)
-    >>> rgmse(y_true, y_pred)
+    >>> rgmse(y_true, y_pred)# doctest: +SKIP
     array([4.80621738e-06, 1.00000000e+00])
     >>> gmse = GeometricMeanSquaredError(multioutput=[0.3, 0.7])
-    >>> gmse(y_true, y_pred)
+    >>> gmse(y_true, y_pred)  # doctest: +SKIP
     0.7000000000069299
     >>> rgmse = GeometricMeanSquaredError(multioutput=[0.3, 0.7], square_root=True)
-    >>> rgmse(y_true, y_pred)
+    >>> rgmse(y_true, y_pred)  # doctest: +SKIP
     0.7000014418652152
     """
 

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -2101,26 +2101,26 @@ class MeanAsymmetricError(BaseForecastingErrorMetricFunc):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> asymmetric_error = MeanAsymmetricError()
-    >>> asymmetric_error(y_true, y_pred)
+    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
     0.5
     >>> asymmetric_error = MeanAsymmetricError(left_error_function='absolute', \
     right_error_function='squared')
-    >>> asymmetric_error(y_true, y_pred)
+    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
     0.4625
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> asymmetric_error = MeanAsymmetricError()
-    >>> asymmetric_error(y_true, y_pred)
+    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
     0.75
     >>> asymmetric_error = MeanAsymmetricError(left_error_function='absolute', \
     right_error_function='squared')
-    >>> asymmetric_error(y_true, y_pred)
+    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
     0.7083333333333334
     >>> asymmetric_error = MeanAsymmetricError(multioutput='raw_values')
-    >>> asymmetric_error(y_true, y_pred)
+    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
     array([0.5, 1. ])
     >>> asymmetric_error = MeanAsymmetricError(multioutput=[0.3, 0.7])
-    >>> asymmetric_error(y_true, y_pred)
+    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
     0.85
     """
 

--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -1396,28 +1396,28 @@ def geometric_mean_squared_error(
     --------
     >>> import numpy as np
     >>> from sktime.performance_metrics.forecasting import \
-    geometric_mean_squared_error
+    geometric_mean_squared_error as gmse
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
-    >>> geometric_mean_squared_error(y_true, y_pred)
+    >>> gmse(y_true, y_pred)  # doctest: +SKIP
     2.80399089461488e-07
-    >>> geometric_mean_squared_error(y_true, y_pred, square_root=True)
+    >>> gmse(y_true, y_pred, square_root=True)  # doctest: +SKIP
     0.000529527232030127
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> geometric_mean_squared_error(y_true, y_pred)
+    >>> gmse(y_true, y_pred)  # doctest: +SKIP
     0.5000000000115499
-    >>> geometric_mean_squared_error(y_true, y_pred, square_root=True)
+    >>> gmse(y_true, y_pred, square_root=True)  # doctest: +SKIP
     0.5000024031086919
-    >>> geometric_mean_squared_error(y_true, y_pred, multioutput='raw_values')
+    >>> gmse(y_true, y_pred, multioutput='raw_values')  # doctest: +SKIP
     array([2.30997255e-11, 1.00000000e+00])
-    >>> geometric_mean_squared_error(y_true, y_pred, multioutput='raw_values', \
-    square_root=True)
+    >>> gmse(y_true, y_pred, multioutput='raw_values', \
+    square_root=True)  # doctest: +SKIP
     array([4.80621738e-06, 1.00000000e+00])
-    >>> geometric_mean_squared_error(y_true, y_pred, multioutput=[0.3, 0.7])
+    >>> gmse(y_true, y_pred, multioutput=[0.3, 0.7])  # doctest: +SKIP
     0.7000000000069299
-    >>> geometric_mean_squared_error(y_true, y_pred, multioutput=[0.3, 0.7], \
-    square_root=True)
+    >>> gmse(y_true, y_pred, multioutput=[0.3, 0.7], \
+    square_root=True)  # doctest: +SKIP
     0.7000014418652152
     """
     _, y_true, y_pred, multioutput = _check_reg_targets(y_true, y_pred, multioutput)

--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -142,21 +142,21 @@ def mean_linex_error(
     >>> from sktime.performance_metrics.forecasting import mean_linex_error
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
-    >>> mean_linex_error(y_true, y_pred)
+    >>> mean_linex_error(y_true, y_pred)  # doctest: +SKIP
     0.19802627763937575
-    >>> mean_linex_error(y_true, y_pred, b=2)
+    >>> mean_linex_error(y_true, y_pred, b=2)  # doctest: +SKIP
     0.3960525552787515
-    >>> mean_linex_error(y_true, y_pred, a=-1)
+    >>> mean_linex_error(y_true, y_pred, a=-1)  # doctest: +SKIP
     0.2391800623225643
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> mean_linex_error(y_true, y_pred)
+    >>> mean_linex_error(y_true, y_pred)  # doctest: +SKIP
     0.2700398392309829
-    >>> mean_linex_error(y_true, y_pred, a=-1)
+    >>> mean_linex_error(y_true, y_pred, a=-1)  # doctest: +SKIP
     0.49660966225813563
-    >>> mean_linex_error(y_true, y_pred, multioutput='raw_values')
+    >>> mean_linex_error(y_true, y_pred, multioutput='raw_values')  # doctest: +SKIP
     array([0.17220024, 0.36787944])
-    >>> mean_linex_error(y_true, y_pred, multioutput=[0.3, 0.7])
+    >>> mean_linex_error(y_true, y_pred, multioutput=[0.3, 0.7])  # doctest: +SKIP
     0.30917568000716666
     """
     _, y_true, y_pred, multioutput = _check_reg_targets(y_true, y_pred, multioutput)

--- a/sktime/performance_metrics/forecasting/tests/__init__.py
+++ b/sktime/performance_metrics/forecasting/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for sktime performance metrics module."""

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -63,3 +63,49 @@ def test_gmse_function():
         gmse(y_true, y_pred, multioutput=[0.3, 0.7], square_root=True),
         0.7000014418652152,
     )
+
+
+def test_linex_class():
+    """Doctest from MeanLinexError."""
+    from sktime.performance_metrics.forecasting import MeanLinexError
+
+    linex_error = MeanLinexError()
+    y_true = np.array([3, -0.5, 2, 7, 2])
+    y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    assert np.allclose(linex_error(y_true, y_pred), 0.19802627763937575)
+    linex_error = MeanLinexError(b=2)
+    assert np.allclose(linex_error(y_true, y_pred), 0.3960525552787515)
+    linex_error = MeanLinexError(a=-1)
+    assert np.allclose(linex_error(y_true, y_pred), 0.2391800623225643)
+    y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    linex_error = MeanLinexError()
+    assert np.allclose(linex_error(y_true, y_pred), 0.2700398392309829)
+    linex_error = MeanLinexError(a=-1)
+    assert np.allclose(linex_error(y_true, y_pred), 0.49660966225813563)
+    linex_error = MeanLinexError(multioutput='raw_values')
+    assert np.allclose(linex_error(y_true, y_pred), np.array([0.17220024, 0.36787944]))
+    linex_error = MeanLinexError(multioutput=[0.3, 0.7])
+    assert np.allclose(linex_error(y_true, y_pred), 0.30917568000716666)
+
+
+def test_linex_function():
+    """Doctest from mean_linex_error."""
+    from sktime.performance_metrics.forecasting import mean_linex_error
+
+    y_true = np.array([3, -0.5, 2, 7, 2])
+    y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    assert np.allclose(mean_linex_error(y_true, y_pred), 0.19802627763937575)
+    assert np.allclose(mean_linex_error(y_true, y_pred, b=2), 0.3960525552787515)
+    assert np.allclose(mean_linex_error(y_true, y_pred, a=-1), 0.2391800623225643)
+    y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    assert np.allclose(mean_linex_error(y_true, y_pred), 0.2700398392309829)
+    assert np.allclose(mean_linex_error(y_true, y_pred, a=-1), 0.49660966225813563)
+    assert np.allclose(
+        mean_linex_error(y_true, y_pred, multioutput='raw_values'),
+        np.array([0.17220024, 0.36787944]),
+    )
+    assert np.allclose(
+        mean_linex_error(y_true, y_pred, multioutput=[0.3, 0.7]), 0.30917568000716666
+    )

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -25,9 +25,9 @@ def test_gmse_class():
     assert np.allclose(gmse(y_true, y_pred), 0.5000000000115499)
     rgmse = GeometricMeanSquaredError(square_root=True)
     assert np.allclose(rgmse(y_true, y_pred), 0.5000024031086919)
-    gmse = GeometricMeanSquaredError(multioutput='raw_values')
+    gmse = GeometricMeanSquaredError(multioutput="raw_values")
     assert np.allclose(gmse(y_true, y_pred), np.array([2.30997255e-11, 1.00000000e+00]))
-    rgmse = GeometricMeanSquaredError(multioutput='raw_values', square_root=True)
+    rgmse = GeometricMeanSquaredError(multioutput="raw_values", square_root=True)
     assert np.allclose(
         rgmse(y_true, y_pred), np.array([4.80621738e-06, 1.00000000e+00])
     )
@@ -51,11 +51,11 @@ def test_gmse_function():
     assert np.allclose(gmse(y_true, y_pred), 0.5000000000115499)
     assert np.allclose(gmse(y_true, y_pred, square_root=True), 0.5000024031086919)
     assert np.allclose(
-        gmse(y_true, y_pred, multioutput='raw_values'),
+        gmse(y_true, y_pred, multioutput="raw_values"),
         np.array([2.30997255e-11, 1.00000000e+00]),
     )
     assert np.allclose(
-        gmse(y_true, y_pred, multioutput='raw_values', square_root=True),
+        gmse(y_true, y_pred, multioutput="raw_values", square_root=True),
         np.array([4.80621738e-06, 1.00000000e+00]),
     )
     assert np.allclose(gmse(y_true, y_pred, multioutput=[0.3, 0.7]), 0.7000000000069299)
@@ -83,7 +83,7 @@ def test_linex_class():
     assert np.allclose(linex_error(y_true, y_pred), 0.2700398392309829)
     linex_error = MeanLinexError(a=-1)
     assert np.allclose(linex_error(y_true, y_pred), 0.49660966225813563)
-    linex_error = MeanLinexError(multioutput='raw_values')
+    linex_error = MeanLinexError(multioutput="raw_values")
     assert np.allclose(linex_error(y_true, y_pred), np.array([0.17220024, 0.36787944]))
     linex_error = MeanLinexError(multioutput=[0.3, 0.7])
     assert np.allclose(linex_error(y_true, y_pred), 0.30917568000716666)
@@ -103,7 +103,7 @@ def test_linex_function():
     assert np.allclose(mean_linex_error(y_true, y_pred), 0.2700398392309829)
     assert np.allclose(mean_linex_error(y_true, y_pred, a=-1), 0.49660966225813563)
     assert np.allclose(
-        mean_linex_error(y_true, y_pred, multioutput='raw_values'),
+        mean_linex_error(y_true, y_pred, multioutput="raw_values"),
         np.array([0.17220024, 0.36787944]),
     )
     assert np.allclose(

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -26,10 +26,10 @@ def test_gmse_class():
     rgmse = GeometricMeanSquaredError(square_root=True)
     assert np.allclose(rgmse(y_true, y_pred), 0.5000024031086919)
     gmse = GeometricMeanSquaredError(multioutput="raw_values")
-    assert np.allclose(gmse(y_true, y_pred), np.array([2.30997255e-11, 1.00000000e+00]))
+    assert np.allclose(gmse(y_true, y_pred), np.array([2.30997255e-11, 1.00000000e00]))
     rgmse = GeometricMeanSquaredError(multioutput="raw_values", square_root=True)
     assert np.allclose(
-        rgmse(y_true, y_pred), np.array([4.80621738e-06, 1.00000000e+00])
+        rgmse(y_true, y_pred), np.array([4.80621738e-06, 1.00000000e00])
     )
     gmse = GeometricMeanSquaredError(multioutput=[0.3, 0.7])
     assert np.allclose(gmse(y_true, y_pred), 0.7000000000069299)
@@ -52,11 +52,11 @@ def test_gmse_function():
     assert np.allclose(gmse(y_true, y_pred, square_root=True), 0.5000024031086919)
     assert np.allclose(
         gmse(y_true, y_pred, multioutput="raw_values"),
-        np.array([2.30997255e-11, 1.00000000e+00]),
+        np.array([2.30997255e-11, 1.00000000e00]),
     )
     assert np.allclose(
         gmse(y_true, y_pred, multioutput="raw_values", square_root=True),
-        np.array([4.80621738e-06, 1.00000000e+00]),
+        np.array([4.80621738e-06, 1.00000000e00]),
     )
     assert np.allclose(gmse(y_true, y_pred, multioutput=[0.3, 0.7]), 0.7000000000069299)
     assert np.allclose(

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -28,9 +28,7 @@ def test_gmse_class():
     gmse = GeometricMeanSquaredError(multioutput="raw_values")
     assert np.allclose(gmse(y_true, y_pred), np.array([2.30997255e-11, 1.00000000e00]))
     rgmse = GeometricMeanSquaredError(multioutput="raw_values", square_root=True)
-    assert np.allclose(
-        rgmse(y_true, y_pred), np.array([4.80621738e-06, 1.00000000e00])
-    )
+    assert np.allclose(rgmse(y_true, y_pred), np.array([4.80621738e-06, 1.00000000e00]))
     gmse = GeometricMeanSquaredError(multioutput=[0.3, 0.7])
     assert np.allclose(gmse(y_true, y_pred), 0.7000000000069299)
     rgmse = GeometricMeanSquaredError(multioutput=[0.3, 0.7], square_root=True)

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for some metrics."""
+# currently this consists entirely of doctests from _classes and _functions
+# since the numpy output print changes between versions
+
+import numpy as np
+
+
+def test_gmse_class():
+    """Doctest from GeometricMeanSquaredError."""
+    from sktime.performance_metrics.forecasting import GeometricMeanSquaredError
+
+    y_true = np.array([3, -0.5, 2, 7, 2])
+    y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    gmse = GeometricMeanSquaredError()
+
+    assert np.allclose(gmse(y_true, y_pred), 2.80399089461488e-07)
+    rgmse = GeometricMeanSquaredError(square_root=True)
+    assert np.allclose(rgmse(y_true, y_pred), 0.000529527232030127)
+
+    y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    gmse = GeometricMeanSquaredError()
+    assert np.allclose(gmse(y_true, y_pred), 0.5000000000115499)
+    rgmse = GeometricMeanSquaredError(square_root=True)
+    assert np.allclose(rgmse(y_true, y_pred), 0.5000024031086919)
+    gmse = GeometricMeanSquaredError(multioutput='raw_values')
+    assert np.allclose(gmse(y_true, y_pred), np.array([2.30997255e-11, 1.00000000e+00]))
+    rgmse = GeometricMeanSquaredError(multioutput='raw_values', square_root=True)
+    assert np.allclose(
+        rgmse(y_true, y_pred), np.array([4.80621738e-06, 1.00000000e+00])
+    )
+    gmse = GeometricMeanSquaredError(multioutput=[0.3, 0.7])
+    assert np.allclose(gmse(y_true, y_pred), 0.7000000000069299)
+    rgmse = GeometricMeanSquaredError(multioutput=[0.3, 0.7], square_root=True)
+    assert np.allclose(rgmse(y_true, y_pred), 0.7000014418652152)
+
+
+def test_gmse_function():
+    """Doctest from geometric_mean_squared_error."""
+    from sktime.performance_metrics.forecasting import geometric_mean_squared_error
+
+    gmse = geometric_mean_squared_error
+    y_true = np.array([3, -0.5, 2, 7, 2])
+    y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
+    assert np.allclose(gmse(y_true, y_pred), 2.80399089461488e-07)
+    assert np.allclose(gmse(y_true, y_pred, square_root=True), 0.000529527232030127)
+    y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    assert np.allclose(gmse(y_true, y_pred), 0.5000000000115499)
+    assert np.allclose(gmse(y_true, y_pred, square_root=True), 0.5000024031086919)
+    assert np.allclose(
+        gmse(y_true, y_pred, multioutput='raw_values'),
+        np.array([2.30997255e-11, 1.00000000e+00]),
+    )
+    assert np.allclose(
+        gmse(y_true, y_pred, multioutput='raw_values', square_root=True),
+        np.array([4.80621738e-06, 1.00000000e+00]),
+    )
+    assert np.allclose(gmse(y_true, y_pred, multioutput=[0.3, 0.7]), 0.7000000000069299)
+    assert np.allclose(
+        gmse(y_true, y_pred, multioutput=[0.3, 0.7], square_root=True),
+        0.7000014418652152,
+    )


### PR DESCRIPTION
Fixes #3907 

* moves upper bound for `numpy` to `1.25` (`1.24` is out)
* fixes some compatibility issues due to some high precision numbers in doctests (by @fkiraly) 