### PR TITLE
[BUG] fix `start_with_window` deprecation in `ExpandingWindowSplitter`

### DIFF
--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -69,9 +69,7 @@ class MultiplexForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     ...     ("ets", AutoETS()),
     ...     ("theta", ThetaForecaster()),
     ...     ("naive", NaiveForecaster())])  # doctest: +SKIP
-    >>> cv = ExpandingWindowSplitter(
-    ...     start_with_window=True,
-    ...     step_length=12)  # doctest: +SKIP
+    >>> cv = ExpandingWindowSplitter(step_length=12)  # doctest: +SKIP
     >>> gscv = ForecastingGridSearchCV(
     ...     cv=cv,
     ...     param_grid={"selected_forecaster":["ets", "theta", "naive"]},

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -1498,9 +1498,7 @@ class Permute(_DelegatedForecaster, BaseForecaster, _HeterogenousMetaEstimator):
     ...     ForecastingGridSearchCV,
     ... )
     >>> fh = [1,2,3]
-    >>> cv = ExpandingWindowSplitter(
-    ...     start_with_window=True,
-    ...     fh=fh)
+    >>> cv = ExpandingWindowSplitter(fh=fh)
     >>> forecaster = NaiveForecaster()
     >>> # check which of the two sequences of transformers is better
     >>> param_grid = {

--- a/sktime/forecasting/compose/tests/test_multiplex.py
+++ b/sktime/forecasting/compose/tests/test_multiplex.py
@@ -90,7 +90,7 @@ def test_multiplex_with_grid_search():
     ]
     multiplex_forecaster = MultiplexForecaster(forecasters=forecasters)
     forecaster_names = [name for name, _ in forecasters]
-    cv = ExpandingWindowSplitter(start_with_window=True, step_length=12)
+    cv = ExpandingWindowSplitter(step_length=12)
     gscv = ForecastingGridSearchCV(
         cv=cv,
         param_grid={"selected_forecaster": forecaster_names},

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -190,7 +190,6 @@ def test_pipeline_with_dimension_changing_transformer():
     step_cv = 1
     cv = ExpandingWindowSplitter(
         initial_window=len(train_model) - (N_cv_fold - 1) * step_cv - len(fh),
-        start_with_window=True,
         step_length=step_cv,
         fh=fh,
     )

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -188,9 +188,7 @@ def test_evaluate_error_score(error_score, return_data, strategy, backend):
     # add NaN to make ExponentialSmoothing fail
     y.iloc[1] = np.nan
     fh = [1, 2, 3]
-    cv = ExpandingWindowSplitter(
-        start_with_window=True, step_length=48, initial_window=12, fh=fh
-    )
+    cv = ExpandingWindowSplitter(step_length=48, initial_window=12, fh=fh)
     if error_score in [np.nan, 1000]:
         with pytest.warns(FitFailedWarning):
             results = evaluate(

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -13,7 +13,6 @@ __all__ = [
 __author__ = ["mloning", "kkoralturk", "khrapovs", "chillerobscuro"]
 
 from typing import Iterator, Optional, Tuple, Union
-from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -1177,12 +1176,9 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
     fh : int, list or np.array, optional (default=1)
         Forecasting horizon
     initial_window : int or timedelta or pd.DateOffset, optional (default=10)
-        Window length
+        Window length of initial training fold. If =0, initial training fold is empty.
     step_length : int or timedelta or pd.DateOffset, optional (default=1)
         Step length between windows
-    start_with_window : bool, optional (default=True)
-        - If True, starts with full window.
-        - If False, starts with empty window.
 
     Examples
     --------
@@ -1200,8 +1196,10 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
         fh: FORECASTING_HORIZON_TYPES = DEFAULT_FH,
         initial_window: ACCEPTED_WINDOW_LENGTH_TYPES = DEFAULT_WINDOW_LENGTH,
         step_length: NON_FLOAT_WINDOW_LENGTH_TYPES = DEFAULT_STEP_LENGTH,
-        start_with_window: bool = True,  # TODO: remove 0.15.0
     ) -> None:
+
+        start_with_window = initial_window == 0
+
         # Note that we pass the initial window as the window_length below. This
         # allows us to use the common logic from the parent class, while at the same
         # time expose the more intuitive name for the ExpandingWindowSplitter.
@@ -1210,14 +1208,8 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
             window_length=initial_window,
             initial_window=None,
             step_length=step_length,
-            start_with_window=start_with_window,  # TODO: remove 0.15.0
+            start_with_window=start_with_window,
         )
-
-        if not start_with_window:  # TODO: remove 0.15.0
-            warn(
-                '"start_with_window" will be depreciated in 0.15.0, '
-                "use initial_window=0 instead"
-            )
 
         # initial_window needs to be written to self for sklearn compatibility
         self.initial_window = initial_window

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1198,7 +1198,7 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
         step_length: NON_FLOAT_WINDOW_LENGTH_TYPES = DEFAULT_STEP_LENGTH,
     ) -> None:
 
