### PR TITLE
[ENH] Reduce repetitive code in test_boss.py and add check for string datatype in _boss.py

### DIFF
--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -617,7 +617,7 @@ class IndividualBOSS(BaseClassifier):
         """
         test_bags = self._transformer.transform(X)
         data_type = type(self._class_vals[0])
-        if data_type == np.str_:
+        if data_type == np.str_ or data_type == str:
             data_type = "object"
 
         classes = np.zeros(test_bags.shape[0], dtype=data_type)

--- a/sktime/classification/dictionary_based/tests/test_boss.py
+++ b/sktime/classification/dictionary_based/tests/test_boss.py
@@ -49,7 +49,7 @@ def test_individual_boss_classes(dataset, new_class, expected_dtype):
 @pytest.mark.parametrize(
     "new_class,expected_dtype",
     [
-        ({"1": "Class1", "2": "Class2"}, object),
+        ({"1": "Class1", "2": "Class2"}, "<U6"),
         ({"1": 1, "2": 2}, int),
         ({"1": 1.0, "2": 2.0}, float),
         ({"1": True, "2": False}, bool),
@@ -70,5 +70,5 @@ def test_boss_ensemble_classes(dataset, new_class, expected_dtype):
     y_pred = boss_ensemble.predict(X_test)
 
     # assert class type and names
-    assert y_pred.dtype == "<U6"
+    assert y_pred.dtype == expected_dtype
     assert set(y_pred) == set(y_train)

--- a/sktime/classification/dictionary_based/tests/test_boss.py
+++ b/sktime/classification/dictionary_based/tests/test_boss.py
@@ -61,7 +61,6 @@ def test_boss_ensemble_classes(dataset, new_class, expected_dtype):
     X_train, y_train, X_test, y_test = dataset
 
     # change class
-    new_class = {"1": "Class1", "2": "Class2"}
     y_train = np.array([new_class[y] for y in y_train])
 
     # train boss_ensemble and predict X_test

--- a/sktime/classification/dictionary_based/tests/test_boss.py
+++ b/sktime/classification/dictionary_based/tests/test_boss.py
@@ -19,13 +19,21 @@ def dataset():
     return (X_train, y_train, X_test, y_test)
 
 
-def test_individual_boss_classes_string(dataset):
-    """Test of Individual Boss on unit test data with class dtype as STRING."""
+@pytest.mark.parametrize(
+    "new_class,expected_dtype",
+    [
+        ({"1": "Class1", "2": "Class2"}, object),
+        ({"1": 1, "2": 2}, int),
+        ({"1": 1.0, "2": 2.0}, float),
+        ({"1": True, "2": False}, bool),
+    ],
+)
+def test_individual_boss_classes(dataset, new_class, expected_dtype):
+    """Test Individual BOSS on unit_test data with different datatypes as classes."""
     # load unit test data
     X_train, y_train, X_test, y_test = dataset
 
     # change class
-    new_class = {"1": "Class1", "2": "Class2"}
     y_train = np.array([new_class[y] for y in y_train])
 
     # train iboss and predict X_test
@@ -34,69 +42,21 @@ def test_individual_boss_classes_string(dataset):
     y_pred = iboss.predict(X_test)
 
     # assert class type and names
-    assert y_pred.dtype == object
+    assert y_pred.dtype == expected_dtype
     assert set(y_pred) == set(y_train)
 
 
-def test_individual_boss_classes_integer(dataset):
-    """Test of Individual Boss on unit test data with class dtype as INTEGER."""
-    # load unit test data
-    X_train, y_train, X_test, y_test = dataset
-
-    # change class
-    new_class = {"1": 1, "2": 2}
-    y_train = np.array([new_class[y] for y in y_train])
-
-    # train iboss and predict X_test
-    iboss = IndividualBOSS()
-    iboss.fit(X_train, y_train)
-    y_pred = iboss.predict(X_test)
-
-    # assert class type and names
-    assert y_pred.dtype == int
-    assert set(y_pred) == set(y_train)
-
-
-def test_individual_boss_classes_float(dataset):
-    """Test of Individual Boss on unit test data with class dtype as FLOAT."""
-    # load unit test data
-    X_train, y_train, X_test, y_test = dataset
-
-    # change class
-    new_class = {"1": 1.0, "2": 2.0}
-    y_train = np.array([new_class[y] for y in y_train])
-
-    # train iboss and predict X_test
-    iboss = IndividualBOSS()
-    iboss.fit(X_train, y_train)
-    y_pred = iboss.predict(X_test)
-
-    # assert class type and names
-    assert y_pred.dtype == float
-    assert set(y_pred) == set(y_train)
-
-
-def test_individual_boss_classes_boolean(dataset):
-    """Test of Individual Boss on unit test data with class dtype as BOOLEAN."""
-    # load unit test data
-    X_train, y_train, X_test, y_test = dataset
-
-    # change class
-    new_class = {"1": True, "2": False}
-    y_train = np.array([new_class[y] for y in y_train])
-
-    # train iboss and predict X_test
-    iboss = IndividualBOSS()
-    iboss.fit(X_train, y_train)
-    y_pred = iboss.predict(X_test)
-
-    # assert class type and names
-    assert y_pred.dtype == bool
-    assert set(y_pred) == set(y_train)
-
-
-def test_boss_ensemble_classes_string(dataset):
-    """Test of Boss Ensemble on unit test data with class dtype as STRING."""
+@pytest.mark.parametrize(
+    "new_class,expected_dtype",
+    [
+        ({"1": "Class1", "2": "Class2"}, object),
+        ({"1": 1, "2": 2}, int),
+        ({"1": 1.0, "2": 2.0}, float),
+        ({"1": True, "2": False}, bool),
+    ],
+)
+def test_boss_ensemble_classes(dataset, new_class, expected_dtype):
+    """Test BOSS Ensemble on unit_test data with different datatypes as classes."""
     # load unit test data
     X_train, y_train, X_test, y_test = dataset
 
@@ -111,61 +71,4 @@ def test_boss_ensemble_classes_string(dataset):
 
     # assert class type and names
     assert y_pred.dtype == "<U6"
-    assert set(y_pred) == set(y_train)
-
-
-def test_boss_ensemble_classes_integer(dataset):
-    """Test of Boss Ensemble on unit test data with class dtype as INTEGER."""
-    # load unit test data
-    X_train, y_train, X_test, y_test = dataset
-
-    # change class
-    new_class = {"1": 1, "2": 2}
-    y_train = np.array([new_class[y] for y in y_train])
-
-    # train boss_ensemble and predict X_test
-    boss_ensemble = BOSSEnsemble()
-    boss_ensemble.fit(X_train, y_train)
-    y_pred = boss_ensemble.predict(X_test)
-
-    # assert class type and names
-    assert y_pred.dtype == int
-    assert set(y_pred) == set(y_train)
-
-
-def test_boss_ensemble_classes_float(dataset):
-    """Test of Boss Ensemble on unit test data with class dtype as FLOAT."""
-    # load unit test data
-    X_train, y_train, X_test, y_test = dataset
-
-    # change class
-    new_class = {"1": 1.0, "2": 2.0}
-    y_train = np.array([new_class[y] for y in y_train])
-
-    # train boss_ensemble and predict X_test
-    boss_ensemble = BOSSEnsemble()
-    boss_ensemble.fit(X_train, y_train)
-    y_pred = boss_ensemble.predict(X_test)
-
-    # assert class type and names
-    assert y_pred.dtype == float
-    assert set(y_pred) == set(y_train)
-
-
-def test_boss_ensemble_classes_boolean(dataset):
-    """Test of Boss Ensemble on unit test data with class dtype as BOOLEAN."""
-    # load unit test data
-    X_train, y_train, X_test, y_test = dataset
-
-    # change class
-    new_class = {"1": True, "2": False}
-    y_train = np.array([new_class[y] for y in y_train])
-
-    # train boss_ensemble and predict X_test
-    boss_ensemble = BOSSEnsemble()
-    boss_ensemble.fit(X_train, y_train)
-    y_pred = boss_ensemble.predict(X_test)
-
-    # assert class type and names
-    assert y_pred.dtype == bool
     assert set(y_pred) == set(y_train)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Improve testing parameter for `BOSSEnsemble` and `IndividualBOSS`, towards #4096 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
- Reduce repetitive tests and group them together using `@pytest.mark.parametrize`
- Improve robustness by adding checks for `str` on top of `numpy.str_` for BOSS based classifier

#### Does your contribution introduce a new dependency? If yes, which one?
No

