### PR TITLE
[BUG] fix `ForecastX` predictions

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -1264,6 +1264,10 @@ class ForecastX(BaseForecaster):
         if X is not None:
             X_pred = X_pred.combine_first(X)
 
+        # order columns so they are in the same order as in X seen
+        X_cols_ordered = [col for col in self._X.columns if col in X_pred.columns]
+        X_pred = X_pred[X_cols_ordered]
+
         return X_pred
 
     def _predict(self, fh=None, X=None):

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -456,13 +456,13 @@ def test_forecastx_logic():
     columns = ["ARMED", "POP"]
 
     # ForecastX
-    pipe = ForecastX(  
+    pipe = ForecastX(
         forecaster_X=VAR(),
         forecaster_y=ARIMA(),
         columns=columns,
     )
-    pipe = pipe.fit(y_train, X=X_train, fh=fh) 
-    # dropping ["ARMED", "POP"] as those are the columns where we expect not to have future values
+    pipe = pipe.fit(y_train, X=X_train, fh=fh)
+    # dropping ["ARMED", "POP"] = columns where we expect not to have future values
     y_pred = pipe.predict(fh=fh, X=X_test.drop(columns=columns))
 
     # comparison case: manual execution

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -443,6 +443,7 @@ def test_subset_getitem():
     reason="skip test if required soft dependency is not available",
 )
 def test_forecastx_logic():
+    """Test that ForecastX logic is as expected, compared to manual execution."""
     from sktime.forecasting.arima import ARIMA
     from sktime.forecasting.base import ForecastingHorizon
     from sktime.forecasting.compose import ForecastX

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -444,7 +444,6 @@ def test_subset_getitem():
 )
 def test_forecastx_logic():
     """Test that ForecastX logic is as expected, compared to manual execution."""
-    from sktime.forecasting.arima import ARIMA
     from sktime.forecasting.base import ForecastingHorizon
     from sktime.forecasting.compose import ForecastX
     from sktime.forecasting.model_selection import temporal_train_test_split
@@ -459,7 +458,7 @@ def test_forecastx_logic():
     # ForecastX
     pipe = ForecastX(
         forecaster_X=VAR(),
-        forecaster_y=ARIMA(),
+        forecaster_y=SARIMAX(),
         columns=columns,
     )
     pipe = pipe.fit(y_train, X=X_train, fh=fh)
@@ -468,7 +467,7 @@ def test_forecastx_logic():
 
     # comparison case: manual execution
     # fit y forecaster
-    arima = ARIMA().fit(y_train, X=X_train)
+    arima = SARIMAX().fit(y_train, X=X_train)
 
     # fit and predict X forecaster
     var = VAR()


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/3986 and includes consistency tests.

The reason for the bug is that columns may end up permuted, and the wrapped forecaster may or may not be able to cope with that. The fix is ensuring that the `X` in predict always has columns in the same order as in `fit`.

Probably, we should ensure that all estimators can deal with permuted columns by coercing in the base class, but that's a separate topic.