### PR TITLE
[ENH] dunders for time series distances and kernels

### DIFF
--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -400,7 +400,7 @@ class _HeterogenousMetaEstimator:
         concat_order : str, one of "left" and "right", optional, default="left"
             if "left", result attr_name will be like self.attr_name + other.attr_name
             if "right", result attr_name will be like other.attr_name + self.attr_name
-        composite_params : dict, optional, default=None
+        composite_params : dict, optional, default=None; else, pairs strname-value
             if not None, parameters of the composite are always set accordingly
             i.e., contains key-value pairs, and composite_class has key set to value
 

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -370,7 +370,13 @@ class _HeterogenousMetaEstimator:
         return self._make_strings_unique(uniquestr)
 
     def _dunder_concat(
-        self, other, base_class, composite_class, attr_name="steps", concat_order="left"
+        self,
+        other,
+        base_class,
+        composite_class,
+        attr_name="steps",
+        concat_order="left",
+        composite_params=None,
     ):
         """Concatenate pipelines for dunder parsing, helper function.
 
@@ -394,6 +400,9 @@ class _HeterogenousMetaEstimator:
         concat_order : str, one of "left" and "right", optional, default="left"
             if "left", result attr_name will be like self.attr_name + other.attr_name
             if "right", result attr_name will be like other.attr_name + self.attr_name
+        composite_params : dict, optional, default=None
+            if not None, parameters of the composite are always set accordingly
+            i.e., contains key-value pairs, and composite_class has key set to value
 
         Returns
         -------
@@ -456,11 +465,22 @@ class _HeterogenousMetaEstimator:
         else:
             return NotImplemented
 
+        # create the "steps" param for the composite
         # if all the names are equal to class names, we eat them away
         if all(type(x[1]).__name__ == x[0] for x in zip(new_names, new_ests)):
-            return composite_class(**{attr_name: list(new_ests)})
+            step_param = {attr_name: list(new_ests)}
         else:
-            return composite_class(**{attr_name: list(zip(new_names, new_ests))})
+            step_param = {attr_name: list(zip(new_names, new_ests))}
+
+        # retrieve other parameters, from composite_params attribute
+        if composite_params is None:
+            composite_params = {}
+        else:
+            composite_params = composite_params.copy()
+
+        # construct the composite with both step and additional params
+        composite_params.update(step_param)
+        return composite_class(**composite_params)
 
     def _anytagis(self, tag_name, value, estimators):
         """Return whether any estimator in list has tag `tag_name` of value `value`.

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -251,7 +251,7 @@ class BasePairwiseTransformerPanel(BaseEstimator):
         #   the CombinedDistance does the rest, e.g., dispatch on other
         if isinstance(other, BasePairwiseTransformerPanel):
             if not isinstance(self, CombinedDistance):
-                self_as_pipeline = CombinedDistance(steps=[self], operation="*")
+                self_as_pipeline = CombinedDistance(pw_trafos=[self], operation="*")
             else:
                 self_as_pipeline = self
             return self_as_pipeline * other

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -246,6 +246,11 @@ class BasePairwiseTransformerPanel(BaseEstimator):
             not nested, contains only non-CombinedDistance `sktime` transformers
         """
         from sktime.dists_kernels.algebra import CombinedDistance
+        from sktime.dists_kernels.dummy import ConstantPwTrafoPanel
+
+        # when other is an integer or float, treat it as constant distance/kernel
+        if isinstance(other, (int, float)):
+            other = ConstantPwTrafoPanel(constant=other)
 
         # we wrap self in a CombinedDistance, and concatenate with the other
         #   the CombinedDistance does the rest, e.g., dispatch on other
@@ -278,10 +283,15 @@ class BasePairwiseTransformerPanel(BaseEstimator):
             not nested, contains only non-TransformerPipeline `sktime` steps
         """
         from sktime.dists_kernels.compose import PwTrafoPanelPipeline
+        from sktime.dists_kernels.dummy import ConstantPwTrafoPanel
         from sktime.transformations.base import BaseTransformer
         from sktime.transformations.compose import TransformerPipeline
         from sktime.transformations.series.adapt import TabularToSeriesAdaptor
         from sktime.utils.sklearn import is_sklearn_transformer
+
+        # when other is an integer or float, treat it as constant distance/kernel
+        if isinstance(other, (int, float)):
+            other = ConstantPwTrafoPanel(constant=other)
 
         # behaviour is implemented only if other inherits from BaseTransformer
         #  in that case, distinctions arise from whether self or other is a pipeline
