### PR TITLE
&matthewmiddlehurst [DOC] `all_estimators` reference on all estimator pages

### DIFF
--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -5,6 +5,10 @@ Time series classification
 
 The :mod:`sktime.classification` module contains algorithms and composition tools for time series classification.
 
+All classifiers in ``sktime``can be listed using the ``sktime.registry.all_estimators`` utility,
+using ``estimator_types="classifier"``, optionally filtered by tags.
+Valid tags can be listed using ``sktime.registry.all_tags``.
+
 Composition
 -----------
 

--- a/docs/source/api_reference/clustering.rst
+++ b/docs/source/api_reference/clustering.rst
@@ -6,6 +6,10 @@ Time series clustering
 
 The :mod:`sktime.clustering` module contains algorithms for time series clustering.
 
+All clusterers in ``sktime``can be listed using the ``sktime.registry.all_estimators`` utility,
+using ``estimator_types="clusterer"``, optionally filtered by tags.
+Valid tags can be listed using ``sktime.registry.all_tags``.
+
 Base
 ----
 

--- a/docs/source/api_reference/dists_kernels.rst
+++ b/docs/source/api_reference/dists_kernels.rst
@@ -1,4 +1,4 @@
-.. _transformations_ref:
+.. _transformations_pairwise_ref:
 
 Time series distances/kernels
 =============================
@@ -13,6 +13,12 @@ Below, we list separately pairwise transformers for time series, and pairwise tr
 .. automodule:: sktime.dists_kernels
    :no-members:
    :no-inherited-members:
+
+All time series distances and kernels in ``sktime``can be listed using the ``sktime.registry.all_estimators`` utility,
+using ``estimator_types="transformer-pairwise-panel"``, optionally filtered by tags.
+Valid tags can be listed using ``sktime.registry.all_tags``.
+
+Distances and kernels for vector-valued features can be listed using ``estimator_types="transformer-pairwise"``.
 
 Time series distances/kernels
 -----------------------------

--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -6,7 +6,9 @@ Forecasting
 
 The :mod:`sktime.forecasting` module contains algorithms and composition tools for forecasting.
 
-Use ``sktime.registry.all_estimators`` and ``sktime.registry.all_tags`` for dynamic search and tag-based listing of forecasters.
+All clusterers in ``sktime``can be listed using the ``sktime.registry.all_estimators`` utility,
+using ``estimator_types="forecaster"``, optionally filtered by tags.
+Valid tags can be listed using ``sktime.registry.all_tags``.
 
 Base
 ----

--- a/docs/source/api_reference/regression.rst
+++ b/docs/source/api_reference/regression.rst
@@ -5,8 +5,9 @@ Time series regression
 
 The :mod:`sktime.regression` module contains algorithms and composition tools for time series regression.
 
-All current sktime Regressors can be listed using the ``sktime.registry import
-all_estimators`` function.
+All regressors in ``sktime``can be listed using the ``sktime.registry.all_estimators`` utility,
+using ``estimator_types="regressor"``, optionally filtered by tags.
+Valid tags can be listed using ``sktime.registry.all_tags``.
 
 Composition
 -----------

--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -10,6 +10,12 @@ transformations.
    :no-members:
    :no-inherited-members:
 
+All (simple) transformers in ``sktime``can be listed using the ``sktime.registry.all_estimators`` utility,
+using ``estimator_types="regressor"``, optionally filtered by tags.
+Valid tags can be listed using ``sktime.registry.all_tags``.
+
+For pairwise transformers (time series distances, kernels), instead see :ref:`_transformations_pairwise_ref`.
+
 Transformations are categorized as follows:
 
 .. list-table::


### PR DESCRIPTION
This adds a reference to `all_estimators` on all pages for estimators.

Taken partially from https://github.com/sktime/sktime/pull/3852 (which added this for some estimator types).