### PR TITLE
[BUG] `sklearn 1.2.0` compatibility - decouple `sklearn.base._pprint`

### DIFF
--- a/sktime/benchmarking/strategies.py
+++ b/sktime/benchmarking/strategies.py
@@ -6,7 +6,7 @@ __author__ = ["mloning", "sajaysurya"]
 
 import pandas as pd
 from joblib import dump, load
-from sklearn.base import ClassifierMixin, RegressorMixin, _pprint
+from sklearn.base import ClassifierMixin, RegressorMixin
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
 from sklearn.pipeline import Pipeline
 
@@ -176,10 +176,7 @@ class BaseStrategy(BaseEstimator):
         return "%s(%s(%s))" % (
             strategy_name,
             estimator_name,
-            _pprint(
-                self.get_params(deep=False),
-                offset=len(strategy_name),
-            ),
+            repr(self.get_params(deep=False)),
         )
 
 


### PR DESCRIPTION
The benchmarking module was still calling the private method `sklearn.base._pprint` which has moved in `1.2.0`.

This is solved by replacing `_pprint` which a `repr` call, which may make things a bit less pretty but still leaves them functional (and compatible across `sktime` versions)