@@ -320,6 +330,11 @@ class BasePairwiseTransformerPanel(BaseEstimator):
             not nested, contains only non-CombinedDistance `sktime` transformers
         """
         from sktime.dists_kernels.algebra import CombinedDistance
+        from sktime.dists_kernels.dummy import ConstantPwTrafoPanel
+
+        # when other is an integer or float, treat it as constant distance/kernel
+        if isinstance(other, (int, float)):
+            other = ConstantPwTrafoPanel(constant=other)
 
         # we wrap self in a CombinedDistance, and concatenate with the other
         #   the CombinedDistance does the rest, e.g., dispatch on other

--- a/sktime/dists_kernels/algebra.py
+++ b/sktime/dists_kernels/algebra.py
@@ -108,6 +108,54 @@ class CombinedDistance(_HeterogenousMetaEstimator, BasePairwiseTransformerPanel)
     def _pw_trafos(self, value):
         self.pw_trafos = value
 
+    def __mul__(self, other):
+        """Magic * method, return (right) multiplied CombinedDistance.
+
+        Implemented for `other` being a transformer, otherwise returns `NotImplemented`.
+
+        Parameters
+        ----------
+        other: `sktime` pairwise transformer, must inherit BasePairwiseTransformerPanel
+            otherwise, `NotImplemented` is returned
+
+        Returns
+        -------
+        CombinedDistance object, algebraic * of `self` (first) with `other` (last).
+            not nested, contains only non-CombinedDistance `sktime` transformers
+        """
+        return self._dunder_concat(
+            other=other,
+            base_class=BasePairwiseTransformerPanel,
+            composite_class=CombinedDistance,
+            attr_name="pw_trafos",
+            concat_order="left",
+            composite_params={"operation": "*"},
+        )
+
+    def __add__(self, other):
+        """Magic + method, return (right) multiplied CombinedDistance.
+
+        Implemented for `other` being a transformer, otherwise returns `NotImplemented`.
+
+        Parameters
+        ----------
+        other: `sktime` pairwise transformer, must inherit BasePairwiseTransformerPanel
+            otherwise, `NotImplemented` is returned
+
+        Returns
+        -------
+        CombinedDistance object, algebraic + of `self` (first) with `other` (last).
+            not nested, contains only non-CombinedDistance `sktime` transformers
+        """
+        return self._dunder_concat(
+            other=other,
+            base_class=BasePairwiseTransformerPanel,
+            composite_class=CombinedDistance,
+            attr_name="pw_trafos",
+            concat_order="left",
+            composite_params={"operation": "+"},
+        )
+
     def _transform(self, X, X2=None):
         """Compute distance/kernel matrix.
 

--- a/sktime/dists_kernels/algebra.py
+++ b/sktime/dists_kernels/algebra.py
@@ -109,7 +109,7 @@ class CombinedDistance(_HeterogenousMetaEstimator, BasePairwiseTransformerPanel)
         self.pw_trafos = value
 
     def _algebra_dunder_concat(self, other, operation):
-        """Common boilerplate for magic methods return (right) concat CombinedDistance.
+        """Return (right) concat CombinedDistance, common boilerplate for dunders.
 
         Implemented for `other` being a transformer, otherwise returns `NotImplemented`.
 

--- a/sktime/dists_kernels/tests/test_dist_kernels_dunders.py
+++ b/sktime/dists_kernels/tests/test_dist_kernels_dunders.py
@@ -4,14 +4,19 @@
 __author__ = ["fkiraly"]
 
 import numpy as np
+import pytest
 
 from sktime.dists_kernels.algebra import CombinedDistance
 from sktime.dists_kernels.compose import PwTrafoPanelPipeline
 from sktime.dists_kernels.edit_dist import EditDist
 from sktime.utils._testing.panel import _make_panel_X
 
-X1 = _make_panel_X(n_instances=5, n_columns=5, n_timepoints=5, random_state=1)
-X2 = _make_panel_X(n_instances=6, n_columns=5, n_timepoints=5, random_state=2)
+X1 = _make_panel_X(
+    n_instances=5, n_columns=5, n_timepoints=5, random_state=1, all_positive=True
+)
+X2 = _make_panel_X(
+    n_instances=6, n_columns=5, n_timepoints=5, random_state=2, all_positive=True
+)
 
 
 def test_mul_algebra_dunder():
@@ -112,8 +117,8 @@ def test_pw_trafo_pipeline_mul_dunder():
     from sktime.transformations.series.exponent import ExponentTransformer
 
     t3 = EditDist()
-    t1 = ExponentTransformer()
-    t2 = ExponentTransformer(2)
+    t1 = ExponentTransformer(2)
+    t2 = ExponentTransformer(0.5)
 
     m3 = t3.transform(X1, X2)
 
