### PR TITLE
[BUG] Fix `OptionalPassthrough` `X_inner_mtype` tag

### DIFF
--- a/sktime/transformations/compose.py
+++ b/sktime/transformations/compose.py
@@ -1347,7 +1347,6 @@ class OptionalPassthrough(_DelegatedTransformer):
             "scitype:transform-input",
             "scitype:transform-output",
             "scitype:instancewise",
-            "X_inner_mtype",
             "y_inner_mtype",
             "capability:inverse_transform",
             "handles-missing-data",

--- a/sktime/transformations/tests/test_optionalpassthrough.py
+++ b/sktime/transformations/tests/test_optionalpassthrough.py
@@ -50,3 +50,27 @@ def test_optionalpassthrough():
         forecaster=pipe, param_grid=param_grid, cv=cv, n_jobs=-1
     )
     gscv.fit(load_airline())
+
+
+def test_passthrough_does_not_broadcast_variables():
+    """Test that OptionalPassthrough does not itself vectorize/broadcast columns."""
+    from sktime.datasets import load_longley
+    from sktime.transformations.compose import OptionalPassthrough
+    from sktime.transformations.series.detrend import Deseasonalizer
+
+    _, X = load_longley()
+
+    t = OptionalPassthrough(Deseasonalizer())
+    t.fit(X)
+
+
+def test_passthrough_does_not_broadcast_instances():
+    """Test that OptionalPassthrough does not itself vectorize/broadcast rows."""
+    from sktime.transformations.compose import OptionalPassthrough
+    from sktime.transformations.series.detrend import Deseasonalizer
+    from sktime.utils._testing.hierarchical import _make_hierarchical
+
+    X = _make_hierarchical()
+
+    t = OptionalPassthrough(Deseasonalizer())
+    t.fit(X)


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4114.

The bug occurs when the `OptionalPassthrough` is applied in a case that requires broadcasting. Through interaction with the `_DelegatedTransformer`, this can lead to wrong conversions.

The fix is delegating all conversions to the wrapped transformer (by removing the override of the `X_inner_mtype` tag and letting all mtypes through).

Adds two tests for the failure case in #4114 (column broadcast) and the parallel failure case for rows.