### PR TITLE
[ENH] sklearn to sktime pipeline adapter, API ref for `pipeline` module

### DIFF
--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -6,6 +6,7 @@ Utility functions
 ``sktime`` has a number of modules dedicated to utilities:
 
 * :mod:`sktime.datatypes`, which contains utilities for data format checks and conversion.
+* :mod:`sktime.pipeline`, which contains generics for pipeline construction.
 * :mod:`sktime.registry`, which contains utilities for estimator and tag search.
 * :mod:`sktime.utils`, which contains generic utility functions.
 
@@ -34,6 +35,26 @@ Data Format Checking and Conversion
     scitype
     mtype_to_scitype
     scitype_to_mtype
+
+
+Pipeline construction generics
+------------------------------
+
+:mod:`sktime.pipeline`
+
+.. automodule:: sktime.pipeline
+    :no-members:
+    :no-inherited-members:
+
+.. currentmodule:: sktime.pipeline
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: function.rst
+
+    make_pipeline
+    sklearn_to_sktime
+
 
 Estimator Search and Retrieval, Estimator Tags
 ----------------------------------------------

--- a/sktime/pipeline/__init__.py
+++ b/sktime/pipeline/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Pipeline maker utility."""
 
-__all__ = ["make_pipeline"]
+__all__ = ["make_pipeline", "sklearn_to_sktime"]
 
 from sktime.pipeline._make_pipeline import make_pipeline
+from sktime.pipeline._sklearn_to_sktime import sklearn_to_sktime

--- a/sktime/pipeline/_sklearn_to_sktime.py
+++ b/sktime/pipeline/_sklearn_to_sktime.py
@@ -8,10 +8,13 @@ from sktime.pipeline._make_pipeline import make_pipeline
 
 
 def sklearn_to_sktime(estimator):
-    """Coerces an sklearn estimator to the sktime interface.
+    """Coerces an sklearn estimator to the sktime pipeline interface.
 
-    Under the hood, creates a pipeline with the identity transformer and the estimator.
-    The dispatch logic is in the transformer base class, in the `__mul__` dunder.
+    Creates a pipeline of two elements, the identity transformer and the estimator.
+    The identity transformer acts as adapter and holds sktime base class logic.
+
+    Developer note:
+    Type dispatch logic is in the transformer base class, in the `__mul__` dunder.
 
     Parameters
     ----------

--- a/sktime/pipeline/_sklearn_to_sktime.py
+++ b/sktime/pipeline/_sklearn_to_sktime.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""Sklearn to sktime coercion utility."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file).
+
+__author__ = ["fkiraly"]
+
+from sktime.pipeline._make_pipeline import make_pipeline
+
+
+def sklearn_to_sktime(estimator):
+    """Coerces an sklearn estimator to the sktime interface.
+
+    Under the hood, creates a pipeline with the identity transformer and the estimator.
+    The dispatch logic is in the transformer base class, in the `__mul__` dunder.
+
+    Parameters
+    ----------
+    estimator : sklearn compatible estimator
+        can be classifier, regressor, transformer, clusterer
+
+    Returns
+    -------
+    pipe : sktime estimator of corresponding time series type
+        classifiers, regressors, clusterers are converted to time series counterparts
+        by flattening time series. Assumes equal length time series.
+        transformers are converted to time series transformer by application per series
+    """
+    from sktime.transformations.compose import Id
+
+    return make_pipeline(Id(), estimator)


### PR DESCRIPTION
This PR adds an generic adapter `sklearn_to_sktime` that exposes any `sklearn` estimator as an `sktime` pipeline (with one non-trivial element).

It also adds the `pipeline` module to the `sktime` API reference.