### PR TITLE
[ENH] MLflow custom flavor - naive soft dependency isolation

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1851,6 +1851,15 @@
       "contributions": [
         "build"
       ]
+    },
+    {
+      "login": "benjaminbluhm",
+      "name": "Benjamin Bluhm",
+      "profile": "https://github.com/benjaminbluhm",
+      "contributions": [
+        "code",
+        "example"
+      ]
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ sktime/_contrib/debug.py
 sktime/_contrib/local_code.py
 sktime/_contrib/main.py
 sktime/_contrib/temp/
+
+# example mlflow runs
+examples/local/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -89,3 +89,5 @@ sktime/annotation/datagen.py @lmmentel
 sktime/transformations/series/clasp.py @patrickzib @ermshaua
 
 .github/workflows/* @lmmentel @freddyaboulton
+
+sktime/utils/mlflow_sktime.py @benjaminbluhm

--- a/examples/mlflow.ipynb
+++ b/examples/mlflow.ipynb
@@ -1,0 +1,749 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MLflow \n",
+    "\n",
+    "The sktime custom model flavor enables logging of sktime models in MLflow format via the `sktime.utils.mlflow_sktime.save_model()` and `sktime.utils.mlflow_sktime.log_model()` methods. These methods also add the `pyfunc` flavor to the MLflow Models that they produce, allowing the model to be interpreted as generic Python functions for inference via `sktime.utils.mlflow_sktime.pyfunc.load_model()`. This loaded PyFunc model can only be scored with a DataFrame input. You can also use the `sktime.utils.mlflow_sktime.load_model()` method to load MLflow Models with the sktime model flavor in native sktime formats.\n",
+    "\n",
+    "The `pyfunc` flavor of the model supports sktime predict methods `predict`,  `predict_interval`, `predict_quantiles` and `predict_var` for scitypes `\"Series\"` and `\"Panel\"`.\n",
+    "\n",
+    "The interface for utilizing a sktime model loaded as a `pyfunc` type for generating forecasts uses a *single-row* Pandas DataFrame configuration argument. The following columns in this configuration Pandas DataFrame are supported:\n",
+    "\n",
+    "\n",
+    "* ``predict_method`` (optional) - a string (default: ``predict``) specifies the sktime predict method. \n",
+    "    For example, if the objective is to compute prediction interval forecasts, set the column ``predict_method`` to ``predict_interval``.\n",
+    "* ``X`` (optional) - exogenous regressor values as 2D or 3D numpy array of values for future time period events (default: ``None``). \n",
+    "* ``fh`` (optional) - the forecasting horizon encoding the time stamps to be forecasted, optional (default: ``None``). \n",
+    "* ``coverage`` (optional) - nominal coverage(s) of predictive interval(s) (default: ``0.90``), can only be used with ``predict_method=predict_interval``.\n",
+    "* ``alpha`` (optional) - A probability or list of, at which quantile forecasts are computed (default: ``None``), can only be used with ``predict_method=predict_quantiles``.\n",
+    "* ``cov`` (optional) - if True, computes covariance matrix forecast. if False, computes marginal variance forecasts. (default: ``False``), can only be used with ``predict_method=predict_var``.\n",
+    "\n",
+    "An example configuration for the ``pyfunc`` prediction interval forecast of a sktime model is shown below, with a forecast horizon of one to three periods and two prediction intervals:\n",
+    "\n",
+    "| predict_method      | fh | coverage    |\n",
+    "| :---        |    :----   |          :--- |\n",
+    "| predict_interval      | [1, 2, 3]      | [0.1, 0.9]   |\n",
+    "\n",
+    "Signature logging for sktime from a non-pyfunc artifact will not function correctly for `predict_interval` or `predict_quantiles`. The output of the native sktime model flavor for these methods is not a recognized signature type due to the MultiIndex column structure of the returned DataFrame. MLflow's ``infer_schema`` will function correctly if using the ``pyfunc`` flavor of the model, though."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Setup\n",
+    "### 1.1 Config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_path = \"model\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.1 Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mlflow\n",
+    "import pandas as pd\n",
+    "\n",
+    "from sktime.datasets import load_longley\n",
+    "from sktime.datatypes import convert\n",
+    "from sktime.forecasting.model_selection import temporal_train_test_split\n",
+    "from sktime.forecasting.naive import NaiveForecaster\n",
+    "from sktime.utils import mlflow_sktime"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2 Load sample data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y, X = load_longley()\n",
+    "y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)\n",
+    "\n",
+    "# For utilizing sktime model in pyfunc flavor the exogenous regressor must be passed as a numpy array to configuration DataFrame  # noqa: E501\n",
+    "X_test_array = convert(X_test, \"pd.DataFrame\", \"np.ndarray\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Example usage of `mlflow_sktime.save_model()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with mlflow.start_run():\n",
+    "\n",
+    "    forecaster = NaiveForecaster()\n",
+    "    forecaster.fit(y_train, X_train)\n",
+    "\n",
+    "    mlflow_sktime.save_model(forecaster, model_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3. Loading model in different flavors\n",
+    "\n",
+    "### 3.1 Native sktime flavor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loaded_model = mlflow_sktime.load_model(model_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.2 Pyfunc flavor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loaded_pyfunc = mlflow_sktime.pyfunc.load_model(model_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Example usage of sktime `predict()`\n",
+    "\n",
+    "### 4.1 Native sktime flavor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1959    66513.0\n",
+       "1960    66513.0\n",
+       "1961    66513.0\n",
+       "Freq: A-DEC, dtype: float64"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions = loaded_model.predict(fh=[1, 2, 3], X=X_test)\n",
+    "predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.2 Pyfunc flavor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1959    66513.0\n",
+       "1960    66513.0\n",
+       "1961    66513.0\n",
+       "Freq: A-DEC, dtype: float64"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prediction_conf = pd.DataFrame(\n",
+    "    [\n",
+    "        {\n",
+    "            \"predict_method\": \"predict\",\n",
+    "            \"fh\": [1, 2, 3],\n",
+    "            \"coverage\": [0.1, 0.9],\n",
+    "            \"X\": X_test_array,\n",
+    "        }\n",
+    "    ]\n",
+    ")\n",
+    "predictions = loaded_pyfunc.predict(prediction_conf)\n",
+    "predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Example usage of sktime `predict_interval()`\n",
+    "\n",
+    "### 5.1 Native sktime flavor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"4\" halign=\"left\">Coverage</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"2\" halign=\"left\">0.1</th>\n",
+       "      <th colspan=\"2\" halign=\"left\">0.9</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>lower</th>\n",
+       "      <th>upper</th>\n",
+       "      <th>lower</th>\n",
+       "      <th>upper</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1959</th>\n",
+       "      <td>66337.180592</td>\n",
+       "      <td>66688.819408</td>\n",
+       "      <td>64211.598663</td>\n",
+       "      <td>68814.401337</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1960</th>\n",
+       "      <td>66264.353808</td>\n",
+       "      <td>66761.646192</td>\n",
+       "      <td>63258.327017</td>\n",
+       "      <td>69767.672983</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1961</th>\n",
+       "      <td>66208.471852</td>\n",
+       "      <td>66817.528148</td>\n",
+       "      <td>62526.855956</td>\n",
+       "      <td>70499.144044</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          Coverage                                          \n",
+       "               0.1                         0.9              \n",
+       "             lower         upper         lower         upper\n",
+       "1959  66337.180592  66688.819408  64211.598663  68814.401337\n",
+       "1960  66264.353808  66761.646192  63258.327017  69767.672983\n",
+       "1961  66208.471852  66817.528148  62526.855956  70499.144044"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions = loaded_model.predict_interval(fh=[1, 2, 3], coverage=[0.1, 0.9], X=X_test)\n",
+    "predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.2 Pyfunc flavor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>('Coverage', 0.1, 'lower')</th>\n",
+       "      <th>('Coverage', 0.1, 'upper')</th>\n",
+       "      <th>('Coverage', 0.9, 'lower')</th>\n",
+       "      <th>('Coverage', 0.9, 'upper')</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1959</th>\n",
+       "      <td>66337.180592</td>\n",
+       "      <td>66688.819408</td>\n",
+       "      <td>64211.598663</td>\n",
+       "      <td>68814.401337</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1960</th>\n",
+       "      <td>66264.353808</td>\n",
+       "      <td>66761.646192</td>\n",
+       "      <td>63258.327017</td>\n",
+       "      <td>69767.672983</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1961</th>\n",
+       "      <td>66208.471852</td>\n",
+       "      <td>66817.528148</td>\n",
+       "      <td>62526.855956</td>\n",
+       "      <td>70499.144044</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      ('Coverage', 0.1, 'lower')  ('Coverage', 0.1, 'upper')  \\\n",
+       "1959                66337.180592                66688.819408   \n",
+       "1960                66264.353808                66761.646192   \n",
+       "1961                66208.471852                66817.528148   \n",
+       "\n",
+       "      ('Coverage', 0.9, 'lower')  ('Coverage', 0.9, 'upper')  \n",
+       "1959                64211.598663                68814.401337  \n",
+       "1960                63258.327017                69767.672983  \n",
+       "1961                62526.855956                70499.144044  "
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prediction_conf = pd.DataFrame(\n",
+    "    [\n",
+    "        {\n",
+    "            \"predict_method\": \"predict_interval\",\n",
+    "            \"fh\": [1, 2, 3],\n",
+    "            \"coverage\": [0.1, 0.9],\n",
+    "            \"X\": X_test_array,\n",
+    "        }\n",
+    "    ]\n",
+    ")\n",
+    "predictions = loaded_pyfunc.predict(prediction_conf)\n",
+    "predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Example usage of sktime `predict_quantiles()`\n",
+    "\n",
+    "### 6.1 Native sktime flavor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"3\" halign=\"left\">Quantiles</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>0.1</th>\n",
+       "      <th>0.5</th>\n",
+       "      <th>0.9</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1959</th>\n",
+       "      <td>64719.913711</td>\n",
+       "      <td>66513.0</td>\n",
+       "      <td>68306.086289</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1960</th>\n",
+       "      <td>63977.193051</td>\n",
+       "      <td>66513.0</td>\n",
+       "      <td>69048.806949</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1961</th>\n",
+       "      <td>63407.283445</td>\n",
+       "      <td>66513.0</td>\n",
+       "      <td>69618.716555</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         Quantiles                       \n",
+       "               0.1      0.5           0.9\n",
+       "1959  64719.913711  66513.0  68306.086289\n",
+       "1960  63977.193051  66513.0  69048.806949\n",
+       "1961  63407.283445  66513.0  69618.716555"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions = loaded_model.predict_quantiles(\n",
+    "    fh=[1, 2, 3], alpha=[0.1, 0.5, 0.9], X=X_test\n",
+    ")\n",
+    "predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6.2 Pyfunc flavor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>('Quantiles', 0.1)</th>\n",
+       "      <th>('Quantiles', 0.5)</th>\n",
+       "      <th>('Quantiles', 0.9)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1959</th>\n",
+       "      <td>64719.913711</td>\n",
+       "      <td>66513.0</td>\n",
+       "      <td>68306.086289</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1960</th>\n",
+       "      <td>63977.193051</td>\n",
+       "      <td>66513.0</td>\n",
+       "      <td>69048.806949</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1961</th>\n",
+       "      <td>63407.283445</td>\n",
+       "      <td>66513.0</td>\n",
+       "      <td>69618.716555</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      ('Quantiles', 0.1)  ('Quantiles', 0.5)  ('Quantiles', 0.9)\n",
+       "1959        64719.913711             66513.0        68306.086289\n",
+       "1960        63977.193051             66513.0        69048.806949\n",
+       "1961        63407.283445             66513.0        69618.716555"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prediction_conf = pd.DataFrame(\n",
+    "    [\n",
+    "        {\n",
+    "            \"predict_method\": \"predict_quantiles\",\n",
+    "            \"fh\": [1, 2, 3],\n",
+    "            \"alpha\": [0.1, 0.5, 0.9],\n",
+    "            \"X\": X_test_array,\n",
+    "        }\n",
+    "    ]\n",
+    ")\n",
+    "predictions = loaded_pyfunc.predict(prediction_conf)\n",
+    "predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Example usage of sktime `predict_var()`\n",
+    "\n",
+    "### 7.1 Native sktime flavor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1959</th>\n",
+       "      <td>1.957628e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1960</th>\n",
+       "      <td>3.915256e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1961</th>\n",
+       "      <td>5.872885e+06</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 0\n",
+       "1959  1.957628e+06\n",
+       "1960  3.915256e+06\n",
+       "1961  5.872885e+06"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions = loaded_model.predict_var(fh=[1, 2, 3], X=X_test)\n",
+    "predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1959</th>\n",
+       "      <td>1.957628e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1960</th>\n",
+       "      <td>3.915256e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1961</th>\n",
+       "      <td>5.872885e+06</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 0\n",
+       "1959  1.957628e+06\n",
+       "1960  3.915256e+06\n",
+       "1961  5.872885e+06"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prediction_conf = pd.DataFrame(\n",
+    "    [{\"predict_method\": \"predict_var\", \"fh\": [1, 2, 3], \"X\": X_test_array}]\n",
+    ")\n",
+    "predictions = loaded_pyfunc.predict(prediction_conf)\n",
+    "predictions"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ dependencies = [
 
 [project.optional-dependencies]
 all_extras = [
-    "boto3",
     "dtw-python",
     "esig==0.9.7; python_version < '3.10'",
     "filterpy>=1.4.5",
@@ -66,7 +65,6 @@ all_extras = [
     "matplotlib>=3.3.2",
     "mlflow",
     "mne",
-    "moto",
     "pmdarima>=1.8.0,!=1.8.1,<3.0.0",
     "prophet>=1.1",
     "pycatch22",
@@ -87,7 +85,10 @@ all_extras = [
 
 dev = [
     "backoff",
+    "boto3",
+    "botocore",
     "httpx",
+    "moto",
     "pre-commit",
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
 
 [project.optional-dependencies]
 all_extras = [
+    "boto3",
     "dtw-python",
     "esig==0.9.7; python_version < '3.10'",
     "filterpy>=1.4.5",
@@ -63,7 +64,9 @@ all_extras = [
     "gluonts>=0.9.0",
     "keras-self-attention",
     "matplotlib>=3.3.2",
+    "mlflow",
     "mne",
+    "moto",
     "pmdarima>=1.8.0,!=1.8.1,<3.0.0",
     "prophet>=1.1",
     "pycatch22",

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -143,10 +143,6 @@ def save_model(
         path to a pip requirements file on the local filesystem (e.g. "requirements.txt")
 
 
-    See Also
-    --------
-    MLflow
-
     References
     ----------
     .. [1] https://www.mlflow.org/docs/latest/python_api/mlflow.models.html#mlflow.models.Model.save
@@ -403,10 +399,6 @@ def load_model(model_uri, dst_path=None):
     Returns
     -------
     A sktime model instance.
-
-    See Also
-    --------
-    MLflow
 
     References
     ----------

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -30,9 +30,6 @@ import pickle
 
 import pandas as pd
 import yaml
-from mlflow import pyfunc
-from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
-from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 
 import sktime
 from sktime import utils
@@ -78,7 +75,6 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
 
-@format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 def save_model(
     sktime_model,
     path,
@@ -168,6 +164,7 @@ def save_model(
     """  # noqa: E501
     _check_soft_dependencies("mlflow", severity="error")
     import mlflow
+    from mlflow import pyfunc
     from mlflow.models import Model
     from mlflow.models.model import MLMODEL_FILE_NAME
     from mlflow.models.utils import _save_example
@@ -250,7 +247,6 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-@format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 def log_model(
     sktime_model,
     artifact_path,
@@ -259,7 +255,7 @@ def log_model(
     registered_model_name=None,
     signature=None,
     input_example=None,
-    await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
+    await_registration_for=None,
     pip_requirements=None,
     extra_pip_requirements=None,
     **kwargs,
@@ -362,6 +358,11 @@ def log_model(
     """  # noqa: E501
     _check_soft_dependencies("mlflow", severity="error")
     from mlflow.models import Model
+
+    if await_registration_for is None:
+        from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+
+        await_registration_for = DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
     return Model.log(
         artifact_path=artifact_path,

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -516,32 +516,6 @@ class _SktimeModelWrapper:
                 lambda x: "".join(str(x))
             )
 
-        # # TODO: "predict_proba" is currently not robust across estimators
-        #     (fails for VAR and possibly other estimators)
-        #     remove "predict_proba" or modify logic to be robust across estimators
-        # if predict_method == "predict_proba":
-        #     marginal = attrs.get("marginal", True)
-        #     quantiles = attrs.get("quantiles", None)
-        #
-        #     if not quantiles:
-        #         raise MlflowException(
-        #             f"The provided `quantiles` value {quantiles} must be provided.",
-        #             error_code=INVALID_PARAMETER_VALUE,
-        #         )
-        #
-        #     y_pred_dist = self.sktime_model.predict_proba(
-        #           fh=fh, X=X, marginal=marginal)
-        #
-        #     y_pred_dist_quantiles = pd.DataFrame(y_pred_dist.quantile(quantiles))
-        #     y_pred_dist_quantiles.columns = [f"(Quantile, {q})" for q in quantiles]
-        #     y_pred_dist_quantiles.index = y_pred_dist.parameters['loc'].index
-        #
-        #     y_pred_dist_parameters = pd.DataFrame()
-        #     for k, v in y_pred_dist.parameters.items():
-        #         y_pred_dist_parameters[k] = v
-        #
-        #     y_pred = y_pred_dist_parameters.join(y_pred_dist_quantiles)
-
         if predict_method == "predict_quantiles":
             alpha = attrs.get("alpha", None)
             y_pred = self.sktime_model.predict_quantiles(fh=fh, X=X, alpha=alpha)
@@ -549,10 +523,6 @@ class _SktimeModelWrapper:
             y_pred.columns = y_pred.columns.to_flat_index().map(
                 lambda x: "".join(str(x))
             )
-
-        # if predict_method == "predict_residuals":
-        #     y = attrs.get("y", None)
-        #     y_pred = self.sktime_model.predict_residuals(y=y, X=X)
 
         if predict_method == "predict_var":
             cov = attrs.get("cov", False)

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -30,7 +30,7 @@ import pickle
 
 import pandas as pd
 import yaml
-from mlflow import pyfunc  # noqa: F401
+from mlflow import pyfunc
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 
@@ -136,11 +136,13 @@ def save_model(
     pip_requirements : Union[Iterable, str], optional (default=None)
         Either an iterable of pip requirement strings
         (e.g. ["sktime", "-r requirements.txt", "-c constraints.txt"]) or the string
-        path to a pip requirements file on the local filesystem (e.g. "requirements.txt")
+        path to a pip requirements file on the local filesystem
+        (e.g. "requirements.txt")
     extra_pip_requirements : Union[Iterable, str], optional (default=None)
         Either an iterable of pip requirement strings
         (e.g. ["pandas", "-r requirements.txt", "-c constraints.txt"]) or the string
-        path to a pip requirements file on the local filesystem (e.g. "requirements.txt")
+        path to a pip requirements file on the local filesystem
+        (e.g. "requirements.txt")
 
 
     References
@@ -160,7 +162,9 @@ def save_model(
     >>> forecaster.fit(y)  # doctest: +SKIP
     ARIMA(...)
     >>> model_path = "model"
-    >>> mlflow_sktime.save_model(sktime_model=forecaster, path=model_path)  # doctest: +SKIP
+    >>> mlflow_sktime.save_model(
+    ...     sktime_model=forecaster,
+    ...     path=model_path)  # doctest: +SKIP
     """  # noqa: E501
     _check_soft_dependencies("mlflow", severity="error")
     import mlflow
@@ -315,11 +319,13 @@ def log_model(
     pip_requirements : Union[Iterable, str], optional (default=None)
         Either an iterable of pip requirement strings
         (e.g. ["sktime", "-r requirements.txt", "-c constraints.txt"]) or the string
-        path to a pip requirements file on the local filesystem (e.g. "requirements.txt")
+        path to a pip requirements file on the local filesystem
+        (e.g. "requirements.txt")
     extra_pip_requirements : Union[Iterable, str], optional (default=None)
         Either an iterable of pip requirement strings
         (e.g. ["pandas", "-r requirements.txt", "-c constraints.txt"]) or the string
-        path to a pip requirements file on the local filesystem (e.g. "requirements.txt")
+        path to a pip requirements file on the local filesystem
+        (e.g. "requirements.txt")
     kwargs:
         Additional arguments for :py:class:`mlflow.models.model.Model`
 
@@ -417,7 +423,9 @@ def load_model(model_uri, dst_path=None):
     >>> forecaster.fit(y)  # doctest: +SKIP
     ARIMA(...)
     >>> model_path = "model"
-    >>> mlflow_sktime.save_model(sktime_model=forecaster, path=model_path)  # doctest: +SKIP
+    >>> mlflow_sktime.save_model(
+    ...     sktime_model=forecaster,
+    ...     path=model_path)  # doctest: +SKIP
     >>> loaded_model = mlflow_sktime.load_model(model_uri=model_path)  # doctest: +SKIP
     """  # noqa: E501
     _check_soft_dependencies("mlflow", severity="error")

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -58,6 +58,7 @@ def get_default_pip_requirements():
     Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
     that, at a minimum, contains these requirements.
     """
+    _check_soft_dependencies("mlflow", severity="error")
     from mlflow.utils.requirements_utils import _get_pinned_requirement
 
     return [_get_pinned_requirement("sktime")]
@@ -71,6 +72,7 @@ def get_default_conda_env():
     The default Conda environment for MLflow Models produced by calls to
     :func:`save_model()` and :func:`log_model()`
     """
+    _check_soft_dependencies("mlflow", severity="error")
     from mlflow.utils.environment import _mlflow_conda_env
 
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
@@ -164,6 +166,7 @@ def save_model(
     >>> model_path = "model"
     >>> mlflow_sktime.save_model(sktime_model=forecaster, path=model_path)  # doctest: +SKIP
     """  # noqa: E501
+    _check_soft_dependencies("mlflow", severity="error")
     import mlflow
     from mlflow.models import Model
     from mlflow.models.model import MLMODEL_FILE_NAME
@@ -355,6 +358,7 @@ def log_model(
     ...     sktime_model=forecaster,
     ...     artifact_path=artifact_path)
     """  # noqa: E501
+    _check_soft_dependencies("mlflow", severity="error")
     from mlflow.models import Model
 
     return Model.log(
@@ -478,6 +482,7 @@ def _load_pyfunc(path):
 
 class _SktimeModelWrapper:
     def __init__(self, sktime_model):
+        _check_soft_dependencies("mlflow", severity="error")
         self.sktime_model = sktime_model
 
     def predict(self, dataframe) -> pd.DataFrame:

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -35,7 +35,8 @@ import sktime
 from sktime import utils
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("mlflow", severity="warning")
+if _check_soft_dependencies("mlflow", severity="warning"):
+    from mlflow import pyfunc
 
 FLAVOR_NAME = "mlflow_sktime"
 _MODEL_BINARY_KEY = "data"
@@ -164,7 +165,6 @@ def save_model(
     """  # noqa: E501
     _check_soft_dependencies("mlflow", severity="error")
     import mlflow
-    from mlflow import pyfunc
     from mlflow.models import Model
     from mlflow.models.model import MLMODEL_FILE_NAME
     from mlflow.models.utils import _save_example

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -9,6 +9,10 @@ sktime (native) format
     internally to serialize a model.
 mlflow.pyfunc
     Produced for use by generic pyfunc-based deployment tools and batch inference.
+
+    The ``pyfunc`` flavor of the model supports sktime predict methods ``predict``,
+    ``predict_interval``, ``predict_quantiles`` and ``predict_var`` (``predict_proba``
+    and ``predict_residuals`` are currently not supported).
 """
 
 __author__ = ["benjaminbluhm"]
@@ -120,10 +124,7 @@ def save_model(
           on the returned prediction object will not be correctly inferred due
           to the Pandas MultiIndex column type when using the these methods.
           ``infer_schema`` will function correctly if using the ``pyfunc`` flavor
-          of the model, though. The ``pyfunc`` flavor of the model supports sktime
-          predict methods ``predict``, ``predict_interval``, ``predict_quantiles``
-          and ``predict_var`` while ``predict_proba`` and ``predict_residuals`` are
-          currently not supported.
+          of the model, though.
     input_example : Union[pandas.core.frame.DataFrame, numpy.ndarray, dict, list, csr_matrix, csc_matrix], optional (default=None)
         Input example provides one or several instances of valid model input.
         The example can be used as a hint of what data to feed the model. The given

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -148,18 +148,18 @@ def save_model(
 
     Examples
     --------
-    >>> from sktime.datasets import load_airline
-    >>> from sktime.forecasting.arima import ARIMA
-    >>> from sktime.utils import mlflow_sktime
-    >>> y = load_airline()
-    >>> forecaster = ARIMA(
+    >>> from sktime.datasets import load_airline  # doctest: +SKIP
+    >>> from sktime.forecasting.arima import ARIMA  # doctest: +SKIP
+    >>> from sktime.utils import mlflow_sktime  # doctest: +SKIP
+    >>> y = load_airline()  # doctest: +SKIP
+    >>> forecaster = ARIMA(  # doctest: +SKIP
     ...     order=(1, 1, 0),
     ...     seasonal_order=(0, 1, 0, 12),
     ...     suppress_warnings=True)
-    >>> forecaster.fit(y)
+    >>> forecaster.fit(y)  # doctest: +SKIP
     ARIMA(...)
-    >>> model_path = "model"
-    >>> mlflow_sktime.save_model(
+    >>> model_path = "model"  # doctest: +SKIP
+    >>> mlflow_sktime.save_model(  # doctest: +SKIP
     ...     sktime_model=forecaster,
     ...     path=model_path)  # doctest: +SKIP
     """  # noqa: E501
@@ -338,20 +338,20 @@ def log_model(
     ----------
     .. [1] https://www.mlflow.org/docs/latest/python_api/mlflow.models.html#mlflow.models.Model.log
 
-    >>> import mlflow
-    >>> from mlflow.utils.environment import _mlflow_conda_env
-    >>> from sktime.datasets import load_airline
-    >>> from sktime.forecasting.arima import ARIMA
-    >>> from sktime.utils import mlflow_sktime
-    >>> y = load_airline()
-    >>> forecaster = ARIMA(
+    >>> import mlflow  # doctest: +SKIP
+    >>> from mlflow.utils.environment import _mlflow_conda_env  # doctest: +SKIP
+    >>> from sktime.datasets import load_airline  # doctest: +SKIP
+    >>> from sktime.forecasting.arima import ARIMA  # doctest: +SKIP
+    >>> from sktime.utils import mlflow_sktime  # doctest: +SKIP
+    >>> y = load_airline()  # doctest: +SKIP
+    >>> forecaster = ARIMA(  # doctest: +SKIP
     ...     order=(1, 1, 0),
     ...     seasonal_order=(0, 1, 0, 12),
     ...     suppress_warnings=True)
-    >>> forecaster.fit(y)
+    >>> forecaster.fit(y)  # doctest: +SKIP
     ARIMA(...)
-    >>> mlflow.start_run()
-    >>> artifact_path = "model"
+    >>> mlflow.start_run()  # doctest: +SKIP
+    >>> artifact_path = "model"  # doctest: +SKIP
     >>> model_info = mlflow_sktime.log_model(
     ...     sktime_model=forecaster,
     ...     artifact_path=artifact_path)  # doctest: +SKIP
@@ -415,16 +415,16 @@ def load_model(model_uri, dst_path=None):
     --------
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.arima import ARIMA
-    >>> from sktime.utils import mlflow_sktime
-    >>> y = load_airline()
-    >>> forecaster = ARIMA(
+    >>> from sktime.utils import mlflow_sktime  # doctest: +SKIP
+    >>> y = load_airline()  # doctest: +SKIP
+    >>> forecaster = ARIMA(  # doctest: +SKIP
     ...     order=(1, 1, 0),
     ...     seasonal_order=(0, 1, 0, 12),
     ...     suppress_warnings=True)
-    >>> forecaster.fit(y)
+    >>> forecaster.fit(y)  # doctest: +SKIP
     ARIMA(...)
-    >>> model_path = "model"
-    >>> mlflow_sktime.save_model(
+    >>> model_path = "model"  # doctest: +SKIP
+    >>> mlflow_sktime.save_model(  # doctest: +SKIP
     ...     sktime_model=forecaster,
     ...     path=model_path)
     >>> loaded_model = mlflow_sktime.load_model(model_uri=model_path)  # doctest: +SKIP

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -34,6 +34,7 @@ from mlflow import pyfunc  # noqa: F401
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 
+import sktime
 from sktime import utils
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
@@ -182,8 +183,6 @@ def save_model(
         _validate_and_copy_code_paths,
         _validate_and_prepare_target_save_path,
     )
-
-    import sktime
 
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -420,6 +420,7 @@ def load_model(model_uri, dst_path=None):
     >>> mlflow_sktime.save_model(sktime_model=forecaster, path=model_path)  # doctest: +SKIP
     >>> loaded_model = mlflow_sktime.load_model(model_uri=model_path)  # doctest: +SKIP
     """  # noqa: E501
+    _check_soft_dependencies("mlflow", severity="error")
     from mlflow.tracking.artifact_utils import _download_artifact_from_uri
     from mlflow.utils.model_utils import (
         _add_code_from_conf_to_system_path,

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -155,11 +155,11 @@ def save_model(
     >>> from sktime.forecasting.arima import ARIMA
     >>> from sktime.utils import mlflow_sktime
     >>> y = load_airline()
-    >>> forecaster = ARIMA(  # doctest: +SKIP
+    >>> forecaster = ARIMA(
     ...     order=(1, 1, 0),
     ...     seasonal_order=(0, 1, 0, 12),
     ...     suppress_warnings=True)
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster.fit(y)
     ARIMA(...)
     >>> model_path = "model"
     >>> mlflow_sktime.save_model(
@@ -348,17 +348,17 @@ def log_model(
     >>> from sktime.forecasting.arima import ARIMA
     >>> from sktime.utils import mlflow_sktime
     >>> y = load_airline()
-    >>> forecaster = ARIMA(  # doctest: +SKIP
+    >>> forecaster = ARIMA(
     ...     order=(1, 1, 0),
     ...     seasonal_order=(0, 1, 0, 12),
     ...     suppress_warnings=True)
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster.fit(y)
     ARIMA(...)
-    >>> mlflow.start_run()  # doctest: +SKIP
+    >>> mlflow.start_run()
     >>> artifact_path = "model"
-    >>> model_info = mlflow_sktime.log_model(  # doctest: +SKIP
+    >>> model_info = mlflow_sktime.log_model(
     ...     sktime_model=forecaster,
-    ...     artifact_path=artifact_path)
+    ...     artifact_path=artifact_path)  # doctest: +SKIP
     """  # noqa: E501
     _check_soft_dependencies("mlflow", severity="error")
     from mlflow.models import Model
@@ -416,16 +416,16 @@ def load_model(model_uri, dst_path=None):
     >>> from sktime.forecasting.arima import ARIMA
     >>> from sktime.utils import mlflow_sktime
     >>> y = load_airline()
-    >>> forecaster = ARIMA(  # doctest: +SKIP
+    >>> forecaster = ARIMA(
     ...     order=(1, 1, 0),
     ...     seasonal_order=(0, 1, 0, 12),
     ...     suppress_warnings=True)
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster.fit(y)
     ARIMA(...)
     >>> model_path = "model"
     >>> mlflow_sktime.save_model(
     ...     sktime_model=forecaster,
-    ...     path=model_path)  # doctest: +SKIP
+    ...     path=model_path)
     >>> loaded_model = mlflow_sktime.load_model(model_uri=model_path)  # doctest: +SKIP
     """  # noqa: E501
     _check_soft_dependencies("mlflow", severity="error")

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3 -u
+# -*- coding: utf-8 -*-
+"""The ``mlflow_sktime`` module provides an MLflow API for ``sktime`` models.
+
+This module exports ``sktime`` models in the following formats:
+
+sktime (native) format
+    This is the main flavor that can be loaded back into sktime, which relies on pickle
+    internally to serialize a model.
+mlflow.pyfunc
+    Produced for use by generic pyfunc-based deployment tools and batch inference.
+"""
+
+__author__ = ["benjaminbluhm"]
+__all__ = [
+    "get_default_pip_requirements",
+    "get_default_conda_env",
+    "save_model",
+    "log_model",
+    "load_model",
+]
+
+import logging
+import os
+import pickle
+
+import pandas as pd
+import yaml
+from mlflow import pyfunc  # noqa: F401
+from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
+
+from sktime import utils
+from sktime.utils.validation._dependencies import _check_soft_dependencies
+
+_check_soft_dependencies("mlflow", severity="warning")
+
+FLAVOR_NAME = "mlflow_sktime"
+_MODEL_BINARY_KEY = "data"
+_MODEL_BINARY_FILE_NAME = "model.skt"
+_MODEL_TYPE_KEY = "model_type"
+PREDICT_METHODS = ["predict", "predict_interval", "predict_quantiles", "predict_var"]
+
+_logger = logging.getLogger(__name__)
+
+
+def get_default_pip_requirements():
+    """Create list of default pip requirements for MLflow Models.
+
+    Returns
+    -------
+    list of default pip requirements for MLflow Models produced by this flavor.
+    Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
+    that, at a minimum, contains these requirements.
+    """
+    from mlflow.utils.requirements_utils import _get_pinned_requirement
+
+    return [_get_pinned_requirement("sktime")]
+
+
+def get_default_conda_env():
+    """Return default Conda environment for MLflow Models.
+
+    Returns
+    -------
+    The default Conda environment for MLflow Models produced by calls to
+    :func:`save_model()` and :func:`log_model()`
+    """
+    from mlflow.utils.environment import _mlflow_conda_env
+
+    return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
+
+
+@format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
+def save_model(
+    sktime_model,
+    path,
+    conda_env=None,
+    code_paths=None,
+    mlflow_model=None,
+    signature=None,
+    input_example=None,
+    pip_requirements=None,
+    extra_pip_requirements=None,
+):  # TODO: can we specify a type for fitted instance of sktime model below?
+    """Save a sktime model to a path on the local file system.
+
+    Parameters
+    ----------
+    sktime_model :
+        Fitted sktime model object.
+    path : str
+        Local path where the model is to be saved.
+    conda_env : Union[dict, str], optional (default=None)
+        Either a dictionary representation of a Conda environment or the path to a
+        conda environment yaml file.
+    code_paths : array-like, optional (default=None)
+        A list of local filesystem paths to Python file dependencies (or directories
+        containing file dependencies). These files are *prepended* to the system path
+        when the model is loaded.
+    mlflow_model: mlflow.models.Model, optional (default=None)
+        mlflow.models.Model configuration to which to add the python_function flavor.
+    signature : mlflow.models.signature.ModelSignature, optional (default=None)
+        Model Signature mlflow.models.ModelSignature describes
+        model input and output :py:class:`Schema <mlflow.types.Schema>`. The model
+        signature can be :py:func:`inferred <mlflow.models.infer_signature>` from
+        datasets with valid model input (e.g. the training dataset with target column
+        omitted) and valid model output (e.g. model predictions generated on the
+        training dataset), for example:
+
+        .. code-block:: py
+
+          from mlflow.models.signature import infer_signature
+          train = df.drop_column("target_label")
+          predictions = ... # compute model predictions
+          signature = infer_signature(train, predictions)
+
+        .. Warning:: if performing probabilistic forecasts (``predict_interval``,
+          ``predict_quantiles``) with a sktime model, the signature
+          on the returned prediction object will not be correctly inferred due
+          to the Pandas MultiIndex column type when using the these methods.
+          ``infer_schema`` will function correctly if using the ``pyfunc`` flavor
+          of the model, though. The ``pyfunc`` flavor of the model supports sktime
+          predict methods ``predict``, ``predict_interval``, ``predict_quantiles``
+          and ``predict_var`` while ``predict_proba`` and ``predict_residuals`` are
+          currently not supported.
+    input_example : Union[pandas.core.frame.DataFrame, numpy.ndarray, dict, list, csr_matrix, csc_matrix], optional (default=None)
+        Input example provides one or several instances of valid model input.
+        The example can be used as a hint of what data to feed the model. The given
+        example will be converted to a ``Pandas DataFrame`` and then serialized to json
+        using the ``Pandas`` split-oriented format. Bytes are base64-encoded.
+    pip_requirements : Union[Iterable, str], optional (default=None)
+        Either an iterable of pip requirement strings
+        (e.g. ["sktime", "-r requirements.txt", "-c constraints.txt"]) or the string
+        path to a pip requirements file on the local filesystem (e.g. "requirements.txt")
+    extra_pip_requirements : Union[Iterable, str], optional (default=None)
+        Either an iterable of pip requirement strings
+        (e.g. ["pandas", "-r requirements.txt", "-c constraints.txt"]) or the string
+        path to a pip requirements file on the local filesystem (e.g. "requirements.txt")
+
+
+    See Also
+    --------
+    MLflow
+
+    References
+    ----------
+    .. [1] https://www.mlflow.org/docs/latest/python_api/mlflow.models.html#mlflow.models.Model.save
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.arima import ARIMA
+    >>> from sktime.utils import mlflow_sktime
+    >>> y = load_airline()
+    >>> forecaster = ARIMA(  # doctest: +SKIP
+    ...     order=(1, 1, 0),
+    ...     seasonal_order=(0, 1, 0, 12),
+    ...     suppress_warnings=True)
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    ARIMA(...)
+    >>> model_path = "model"
+    >>> mlflow_sktime.save_model(sktime_model=forecaster, path=model_path)  # doctest: +SKIP
+    """  # noqa: E501
+    import mlflow
+    from mlflow.models import Model
+    from mlflow.models.model import MLMODEL_FILE_NAME
+    from mlflow.models.utils import _save_example
+    from mlflow.utils.environment import (
+        _CONDA_ENV_FILE_NAME,
+        _CONSTRAINTS_FILE_NAME,
+        _PYTHON_ENV_FILE_NAME,
+        _REQUIREMENTS_FILE_NAME,
+        _process_conda_env,
+        _process_pip_requirements,
+        _PythonEnv,
+        _validate_env_arguments,
+    )
+    from mlflow.utils.file_utils import write_to
+    from mlflow.utils.model_utils import (
+        _validate_and_copy_code_paths,
+        _validate_and_prepare_target_save_path,
+    )
+
+    import sktime
+
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+
+    path = os.path.abspath(path)
+    _validate_and_prepare_target_save_path(path)
+    code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
+
+    if mlflow_model is None:
+        mlflow_model = Model()
+    if signature is not None:
+        mlflow_model.signature = signature
+    if input_example is not None:
+        _save_example(mlflow_model, input_example, path)
+
+    model_data_path = os.path.join(path, _MODEL_BINARY_FILE_NAME)
+    _save_model(sktime_model, model_data_path)
+
+    model_bin_kwargs = {_MODEL_BINARY_KEY: _MODEL_BINARY_FILE_NAME}
+    pyfunc.add_to_model(
+        mlflow_model,
+        loader_module="sktime.utils.mlflow_sktime",
+        conda_env=_CONDA_ENV_FILE_NAME,
+        python_env=_PYTHON_ENV_FILE_NAME,
+        code=code_dir_subpath,
+        **model_bin_kwargs,
+    )
+    flavor_conf = {
+        _MODEL_TYPE_KEY: sktime_model.__class__.__name__,
+        **model_bin_kwargs,
+    }
+    mlflow_model.add_flavor(
+        FLAVOR_NAME,
+        sktime_version=sktime.__version__,
+        code=code_dir_subpath,
+        **flavor_conf,
+    )
+    mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
+
+    if conda_env is None:
+        if pip_requirements is None:
+            default_reqs = get_default_pip_requirements()
+            inferred_reqs = mlflow.models.infer_pip_requirements(
+                path, FLAVOR_NAME, fallback=default_reqs
+            )
+            default_reqs = sorted(set(inferred_reqs).union(default_reqs))
+        else:
+            default_reqs = None
+        conda_env, pip_requirements, pip_constraints = _process_pip_requirements(
+            default_reqs, pip_requirements, extra_pip_requirements
+        )
+    else:
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+
+    with open(os.path.join(path, _CONDA_ENV_FILE_NAME), "w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
+
+    if pip_constraints:
+        write_to(os.path.join(path, _CONSTRAINTS_FILE_NAME), "\n".join(pip_constraints))
+
+    write_to(os.path.join(path, _REQUIREMENTS_FILE_NAME), "\n".join(pip_requirements))
+
+    _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
+
+
+@format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
+def log_model(
+    sktime_model,
+    artifact_path,
+    conda_env=None,
+    code_paths=None,
+    registered_model_name=None,
+    signature=None,
+    input_example=None,
+    await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
+    pip_requirements=None,
+    extra_pip_requirements=None,
+    **kwargs,
+):  # TODO: can we specify a type for fitted instance of sktime model below?
+    """
+    Log a sktime model as an MLflow artifact for the current run.
+
+    Parameters
+    ----------
+    sktime_model : fitted sktime model
+        Fitted sktime model object.
+    artifact_path : str
+        Run-relative artifact path to save the model to.
+    conda_env : Union[dict, str], optional (default=None)
+        Either a dictionary representation of a Conda environment or the path to a
+        conda environment yaml file.
+    code_paths : array-like, optional (default=None)
+        A list of local filesystem paths to Python file dependencies (or directories
+        containing file dependencies). These files are *prepended* to the system path
+        when the model is loaded.
+    registered_model_name : str, optional (default=None)
+        If given, create a model version under ``registered_model_name``, also creating
+        a registered model if one with the given name does not exist.
+    signature : mlflow.models.signature.ModelSignature, optional (default=None)
+        Model Signature mlflow.models.ModelSignature describes
+        model input and output :py:class:`Schema <mlflow.types.Schema>`. The model
+        signature can be :py:func:`inferred <mlflow.models.infer_signature>` from
+        datasets with valid model input (e.g. the training dataset with target column
+        omitted) and valid model output (e.g. model predictions generated on the
+        training dataset), for example:
+
+        .. code-block:: py
+
+          from mlflow.models.signature import infer_signature
+          train = df.drop_column("target_label")
+          predictions = ... # compute model predictions
+          signature = infer_signature(train, predictions)
+
+        .. Warning:: if performing probabilistic forecasts (``predict_interval``,
+          ``predict_quantiles``) with a sktime model, the signature
+          on the returned prediction object will not be correctly inferred due
+          to the Pandas MultiIndex column type when using the these methods.
+          ``infer_schema`` will function correctly if using the ``pyfunc`` flavor
+          of the model, though. The ``pyfunc`` flavor of the model supports sktime
+          predict methods ``predict``, ``predict_interval``, ``predict_quantiles``
+          and ``predict_var`` while ``predict_proba`` and ``predict_residuals`` are
+          currently not supported.
+    input_example : Union[pandas.core.frame.DataFrame, numpy.ndarray, dict, list, csr_matrix, csc_matrix], optional (default=None)
+        Input example provides one or several instances of valid model input.
+        The example can be used as a hint of what data to feed the model. The given
+        example will be converted to a ``Pandas DataFrame`` and then serialized to json
+        using the ``Pandas`` split-oriented format. Bytes are base64-encoded.
+    await_registration_for : int, optional (default=None)
+        Number of seconds to wait for the model version to finish being created and is
+        in ``READY`` status. By default, the function waits for five minutes. Specify 0
+        or None to skip waiting.
+    pip_requirements : Union[Iterable, str], optional (default=None)
+        Either an iterable of pip requirement strings
+        (e.g. ["sktime", "-r requirements.txt", "-c constraints.txt"]) or the string
+        path to a pip requirements file on the local filesystem (e.g. "requirements.txt")
+    extra_pip_requirements : Union[Iterable, str], optional (default=None)
+        Either an iterable of pip requirement strings
+        (e.g. ["pandas", "-r requirements.txt", "-c constraints.txt"]) or the string
+        path to a pip requirements file on the local filesystem (e.g. "requirements.txt")
+    kwargs:
+        Additional arguments for :py:class:`mlflow.models.model.Model`
+
+    Returns
+    -------
+    A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
+    metadata of the logged model.
+
+    See Also
+    --------
+    MLflow
+
+    References
+    ----------
+    .. [1] https://www.mlflow.org/docs/latest/python_api/mlflow.models.html#mlflow.models.Model.log
+
+    >>> import mlflow
+    >>> from mlflow.utils.environment import _mlflow_conda_env
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.arima import ARIMA
+    >>> from sktime.utils import mlflow_sktime
+    >>> y = load_airline()
+    >>> forecaster = ARIMA(  # doctest: +SKIP
+    ...     order=(1, 1, 0),
+    ...     seasonal_order=(0, 1, 0, 12),
+    ...     suppress_warnings=True)
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    ARIMA(...)
+    >>> mlflow.start_run()  # doctest: +SKIP
+    >>> artifact_path = "model"
+    >>> model_info = mlflow_sktime.log_model(  # doctest: +SKIP
+    ...     sktime_model=forecaster,
+    ...     artifact_path=artifact_path)
+    """  # noqa: E501
+    from mlflow.models import Model
+
+    return Model.log(
+        artifact_path=artifact_path,
+        flavor=utils.mlflow_sktime,
+        registered_model_name=registered_model_name,
+        sktime_model=sktime_model,
+        conda_env=conda_env,
+        code_paths=code_paths,
+        signature=signature,
+        input_example=input_example,
+        await_registration_for=await_registration_for,
+        pip_requirements=pip_requirements,
+        extra_pip_requirements=extra_pip_requirements,
+        **kwargs,
+    )
+
+
+def load_model(model_uri, dst_path=None):
+    """
+    Load a sktime model from a local file or a run.
+
+    Parameters
+    ----------
+    model_uri : str
+        The location, in URI format, of the MLflow model. For example:
+
+                    - ``/Users/me/path/to/local/model``
+                    - ``relative/path/to/local/model``
+                    - ``s3://my_bucket/path/to/model``
+                    - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+                    - ``mlflow-artifacts:/path/to/model``
+
+        For more information about supported URI schemes, see
+        `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
+        artifact-locations>`_.
+    dst_path : str, optional (default=None)
+        The local filesystem path to which to download the model artifact.This
+        directory must already exist. If unspecified, a local output path will
+        be created.
+
+    Returns
+    -------
+    A sktime model instance.
+
+    See Also
+    --------
+    MLflow
+
+    References
+    ----------
+    .. [1] https://www.mlflow.org/docs/latest/python_api/mlflow.models.html#mlflow.models.Model.load
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.arima import ARIMA
+    >>> from sktime.utils import mlflow_sktime
+    >>> y = load_airline()
+    >>> forecaster = ARIMA(  # doctest: +SKIP
+    ...     order=(1, 1, 0),
+    ...     seasonal_order=(0, 1, 0, 12),
+    ...     suppress_warnings=True)
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    ARIMA(...)
+    >>> model_path = "model"
+    >>> mlflow_sktime.save_model(sktime_model=forecaster, path=model_path)  # doctest: +SKIP
+    >>> loaded_model = mlflow_sktime.load_model(model_uri=model_path)  # doctest: +SKIP
+    """  # noqa: E501
+    from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+    from mlflow.utils.model_utils import (
+        _add_code_from_conf_to_system_path,
+        _get_flavor_configuration,
+    )
+
+    local_model_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=dst_path
+    )
+    flavor_conf = _get_flavor_configuration(
+        model_path=local_model_path, flavor_name=FLAVOR_NAME
+    )
+    _add_code_from_conf_to_system_path(local_model_path, flavor_conf)
+    sktime_model_file_path = os.path.join(
+        local_model_path, flavor_conf.get(_MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME)
+    )
+
+    return _load_model(sktime_model_file_path)
+
+
+def _save_model(model, path):
+
+    with open(path, "wb") as f:
+        pickle.dump(model, f)
+
+
+def _load_model(path):
+
+    with open(path, "rb") as pickled_model:
+        model = pickle.load(pickled_model)
+    return model
+
+
+def _load_pyfunc(path):
+    """Load PyFunc implementation. Called by ``pyfunc.load_model``.
+
+    Parameters
+    ----------
+    path : str
+        Local filesystem path to the MLflow Model with the sktime flavor.
+
+    See Also
+    --------
+    MLflow
+
+    References
+    ----------
+    .. [1] https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.load_model
+    """  # noqa: E501
+    return _SktimeModelWrapper(_load_model(path))
+
+
+class _SktimeModelWrapper:
+    def __init__(self, sktime_model):
+        self.sktime_model = sktime_model
+
+    def predict(self, dataframe) -> pd.DataFrame:
+
+        from mlflow.exceptions import MlflowException
+        from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+
+        if len(dataframe) > 1:
+            raise MlflowException(
+                f"The provided prediction pd.DataFrame contains {len(dataframe)} rows. "
+                "Only 1 row should be supplied.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
+        attrs = dataframe.to_dict(orient="index").get(0)
+        fh = attrs.get("fh", None)
+        X = attrs.get("X", None)
+
+        predict_method = attrs.get("predict_method", "predict")
+
+        if predict_method not in PREDICT_METHODS:
+            raise MlflowException(
+                f"The provided `predict_method` value {predict_method} "
+                f"must be one of {PREDICT_METHODS}.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
+        if predict_method == "predict":
+            y_pred = self.sktime_model.predict(fh=fh, X=X)
+
+        if predict_method == "predict_interval":
+            coverage = attrs.get("coverage", 0.9)
+            y_pred = self.sktime_model.predict_interval(fh=fh, X=X, coverage=coverage)
+            # Signature inference does not support pandas MultiIndex column format
+            y_pred.columns = y_pred.columns.to_flat_index().map(
+                lambda x: "".join(str(x))
+            )
+
+        # # TODO: "predict_proba" is currently not robust across estimators
+        #     (fails for VAR and possibly other estimators)
+        #     remove "predict_proba" or modify logic to be robust across estimators
+        # if predict_method == "predict_proba":
+        #     marginal = attrs.get("marginal", True)
+        #     quantiles = attrs.get("quantiles", None)
+        #
+        #     if not quantiles:
+        #         raise MlflowException(
+        #             f"The provided `quantiles` value {quantiles} must be provided.",
+        #             error_code=INVALID_PARAMETER_VALUE,
+        #         )
+        #
+        #     y_pred_dist = self.sktime_model.predict_proba(
+        #           fh=fh, X=X, marginal=marginal)
+        #
+        #     y_pred_dist_quantiles = pd.DataFrame(y_pred_dist.quantile(quantiles))
+        #     y_pred_dist_quantiles.columns = [f"(Quantile, {q})" for q in quantiles]
+        #     y_pred_dist_quantiles.index = y_pred_dist.parameters['loc'].index
+        #
+        #     y_pred_dist_parameters = pd.DataFrame()
+        #     for k, v in y_pred_dist.parameters.items():
+        #         y_pred_dist_parameters[k] = v
+        #
+        #     y_pred = y_pred_dist_parameters.join(y_pred_dist_quantiles)
+
+        if predict_method == "predict_quantiles":
+            alpha = attrs.get("alpha", None)
+            y_pred = self.sktime_model.predict_quantiles(fh=fh, X=X, alpha=alpha)
+            # Signature inference does not support pandas MultiIndex column format
+            y_pred.columns = y_pred.columns.to_flat_index().map(
+                lambda x: "".join(str(x))
+            )
+
+        # if predict_method == "predict_residuals":
+        #     y = attrs.get("y", None)
+        #     y_pred = self.sktime_model.predict_residuals(y=y, X=X)
+
+        if predict_method == "predict_var":
+            cov = attrs.get("cov", False)
+            y_pred = self.sktime_model.predict_var(fh=fh, X=X, cov=cov)
+
+        return y_pred
+
+
+# TODO: Add support for autologging

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -7,7 +7,6 @@ import os
 from pathlib import Path
 from unittest import mock
 
-# import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import numpy as np
 import pandas as pd
 import pytest
@@ -19,20 +18,6 @@ from sktime.forecasting.arima import AutoARIMA
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.utils.validation._dependencies import _check_soft_dependencies
-
-# from tests.helper_functions import (
-#     _compare_conda_env_requirements,
-#     _assert_pip_requirements,
-#     pyfunc_serve_and_score_model,
-#     _is_available_on_pypi,
-#     _compare_logged_code_paths,
-#     _mlflow_major_version_string,
-# )
-
-
-# EXTRA_PYFUNC_SERVING_TEST_ARGS = (
-#     [] if _is_available_on_pypi("pmdarima") else ["--env-manager", "local"]
-# )
 
 
 @pytest.fixture
@@ -561,161 +546,6 @@ def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
     assert saved_conda_env_parsed == sktime_custom_env_parsed
 
 
-# def test_model_save_persists_requirements_in_mlflow_model_directory(
-#     auto_arima_model, model_path, sktime_custom_env
-# ):
-#     mlflow.pmdarima.save_model(
-#         pmdarima_model=auto_arima_model,
-#         path=model_path,
-#         conda_env=str(sktime_custom_env)
-#     )
-#     saved_pip_req_path = model_path.joinpath("requirements.txt")
-#     _compare_conda_env_requirements(sktime_custom_env, str(saved_pip_req_path))
-
-
-# def test_pmdarima_log_model_with_pip_requirements(auto_arima_model, tmp_path):
-#     expected_mlflow_version = _mlflow_major_version_string()
-#     req_file = tmp_path.joinpath("requirements.txt")
-#     req_file.write_text("a")
-#     with mlflow.start_run():
-#         mlflow.pmdarima.log_model(
-#           auto_arima_model,
-#           "model",
-#           pip_requirements=str(req_file)
-#         )
-#         _assert_pip_requirements(
-#             mlflow.get_artifact_uri("model"),
-#             [expected_mlflow_version, "a"],
-#             strict=True
-#         )
-#
-#     # List of requirements
-#     with mlflow.start_run():
-#         mlflow.pmdarima.log_model(
-#             auto_arima_model,
-#             "model",
-#             pip_requirements=[f"-r {req_file}", "b"]
-#         )
-#         _assert_pip_requirements(
-#             mlflow.get_artifact_uri("model"),
-#             [expected_mlflow_version, "a", "b"],
-#             strict=True
-#         )
-#
-#     # Constraints file
-#     with mlflow.start_run():
-#         mlflow.pmdarima.log_model(
-#             auto_arima_model,
-#             "model",
-#             pip_requirements=[f"-c {req_file}", "b"]
-#         )
-#         _assert_pip_requirements(
-#             mlflow.get_artifact_uri("model"),
-#             [expected_mlflow_version, "b", "-c constraints.txt"],
-#             ["a"],
-#             strict=True,
-#         )
-#
-
-# def test_pmdarima_log_model_with_extra_pip_requirements(auto_arima_model, tmp_path):
-#     expected_mlflow_version = _mlflow_major_version_string()
-#     default_reqs = mlflow.pmdarima.get_default_pip_requirements()
-#
-#     # Path to a requirements file
-#     req_file = tmp_path.joinpath("requirements.txt")
-#     req_file.write_text("a")
-#     with mlflow.start_run():
-#         mlflow.pmdarima.log_model(
-#           auto_arima_model,
-#           "model",
-#           extra_pip_requirements=str(req_file)
-#         )
-#         _assert_pip_requirements(
-#             mlflow.get_artifact_uri("model"),
-#             [expected_mlflow_version, *default_reqs, "a"]
-#         )
-#
-#     # List of requirements
-#     with mlflow.start_run():
-#         mlflow.pmdarima.log_model(
-#             auto_arima_model,
-#             "model",
-#             extra_pip_requirements=[f"-r {req_file}", "b"]
-#         )
-#         _assert_pip_requirements(
-#             mlflow.get_artifact_uri("model"),
-#             [expected_mlflow_version, *default_reqs, "a", "b"]
-#         )
-#
-#     # Constraints file
-#     with mlflow.start_run():
-#         mlflow.pmdarima.log_model(
-#             auto_arima_model,
-#             "model",
-#             extra_pip_requirements=[f"-c {req_file}", "b"]
-#         )
-#         _assert_pip_requirements(
-#             model_uri=mlflow.get_artifact_uri("model"),
-#             requirements=[expected_mlflow_version,
-#             *default_reqs, "b", "-c constraints.txt"],
-#             constraints=["a"],
-#             strict=False,
-#         )
-#
-
-# def test_model_save_without_conda_env_uses_default_env_with_expected_dependencies(
-#     auto_arima_model, model_path
-# ):
-#     mlflow.pmdarima.save_model(auto_arima_model, model_path)
-#     _assert_pip_requirements(
-#       model_path,
-#       mlflow.pmdarima.get_default_pip_requirements()
-#     )
-#
-
-# def test_model_log_without_conda_env_uses_default_env_with_expected_dependencies(
-#     auto_arima_model,
-# ):
-#     artifact_path = "model"
-#     with mlflow.start_run():
-#         mlflow.pmdarima.log_model(auto_arima_model, artifact_path)
-#         model_uri = mlflow.get_artifact_uri(artifact_path)
-#     _assert_pip_requirements(
-#       model_uri,
-#       mlflow.pmdarima.get_default_pip_requirements()
-#     )
-#
-#
-# def test_pyfunc_serve_and_score(auto_arima_model):
-#
-#     import mlflow
-#     import sktime.utils.mlflow_sktime
-#
-#     artifact_path = "model"
-#     with mlflow.start_run():
-#         mlflow_sktime.log_model(
-#             auto_arima_model,
-#             artifact_path,
-#         )
-#         model_uri = mlflow.get_artifact_uri(artifact_path)
-#     local_predict = auto_arima_model.predict(30)
-#
-#     inference_data = pd.DataFrame({"n_periods": 30}, index=[0])
-#
-#     resp = pyfunc_serve_and_score_model(
-#         model_uri,
-#         data=inference_data,
-#         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-#         extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
-#     )
-#     scores = (
-#         pd.DataFrame(data=json.loads(resp.content.decode("utf-8"))["predictions"])
-#         .to_numpy()
-#         .flatten()
-#     )
-#     np.testing.assert_array_almost_equal(scores, local_predict)
-
-
 @pytest.mark.skipif(
     not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
@@ -791,31 +621,8 @@ def test_pyfunc_return_auto_arima_model(auto_arima_model, model_path):
     assert isinstance(pyfunc_predict_var, pd.DataFrame)
     assert len(pyfunc_predict_var) == 3
     assert len(pyfunc_predict_var.columns.values) == 1
-    #
-    # predict_residuals_conf = pd.DataFrame(
-    #     [{"predict_method": "predict_residuals"}]
-    # )
-    # forecast_residuals = loaded_pyfunc.predict(predict_residuals_conf)
-    # TODO:check why this assert fails:
-    # # assert isinstance(forecast_residuals, pd.Series)
-    # assert len(forecast_residuals) == 144
 
 
-# def test_log_model_with_code_paths(auto_arima_model):
-#     artifact_path = "model"
-#     with mlflow.start_run(), mock.patch(
-#         "mlflow.pmdarima._add_code_from_conf_to_system_path"
-#     ) as add_mock:
-#         mlflow.pmdarima.log_model(
-#           auto_arima_model,
-#           artifact_path,
-#           code_paths=[__file__]
-#         )
-#         model_uri = mlflow.get_artifact_uri(artifact_path)
-#         _compare_logged_code_paths(__file__, model_uri, mlflow.pmdarima.FLAVOR_NAME)
-#         mlflow.pmdarima.load_model(model_uri)
-#         add_mock.assert_called()
-#
 @pytest.mark.skipif(
     not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -7,10 +7,13 @@ import os
 from pathlib import Path
 from unittest import mock
 
+import boto3
+import moto
 import numpy as np
 import pandas as pd
 import pytest
 import yaml
+from botocore.config import Config
 
 from sktime.datasets import load_airline, load_longley
 from sktime.datatypes import convert
@@ -26,10 +29,6 @@ def model_path(tmp_path):
     return tmp_path.joinpath("model")
 
 
-@pytest.mark.skipif(
-    not _check_soft_dependencies("boto3", "moto", severity="none"),
-    reason="skip test if required soft dependency not available",
-)
 @pytest.fixture(scope="module")
 def mock_s3_bucket():
     """Create a mock S3 bucket using moto.
@@ -38,10 +37,6 @@ def mock_s3_bucket():
     -------
     string with name of mock S3 bucket
     """
-    import boto3
-    import moto
-    from botocore.config import Config
-
     with moto.mock_s3():
         bucket_name = "mock-bucket"
         my_config = Config(region_name="us-east-1")

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -1,0 +1,836 @@
+# -*- coding: utf-8 -*-
+"""Tests for mlflow-sktime custom model flavor."""
+
+__author__ = ["benjaminbluhm"]
+
+import os
+from pathlib import Path
+from unittest import mock
+
+# import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
+import numpy as np
+import pandas as pd
+import pytest
+import yaml
+
+from sktime.datasets import load_airline, load_longley
+from sktime.datatypes import convert
+from sktime.forecasting.arima import AutoARIMA
+from sktime.forecasting.model_selection import temporal_train_test_split
+from sktime.forecasting.naive import NaiveForecaster
+from sktime.utils.validation._dependencies import _check_soft_dependencies
+
+# from tests.helper_functions import (
+#     _compare_conda_env_requirements,
+#     _assert_pip_requirements,
+#     pyfunc_serve_and_score_model,
+#     _is_available_on_pypi,
+#     _compare_logged_code_paths,
+#     _mlflow_major_version_string,
+# )
+
+
+# EXTRA_PYFUNC_SERVING_TEST_ARGS = (
+#     [] if _is_available_on_pypi("pmdarima") else ["--env-manager", "local"]
+# )
+
+
+@pytest.fixture
+def model_path(tmp_path):
+    """Create a temporary path to save/log model."""
+    return tmp_path.joinpath("model")
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("boto3", "moto", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+@pytest.fixture(scope="module")
+def mock_s3_bucket():
+    """Create a mock S3 bucket using moto.
+
+    Returns
+    -------
+    string with name of mock S3 bucket
+    """
+    import boto3
+    import moto
+    from botocore.config import Config
+
+    with moto.mock_s3():
+        bucket_name = "mock-bucket"
+        my_config = Config(region_name="us-east-1")
+        s3_client = boto3.client("s3", config=my_config)
+        s3_client.create_bucket(Bucket=bucket_name)
+        yield bucket_name
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+@pytest.fixture
+def sktime_custom_env(tmp_path):
+    """Create a conda environment and returns path to conda environment yml file.
+
+    Returns
+    -------
+    string with path to conda environment yml file
+    """
+    from mlflow.utils.environment import _mlflow_conda_env
+
+    conda_env = tmp_path.joinpath("conda_env.yml")
+    _mlflow_conda_env(conda_env, additional_pip_deps=["sktime"])
+    return conda_env
+
+
+@pytest.fixture(scope="module")
+def test_data_airline():
+    """Create sample data for univariate model without exogenous regressor."""
+    return load_airline()
+
+
+@pytest.fixture(scope="module")
+def test_data_longley():
+    """Create sample data for univariate model with exogenous regressor."""
+    y, X = load_longley()
+    y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
+    return y_train, y_test, X_train, X_test
+
+
+@pytest.fixture(scope="module")
+def auto_arima_model(test_data_airline):
+    """Create instance of fitted auto arima model."""
+    return AutoARIMA(sp=12, d=0, max_p=2, max_q=2, suppress_warnings=True).fit(
+        test_data_airline
+    )
+
+
+@pytest.fixture(scope="module")
+def naive_forecaster_model_with_regressor(test_data_longley):
+    """Create instance of fitted naive forecaster model."""
+    y_train, _, X_train, _ = test_data_longley
+    model = NaiveForecaster()
+    return model.fit(y_train, X_train)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_auto_arima_model_save_and_load(auto_arima_model, model_path):
+    """Test saving and loading of native sktime auto_arima_model."""
+    from sktime.utils import mlflow_sktime
+
+    mlflow_sktime.save_model(sktime_model=auto_arima_model, path=model_path)
+    loaded_model = mlflow_sktime.load_model(model_uri=model_path)
+
+    np.testing.assert_array_equal(
+        auto_arima_model.predict(fh=[1, 2, 3]), loaded_model.predict(fh=[1, 2, 3])
+    )
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_auto_arima_model_pyfunc_output(auto_arima_model, model_path):
+    """Test auto arima prediction of loaded pyfunc model."""
+    from sktime.utils import mlflow_sktime
+
+    mlflow_sktime.save_model(sktime_model=auto_arima_model, path=model_path)
+    loaded_pyfunc = mlflow_sktime.pyfunc.load_model(model_uri=model_path)
+
+    model_predict = auto_arima_model.predict(fh=[1, 2, 3])
+    predict_conf = pd.DataFrame([{"fh": [1, 2, 3], "predict_method": "predict"}])
+    pyfunc_predict = loaded_pyfunc.predict(predict_conf)
+    np.testing.assert_array_equal(model_predict, pyfunc_predict)
+
+    model_predict_interval = auto_arima_model.predict_interval(
+        fh=[1, 2, 3], coverage=[0.1, 0.5, 0.9]
+    )
+    predict_interval_conf = pd.DataFrame(
+        [
+            {
+                "fh": [1, 2, 3],
+                "predict_method": "predict_interval",
+                "coverage": [0.1, 0.5, 0.9],
+            }
+        ]
+    )
+    pyfunc_predict_interval = loaded_pyfunc.predict(predict_interval_conf)
+    np.testing.assert_array_equal(
+        model_predict_interval.values, pyfunc_predict_interval.values
+    )
+
+    model_predict_quantiles = auto_arima_model.predict_quantiles(
+        fh=[1, 2, 3], alpha=[0.1, 0.5, 0.9]
+    )
+    predict_quantiles_conf = pd.DataFrame(
+        [
+            {
+                "fh": [1, 2, 3],
+                "predict_method": "predict_quantiles",
+                "alpha": [0.1, 0.5, 0.9],
+            }
+        ]
+    )
+    pyfunc_predict_quantiles = loaded_pyfunc.predict(predict_quantiles_conf)
+    np.testing.assert_array_equal(
+        model_predict_quantiles.values, pyfunc_predict_quantiles.values
+    )
+
+    model_predict_var = auto_arima_model.predict_var(fh=[1, 2, 3], cov=False)
+    predict_var_conf = pd.DataFrame(
+        [{"fh": [1, 2, 3], "predict_method": "predict_var", "cov": False}]
+    )
+    pyfunc_predict_var = loaded_pyfunc.predict(predict_var_conf)
+    np.testing.assert_array_equal(model_predict_var.values, pyfunc_predict_var.values)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_naive_forecaster_model_with_regressor_pyfunc_output(
+    naive_forecaster_model_with_regressor, model_path, test_data_longley
+):
+    """Test naive forecaster prediction of loaded pyfunc model."""
+    from sktime.utils import mlflow_sktime
+
+    _, _, _, X_test = test_data_longley
+
+    mlflow_sktime.save_model(
+        sktime_model=naive_forecaster_model_with_regressor, path=model_path
+    )
+    loaded_pyfunc = mlflow_sktime.pyfunc.load_model(model_uri=model_path)
+
+    X_test_array = convert(X_test, "pd.DataFrame", "np.ndarray")
+
+    model_predict = naive_forecaster_model_with_regressor.predict(
+        fh=[1, 2, 3], X=X_test
+    )
+    predict_conf = pd.DataFrame(
+        [{"fh": [1, 2, 3], "predict_method": "predict", "X": X_test_array}]
+    )
+    pyfunc_predict = loaded_pyfunc.predict(predict_conf)
+    np.testing.assert_array_equal(model_predict, pyfunc_predict)
+
+    model_predict_interval = naive_forecaster_model_with_regressor.predict_interval(
+        fh=[1, 2, 3], coverage=[0.1, 0.5, 0.9], X=X_test
+    )
+    predict_interval_conf = pd.DataFrame(
+        [
+            {
+                "fh": [1, 2, 3],
+                "predict_method": "predict_interval",
+                "coverage": [0.1, 0.5, 0.9],
+                "X": X_test_array,
+            }
+        ]
+    )
+    pyfunc_predict_interval = loaded_pyfunc.predict(predict_interval_conf)
+    np.testing.assert_array_equal(
+        model_predict_interval.values, pyfunc_predict_interval.values
+    )
+
+    model_predict_quantiles = naive_forecaster_model_with_regressor.predict_quantiles(
+        fh=[1, 2, 3], alpha=[0.1, 0.5, 0.9], X=X_test
+    )
+    predict_quantiles_conf = pd.DataFrame(
+        [
+            {
+                "fh": [1, 2, 3],
+                "predict_method": "predict_quantiles",
+                "alpha": [0.1, 0.5, 0.9],
+                "X": X_test_array,
+            }
+        ]
+    )
+    pyfunc_predict_quantiles = loaded_pyfunc.predict(predict_quantiles_conf)
+    np.testing.assert_array_equal(
+        model_predict_quantiles.values, pyfunc_predict_quantiles.values
+    )
+
+    model_predict_var = naive_forecaster_model_with_regressor.predict_var(
+        fh=[1, 2, 3], cov=False, X=X_test
+    )
+    predict_var_conf = pd.DataFrame(
+        [
+            {
+                "fh": [1, 2, 3],
+                "predict_method": "predict_var",
+                "cov": False,
+                "X": X_test_array,
+            }
+        ]
+    )
+    pyfunc_predict_var = loaded_pyfunc.predict(predict_var_conf)
+    np.testing.assert_array_equal(model_predict_var.values, pyfunc_predict_var.values)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+@pytest.mark.parametrize("use_signature", [True, False])
+@pytest.mark.parametrize("use_example", [True, False])
+def test_signature_and_examples_saved_correctly(
+    auto_arima_model, test_data_airline, model_path, use_signature, use_example
+):
+    """Test saving of mlflow signature and example for native sktime predict method."""
+    from mlflow.models import Model, infer_signature
+    from mlflow.models.utils import _read_example
+
+    from sktime.utils import mlflow_sktime
+
+    # Note: Signature inference fails on native model predict_interval/predict_quantiles
+    prediction = auto_arima_model.predict(fh=[1, 2, 3])
+    signature = (
+        infer_signature(test_data_airline, prediction) if use_signature else None
+    )
+    example = (
+        pd.DataFrame(test_data_airline[0:5].copy(deep=False)) if use_example else None
+    )
+    mlflow_sktime.save_model(
+        auto_arima_model, path=model_path, signature=signature, input_example=example
+    )
+    mlflow_model = Model.load(model_path)
+    assert signature == mlflow_model.signature
+    if example is None:
+        assert mlflow_model.saved_input_example_info is None
+    else:
+        r_example = _read_example(mlflow_model, model_path).copy(deep=False)
+        np.testing.assert_array_equal(r_example, example)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+@pytest.mark.parametrize("use_signature", [True, False])
+def test_predict_var_signature_saved_correctly(
+    auto_arima_model, test_data_airline, model_path, use_signature
+):
+    """Test saving of mlflow signature for native sktime predict_var method."""
+    from mlflow.models import Model, infer_signature
+
+    from sktime.utils import mlflow_sktime
+
+    # Note: Signature inference fails on native model predict_interval/predict_quantiles
+    prediction = auto_arima_model.predict_var(fh=[1, 2, 3])
+    signature = (
+        infer_signature(test_data_airline, prediction) if use_signature else None
+    )
+    mlflow_sktime.save_model(auto_arima_model, path=model_path, signature=signature)
+    mlflow_model = Model.load(model_path)
+    assert signature == mlflow_model.signature
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+@pytest.mark.parametrize("use_signature", [True, False])
+@pytest.mark.parametrize("use_example", [True, False])
+def test_signature_and_example_for_predict_interval_method(
+    auto_arima_model, model_path, test_data_airline, use_signature, use_example
+):
+    """Test saving of mlflow signature and example for pyfunc predict_interval."""
+    from mlflow.models import Model, infer_signature
+    from mlflow.models.utils import _read_example
+
+    from sktime.utils import mlflow_sktime
+
+    model_path_primary = model_path.joinpath("primary")
+    model_path_secondary = model_path.joinpath("secondary")
+    mlflow_sktime.save_model(sktime_model=auto_arima_model, path=model_path_primary)
+    loaded_pyfunc = mlflow_sktime.pyfunc.load_model(model_uri=model_path_primary)
+    predict_conf = pd.DataFrame(
+        [
+            {
+                "fh": [1, 2, 3],
+                "predict_method": "predict_interval",
+                "coverage": [0.1, 0.5, 0.9],
+            }
+        ]
+    )
+    forecast = loaded_pyfunc.predict(predict_conf)
+    signature = infer_signature(test_data_airline, forecast) if use_signature else None
+    example = (
+        pd.DataFrame(test_data_airline[0:5].copy(deep=False)) if use_example else None
+    )
+    mlflow_sktime.save_model(
+        auto_arima_model,
+        path=model_path_secondary,
+        signature=signature,
+        input_example=example,
+    )
+    mlflow_model = Model.load(model_path_secondary)
+    assert signature == mlflow_model.signature
+    if example is None:
+        assert mlflow_model.saved_input_example_info is None
+    else:
+        r_example = _read_example(mlflow_model, model_path_secondary).copy(deep=False)
+        np.testing.assert_array_equal(r_example, example)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+@pytest.mark.parametrize("use_signature", [True, False])
+def test_signature_for_predict_quantiles_method(
+    auto_arima_model, model_path, test_data_airline, use_signature
+):
+    """Test saving of mlflow signature for pyfunc sktime predict_quantiles method."""
+    from mlflow.models import Model, infer_signature
+
+    from sktime.utils import mlflow_sktime
+
+    model_path_primary = model_path.joinpath("primary")
+    model_path_secondary = model_path.joinpath("secondary")
+    mlflow_sktime.save_model(sktime_model=auto_arima_model, path=model_path_primary)
+    loaded_pyfunc = mlflow_sktime.pyfunc.load_model(model_uri=model_path_primary)
+    predict_conf = pd.DataFrame(
+        [
+            {
+                "fh": [1, 2, 3],
+                "predict_method": "predict_quantiles",
+                "alpha": [0.1, 0.5, 0.9],
+            }
+        ]
+    )
+    forecast = loaded_pyfunc.predict(predict_conf)
+    signature = infer_signature(test_data_airline, forecast) if use_signature else None
+    mlflow_sktime.save_model(
+        auto_arima_model, path=model_path_secondary, signature=signature
+    )
+    mlflow_model = Model.load(model_path_secondary)
+    assert signature == mlflow_model.signature
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_load_from_remote_uri_succeeds(auto_arima_model, model_path, mock_s3_bucket):
+    """Test loading native sktime model from mock S3 bucket."""
+    from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
+
+    from sktime.utils import mlflow_sktime
+
+    mlflow_sktime.save_model(sktime_model=auto_arima_model, path=model_path)
+
+    artifact_root = f"s3://{mock_s3_bucket}"
+    artifact_path = "model"
+    artifact_repo = S3ArtifactRepository(artifact_root)
+    artifact_repo.log_artifacts(model_path, artifact_path=artifact_path)
+
+    model_uri = os.path.join(artifact_root, artifact_path)
+    reloaded_sktime_model = mlflow_sktime.load_model(model_uri=model_uri)
+
+    np.testing.assert_array_equal(
+        auto_arima_model.predict(fh=[1, 2, 3]),
+        reloaded_sktime_model.predict(fh=[1, 2, 3]),
+    )
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+@pytest.mark.parametrize("should_start_run", [True, False])
+def test_log_model(auto_arima_model, tmp_path, should_start_run):
+    """Test logging and reloading sktime model."""
+    import mlflow
+    from mlflow import pyfunc
+    from mlflow.models import Model
+    from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+    from mlflow.utils.environment import _mlflow_conda_env
+
+    from sktime.utils import mlflow_sktime
+
+    try:
+        if should_start_run:
+            mlflow.start_run()
+        artifact_path = "sktime"
+        conda_env = tmp_path.joinpath("conda_env.yaml")
+        _mlflow_conda_env(conda_env, additional_pip_deps=["sktime"])
+        model_info = mlflow_sktime.log_model(
+            sktime_model=auto_arima_model,
+            artifact_path=artifact_path,
+            conda_env=str(conda_env),
+        )
+        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
+        assert model_info.model_uri == model_uri
+        reloaded_model = mlflow_sktime.load_model(model_uri=model_uri)
+        np.testing.assert_array_equal(
+            auto_arima_model.predict(fh=[1, 2, 3]), reloaded_model.predict(fh=[1, 2, 3])
+        )
+        model_path = Path(_download_artifact_from_uri(artifact_uri=model_uri))
+        model_config = Model.load(str(model_path.joinpath("MLmodel")))
+        assert pyfunc.FLAVOR_NAME in model_config.flavors
+        assert pyfunc.ENV in model_config.flavors[pyfunc.FLAVOR_NAME]
+        env_path = model_config.flavors[pyfunc.FLAVOR_NAME][pyfunc.ENV]["conda"]
+        assert model_path.joinpath(env_path).exists()
+    finally:
+        mlflow.end_run()
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_log_model_calls_register_model(auto_arima_model, tmp_path):
+    """Test log model calls register model."""
+    import mlflow
+    from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+    from mlflow.utils.environment import _mlflow_conda_env
+
+    from sktime.utils import mlflow_sktime
+
+    artifact_path = "sktime"
+    register_model_patch = mock.patch("mlflow.register_model")
+    with mlflow.start_run(), register_model_patch:
+        conda_env = tmp_path.joinpath("conda_env.yaml")
+        _mlflow_conda_env(conda_env, additional_pip_deps=["sktime"])
+        mlflow_sktime.log_model(
+            sktime_model=auto_arima_model,
+            artifact_path=artifact_path,
+            conda_env=str(conda_env),
+            registered_model_name="SktimeModel",
+        )
+        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
+        mlflow.register_model.assert_called_once_with(
+            model_uri,
+            "SktimeModel",
+            await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
+        )
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_log_model_no_registered_model_name(auto_arima_model, tmp_path):
+    """Test log model calls register model without registered model name."""
+    import mlflow
+    from mlflow.utils.environment import _mlflow_conda_env
+
+    from sktime.utils import mlflow_sktime
+
+    artifact_path = "sktime"
+    register_model_patch = mock.patch("mlflow.register_model")
+    with mlflow.start_run(), register_model_patch:
+        conda_env = tmp_path.joinpath("conda_env.yaml")
+        _mlflow_conda_env(conda_env, additional_pip_deps=["sktime"])
+        mlflow_sktime.log_model(
+            sktime_model=auto_arima_model,
+            artifact_path=artifact_path,
+            conda_env=str(conda_env),
+        )
+        mlflow.register_model.assert_not_called()
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
+    auto_arima_model, model_path, sktime_custom_env
+):
+    """Test model saving persists conda environment in mlflow model directory."""
+    from mlflow import pyfunc
+    from mlflow.utils.model_utils import _get_flavor_configuration
+
+    from sktime.utils import mlflow_sktime
+
+    mlflow_sktime.save_model(
+        sktime_model=auto_arima_model, path=model_path, conda_env=str(sktime_custom_env)
+    )
+    pyfunc_conf = _get_flavor_configuration(
+        model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME
+    )
+    saved_conda_env_path = model_path.joinpath(pyfunc_conf[pyfunc.ENV]["conda"])
+    assert saved_conda_env_path.exists()
+    assert not sktime_custom_env.samefile(saved_conda_env_path)
+
+    sktime_custom_env_parsed = yaml.safe_load(sktime_custom_env.read_bytes())
+    saved_conda_env_parsed = yaml.safe_load(saved_conda_env_path.read_bytes())
+    assert saved_conda_env_parsed == sktime_custom_env_parsed
+
+
+# def test_model_save_persists_requirements_in_mlflow_model_directory(
+#     auto_arima_model, model_path, sktime_custom_env
+# ):
+#     mlflow.pmdarima.save_model(
+#         pmdarima_model=auto_arima_model,
+#         path=model_path,
+#         conda_env=str(sktime_custom_env)
+#     )
+#     saved_pip_req_path = model_path.joinpath("requirements.txt")
+#     _compare_conda_env_requirements(sktime_custom_env, str(saved_pip_req_path))
+
+
+# def test_pmdarima_log_model_with_pip_requirements(auto_arima_model, tmp_path):
+#     expected_mlflow_version = _mlflow_major_version_string()
+#     req_file = tmp_path.joinpath("requirements.txt")
+#     req_file.write_text("a")
+#     with mlflow.start_run():
+#         mlflow.pmdarima.log_model(
+#           auto_arima_model,
+#           "model",
+#           pip_requirements=str(req_file)
+#         )
+#         _assert_pip_requirements(
+#             mlflow.get_artifact_uri("model"),
+#             [expected_mlflow_version, "a"],
+#             strict=True
+#         )
+#
+#     # List of requirements
+#     with mlflow.start_run():
+#         mlflow.pmdarima.log_model(
+#             auto_arima_model,
+#             "model",
+#             pip_requirements=[f"-r {req_file}", "b"]
+#         )
+#         _assert_pip_requirements(
+#             mlflow.get_artifact_uri("model"),
+#             [expected_mlflow_version, "a", "b"],
+#             strict=True
+#         )
+#
+#     # Constraints file
+#     with mlflow.start_run():
+#         mlflow.pmdarima.log_model(
+#             auto_arima_model,
+#             "model",
+#             pip_requirements=[f"-c {req_file}", "b"]
+#         )
+#         _assert_pip_requirements(
+#             mlflow.get_artifact_uri("model"),
+#             [expected_mlflow_version, "b", "-c constraints.txt"],
+#             ["a"],
+#             strict=True,
+#         )
+#
+
+# def test_pmdarima_log_model_with_extra_pip_requirements(auto_arima_model, tmp_path):
+#     expected_mlflow_version = _mlflow_major_version_string()
+#     default_reqs = mlflow.pmdarima.get_default_pip_requirements()
+#
+#     # Path to a requirements file
+#     req_file = tmp_path.joinpath("requirements.txt")
+#     req_file.write_text("a")
+#     with mlflow.start_run():
+#         mlflow.pmdarima.log_model(
+#           auto_arima_model,
+#           "model",
+#           extra_pip_requirements=str(req_file)
+#         )
+#         _assert_pip_requirements(
+#             mlflow.get_artifact_uri("model"),
+#             [expected_mlflow_version, *default_reqs, "a"]
+#         )
+#
+#     # List of requirements
+#     with mlflow.start_run():
+#         mlflow.pmdarima.log_model(
+#             auto_arima_model,
+#             "model",
+#             extra_pip_requirements=[f"-r {req_file}", "b"]
+#         )
+#         _assert_pip_requirements(
+#             mlflow.get_artifact_uri("model"),
+#             [expected_mlflow_version, *default_reqs, "a", "b"]
+#         )
+#
+#     # Constraints file
+#     with mlflow.start_run():
+#         mlflow.pmdarima.log_model(
+#             auto_arima_model,
+#             "model",
+#             extra_pip_requirements=[f"-c {req_file}", "b"]
+#         )
+#         _assert_pip_requirements(
+#             model_uri=mlflow.get_artifact_uri("model"),
+#             requirements=[expected_mlflow_version,
+#             *default_reqs, "b", "-c constraints.txt"],
+#             constraints=["a"],
+#             strict=False,
+#         )
+#
+
+# def test_model_save_without_conda_env_uses_default_env_with_expected_dependencies(
+#     auto_arima_model, model_path
+# ):
+#     mlflow.pmdarima.save_model(auto_arima_model, model_path)
+#     _assert_pip_requirements(
+#       model_path,
+#       mlflow.pmdarima.get_default_pip_requirements()
+#     )
+#
+
+# def test_model_log_without_conda_env_uses_default_env_with_expected_dependencies(
+#     auto_arima_model,
+# ):
+#     artifact_path = "model"
+#     with mlflow.start_run():
+#         mlflow.pmdarima.log_model(auto_arima_model, artifact_path)
+#         model_uri = mlflow.get_artifact_uri(artifact_path)
+#     _assert_pip_requirements(
+#       model_uri,
+#       mlflow.pmdarima.get_default_pip_requirements()
+#     )
+#
+#
+# def test_pyfunc_serve_and_score(auto_arima_model):
+#
+#     import mlflow
+#     import sktime.utils.mlflow_sktime
+#
+#     artifact_path = "model"
+#     with mlflow.start_run():
+#         mlflow_sktime.log_model(
+#             auto_arima_model,
+#             artifact_path,
+#         )
+#         model_uri = mlflow.get_artifact_uri(artifact_path)
+#     local_predict = auto_arima_model.predict(30)
+#
+#     inference_data = pd.DataFrame({"n_periods": 30}, index=[0])
+#
+#     resp = pyfunc_serve_and_score_model(
+#         model_uri,
+#         data=inference_data,
+#         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+#         extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
+#     )
+#     scores = (
+#         pd.DataFrame(data=json.loads(resp.content.decode("utf-8"))["predictions"])
+#         .to_numpy()
+#         .flatten()
+#     )
+#     np.testing.assert_array_almost_equal(scores, local_predict)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_pyfunc_raises_invalid_df_input(auto_arima_model, model_path):
+    """Test pyfunc raises exception with invalid input."""
+    from mlflow.exceptions import MlflowException
+
+    from sktime.utils import mlflow_sktime
+
+    mlflow_sktime.save_model(sktime_model=auto_arima_model, path=model_path)
+    loaded_pyfunc = mlflow_sktime.pyfunc.load_model(model_uri=model_path)
+
+    with pytest.raises(MlflowException, match="The provided prediction pd.DataFrame "):
+        loaded_pyfunc.predict(pd.DataFrame([{"fh": [1, 2, 3]}, {"fh": [1, 2, 3]}]))
+
+    with pytest.raises(MlflowException, match="The provided `predict_method` value "):
+        loaded_pyfunc.predict(pd.DataFrame([{"predict_method": "pred"}]))
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_pyfunc_return_auto_arima_model(auto_arima_model, model_path):
+    """Test correct output structure of pyfunc sktime model prediction."""
+    from sktime.utils import mlflow_sktime
+
+    mlflow_sktime.save_model(sktime_model=auto_arima_model, path=model_path)
+    loaded_pyfunc = mlflow_sktime.pyfunc.load_model(model_uri=model_path)
+
+    predict_conf = pd.DataFrame([{"fh": [1, 2, 3], "predict_method": "predict"}])
+    pyfunc_predict = loaded_pyfunc.predict(predict_conf)
+
+    # assert isinstance(forecast, pd.Series)  # TODO:check why this assert fails
+    assert len(pyfunc_predict) == 3
+
+    predict_interval_conf = pd.DataFrame(
+        [
+            {
+                "fh": [1, 2, 3],
+                "predict_method": "predict_interval",
+                "coverage": [0.1, 0.5, 0.9],
+            }
+        ]
+    )
+    pyfunc_predict_interval = loaded_pyfunc.predict(predict_interval_conf)
+
+    assert isinstance(pyfunc_predict_interval, pd.DataFrame)
+    assert len(pyfunc_predict_interval) == 3
+    assert len(pyfunc_predict_interval.columns.values) == 6
+
+    predict_quantiles_conf = pd.DataFrame(
+        [
+            {
+                "fh": [1, 2, 3],
+                "predict_method": "predict_quantiles",
+                "alpha": [0.1, 0.5, 0.9],
+            }
+        ]
+    )
+    pyfunc_predict_quantiles = loaded_pyfunc.predict(predict_quantiles_conf)
+
+    assert isinstance(pyfunc_predict_quantiles, pd.DataFrame)
+    assert len(pyfunc_predict_quantiles) == 3
+    assert len(pyfunc_predict_quantiles.columns.values) == 3
+
+    predict_var_conf = pd.DataFrame(
+        [{"fh": [1, 2, 3], "predict_method": "predict_var", "cov": False}]
+    )
+    pyfunc_predict_var = loaded_pyfunc.predict(predict_var_conf)
+
+    assert isinstance(pyfunc_predict_var, pd.DataFrame)
+    assert len(pyfunc_predict_var) == 3
+    assert len(pyfunc_predict_var.columns.values) == 1
+    #
+    # predict_residuals_conf = pd.DataFrame(
+    #     [{"predict_method": "predict_residuals"}]
+    # )
+    # forecast_residuals = loaded_pyfunc.predict(predict_residuals_conf)
+    # TODO:check why this assert fails:
+    # # assert isinstance(forecast_residuals, pd.Series)
+    # assert len(forecast_residuals) == 144
+
+
+# def test_log_model_with_code_paths(auto_arima_model):
+#     artifact_path = "model"
+#     with mlflow.start_run(), mock.patch(
+#         "mlflow.pmdarima._add_code_from_conf_to_system_path"
+#     ) as add_mock:
+#         mlflow.pmdarima.log_model(
+#           auto_arima_model,
+#           artifact_path,
+#           code_paths=[__file__]
+#         )
+#         model_uri = mlflow.get_artifact_uri(artifact_path)
+#         _compare_logged_code_paths(__file__, model_uri, mlflow.pmdarima.FLAVOR_NAME)
+#         mlflow.pmdarima.load_model(model_uri)
+#         add_mock.assert_called()
+#
+@pytest.mark.skipif(
+    not _check_soft_dependencies("mlflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_virtualenv_subfield_points_to_correct_path(auto_arima_model, model_path):
+    """Test virtual environment subfield points to correct path."""
+    from mlflow import pyfunc
+    from mlflow.utils.model_utils import _get_flavor_configuration
+
+    from sktime.utils import mlflow_sktime
+
+    mlflow_sktime.save_model(auto_arima_model, path=model_path)
+    pyfunc_conf = _get_flavor_configuration(
+        model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME
+    )
+    python_env_path = Path(model_path, pyfunc_conf[pyfunc.ENV]["virtualenv"])
+    assert python_env_path.exists()
+    assert python_env_path.is_file()

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -56,12 +56,7 @@ def mock_s3_bucket():
 )
 @pytest.fixture
 def sktime_custom_env(tmp_path):
-    """Create a conda environment and returns path to conda environment yml file.
-
-    Returns
-    -------
-    string with path to conda environment yml file
-    """
+    """Create a conda environment and returns path to conda environment yml file."""
     from mlflow.utils.environment import _mlflow_conda_env
 
     conda_env = tmp_path.joinpath("conda_env.yml")


### PR DESCRIPTION
Takes @benjaminbluhm's PR https://github.com/sktime/sktime/pull/3912 and carries out a very naive soft dependency isolation.

I would like to see what happens if `pyfunc` is moved into a function and the docstring stuff is removed.

Surely nothing bad? ...

Update: indeed `pyfunc` must be at module level. How about conditional import (based on env check) then?