### PR TITLE
[MNT] `sklearn 1.2.0` compatibility - remove `normalize=False` args from `RidgeClassifierCV`

### DIFF
--- a/examples/rocket.ipynb
+++ b/examples/rocket.ipynb
@@ -149,7 +149,12 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "RidgeClassifierCV(alphas=array([1.00000000e-03, 4.64158883e-03, 2.15443469e-02, 1.00000000e-01,\n       4.64158883e-01, 2.15443469e+00, 1.00000000e+01, 4.64158883e+01,\n       2.15443469e+02, 1.00000000e+03]),\n                  normalize=True)"
+      "text/plain": [
+       "RidgeClassifierCV(alphas=array([1.00000000e-03, 4.64158883e-03, 2.15443469e-02, 1.00000000e-01,\n",
+       "       4.64158883e-01, 2.15443469e+00, 1.00000000e+01, 4.64158883e+01,\n",
+       "       2.15443469e+02, 1.00000000e+03]),\n",
+       "                  normalize=True)"
+      ]
      },
      "execution_count": 5,
      "metadata": {},
@@ -157,7 +162,7 @@
     }
    ],
    "source": [
-    "classifier = RidgeClassifierCV(alphas=np.logspace(-3, 3, 10), normalize=True)\n",
+    "classifier = RidgeClassifierCV(alphas=np.logspace(-3, 3, 10))\n",
     "classifier.fit(X_train_transform, y_train)"
    ]
   },
@@ -207,7 +212,9 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "0.8171428571428572"
+      "text/plain": [
+       "0.8171428571428572"
+      ]
      },
      "execution_count": 7,
      "metadata": {},
@@ -293,7 +300,12 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "RidgeClassifierCV(alphas=array([1.00000000e-03, 4.64158883e-03, 2.15443469e-02, 1.00000000e-01,\n       4.64158883e-01, 2.15443469e+00, 1.00000000e+01, 4.64158883e+01,\n       2.15443469e+02, 1.00000000e+03]),\n                  normalize=True)"
+      "text/plain": [
+       "RidgeClassifierCV(alphas=array([1.00000000e-03, 4.64158883e-03, 2.15443469e-02, 1.00000000e-01,\n",
+       "       4.64158883e-01, 2.15443469e+00, 1.00000000e+01, 4.64158883e+01,\n",
+       "       2.15443469e+02, 1.00000000e+03]),\n",
+       "                  normalize=True)"
+      ]
      },
      "execution_count": 10,
      "metadata": {},
@@ -301,7 +313,7 @@
     }
    ],
    "source": [
-    "classifier = RidgeClassifierCV(alphas=np.logspace(-3, 3, 10), normalize=True)\n",
+    "classifier = RidgeClassifierCV(alphas=np.logspace(-3, 3, 10))\n",
     "classifier.fit(X_train_transform, y_train)"
    ]
   },
@@ -351,7 +363,9 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "1.0"
+      "text/plain": [
+       "1.0"
+      ]
      },
      "execution_count": 12,
      "metadata": {},
@@ -389,7 +403,7 @@
    "outputs": [],
    "source": [
     "rocket_pipeline = make_pipeline(\n",
-    "    Rocket(), RidgeClassifierCV(alphas=np.logspace(-3, 3, 10), normalize=True)\n",
+    "    Rocket(), RidgeClassifierCV(alphas=np.logspace(-3, 3, 10))\n",
     ")"
    ]
   },
@@ -414,7 +428,14 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "Pipeline(steps=[('rocket', Rocket()),\n                ('ridgeclassifiercv',\n                 RidgeClassifierCV(alphas=array([1.00000000e-03, 4.64158883e-03, 2.15443469e-02, 1.00000000e-01,\n       4.64158883e-01, 2.15443469e+00, 1.00000000e+01, 4.64158883e+01,\n       2.15443469e+02, 1.00000000e+03]),\n                                   normalize=True))])"
+      "text/plain": [
+       "Pipeline(steps=[('rocket', Rocket()),\n",
+       "                ('ridgeclassifiercv',\n",
+       "                 RidgeClassifierCV(alphas=array([1.00000000e-03, 4.64158883e-03, 2.15443469e-02, 1.00000000e-01,\n",
+       "       4.64158883e-01, 2.15443469e+00, 1.00000000e+01, 4.64158883e+01,\n",
+       "       2.15443469e+02, 1.00000000e+03]),\n",
+       "                                   normalize=True))])"
+      ]
      },
      "execution_count": 14,
      "metadata": {},
@@ -450,7 +471,9 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "0.7942857142857143"
+      "text/plain": [
+       "0.7942857142857143"
+      ]
      },
      "execution_count": 15,
      "metadata": {},

--- a/sktime/classification/dictionary_based/_muse.py
+++ b/sktime/classification/dictionary_based/_muse.py
@@ -250,7 +250,7 @@ class MUSE(BaseClassifier):
 
         # Ridge Classifier does not give probabilities
         if not self.support_probabilities:
-            self.clf = RidgeClassifierCV(alphas=np.logspace(-3, 3, 10), normalize=False)
+            self.clf = RidgeClassifierCV(alphas=np.logspace(-3, 3, 10))
         else:
             self.clf = LogisticRegression(
                 max_iter=5000,

--- a/sktime/classification/dictionary_based/_weasel.py
+++ b/sktime/classification/dictionary_based/_weasel.py
@@ -251,7 +251,7 @@ class WEASEL(BaseClassifier):
 
         # Ridge Classifier does not give probabilities
         if not self.support_probabilities:
-            self.clf = RidgeClassifierCV(alphas=np.logspace(-3, 3, 10), normalize=False)
+            self.clf = RidgeClassifierCV(alphas=np.logspace(-3, 3, 10))
         else:
             self.clf = LogisticRegression(
                 max_iter=5000,


### PR DESCRIPTION
This PR removes superfluous `normalize=False` args from `RidgeClassifierCV`.

The arg has been deprecated in `sklearn 1.2.0`, but was default `normalize=False` prior.

Simply removing the arg makes the occurrences compatible with `sklearn 1.2.0`.

Further, this PR removes use of the `normalize` argument from one of the secondary notebooks.