### PR TITLE
[ENH] `BaseObject` `get_fitted_params` with `param` key, vectorization compatible for transformers and forecasters

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -904,22 +904,33 @@ class BaseEstimator(BaseObject):
                 f"been fitted yet; please call `fit` first."
             )
 
-    def get_fitted_params(self):
+    def get_fitted_params(self, param=None):
         """Get fitted parameters.
 
         State required:
             Requires state to be "fitted".
 
+        Parameters
+        ----------
+        param : str or None, optional, default=None
+            optional, name of the parameter to retrieve
+            if passed, changes return to be `fitted_params.get(param, None)` instead
+
         Returns
         -------
         fitted_params : dict of fitted parameters, keys are str names of parameters
             parameters of components are indexed as [componentname]__[paramname]
+            if `param` is provided, returns instead `fitted_params.get(param, None)`
         """
         if not self.is_fitted:
             raise NotFittedError(
                 f"estimator of type {type(self).__name__} has not been "
                 "fitted yet, please call fit on data before get_fitted_params"
             )
+
+        # treat case where param is not None
+        if param is not None:
+            return self.get_fitted_params().get(param, None)
 
         fitted_params = dict()
 

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -325,6 +325,10 @@ def test_get_fitted_params():
     assert comp_f_params["foo"] is composite.foo_
     assert comp_f_params["foo"] is not composite.foo
 
+    assert composite.get_fitted_params("foo") is composite.foo_
+    assert composite.get_fitted_params("foo") is not composite.foo
+    assert non_composite.get_fitted_params("bar") is None
+
 
 def test_eq_dunder():
     """Tests equality dunder for BaseObject descendants.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1219,10 +1219,15 @@ class BaseForecaster(BaseEstimator):
         # return forecasters in the "forecasters" param
         fitted_params["forecasters"] = forecasters
 
+        def _to_str(x):
+            if isinstance(x, str):
+                x = f"'{x}'"
+            return str(x)
+
         # populate fitted_params with forecasters and their parameters
-        for ix, col in zip(forecasters.index, forecasters.columns):
+        for ix, col in product(forecasters.index, forecasters.columns):
             fcst = forecasters.loc[ix, col]
-            fcst_key = f"forecasters.loc[{ix},{col}]"
+            fcst_key = f"forecasters.loc[{_to_str(ix)},{_to_str(col)}]"
             fitted_params[fcst_key] = fcst
             fcst_params = fcst.get_fitted_params()
             for key, val in fcst_params.items():

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1192,7 +1192,7 @@ class BaseForecaster(BaseEstimator):
 
         return mean_absolute_percentage_error(y, self.predict(fh, X))
 
-    def get_fitted_params(self):
+    def get_fitted_params(self, param=None):
         """Get fitted parameters.
 
         Overrides BaseEstimator default in case of vectorization.
@@ -1200,14 +1200,26 @@ class BaseForecaster(BaseEstimator):
         State required:
             Requires state to be "fitted".
 
+        Parameters
+        ----------
+        param : str or None, optional, default=None
+            optional, name of the parameter to retrieve
+            if provided, changes return as follows:
+            * if `self` is not vectorized, returns `fitted_params.get(param, None)`
+            * if `self` is vectorized and `param` is valid in `fitted_params`, same
+            * if `self` is vectorized and `param` not valid in `fitted_params`, returns
+              a modified `self.get_fitted_params("forecasters")` (a `pd.DataFrame`),
+              where each entry `x` is replaced by `x.get_fitted_params(param, None)`
+
         Returns
         -------
         fitted_params : dict of fitted parameters, keys are str names of parameters
             parameters of components are indexed as [componentname]__[paramname]
