### PR TITLE
[MNT] skip #4033 related failures until fixed

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -92,11 +92,11 @@ EXCLUDED_TESTS = {
     ],
     "LSTMFCNClassifier": [
         "test_fit_idempotent",
-        "test_methods_have_no_side_effects", # unknown cause, see bug report #4033
+        "test_methods_have_no_side_effects",  # unknown cause, see bug report #4033
     ],
     "MLPClassifier": [
         "test_fit_idempotent",
-        "test_methods_have_no_side_effects", # unknown cause, see bug report #4033
+        "test_methods_have_no_side_effects",  # unknown cause, see bug report #4033
     ],
     # sth is not quite right with the RowTransformer-s changing state,
     #   but these are anyway on their path to deprecation, see #2370

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -92,9 +92,11 @@ EXCLUDED_TESTS = {
     ],
     "LSTMFCNClassifier": [
         "test_fit_idempotent",
+        "test_methods_have_no_side_effects", # unknown cause, see bug report #4033
     ],
     "MLPClassifier": [
         "test_fit_idempotent",
+        "test_methods_have_no_side_effects", # unknown cause, see bug report #4033
     ],
     # sth is not quite right with the RowTransformer-s changing state,
     #   but these are anyway on their path to deprecation, see #2370


### PR DESCRIPTION
Skips two recent test failures on `main` until diagnosed and fixed.

Failures are described in https://github.com/sktime/sktime/issues/4033