### PR TITLE
[ENH] Improve error messages in `test_estimator_tags` test

### DIFF
--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -773,12 +773,19 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         assert all(isinstance(key, str) for key in all_tags.keys())
         if hasattr(Estimator, "_tags"):
             tags = Estimator._tags
-            msg = f"_tags must be a dict, but found {type(tags)}"
+            msg = (
+                f"_tags attribute of {estimator_class} must be dict, "
+                f"but found {type(tags)}"
+            )
             assert isinstance(tags, dict), msg
-            assert len(tags) > 0, "_tags is empty"
-            assert all(
-                tag in VALID_ESTIMATOR_TAGS for tag in tags.keys()
-            ), "Some tags in _tags are invalid"
+            assert len(tags) > 0, f"_tags dict of class {estimator_class} is empty"
+            invalid_tags = [
+                tag for tag in tags.keys() if tag not in VALID_ESTIMATOR_TAGS
+            ]
+            assert len(invalid_tags) == 0, (
+                f"_tags of {estimator_class} contains invalid tags: {invalid_tags}. "
+                "For a list of valid tags, see registry.all_tags, or registry._tags. "
+            )
 
         # Avoid ambiguous class attributes
         ambiguous_attrs = ("tags", "tags_")


### PR DESCRIPTION
This PR improves error messages in the `test_estimator_tags` interface contract test, adding the source class and specific reasons for failures.