### PR TITLE
[MNT] isolate `mlflow` and AWS dependency set

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Install sktime and dependencies
         run: |
-          python -m pip install .[dev,mlflow] --no-cache-dir
+          python -m pip install .[all_extras,dev,mlflow] --no-cache-dir
 
       - name: Show dependencies
         run: python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,13 +102,13 @@ jobs:
 
       - name: Install sktime and dependencies
         run: |
-          python -m pip install .[dev,mlflow]
+          python -m pip install .[dev,mlflow] --no-cache-dir
 
       - name: Show dependencies
         run: python -m pip list
 
       - name: Run tests
-        run: make PYTESTOPTIONS="--cov --cov-report=xml --timeout=600" test_softdeps_full
+        run: make PYTESTOPTIONS="--cov --cov-report=xml --timeout=600" test_mlflow
 
   test-windows:
     needs: test-nosoftdeps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[all_extras,binder,dev]
+          python -m pip install .[all_extras,binder,dev,mlflow]
       - name: Run example notebooks
         run: build_tools/run_examples.sh
         shell: bash
@@ -81,6 +81,28 @@ jobs:
       - name: Install sktime and dependencies
         run: |
           python -m pip install .[dev]
+
+      - name: Show dependencies
+        run: python -m pip list
+
+      - name: Run tests
+        run: make PYTESTOPTIONS="--cov --cov-report=xml --timeout=600" test_softdeps_full
+
+  test-mlflow:
+    needs: test-nosoftdeps
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install sktime and dependencies
+        run: |
+          python -m pip install .[dev,mlflow]
 
       - name: Show dependencies
         run: python -m pip list

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,13 @@ test_softdeps_full: ## Run all non-suite unit tests without soft dependencies
 	cd ${TEST_DIR}
 	python -m pytest -v --showlocals --durations=20 -k 'not TestAll' $(PYTESTOPTIONS)
 
+test_mlflow: ## Run mlflow integration tests
+	-rm -rf ${TEST_DIR}
+	mkdir -p ${TEST_DIR}
+	cp setup.cfg ${TEST_DIR}
+	cd ${TEST_DIR}
+	python -m pytest -v --showlocals --durations=20 $(PYTESTOPTIONS) --pyargs sktime.utils.tests.test_mlflow_sktime_model_export
+
 tests: test
 
 clean: ## Clean build dist and egg directories left after install

--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -73,27 +73,6 @@ Plotting
     plot_lags
     plot_correlations
 
-MLflow
---------
-
-:mod:`sktime.utils.mlflow_sktime`
-
-.. automodule:: sktime.utils.mlflow_sktime
-    :no-members:
-    :no-inherited-members:
-
-.. currentmodule:: sktime.utils.mlflow_sktime
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: function.rst
-
-    get_default_pip_requirements
-    get_default_conda_env
-    save_model
-    log_model
-    load_model
-
 Estimator Validity Checking
 ---------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ all_extras = [
     "gluonts>=0.9.0",
     "keras-self-attention",
     "matplotlib>=3.3.2",
-    "mlflow",
     "mne",
     "pmdarima>=1.8.0,!=1.8.1,<3.0.0",
     "prophet>=1.1",
@@ -85,10 +84,7 @@ all_extras = [
 
 dev = [
     "backoff",
-    "boto3",
-    "botocore",
     "httpx",
-    "moto",
     "pre-commit",
     "pytest",
     "pytest-cov",
@@ -96,6 +92,13 @@ dev = [
     "pytest-timeout",
     "pytest-xdist",
     "wheel",
+]
+
+mlflow = [
+    "boto3",
+    "botocore",
+    "mlflow",
+    "moto",
 ]
 
 binder = [

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -8,7 +8,6 @@ import sys
 from pathlib import Path
 from unittest import mock
 
-
 import numpy as np
 import pandas as pd
 import pytest

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -8,12 +8,10 @@ import sys
 from pathlib import Path
 from unittest import mock
 
-import boto3
-import moto
+
 import numpy as np
 import pandas as pd
 import pytest
-from botocore.config import Config
 
 from sktime.datasets import load_airline, load_longley
 from sktime.forecasting.arima import AutoARIMA
@@ -21,6 +19,11 @@ from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.utils.multiindex import flatten_multiindex
 from sktime.utils.validation._dependencies import _check_soft_dependencies
+
+if _check_soft_dependencies("mlflow", "boto3", "moto", "botocore" severity="none"):
+    import boto3
+    import moto
+    from botocore.config import Config
 
 if not sys.platform.startswith("linux"):
     pytest.skip("Skipping MLflow tests for Windows and macOS", allow_module_level=True)

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -20,7 +20,7 @@ from sktime.forecasting.naive import NaiveForecaster
 from sktime.utils.multiindex import flatten_multiindex
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-if _check_soft_dependencies("mlflow", "boto3", "moto", "botocore" severity="none"):
+if _check_soft_dependencies("mlflow", "boto3", "moto", "botocore", severity="none"):
     import boto3
     import moto
     from botocore.config import Config


### PR DESCRIPTION
This PR makes two changes:

1. cleans up the dependency set from https://github.com/sktime/sktime/pull/3912 - `mlflow` and AWS dependencies are moved to a separate dependency set `mlflow`.
The CI for `mlflow` is also separated and isolated from the remaining tests, ensuring that the remaining tests, or a user who wants `all_extras` do not need to install a large python env or packages they do not want (e.g., AWS specific ones).

2. removes duplicate API reference from `utils`