### PR TITLE
[BUG] Fix BOSS based classifiers truncating class names to single character length

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1982,7 +1982,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/109052378?v=4",
       "profile": "https://www.linkedin.com/in/erjieyong",
       "contributions": [
-        "bug"
+        "bug",
+        "code"
       ]
     }
   ]

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -162,7 +162,7 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/65773314?v=4",
       "profile": "https://github.com/nilesh05apr",
       "contributions": [
-      "code"
+        "code"
       ]
     },
     {
@@ -1974,6 +1974,15 @@
       "profile": "https://github.com/arnavrneo",
       "contributions": [
         "code"
+      ]
+    },
+    {
+      "login": "erjieyong",
+      "name": "Er Jie Yong",
+      "avatar_url": "https://avatars.githubusercontent.com/u/109052378?v=4",
+      "profile": "https://www.linkedin.com/in/erjieyong",
+      "contributions": [
+        "bug"
       ]
     }
   ]

--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -616,7 +616,11 @@ class IndividualBOSS(BaseClassifier):
             Predicted class labels.
         """
         test_bags = self._transformer.transform(X)
-        classes = np.zeros(test_bags.shape[0], dtype=type(self._class_vals[0]))
+        data_type = type(self._class_vals[0])
+        if data_type == str:
+            data_type = "object"
+
+        classes = np.zeros(test_bags.shape[0], dtype=data_type)
 
         if self._transformed_data.shape[1] > 0:
             distance_matrix = pairwise_distances(

--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -617,7 +617,7 @@ class IndividualBOSS(BaseClassifier):
         """
         test_bags = self._transformer.transform(X)
         data_type = type(self._class_vals[0])
-        if data_type == str:
+        if data_type == np.str_:
             data_type = "object"
 
         classes = np.zeros(test_bags.shape[0], dtype=data_type)

--- a/sktime/classification/dictionary_based/tests/test_boss.py
+++ b/sktime/classification/dictionary_based/tests/test_boss.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+"""BOSS test code."""
+import numpy as np
+import pytest
+
+from sktime.classification.dictionary_based import IndividualBOSS, BOSSEnsemble
+from sktime.datasets import load_unit_test
+
+
+@pytest.fixture
+def dataset():
+    X_train, y_train = load_unit_test(split="train")
+    X_test, y_test = load_unit_test(split="test")
+    return (X_train, y_train, X_test, y_test)
+
+
+def test_individual_boss_classes_string(dataset):
+    """Test of Individual Boss on unit test data"""
+    # load unit test data
+    X_train, y_train, X_test, y_test = dataset
+
+    # change class
+    new_class = {"1": "Class1", "2": "Class2"}
+    y_train = np.array([new_class[y] for y in y_train])
+
+    # train iboss and predict X_test
+    iboss = IndividualBOSS()
+    iboss.fit(X_train, y_train)
+    y_pred = iboss.predict(X_test)
+
+    # assert class type and names
+    assert y_pred.dtype == object
+    assert set(y_pred) == set(y_train)
+
+
+def test_individual_boss_classes_integer(dataset):
+    """Test of Individual Boss on unit test data"""
+    # load unit test data
+    X_train, y_train, X_test, y_test = dataset
+
+    # change class
+    new_class = {"1": 1, "2": 2}
+    y_train = np.array([new_class[y] for y in y_train])
+
+    # train iboss and predict X_test
+    iboss = IndividualBOSS()
+    iboss.fit(X_train, y_train)
+    y_pred = iboss.predict(X_test)
+
+    # assert class type and names
+    assert y_pred.dtype == int
+    assert set(y_pred) == set(y_train)
+
+
+def test_individual_boss_classes_float(dataset):
+    """Test of Individual Boss on unit test data"""
+    # load unit test data
+    X_train, y_train, X_test, y_test = dataset
+
+    # change class
+    new_class = {"1": 1.0, "2": 2.0}
+    y_train = np.array([new_class[y] for y in y_train])
+
+    # train iboss and predict X_test
+    iboss = IndividualBOSS()
+    iboss.fit(X_train, y_train)
+    y_pred = iboss.predict(X_test)
+
+    # assert class type and names
+    assert y_pred.dtype == float
+    assert set(y_pred) == set(y_train)
+
+
+def test_individual_boss_classes_boolean(dataset):
+    """Test of Individual Boss on unit test data"""
+    # load unit test data
+    X_train, y_train, X_test, y_test = dataset
+
+    # change class
+    new_class = {"1": True, "2": False}
+    y_train = np.array([new_class[y] for y in y_train])
+
+    # train iboss and predict X_test
+    iboss = IndividualBOSS()
+    iboss.fit(X_train, y_train)
+    y_pred = iboss.predict(X_test)
+
+    # assert class type and names
+    assert y_pred.dtype == bool
+    assert set(y_pred) == set(y_train)
+
+
+def test_boss_ensemble_classes_string(dataset):
+    """Test of Individual Boss on unit test data"""
+    # load unit test data
+    X_train, y_train, X_test, y_test = dataset
+
+    # change class
+    new_class = {"1": "Class1", "2": "Class2"}
+    y_train = np.array([new_class[y] for y in y_train])
+
+    # train boss_ensemble and predict X_test
+    boss_ensemble = BOSSEnsemble()
+    boss_ensemble.fit(X_train, y_train)
+    y_pred = boss_ensemble.predict(X_test)
+
+    # assert class type and names
+    assert y_pred.dtype == "<U6"
+    assert set(y_pred) == set(y_train)
+
+
+def test_boss_ensemble_classes_integer(dataset):
+    """Test of Individual Boss on unit test data"""
+    # load unit test data
+    X_train, y_train, X_test, y_test = dataset
+
+    # change class
+    new_class = {"1": 1, "2": 2}
+    y_train = np.array([new_class[y] for y in y_train])
+
+    # train boss_ensemble and predict X_test
+    boss_ensemble = BOSSEnsemble()
+    boss_ensemble.fit(X_train, y_train)
+    y_pred = boss_ensemble.predict(X_test)
+
+    # assert class type and names
+    assert y_pred.dtype == int
+    assert set(y_pred) == set(y_train)
+
+
+def test_boss_ensemble_classes_float(dataset):
+    """Test of Individual Boss on unit test data"""
+    # load unit test data
+    X_train, y_train, X_test, y_test = dataset
+
+    # change class
+    new_class = {"1": 1.0, "2": 2.0}
+    y_train = np.array([new_class[y] for y in y_train])
+
+    # train boss_ensemble and predict X_test
+    boss_ensemble = BOSSEnsemble()
+    boss_ensemble.fit(X_train, y_train)
+    y_pred = boss_ensemble.predict(X_test)
+
+    # assert class type and names
+    assert y_pred.dtype == float
+    assert set(y_pred) == set(y_train)
+
+
+def test_boss_ensemble_classes_boolean(dataset):
+    """Test of Individual Boss on unit test data"""
+    # load unit test data
+    X_train, y_train, X_test, y_test = dataset
+
+    # change class
+    new_class = {"1": True, "2": False}
+    y_train = np.array([new_class[y] for y in y_train])
+
+    # train boss_ensemble and predict X_test
+    boss_ensemble = BOSSEnsemble()
+    boss_ensemble.fit(X_train, y_train)
+    y_pred = boss_ensemble.predict(X_test)
+
+    # assert class type and names
+    assert y_pred.dtype == bool
+    assert set(y_pred) == set(y_train)

