### PR TITLE
[BUG] Fix `TimeSince` check of inconsistency between `time_index` and `start`

### DIFF
--- a/sktime/transformations/series/time_since.py
+++ b/sktime/transformations/series/time_since.py
@@ -182,7 +182,7 @@ class TimeSince(BaseTransformer):
                     f"Period index. Check that `start` is of type "
                     f"pd.Period or a pd.Period parsable string."
                 )
-            elif X.index.is_numeric() and not isinstance(start_, (int, np.integer)):
+            elif time_index.is_numeric() and not isinstance(start_, (int, np.integer)):
                 raise ValueError(
                     f"start_={start_} incompatible with a numeric index."
                     f"Check that `start` is an integer."

--- a/sktime/transformations/series/time_since.py
+++ b/sktime/transformations/series/time_since.py
@@ -58,13 +58,13 @@ class TimeSince(BaseTransformer):
     >>> from sktime.transformations.series.time_since import TimeSince
     >>> X = load_airline()
 
-    Create a single column with time elapsed since start date of time series.
-    The output is in units of integer number of months, same as the index `freq`.
+        Create a single column with time elapsed since start date of time series.
+        The output is in units of integer number of months, same as the index `freq`.
     >>> transformer = TimeSince()
     >>> Xt = transformer.fit_transform(X)
 
-    Create multiple columns with different start times. The output is in units
-    of integer number of months, same as the index `freq`.
+        Create multiple columns with different start times. The output is in units
+        of integer number of months, same as the index `freq`.
     >>> transformer = TimeSince(["2000-01", "2000-02"])
     >>> Xt = transformer.fit_transform(X)
     """
@@ -229,7 +229,7 @@ class TimeSince(BaseTransformer):
                     freq_ = _remove_digits_from_str(self.freq_)
                     freq_period = get_period_alias(freq_)
 
-                    # Convert `start` and datetime index to period.
+                    # Convert `start` and datetime index to integers.
                     start_period = pd.Period(start_, freq=freq_period)
                     time_index_period = time_index.to_period(freq=freq_period)
                     # Compute time differences and convert to integers.

--- a/sktime/transformations/series/time_since.py
+++ b/sktime/transformations/series/time_since.py
@@ -33,11 +33,13 @@ class TimeSince(BaseTransformer):
     ----------
     start : a list of start times, optional, default=None (use earliest time in index)
         a "start time" can be one of the following types:
-        int - Start time to compute the time elapsed, use when index is integer
-        time-like: `Period` or `datetime`
+
+        * int: Start time to compute the time elapsed, use when index is integer.
+        * time-like: `Period` or `datetime`
             Start time to compute the time elapsed.
-        str - String is converted to datetime/period using pd.to_datetime()/pd.Period()
-              to give the start time.
+        * str: String is converted to datetime or period, depending on the index type, \
+            to give the start time.
+
     to_numeric : string, optional (default=True)
         Return the integer number of periods elapsed since `start`; the period
         is defined by the frequency of the data. Converts datetime types to
@@ -48,7 +50,7 @@ class TimeSince(BaseTransformer):
         match a pandas offset alias:
         https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
     keep_original_columns :  boolean, optional, default=False
-        Keep original columns in X passed to `.transform()`
+        Keep original columns in X passed to `.transform()`.
     positive_only :  boolean, optional, default=False
         Clips negative values to zero when `to_numeric` is True.
 
@@ -229,7 +231,7 @@ class TimeSince(BaseTransformer):
                     freq_ = _remove_digits_from_str(self.freq_)
                     freq_period = get_period_alias(freq_)
 
-                    # Convert `start` and datetime index to integers.
+                    # Convert `start` and datetime index to period.
                     start_period = pd.Period(start_, freq=freq_period)
                     time_index_period = time_index.to_period(freq=freq_period)
                     # Compute time differences and convert to integers.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
There is a check that the type of the time index and the `start` argument are consistent. The check was still being done on `X.index` which is fine for series data, but not for panel or hierarchical data. The check has been changed to the `time_index` variable.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.
<!--
Thanks for contributing!
-->
