### PR TITLE
[MNT] skip `LSTMFCNClassifier` tests due to unfixed failure on `main`

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -12,8 +12,6 @@ from sktime.registry import (
 )
 from sktime.transformations.base import BaseTransformer
 
-# The following estimators currently do not pass all unit tests
-# https://github.com/sktime/sktime/issues/1627
 EXCLUDE_ESTIMATORS = [
     # SFA is non-compliant with any transformer interfaces, #2064
     "SFA",
@@ -33,6 +31,7 @@ EXCLUDE_ESTIMATORS = [
     "TapNetRegressor",
     "TapNetClassifier",
     "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
+    "LSTMFCNClassifier",  # unknown cause, see bug report #4033
 ]
 
 
@@ -92,7 +91,6 @@ EXCLUDED_TESTS = {
     ],
     "LSTMFCNClassifier": [
         "test_fit_idempotent",
-        "test_methods_have_no_side_effects",  # unknown cause, see bug report #4033
     ],
     "MLPClassifier": [
         "test_fit_idempotent",


### PR DESCRIPTION
This skips all tests for `LSTMFCNClassifier` due to unfixed sporadic failures on `main`, see this issue: https://github.com/sktime/sktime/issues/4033
After fixing, we should add the tests back.

Also removes an orphaned comment related to this old issue which has been superseded in the exclusion list: https://github.com/sktime/sktime/issues/1627
