### PR TITLE
[GOV] Remove ability of CC to overrule core dev decisions

### DIFF
--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -447,8 +447,6 @@ tracker <https://github.com/sktime/sktime/issues>`__,
 `pull requests <https://github.com/sktime/sktime/pulls>`__ or an :ref:`steps`. Some
 sensitive discussions and appointment votes occur on private chats.
 
-The CC reserves the right to overrule decisions.
-
 We distinguish between the following types of proposed changes. The
 corresponding decision making process is described in more detail below.
 


### PR DESCRIPTION
Reference Issues/PRs
https://github.com/sktime/sktime/issues/3865

What does this implement/fix? Explain your changes.
Remove ability of CC to overrule decisions made by core devs.