### PR TITLE
[ENH] second set of test parameters for `ARIMA`

### DIFF
--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -738,3 +738,25 @@ class ARIMA(_PmdArimaAdapter):
             with_intercept=self.with_intercept,
             **sarimax_kwargs,
         )
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict
+        """
+        params1 = {"maxiter": 3}
+        params2 = {
+            "order": (1, 1, 0),
+            "seasonal_order": (1, 0, 0, 2),
+            "maxiter": 3,
+        }
+        return [params1, params2]


### PR DESCRIPTION
Second test parameter set for `ARIMA`, towards #3429.

Split off from https://github.com/sktime/sktime/pull/2862 where it must have ended up accidentally.