### PR TITLE
[MNT] skip sporadic `ResNetClassifier` failures

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -32,6 +32,7 @@ EXCLUDE_ESTIMATORS = [
     # tapnet based estimators fail stochastically for unknown reasons, see #3525
     "TapNetRegressor",
     "TapNetClassifier",
+    "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
 ]
 
 
@@ -79,7 +80,6 @@ EXCLUDED_TESTS = {
     # `test_fit_idempotent` fails with `AssertionError`, see #3616
     "ResNetClassifier": [
         "test_fit_idempotent",
-        "test_classifier_output",  # known ResNetClassifier sporafic failures, see #3954
     ],
     "CNNClassifier": [
         "test_fit_idempotent",

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -79,6 +79,7 @@ EXCLUDED_TESTS = {
     # `test_fit_idempotent` fails with `AssertionError`, see #3616
     "ResNetClassifier": [
         "test_fit_idempotent",
+        "test_classifier_output",  # known ResNetClassifier sporafic failures, see #3954
     ],
     "CNNClassifier": [
         "test_fit_idempotent",


### PR DESCRIPTION
This PR skips the known sporadic `ResNetClassifier` failures, see https://github.com/sktime/sktime/issues/3954

Since the failure seemingly appears in any test, we skip the entire estimator.