### PR TITLE
Revert "[ENH] isolating `scipy` imports, part 1"

### DIFF
--- a/sktime/series_as_features/base/estimators/_ensemble.py
+++ b/sktime/series_as_features/base/estimators/_ensemble.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
 from numpy import float64 as DOUBLE
+from scipy.sparse import issparse
 from sklearn.base import clone
 from sklearn.ensemble._base import _set_random_states
 from sklearn.ensemble._forest import (
@@ -142,7 +143,7 @@ class BaseTimeSeriesForest(BaseForest):
         -------
         self : object
         """
-        from scipy.sparse import issparse
+        #        X, y = check_X_y(X, y, enforce_univariate=True)
 
         # Validate or convert input data
         if sample_weight is not None:

--- a/sktime/transformations/panel/channel_selection.py
+++ b/sktime/transformations/panel/channel_selection.py
@@ -14,6 +14,7 @@ import time
 
 import numpy as np
 import pandas as pd
+from scipy.spatial.distance import euclidean
 from sklearn.neighbors import NearestCentroid
 
 from sktime.datatypes import convert
@@ -23,8 +24,6 @@ from sktime.transformations.base import BaseTransformer
 
 def _eu_dist(x, y):
     """Calculate the euclidean distance."""
-    from scipy.spatial.distance import euclidean
-
     return euclidean(x, y)
 
 
@@ -358,7 +357,6 @@ class ElbowClassPairwise(BaseTransformer):
         "skip-inverse-transform": True,  # is inverse-transform skipped when called?
         "capability:unequal_length": False,
         # can the transformer handle unequal length time series (if passed Panel)?
-        "python_dependencies": "scipy",
     }
 
     def __init__(self):

--- a/sktime/transformations/panel/compose.py
+++ b/sktime/transformations/panel/compose.py
@@ -6,6 +6,7 @@ transformations as building blocks.
 """
 import numpy as np
 import pandas as pd
+from scipy import sparse
 from sklearn.compose import ColumnTransformer as _ColumnTransformer
 
 from sktime.transformations.base import BaseTransformer, _PanelToPanelTransformer
@@ -105,8 +106,6 @@ class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
         of the individual transformations and the `sparse_threshold` keyword.
     """
 
-    _tags = {"python_dependencies": "scipy"}
-
     def __init__(
         self,
         transformers,
@@ -137,8 +136,6 @@ class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
         types = set(type(X) for X in Xs)
 
         if self.sparse_output_:
-            from scipy import sparse
-
             return sparse.hstack(Xs).tocsr()
         if self.preserve_dataframe and (pd.Series in types or pd.DataFrame in types):
             vars = [y for x in self.transformers for y in x[2]]

--- a/sktime/transformations/panel/dictionary_based/_sfa_fast.py
+++ b/sktime/transformations/panel/dictionary_based/_sfa_fast.py
@@ -25,6 +25,7 @@ from numba import (
 )
 from numba.core import types
 from numba.typed import Dict
+from scipy.sparse import csr_matrix
 from sklearn.feature_selection import chi2, f_classif
 from sklearn.preprocessing import KBinsDiscretizer
 from sklearn.tree import DecisionTreeClassifier
@@ -148,7 +149,6 @@ class SFAFast(BaseTransformer):
         "X_inner_mtype": "numpy3D",  # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "pd_Series_Table",  # which mtypes does y require?
         "requires_y": True,  # does y need to be passed in fit?
-        "python_dependencies": "scipy",
     }
 
     def __init__(
@@ -324,8 +324,6 @@ class SFAFast(BaseTransformer):
         -------
         List of dictionaries containing SFA words
         """
-        from scipy.sparse import csr_matrix
-
         self.check_is_fitted()
         X = check_X(X, enforce_univariate=True, coerce_to_numpy=True)
         X = X.squeeze(1)
@@ -378,8 +376,6 @@ class SFAFast(BaseTransformer):
 
     def transform_to_bag(self, words, word_len, y=None):
         """Transform words to bag-of-pattern and apply feature selection."""
-        from scipy.sparse import csr_matrix
-
         bag_of_words = None
         rng = check_random_state(self.random_state)
 

--- a/sktime/transformations/panel/interpolate.py
+++ b/sktime/transformations/panel/interpolate.py
@@ -2,6 +2,7 @@
 """Time series interpolator/re-sampler."""
 import numpy as np
 import pandas as pd
+from scipy import interpolate
 
 from sktime.transformations.base import BaseTransformer
 
@@ -33,7 +34,6 @@ class TSInterpolator(BaseTransformer):
         "X_inner_mtype": "nested_univ",  # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for X?
         "fit_is_empty": True,
-        "python_dependencies": "scipy",
     }
 
     def __init__(self, length):
