### PR TITLE
[ENH] extend `Prophet` to allow `pd.PeriodIndex`; [BUG] fix `Prophet` not working with non-integer forecast horizon

### DIFF
--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -136,18 +136,21 @@ class _ProphetAdapter(BaseForecaster):
             fh = fh_date[fh]
         return fh
 
-    def _convert_X_for_exog(self, X):
+    def _convert_X_for_exog(self, X, fh):
         """Conerce index of X to index expected by prophet."""
         if X is None:
             return None
         elif isinstance(X.index, pd.PeriodIndex):
             X = X.copy()
             X.index = X.index.to_timestamp()
+            X = X.loc[self.fh.to_absolute(self.cutoff)]
         elif X.index.is_integer():
             X = X.copy()
             X = X.loc[self.fh.to_absolute(self.cutoff).to_numpy()]
-            X.index = self.fh
+            X.index = fh
         # else X is pd.DateTimeIndex as prophet expects, and needs no conversion
+        else:
+            X = X.loc[fh]
         return X
 
     def _predict(self, fh=None, X=None):
@@ -175,7 +178,7 @@ class _ProphetAdapter(BaseForecaster):
         fh = self._get_prophet_fh()
         df = pd.DataFrame({"ds": fh}, index=fh)
 
-        X = self._convert_X_for_exog(X)
+        X = self._convert_X_for_exog(X, fh)
 
         # Merge X with df (of created future DatetimeIndex values)
         if X is not None:
