### PR TITLE
[DOC][BUG] Add warning regarding issues with macOS ARM

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1937,6 +1937,16 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "dainelli98",
+      "name": "Daniel Martín Martínez",
+      "avatar_url": "https://avatars.githubusercontent.com/dainelli98",
+      "profile": "https://www.linkedin.com/in/daniel-martin-martinez",
+      "contributions": [
+        "doc",
+        "bug"
+      ]
     }
   ]
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,6 +42,7 @@ if ON_READTHEDOCS:
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx.ext.autosectionlabel",
     "numpydoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.linkcode",  # link to GitHub source code via linkcode_resolve()

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -39,7 +39,8 @@ To install ``sktime`` with maximum dependencies, including soft dependencies, in
 
 .. warning::
     Some of the dependencies included in ``all_extras`` do not work on mac ARM-based processors, such
-    as M1, M1Pro, M1Max or M1Ultra. This may cause an error during installation.
+    as M1, M1Pro, M1Max or M1Ultra. This may cause an error during installation. Mode details can be found
+    in troubleshooting section below.
 
 
 Installing sktime from conda
@@ -217,6 +218,24 @@ Import errors are often caused by an improperly linked virtual environment.  Mak
 your environment is activated and linked to whatever IDE you are using.  If you are using Jupyter
 Notebooks, follow `these instructions <https://janakiev.com/blog/jupyter-virtual-envs/>`_ for
 adding your virtual environment as a new kernel for your notebook.
+
+Dependency error on mac ARM
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you are using a mac with an ARM processor, you may encounter an error when installing
+``sktime[all_extras]``.  This is due to the fact that some libraries included in ``all_extras``
+are not prepared to run in ARM-based processors.
+
+If you want to still install all the remaining compatible libraries from ``all_extras`` you need
+to take into account the following:
+
+* Avoid the following packages:
+    * esig
+    * prophet
+    * tsfresh
+    * tslearn
+* Replace tensorflow package with the following packages:
+    * tensorflow-macos
+    * tensorflow-metal (optional)
 
 Other Startup Resources
 -----------------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -171,7 +171,7 @@ In the ``anaconda prompt`` terminal:
 2. Create new environment with python 3.8: :code:`conda create -n sktime-dev python=3.8`
 
    .. warning::
-       If you already have an environment called "sktime-dev" from a previous attempt you will first need to remove this
+       If you already have an environment called "sktime-dev" from a previous attempt you will first need to remove this.
 
 3. Activate the environment: :code:`conda activate sktime-dev`
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -229,13 +229,13 @@ If you want to still install all the remaining compatible libraries from ``all_e
 to take into account the following:
 
 * Avoid the following packages:
-    * esig
-    * prophet
-    * tsfresh
-    * tslearn
-* Replace tensorflow package with the following packages:
-    * tensorflow-macos
-    * tensorflow-metal (optional)
+    * ``esig``
+    * ``prophet``
+    * ``tsfresh``
+    * ``tslearn``
+* Replace ``tensorflow`` package with the following packages:
+    * ``tensorflow-macos``
+    * ``tensorflow-metal`` (optional)
 
 Other Startup Resources
 -----------------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -39,8 +39,8 @@ To install ``sktime`` with maximum dependencies, including soft dependencies, in
 
 .. warning::
     Some of the dependencies included in ``all_extras`` do not work on mac ARM-based processors, such
-    as M1, M1Pro, M1Max or M1Ultra. This may cause an error during installation. Mode details can be found
-    in troubleshooting section below.
+    as M1, M2, M1Pro, M1Max or M1Ultra. This may cause an error during installation. Mode details can
+    be found in the :ref:`troubleshooting section<Dependency error on mac ARM>` below.
 
 
 Installing sktime from conda

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -37,6 +37,10 @@ To install ``sktime`` with maximum dependencies, including soft dependencies, in
 
     pip install sktime[all_extras]
 
+.. warning::
+    Some of the dependencies included in ``all_extras`` do not work on mac ARM-based processors, such
+    as M1, M1Pro, M1Max or M1Ultra. This may cause an error during installation.
+
 
 Installing sktime from conda
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -237,6 +237,10 @@ replacements for others:
     * ``tensorflow-macos``
     * ``tensorflow-metal`` (optional)
 
+Also, ARM-based processors have issues when installing packages distributed as source distributions
+instead of Python wheels. To avoid this issue when installing a package you can try installing it
+though conda or use a prior version of the package that was distributed as a wheel.
+
 Other Startup Resources
 -----------------------
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -219,16 +219,16 @@ your environment is activated and linked to whatever IDE you are using.  If you 
 Notebooks, follow `these instructions <https://janakiev.com/blog/jupyter-virtual-envs/>`_ for
 adding your virtual environment as a new kernel for your notebook.
 
-Dependency error on mac ARM
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Installing ``all_extras`` on mac with ARM processor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If you are using a mac with an ARM processor, you may encounter an error when installing
 ``sktime[all_extras]``.  This is due to the fact that some libraries included in ``all_extras``
-are not prepared to run in ARM-based processors.
+are not compatible with ARM-based processors.
 
-If you want to still install all the remaining compatible libraries from ``all_extras`` you need
-to take into account the following:
+The workaround is not to install some of the packages in ``all_extras`` and install ARM compatible
+replacements for others:
 
-* Avoid the following packages:
+* Do not install the following packages:
     * ``esig``
     * ``prophet``
     * ``tsfresh``

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -239,7 +239,7 @@ replacements for others:
 
 Also, ARM-based processors have issues when installing packages distributed as source distributions
 instead of Python wheels. To avoid this issue when installing a package you can try installing it
-though conda or use a prior version of the package that was distributed as a wheel.
+through conda or use a prior version of the package that was distributed as a wheel.
 
 Other Startup Resources
 -----------------------


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3994.

#### What does this implement/fix? Explain your changes.

This PR adds a warning for macOS users using ARM macs of the issues that they may encounter when installing ``all_extras``, related to some dependencies not compatible with that kind of setup.

#### Does your contribution introduce a new dependency? If yes, which one?

This contribution does not add any new dependency.

#### What should a reviewer concentrate their feedback on?

Check if the warning is enough, or it would be appropriate to add a link to a separate new article in the documentation explaining in more detail the issue, listing the dependencies that cause the error, in case the user wants to install all the other dependencies in ``all_extras`` that do not generate any errors.

#### PR checklist

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.