### PR TITLE
[MNT] `sklearn 1.2.0` compatibility - cover `BaseForest` parameter change

### DIFF
--- a/sktime/series_as_features/base/estimators/interval_based/_tsf.py
+++ b/sktime/series_as_features/base/estimators/interval_based/_tsf.py
@@ -69,7 +69,7 @@ class BaseTimeSeriesForest:
 
         sklearn_version = sklearn.__version__
 
-        if sklearn_version in SpecifierSet(">1.2.0"):
+        if sklearn_version in SpecifierSet(">=1.2.0"):
             return self.estimator
         else:
             return self.base_estimator

--- a/sktime/series_as_features/base/estimators/interval_based/_tsf.py
+++ b/sktime/series_as_features/base/estimators/interval_based/_tsf.py
@@ -64,9 +64,8 @@ class BaseTimeSeriesForest:
 
         The attribute was renamed from base_estimator to estimator in sklearn 1.2.0.
         """
-        from packaging.specifiers import SpecifierSet
-
         import sklearn
+        from packaging.specifiers import SpecifierSet
 
         sklearn_version = sklearn.__version__
 

--- a/sktime/series_as_features/base/estimators/interval_based/_tsf.py
+++ b/sktime/series_as_features/base/estimators/interval_based/_tsf.py
@@ -39,7 +39,7 @@ class BaseTimeSeriesForest:
         random_state=None,
     ):
         super(BaseTimeSeriesForest, self).__init__(
-            base_estimator=self._base_estimator,
+            self._base_estimator,
             n_estimators=n_estimators,
         )
 


### PR DESCRIPTION
In `sklearn 1.2.0`, the `base_estimator` parameter of `BaseForest` changed to `estimator`, but remained the first arg.

This ensures compatibility of  `sktime` interface points across versions, by

* removing the keyword from an instance of `BaseForest` init call for the `base_estimator` / `estimator` parameter
* dispatching on `sklearn` version when the attribute is being accessed

