### PR TITLE
[ENH] extend `sklearn_scitype` to infer the scitype correctly from composites

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -30,7 +30,7 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
-from sklearn.base import RegressorMixin, clone
+from sklearn.base import clone
 from sklearn.multioutput import MultiOutputRegressor
 
 from sktime.datatypes._utilities import get_time_index

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -42,6 +42,7 @@ from sktime.regression.base import BaseRegressor
 from sktime.transformations.compose import FeatureUnion
 from sktime.transformations.series.summarize import WindowSummarizer
 from sktime.utils.datetime import _shift
+from sktime.utils.sklearn import is_sklearn_regressor
 from sktime.utils.validation import check_window_length
 
 
@@ -1241,7 +1242,7 @@ def _infer_scitype(estimator):
     # check matters and we first need to check for BaseRegressor.
     if isinstance(estimator, BaseRegressor):
         return "time-series-regressor"
-    elif isinstance(estimator, RegressorMixin):
+    elif is_sklearn_regressor(estimator):
         return "tabular-regressor"
     else:
         raise ValueError(

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -4,7 +4,7 @@
 
 """Test reduce."""
 
-__author__ = ["Lovkush Agarwal", "mloning", "Luis Zugasti", "AyushmaanSeth"]
+__author__ = ["Lovkush-A", "mloning", "LuisZugasti", "AyushmaanSeth"]
 
 import numpy as np
 import pandas as pd

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -387,15 +387,15 @@ def test_make_reduction_infer_scitype(estimator, scitype):
     assert forecaster._estimator_scitype == scitype
 
 
-def test_make_reduction_infer_scitype_raises_error():
+def test_make_reduction_infer_scitype_for_sklearn_pipeline():
     """Test make_reduction.
 
     The scitype of pipeline cannot be inferred here, as it may be used together
     with a tabular or time series regressor.
     """
     estimator = make_pipeline(Tabularizer(), LinearRegression())
-    with pytest.raises(ValueError):
-        make_reduction(estimator, scitype="infer")
+    forecaster = make_reduction(estimator, scitype="infer")
+    assert forecaster._estimator_scitype == "tabular-regressor"
 
 
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)

--- a/sktime/utils/sklearn.py
+++ b/sktime/utils/sklearn.py
@@ -70,7 +70,7 @@ def sklearn_scitype(obj, var_name="obj"):
         raise TypeError(f"{var_name} is not an sklearn estimator, has type {type(obj)}")
 
     if isinstance(obj, Pipeline):
-        return sklearn_scitype(estimator.steps[-1][1], var_name=var_name)
+        return sklearn_scitype(obj.steps[-1][1], var_name=var_name)
 
     sklearn_mixins = tuple(mixin_to_scitype.keys())
 

--- a/sktime/utils/sklearn.py
+++ b/sktime/utils/sklearn.py
@@ -6,6 +6,7 @@ from inspect import isclass
 
 from sklearn.base import BaseEstimator as SklearnBaseEstimator
 from sklearn.base import ClassifierMixin, ClusterMixin, RegressorMixin, TransformerMixin
+from sklearn.pipeline import Pipeline
 
 from sktime.base import BaseObject
 
@@ -67,6 +68,9 @@ def sklearn_scitype(obj, var_name="obj"):
 
     if not is_sklearn_estimator(obj):
         raise TypeError(f"{var_name} is not an sklearn estimator, has type {type(obj)}")
+
+    if isinstance(obj, Pipeline):
+        return sklearn_scitype(estimator.steps[-1][1], var_name=var_name)
 
     sklearn_mixins = tuple(mixin_to_scitype.keys())
 

--- a/sktime/utils/sklearn.py
+++ b/sktime/utils/sklearn.py
@@ -63,14 +63,15 @@ def sklearn_scitype(obj, var_name="obj"):
     ------
     TypeError if obj is not an sklearn estimator, according to is_sklearn_estimator
     """
+    # deal with sklearn pipelines: scitype is determined by the last element
+    if isinstance(obj, Pipeline):
+        return sklearn_scitype(obj.steps[-1][1], var_name=var_name)
+
     if not isclass(obj):
         obj = type(obj)
 
     if not is_sklearn_estimator(obj):
         raise TypeError(f"{var_name} is not an sklearn estimator, has type {type(obj)}")
-
-    if isinstance(obj, Pipeline):
-        return sklearn_scitype(obj.steps[-1][1], var_name=var_name)
 
     sklearn_mixins = tuple(mixin_to_scitype.keys())
 

--- a/sktime/utils/sklearn.py
+++ b/sktime/utils/sklearn.py
@@ -6,6 +6,7 @@ from inspect import isclass
 
 from sklearn.base import BaseEstimator as SklearnBaseEstimator
 from sklearn.base import ClassifierMixin, ClusterMixin, RegressorMixin, TransformerMixin
+from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
 from sklearn.pipeline import Pipeline
 
 from sktime.base import BaseObject
@@ -58,29 +59,37 @@ def sklearn_scitype(obj, var_name="obj"):
         "clusterer" - unsupervised clusterer
         "regressor" - supervised regressor
         "transformer" - transformer (pipeline element, feature extractor, unsupervised)
+        "estimator" - sklearn estimator of indeterminate type
 
     Raises
     ------
     TypeError if obj is not an sklearn estimator, according to is_sklearn_estimator
     """
-    # deal with sklearn pipelines: scitype is determined by the last element
-    if isinstance(obj, Pipeline):
-        return sklearn_scitype(obj.steps[-1][1], var_name=var_name)
-
-    if not isclass(obj):
-        obj = type(obj)
-
     if not is_sklearn_estimator(obj):
         raise TypeError(f"{var_name} is not an sklearn estimator, has type {type(obj)}")
 
+    # first check whether obj class inherits from sklearn mixins
     sklearn_mixins = tuple(mixin_to_scitype.keys())
 
-    if issubclass(obj, sklearn_mixins):
-        for mx in sklearn_mixins:
-            if issubclass(obj, mx):
-                return mixin_to_scitype[mx]
+    if not isclass(obj):
+        obj_class = type(obj)
     else:
-        return "estimator"
+        obj_class = obj
+    if issubclass(obj_class, sklearn_mixins):
+        for mx in sklearn_mixins:
+            if issubclass(obj_class, mx):
+                return mixin_to_scitype[mx]
+
+    # deal with sklearn pipelines: scitype is determined by the last element
+    if isinstance(obj, Pipeline) or hasattr(obj, "steps"):
+        return sklearn_scitype(obj.steps[-1][1], var_name=var_name)
+
+    # deal with generic composites: scitype is type of wrapped "estimator"
+    if isinstance(obj, (GridSearchCV, RandomizedSearchCV)) or hasattr(obj, "estimator"):
+        return sklearn_scitype(obj.estimator, var_name=var_name)
+
+    # fallback - estimator of indeterminate type
+    return "estimator"
 
 
 def is_sklearn_transformer(obj):


### PR DESCRIPTION
This PR extends the utility `sklearn_scitype` to infer the scitype correctly from `Pipeline`-s and grid/random searches, and by extension also the `is_sklearn_[scitype]` functions.

Also changes a test for `make_reduction` raising an error on a pipeline to a test that it is correctly inferred.

Related to this discussion: https://github.com/sktime/sktime/discussions/3841