-        start_with_window = initial_window == 0
+        start_with_window = initial_window != 0
 
         # Note that we pass the initial window as the window_length below. This
         # allows us to use the common logic from the parent class, while at the same

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1208,6 +1208,7 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
             window_length=initial_window,
             initial_window=None,
             step_length=step_length,
+            start_with_window=start_with_window,
         )
 
         # initial_window needs to be written to self for sklearn compatibility

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1208,7 +1208,6 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
             window_length=initial_window,
             initial_window=None,
             step_length=step_length,
-            start_with_window=start_with_window,
         )
 
         # initial_window needs to be written to self for sklearn compatibility

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -389,9 +389,7 @@ class ForecastingGridSearchCV(BaseGridSearch):
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> y = load_shampoo_sales()
     >>> fh = [1,2,3]
-    >>> cv = ExpandingWindowSplitter(
-    ...     start_with_window=True,
-    ...     fh=fh)
+    >>> cv = ExpandingWindowSplitter(fh=fh)
     >>> forecaster = NaiveForecaster()
     >>> param_grid = {"strategy" : ["last", "mean", "drift"]}
     >>> gscv = ForecastingGridSearchCV(

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -417,7 +417,6 @@ class ForecastingGridSearchCV(BaseGridSearch):
     >>> cv = ExpandingWindowSplitter(
     ...     initial_window=24,
     ...     step_length=12,
-    ...     start_with_window=True,
     ...     fh=[1,2,3])
     >>> gscv = ForecastingGridSearchCV(
     ...     forecaster=pipe,

--- a/sktime/forecasting/model_selection/tests/test_split.py
+++ b/sktime/forecasting/model_selection/tests/test_split.py
@@ -442,7 +442,6 @@ def test_expanding_window_splitter(y, fh, initial_window, step_length):
                 fh=fh,
                 initial_window=initial_window,
                 step_length=step_length,
-                start_with_window=True,
             )
 
 

--- a/sktime/forecasting/model_selection/tests/test_split.py
+++ b/sktime/forecasting/model_selection/tests/test_split.py
@@ -400,7 +400,6 @@ def test_expanding_window_splitter_start_with_empty_window(
             fh=fh,
             initial_window=initial_window,
             step_length=step_length,
-            start_with_window=True,
         )
         train_windows, test_windows, _, n_splits = _check_cv(cv, y)
         assert np.vstack(test_windows).shape == (n_splits, len(check_fh(fh)))
@@ -415,7 +414,6 @@ def test_expanding_window_splitter_start_with_empty_window(
                 fh=fh,
                 initial_window=initial_window,
                 step_length=step_length,
-                start_with_window=True,
             )
 
 
@@ -430,7 +428,6 @@ def test_expanding_window_splitter(y, fh, initial_window, step_length):
             fh=fh,
             initial_window=initial_window,
             step_length=step_length,
-            start_with_window=True,
         )
         train_windows, test_windows, _, n_splits = _check_cv(cv, y)
         assert np.vstack(test_windows).shape == (n_splits, len(check_fh(fh)))

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -858,7 +858,6 @@ class MultiplexTransformer(_HeterogenousMetaEstimator, _DelegatedTransformer):
     >>> cv = ExpandingWindowSplitter(
     ...     initial_window=24,
     ...     step_length=12,
-    ...     start_with_window=True,
     ...     fh=[1,2,3])
     >>> pipe = TransformedTargetForecaster(steps = [
     ...     ("multiplex", multiplexer),

--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -140,7 +140,6 @@ def test_differencer_cutoff():
     step_cv = 1
     cv = ExpandingWindowSplitter(
         initial_window=len(train_model) - (N_cv_fold - 1) * step_cv - len(fh),
-        start_with_window=True,
         step_length=step_cv,
         fh=fh,
     )

--- a/sktime/transformations/tests/test_multiplexer.py
+++ b/sktime/transformations/tests/test_multiplexer.py
@@ -87,9 +87,7 @@ def test_multiplex_transformer_in_grid():
     ]
     transformer_names = [name for name, _ in transformer_tuples]
     multiplex_transformer = MultiplexTransformer(transformers=transformer_tuples)
-    cv = ExpandingWindowSplitter(
-        initial_window=24, step_length=12, start_with_window=True, fh=[1, 2, 3]
-    )
+    cv = ExpandingWindowSplitter(initial_window=24, step_length=12, fh=[1, 2, 3])
     pipe = TransformedTargetForecaster(
         steps=[
             ("multiplex", multiplex_transformer),


### PR DESCRIPTION
It would appear the deprecation of `start_with_window` in `ExpandingWindowSplitter` according to https://github.com/sktime/sktime/issues/2678 was carried out incompletely - simply carrying out the deprecation action results in error, due to the parameter still being there in super calls and base constructor.

This PR introduces a quick fix which translates the parameter in `ExpandingWindowSplitter`, to the desired deprecation end state, but without full removal of the parameter in the base interface.

The original deprecation in #2678 still needs to be carried out fully.