### PR TITLE
[MNT] address `pd.Series` constructor `dtype` deprecation

### DIFF
--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1272,7 +1272,8 @@ class SingleWindowSplitter(BaseSplitter):
         train_end = _get_end(y_index=y, fh=fh)
 
         training_window = get_window(
-            pd.Series(index=y[y <= y[train_end]]), window_length=window_length
+            pd.Series(index=y[y <= y[train_end]], dtype=y.dtype),
+            window_length=window_length,
         ).index
         training_window = y.get_indexer(training_window)
         if array_is_int(fh):


### PR DESCRIPTION
This PR addresses the deprecation message received from `pandas` for one instance of `pd.Series` constructor with `dtype` not explicitly set.

The fix is setting the `dtype` explicitly, which resolves the deprecation message in case the resulting series is empty.