@@ -121,10 +126,42 @@ def test_pw_trafo_pipeline_mul_dunder():
     assert isinstance(t23, PwTrafoPanelPipeline)
     assert len(t23.transformers) == 1
 
+    m23 = t23.transform(X1, X2)
+    X1t = t2.clone().fit_transform(X1)
+    X2t = t2.clone().fit_transform(X2)
+    m23_manual = t3.transform(X1t, X2t)
+    assert np.allclose(m23, m23_manual)
+
     t123 = t1 * t2 * t3
     assert isinstance(t123, PwTrafoPanelPipeline)
-    assert len(t23.transformers) == 2
+    assert len(t123.transformers) == 2
 
     m123 = t123.transform(X1, X2)
 
     assert np.allclose(m123, m3)
+
+
+@pytest.mark.parametrize("constant", [0, 1, -0.25])
+def test_dunders_with_constants(constant):
+    """Tests creation of pairwise panel trafo pipeliens using mul dunder."""
+    t = EditDist()
+
+    m = t.transform(X1, X2)
+
+    tplusc = t + constant
+
+    assert isinstance(tplusc, CombinedDistance)
+    assert len(tplusc.pw_trafos) == 2
+    assert tplusc.get_params()["operation"] == "+"
+
+    mplusc = tplusc.transform(X1, X2)
+    assert np.allclose(m + constant, mplusc)
+
+    ttimesc = t * constant
+
+    assert isinstance(ttimesc, CombinedDistance)
+    assert len(ttimesc.pw_trafos) == 2
+    assert ttimesc.get_params()["operation"] == "*"
+
+    mtimesc = ttimesc.transform(X1, X2)
+    assert np.allclose(m * constant, mtimesc)