@@ -240,7 +243,7 @@ class _ProphetAdapter(BaseForecaster):
         """
         fh = self._get_prophet_fh()
 
-        X = self._convert_X_for_exog(X)
+        X = self._convert_X_for_exog(X, fh)
 
         # prepare the return DataFrame - empty with correct cols
         var_names = ["Coverage"]

--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -128,6 +128,8 @@ class _ProphetAdapter(BaseForecaster):
     def _get_prophet_fh(self):
         """Get a prophet compatible fh, in datetime, even if fh was int."""
         fh = self.fh.to_absolute(cutoff=self.cutoff).to_pandas()
+        if isinstance(fh, pd.PeriodIndex):
+            fh = fh.to_timestamp()
         if not isinstance(fh, pd.DatetimeIndex):
             max_int = fh[-1] + 1
             fh_date = pd.date_range(start="2000-01-01", periods=max_int, freq="D")
@@ -138,7 +140,10 @@ class _ProphetAdapter(BaseForecaster):
         """Conerce index of X to index expected by prophet."""
         if X is None:
             return None
-        elif type(X.index) is pd.PeriodIndex or X.index.is_integer():
+        elif isinstance(X.index, pd.PeriodIndex):
+            X = X.copy()
+            X.index = X.index.to_timestamp()
+        elif X.index.is_integer():
             X = X.copy()
             X = X.loc[self.fh.to_absolute(self.cutoff).to_numpy()]
             X.index = self.fh

--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -35,7 +35,7 @@ class _ProphetAdapter(BaseForecaster):
         return y
 
     def _convert_input_to_date(self, y):
-        """Coerce y.index to pd.DateTimeIndex, for use by prophet."""
+        """Coerce y.index to pd.DatetimeIndex, for use by prophet."""
         if y is None:
             return None
         elif type(y.index) is pd.PeriodIndex:
@@ -43,7 +43,7 @@ class _ProphetAdapter(BaseForecaster):
             y.index = y.index.to_timestamp()
         elif y.index.is_integer():
             y = self._convert_int_to_date(y)
-        # else y is pd.DateTimeIndex as prophet expects, and needs no conversion
+        # else y is pd.DatetimeIndex as prophet expects, and needs no conversion
         return y
 
     def _remember_y_input_index_type(self, y):
@@ -142,13 +142,13 @@ class _ProphetAdapter(BaseForecaster):
             return None
         elif isinstance(X.index, pd.PeriodIndex):
             X = X.copy()
+            X = X.loc[self.fh.to_absolute(self.cutoff).to_pandas()]
             X.index = X.index.to_timestamp()
-            X = X.loc[self.fh.to_absolute(self.cutoff)]
         elif X.index.is_integer():
             X = X.copy()
             X = X.loc[self.fh.to_absolute(self.cutoff).to_numpy()]
             X.index = fh
-        # else X is pd.DateTimeIndex as prophet expects, and needs no conversion
+        # else X is pd.DatetimeIndex as prophet expects, and needs no conversion
         else:
             X = X.loc[fh]
         return X

--- a/sktime/forecasting/fbprophet.py
+++ b/sktime/forecasting/fbprophet.py
@@ -23,8 +23,9 @@ class Prophet(_ProphetAdapter):
     Data can be passed in one of the sktime compatible formats,
     naming a column `ds` such as in the prophet package is not necessary.
 
-    Integer indices can also be passed, in which case internally a conversion
-    to days since Jan 1, 2000 is carried out before passing to prophet.
+    Unlike vanilla `prophet`, also supports integer/range and period index:
+    * integer/range index is interpreted as days since Jan 1, 2000
+    * `PeriodIndex` is converted using the `pandas` method `to_timestamp`
 
     Parameters
     ----------

--- a/sktime/forecasting/tests/test_prophet.py
+++ b/sktime/forecasting/tests/test_prophet.py
@@ -37,7 +37,7 @@ def test_prophet_nonnative_index(indextype):
     y_pred = f.predict(fh=fh, X=X_test)
 
     if indextype == "range":
-        assert isinstance(y_pred.index, pd.RangeIndex)
+        assert y_pred.index.is_integer()
     if indextype == "period":
         assert isinstance(y_pred.index, pd.PeriodIndex)
 
@@ -73,7 +73,7 @@ def test_prophet_period_fh(convert_to_datetime):
 
     assert len(y_pred) == len(fh_index)
     if convert_to_datetime:
-        assert isinstance(y_pred, pd.DateTimeIndex)
+        assert isinstance(y_pred, pd.DatetimeIndex)
         assert (y_pred.index == fh_index.to_timestamp()).all()
     else:
         assert isinstance(y_pred, pd.PeriodIndex)

--- a/sktime/forecasting/tests/test_prophet.py
+++ b/sktime/forecasting/tests/test_prophet.py
@@ -60,11 +60,11 @@ def test_prophet_period_fh(convert_to_datetime):
     fh_index = pd.PeriodIndex(pd.date_range("1961-01", periods=36, freq="M"))
     fh = ForecastingHorizon(fh_index, is_relative=False)
 
-    forecaster = Prophet(  
+    forecaster = Prophet(
         seasonality_mode="multiplicative",
         n_changepoints=int(len(y) / 12),
         add_country_holidays={"country_name": "UnitedStates"},
-        yearly_seasonality=True
+        yearly_seasonality=True,
     )
 
     forecaster.fit(y)

--- a/sktime/forecasting/tests/test_prophet.py
+++ b/sktime/forecasting/tests/test_prophet.py
@@ -24,8 +24,8 @@ def test_prophet_nonnative_index(indextype):
     X = pd.DataFrame({"b": [1, 5, 3, 3, 5, 6], "c": [5, 5, 3, 3, 4, 2]})
 
     if indextype == "period":
-        y.index = pd.period_range('2000-01-01', periods=4)
-        X.index = pd.period_range('2000-01-01', periods=6)
+        y.index = pd.period_range("2000-01-01", periods=4)
+        X.index = pd.period_range("2000-01-01", periods=6)
 
     X_train = X.iloc[:4]
     X_test = X.iloc[4:]

--- a/sktime/forecasting/tests/test_prophet.py
+++ b/sktime/forecasting/tests/test_prophet.py
@@ -73,8 +73,8 @@ def test_prophet_period_fh(convert_to_datetime):
 
     assert len(y_pred) == len(fh_index)
     if convert_to_datetime:
-        assert isinstance(y_pred, pd.DatetimeIndex)
+        assert isinstance(y_pred.index, pd.DatetimeIndex)
         assert (y_pred.index == fh_index.to_timestamp()).all()
     else:
-        assert isinstance(y_pred, pd.PeriodIndex)
+        assert isinstance(y_pred.index, pd.PeriodIndex)
         assert (y_pred.index == fh_index).all()

--- a/sktime/forecasting/tests/test_prophet.py
+++ b/sktime/forecasting/tests/test_prophet.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Tests for Prophet.
+
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""
+
+__author__ = ["fkiraly"]
+
+import pandas as pd
+import pytest
+
+from sktime.forecasting.fbprophet import Prophet
+from sktime.utils.validation._dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("prophet", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+@pytest.mark.parametrize("indextype", ["range", "period"])
+def test_prophet_nonnative_index(indextype):
+    """Check prophet with RangeIndex and PeriodIndex."""
+    y = pd.DataFrame({"a": [1, 2, 3, 4]})
+    X = pd.DataFrame({"b": [1, 5, 3, 3, 5, 6], "c": [5, 5, 3, 3, 4, 2]})
+
+    if indextype == "period":
+        y.index = pd.period_range('2000-01-01', periods=4)
+        X.index = pd.period_range('2000-01-01', periods=6)
+
+    X_train = X.iloc[:4]
+    X_test = X.iloc[4:]
+
+    fh = [1, 2]
+
+    f = Prophet()
+    f.fit(y, X=X_train)
+    y_pred = f.predict(fh=fh, X=X_test)
+
+    if indextype == "range":
+        assert isinstance(y_pred.index, pd.RangeIndex)
+    if indextype == "period":
+        assert isinstance(y_pred.index, pd.PeriodIndex)


### PR DESCRIPTION
This PR adds functionality to the `Prophet` interface to also allow `pd.PeriodIndex`. Fixes https://github.com/sktime/sktime/issues/2475 and also fixes https://github.com/sktime/sktime/issues/3537.

Also tests:
* testing `Prophet` functionality for `RangeIndex` and `PeriodIndex` in exogeneous and endogeneous data
* testing failure case in https://github.com/sktime/sktime/issues/3537