--- a/sktime/classification/dictionary_based/tests/test_boss.py
+++ b/sktime/classification/dictionary_based/tests/test_boss.py
@@ -3,19 +3,24 @@
 import numpy as np
 import pytest
 
-from sktime.classification.dictionary_based import IndividualBOSS, BOSSEnsemble
+from sktime.classification.dictionary_based import BOSSEnsemble, IndividualBOSS
 from sktime.datasets import load_unit_test
 
 
 @pytest.fixture
 def dataset():
+    """
+    Load unit_test train and test data set from sktime.
+
+    :return: tuple, (X_train, y_train, X_test, y_test).
+    """
     X_train, y_train = load_unit_test(split="train")
     X_test, y_test = load_unit_test(split="test")
     return (X_train, y_train, X_test, y_test)
 
 
 def test_individual_boss_classes_string(dataset):
-    """Test of Individual Boss on unit test data"""
+    """Test of Individual Boss on unit test data with class dtype as STRING."""
     # load unit test data
     X_train, y_train, X_test, y_test = dataset
 
@@ -34,7 +39,7 @@ def test_individual_boss_classes_string(dataset):
 
 
 def test_individual_boss_classes_integer(dataset):
-    """Test of Individual Boss on unit test data"""
+    """Test of Individual Boss on unit test data with class dtype as INTEGER."""
     # load unit test data
     X_train, y_train, X_test, y_test = dataset
 
@@ -53,7 +58,7 @@ def test_individual_boss_classes_integer(dataset):
 
 
 def test_individual_boss_classes_float(dataset):
-    """Test of Individual Boss on unit test data"""
+    """Test of Individual Boss on unit test data with class dtype as FLOAT."""
     # load unit test data
     X_train, y_train, X_test, y_test = dataset
 
@@ -72,7 +77,7 @@ def test_individual_boss_classes_float(dataset):
 
 
 def test_individual_boss_classes_boolean(dataset):
-    """Test of Individual Boss on unit test data"""
+    """Test of Individual Boss on unit test data with class dtype as BOOLEAN."""
     # load unit test data
     X_train, y_train, X_test, y_test = dataset
 
@@ -91,7 +96,7 @@ def test_individual_boss_classes_boolean(dataset):
 
 
 def test_boss_ensemble_classes_string(dataset):
-    """Test of Individual Boss on unit test data"""
+    """Test of Boss Ensemble on unit test data with class dtype as STRING."""
     # load unit test data
     X_train, y_train, X_test, y_test = dataset
 
@@ -110,7 +115,7 @@ def test_boss_ensemble_classes_string(dataset):
 
 
 def test_boss_ensemble_classes_integer(dataset):
-    """Test of Individual Boss on unit test data"""
+    """Test of Boss Ensemble on unit test data with class dtype as INTEGER."""
     # load unit test data
     X_train, y_train, X_test, y_test = dataset
 
@@ -129,7 +134,7 @@ def test_boss_ensemble_classes_integer(dataset):
 
 
 def test_boss_ensemble_classes_float(dataset):
-    """Test of Individual Boss on unit test data"""
+    """Test of Boss Ensemble on unit test data with class dtype as FLOAT."""
     # load unit test data
     X_train, y_train, X_test, y_test = dataset
 
@@ -148,7 +153,7 @@ def test_boss_ensemble_classes_float(dataset):
 
 
 def test_boss_ensemble_classes_boolean(dataset):
-    """Test of Individual Boss on unit test data"""
+    """Test of Boss Ensemble on unit test data with class dtype as BOOLEAN."""
     # load unit test data
     X_train, y_train, X_test, y_test = dataset
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This will fix #4090 which prevent predicted classes list from being populated correctly


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
When calling `np.zeros`, change `string` datatype to `object` so that np.zeros will not truncate the string to only the first character.

I've also tested this locally using provided example in the issues as well as running `check_estimator(IndividualBOSS)`. All tests PASSED!

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

No

