### PR TITLE
[BUG] fix default `BaseClusterer._predict_proba` for all mtypes

### DIFF
--- a/sktime/clustering/base.py
+++ b/sktime/clustering/base.py
@@ -203,11 +203,12 @@ class BaseClusterer(BaseEstimator, ABC):
             (i, j)-th entry is predictive probability that i-th instance is of class j
         """
         preds = self._predict(X)
+        n_instances = len(preds)
         n_clusters = self.n_clusters
         if n_clusters is None:
             n_clusters = max(preds) + 1
         dists = np.zeros((X.shape[0], n_clusters))
-        for i in range(X.shape[0]):
+        for i in range(n_instances):
             dists[i, preds[i]] = 1
         return dists
 


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/3984 by using `len(preds)` and not `len(X)` as a proxy for number of instances.

A test covering this by integration is the classifier pipeline in https://github.com/sktime/sktime/pull/3967