### PR TITLE
[ENH] wrapper to convert kernels to distances and distances to kernels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "numba>=0.55",
     "numpy>=1.21.0,<1.23",
     "pandas>=1.1.0,<1.6.0",
-    "scikit-learn>=0.24.0,<1.2.0",
+    "scikit-learn>=0.24.0,<1.3.0",
     "statsmodels>=0.12.1",
     "scipy<2.0.0",
 ]

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -16,6 +16,7 @@ Interface specifications below.
 Scitype defining methods:
     computing distance/kernel matrix (shorthand) - __call__(self, X, X2=X)
     computing distance/kernel matrix             - transform(self, X, X2=X)
+    computing diagonal of distance/kernel matrix - transform_diag(self, X)
 
 Inspection methods:
     hyper-parameter inspection  - get_params()
@@ -290,6 +291,40 @@ class BasePairwiseTransformerPanel(BaseEstimator):
             (i,j)-th entry contains distance/kernel between X[i] and X2[j]
         """
         raise NotImplementedError
+
+    def transform_diag(self, X):
+        """Compute diagonal of distance/kernel matrix.
+
+        Behaviour: returns diagonal of distance/kernel matrix for samples in X
+
+        Parameters
+        ----------
+        X : Series or Panel, any supported mtype, of n instances
+            Data to transform, of python type as follows:
+                Series: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
+                Panel: pd.DataFrame with 2-level MultiIndex, list of pd.DataFrame,
+                    nested pd.DataFrame, or pd.DataFrame in long/wide format
+                subject to sktime mtype format specifications, for further details see
+                    examples/AA_datatypes_and_datasets.ipynb
+
+        Returns
+        -------
+        diag: np.array of shape [n]
+            i-th entry contains distance/kernel between X[i] and X[i]
+        """
+        import numpy as np
+
+        from sktime.datatypes._vectorize import VectorizedDF
+
+        X = self._pairwise_panel_x_check(X)
+        X_spl = VectorizedDF(X, iterate_as="Series")
+
+        diag = np.zeros(len(X_spl))
+
+        for i, X_instance in enumerate(X_spl):
+            diag[i] = self.transform(X=X_instance)
+
+        return diag
 
     def fit(self, X=None, X2=None):
         """Fit method for interface compatibility (no logic inside)."""

--- a/sktime/dists_kernels/dist_to_kern.py
+++ b/sktime/dists_kernels/dist_to_kern.py
@@ -112,8 +112,6 @@ class KernelFromDist(BasePairwiseTransformerPanel):
         else:
             diag2 = diagfun(X2)
 
-        print(diag1)
-
         diag1 = np.array(diag1).flatten() ** 2
         diag2 = np.array(diag2).flatten() ** 2
 

--- a/sktime/dists_kernels/dist_to_kern.py
+++ b/sktime/dists_kernels/dist_to_kern.py
@@ -5,10 +5,7 @@ __author__ = ["fkiraly"]
 
 import numpy as np
 
-from sktime.dists_kernels._base import (
-    BasePairwiseTransformer,
-    BasePairwiseTransformerPanel,
-)
+from sktime.dists_kernels._base import BasePairwiseTransformerPanel
 
 SUPPORTED_MTYPES = ["pd-multiindex", "nested_univ", "df-list", "numpy3D"]
 
@@ -93,6 +90,8 @@ class KernelFromDist(BasePairwiseTransformerPanel):
         distmat: np.array of shape [n, m]
             (i,j)-th entry contains distance/kernel between X.iloc[i] and X2.iloc[j]
         """
+        from sktime.transformations.base import BaseTransformer
+
         dist = self.dist
         dist_diag = self.dist_diag
         if dist_diag is None:
@@ -100,7 +99,7 @@ class KernelFromDist(BasePairwiseTransformerPanel):
 
         if isinstance(dist_diag, BasePairwiseTransformerPanel):
             diagfun = dist_diag.transform_diag
-        elif isinstance(dist_diag, BasePairwiseTransformer):
+        elif isinstance(dist_diag, BaseTransformer):
             diagfun = dist_diag.fit_transform
         else:
             diagfun = _trafo_diag(dist_diag)

