### PR TITLE
[BUG] fix `TrendForecaster` if `regressor` is not boolean coercible

### DIFF
--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -66,10 +66,10 @@ class TrendForecaster(BaseForecaster):
         -------
         self : returns an instance of self.
         """
-        self.regressor_ = self.regressor or LinearRegression(fit_intercept=True)
-
-        # create a clone of self.regressor
-        self.regressor_ = clone(self.regressor_)
+        if self.regressor is None:
+            self.regressor_ = LinearRegression(fit_intercept=True)
+        else:
+            self.regressor_ = clone(self.regressor)
 
         # transform data
         X = y.index.astype("int").to_numpy().reshape(-1, 1)


### PR DESCRIPTION
This fixes an unreported but with `TrendForecaster` detected through the new parameter set in https://github.com/sktime/sktime/pull/4043.

If `regressor` is not boolean coercible (e.g., for `sklearn` `RandomForestRegressor`), the `_fit` method breaks at the line

```python
self.regressor_ = self.regressor or LinearRegression(fit_intercept=True)
```

This is fixed by replacing that line by an if/else that does not require said coercion.