### PR TITLE
[ENH] generalize `AggrDist` and `FlatDist` to allow arbitrary callables, including `sklearn` kernel functions

### DIFF
--- a/sktime/dists_kernels/compose_tab_to_panel.py
+++ b/sktime/dists_kernels/compose_tab_to_panel.py
@@ -154,7 +154,18 @@ class FlatDist(BasePairwiseTransformerPanel):
 
     Parameters
     ----------
-    transformer: pairwise transformer of BasePairwiseTransformer scitype
+    transformer: pairwise transformer of BasePairwiseTransformer scitype, or
+        callable np.ndarray (n_samples, d) x (n_samples, d) -> (n_samples x n_samples)
+
+    Examples
+    --------
+    Euclidean distance between time series of equal length, considered as vectors
+    >>> from sktime.dists_kernels import FlatDist, ScipyDist
+    >>> euc_tsdist = FlatDist(ScipyDist())
+
+    Gaussian kernel between time series of equal length, considered as vectors
+    >>> from sklearn.gaussian_process.kernels import RBF
+    >>> flat_gaussian_tskernel = FlatDist(RBF())
     """
 
     _tags = {
@@ -196,14 +207,21 @@ class FlatDist(BasePairwiseTransformerPanel):
         X2 = X2.reshape(n_inst2, n_vars2 * n_tts2)
 
         if deep_equals(X, X2):
-            return self.transformer.transform(X)
+            return self.transformer(X)
         else:
-            return self.transformer.transform(X, X2)
+            return self.transformer(X, X2)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Test parameters for FlatDist."""
-        # importing inside to avoid circular dependencies
+        from sklearn.gaussian_process.kernels import RBF
+
         from sktime.dists_kernels import ScipyDist
 
-        return {"transformer": ScipyDist()}
+        # using sktime pairwise transformer
+        params1 = {"transformer": ScipyDist()}
+
+        # using callable from sklearn
+        params2 = {"transformer": RBF()}
+
+        return [params1, params2]

--- a/sktime/dists_kernels/compose_tab_to_panel.py
+++ b/sktime/dists_kernels/compose_tab_to_panel.py
@@ -132,14 +132,15 @@ class AggrDist(BasePairwiseTransformerPanel):
 
 
 class FlatDist(BasePairwiseTransformerPanel):
-    r"""Panel distance from applying tabular distance to flattened time series.
+    r"""Panel distance or kernel from applying tabular trafo to flattened time series.
 
-    Applies the wrapped tabular distance to flattened series.
+    Applies the wrapped tabular distance or kernel to flattened series.
     Flattening is done to a 2D numpy array of shape (n_instances, (n_vars, n_timepts))
 
     Formal details (for real valued objects, mixed typed rows in analogy):
     Let :math:`d:\mathbb{R}^k \times \mathbb{R}^{k}\rightarrow \mathbb{R}`
-    be the pairwise function in `transformer`, when applied to `k`-vectors.
+    be the pairwise function in `transformer`, when applied to `k`-vectors
+    (here, :math:`d` could be a distance function or a kernel function).
     Let :math:`x_1, \dots, x_N\in \mathbb{R}^{n \times \ell}`,
     :math:`y_1, \dots y_M \in \mathbb{R}^{n \times \ell}` be collections of matrices,
     representing time series panel valued inputs `X` and `X2`, as follows:


### PR DESCRIPTION
This PR generalizes `AggrDist` and `FlatDist` to allow for arbitrary callables of suitable signature as distances/kernels inside.

This allows easy definition of common time series distances such as mean Gaussian kernel, mean pairwise Euclidean distance, or index flattened Euclidean distance.

This also adds:

* a test parameter case, using an `sklearn` kernel
* examples in the docstring to construct the distance/kernel either using an `sktime` distance or an `sklearn` kernel