### PR TITLE
[ENH] Update `_check_soft_dependencies` to allow PEP 440 specifier strings for version bounds

### DIFF
--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -9,6 +9,7 @@ import warnings
 from importlib import import_module
 from inspect import isclass
 
+from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 
 
@@ -24,8 +25,11 @@ def _check_soft_dependencies(
     Parameters
     ----------
     packages : str or tuple of str
-        One or more package names to check. This needs to be the *package* name,
-        i.e., the name of the package on pypi, installed by pip install package
+        One or more package names to check.
+        Each tuple element must be a PEP 440 compatibe specifier string,
+        for a single package.
+        For instance, the PEP 440 compatible package name such as "pandas";
+        or a package requirement specifier string such as "pandas>1.2.3".
     package_import_alias : dict with str keys and values, optional, default=empty
         key-value pairs are package name, import name
         import name is str used in python import, i.e., from import_name import ...
@@ -68,21 +72,35 @@ def _check_soft_dependencies(
         raise TypeError(msg)
 
     for package in packages:
+
+        try:
+            req = Requirement(package)
+        except InvalidRequirement:
+            msg_version = (
+                f"wrong format for package requirement string, "
+                f'must be PEP 440 compatible requirement string, e.g., "pandas>1.1",'
+                f' but found "{package}"'
+            )
+            raise InvalidRequirement(msg_version)
+
+        req = Requirement(package)
+        package_name = req.name
+        package_version_req = req.specifier
+
         # determine the package import
-        if package in package_import_alias.keys():
-            package_import_name = package_import_alias[package]
+        if package_name in package_import_alias.keys():
+            package_import_name = package_import_alias[package_name]
         else:
-            package_import_name = package
+            package_import_name = package_name
         # attempt import - if not possible, we know we need to raise warning/exception
         try:
             if suppress_import_stdout:
                 # setup text trap, import, then restore
                 sys.stdout = io.StringIO()
-                import_module(package_import_name)
+                pkg_ref = import_module(package_import_name)
                 sys.stdout = sys.__stdout__
             else:
-                import_module(package_import_name)
-            return True
+                pkg_ref = import_module(package_import_name)
         # if package cannot be imported, make the user aware of installation requirement
         except ModuleNotFoundError as e:
             if obj is None:
@@ -124,6 +142,37 @@ def _check_soft_dependencies(
                     'argument must be "error", "warning", or "none",'
                     f'found "{severity}".'
                 )
+
+        # now we check compatibility with the version specifier if non-empty
+        if package_version_req != SpecifierSet(""):
+            pkg_env_version = pkg_ref.__version__
+
+            msg = (
+                f"{class_name} requires package '{package}' to be present "
+                f"in the python environment, with version {package_version_req}, "
+                f"but incompatible version {pkg_env_version} was found. "
+            )
+            if obj is not None:
+                msg = msg + (
+                    f"This version requirement is not one by sktime, but specific "
+                    f"to the module, class or object with name {obj}."
+                )
+
+        if severity == "error":
+            raise ModuleNotFoundError(msg)
+        elif severity == "warning":
+            warnings.warn(msg)
+        elif severity == "none":
+            return False
+        else:
+            raise RuntimeError(
+                "Error in calling _check_soft_dependencies, severity "
+                f'argument must be "error", "warning", or "none", found "{severity}".'
+            )
+
+    # if package can be imported and no version issue was caught for any string,
+    # then obj is compatible with the requirements and we should return True
+    return True
 
 
 def _check_dl_dependencies(msg=None, severity="error"):

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -78,8 +78,8 @@ def _check_soft_dependencies(
         except InvalidRequirement:
             msg_version = (
                 f"wrong format for package requirement string, "
-                f'must be PEP 440 compatible requirement string, e.g., "pandas>1.1",'
-                f' but found "{package}"'
+                f'must be PEP 440 compatible requirement string, e.g., "pandas"'
+                f' or "pandas>1.1", but found "{package}"'
             )
             raise InvalidRequirement(msg_version)
 
@@ -158,17 +158,19 @@ def _check_soft_dependencies(
                     f"to the module, class or object with name {obj}."
                 )
 
-        if severity == "error":
-            raise ModuleNotFoundError(msg)
-        elif severity == "warning":
-            warnings.warn(msg)
-        elif severity == "none":
-            return False
-        else:
-            raise RuntimeError(
-                "Error in calling _check_soft_dependencies, severity "
-                f'argument must be "error", "warning", or "none", found "{severity}".'
-            )
+            # raise error/warning or return False if version is incompatible
+            if pkg_env_version not in package_version_req:
+                if severity == "error":
+                    raise ModuleNotFoundError(msg)
+                elif severity == "warning":
+                    warnings.warn(msg)
+                elif severity == "none":
+                    return False
+                else:
+                    raise RuntimeError(
+                        "Error in calling _check_soft_dependencies, severity argument"
+                        f' must be "error", "warning", or "none", found "{severity}".'
+                    )
 
     # if package can be imported and no version issue was caught for any string,
     # then obj is compatible with the requirements and we should return True

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -25,7 +25,7 @@ def _check_soft_dependencies(
     Parameters
     ----------
     packages : str or tuple of str
-        One or more package names to check.
+        One or more package names and/or package version specifications to check.
         Each tuple element must be a PEP 440 compatibe specifier string,
         for a single package.
         For instance, the PEP 440 compatible package name such as "pandas";


### PR DESCRIPTION
This PR adds functionality to `_check_soft_dependencies` to parse and check PEP 440 package version specifier strings.

This is useful in a case where certain estimators require specific versions of dependencies, but this is not a requirement of the `sktime` framework itself.

An example where this could be useful is the case of version increments of `sktime` dependencies which do not break the framework but break individual estimators. The problems in those estimators would then be isolated to the estimators and do not prevent `sktime` version compatibility, i.e., of the framework code. Issues with individual estimators can then be resolved in a staggered way, not blocking framework releases for people who do not want to use that specific estimator (which is not an uncommon case as `sktime` has a number of rarely used ones, and those are usually also the ones that are less well maintained).

For a recent example, of this kind of failure, see the issues around the recent version increase of `sklearn` to 1.2.0:
https://github.com/sktime/sktime/pull/3922