### PR TITLE
[BUG] fix faulty deprecation for `ProbabilityThresholdEarlyClassifier` base class change

### DIFF
--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -11,24 +11,17 @@ __all__ = ["ProbabilityThresholdEarlyClassifier"]
 import copy
 
 import numpy as np
-from deprecated.sphinx import deprecated
 from joblib import Parallel, delayed
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.utils import check_random_state
 
 from sktime.base._base import _clone_estimator
-from sktime.classification.base import BaseClassifier
+from sktime.classification.early_classification import BaseEarlyClassifier
 from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.utils.validation.panel import check_X
 
 
-# TODO: remove message in v0.15.0 and change base class
-@deprecated(
-    version="0.13.0",
-    reason="The base class of ProbabilityThresholdEarlyClassifier will be changed to BaseEarlyClassifier in v0.15.0. This will change how classification safety decisions are made and returned, see BaseEarlyClassifier or TEASER for the new interface.",  # noqa: E501
-    category=FutureWarning,
-)
-class ProbabilityThresholdEarlyClassifier(BaseClassifier):
+class ProbabilityThresholdEarlyClassifier(BaseEarlyClassifier):
     """Probability Threshold Early Classifier.
 
     An early classifier which uses a threshold of prediction probability to determine

--- a/sktime/classification/early_classification/base.py
+++ b/sktime/classification/early_classification/base.py
@@ -28,7 +28,6 @@ __all__ = [
 ]
 __author__ = ["mloning", "fkiraly", "TonyBagnall", "MatthewMiddlehurst"]
 
-from abc import ABC, abstractmethod
 from typing import Tuple
 
 import numpy as np
@@ -37,7 +36,7 @@ from sktime.base import BaseEstimator
 from sktime.classification import BaseClassifier
 
 
-class BaseEarlyClassifier(BaseEstimator, ABC):
+class BaseEarlyClassifier(BaseEstimator):
     """Abstract base class for early time series classifiers.
 
     The base classifier specifies the methods and method signatures that all
@@ -353,7 +352,6 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
         inv_dec = np.invert(decisions)
         return X[inv_dec], indices[inv_dec], indices[decisions]
 
-    @abstractmethod
     def _fit(self, X, y):
         """Fit time series classifier to training data.
 
@@ -383,7 +381,6 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
         """
         ...
 
-    @abstractmethod
     def _predict(self, X) -> Tuple[np.ndarray, np.ndarray]:
         """Predicts labels for sequences in X.
 
@@ -415,7 +412,6 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
         """
         ...
 
-    @abstractmethod
     def _update_predict(self, X) -> Tuple[np.ndarray, np.ndarray]:
         """Update label prediction for sequences in X at a larger series length.
 
@@ -535,7 +531,6 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
 
         return dists, decisions
 
-    @abstractmethod
     def _score(self, X, y) -> Tuple[float, float, float]:
         """Scores predicted labels against ground truth labels on X.
 


### PR DESCRIPTION
This PR fixes faulty preparation of the deprecation/change action where `ProbabilityThresholdEarlyClassifier` should change its base class to `BaseEarlyClassifier`.

As `BaseEarlyClassifier` is formally abstract (abc) and `ProbabilityThresholdEarlyClassifier` does not implement some of the optional methods, carrying out the change as per current deprecation action instructions leads to an exception.

This is remedied by removing `ABC` from the `BaseEarlyClassifier`, allowing `ProbabilityThresholdEarlyClassifier` to inherit without implementing the optional methods.

We can add `ABC` back at a later time, this is to enable the change action shortly before the release.