### PR TITLE
[DOC][BUG] Add warning regarding issues with macOS ARM

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1937,6 +1937,16 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "dainelli98",
+      "name": "Daniel Martín Martínez",
+      "avatar_url": "https://avatars.githubusercontent.com/dainelli98",
+      "profile": "https://www.linkedin.com/in/daniel-martin-martinez",
+      "contributions": [
+        "doc",
+        "bug"
+      ]
     }
   ]
 }

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -171,7 +171,7 @@ In the ``anaconda prompt`` terminal:
 2. Create new environment with python 3.8: :code:`conda create -n sktime-dev python=3.8`
 
    .. warning::
-       If you already have an environment called "sktime-dev" from a previous attempt you will first need to remove this
+       If you already have an environment called "sktime-dev" from a previous attempt you will first need to remove this.
 
 3. Activate the environment: :code:`conda activate sktime-dev`
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -37,6 +37,10 @@ To install ``sktime`` with maximum dependencies, including soft dependencies, in
 
     pip install sktime[all_extras]
 
+.. warning::
+    Some of the dependencies included in ``all_extras`` do not work on mac ARM-based processors, such
+    as M1, M1Pro, M1Max or M1Ultra. This may cause an error during installation.
+
 
 Installing sktime from conda
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3994.

#### What does this implement/fix? Explain your changes.

This PR adds a warning for macOS users using ARM macs of the issues that they may encounter when installing ``all_extras``, related to some dependencies not compatible with that kind of setup.

#### Does your contribution introduce a new dependency? If yes, which one?

This contribution does not add any new dependency.

#### What should a reviewer concentrate their feedback on?

Check if the warning is enough, or it would be appropriate to add a link to a separate new article in the documentation explaining in more detail the issue, listing the dependencies that cause the error, in case the user wants to install all the other dependencies in ``all_extras`` that do not generate any errors.

#### PR checklist

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.
