### PR TITLE
[MNT] address `pd.Series` constructor `dtype` deprecation / `FutureWarning` - part 2

### DIFF
--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -708,9 +708,8 @@ class CutoffSplitter(BaseSplitter):
             null = 0 if is_int(cutoff) else pd.Timestamp(0)
             if cutoff >= null:
                 train_end = y[cutoff] if is_int(cutoff) else cutoff
-                training_window = get_window(
-                    pd.Series(index=y[y <= train_end]), window_length=window_length
-                ).index
+                y_train = pd.Series(index=y[y <= train_end], dtype=y.dtype)
+                training_window = get_window(y_train, window_length=window_length).index
             else:
                 training_window = []
             training_window = y.get_indexer(training_window)


### PR DESCRIPTION
This PR addresses the `FutureWarning` deprecation message received from `pandas` for one instance of `pd.Series` constructor with `dtype` not explicitly set.

The fix is setting the `dtype` explicitly, which resolves the deprecation message in case the resulting series is empty.

Same as the fix in #4031, but for another splitter - I unfortunately did not spot the second instance here.