### PR TITLE
[MNT] downwards compatibility fixes for minimal dependency set

### DIFF
--- a/sktime/forecasting/compose/tests/test_reduce_global.py
+++ b/sktime/forecasting/compose/tests/test_reduce_global.py
@@ -11,7 +11,6 @@ import random
 import numpy as np
 import pandas as pd
 import pytest
-
 from sklearn.ensemble import (
     GradientBoostingRegressor,
     HistGradientBoostingRegressor,
@@ -27,7 +26,6 @@ from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.performance_metrics.forecasting import mean_absolute_percentage_error
 from sktime.transformations.series.summarize import WindowSummarizer
 from sktime.utils.validation._dependencies import _check_soft_dependencies
-
 
 # Load data that will be the basis of tests
 y = load_airline()

--- a/sktime/forecasting/compose/tests/test_reduce_global.py
+++ b/sktime/forecasting/compose/tests/test_reduce_global.py
@@ -2,11 +2,16 @@
 """Test extraction of features across (shifted) windows."""
 __author__ = ["danbartl"]
 
+# HistGradientBoostingRegressor requires experimental flag in old sklearn versions
+if _check_soft_dependencies("sklearn<1.0", severity="none"):
+    from sklearn.experimental import enable_hist_gradient_boosting  # noqa
+
 import random
 
 import numpy as np
 import pandas as pd
 import pytest
+
 from sklearn.ensemble import (
     GradientBoostingRegressor,
     HistGradientBoostingRegressor,
@@ -21,6 +26,8 @@ from sktime.forecasting.compose import make_reduction
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.performance_metrics.forecasting import mean_absolute_percentage_error
 from sktime.transformations.series.summarize import WindowSummarizer
+from sktime.utils.validation._dependencies import _check_soft_dependencies
+
 
 # Load data that will be the basis of tests
 y = load_airline()

--- a/sktime/forecasting/compose/tests/test_reduce_global.py
+++ b/sktime/forecasting/compose/tests/test_reduce_global.py
@@ -2,6 +2,8 @@
 """Test extraction of features across (shifted) windows."""
 __author__ = ["danbartl"]
 
+from sktime.utils.validation._dependencies import _check_soft_dependencies
+
 # HistGradientBoostingRegressor requires experimental flag in old sklearn versions
 if _check_soft_dependencies("sklearn<1.0", severity="none"):
     from sklearn.experimental import enable_hist_gradient_boosting  # noqa
@@ -25,7 +27,6 @@ from sktime.forecasting.compose import make_reduction
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.performance_metrics.forecasting import mean_absolute_percentage_error
 from sktime.transformations.series.summarize import WindowSummarizer
-from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 # Load data that will be the basis of tests
 y = load_airline()

--- a/sktime/transformations/series/date.py
+++ b/sktime/transformations/series/date.py
@@ -132,6 +132,7 @@ class DateTimeFeatures(BaseTransformer):
         "transform-returns-same-time-index": True,
         "enforce_index_type": [pd.DatetimeIndex, pd.PeriodIndex],
         "skip-inverse-transform": True,
+        "python_dependencies": "pandas>=1.2.0",  # from DateTimeProperties
     }
 
     def __init__(

--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -11,81 +11,86 @@ from sktime.datasets import load_airline, load_longley
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.transformations.series.date import DateTimeFeatures
 from sktime.utils._testing.hierarchical import _make_hierarchical
+from sktime.utils.validation._dependencies import _check_estimator_deps
 
-# Load multivariate dataset longley and apply calendar extraction
 
-y, X = load_longley()
-y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
+if _check_estimator_deps(DateTimeFeatures, severity="none"):
 
-# Test that comprehensive feature_scope works for weeks
-pipe = DateTimeFeatures(
-    ts_freq="W", feature_scope="comprehensive", keep_original_columns=True
-)
-pipe.fit(X_train)
-test_full_featurescope = pipe.transform(X_train).columns.to_list()
+    # Load multivariate dataset longley and apply calendar extraction
 
-# Test that minimal feature_scope works for weeks
-pipe = DateTimeFeatures(
-    ts_freq="W", feature_scope="minimal", keep_original_columns=True
-)
-pipe.fit(X_train)
-test_reduced_featurescope = pipe.transform(X_train).columns.to_list()
+    y, X = load_longley()
+    y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
 
-# Test that comprehensive feature_scope works for months
-pipe = DateTimeFeatures(
-    ts_freq="M", feature_scope="comprehensive", keep_original_columns=True
-)
-pipe.fit(X_train)
-test_changing_frequency = pipe.transform(X_train).columns.to_list()
+    # Test that comprehensive feature_scope works for weeks
+    pipe = DateTimeFeatures(
+        ts_freq="W", feature_scope="comprehensive", keep_original_columns=True
+    )
+    pipe.fit(X_train)
+    test_full_featurescope = pipe.transform(X_train).columns.to_list()
 
-# Test that manual_selection works for with provided arguments
-# Should ignore feature scope and raise warning for second_of_minute,
-# since ts_freq = "M" is provided.
-# (dummies with frequency higher than ts_freq)
-pipe = DateTimeFeatures(
-    ts_freq="M",
-    feature_scope="comprehensive",
-    manual_selection=["year", "second_of_minute"],
-    keep_original_columns=True,
-)
-pipe.fit(X_train)
-test_manspec_with_tsfreq = pipe.transform(X_train).columns.to_list()
+    # Test that minimal feature_scope works for weeks
+    pipe = DateTimeFeatures(
+        ts_freq="W", feature_scope="minimal", keep_original_columns=True
+    )
+    pipe.fit(X_train)
+    test_reduced_featurescope = pipe.transform(X_train).columns.to_list()
 
-# Test that manual_selection works for with provided arguments
-# Should ignore feature scope and raise no warning for second_of_minute,
-# since ts_freq is not provided.
+    # Test that comprehensive feature_scope works for months
+    pipe = DateTimeFeatures(
+        ts_freq="M", feature_scope="comprehensive", keep_original_columns=True
+    )
+    pipe.fit(X_train)
+    test_changing_frequency = pipe.transform(X_train).columns.to_list()
 
-pipe = DateTimeFeatures(
-    manual_selection=["year", "second_of_minute"], keep_original_columns=True
-)
-pipe.fit(X_train)
-test_manspec_wo_tsfreq = pipe.transform(X_train).columns.to_list()
+    # Test that manual_selection works for with provided arguments
+    # Should ignore feature scope and raise warning for second_of_minute,
+    # since ts_freq = "M" is provided.
+    # (dummies with frequency higher than ts_freq)
+    pipe = DateTimeFeatures(
+        ts_freq="M",
+        feature_scope="comprehensive",
+        manual_selection=["year", "second_of_minute"],
+        keep_original_columns=True,
+    )
+    pipe.fit(X_train)
+    test_manspec_with_tsfreq = pipe.transform(X_train).columns.to_list()
 
-# Test that prior test works for with univariate dataset
-y = load_airline()
-y_train, y_test = temporal_train_test_split(y)
+    # Test that manual_selection works for with provided arguments
+    # Should ignore feature scope and raise no warning for second_of_minute,
+    # since ts_freq is not provided.
 
-pipe = DateTimeFeatures(
-    manual_selection=["year", "second_of_minute"], keep_original_columns=True
-)
-pipe.fit(y_train)
-test_univariate_data = pipe.transform(y_train).columns.to_list()
+    pipe = DateTimeFeatures(
+        manual_selection=["year", "second_of_minute"], keep_original_columns=True
+    )
+    pipe.fit(X_train)
+    test_manspec_wo_tsfreq = pipe.transform(X_train).columns.to_list()
 
-# Test that prior test also works when Index is converted to DateTime index
-y.index = y.index.to_timestamp().astype("datetime64[ns]")
-y_train, y_test = temporal_train_test_split(y)
-pipe = DateTimeFeatures(
-    manual_selection=["year", "second_of_minute"], keep_original_columns=True
-)
-pipe.fit(y_train)
-test_diffdateformat = pipe.transform(y_train).columns.to_list()
+    # Test that prior test works for with univariate dataset
+    y = load_airline()
+    y_train, y_test = temporal_train_test_split(y)
 
-pipe = DateTimeFeatures(
-    ts_freq="L", feature_scope="comprehensive", keep_original_columns=True
-)
-pipe.fit(y_train)
-test_full = pipe.transform(y_train).columns.to_list()
-test_types = pipe.transform(y_train).select_dtypes(include=["int64"]).columns.to_list()
+    pipe = DateTimeFeatures(
+        manual_selection=["year", "second_of_minute"], keep_original_columns=True
+    )
+    pipe.fit(y_train)
+    test_univariate_data = pipe.transform(y_train).columns.to_list()
+
+    # Test that prior test also works when Index is converted to DateTime index
+    y.index = y.index.to_timestamp().astype("datetime64[ns]")
+    y_train, y_test = temporal_train_test_split(y)
+    pipe = DateTimeFeatures(
+        manual_selection=["year", "second_of_minute"], keep_original_columns=True
+    )
+    pipe.fit(y_train)
+    test_diffdateformat = pipe.transform(y_train).columns.to_list()
+
+    pipe = DateTimeFeatures(
+        ts_freq="L", feature_scope="comprehensive", keep_original_columns=True
+    )
+    pipe.fit(y_train)
+    y_train_t = pipe.transform(y_train)
+    test_full = y_train_t.columns.to_list()
+    test_types = y_train_t.select_dtypes(include=["int64"]).columns.to_list()
 
 
 # Test `is_weekend` works in manual selection
@@ -125,6 +130,10 @@ all_args = [
 ]
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(DateTimeFeatures, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
 @pytest.mark.parametrize(
     "test_input,expected",
     [
@@ -199,6 +208,10 @@ def test_eval(test_input, expected):
     assert all([a == b for a, b in zip(test_input, expected)])
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(DateTimeFeatures, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
 def test_manual_selection_is_weekend(df_datetime_daily_idx):
     """Tests that "is_weekend" returns correct result in `manual_selection`."""
     transformer = DateTimeFeatures(
@@ -213,6 +226,10 @@ def test_manual_selection_is_weekend(df_datetime_daily_idx):
     assert_frame_equal(Xt, expected)
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(DateTimeFeatures, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
 def test_transform_panel(df_panel):
     """Test `.transform()` on panel data."""
     transformer = DateTimeFeatures(
@@ -233,6 +250,10 @@ def test_transform_panel(df_panel):
     assert_frame_equal(Xt, expected)
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(DateTimeFeatures, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
 def test_keep_original_columns(df_panel):
     """Test `.transform()` on panel data."""
     transformer = DateTimeFeatures(

--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -13,7 +13,6 @@ from sktime.transformations.series.date import DateTimeFeatures
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils.validation._dependencies import _check_estimator_deps
 
-
 if _check_estimator_deps(DateTimeFeatures, severity="none"):
 
     # Load multivariate dataset longley and apply calendar extraction

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -88,7 +88,6 @@ def _check_soft_dependencies(
     else:
         raise TypeError("obj must be a class, an object, a str, or None")
 
-
     for package in packages:
 
         try:

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -77,6 +77,18 @@ def _check_soft_dependencies(
     if not all(isinstance(x, str) for x in package_import_alias.values()):
         raise TypeError(msg)
 
+    if obj is None:
+        class_name = "This functionality"
+    elif not isclass(obj):
+        class_name = type(obj).__name__
+    elif isclass(obj):
+        class_name = obj.__name__
+    elif isinstance(obj, str):
+        class_name = obj
+    else:
+        raise TypeError("obj must be a class, an object, a str, or None")
+
+
     for package in packages:
 
         try:
@@ -89,7 +101,6 @@ def _check_soft_dependencies(
             )
             raise InvalidRequirement(msg_version)
 
-        req = Requirement(package)
         package_name = req.name
         package_version_req = req.specifier
 
@@ -118,14 +129,6 @@ def _check_soft_dependencies(
                     f"sktime[all_extras]`"
                 )
             else:
-                if not isclass(obj):
-                    class_name = type(obj).__name__
-                elif isclass(obj):
-                    class_name = obj.__name__
-                elif isinstance(obj, str):
-                    class_name = obj
-                else:
-                    raise TypeError("obj must be a class, an object, a str, or None")
                 msg = (
                     f"{class_name} requires package '{package}' to be present "
                     f"in the python environment, but '{package}' was not found. "


### PR DESCRIPTION
This PR contains downwards compatibility fixes for the minimal version dependency set currently supported by `sktime`.
Because CI was not testing for minimal version dependencies, there have been punctual divergences in compatibility with the minimal dependency set. This PR aims to fix this.

PR https://github.com/sktime/sktime/pull/4016 introduces a CI element to test on the minimal dependency set, against which the fixes in this PR are developed.

Fixes:
* old `sklearn` versions require an experimental enablement flag for use of `HistGradientBoostingRegressor`. The fix is to include that flag conditional on `sklearn` version.
* the `DateTimeFeatures` transformer depends on `pandas` `DatetimeProperties` which is only available in its current form since `pandas 1.2.0`. The fix is to include this as a dependency requirement in the estimator and isolate the tests conditionally.

Depends on:
* https://github.com/sktime/sktime/pull/4044 as PEP 440 specifiers are introduced in estimator dependencies