### PR TITLE
[MNT] address `pandas` `astype` deprecation in `TrendForecaster`

### DIFF
--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -72,7 +72,7 @@ class TrendForecaster(BaseForecaster):
         self.regressor_ = clone(self.regressor_)
 
         # transform data
-        X = y.index.astype("int").to_numpy().reshape(-1, 1)
+        X = y.index.astype("int64").to_numpy().reshape(-1, 1)
 
         # fit regressor
         self.regressor_.fit(X, y)


### PR DESCRIPTION
Addresses a `pandas` deprecation warning from `TrendForecaster`.

Warning addressed is the following one:

```
FutureWarning: The behavior of .astype from datetime64[ns] to int32 is
deprecated. In a future version, this astype will return exactly the specified dtype
instead of int64, and will raise if that conversion overflows.
```