### PR TITLE
[ENH] improve handling of `scitype` in `make_reduction`

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -7,8 +7,8 @@
 __author__ = [
     "mloning",
     "AyushmaanSeth",
-    "Kavin Anand",
-    "Luis Zugasti",
+    "kAnand77",
+    "LuisZugasti",
     "Lovkush-A",
     "fkiraly",
 ]
@@ -30,7 +30,7 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
-from sklearn.base import RegressorMixin, clone
+from sklearn.base import clone
 from sklearn.multioutput import MultiOutputRegressor
 
 from sktime.datatypes._utilities import get_time_index
@@ -42,6 +42,7 @@ from sktime.regression.base import BaseRegressor
 from sktime.transformations.compose import FeatureUnion
 from sktime.transformations.series.summarize import WindowSummarizer
 from sktime.utils.datetime import _shift
+from sktime.utils.sklearn import is_sklearn_regressor
 from sktime.utils.validation import check_window_length
 
 
@@ -1170,9 +1171,11 @@ def make_reduction(
     window_length : int, optional (default=10)
         Window length used in sliding window transformation.
     scitype : str, optional (default="infer")
-        Must be one of "infer", "tabular-regressor" or "time-series-regressor". If
-        the scitype cannot be inferred, please specify it explicitly.
-        See :term:`scitype`.
+        Legacy argument for downwards compatibility, should not be used.
+        `make_reduction` will automatically infer the correct type of `estimator`.
+        This internal inference can be force-overridden by the `scitype` argument.
+        Must be one of "infer", "tabular-regressor" or "time-series-regressor".
+        If the scitype cannot be inferred, this is a bug and should be reported.
     transformers: list of transformers (default = None)
         A suitable list of transformers that allows for using an en-bloc approach with
         make_reduction. This means that instead of using the raw past observations of
@@ -1241,13 +1244,16 @@ def _infer_scitype(estimator):
     # check matters and we first need to check for BaseRegressor.
     if isinstance(estimator, BaseRegressor):
         return "time-series-regressor"
-    elif isinstance(estimator, RegressorMixin):
+    elif is_sklearn_regressor(estimator):
         return "tabular-regressor"
     else:
-        raise ValueError(
+        warn(
             "The `scitype` of the given `estimator` cannot be inferred. "
-            "Please specify the `scitype` explicitly."
+            'Assuming "tabular-regressor" = scikit-learn regressor interface. '
+            "If this warning is followed by an unexpected exception, "
+            "please consider report as a bug on the sktime issue tracker."
         )
+        return "tabular-regressor"
 
 
 def _check_strategy(strategy):


### PR DESCRIPTION
This PR improves documentation and handling of the `scitype` argument in `make_reduction`, overall reducing the need for users to specify it.

In the optimal case, the `scitype` argument is completely redundant and can be inferred from `estimator`, so should move to a deprecable state.

This PR makes the following changes towards that:

* the docstring clearly explains that users should typically not override it. Together with https://github.com/sktime/sktime/pull/4020, readers of the docs should no longer be promted to use it.
* `_infer_scitype` is changed to use `_is_sklearn_regressor` which may be more powerful than just checking inheritance from the mixin, see, e.g., https://github.com/sktime/sktime/pull/4021
* `_infer_scitype` assumes `tabular-regressor` when the scitype cannot be inferred and raises a warning - changed from raising an exception. This should be valid in most cases, including the pipeline case, because `sktime` time series regressors are strictly typed and always inferrable, whereas `sklearn` regressors may or may not be inferrable.