### PR TITLE
[ENH] `get_fitted_params` for pipelines and other heterogenous meta-estimators

### DIFF
--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -102,14 +102,13 @@ class _HeterogenousMetaEstimator:
             deepkw = {"deep": deep}
 
         out = getattr(super(), method)(**deepkw)
-        if not deep:
-            return out
-        estimators = getattr(self, attr)
-        out.update(estimators)
-        for name, estimator in estimators:
-            if hasattr(estimator, "get_params"):
-                for key, value in getattr(estimator, method)(**deepkw).items():
-                    out["%s__%s" % (name, key)] = value
+        if deep and hasattr(self, attr):
+            estimators = getattr(self, attr)
+            out.update(estimators)
+            for name, estimator in estimators:
+                if hasattr(estimator, "get_params"):
+                    for key, value in getattr(estimator, method)(**deepkw).items():
+                        out["%s__%s" % (name, key)] = value
         return out
 
     def _set_params(self, attr, **params):

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -95,11 +95,11 @@ class _HeterogenousMetaEstimator:
     def _get_params(self, attr, deep=True, fitted=False):
 
         if fitted:
-            method = "get_fitted_params"
+            method = "_get_fitted_params"
         else:
             method = "get_params"
 
-        out = getattr(super(), method)(deep=deep)
+        out = getattr(super(), method)()
         if not deep:
             return out
         estimators = getattr(self, attr)

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -104,6 +104,7 @@ class _HeterogenousMetaEstimator:
         out = getattr(super(), method)(**deepkw)
         if deep and hasattr(self, attr):
             estimators = getattr(self, attr)
