### PR TITLE
[ENH] `transform_diag` method for pairwise transformers, for computing diagonal of distance/kernel matrix

### DIFF
--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -16,6 +16,7 @@ Interface specifications below.
 Scitype defining methods:
     computing distance/kernel matrix (shorthand) - __call__(self, X, X2=X)
     computing distance/kernel matrix             - transform(self, X, X2=X)
+    computing diagonal of distance/kernel matrix - transform_diag(self, X)
 
 Inspection methods:
     hyper-parameter inspection  - get_params()
@@ -290,6 +291,40 @@ class BasePairwiseTransformerPanel(BaseEstimator):
             (i,j)-th entry contains distance/kernel between X[i] and X2[j]
         """
         raise NotImplementedError
+
+    def transform_diag(self, X):
+        """Compute diagonal of distance/kernel matrix.
+
+        Behaviour: returns diagonal of distance/kernel matrix for samples in X
+
+        Parameters
+        ----------
+        X : Series or Panel, any supported mtype, of n instances
+            Data to transform, of python type as follows:
+                Series: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
+                Panel: pd.DataFrame with 2-level MultiIndex, list of pd.DataFrame,
+                    nested pd.DataFrame, or pd.DataFrame in long/wide format
+                subject to sktime mtype format specifications, for further details see
+                    examples/AA_datatypes_and_datasets.ipynb
+
+        Returns
+        -------
+        diag: np.array of shape [n]
+            i-th entry contains distance/kernel between X[i] and X[i]
+        """
+        import numpy as np
+
+        from sktime.datatypes._vectorize import VectorizedDF
+
+        X = self._pairwise_panel_x_check(X)
+        X_spl = VectorizedDF(X, iterate_as="Series")
+
+        diag = np.zeros(len(X_spl))
+
+        for i, X_instance in enumerate(X_spl):
+            diag[i] = self.transform(X=X_instance)
+
+        return diag
 
     def fit(self, X=None, X2=None):
         """Fit method for interface compatibility (no logic inside)."""

--- a/sktime/dists_kernels/tests/test_all_dist_kernels.py
+++ b/sktime/dists_kernels/tests/test_all_dist_kernels.py
@@ -88,3 +88,20 @@ class TestAllPanelTransformers(TransformerPairwisePanelFixtureGenerator, QuickTe
             dist_mat.shape
             == (len_X, len_X2)
         ), f"Shape of matrix returned by transform is wrong for {trafo_name}"
+
+    def test_transform_diag(self, estimator_instance, scenario):
+        """Test expected output of transform_diag."""
+        trafo_name = type(estimator_instance).__name__
+        diag_vec = scenario.run(estimator_instance, method_sequence=["transform_diag"])
+
+        len_X = len(scenario.args["transform"]["X"])
+
+        assert isinstance(
+            diag_vec, np.ndarray
+        ), f"Shape of matrix returned by transform is wrong for {trafo_name}"
+        assert (
+            # this is only true as long as fixture are of mtypes where len = n_instances
+            # should that change, use check_is_mtype to get n_instances metadata
+            diag_vec.shape
+            == (len_X,)
+        ), f"Shape of matrix returned by transform is wrong for {trafo_name}"

--- a/sktime/utils/_testing/scenarios_transformers_pairwise.py
+++ b/sktime/utils/_testing/scenarios_transformers_pairwise.py
@@ -130,6 +130,7 @@ class TransformerPairwisePanelTransformSymm(TransformerPairwisePanelTestScenario
     args = {
         "fit": {"X": None, "X2": None},
         "transform": {"X": X},
+        "transform_diag": {"X": X},
     }
     default_method_sequence = ["fit", "transform"]
 
@@ -142,6 +143,7 @@ class TransformerPairwisePanelTransformAsymm(TransformerPairwisePanelTestScenari
     args = {
         "fit": {"X": None, "X2": None},
         "transform": {"X": X, "X2": X2},
+        "transform_diag": {"X": X},
     }
     default_method_sequence = ["fit", "transform"]
 
@@ -154,6 +156,7 @@ class TransformerPairwisePanelTransformListdf(TransformerPairwisePanelTestScenar
     args = {
         "fit": {"X": None, "X2": None},
         "transform": {"X": X1_list_df, "X2": X2_list_df},
+        "transform_diag": {"X": X1_list_df},
     }
     default_method_sequence = ["fit", "transform"]
 
@@ -166,6 +169,7 @@ class TransformerPairwisePanelTransformNumpy(TransformerPairwisePanelTestScenari
     args = {
         "fit": {"X": None, "X2": None},
         "transform": {"X": X1_num_pan, "X2": X2_num_pan},
+        "transform_diag": {"X": X1_num_pan},
     }
     default_method_sequence = ["fit", "transform"]
 

--- a/sktime/utils/_testing/scenarios_transformers_pairwise.py
+++ b/sktime/utils/_testing/scenarios_transformers_pairwise.py
@@ -71,6 +71,7 @@ class TransformerPairwiseTransformSymm(TransformerPairwiseTestScenario):
     args = {
         "fit": {"X": None, "X2": None},
         "transform": {"X": d},
+        "transform_diag": {"X": d},
     }
     default_method_sequence = ["fit", "transform"]
 
@@ -83,6 +84,7 @@ class TransformerPairwiseTransformAsymm(TransformerPairwiseTestScenario):
     args = {
         "fit": {"X": None, "X2": None},
         "transform": {"X": d, "X2": d2},
+        "transform_diag": {"X": d},
     }
     default_method_sequence = ["fit", "transform"]
 
@@ -95,6 +97,7 @@ class TransformerPairwiseTransformNumpy(TransformerPairwiseTestScenario):
     args = {
         "fit": {"X": None, "X2": None},
         "transform": {"X": X1_np, "X2": X2_np},
+        "transform_diag": {"X": X1_np},
     }
     default_method_sequence = ["fit", "transform"]
 


### PR DESCRIPTION
This PR adds a `transform_diag` method to pairwise transformers which allows to obtain the diagonal of a distance or kernel matrix, plus a generic test for the method in the estimator checks.

This parallels the `diag` interface point in kernels of `sklearn`, in `sklearn.gaussian_process.kernels`.

Currently this has only a default implementation, but we could extend this later to make room for a two-layer architecture if needed.