### PR TITLE
[DOC] fixes table of contents in `01_forecasting.ipynb` tutorial

### DIFF
--- a/examples/01_forecasting.ipynb
+++ b/examples/01_forecasting.ipynb
@@ -39,6 +39,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -48,7 +49,7 @@
     "    * [1.1 Data container format](#section_1_1)\n",
     "    * [1.2 Basic deployment workflow - batch fitting and forecasting](#section_1_2)\n",
     "        * [1.2.1 Basic deployment workflow in a nutshell](#section_1_2_1)\n",
-    "        * [1.2.2 Forecasters that require the horizon already in `fit`](#section_1_2_2)\n",
+    "        * [1.2.2 Forecasters that require the horizon when fitting](#section_1_2_2)\n",
     "        * [1.2.3 Forecasters that can make use of exogeneous data](#section_1_2_3)\n",
     "        * [1.2.4 Multivariate Forecasters](#section_1_2_4)\n",
     "        * [1.2.5 Prediction intervals and quantile forecasts](#section_1_2_5)  \n",


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4118, hopefully, by removing the quotes from the ToC line