### PR TITLE
[ENH] linting & pre-commit hook dependency set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,18 @@ dev = [
     "wheel",
 ]
 
+dev_precommit = [
+    "black",
+    "check-manifest",
+    "flake8",
+    "isort",
+    "nbqa",
+    "nbqa-black",
+    "nbqa-flake8",
+    "nbqa-isort",
+    "pydocstyle",
+]
+
 mlflow = [
     "mlflow",
 ]


### PR DESCRIPTION
This is a potential fix for https://github.com/sktime/sktime/issues/4064 and includes an extra dependency set for linters and pre-commit hook dependencies.

This is for developers who may like to set up a python env for auto-linting in their local IDE, or a custom CI element for pre-commits or linting.