### PR TITLE
[BUG] fix `get_fitted_params` in case of vectoriztion for forecasters, transformers

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1219,10 +1219,15 @@ class BaseForecaster(BaseEstimator):
         # return forecasters in the "forecasters" param
         fitted_params["forecasters"] = forecasters
 
+        def _to_str(x):
+            if isinstance(x, str):
+                x = f"'{x}'"
+            return str(x)
+
         # populate fitted_params with forecasters and their parameters
-        for ix, col in zip(forecasters.index, forecasters.columns):
+        for ix, col in product(forecasters.index, forecasters.columns):
             fcst = forecasters.loc[ix, col]
-            fcst_key = f"forecasters.loc[{ix},{col}]"
+            fcst_key = f"forecasters.loc[{_to_str(ix)},{_to_str(col)}]"
             fitted_params[fcst_key] = fcst
             fcst_params = fcst.get_fitted_params()
             for key, val in fcst_params.items():

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -708,14 +708,19 @@ class BaseTransformer(BaseEstimator):
         # return forecasters in the "forecasters" param
         fitted_params["transformers"] = transformers
 
-        # populate fitted_params with ftransformers and their parameters
-        for ix, col in zip(transformers.index, transformers.columns):
-            fcst = transformers.loc[ix, col]
-            fcst_key = f"transformers.loc[{ix},{col}]"
-            fitted_params[fcst_key] = fcst
-            fcst_params = fcst.get_fitted_params()
-            for key, val in fcst_params.items():
-                fitted_params[f"{fcst_key}__{key}"] = val
+        def _to_str(x):
+            if isinstance(x, str):
+                x = f"'{x}'"
+            return str(x)
+
+        # populate fitted_params with transformers and their parameters
+        for ix, col in product(transformers.index, transformers.columns):
+            trafo = transformers.loc[ix, col]
+            trafo_key = f"forecasters.loc[{_to_str(ix)},{_to_str(col)}]"
+            fitted_params[trafo_key] = trafo
+            trafo_params = trafo.get_fitted_params()
+            for key, val in trafo_params.items():
+                fitted_params[f"{trafo_key}__{key}"] = val
 
         return fitted_params
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -716,7 +716,7 @@ class BaseTransformer(BaseEstimator):
         # populate fitted_params with transformers and their parameters
         for ix, col in product(transformers.index, transformers.columns):
             trafo = transformers.loc[ix, col]
-            trafo_key = f"forecasters.loc[{_to_str(ix)},{_to_str(col)}]"
+            trafo_key = f"transformers.loc[{_to_str(ix)},{_to_str(col)}]"
             fitted_params[trafo_key] = trafo
             trafo_params = trafo.get_fitted_params()
             for key, val in trafo_params.items():


### PR DESCRIPTION
This PR fixes an unreported bug that was noticed here: https://github.com/sktime/sktime/discussions/4101#discussioncomment-4679066

The bug causes only the diagonal combinations of rows/columns to be present as string keyable values in the fitted params dict in case of vectorized forecasters and transformers.

What should be present is the cartesian product, not the diagonal. This is solved by correctly using `product` instead of `zip` that was used accidentally.

Also fixes an issue (not necessarily bug) with the convention of constructing the strings - they should now always be a string that evaluates to a correct data frame `loc` access command, which previously was not the case for `str` keys (as that would eat away the quotes in `str` coercion).