### PR TITLE
[ENH][BUG] clean up `Detrender` and implement correct multivariate behaviour

### DIFF
--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -131,12 +131,12 @@ class Detrender(BaseTransformer):
             time_index = X.index.get_level_values(-1).unique()
         return ForecastingHorizon(time_index, is_relative=False)
 
-    def _get_fitted_forecaster(self, X, y):
+    def _get_fitted_forecaster(self, X, y, fh):
         """Obtain fitted forecaster from self."""
         if self.forecaster.get_tag("requires-fh-in-fit", True):
             X = update_data(self._X, X)
             y = update_data(self._y, y)
-            forecaster = self.forecaster_.clone().fit(y=X, X=y)
+            forecaster = self.forecaster_.clone().fit(y=X, X=y, fh=fh)
         else:
             forecaster = self.forecaster_
         return forecaster
@@ -159,7 +159,7 @@ class Detrender(BaseTransformer):
             transformed version of X, detrended series
         """
         fh = self._get_fh_from_X(X)
-        forecaster = self._get_fitted_forecaster(X, y)
+        forecaster = self._get_fitted_forecaster(X, y, fh)
 
         X_pred = forecaster.predict(fh=fh, X=y)
 

--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -184,7 +184,9 @@ class Detrender(BaseTransformer):
             inverse transformed version of X
         """
         fh = self._get_fh_from_X(X=X)
-        forecaster = self._get_fitted_forecaster(X=X, y=y, fh=fh)
+        # we pass X and y as None, since the X passed is inverse transformed (detrended)
+        # the fit, in case fh needs be passed late, is done on remembered data from fit
+        forecaster = self._get_fitted_forecaster(X=None, y=None, fh=fh)
 
         X_pred = forecaster.predict(fh=fh, X=y)
 

--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -212,7 +212,7 @@ class Detrender(BaseTransformer):
         -------
         self : an instance of self
         """
-        if not self.forecaster.get_tag("requires-fh-in-fit", True):
+        if not self.forecaster_.get_tag("requires-fh-in-fit", True):
             self.forecaster_.update(y=X, X=y, update_params=update_params)
         else:
             self._X = update_data(self._X, X)

--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -6,8 +6,6 @@
 __all__ = ["Detrender"]
 __author__ = ["mloning", "SveaMeyer13", "KishManani", "fkiraly"]
 
-import pandas as pd
-
 from sktime.forecasting.base._fh import ForecastingHorizon
 from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.transformations.base import BaseTransformer

--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -158,8 +158,8 @@ class Detrender(BaseTransformer):
         Xt : pd.Series or pd.DataFrame, same type as X
             transformed version of X, detrended series
         """
-        fh = self._get_fh_from_X(X)
-        forecaster = self._get_fitted_forecaster(X, y, fh)
+        fh = self._get_fh_from_X(X=X)
+        forecaster = self._get_fitted_forecaster(X=X, y=y, fh=fh)
 
         X_pred = forecaster.predict(fh=fh, X=y)
 
@@ -183,8 +183,8 @@ class Detrender(BaseTransformer):
         Xt : pd.Series or pd.DataFrame, same type as X
             inverse transformed version of X
         """
-        fh = self._get_fh_from_X(X)
-        forecaster = self._get_fitted_forecaster(X, y)
+        fh = self._get_fh_from_X(X=X)
+        forecaster = self._get_fitted_forecaster(X=X, y=y, fh=fh)
 
         X_pred = forecaster.predict(fh=fh, X=y)
 

--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -116,7 +116,7 @@ class Detrender(BaseTransformer):
         -------
         self: a fitted instance of the estimator
         """
-        if not self.forecaster.get_tag("requires-fh-in-fit", True):
+        if not self.forecaster_.get_tag("requires-fh-in-fit", True):
             self.forecaster_.fit(y=X, X=y)
         else:
             self._X = X
@@ -133,7 +133,7 @@ class Detrender(BaseTransformer):
 
     def _get_fitted_forecaster(self, X, y, fh):
         """Obtain fitted forecaster from self."""
-        if self.forecaster.get_tag("requires-fh-in-fit", True):
+        if self.forecaster_.get_tag("requires-fh-in-fit", True):
             X = update_data(self._X, X)
             y = update_data(self._y, y)
             forecaster = self.forecaster_.clone().fit(y=X, X=y, fh=fh)

--- a/sktime/transformations/series/detrend/tests/test_detrend.py
+++ b/sktime/transformations/series/detrend/tests/test_detrend.py
@@ -24,7 +24,7 @@ def y_dataframe():
 
 
 def test_polynomial_detrending():
-
+    """Test that transformer results agree with manual detrending."""
     y = pd.Series(np.arange(20) * 0.5) + np.random.normal(0, 1, size=20)
     forecaster = PolynomialTrendForecaster(degree=1, with_intercept=True)
     transformer = Detrender(forecaster)
@@ -38,9 +38,11 @@ def test_polynomial_detrending():
     np.testing.assert_array_almost_equal(actual_coefs, expected_coefs)
 
     # check trend
-    expected_trend = expected_coefs[0] + np.arange(len(y)) * expected_coefs[1]
-    actual_trend = transformer.forecaster_.predict(-np.arange(len(y)))
-    np.testing.assert_array_almost_equal(actual_trend, expected_trend)
+    n = len(y)
+    expected_trend = expected_coefs[0] + np.arange(n) * expected_coefs[1]
+    expected_trend_2D = np.reshape(expected_trend, (n, 1))
+    actual_trend = transformer.forecaster_.predict(-np.arange(n))
+    np.testing.assert_array_almost_equal(actual_trend, expected_trend_2D)
 
     # check residuals
     actual = transformer.transform(y)


### PR DESCRIPTION
This PR improves the `Detrender`:
* it fixes https://github.com/sktime/sktime/issues/4051 and also simplifies the logic in the `Detrender`. As the `BaseForecasting` interface supports loop over hierarchy instances and variables natively, all the case distinctions internally can go, and with it goes the incorrect multivariate implementation.
* adds support for detrending with hierarchical forecasters
* adds support for detrending with forecasters that require `fh` in `fit` already (this was not possible previously)

As a consequence, the test `test_polynomial_detrending` had to be updated since the internal mtype of the `Detrender` changed, from `pd.Series` based to `pd.DataFrame` based (requiring a minor change in how objects are being compared).