### PR TITLE
[MNT] remove `pycatch22` as a soft dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ all_extras = [
     "mne",
     "pmdarima>=1.8.0,!=1.8.1,<3.0.0",
     "prophet>=1.1",
-    "pycatch22",
     "pykalman>=0.9.5",
     "pyod>=0.8.0",
     "scikit_posthocs>=0.6.5",


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/3895 where users are reporting failure to install `sktime[all_extras]` due to `pycatch22`.

This is a potential solution that removes `pycatch22` from the set of soft dependencies.

The dependent estimators can still be found in search via `all_estimators`, and users can install `pycatch22` manually, which should be an improvement above the `all_extras` dependencies set not installing at all for our users.