### PR TITLE
[ENH] Enable `TimeSince` trafo to transform multiindex dataframes directly

### DIFF
--- a/sktime/transformations/series/tests/test_time_since.py
+++ b/sktime/transformations/series/tests/test_time_since.py
@@ -29,6 +29,15 @@ def df_datetime_15mins_idx():
 
 
 @pytest.fixture
+def df_datetime_weekly_wed_idx():
+    """Create timeseries with Datetime index, weekly with Wed start frequency."""
+    return pd.DataFrame(
+        data={"y": [1, 1, 1, 1, 1]},
+        index=pd.date_range(start="2000-01-05", freq="W-WED", periods=5),
+    )
+
+
+@pytest.fixture
 def df_datetime_monthly_idx():
     """Create timeseries with Datetime index, month start frequency."""
     return pd.DataFrame(
@@ -77,6 +86,23 @@ def test_fit_transform_datetime_15mins_idx_numeric_output(df_datetime_15mins_idx
     expected = pd.DataFrame(
         data={"time_since_2000-01-01 00:00:00": [0, 15, 30, 45, 60]},
         index=df_datetime_15mins_idx.index,
+    )
+    assert_frame_equal(Xt, expected)
+
+
+def test_fit_transform_datetime_weekly_wed_idx_numeric_output(
+    df_datetime_weekly_wed_idx,
+):
+    """Tests that we get the expected outputs."""
+    transformer = TimeSince(
+        start=None, to_numeric=True, keep_original_columns=False, positive_only=False
+    )
+
+    Xt = transformer.fit_transform(df_datetime_weekly_wed_idx)
+
+    expected = pd.DataFrame(
+        data={"time_since_2000-01-05 00:00:00": [0, 1, 2, 3, 4]},
+        index=df_datetime_weekly_wed_idx.index,
     )
     assert_frame_equal(Xt, expected)
 

--- a/sktime/transformations/series/time_since.py
+++ b/sktime/transformations/series/time_since.py
@@ -11,6 +11,7 @@ from string import digits
 
 import numpy as np
 import pandas as pd
+from pandas.tseries.frequencies import get_period_alias
 
 from sktime.transformations.base import BaseTransformer
 
@@ -75,7 +76,7 @@ class TimeSince(BaseTransformer):
         "scitype:transform-output": "Series",
         "scitype:instancewise": True,  # is this an instance-wise transform?
         "scitype:transform-labels": "None",
-        "X_inner_mtype": "pd.DataFrame",
+        "X_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         "y_inner_mtype": "None",
         "univariate-only": False,
         "requires_y": False,
@@ -125,18 +126,23 @@ class TimeSince(BaseTransformer):
         -------
         self: reference to self
         """
-        if X.index.is_numeric():
+        if isinstance(X.index, pd.MultiIndex):
+            time_index = X.index.get_level_values(-1)
+        else:
+            time_index = X.index
+
+        if time_index.is_numeric():
             if self.freq:
                 warnings.warn("Index is integer type. `freq` will be ignored.")
             self.freq_ = None
-        elif isinstance(X.index, (pd.DatetimeIndex, pd.PeriodIndex)):
+        elif isinstance(time_index, (pd.DatetimeIndex, pd.PeriodIndex)):
             # Chooses first non None value
-            self.freq_ = X.index.freq or self.freq or pd.infer_freq(X.index)
+            self.freq_ = time_index.freqstr or self.freq or pd.infer_freq(time_index)
             if self.freq_ is None:
                 raise ValueError("X has no known frequency and none is supplied")
-            if self.freq_ == X.index.freq and self.freq_ != self.freq and self.freq:
+            if self.freq_ == time_index.freqstr and self.freq_ != self.freq:
                 warnings.warn(
-                    f"Using frequency from index: {X.index.freq}, which "
+                    f"Using frequency from index: {time_index.freq}, which "
                     f"does not match the frequency given: {self.freq}."
                 )
         else:
@@ -144,13 +150,13 @@ class TimeSince(BaseTransformer):
 
         self.start_ = []
         if self.start is None:
-            self.start_.append(X.index.min())
+            self.start_.append(time_index.min())
         else:
             for start in self.start:
                 if start is None:
-                    self.start_.append(X.index.min())
+                    self.start_.append(time_index.min())
                 elif isinstance(start, str):
-                    if isinstance(X.index, pd.PeriodIndex):
+                    if isinstance(time_index, pd.PeriodIndex):
                         self.start_.append(pd.Period(start))
                     else:
                         self.start_.append(pd.to_datetime(start))
@@ -159,7 +165,7 @@ class TimeSince(BaseTransformer):
 
         # Check `start_` is compatible with index
         for start_ in self.start_:
-            if isinstance(X.index, pd.DatetimeIndex) and not isinstance(
+            if isinstance(time_index, pd.DatetimeIndex) and not isinstance(
                 start_, datetime.datetime
             ):
                 raise ValueError(
@@ -167,7 +173,7 @@ class TimeSince(BaseTransformer):
                     f"datetime index. Check that `start` is of type "
                     f"datetime or a pd.Datetime parsable string."
                 )
-            elif isinstance(X.index, pd.PeriodIndex) and not isinstance(
+            elif isinstance(time_index, pd.PeriodIndex) and not isinstance(
                 start_, pd.Period
             ):
                 raise ValueError(
@@ -200,62 +206,65 @@ class TimeSince(BaseTransformer):
         -------
         transformed version of X
         """
-        X = X.copy()
-        col_names = []
+        if isinstance(X.index, pd.MultiIndex):
+            time_index = X.index.get_level_values(-1)
+        else:
+            time_index = X.index
+
+        Xt = pd.DataFrame(index=X.index)
         for start_ in self.start_:
             if self.to_numeric:
-                if isinstance(X.index, pd.DatetimeIndex):
-                    #  To support calculating integer time differences when `freq`
-                    #  is not compatible with timedelta type (e.g., "M", "MS", "Y")
-                    #  X.index and `start` are first converted to pandas Period
+                if isinstance(time_index, pd.DatetimeIndex):
+                    # To support calculating integer time differences when `freq`
+                    # is not compatible with timedelta type (e.g., "M", "MS", "Y")
+                    # X.index and `start` are first converted to pandas Period.
 
-                    # Infer the freq needed to convert to period
-                    if X.index.freq is None:
-                        freq_period = X.asfreq(self.freq_).index.to_period().freqstr
-                    else:
-                        freq_period = X.index.to_period().freqstr
+                    # Infer the freq needed to convert to period. We use the
+                    # `get_period_alas` helper method from Pandas. This method
+                    # maps from a frequency that is compatible with a datetime
+                    # index to one that is compatible with a period index
+                    # (e.g., "MS" -> "M"). We must strip the freq str of any
+                    # integer multiplier (e.g., "15T" -> "T"). This is needed so that
+                    # `get_period_alias` returns the correct result.
+                    # If `get_period_alias` recieves a freq str with a multiplier
+                    # (e.g., "15T") it returns `None` which causes errors downstream.
+                    freq_ = _remove_digits_from_str(self.freq_)
+                    freq_period = get_period_alias(freq_)
 
-                    if pd.__version__ < "1.5.0":
-                        # Earlier versions of pandas returned incorrect result
-                        # when taking a difference between Periods when the frequency
-                        # is a multiple of a unit (e.g. "15T"). Solution is to
-                        # cast to lowest frequency when taking difference (e.g., "T").
-                        freq_period = _remove_digits_from_str(freq_period)
-
-                    # Convert `start` and datetime index to period
+                    # Convert `start` and datetime index to period.
                     start_period = pd.Period(start_, freq=freq_period)
-                    X_idx_period = X.index.to_period(freq_period)
-                    time_deltas_period = X_idx_period - start_period
+                    time_index_period = time_index.to_period(freq=freq_period)
+                    # Compute time differences and convert to integers.
+                    time_deltas_period = time_index_period - start_period
                     time_deltas = _period_to_int(time_deltas_period)
-                elif isinstance(X.index, pd.PeriodIndex):
+                elif isinstance(time_index, pd.PeriodIndex):
                     if pd.__version__ < "1.5.0":
                         # Earlier versions of pandas returned incorrect result
                         # when taking a difference between Periods when the frequency
                         # is a multiple of a unit (e.g. "15T"). Solution is to
                         # cast to lowest frequency when taking difference (e.g., "T").
-                        freq_ = _remove_digits_from_str(X.index.freqstr)
-                        time_deltas_period = X.index.to_timestamp().to_period(
+                        freq_ = _remove_digits_from_str(time_index.freqstr)
+                        time_deltas_period = time_index.to_timestamp().to_period(
                             freq_
                         ) - start_.to_timestamp().to_period(freq_)
                     else:
-                        time_deltas_period = X.index - start_
+                        time_deltas_period = time_index - start_
                     time_deltas = _period_to_int(time_deltas_period)
                 elif X.index.is_numeric():
-                    time_deltas = X.index - start_
+                    time_deltas = time_index - start_
             else:
-                time_deltas = X.index - start_
+                time_deltas = time_index - start_
 
             col_name = f"time_since_{start_}"
-            X[col_name] = time_deltas
-            col_names.append(col_name)
+            Xt[col_name] = time_deltas
 
         if self.to_numeric and self.positive_only:
-            X.loc[:, col_names] = X.loc[:, col_names].clip(lower=0)
+            Xt = Xt.clip(lower=0)
 
-        if self.keep_original_columns is False:
-            X = X[col_names]
+        if self.keep_original_columns:
+            Xt = pd.concat([X, Xt], axis=1, copy=True)
 
-        return X
+        return Xt
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/transformations/series/time_since.py
+++ b/sktime/transformations/series/time_since.py
@@ -137,7 +137,11 @@ class TimeSince(BaseTransformer):
             self.freq_ = time_index.freqstr or self.freq or pd.infer_freq(time_index)
             if self.freq_ is None:
                 raise ValueError("X has no known frequency and none is supplied")
-            if self.freq_ == time_index.freqstr and self.freq_ != self.freq:
+            if (
+                (self.freq_ == time_index.freqstr)
+                and (self.freq_ != self.freq)
+                and (self.freq)
+            ):
                 warnings.warn(
                     f"Using frequency from index: {time_index.freq}, which "
                     f"does not match the frequency given: {self.freq}."

--- a/sktime/transformations/series/time_since.py
+++ b/sktime/transformations/series/time_since.py
@@ -126,10 +126,7 @@ class TimeSince(BaseTransformer):
         -------
         self: reference to self
         """
-        if isinstance(X.index, pd.MultiIndex):
-            time_index = X.index.get_level_values(-1)
-        else:
-            time_index = X.index
+        time_index = _get_time_index(X)
 
         if time_index.is_numeric():
             if self.freq:
@@ -206,10 +203,7 @@ class TimeSince(BaseTransformer):
         -------
         transformed version of X
         """
-        if isinstance(X.index, pd.MultiIndex):
-            time_index = X.index.get_level_values(-1)
-        else:
-            time_index = X.index
+        time_index = _get_time_index(X)
 
         Xt = pd.DataFrame(index=X.index)
         for start_ in self.start_:
@@ -301,3 +295,12 @@ def _period_to_int(x: pd.PeriodIndex | list[pd.offsets.DateOffset]) -> int:
 
 def _remove_digits_from_str(x: str) -> str:
     return x.translate({ord(k): None for k in digits})
+
+
+def _get_time_index(X: pd.DataFrame) -> pd.PeriodIndex | pd.DatetimeIndex:
+    """Get time index from single and multi-index dataframes."""
+    if isinstance(X.index, pd.MultiIndex):
+        time_index = X.index.get_level_values(-1)
+    else:
+        time_index = X.index
+    return time_index


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR:
1.  allows the `TimeSince` transformer to operate directly on the time index of multi-index dataframes. This should give a performance boost when working with panel and hierarchical data.
2. simplifies the logic in `transform` and removes an unnecessary resampling of the dataframe when the index is of type `DateTimeIndex`. 
3. removes unnecessary copying of `X` unless `keep_original_columns=True`, in which case a copy of `X` is made so that we can return the original columns.

#### What should a reviewer concentrate their feedback on?
The use of `get_period_alias` to make it easier to convert from a datetime index to a period index.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

<!--
Thanks for contributing!
-->