--- a/sktime/dists_kernels/tests/test_dist_kernels_dunders.py
+++ b/sktime/dists_kernels/tests/test_dist_kernels_dunders.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""Tests for pairwise panel transformer dunders."""
+
+__author__ = ["fkiraly"]
+
+import numpy as np
+
+from sktime.dists_kernels.algebra import CombinedDistance
+from sktime.dists_kernels.edit_dist import EditDist
+from sktime.utils._testing.panel import _make_panel_X
+
+X1 = _make_panel_X(n_instances=5, n_columns=5, n_timepoints=5, random_state=1)
+X2 = _make_panel_X(n_instances=6, n_columns=5, n_timepoints=5, random_state=2)
+
+
+def test_mul_algebra_dunder():
+    """Test multiplication dunder, algebraic case (two panel distances)."""
+    t1 = EditDist()
+    t2 = EditDist(distance="edr")
+    t3 = EditDist(distance="erp")
+
+    m1 = t1.transform(X1, X2)
+    m2 = t2.transform(X1, X2)
+    m3 = t3.transform(X1, X2)
+
+    t12 = t1 * t2
+    assert isinstance(t12, CombinedDistance)
+    assert len(t12.pw_trafos) == 2
+    assert t12.get_params()["operation"] == "*"
+
+    m12 = t12.transform(X1, X2)
+    assert np.allclose(m12, m1 * m2)
+
+    t123 = t1 * t2 * t3
+    assert isinstance(t123, CombinedDistance)
+    assert len(t123.pw_trafos) == 3
+    assert t123.get_params()["operation"] == "*"
+
+    m123 = t123.transform(X1, X2)
+    assert np.allclose(m123, m1 * m2 * m3)
+
+    t123r = t1 * (t2 * t3)
+    assert isinstance(t123r, CombinedDistance)
+    assert len(t123r.pw_trafos) == 3
+    assert t123r.get_params()["operation"] == "*"
+
+    m123r = t123r.transform(X1, X2)
+    assert np.allclose(m123r, m1 * m2 * m3)
+
+
+def test_add_algebra_dunder():
+    """Test addition dunder, algebraic case (two panel distances)."""
+    t1 = EditDist()
+    t2 = EditDist(distance="edr")
+    t3 = EditDist(distance="erp")
+
+    m1 = t1.transform(X1, X2)
+    m2 = t2.transform(X1, X2)
+    m3 = t3.transform(X1, X2)
+
+    t12 = t1 + t2
+    assert isinstance(t12, CombinedDistance)
+    assert len(t12.pw_trafos) == 2
+    assert t12.get_params()["operation"] == "+"
+
+    m12 = t12.transform(X1, X2)
+    assert np.allclose(m12, m1 + m2)
+
+    t123 = t1 + t2 + t3
+    assert isinstance(t123, CombinedDistance)
+    assert len(t123.pw_trafos) == 3
+    assert t123.get_params()["operation"] == "+"
+
+    m123 = t123.transform(X1, X2)
+    assert np.allclose(m123, m1 + m2 + m3)
+
+    t123r = t1 + (t2 + t3)
+    assert isinstance(t123r, CombinedDistance)
+    assert len(t123r.pw_trafos) == 3
+    assert t123r.get_params()["operation"] == "+"
+
+    m123r = t123r.transform(X1, X2)
+    assert np.allclose(m123r, m1 + m2 + m3)
+
+
+def test_mixed_algebra_dunders():
+    """Test mix of algebraic dunders."""
+    t1 = EditDist()
+    t2 = EditDist(distance="edr")
+    t3 = EditDist(distance="erp")
+
+    m1 = t1.transform(X1, X2)
+    m2 = t2.transform(X1, X2)
+    m3 = t3.transform(X1, X2)
+
+    t123 = t1 * t2 + t3
+    assert isinstance(t123, CombinedDistance)
+    assert len(t123.pw_trafos) == 2
+    assert t123.get_params()["operation"] == "+"
+    t12 = t123.pw_trafos[0]
+    assert isinstance(t12, CombinedDistance)
+    assert len(t12.pw_trafos) == 2
+    assert t12.get_params()["operation"] == "*"
+
+    m123 = t123.transform(X1, X2)
+    assert np.allclose(m123, m1 * m2 + m3)

--- a/sktime/dists_kernels/tests/test_dist_kernels_dunders.py
+++ b/sktime/dists_kernels/tests/test_dist_kernels_dunders.py
@@ -6,6 +6,7 @@ __author__ = ["fkiraly"]
 import numpy as np
 
 from sktime.dists_kernels.algebra import CombinedDistance
+from sktime.dists_kernels.compose import PwTrafoPanelPipeline
 from sktime.dists_kernels.edit_dist import EditDist
 from sktime.utils._testing.panel import _make_panel_X
 
@@ -104,3 +105,26 @@ def test_mixed_algebra_dunders():
 
     m123 = t123.transform(X1, X2)
     assert np.allclose(m123, m1 * m2 + m3)
+
+
+def test_pw_trafo_pipeline_mul_dunder():
+    """Tests creation of pairwise panel trafo pipeliens using mul dunder."""
+    from sktime.transformations.series.exponent import ExponentTransformer
+
+    t3 = EditDist()
+    t1 = ExponentTransformer()
+    t2 = ExponentTransformer(2)
+
+    m3 = t3.transform(X1, X2)
+
+    t23 = t2 * t3
+    assert isinstance(t23, PwTrafoPanelPipeline)
+    assert len(t23.transformers) == 1
+
+    t123 = t1 * t2 * t3
+    assert isinstance(t123, PwTrafoPanelPipeline)
+    assert len(t23.transformers) == 2
+
+    m123 = t123.transform(X1, X2)
+
+    assert np.allclose(m123, m3)


### PR DESCRIPTION
This PR adds dunders for time series distances and kernels (descendants of `BasePairwiseTransformerPanel`), behaving as per likely user expectation, description as below.

It also adds tests for the different combinations of dunders and estimators.

### algebraic operations between time series distances and kernels

* `d = dist1 * dist2` satisfies `d(X1, X2) == dist1(X1, X2) * dist2(X1, X2)`, for all pairwise transformers `dist1`, `dist2`, equality for all elements of the resulting matrix
* `d = dist1 + dist2` gives `d(X1, X2) == dist1(X1, X2) + dist2(X1, X2)`, for all pairwise transformers `dist1`, `dist2`
* for a pairwise distance `dist` and an int or float `const`, `d = dist * const` or `d = const * dist` gives `d(X1, X2) == dist(X1, X2) * const`
* for a pairwise distance `dist` and an int or float `const`, `d = dist + const` or `d = const + dist` gives `d(X1, X2) == dist(X1, X2) + const`

### pipeline concatenation between ordinary transformers and time series distances or kernels

* for a transformer `trafo` and a pairwise `dist`, the esteimator `pipe = trafo * dist` is also a pairwise distance, with `pipe(X1, X2) == dist(trafo.fit_transform(X1), trafo.fit_transform(X2))`
* above, the transformer `trafo` can be an `sktime` transformer, or an `sklearn` transformer (which is coerced/wrapped)

This especially may be interesting for users with a research interest in time series classification or clustering, as it allows to obtain common time series distances easily as composition of others.

E.g., ddtw (for common definitions of ddtw) is the same as `Differencer() * DtwDist()` (first difference, then dtw distance). Higher order differences or other combinations are also easy to obtain by this.

