### PR TITLE
[ENH] Add `keep_original_columns` option to `FourierFeatures` trafo

### DIFF
--- a/sktime/transformations/series/fourier.py
+++ b/sktime/transformations/series/fourier.py
@@ -6,7 +6,7 @@ __author__ = ["ltsaprounis"]
 
 import warnings
 from distutils.log import warn
-from typing import List, Union
+from typing import List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -113,8 +113,8 @@ class FourierFeatures(BaseTransformer):
         self,
         sp_list: List[Union[int, float]],
         fourier_terms_list: List[int],
-        freq=None,
-        keep_original_columns=False,
+        freq: Optional[str] = None,
+        keep_original_columns: Optional[bool] = True,
     ):
         self.sp_list = sp_list
         self.fourier_terms_list = fourier_terms_list

--- a/sktime/transformations/series/fourier.py
+++ b/sktime/transformations/series/fourier.py
@@ -5,7 +5,6 @@
 __author__ = ["ltsaprounis"]
 
 import warnings
-from copy import deepcopy
 from distutils.log import warn
 from typing import List, Union
 
@@ -15,6 +14,8 @@ import pandas as pd
 from sktime.transformations.base import BaseTransformer
 
 
+# TODO: Change the default value of `keep_original_columns` from True to False
+# and remove the warning in v0.17.0
 class FourierFeatures(BaseTransformer):
     r"""Fourier Features for time series seasonality.
 
@@ -51,6 +52,8 @@ class FourierFeatures(BaseTransformer):
         Specifies the frequency of the index of your data. The string should
         match a pandas offset alias:
         https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
+    keep_original_columns :  boolean, optional, default=True
+        Keep original columns in X passed to `.transform()`
 
     References
     ----------
@@ -107,11 +110,24 @@ class FourierFeatures(BaseTransformer):
     }
 
     def __init__(
-        self, sp_list: List[Union[int, float]], fourier_terms_list: List[int], freq=None
+        self,
+        sp_list: List[Union[int, float]],
+        fourier_terms_list: List[int],
+        freq=None,
+        keep_original_columns=False,
     ):
         self.sp_list = sp_list
         self.fourier_terms_list = fourier_terms_list
         self.freq = freq
+        self.keep_original_columns = keep_original_columns
+
+        warnings.warn(
+            "Currently the default value of `keep_original_columns\n"
+            " is `True`. In future releases this will be changed \n"
+            " to `False`. To keep the current behaviour explicitly \n"
+            " set `keep_original_columns=True`.",
+            FutureWarning,
+        )
 
         if len(self.sp_list) != len(self.fourier_terms_list):
             raise ValueError(
@@ -166,23 +182,23 @@ class FourierFeatures(BaseTransformer):
                         "exists from other seasonal period, fourier term pairs."
                     )
 
-        X = deepcopy(X)
+        time_index = X.index
 
-        if isinstance(X.index, pd.DatetimeIndex):
+        if isinstance(time_index, pd.DatetimeIndex):
             # Chooses first non None value
-            self.freq_ = X.index.freq or self.freq or pd.infer_freq(X.index)
+            self.freq_ = time_index.freq or self.freq or pd.infer_freq(time_index)
             if self.freq_ is None:
                 ValueError("X has no known frequency and none is supplied")
-            if self.freq_ == X.index.freq and self.freq_ != self.freq:
+            if self.freq_ == time_index.freq and self.freq_ != self.freq:
                 warn(
-                    f"Using frequency from index: {X.index.freq}, which \
+                    f"Using frequency from index: {time_index.freq}, which \
                      does not match the frequency given:{self.freq}."
                 )
-            X.index = X.index.to_period(self.freq_)
+            time_index = time_index.to_period(self.freq_)
         # this is used to make sure that time t is calculated with reference to
         # the data passed on fit
         # store the integer form of the minimum date in the prediod index
-        self.min_t_ = np.min(X.index.astype(int))
+        self.min_t_ = np.min(time_index.astype(int))
 
         return self
 
@@ -203,13 +219,14 @@ class FourierFeatures(BaseTransformer):
         -------
         transformed version of X
         """
-        X_transformed = deepcopy(X)
+        X_transformed = pd.DataFrame(index=X.index)
+        time_index = X.index
 
-        if isinstance(X.index, pd.DatetimeIndex):
-            X_transformed.index = X_transformed.index.to_period(self.freq_)
+        if isinstance(time_index, pd.DatetimeIndex):
+            time_index = time_index.to_period(self.freq_)
 
         # get the integer form of the PeriodIndex
-        int_index = X_transformed.index.astype(int) - self.min_t_
+        int_index = time_index.astype(int) - self.min_t_
 
         for sp_k in self.sp_k_pairs_list_:
             sp = sp_k[0]