+            estimators = [(x[0], x[1]) for x in estimators]
             out.update(estimators)
             for name, estimator in estimators:
                 if hasattr(estimator, "get_params"):

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -249,15 +249,15 @@ class _HeterogenousMetaEstimator:
         TypeError, if estimators in the list are not instances of cls_type
         """
         msg = (
-            f"Invalid '{attr_name}' attribute, '{attr_name}' should be a list"
+            f"Invalid {attr_name!r} attribute, {attr_name!r} should be a list"
             " of estimators, or a list of (string, estimator) tuples. "
         )
         if cls_type is None:
-            msg += f"All estimators in '{attr_name}' must be of type BaseEstimator."
+            msg += f"All estimators in {attr_name!r} must be of type BaseEstimator."
             cls_type = BaseEstimator
         elif isclass(cls_type) or isinstance(cls_type, tuple):
             msg += (
-                f"All estimators in '{attr_name}' must be of type "
+                f"All estimators in {attr_name!r} must be of type "
                 f"{cls_type.__name__}."
             )
         else:
@@ -487,7 +487,7 @@ class _HeterogenousMetaEstimator:
         if concat_order not in ["left", "right"]:
             raise ValueError(
                 f'concat_order must be one of "left", "right", but found '
-                f'"{concat_order}"'
+                f"{concat_order!r}"
             )
         if not isinstance(attr_name, str):
             raise TypeError(f"attr_name must be str, but found {type(attr_name)}")

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -96,17 +96,19 @@ class _HeterogenousMetaEstimator:
 
         if fitted:
             method = "_get_fitted_params"
+            deepkw = {}
         else:
             method = "get_params"
+            deepkw = {"deep": deep}
 
-        out = getattr(super(), method)()
+        out = getattr(super(**deepkw), method)()
         if not deep:
             return out
         estimators = getattr(self, attr)
         out.update(estimators)
         for name, estimator in estimators:
             if hasattr(estimator, "get_params"):
-                for key, value in getattr(estimator, method)().items():
+                for key, value in getattr(estimator, method)(**deepkw).items():
                     out["%s__%s" % (name, key)] = value
         return out
 

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -101,7 +101,7 @@ class _HeterogenousMetaEstimator:
             method = "get_params"
             deepkw = {"deep": deep}
 
-        out = getattr(super(**deepkw), method)()
+        out = getattr(super(), method)(**deepkw)
         if not deep:
             return out
         estimators = getattr(self, attr)

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -20,11 +20,12 @@ class _HeterogenousMetaEstimator:
     # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
-    # this must be an iterable of (name: str, estimator) pairs for the default
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_attr = "_steps"
     # if the estimator is fittable, _HeterogenousMetaEstimator also
     # provides an override for get_fitted_params for params from the fitted estimators
     # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_fitted_attr = "steps_"
 
     def get_params(self, deep=True):

--- a/sktime/classification/compose/_column_ensemble.py
+++ b/sktime/classification/compose/_column_ensemble.py
@@ -244,6 +244,10 @@ class ColumnEnsembleClassifier(BaseColumnEnsembleClassifier):
     # which contains the heterogeneous set of estimators
     # this must be an iterable of (name: str, estimator) pairs for the default
     _steps_attr = "_estimators"
+    # if the estimator is fittable, _HeterogenousMetaEstimator also
+    # provides an override for get_fitted_params for params from the fitted estimators
+    # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    _steps_fitted_attr = "estimators_"
 
     def __init__(self, estimators, remainder="drop", verbose=False):
         self.remainder = remainder

--- a/sktime/classification/compose/_column_ensemble.py
+++ b/sktime/classification/compose/_column_ensemble.py
@@ -242,11 +242,12 @@ class ColumnEnsembleClassifier(BaseColumnEnsembleClassifier):
     # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
-    # this must be an iterable of (name: str, estimator) pairs for the default
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_attr = "_estimators"
     # if the estimator is fittable, _HeterogenousMetaEstimator also
     # provides an override for get_fitted_params for params from the fitted estimators
     # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_fitted_attr = "estimators_"
 
     def __init__(self, estimators, remainder="drop", verbose=False):

--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -640,11 +640,12 @@ class WeightedEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
     # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
-    # this must be an iterable of (name: str, estimator) pairs for the default
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_attr = "_classifiers"
     # if the estimator is fittable, _HeterogenousMetaEstimator also
     # provides an override for get_fitted_params for params from the fitted estimators
     # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_fitted_attr = "classifiers_"
 
     def __init__(

--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -642,6 +642,10 @@ class WeightedEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
     # which contains the heterogeneous set of estimators
     # this must be an iterable of (name: str, estimator) pairs for the default
     _steps_attr = "_classifiers"
+    # if the estimator is fittable, _HeterogenousMetaEstimator also
+    # provides an override for get_fitted_params for params from the fitted estimators
+    # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    _steps_fitted_attr = "classifiers_"
 
     def __init__(
         self,

--- a/sktime/dists_kernels/algebra.py
+++ b/sktime/dists_kernels/algebra.py
@@ -58,7 +58,7 @@ class CombinedDistance(_HeterogenousMetaEstimator, BasePairwiseTransformerPanel)
     # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
-    # this must be an iterable of (name: str, estimator) pairs for the default
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_attr = "_pw_trafos"
 
     def __init__(self, pw_trafos, operation=None):

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -19,7 +19,7 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
     # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
-    # this must be an iterable of (name: str, estimator) pairs for the default
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_attr = "forecasters"
 
     def __init__(self, forecasters, n_jobs=None):

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -89,14 +89,15 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
         "capability:pred_int": True,
     }
 
-    # for default get_params/set_params
+    # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
-    # this must be an iterable of (name: str, estimator) pairs for the default
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_attr = "_forecasters"
     # if the estimator is fittable, _HeterogenousMetaEstimator also
     # provides an override for get_fitted_params for params from the fitted estimators
     # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_fitted_attr = "forecasters_"
 
     def __init__(self, forecasters):

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -94,6 +94,10 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
     # which contains the heterogeneous set of estimators
     # this must be an iterable of (name: str, estimator) pairs for the default
     _steps_attr = "_forecasters"
+    # if the estimator is fittable, _HeterogenousMetaEstimator also
+    # provides an override for get_fitted_params for params from the fitted estimators
+    # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    _steps_fitted_attr = "forecasters_"
 
     def __init__(self, forecasters):
         self.forecasters = forecasters

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -101,6 +101,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
 
     @property
     def forecasters_name_est_(self):
+        """First two elements of forecasters_ attr, for default _get_fitted_params."""
         return [(name, forecaster) for (name, forecaster, _) in self.forecasters_]
 
     def __init__(self, forecasters):

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -97,12 +97,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
     # if the estimator is fittable, _HeterogenousMetaEstimator also
     # provides an override for get_fitted_params for params from the fitted estimators
     # the fitted estimators should be in a different attribute, _steps_fitted_attr
-    _steps_fitted_attr = "forecasters_name_est_"
-
-    @property
-    def forecasters_name_est_(self):
-        """First two elements of forecasters_ attr, for default _get_fitted_params."""
-        return [(name, forecaster) for (name, forecaster, _) in self.forecasters_]
+    _steps_fitted_attr = "forecasters_"
 
     def __init__(self, forecasters):
         self.forecasters = forecasters

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -101,7 +101,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
 
     @property
     def forecasters_name_est_(self):
-        return [(name, forecaster) for (name, forecaster, _)in self.forecasters_]
+        return [(name, forecaster) for (name, forecaster, _) in self.forecasters_]
 
     def __init__(self, forecasters):
         self.forecasters = forecasters

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -97,7 +97,11 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
     # if the estimator is fittable, _HeterogenousMetaEstimator also
     # provides an override for get_fitted_params for params from the fitted estimators
     # the fitted estimators should be in a different attribute, _steps_fitted_attr
-    _steps_fitted_attr = "forecasters_"
+    _steps_fitted_attr = "forecasters_name_est_"
+
+    @property
+    def forecasters_name_est_(self):
+        return [(name, forecaster) for (name, forecaster, _)in self.forecasters_)
 
     def __init__(self, forecasters):
         self.forecasters = forecasters

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -101,7 +101,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster):
 
     @property
     def forecasters_name_est_(self):
-        return [(name, forecaster) for (name, forecaster, _)in self.forecasters_)
+        return [(name, forecaster) for (name, forecaster, _)in self.forecasters_]
 
     def __init__(self, forecasters):
         self.forecasters = forecasters

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -97,6 +97,10 @@ class MultiplexForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     # which contains the heterogeneous set of estimators
     # this must be an iterable of (name: str, estimator) pairs for the default
     _steps_attr = "_forecasters"
+    # if the estimator is fittable, _HeterogenousMetaEstimator also
+    # provides an override for get_fitted_params for params from the fitted estimators
+    # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    _steps_fitted_attr = "forecasters_"
 
     def __init__(
         self,

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -95,11 +95,12 @@ class MultiplexForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
-    # this must be an iterable of (name: str, estimator) pairs for the default
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_attr = "_forecasters"
     # if the estimator is fittable, _HeterogenousMetaEstimator also
     # provides an override for get_fitted_params for params from the fitted estimators
     # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_fitted_attr = "forecasters_"
 
     def __init__(

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -23,6 +23,10 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
     # which contains the heterogeneous set of estimators
     # this must be an iterable of (name: str, estimator) pairs for the default
     _steps_attr = "_steps"
+    # if the estimator is fittable, _HeterogenousMetaEstimator also
+    # provides an override for get_fitted_params for params from the fitted estimators
+    # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    _steps_fitted_attr = "steps_"
 
     def _get_pipeline_scitypes(self, estimators):
         """Get list of scityes (str) from names/estimator list."""

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -21,11 +21,12 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
     # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
-    # this must be an iterable of (name: str, estimator) pairs for the default
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_attr = "_steps"
     # if the estimator is fittable, _HeterogenousMetaEstimator also
     # provides an override for get_fitted_params for params from the fitted estimators
     # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_fitted_attr = "steps_"
 
     def _get_pipeline_scitypes(self, estimators):

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -167,11 +167,12 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
     # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
-    # this must be an iterable of (name: str, estimator) pairs for the default
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_attr = "_steps"
     # if the estimator is fittable, _HeterogenousMetaEstimator also
     # provides an override for get_fitted_params for params from the fitted estimators
     # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_fitted_attr = "steps_"
 
     def __init__(self, steps):

--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -169,6 +169,10 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
     # which contains the heterogeneous set of estimators
     # this must be an iterable of (name: str, estimator) pairs for the default
     _steps_attr = "_steps"
+    # if the estimator is fittable, _HeterogenousMetaEstimator also
+    # provides an override for get_fitted_params for params from the fitted estimators
+    # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    _steps_fitted_attr = "steps_"
 
     def __init__(self, steps):
 
@@ -488,6 +492,10 @@ class FeatureUnion(_HeterogenousMetaEstimator, BaseTransformer):
     # which contains the heterogeneous set of estimators
     # this must be an iterable of (name: str, estimator) pairs for the default
     _steps_attr = "_transformer_list"
+    # if the estimator is fittable, _HeterogenousMetaEstimator also
+    # provides an override for get_fitted_params for params from the fitted estimators
+    # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    _steps_fitted_attr = "transformer_list_"
 
     def __init__(
         self,
@@ -898,6 +906,10 @@ class MultiplexTransformer(_HeterogenousMetaEstimator, _DelegatedTransformer):
     # which contains the heterogeneous set of estimators
     # this must be an iterable of (name: str, estimator) pairs for the default
     _steps_attr = "_transformers"
+    # if the estimator is fittable, _HeterogenousMetaEstimator also
+    # provides an override for get_fitted_params for params from the fitted estimators
+    # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    _steps_fitted_attr = "transformers_"
 
     def __init__(
         self,


### PR DESCRIPTION
This PR adds full functionality for `get_fitted_params` of pipelines (incl forecasting pipelines) and other heterogenous meta-estimators. Fixes https://github.com/sktime/sktime/issues/1468

`get_fitted_params` would already work previously, but not crawl the estimators in the "fitted steps" for fitted parameters.

This is now added, by adding a `_steps_fitted_attr` to configure in the `_HeterogenousMetaEstimator`, which is then used to retrieve the fitted parameters. In effect, this PR adds more keys and values that are retrieved to the return of `get_fitted_params`, from crawling the fitted steps.

Further updates the `_HeterogenousMetaEstimator` with a relaxed interface assumption: the `_steps_attr` now only needs to be an iterable of tuples of which the 0-th element is the name, 1-st element is an estimator. This covers, for instance, the `ColumnEnsembleForecaster` and the `ColumnEnsembleClassifier` natively, for both `get_params` (existing feature) and the new `get_fitted_params` functionality.

FYI @RNKuhns as this concerns an `skbase` object, would be keen to hear your opinion.