### PR TITLE
[ENH] Add multiplicative option to `Detrender`

### DIFF
--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -4,7 +4,7 @@
 """Implements transformations to detrend a time series."""
 
 __all__ = ["Detrender"]
-__author__ = ["mloning", "SveaMeyer13"]
+__author__ = ["mloning", "SveaMeyer13", "KishManani"]
 
 import pandas as pd
 
@@ -38,6 +38,9 @@ class Detrender(BaseTransformer):
         The forecasting model to remove the trend with
             (e.g. PolynomialTrendForecaster).
         If forecaster is None, PolynomialTrendForecaster(degree=1) is used.
+    model : {"additive", "multiplicative"}, default="additive"
+        Determines whether to subtract or divide to remove the trend component.
+
 
     Attributes
     ----------
@@ -74,8 +77,9 @@ class Detrender(BaseTransformer):
         "transform-returns-same-time-index": True,
     }
 
-    def __init__(self, forecaster=None):
+    def __init__(self, forecaster=None, model="additive"):
         self.forecaster = forecaster
+        self.model = model
         self.forecaster_ = None
         super(Detrender, self).__init__()
 
@@ -118,6 +122,10 @@ class Detrender(BaseTransformer):
         else:
             raise TypeError("X must be pd.Series or pd.DataFrame")
 
+        allowed_models = ("additive", "multiplicative")
+        if self.model not in allowed_models:
+            raise ValueError("`model` must be 'additive' or 'multiplicative'")
+
         return self
 
     def _transform(self, X, y=None):
@@ -143,8 +151,10 @@ class Detrender(BaseTransformer):
         if isinstance(X, pd.Series):
             # note: the y in the transformer is exogeneous in the forecaster, i.e., X
             X_pred = self.forecaster_.predict(fh=fh, X=y)
-            Xt = X - X_pred
-            return Xt
+            if self.model == "additive":
+                return X - X_pred
+            elif self.model == "multiplicative":
+                return X / X_pred
         # multivariate: X is pd.DataFrame
         elif isinstance(X, pd.DataFrame):
             Xt = X.copy()
@@ -159,7 +169,10 @@ class Detrender(BaseTransformer):
                 )
             for colname in Xt.columns:
                 X_pred = self.forecaster_[colname].predict(fh=fh, X=y)
-                Xt[colname] = Xt[colname] - X_pred
+                if self.model == "additive":
+                    Xt[colname] = Xt[colname] - X_pred
+                elif self.model == "multiplicative":
+                    Xt[colname] = Xt[colname] / X_pred
             return Xt
         else:
             raise TypeError("X must be pd.Series or pd.DataFrame")
@@ -185,7 +198,10 @@ class Detrender(BaseTransformer):
         if isinstance(X, pd.Series):
             # note: the y in the transformer is exogeneous in the forecaster, i.e., X
             X_pred = self.forecaster_.predict(fh=fh, X=y)
-            return X + X_pred
+            if self.model == "additive":
+                return X + X_pred
+            elif self.model == "multiplicative":
+                return X * X_pred
         # multivariate: X is pd.DataFrame
         if isinstance(X, pd.DataFrame):
             X = X.copy()
@@ -200,7 +216,11 @@ class Detrender(BaseTransformer):
                 )
             for colname in X.columns:
                 X_pred = self.forecaster_[colname].predict(fh=fh, X=y)
-                X[colname] = X[colname] + X_pred
+                if self.model == "additive":
+                    X[colname] = X[colname] + X_pred
+                elif self.model == "multiplicative":
+                    X[colname] = X[colname] * X_pred
+
             return X
 
     def _update(self, X, y=None, update_params=True):

--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -39,8 +39,10 @@ class Detrender(BaseTransformer):
             (e.g. PolynomialTrendForecaster).
         If forecaster is None, PolynomialTrendForecaster(degree=1) is used.
     model : {"additive", "multiplicative"}, default="additive"
-        Determines whether to subtract or divide to remove the trend component.
-
+        If `model="additive"` the `forecaster` is fit to the original time
+        series and the `transform` method subtracts the trend from the time series.
+        If `model="multiplicative"` the `forecaster` is fit to the original time
+        series and the `transform` method divides the trend from the time series.
 
     Attributes
     ----------

--- a/sktime/transformations/series/detrend/tests/test_detrend.py
+++ b/sktime/transformations/series/detrend/tests/test_detrend.py
@@ -1,17 +1,29 @@
 # -*- coding: utf-8 -*-
 """Test detrenders."""
+import numpy as np
+import pandas as pd
+import pytest
 
-__author__ = ["mloning"]
+from sktime.datasets import load_airline
+from sktime.forecasting.tests.test_trend import get_expected_polynomial_coefs
+from sktime.forecasting.trend import PolynomialTrendForecaster
+from sktime.transformations.series.detrend import Detrender
+
+__author__ = ["mloning", "KishManani"]
 __all__ = []
 
 
