### PR TITLE
[DOC] improved docstring for `AutoETS`

### DIFF
--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -20,13 +20,14 @@ from sktime.forecasting.base.adapters import _StatsModelsAdapter
 class AutoETS(_StatsModelsAdapter):
     """ETS models with both manual and automatic fitting capabilities.
 
-    Manual fitting is adapted from the statsmodels version,
-    while automatic fitting is adapted from the R version of ets.
+    Manual (fixed parameter) use is a direct interface to `statsmodels` `ETSModel` [2]_,
+    while automatic fitting is an adaptation of from the R version of ets [3]_,
+    on top of `statsmodels` `ETSModel`.
 
-    The first few parameters are the same as the ones on statsmodels
+    The first parameters are direct interfaces to the `statsmodels` parameters
     (from ``error`` to ``return_params``) [2]_.
 
-    The next few parameters are adapted from the ones on R
+    The remaining parameters are adaptations of the parameters of R ets
     (``auto`` to ``additive_only``) [3]_,
     and are used for automatic model selection.
 
@@ -98,7 +99,7 @@ class AutoETS(_StatsModelsAdapter):
         default), additionally, the parameters
 
         * `initial_level` (:math:`l_{-1}`)
-        * `initial_trend` (:math:`l_{-1}`)
+        * `initial_trend` (:math:`l_{-1fau}`)
         * `initial_seasonal.0` (:math:`s_{-1}`)
         * `initial_seasonal.<m-1>` (:math:`s_{-m}`)
 


### PR DESCRIPTION
This PR contains a minor improvement to the docstrong of `AutoETS`, making the direct interface property to `statsmodels` `ETSModel` clearer.

Related to https://github.com/sktime/sktime/issues/4072 which is possibly based on the docstring not being 100% precise.