### PR TITLE
[ENH] Adding `min_periods` in `WindowSummarizer` to avoid different behaviour in the future

### DIFF
--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -437,22 +437,22 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
     if summarizer in pd_rolling:
         if isinstance(Z, pd.core.groupby.generic.SeriesGroupBy):
             if bfill is False:
-                feat = getattr(Z.shift(lag).rolling(window_length), summarizer)()
+                feat = getattr(Z.shift(lag).rolling(window=window_length, min_periods=window_length), summarizer)()
             else:
                 feat = getattr(
-                    Z.shift(lag).fillna(method="bfill").rolling(window_length),
+                    Z.shift(lag).fillna(method="bfill").rolling(window=window_length, min_periods=window_length),
                     summarizer,
                 )()
             feat = pd.DataFrame(feat)
         else:
             if bfill is False:
                 feat = Z.apply(
-                    lambda x: getattr(x.shift(lag).rolling(window_length), summarizer)()
+                    lambda x: getattr(x.shift(lag).rolling(window=window_length, min_periods=window_length), summarizer)()
                 )
             else:
                 feat = Z.apply(
                     lambda x: getattr(
-                        x.shift(lag).fillna(method="bfill").rolling(window_length),
+                        x.shift(lag).fillna(method="bfill").rolling(window=window_length, min_periods=window_length),
                         summarizer,
                     )()
                 )
@@ -469,7 +469,7 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
             summarizer
         ):
             feat = feat.apply(
-                lambda x: x.rolling(window_length).apply(summarizer, raw=True)
+                lambda x: x.rolling(window=window_length, min_periods=window_length).apply(summarizer, raw=True)
             )
         feat = pd.DataFrame(feat)
     if bfill is True:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #4050

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

In the `WindowSummarizer` class, `min_periods` is explicitly defined in the `pandas` `rolling` function call with the value equal to the `window_length`.

#### Does your contribution introduce a new dependency? If yes, which one?
No.
<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