-def test_polynomial_detrending():
-    import numpy as np
-    import pandas as pd
+@pytest.fixture()
+def y_series():
+    return load_airline()
 
-    from sktime.forecasting.tests.test_trend import get_expected_polynomial_coefs
-    from sktime.forecasting.trend import PolynomialTrendForecaster
-    from sktime.transformations.series.detrend import Detrender
+
+@pytest.fixture()
+def y_dataframe():
+    return load_airline().to_frame()
+
+
+def test_polynomial_detrending():
 
     y = pd.Series(np.arange(20) * 0.5) + np.random.normal(0, 1, size=20)
     forecaster = PolynomialTrendForecaster(degree=1, with_intercept=True)
@@ -34,3 +46,79 @@ def test_polynomial_detrending():
     actual = transformer.transform(y)
     expected = y - expected_trend
     np.testing.assert_array_almost_equal(actual, expected)
+
+
+def test_multiplicative_detrending_series(y_series):
+    """Tests we get the expected result when setting `model=multiplicative`."""
+    # Load test dataset
+    y = y_series
+
+    # Get the trend
+    forecaster = PolynomialTrendForecaster(degree=1, with_intercept=True)
+    trend = forecaster.fit_predict(y, fh=y.index)
+
+    # De-trend the time series
+    detrender = Detrender(forecaster, model="multiplicative")
+    y_transformed = detrender.fit_transform(y)
+
+    # Compute the expected de-trended time series
+    expected = y / trend
+
+    pd.testing.assert_series_equal(y_transformed, expected)
+
+
+def test_multiplicative_detrending_dataframe(y_dataframe):
+    """Tests we get the expected result when setting `model=multiplicative`."""
+    # Load test dataset
+    y = y_dataframe
+
+    # Get the trend
+    forecaster = PolynomialTrendForecaster(degree=1, with_intercept=True)
+    trend = forecaster.fit_predict(y, fh=y.index)
+
+    # De-trend the time series
+    detrender = Detrender(forecaster, model="multiplicative")
+    y_transformed = detrender.fit_transform(y)
+
+    # Compute the expected de-trended time series
+    expected = y / trend
+
+    pd.testing.assert_frame_equal(y_transformed, expected)
+
+
+def test_additive_detrending_series(y_series):
+    """Tests we get the expected result when setting `model=multiplicative`."""
+    # Load test dataset
+    y = y_series
+
+    # Get the trend
+    forecaster = PolynomialTrendForecaster(degree=1, with_intercept=True)
+    trend = forecaster.fit_predict(y, fh=y.index)
+
+    # De-trend the time series
+    detrender = Detrender(forecaster, model="additive")
+    y_transformed = detrender.fit_transform(y)
+
+    # Compute the expected de-trended time series
+    expected = y - trend
+
+    pd.testing.assert_series_equal(y_transformed, expected)
+
+
+def test_additive_detrending_dataframe(y_dataframe):
+    """Tests we get the expected result when setting `model=multiplicative`."""
+    # Load test dataset
+    y = y_dataframe
+
+    # Get the trend
+    forecaster = PolynomialTrendForecaster(degree=1, with_intercept=True)
+    trend = forecaster.fit_predict(y, fh=y.index)
+
+    # De-trend the time series
+    detrender = Detrender(forecaster, model="additive")
+    y_transformed = detrender.fit_transform(y)
+
+    # Compute the expected de-trended time series
+    expected = y - trend
+
+    pd.testing.assert_frame_equal(y_transformed, expected)

--- a/sktime/transformations/series/detrend/tests/test_detrend.py
+++ b/sktime/transformations/series/detrend/tests/test_detrend.py
@@ -87,7 +87,7 @@ def test_multiplicative_detrending_dataframe(y_dataframe):
 
 
 def test_additive_detrending_series(y_series):
-    """Tests we get the expected result when setting `model=multiplicative`."""
+    """Tests we get the expected result when setting `model=additive`."""
     # Load test dataset
     y = y_series
 
@@ -106,7 +106,7 @@ def test_additive_detrending_series(y_series):
 
 
 def test_additive_detrending_dataframe(y_dataframe):
-    """Tests we get the expected result when setting `model=multiplicative`."""
+    """Tests we get the expected result when setting `model=additive`."""
     # Load test dataset
     y = y_dataframe
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### What does this implement/fix? Explain your changes.
This PR adds a `model` argument to `Detrender`, similar to `Deseasonalizer`, which gives the option to divide by the trend component rather than subtract. 

Example usage:
```python
from sktime.datasets import load_airline
from sktime.transformations.series.detrend import Detrender

y = load_airline()
detrender = Detrender(forecaster, model="multiplicative")

# Divide by the trend component
y_transformed = detrender.fit_transform(y)
```


#### What should a reviewer concentrate their feedback on?
If the extracted trend has a zero value at any point, it would result in an `np.inf` value when we divide by the trend. What should the expected behaviour be in this case? Throw an error or return an output with an infinite value? 

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.
