### PR TITLE
[BUG] Fix `StatsForecastAutoARIMA_.predict` incorrect in-sample start index

### DIFF
--- a/sktime/forecasting/base/adapters/_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_statsforecast.py
@@ -131,7 +131,7 @@ class _StatsForecastAdapter(BaseForecaster):
         """
         # initialize return objects
         fh_abs = fh.to_absolute(self.cutoff).to_numpy()
-        fh_idx = fh.to_indexer(self.cutoff, from_cutoff=False)
+        fh_idx = fh.to_indexer(self.cutoff, from_cutoff=True)
         y_pred = pd.Series(index=fh_abs, dtype="float64")
 
         result = self._forecaster.predict_in_sample()


### PR DESCRIPTION
#### Reference Issues/PRs
When I use the StatsForecastAutoARIMA algorithm to forecast the past, the forecast is always returned from the start time of the training, even though fh specifies to start at a moment in the middle of the training time range.

#### What does this implement/fix? Explain your changes.
I think the reason is that the index used is incorrect, the fh passed in is not used correctly, and the past results of the prediction are always returned from the start time of the training. We should use from_cutoff to true. I did this and the final result was as I expected.
![image](https://user-images.githubusercontent.com/7732802/207767909-0ae11960-5812-46c3-a39d-d362fd515031.png)


#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
