### PR TITLE
[BUG] fixes KNN estimators' `kneighbors` methods to work with all mtypes

### DIFF
--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -263,6 +263,9 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         """
         self.check_is_fitted()
 
+        # boilerplate input checks for predict-like methods
+        X = self._check_convert_X_for_predict(X)
+
         # self._X should be the stored _X
         dist_mat = self._distance(X, self._X)
 

--- a/sktime/classification/distance_based/tests/test_time_series_neighbors.py
+++ b/sktime/classification/distance_based/tests/test_time_series_neighbors.py
@@ -119,7 +119,7 @@ def test_knn_kneighbors():
     Xtrain = _make_hierarchical(hierarchy_levels=(3,), n_columns=3)
     Xtest = _make_hierarchical(hierarchy_levels=(5,), n_columns=3)
 
-    ytrain = pd.Series(['label_1', 'label_2', 'label_3'])
+    ytrain = pd.Series(["label_1", "label_2", "label_3"])
 
     kntsc = KNeighborsTimeSeriesClassifier(n_neighbors=1)
     kntsc.fit(Xtrain, ytrain)

--- a/sktime/classification/distance_based/tests/test_time_series_neighbors.py
+++ b/sktime/classification/distance_based/tests/test_time_series_neighbors.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Test function of elastic distance nearest neighbour classifiers."""
+"""Tests for KNeighborsTimeSeriesClassifier."""
 import numpy as np
+import pandas as pd
 import pytest
 
 from sktime.alignment.dtw_python import AlignerDTW
@@ -109,3 +110,26 @@ def test_knn_with_aggrdistance():
     clf = KNeighborsTimeSeriesClassifier(distance=aggr_dist)
 
     clf.fit(X, y)
+
+
+def test_knn_kneighbors():
+    """Tests kneighbors method and absence of bug #3798."""
+    from sktime.utils._testing.hierarchical import _make_hierarchical
+
+    Xtrain = _make_hierarchical(hierarchy_levels=(3,), n_columns=3)
+    Xtest = _make_hierarchical(hierarchy_levels=(5,), n_columns=3)
+
+    ytrain = pd.Series(['label_1', 'label_2', 'label_3'])
+
+    kntsc = KNeighborsTimeSeriesClassifier(n_neighbors=1)
+    kntsc.fit(Xtrain, ytrain)
+
+    ret = kntsc.kneighbors(Xtest)
+    assert isinstance(ret, tuple)
+    assert len(ret) == 2
+
+    dist, ind = ret
+    assert isinstance(dist, np.ndarray)
+    assert dist.shape == (5, 1)
+    assert isinstance(ind, np.ndarray)
+    assert ind.shape == (5, 1)

--- a/sktime/regression/distance_based/_time_series_neighbors.py
+++ b/sktime/regression/distance_based/_time_series_neighbors.py
@@ -210,11 +210,13 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
         ind : array
             Indices of the nearest points in the population matrix.
         """
-        # self._X should be the stored _X
-        dist_mat = self._distance(X, self._X)
+        self.check_is_fitted()
 
         # boilerplate input checks for predict-like methods
         X = self._check_convert_X_for_predict(X)
+
+        # self._X should be the stored _X
+        dist_mat = self._distance(X, self._X)
 
         neigh_ind = self.knn_estimator_.kneighbors(
             dist_mat, n_neighbors=n_neighbors, return_distance=return_distance

--- a/sktime/regression/distance_based/_time_series_neighbors.py
+++ b/sktime/regression/distance_based/_time_series_neighbors.py
@@ -213,6 +213,9 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
         # self._X should be the stored _X
         dist_mat = self._distance(X, self._X)
 
+        # boilerplate input checks for predict-like methods
+        X = self._check_convert_X_for_predict(X)
+
         neigh_ind = self.knn_estimator_.kneighbors(
             dist_mat, n_neighbors=n_neighbors, return_distance=return_distance
         )

--- a/sktime/regression/distance_based/tests/__init__.py
+++ b/sktime/regression/distance_based/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Distance based test code."""

--- a/sktime/regression/distance_based/tests/test_time_series_neighbors.py
+++ b/sktime/regression/distance_based/tests/test_time_series_neighbors.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Tests for KNeighborsTimeSeriesRegressor."""
+import numpy as np
+import pandas as pd
+
+from sktime.regression.distance_based._time_series_neighbors import (
+    KNeighborsTimeSeriesRegressor,
+)
+
+
+def test_knn_kneighbors():
+    """Tests kneighbors method and absence of bug #3798."""
+    from sktime.utils._testing.hierarchical import _make_hierarchical
+
+    Xtrain = _make_hierarchical(hierarchy_levels=(3,), n_columns=3)
+    Xtest = _make_hierarchical(hierarchy_levels=(5,), n_columns=3)
+
+    ytrain = pd.Series([1, 1.5, 2])
+
+    kntsc = KNeighborsTimeSeriesRegressor(n_neighbors=1)
+    kntsc.fit(Xtrain, ytrain)
+
+    ret = kntsc.kneighbors(Xtest)
+    assert isinstance(ret, tuple)
+    assert len(ret) == 2
+
+    dist, ind = ret
+    assert isinstance(dist, np.ndarray)
+    assert dist.shape == (5, 1)
+    assert isinstance(ind, np.ndarray)
+    assert ind.shape == (5, 1)


### PR DESCRIPTION
This PR fixes a bug that prevented KNN estimators' `kneighbors` methods to work with all mtypes.

This fixes #3798 for `KNeighborsTimeSeriesClassifier`, and an unreported analogue bug for `KNeighborsTimeSeriesRegressor`

The reason was missing check/conversion boilerplate that was present in `predict` and similar methods, the fix was simply adding that.

This PR also adds tests for the `kneighbors` method.