### PR TITLE
[BUG] fix `get_fitted_params` for forecaster tuners, missing `best_forecaster` etc

### DIFF
--- a/sktime/forecasting/base/_delegate.py
+++ b/sktime/forecasting/base/_delegate.py
@@ -303,4 +303,4 @@ class _DelegatedForecaster(BaseForecaster):
             fitted parameters, keyed by names of fitted parameter
         """
         estimator = self._get_delegate()
-        return estimator.get_fitted_params()
+        return estimator._get_fitted_params()

--- a/sktime/forecasting/base/_delegate.py
+++ b/sktime/forecasting/base/_delegate.py
@@ -303,4 +303,4 @@ class _DelegatedForecaster(BaseForecaster):
             fitted parameters, keyed by names of fitted parameter
         """
         estimator = self._get_delegate()
-        return estimator._get_fitted_params()
+        return estimator.get_fitted_params()

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -121,6 +121,8 @@ class BaseGridSearch(_DelegatedForecaster):
         except NotImplementedError:
             pass
         fitted_params = {**fitted_params, **self.best_params_}
+        fitted_params.update(self._get_fitted_params_default())
+
         return fitted_params
 
     def _run_search(self, evaluate_candidates):

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -101,6 +101,10 @@ def test_gscv(forecaster, param_grid, cv, scoring, error_score):
     param_grid = ParameterGrid(param_grid)
     _check_cv(forecaster, gscv, cv, param_grid, y, X, scoring)
 
+    fitted_params = gscv.get_fitted_params()
+    assert "best_forecaster" in fitted_params.keys()
+    assert "best_score" in fitted_params.keys()
+
 
 @pytest.mark.parametrize(
     "forecaster, param_grid", [(NAIVE, NAIVE_GRID), (PIPE, PIPE_GRID)]


### PR DESCRIPTION
Due to a faulty override, key fitted parameters of the forecaster tuners (children of `BaseGridSearch`, e.g., `ForecastingGridSearchCV`) such as `"best_forecaster"` would not be returned as key/value pairs of `get_fitted_params` returns.

Only fitted parameters of the best forecaster, but not metadata about the grid search fit would be returned.

This has been fixed by simply adding a getter call for the default fitted parameters of the grid search fit in the private `_get_fitted_params` of the grid search base class `BaseGridSearch`.

Related discussion: https://github.com/sktime/sktime/discussions/4101