### PR TITLE
[DOC] add some missing entries in API reference

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -27,5 +27,6 @@ For a scientific manual, see the :ref:`user_guide`.
     api_reference/annotation
     api_reference/datasets
     api_reference/data_format
+    api_reference/deployment
     api_reference/utils
     api_reference/exceptions

--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -18,6 +18,7 @@ Composition
     ColumnEnsembleClassifier
     ComposableTimeSeriesForestClassifier
     SklearnClassifierPipeline
+    WeightedEnsembleClassifier
 
 Deep learning
 -------------

--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -142,6 +142,7 @@ Kernel-based
     :toctree: auto_generated/
     :template: class.rst
 
+    TimeSeriesSVC
     Arsenal
     RocketClassifier
 

--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -395,6 +395,14 @@ Seasonality and Date-Time Features
 
     DateTimeFeatures
 
+.. currentmodule:: sktime.transformations.series.time_since
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    TimeSince
+
 .. currentmodule:: sktime.transformations.series.fourier
 
 .. autosummary::


### PR DESCRIPTION
adds some missing entries in API reference:

* kernel SVC classifier
* `WeightedEnsembleClassifier` classifier
* link to deployment topical reference
* `TimeSince` transformer