--- a/sktime/dists_kernels/dist_to_kern.py
+++ b/sktime/dists_kernels/dist_to_kern.py
@@ -149,7 +149,7 @@ class DistFromKernel(BasePairwiseTransformerPanel):
     Formal details (for real valued objects, mixed typed rows in analogy):
     Let :math:`k: \mathbb{R}^D \times \mathbb{R}^D\rightarrow \mathbb{R}`
     be the pairwise function in `kernel`, when applied to `D`-vectors.
-    If `dist_diag=None`, then `KernelFromDist(dist)` corresponds to the kernel function
+    `DistFromKernel(dist)` corresponds to the distance function
     :math:`d(x, y) := \sqrt{k(x, x) + k(y, y) - 2 \cdot k(x, y)}`.
 
     It should be noted that if :math:`k` is positive semi-definite,
@@ -168,9 +168,9 @@ class DistFromKernel(BasePairwiseTransformerPanel):
         "capability:unequal_length": True,  # can dist handle unequal length panels?
     }
 
-    def __init__(self, dist):
+    def __init__(self, kernel):
 
-        self.dist = dist
+        self.kernel = kernel
 
         super(DistFromKernel, self).__init__()
 
@@ -181,8 +181,8 @@ class DistFromKernel(BasePairwiseTransformerPanel):
             "capability:unequal_length",
         ]
 
-        if isinstance(dist, BasePairwiseTransformerPanel):
-            self.clone_tags(dist, tags_to_clone)
+        if isinstance(kernel, BasePairwiseTransformerPanel):
+            self.clone_tags(kernel, tags_to_clone)
 
     def _transform(self, X, X2=None):
         """Compute distance/kernel matrix.
@@ -199,26 +199,26 @@ class DistFromKernel(BasePairwiseTransformerPanel):
         distmat: np.array of shape [n, m]
             (i,j)-th entry contains distance/kernel between X.iloc[i] and X2.iloc[j]
         """
-        dist = self.dist
+        kernel = self.kernel
 
-        distmat = dist(X, X2)
+        kernelmat = kernel(X, X2)
 
-        diag1 = dist(X)
+        diag1 = kernel(X)
         if X2 is None:
             diag2 = diag1
         else:
-            diag2 = dist(X2)
+            diag2 = kernel(X2)
 
         diag1 = np.array(diag1).flatten()
         diag2 = np.array(diag2).flatten()
 
-        n, m = distmat.shape
+        n, m = kernelmat.shape
 
         mat1 = np.tile(np.expand_dims(diag1, 1), m)
         mat2 = np.tile(np.expand_dims(diag2, 1), n)
         mat2 = mat2.transpose()
 
-        kernmat = mat1 + mat2 - 2 * distmat
+        kernmat = mat1 + mat2 - 2 * kernelmat
         kernmat = np.sqrt(kernmat)
 
         return kernmat

