### PR TITLE
[ENH] speed up mtype check for `pandas` based mtypes with `pd.PeriodIndex`

### DIFF
--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -245,7 +245,7 @@ def _index_equally_spaced(index):
         return False
 
     # if we arrive at this stage, and the index is PeriodIndex,
-    # we know it must be equally spaced:
+    # we know it must be equally spaced and sorted:
     # it cannot have duplicates, and by the pigeonhole principle, the
     # two necessary conditions we checked are also sufficient
     if isinstance(index, pd.PeriodIndex):

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -245,8 +245,9 @@ def _index_equally_spaced(index):
         return False
 
     # if we arrive at this stage, and the index is PeriodIndex,
-    # we know it must be equally spaced and sorted:
-    # it cannot have duplicates, and by the pigeonhole principle, the
+    # we know it must be equally:
+    # it cannot have duplicates and must be sorted (other conditions for mtype),
+    # therefore, by the pigeonhole principle, the
     # two necessary conditions we checked are also sufficient
     if isinstance(index, pd.PeriodIndex):
         return True

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -245,7 +245,7 @@ def _index_equally_spaced(index):
         return False
 
     # if we arrive at this stage, and the index is PeriodIndex,
-    # we know it must be equally:
+    # we know it must be equally spaced:
     # it cannot have duplicates and must be sorted (other conditions for mtype),
     # therefore, by the pigeonhole principle, the
     # two necessary conditions we checked are also sufficient

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -254,7 +254,7 @@ def _index_equally_spaced(index):
 
     # fallback for all other cases:
     # in general, we need to compute all differences and check explicitly
-    # CAVEAT: this has a comparabily long runtime and memory usage
+    # CAVEAT: this has a comparabily long runtime and high memory usage
     diffs = np.diff(index)
     all_equal = np.all(diffs == diffs[0])
 


### PR DESCRIPTION
This PR fixes #3990; related PR: #3827. FYI @KishManani, @danbartl.

Combining information from @danbartl and @KishManani, I understood where the issue must have been coming from - from a line of `np.diff` on the checked index, in `_index_equally_spaced`, but only in the case of `pd.PeriodIndex` (the latter condition I only understood from @KishManani's analysis).

I have used this insight to replace the time and memory consuming check by a much quicker one, exploiting mathematical assumptions on the `pd.PeriodIndex` (unique and sorted index).

While this PR seems to address the issue, some open questions remain:

* do we want to test this fix, or in general, checks being fast and not memory intensive? If yes, how? Runtimes can vary even on VM.
* is @danbartl's fix in https://github.com/sktime/sktime/pull/3935 redundant or complementary? It seems to address hierarchical and panel types primarily, so I could imagine it either makes no difference, or helps speed up things if the series check is fast.