+            if `param` is provided, this return instead changes as described above
         """
         # if self is not vectorized, run the default get_fitted_params
         if not getattr(self, "_is_vectorized", False):
-            return super(BaseForecaster, self).get_fitted_params()
+            return super(BaseForecaster, self).get_fitted_params(param=param)
 
         # otherwise, we delegate to the instances' get_fitted_params
         # instances' parameters are returned at dataframe-slice-like keys
@@ -1232,6 +1244,19 @@ class BaseForecaster(BaseEstimator):
             fcst_params = fcst.get_fitted_params()
             for key, val in fcst_params.items():
                 fitted_params[f"{fcst_key}__{key}"] = val
+
+        # treat case where param is not None and one of the reserved vectorization attrs
+        if param is not None and param in fitted_params.keys():
+            return self.get_fitted_params().get(param, None)
+
+        # treat case where param needs to be broadcast to vectorized forecasters
+        if param is not None and param not in fitted_params.keys():
+            # shallow copy of self.forecasters_
+            result_df = forecasters.copy()
+            # replace all entries with retrieved key
+            for ix, col in product(forecasters.index, forecasters.columns):
+                result_df.loc[ix, col] = result_df.loc[ix, col].get_fitted_params(param)
+            return result_df
 
         return fitted_params
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -708,14 +708,19 @@ class BaseTransformer(BaseEstimator):
         # return forecasters in the "forecasters" param
         fitted_params["transformers"] = transformers
 
-        # populate fitted_params with ftransformers and their parameters
-        for ix, col in zip(transformers.index, transformers.columns):
-            fcst = transformers.loc[ix, col]
-            fcst_key = f"transformers.loc[{ix},{col}]"
-            fitted_params[fcst_key] = fcst
-            fcst_params = fcst.get_fitted_params()
-            for key, val in fcst_params.items():
-                fitted_params[f"{fcst_key}__{key}"] = val
+        def _to_str(x):
+            if isinstance(x, str):
+                x = f"'{x}'"
+            return str(x)
+
+        # populate fitted_params with transformers and their parameters
+        for ix, col in product(transformers.index, transformers.columns):
+            trafo = transformers.loc[ix, col]
+            trafo_key = f"forecasters.loc[{_to_str(ix)},{_to_str(col)}]"
+            fitted_params[trafo_key] = trafo
+            trafo_params = trafo.get_fitted_params()
+            for key, val in trafo_params.items():
+                fitted_params[f"{trafo_key}__{key}"] = val
 
         return fitted_params
 


### PR DESCRIPTION
This adds a parameter `param` to the `BaseObject`.

When `param` is passed, `estimator.get_fitted_param(param)` behaves per default as `estimator.get_fitted_param().get(param, None)`.

Advantages:
* slightly less clunky syntax
* can be overridden by child base classes with parameter creation on-demand

The fist point might not justify the interface extension, but I think the second one is strong because it allows the following secondary pattern for vectorized transformers and forecasters:

Suppose we have a vectorized transformer or forecaster, and `param` is a parameter of the vanilla transformer (unvectorized).
In that case, `estimator.get_fitted_param(param)` will return a `pd.DataFrame` with row and column indices being the vectorization indices, and entries being `x.get_fitted_param(param)` of the forecaster fitted for that variable/time series instance.

For instance:

```python
from sktime.transformations.series.boxcox import BoxCoxTransformer
from sktime.utils._testing.hierarchical import _make_hierarchical

X = _make_hierarchical()
t = BoxCoxTransformer()
t.fit(X)

t.get_fitted_params("lambda")
```

results in

```
          transformers
h0   h1               
h0_0 h1_0      1.39734
     h1_1     0.997021
     h1_2     2.501377
     h1_3     0.863364
h0_1 h1_0    -0.752334
     h1_1     0.988748
     h1_2    -0.080754
     h1_3     1.668946
```

Not sure whether this is worth the boilerplate overhead though.

Related discussion with @anthoygiorgio97 here:
https://github.com/sktime/sktime/discussions/4101#discussioncomment-4679688

FYI @RNKuhns re `BaseObject`