@@ -65,8 +65,6 @@ class TSInterpolator(BaseTransformer):
         -------
         numpy.array : with user defined size
         """
-        from scipy import interpolate
-
         f = interpolate.interp1d(list(np.linspace(0, 1, len(cell))), cell.to_numpy())
         Xt = f(np.linspace(0, 1, self.length))
         return pd.Series(Xt)

--- a/sktime/transformations/series/augmenter.py
+++ b/sktime/transformations/series/augmenter.py
@@ -13,6 +13,7 @@ __all__ = [
 
 import numpy as np
 import pandas as pd
+from scipy.stats import norm
 from sklearn.utils import check_random_state
 
 from sktime.transformations.base import BaseTransformer
@@ -65,8 +66,6 @@ class WhiteNoiseAugmenter(_AugmenterTags, BaseTransformer):
 
     """
 
-    _tags = {"python_dependencies": "scipy"}
-
     _allowed_statistics = [np.std]
 
     def __init__(self, scale=1.0, random_state=42):
@@ -75,8 +74,6 @@ class WhiteNoiseAugmenter(_AugmenterTags, BaseTransformer):
         super().__init__()
 
     def _transform(self, X, y=None):
-        from scipy.stats import norm
-
         if self.scale in self._allowed_statistics:
             scale = self.scale(X)
         elif isinstance(self.scale, (int, float)):

--- a/sktime/transformations/series/clear_sky.py
+++ b/sktime/transformations/series/clear_sky.py
@@ -7,6 +7,7 @@ __author__ = ["ciaran-g"]
 import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
+from scipy.stats import vonmises
 
 from sktime.transformations.base import BaseTransformer
 
@@ -98,7 +99,7 @@ class ClearSky(BaseTransformer):
         "handles-missing-data": False,
         "capability:missing_values:removes": True,
         "python_version": None,  # PEP 440 python version specifier to limit versions
-        "python_dependencies": ["statsmodels", "scipy"],
+        "python_dependencies": "statsmodels",
     }
 
     def __init__(
@@ -304,7 +305,6 @@ def _clearskypower(y, q, tod_i, doy_i, tod_vec, doy_vec, bw_tod, bw_doy):
     csp : float
         The clear sky power at tod_i and doy_i
     """
-    from scipy.stats import vonmises
     from statsmodels.stats.weightstats import DescrStatsW
 
     wts_tod = vonmises.pdf(

--- a/sktime/transformations/series/dobin.py
+++ b/sktime/transformations/series/dobin.py
@@ -7,6 +7,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
+from scipy.linalg import null_space
 from sklearn.decomposition import PCA
 from sklearn.neighbors import NearestNeighbors
 
@@ -82,7 +83,6 @@ class DOBIN(BaseTransformer):
         "X_inner_mtype": "pd.DataFrame",
         "fit_is_empty": False,
         "skip-inverse-transform": True,
-        "python_dependencies": "scipy",
     }
 
     def __init__(
@@ -110,8 +110,6 @@ class DOBIN(BaseTransformer):
         -------
         self: reference to self
         """
-        from scipy.linalg import null_space
-
         self._X = X
 
         assert all(X.apply(is_numeric_dtype, axis=0))

--- a/sktime/transformations/series/tests/test_boxcox.py
+++ b/sktime/transformations/series/tests/test_boxcox.py
@@ -7,20 +7,13 @@ __all__ = []
 
 import numpy as np
 import pytest
+from scipy.stats import boxcox
 
 from sktime.datasets import load_airline
 from sktime.transformations.series.boxcox import BoxCoxTransformer
-from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 
-@pytest.mark.skipif(
-    not _check_soft_dependencies("scipy", severity="none"),
-    reason="skip test if required soft dependencies not available",
-)
 def test_boxcox_against_scipy():
-    """Test boxcox transformer vs the scipy boxvox function."""
-    from scipy.stats import boxcox
-
     y = load_airline()
 
     t = BoxCoxTransformer()

--- a/sktime/transformations/series/tests/test_sklearn_adaptor.py
+++ b/sktime/transformations/series/tests/test_sklearn_adaptor.py
@@ -5,22 +5,15 @@
 __author__ = ["mloning"]
 
 import numpy as np
-import pytest
+from scipy.stats import boxcox
 from sklearn.preprocessing import PowerTransformer
 
 from sktime.datasets import load_airline
 from sktime.transformations.series.adapt import TabularToSeriesAdaptor
-from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 
-@pytest.mark.skipif(
-    not _check_soft_dependencies("scipy", severity="none"),
-    reason="skip test if required soft dependencies not available",
-)
 def test_boxcox_transform():
     """Test whether adaptor based transformer behaves like the raw wrapped method."""
-    from scipy.stats import boxcox
-
     y = load_airline()
     t = TabularToSeriesAdaptor(PowerTransformer(method="box-cox", standardize=False))
     actual = t.fit_transform(y)


### PR DESCRIPTION
For reference: I did vote this down on 8th of December.

<img width="589" alt="image" src="https://user-images.githubusercontent.com/7783034/209704960-7b45338a-e3bb-4f96-92d2-dca3e0008b28.png">

And you confirmed that my vote is unaffected:
<img width="447" alt="image" src="https://user-images.githubusercontent.com/7783034/209705010-b6a06ad7-8107-4d88-878a-be620fc89b33.png">
