### PR TITLE
[BUG] fix tag logic in `AggrDist` and `FlatDist`

### DIFF
--- a/sktime/dists_kernels/compose_tab_to_panel.py
+++ b/sktime/dists_kernels/compose_tab_to_panel.py
@@ -159,6 +159,7 @@ class FlatDist(BasePairwiseTransformerPanel):
 
     _tags = {
         "X_inner_mtype": "numpy3D",  # which mtype is used internally in _transform?
+        "capability:unequal_length": False,
     }
 
     def __init__(self, transformer):
@@ -166,6 +167,10 @@ class FlatDist(BasePairwiseTransformerPanel):
         self.transformer = transformer
 
         super(FlatDist, self).__init__()
+
+        if isinstance(transformer, BasePairwiseTransformer):
+            tags_to_clone = ["capability:missing_values"]
+            self.clone_tags(transformer, tags_to_clone)
 
     def _transform(self, X, X2=None):
         """Compute distance/kernel matrix.

--- a/sktime/dists_kernels/compose_tab_to_panel.py
+++ b/sktime/dists_kernels/compose_tab_to_panel.py
@@ -12,7 +12,10 @@ __author__ = ["fkiraly"]
 
 import numpy as np
 
-from sktime.dists_kernels._base import BasePairwiseTransformerPanel
+from sktime.dists_kernels._base import (
+    BasePairwiseTransformer,
+    BasePairwiseTransformerPanel,
+)
 from sktime.utils._testing.deep_equals import deep_equals
 
 
@@ -66,6 +69,10 @@ class AggrDist(BasePairwiseTransformerPanel):
 
         if self.aggfunc_is_symm:
             self.set_tags(**{"symmetric": True})
+
+        if isinstance(transformer, BasePairwiseTransformer):
+            tags_to_clone = ["capability:missing_values"]
+            self.clone_tags(transformer, tags_to_clone)
 
     def _transform(self, X, X2=None):
         """Compute distance/kernel matrix.


### PR DESCRIPTION
This fixes erroneous tag logic in `AggrDist` and `FlatDist`:

* the `"capability:unequal_length"` tag of `FlatDist` should be `False`, as the compositor flattens the time series to a 2D `numpy` array (with equal length rows). For `AggrDist`, it is correctly set as `True`, as the aggregated distance does not assume equal length.
* the `"capability:missing_values"` of both `AggrDist` and `FlatDist` should be set to the same as the wrapped tabular pairwise transformer.