### PR TITLE
[BUG] fix `EnsembleForecaster` erroneous broadcasting and attribute clash

### DIFF
--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -323,12 +323,12 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
 
         Parameters
         ----------
-        y : pd.Series
+        y : pd.DataFrame - Series, Panel, or Hierarchical mtype format.
             Target time series to which to fit the forecaster.
-        fh : int, list or np.array, optional, default=None
+        fh : ForecastingHorizon, optional, default=None
             The forecasters horizon with the steps ahead to to predict.
-        X : pd.DataFrame, optional, default=None
-            Exogenous variables are ignored.
+        X : pd.DataFrame, optional, default=None, must be of same mtype as y
+            Exogenous data to which to fit the forecaster.
 
         Returns
         -------
@@ -343,13 +343,15 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
 
         Parameters
         ----------
-        fh : int, list or np.array, optional, default=None
-        X : pd.DataFrame
+        fh : ForecastingHorizon, optional, default=None
+        X : pd.DataFrame, optional, default=None, must be of same mtype as y
+            Exogenous data to which to fit the forecaster.
 
         Returns
         -------
-        y_pred : pd.Series
-            Aggregated predictions.
+        y_pred : pd.DataFrame - Series, Panel, or Hierarchical mtype format,
+            will be of same mtype as y in _fit
+            Ensembled predictions
         """
         names, _ = self._check_forecasters()
         y_pred = pd.concat(self._predict_forecasters(fh, X), axis=1, keys=names)

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -304,6 +304,7 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
         "ignores-exogeneous-X": False,
         "requires-fh-in-fit": False,
         "handles-missing-data": False,
+        "X_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         "y_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         "scitype:y": "both",
     }


### PR DESCRIPTION
Fixes #3961.

The bug occurred whenever `EnsembleForecaster` would receive a panel or hierarchical exogeneous data set.

`EnsembleForecaster` should, however, never vectorize/broadcast, and this clash of parameters should never happen.

But, it did happen because the `X_inner_mtype` was incorrectly set, which erroneously triggered vectorization/broadcasting any time an `X` that is panel or hierarchical is passed.

This PR fixes that problem by setting the `X_inner_mtype` tag.

Also corrects the docstrings.