### PR TITLE
[BUG] `sklearn 1.2.0` compatibility - fix invalid elbow variable selection shrinkage parameter passed to `sklearn` `NearestCentroid`

### DIFF
--- a/sktime/transformations/panel/channel_selection.py
+++ b/sktime/transformations/panel/channel_selection.py
@@ -230,7 +230,7 @@ class ElbowClassSum(BaseTransformer):
         t = self.distance_
 
         start = int(round(time.time() * 1000))
-        centroid_obj = _shrunk_centroid(0)
+        centroid_obj = _shrunk_centroid(1e-5)
 
         X_np = convert(X, "nested_univ", "numpy3D")
         centroids = centroid_obj.create_centroid(X_np, y)
@@ -379,7 +379,7 @@ class ElbowClassPairwise(BaseTransformer):
         """
         self.channels_selected_ = []
         start = int(round(time.time() * 1000))
-        centroid_obj = _shrunk_centroid(0)
+        centroid_obj = _shrunk_centroid(1e-5)
         df = centroid_obj.create_centroid(X.copy(), y)
         obj = _distance_matrix()
         self.distance_frame_ = obj.distance(df)


### PR DESCRIPTION
`ElbowClassSum` and `ElbowClassPairwise` call `sklearn`'s `NearestCentroid` with an invalid shrinkage parameter `shrink_threshold=0`.

This parameter has always been invalid, but is only being checked for validity since `1.2.0`.

To be faithful to the current implementation, I suggest to set it to a small value - an alternative option would be to expose it as a parameter in the constructor, and set it to a small default.

I'm not sure whether `shrink_threshold=None` corresponds to zero mathematically.

@haskarb, what do you think?