@@ -218,8 +235,9 @@ class FourierFeatures(BaseTransformer):
             X_transformed[f"sin_{sp}_{k}"] = np.sin(int_index * 2 * k * np.pi / sp)
             X_transformed[f"cos_{sp}_{k}"] = np.cos(int_index * 2 * k * np.pi / sp)
 
-        # Ensure transformed X has same index
-        X_transformed.index = deepcopy(X.index)
+        if self.keep_original_columns:
+            X_transformed = pd.concat([X, X_transformed], axis=1, copy=True)
+
         return X_transformed
 
     @classmethod

--- a/sktime/transformations/series/tests/test_fourier.py
+++ b/sktime/transformations/series/tests/test_fourier.py
@@ -54,11 +54,27 @@ def test_fourier_redundant_terms_dropped():
 def test_fit_transform_outputs():
     """Tests that we get the expected outputs."""
     y = Y.iloc[:3]
-    y_transformed = FourierFeatures(sp_list=[12], fourier_terms_list=[2]).fit_transform(
-        y
-    )
+    y_transformed = FourierFeatures(
+        sp_list=[12], fourier_terms_list=[2], keep_original_columns=True
+    ).fit_transform(y)
     expected = (
         y.to_frame()
+        .assign(sin_12_1=[np.sin(2 * np.pi * i / 12) for i in range(3)])
+        .assign(cos_12_1=[np.cos(2 * np.pi * i / 12) for i in range(3)])
+        .assign(sin_12_2=[np.sin(4 * np.pi * i / 12) for i in range(3)])
+        .assign(cos_12_2=[np.cos(4 * np.pi * i / 12) for i in range(3)])
+    )
+    assert_frame_equal(y_transformed, expected)
+
+
+def test_fit_transform_keep_original_columns_false():
+    """Tests that we get the expected outputs when `keep_original_columns` is False."""
+    y = Y.iloc[:3]
+    y_transformed = FourierFeatures(
+        sp_list=[12], fourier_terms_list=[2], keep_original_columns=False
+    ).fit_transform(y)
+    expected = (
+        pd.DataFrame(index=y.index)
         .assign(sin_12_1=[np.sin(2 * np.pi * i / 12) for i in range(3)])
         .assign(cos_12_1=[np.cos(2 * np.pi * i / 12) for i in range(3)])
         .assign(sin_12_2=[np.sin(4 * np.pi * i / 12) for i in range(3)])
@@ -70,9 +86,9 @@ def test_fit_transform_outputs():
 def test_fit_transform_datetime_outputs():
     """Tests that we get expected outputs when the input has a pd.DatetimeIndex."""
     y = Y_datetime.iloc[:3]
-    y_transformed = FourierFeatures(sp_list=[12], fourier_terms_list=[2]).fit_transform(
-        y
-    )
+    y_transformed = FourierFeatures(
+        sp_list=[12], fourier_terms_list=[2], keep_original_columns=True
+    ).fit_transform(y)
     expected = (
         y.to_frame()
         .assign(sin_12_1=[np.sin(2 * np.pi * i / 12) for i in range(3)])
@@ -86,7 +102,9 @@ def test_fit_transform_datetime_outputs():
 
 def test_fit_transform_behaviour():
     """Tests that the transform method evaluates time steps passed based on X in fit."""
-    transformer = FourierFeatures(sp_list=[12], fourier_terms_list=[2])
+    transformer = FourierFeatures(
+        sp_list=[12], fourier_terms_list=[2], keep_original_columns=True
+    )
     # fit_transform on one part of the dataset
     y_tr_1 = transformer.fit_transform(Y.iloc[:100])
     # transform the rest


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
See discussion here: https://github.com/sktime/sktime/pull/3996#issuecomment-1364733772

#### What does this implement/fix? Explain your changes.
This PR makes the following changes:

1. Adds a `keep_original_columns` option and sets the default to `True` with a deprecation warning that in the future this should be set to `False`. This will make it easier to use `FourierFeatures` in the context of a pipeline (or FeatureUnion) where we do not wish to passthrough the other columns of `X`. 
2. Adds tests and modifies the existing tests now that the class can take a `keep_original_columns` as an argument. 
3. Removes the use of deep copies of `X` to make this more memory efficient. 

#### What should a reviewer concentrate their feedback on?
- Are there any concerns about removing the deep copies of `X` here? @ltsaprounis - would be great to hear your thoughts!

#### Any other comments?
For additional context around the impact of removing copies of `X` see the discussion here: https://github.com/sktime/sktime/pull/3996#issuecomment-1366607145. 

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [X] I've added unit tests and made sure they pass locally.
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

<!--
Thanks for contributing!
-->
