### PR TITLE
[MNT] fix `_check_soft_dependencies` breaking for PEP 440 specifiers without class reference

### DIFF
--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -88,7 +88,6 @@ def _check_soft_dependencies(
     else:
         raise TypeError("obj must be a class, an object, a str, or None")
 
-
     for package in packages:
 
         try:

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -77,6 +77,18 @@ def _check_soft_dependencies(
     if not all(isinstance(x, str) for x in package_import_alias.values()):
         raise TypeError(msg)
 
+    if obj is None:
+        class_name = "This functionality"
+    elif not isclass(obj):
+        class_name = type(obj).__name__
+    elif isclass(obj):
+        class_name = obj.__name__
+    elif isinstance(obj, str):
+        class_name = obj
+    else:
+        raise TypeError("obj must be a class, an object, a str, or None")
+
+
     for package in packages:
 
         try:
@@ -89,7 +101,6 @@ def _check_soft_dependencies(
             )
             raise InvalidRequirement(msg_version)
 
-        req = Requirement(package)
         package_name = req.name
         package_version_req = req.specifier
 
@@ -118,14 +129,6 @@ def _check_soft_dependencies(
                     f"sktime[all_extras]`"
                 )
             else:
-                if not isclass(obj):
-                    class_name = type(obj).__name__
-                elif isclass(obj):
-                    class_name = obj.__name__
-                elif isinstance(obj, str):
-                    class_name = obj
-                else:
-                    raise TypeError("obj must be a class, an object, a str, or None")
                 msg = (
                     f"{class_name} requires package '{package}' to be present "
                     f"in the python environment, but '{package}' was not found. "


### PR DESCRIPTION
This fixes an unreported bug in `_check_soft_dependencies` for PEP 440 specifiers - if no class or class name was passed, the function would break as it was referencing the variable `class_name`.

This error has been detected through testing in `skbase` and is covered there (until we refactor).