### PR TITLE
[ENH] [DO NOT MERGE] Trigger `update_contributors.yml` workflow to run on `pull_request_target`

### DIFF
--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -1,9 +1,8 @@
 name: Update Contributors
 
 on:
-  push:
-    branches:
-      - main
+  pull_request_target:
+    types: [edited, opened, reopened, synchronize]
     paths:
       - '.all-contributorsrc'
 
@@ -12,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
       - name: Set up Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Reference #4103

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
This is an alternative proposal to the current `update_contributors.yml` according to which the workflow will run pre-merge in the context of base PR. Originally, this was meant to be a replacement for the current structure, but recent findings [show](https://github.com/sktime/sktime/issues/4103#issuecomment-1386533283) that it is not necessary for proper functioning.

**_Important_:** Merging the current workflow changes will [introduce](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) security vulnerabilities and hence should not be merged till finalized.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

Firstly, we need to discuss if this alternative is required. If it is then we need to rewrite the workflow file in such a way that we don't accidentally introduce any exploitable nodes.

Assuming we choose to move forward with an alternative, there are two things we can do to:
1. Run this workflow only after approval from a core developer (possibly easy to implement but responsibilities fall on core developers to go through changed files to confirm there are no malicious/fishy changes.)
2. Divide the workflow into two steps, where artifacts are built and saved in a less privileged environment followed by downloading the specific changes and getting the result. See [link](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) for example (difficult to implement, resulting in longer runtime of the job but more secure than the first)

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
No

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.


<!--
Thanks for contributing!
-->
