### PR TITLE
[BUG] fix default parameter mutation by `Detrender`

### DIFF
--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -111,18 +111,19 @@ class Detrender(BaseTransformer):
         self: a fitted instance of the estimator
         """
         if self.forecaster is None:
-            self.forecaster = PolynomialTrendForecaster(degree=1)
+            forecaster_ = PolynomialTrendForecaster(degree=1)
+        else:
+            forecaster_ = self.forecaster.clone()
 
         # univariate: X is pd.Series
         if isinstance(X, pd.Series):
-            forecaster = self.forecaster.clone()
             # note: the y in the transformer is exogeneous in the forecaster, i.e., X
-            self.forecaster_ = forecaster.fit(y=X, X=y)
+            self.forecaster_ = forecaster_.fit(y=X, X=y)
         # multivariate
         elif isinstance(X, pd.DataFrame):
             self.forecaster_ = {}
             for colname in X.columns:
-                forecaster = self.forecaster.clone()
+                forecaster = forecaster_.clone()
                 self.forecaster_[colname] = forecaster.fit(y=X[colname], X=y)
         else:
             raise TypeError("X must be pd.Series or pd.DataFrame")


### PR DESCRIPTION
This fixes an unreported but with `Detrender` detected through the new parameter set in https://github.com/sktime/sktime/pull/4043.

If `forecaster` is not passed, it is mutated by the `_fit` method (from `None` to a default forecaster), which does not conform with the interface contract.

This is fixed by adding a `clone` step in-between.