### PR TITLE
[ENH] Make `TimeSince` trafo faster by changing period diff calculation

### DIFF
--- a/sktime/transformations/series/time_since.py
+++ b/sktime/transformations/series/time_since.py
@@ -229,26 +229,47 @@ class TimeSince(BaseTransformer):
                     freq_ = _remove_digits_from_str(self.freq_)
                     freq_period = get_period_alias(freq_)
 
-                    # Convert `start` and datetime index to period.
-                    start_period = pd.Period(start_, freq=freq_period)
+                    # Convert `start` and `time_index` to period.
+                    # Casting `start_` to PeriodIndex using pd.period_range
+                    # here so we can later cast it to an int using
+                    # `astype(int)` in _get_period_diff_as_int().
+                    start_period = pd.period_range(
+                        start=start_, periods=1, freq=freq_period
+                    )
                     time_index_period = time_index.to_period(freq=freq_period)
-                    # Compute time differences and convert to integers.
-                    time_deltas_period = time_index_period - start_period
-                    time_deltas = _period_to_int(time_deltas_period)
+                    # Compute time differences.
+                    time_deltas = _get_period_diff_as_int(
+                        time_index_period, start_period
+                    )
+
                 elif isinstance(time_index, pd.PeriodIndex):
                     if pd.__version__ < "1.5.0":
                         # Earlier versions of pandas returned incorrect result
                         # when taking a difference between Periods when the frequency
                         # is a multiple of a unit (e.g. "15T"). Solution is to
                         # cast to lowest frequency when taking difference (e.g., "T").
-                        freq_ = _remove_digits_from_str(time_index.freqstr)
-                        time_deltas_period = time_index.to_timestamp().to_period(
-                            freq_
-                        ) - start_.to_timestamp().to_period(freq_)
+                        freq_ = _remove_digits_from_str(self.freq_)
+
+                        # Change freq of `start` and `time_index`.
+                        # Casting `start_` to PeriodIndex using pd.period_range
+                        # here so we can later cast it to an int using
+                        # `astype(int)` in _get_period_diff_as_int().
+                        start_period = pd.period_range(
+                            start=start_.to_timestamp(), periods=1, freq=freq_
+                        )
+                        time_index = time_index.to_timestamp().to_period(freq_)
                     else:
-                        time_deltas_period = time_index - start_
-                    time_deltas = _period_to_int(time_deltas_period)
-                elif X.index.is_numeric():
+                        # Casting `start_` to PeriodIndex using pd.period_range
+                        # here so we can later cast it to an int using
+                        # `astype(int)` in _get_period_diff_as_int().
+                        start_period = pd.period_range(
+                            start=start_, periods=1, freq=self.freq_
+                        )
+
+                    # Compute time differences.
+                    time_deltas = _get_period_diff_as_int(time_index, start_period)
+
+                elif time_index.is_numeric():
                     time_deltas = time_index - start_
             else:
                 time_deltas = time_index - start_
@@ -293,8 +314,8 @@ class TimeSince(BaseTransformer):
         ]
 
 
-def _period_to_int(x: pd.PeriodIndex | list[pd.offsets.DateOffset]) -> int:
-    return x.map(lambda y: y.n)
+def _get_period_diff_as_int(x: pd.PeriodIndex, y: pd.PeriodIndex) -> pd.Index:
+    return x.astype(int) - y.astype(int)
 
 
 def _remove_digits_from_str(x: str) -> str:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Inspired by how @ltsaprounis calculated the integer time difference when using a `PeriodIndex` in the `FourierFeatures` transformer, I've switched to using this alternative method which is *much* faster. I measured a factor of ~100 speed up in `_transform`.

An example to measure the difference:
```Python
from sktime.utils._testing.hierarchical import _make_hierarchical
from sktime.transformations.series.time_since import TimeSince

df =_make_hierarchical(hierarchy_levels=(10000,), min_timepoints=200, max_timepoints=200)

trafo = TimeSince(freq="D")
trafo._fit(df)
trafo._transform(df)
```

This PR will have conflicting changes with https://github.com/sktime/sktime/pull/4015. Once https://github.com/sktime/sktime/pull/4015 has merged I will resolve the conflicts in this PR. 


#### What should a reviewer concentrate their feedback on?
Code quality. I'm having to write a lot of comments to explain the context of what's going on. I'm unsure whether this is a bad smell. 


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [x] I've added unit tests and made sure they pass locally.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

<!--
Thanks for contributing!
-->