--- a/sktime/dists_kernels/dist_to_kern.py
+++ b/sktime/dists_kernels/dist_to_kern.py
@@ -1,0 +1,248 @@
+# -*- coding: utf-8 -*-
+"""Wrappers to convert distance to kernel or kernel to distance."""
+
+__author__ = ["fkiraly"]
+
+import numpy as np
+
+from sktime.dists_kernels._base import (
+    BasePairwiseTransformer,
+    BasePairwiseTransformerPanel,
+)
+
+SUPPORTED_MTYPES = ["pd-multiindex", "nested_univ", "df-list", "numpy3D"]
+
+
+class KernelFromDist(BasePairwiseTransformerPanel):
+    r"""Kernel function obtained from a distance function.
+
+    Formal details (for real valued objects, mixed typed rows in analogy):
+    Let :math:`d: \mathbb{R}^D \times \mathbb{R}^D\rightarrow \mathbb{R}`
+    be the pairwise function in `dist`, when applied to `D`-vectors.
+    If `dist_diag=None`, then `KernelFromDist(dist)` corresponds to the kernel function
+    :math:`k(x, y) := d(x, x) + d(y, y) - 0.5 \cdot d(x, y)`.
+    If `dist_diag` is provided,
+    and corresponds to a function :math:`f:\mathbb{R}^D \rightarrow \mathbb{R}`,
+    then `KernelFromDist(dist)` corresponds to the kernel function
+    :math:`k(x, y) := f(x, x) + f(y, y) - 0.5 \cdot d(x, y)`.
+
+    It should be noted that :math:`k` is, in general, not positive semi-definite.
+
+    Parameters
+    ----------
+    dist : pairwise transformer of BasePairwiseTransformer scitype, or
+        callable np.ndarray (n_samples, nd) x (n_samples, nd) -> (n_samples x n_samples)
+    dist_diag : pairwise transformer of BasePairwiseTransformer scitype, or
+        series-to-panel transformer of Basetransformer scitype, or
+        callable np.ndarray (n_samples, nd) -> (n_samples, )
+    """
+
+    _tags = {
+        "X_inner_mtype": SUPPORTED_MTYPES,
+        "capability:missing_values": True,  # can estimator handle missing data?
+        "capability:multivariate": True,  # can estimator handle multivariate data?
+        "capability:unequal_length": True,  # can dist handle unequal length panels?
+    }
+
+    def __init__(self, dist, dist_diag=None):
+
+        self.dist = dist
+        self.dist_diag = dist_diag
+
+        super(KernelFromDist, self).__init__()
+
+        # set property tags based on tags of components
+        missing = True
+        multi = True
+        unequal = True
+        if isinstance(dist, BasePairwiseTransformerPanel):
+            missing = missing and dist.get_tag("capability:missing_values")
+            multi = multi and dist.get_tag("capability:multivariate")
+            unequal = unequal and dist.get_tag("capability:unequal_length")
+
+        tag_dict = {
+            "capability:missing_values": missing,
+            "capability:multivariate": multi,
+            "capability:unequal_length": unequal,
+        }
+
+        self.set_tags(**tag_dict)
+
+    def _transform(self, X, X2=None):
+        """Compute distance/kernel matrix.
+
+        private _transform containing core logic, called from public transform
+
+        Parameters
+        ----------
+        X: sktime Panel data container
+        X2: sktime Panel data container
+
+        Returns
+        -------
+        distmat: np.array of shape [n, m]
+            (i,j)-th entry contains distance/kernel between X.iloc[i] and X2.iloc[j]
+        """
+        dist = self.dist
+        dist_diag = self.dist_diag
+        if dist_diag is None:
+            dist_diag = dist
+
+        if isinstance(dist_diag, BasePairwiseTransformerPanel):
+            diagfun = dist_diag.transform_diag
+        elif isinstance(dist_diag, BasePairwiseTransformer):
+            diagfun = dist_diag.fit_transform
+        else:
+            diagfun = dist_diag
+
+        distmat = dist(X, X2)
+
+        diag1 = diagfun(X)
+        if X2 is None:
+            diag2 = diag1
+        else:
+            diag2 = diagfun(X2)
+
+        diag1 = np.array(diag1).flatten()
+        diag2 = np.array(diag2).flatten()
+
+        n, m = distmat.shape
+
+        mat1 = np.tile(np.expand_dims(diag1, 1), m)
+        mat2 = np.tile(np.expand_dims(diag2, 1), n)
+        mat2 = mat2.transpose()
+
+        kernmat = mat1 + mat2 - 0.5 * distmat
+
+        return kernmat
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default={}
+            Parameters to create testing instances of the class.
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`.
+        """
+        from sktime.dists_kernels.dtw import DtwDist
+        from sktime.transformations.series.summarize import SummaryTransformer
+
+        params1 = {"dist": DtwDist()}
+        params2 = {"dist": DtwDist(), "dist_diag": SummaryTransformer("mean", None)}
+
+        return [params1, params2]
+
+
+class DistFromKernel(BasePairwiseTransformerPanel):
+    r"""Distance function obtained from a kernel function.
+
+    Formal details (for real valued objects, mixed typed rows in analogy):
+    Let :math:`k: \mathbb{R}^D \times \mathbb{R}^D\rightarrow \mathbb{R}`
+    be the pairwise function in `kernel`, when applied to `D`-vectors.
+    If `dist_diag=None`, then `KernelFromDist(dist)` corresponds to the kernel function
+    :math:`d(x, y) := k(x, x) + k(y, y) - 2 \cdot k(x, y)`.
+
+    It should be noted that if :math:`k` is positive semi-definite,
+    then :math:`d` will be a metric and satisfy the triangle inequality.
+
+    Parameters
+    ----------
+    kernel : pairwise transformer of BasePairwiseTransformer scitype, or
+        callable np.ndarray (n_samples, nd) x (n_samples, nd) -> (n_samples x n_samples)
+    """
+
+    _tags = {
+        "X_inner_mtype": SUPPORTED_MTYPES,
+        "capability:missing_values": True,  # can estimator handle missing data?
+        "capability:multivariate": True,  # can estimator handle multivariate data?
+        "capability:unequal_length": True,  # can dist handle unequal length panels?
+    }
+
+    def __init__(self, dist):
+
+        self.dist = dist
+
+        super(DistFromKernel, self).__init__()
+
+        # set property tags based on tags of components
+        tags_to_clone = [
+            "capability:missing_values",
+            "capability:multivariate",
+            "capability:unequal_length",
+        ]
+
+        if isinstance(dist, BasePairwiseTransformerPanel):
+            self.clone_tags(dist, tags_to_clone)
+
+    def _transform(self, X, X2=None):
+        """Compute distance/kernel matrix.
+
+        private _transform containing core logic, called from public transform
+
+        Parameters
+        ----------
+        X: sktime Panel data container
+        X2: sktime Panel data container
+
+        Returns
+        -------
+        distmat: np.array of shape [n, m]
+            (i,j)-th entry contains distance/kernel between X.iloc[i] and X2.iloc[j]
+        """
+        dist = self.dist
+
+        distmat = dist(X, X2)
+
+        diag1 = dist(X)
+        if X2 is None:
+            diag2 = diag1
+        else:
+            diag2 = dist(X2)
+
+        diag1 = np.array(diag1).flatten()
+        diag2 = np.array(diag2).flatten()
+
+        n, m = distmat.shape
+
+        mat1 = np.tile(np.expand_dims(diag1, 1), m)
+        mat2 = np.tile(np.expand_dims(diag2, 1), n)
+        mat2 = mat2.transpose()
+
+        kernmat = mat1 + mat2 - 2 * distmat
+
+        return kernmat
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default={}
+            Parameters to create testing instances of the class.
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`.
+        """
+        from sktime.dists_kernels import DtwDist, EditDist
+
+        params1 = {"kernel": DtwDist()}
+        params2 = {"kernel": EditDist()}
+
+        return [params1, params2]

--- a/sktime/dists_kernels/dist_to_kern.py
+++ b/sktime/dists_kernels/dist_to_kern.py
@@ -112,6 +112,8 @@ class KernelFromDist(BasePairwiseTransformerPanel):
         else:
             diag2 = diagfun(X2)
 
+        print(diag1)
+
         diag1 = np.array(diag1).flatten() ** 2
         diag2 = np.array(diag2).flatten() ** 2
 
@@ -144,10 +146,15 @@ class KernelFromDist(BasePairwiseTransformerPanel):
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
         from sktime.dists_kernels.dtw import DtwDist
+        from sktime.transformations.series.adapt import PandasTransformAdaptor
         from sktime.transformations.series.summarize import SummaryTransformer
 
         params1 = {"dist": DtwDist()}
-        params2 = {"dist": DtwDist(), "dist_diag": SummaryTransformer("mean", None)}
+        t = SummaryTransformer("mean", None)
+        # we need this since multivariate summary produces two columns
+        # if one column, has no effect; if multiple, takes means by row
+        t = PandasTransformAdaptor("mean", {"axis": 1}) * t
+        params2 = {"dist": DtwDist(), "dist_diag": t}
 
         return [params1, params2]
 

--- a/sktime/dists_kernels/dist_to_kern.py
+++ b/sktime/dists_kernels/dist_to_kern.py
@@ -15,6 +15,7 @@ SUPPORTED_MTYPES = ["pd-multiindex", "nested_univ", "df-list", "numpy3D"]
 
 def _trafo_diag(fun):
     """Obtain a function which returns the diagonal from one that returns a matrix."""
+
     def diag(X):
         mat = fun(X)
         return np.diag(mat)

--- a/sktime/dists_kernels/dist_to_kern.py
+++ b/sktime/dists_kernels/dist_to_kern.py
@@ -20,11 +20,11 @@ class KernelFromDist(BasePairwiseTransformerPanel):
     Let :math:`d: \mathbb{R}^D \times \mathbb{R}^D\rightarrow \mathbb{R}`
     be the pairwise function in `dist`, when applied to `D`-vectors.
     If `dist_diag=None`, then `KernelFromDist(dist)` corresponds to the kernel function
-    :math:`k(x, y) := d(x, x) + d(y, y) - 0.5 \cdot d(x, y)`.
+    :math:`k(x, y) := d(x, x)^2 + d(y, y)^2 - 0.5 \cdot d(x, y)^2`.
     If `dist_diag` is provided,
     and corresponds to a function :math:`f:\mathbb{R}^D \rightarrow \mathbb{R}`,
     then `KernelFromDist(dist)` corresponds to the kernel function
-    :math:`k(x, y) := f(x, x) + f(y, y) - 0.5 \cdot d(x, y)`.
+    :math:`k(x, y) := f(x, x)^2 + f(y, y)^2 - 0.5 \cdot d(x, y)^2`.
 
     It should be noted that :math:`k` is, in general, not positive semi-definite.
 
@@ -95,7 +95,7 @@ class KernelFromDist(BasePairwiseTransformerPanel):
         else:
             diagfun = dist_diag
 
-        distmat = dist(X, X2)
+        distmat = dist(X, X2) ** 2
 
         diag1 = diagfun(X)
         if X2 is None:
@@ -103,8 +103,8 @@ class KernelFromDist(BasePairwiseTransformerPanel):
         else:
             diag2 = diagfun(X2)
 
-        diag1 = np.array(diag1).flatten()
-        diag2 = np.array(diag2).flatten()
+        diag1 = np.array(diag1).flatten() ** 2
+        diag2 = np.array(diag2).flatten() ** 2
 
         n, m = distmat.shape
 
@@ -150,7 +150,7 @@ class DistFromKernel(BasePairwiseTransformerPanel):
     Let :math:`k: \mathbb{R}^D \times \mathbb{R}^D\rightarrow \mathbb{R}`
     be the pairwise function in `kernel`, when applied to `D`-vectors.
     If `dist_diag=None`, then `KernelFromDist(dist)` corresponds to the kernel function
-    :math:`d(x, y) := k(x, x) + k(y, y) - 2 \cdot k(x, y)`.
+    :math:`d(x, y) := \sqrt{k(x, x) + k(y, y) - 2 \cdot k(x, y)}`.
 
     It should be noted that if :math:`k` is positive semi-definite,
     then :math:`d` will be a metric and satisfy the triangle inequality.
@@ -219,6 +219,7 @@ class DistFromKernel(BasePairwiseTransformerPanel):
         mat2 = mat2.transpose()
 
         kernmat = mat1 + mat2 - 2 * distmat
+        kernmat = np.sqrt(kernmat)
 
         return kernmat
 

--- a/sktime/dists_kernels/tests/test_all_dist_kernels.py
+++ b/sktime/dists_kernels/tests/test_all_dist_kernels.py
@@ -88,3 +88,20 @@ class TestAllPanelTransformers(TransformerPairwisePanelFixtureGenerator, QuickTe
             dist_mat.shape
             == (len_X, len_X2)
         ), f"Shape of matrix returned by transform is wrong for {trafo_name}"
+
+    def test_transform_diag(self, estimator_instance, scenario):
+        """Test expected output of transform_diag."""
+        trafo_name = type(estimator_instance).__name__
+        diag_vec = scenario.run(estimator_instance, method_sequence=["transform_diag"])
+
+        len_X = len(scenario.args["transform"]["X"])
+
+        assert isinstance(
+            diag_vec, np.ndarray
+        ), f"Shape of matrix returned by transform is wrong for {trafo_name}"
+        assert (
+            # this is only true as long as fixture are of mtypes where len = n_instances
+            # should that change, use check_is_mtype to get n_instances metadata
+            diag_vec.shape
+            == (len_X,)
+        ), f"Shape of matrix returned by transform is wrong for {trafo_name}"

--- a/sktime/utils/plotting.py
+++ b/sktime/utils/plotting.py
@@ -307,7 +307,7 @@ def plot_correlations(
     >>> y = load_airline()
     >>> fig, ax = plot_correlations(y)  # doctest: +SKIP
     """
-    _check_soft_dependencies(("matplotlib", "statsmodels"))
+    _check_soft_dependencies("matplotlib", "statsmodels")
     import matplotlib.pyplot as plt
     from statsmodels.graphics.tsaplots import plot_acf, plot_pacf
 


### PR DESCRIPTION
This PR introduces two wrappers, `DistFromKernel` and `KernelFromDist`, which converts distances to kernels, resp kernels to distances.

Kernel to distances is via the common RKHS distance definition; distance to kernel is via a pseudo-inverse to the former, possibly using a transformer for the diagonal values.

Relies on PR https://github.com/sktime/sktime/pull/3957 for the diagonal transform method.