### PR TITLE
[ENH] `sklearn 1.2.0` compatibility - remove private `_check_weights` import in `KNeighborsTimeSeriesClassifier` and -`Regressor`

### DIFF
--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -24,7 +24,6 @@ from inspect import signature
 
 import numpy as np
 from sklearn.neighbors import KNeighborsClassifier
-from sklearn.neighbors._base import _check_weights
 
 from sktime.classification.base import BaseClassifier
 from sktime.datatypes import check_is_mtype
@@ -139,7 +138,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         n_jobs=None,
     ):
         self.n_neighbors = n_neighbors
-        self.weights = _check_weights(weights)
+        self.weights = weights
         self.algorithm = algorithm
         self.distance = distance
         self.distance_params = distance_params

--- a/sktime/regression/distance_based/_time_series_neighbors.py
+++ b/sktime/regression/distance_based/_time_series_neighbors.py
@@ -13,7 +13,6 @@ __author__ = ["fkiraly"]
 __all__ = ["KNeighborsTimeSeriesRegressor"]
 
 from sklearn.neighbors import KNeighborsRegressor
-from sklearn.neighbors._base import _check_weights
 
 from sktime.distances import pairwise_distance
 from sktime.regression.base import BaseRegressor
@@ -132,7 +131,7 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
             leaf_size=leaf_size,
             n_jobs=n_jobs,
         )
-        self.weights = _check_weights(weights)
+        self.weights = weights
 
         super(KNeighborsTimeSeriesRegressor, self).__init__()
 


### PR DESCRIPTION
This PR fixes a compatibility issue with `sklearn 1.2` and removes the private import `_check_weights` from `KNeighborsTimeSeriesClassifier` and `KNeighborsTimeSeriesRegressor`.

This can be done without deprecation or change in functionality, because `_check_weights` was just an erroneous leftover from an earlier version that used inheritance and not composition.

Right now, the `sklearn` classifier is wrapped as a component, so `_check_weights` (or its 1.2 equivalent) is called again inside the component - therefore, naive removal simply removes an unnecessary duplication. 