### PR TITLE
[MNT] explicit lower version bound on `scipy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "pandas>=1.1.0,<1.6.0",
     "scikit-learn>=0.24.0,<1.3.0",
     "statsmodels>=0.12.1",
-    "scipy<2.0.0",
+    "scipy<2.0.0,>=1.2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The combined lower bounds of current core dependencies imply `scipy>=1.2.0` (from `pandas 1.1.0`).

This PR makes that lower bound explicit and consistent with other version specifications in the core dependency set.