### PR TITLE
[BUG] fix dropped column index in `BaggingForecaster`

### DIFF
--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -320,10 +320,11 @@ class VectorizedDF:
             X_mi_reconstructed = self.X_multiindex
         elif col_ix is None:
             X_mi_reconstructed = pd.concat(df_list, keys=row_ix, axis=0)
+            X_mi_reconstructed.columns = self.X_multiindex.columns
         elif row_ix is None:
             force_flat = _force_flat(df_list)
             if col_multiindex in ["flat", "multiindex"] or force_flat:
-                col_keys = self.X_multiindex.columns
+                col_keys = col_ix
             else:
                 col_keys = None
             X_mi_reconstructed = pd.concat(df_list, axis=1, keys=col_keys)
@@ -335,7 +336,7 @@ class VectorizedDF:
                 ith_col_block = df_list[i * col_n : (i + 1) * col_n]
                 force_flat = force_flat or _force_flat(ith_col_block)
                 if col_multiindex in ["flat", "multiindex"] or force_flat:
-                    col_keys = self.X_multiindex.columns
+                    col_keys = col_ix
                 else:
                     col_keys = None
                 col_concats += [pd.concat(ith_col_block, axis=1, keys=col_keys)]

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -320,7 +320,6 @@ class VectorizedDF:
             X_mi_reconstructed = self.X_multiindex
         elif col_ix is None:
             X_mi_reconstructed = pd.concat(df_list, keys=row_ix, axis=0)
-            X_mi_reconstructed.columns = self.X_multiindex.columns
         elif row_ix is None:
             force_flat = _force_flat(df_list)
             if col_multiindex in ["flat", "multiindex"] or force_flat:

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -225,7 +225,8 @@ class BaggingForecaster(BaseForecaster):
             Point predictions
         """
         y_bootstraps_pred = self.forecaster_.predict(fh=fh, X=None)
-        return y_bootstraps_pred.groupby(level=-1).mean()
+        y_pred = y_bootstraps_pred.groupby(level=-1).mean().iloc[:, 0]
+        return y_pred
 
     def _predict_quantiles(self, fh, X=None, alpha=None):
         """Compute/return prediction quantiles for a forecast.

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -226,6 +226,7 @@ class BaggingForecaster(BaseForecaster):
         """
         y_bootstraps_pred = self.forecaster_.predict(fh=fh, X=None)
         y_pred = y_bootstraps_pred.groupby(level=-1).mean().iloc[:, 0]
+        y_pred.name = None
         return y_pred
 
     def _predict_quantiles(self, fh, X=None, alpha=None):


### PR DESCRIPTION
This PR fixes an unreported bug (discovered by #3969) with `BaggingForecaster` which would drop its column names if `pd.DataFrame` were passed.

The reason was that the internal type was set as `pd.Series`, but it always returned a `pd.DataFrame` (and with inconsistent column name, always the integer zero).
The back-conversion of `BaseForecaster` would get confused and not retrieve the input column names as it would with a returned `pd.Series`.