### PR TITLE
[BUG] fix mutation of `regressor` in `PolynomialTrendForecaster._fit`

### DIFF
--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -108,9 +108,9 @@ class PolynomialTrendForecaster(BaseForecaster):
 
     Parameters
     ----------
-    regressor : estimator object, default = None
+    regressor : sklearn regressor estimator object, default = None
         Define the regression model type. If not set, will default to
-         sklearn.linear_model.LinearRegression
+        sklearn.linear_model.LinearRegression
     degree : int, default = 1
         Degree of polynomial function
     with_intercept : bool, default=True
@@ -163,7 +163,7 @@ class PolynomialTrendForecaster(BaseForecaster):
         if self.regressor is None:
             regressor = LinearRegression(fit_intercept=False)
         else:
-            regressor = self.regressor
+            regressor = clone(self.regressor)
 
         # make pipeline with polynomial features
         self.regressor_ = make_pipeline(


### PR DESCRIPTION
This fixes an unreported but with `PolynomialTrendForecaster` detected through the new parameter set in https://github.com/sktime/sktime/pull/4043.

If `regressor` was passed, the `_fit` method would mutate it, by fitting an identity-equal instance inside an `sklearn` pipeline.

This is fixed by adding a `clone` around `regressor`.