### PR TITLE
[ENH] refactor - localize broadcasting in `VectorizedDF`

### DIFF
--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -471,7 +471,6 @@ class VectorizedDF:
             kwargs[varname_of_self] = self
 
         def vec_dict(d, i, vectorize_cols=True):
-
             def fun(v):
                 return self._vectorize_slice(v, i=i, vectorize_cols=vectorize_cols)
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -479,7 +479,7 @@ class VectorizedDF:
         for i in range(len(self)):
 
             args_i = vec_dict(args, i=i, vectorize_cols=True)
-            args_i_rowvec = vec_dict(args_rowvec, i=i, vectorize_cols=True)
+            args_i_rowvec = vec_dict(args_rowvec, i=i, vectorize_cols=False)
             args_i.update(args_i_rowvec)
 
             row_ind, col_ind = self.get_iloc_indexer(i)

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -303,7 +303,6 @@ class VectorizedDF:
         -------
         self._iter_indices(X=X)[i], tuple elements coerced to pd.Index coercible
         """
-
         row_ind, col_ind = self._iter_indices(X=X)[i]
         if isinstance(col_ind, list):
             col_ind = pd.Index(col_ind)

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -405,7 +405,42 @@ class VectorizedDF:
         varname_of_self=None,
         **kwargs,
     ):
+        """Fit multiple clones of estimator in broadcast shape, return in pd.DataFrame.
 
+        This function returns a `pd.DataFrame` with `estimator` fitted on
+        vectorization slices of `self`. Row and column indices are the
+        same as obtained from `get_iter_indices`.
+
+        For a row and column of the return, the entry is a clone of `estimator`,
+        where `fit` has been executed with the following arguments:
+        * `varname=value`, where `varname`/`value` are key-value pair of `kwargs`,
+          and `value` is not an instance of `VectorizedDF`, for all such `value`
+        * `varname=value[i]`, where `varname`/`value` are key-value pair of `kwargs`,
+          and `i` is the iteration index corresponding to row/column,
+          and `value` is an instance of `VectorizedDF`, for all such `value`
+        * `varname_of_self=self`, if `varname_of_self` is not `None`. Here,
+          `varname_of_self` should be read as the `str` value of that variable.
+
+        Parameters
+        ----------
+        estimator : an sktime estimator object, instance of descendant of BaseEstimator
+            clones of the estimator will be fitted to vectorized slices of self
+        rowname_default : str, optional, default="estimators"
+            used as index name of single row if no row vectorization is performed
+        colname_default : str, optional, default="estimators"
+            used as index name of single column if no column vectorization is performed
+        varname_of_self : str, optional, default=None
+            if not None, self will be passed as kwarg under name "varname_of_self"
+        kwargs : will be passed to `fit` of clones on vectorized slices
+
+        Returns
+        -------
+        pd.DataFrame, with rows and columns as the return of `get_iter_indices`.
+          If rows or columns are not vectorized over, the single index
+          will be `rowname_default` resp `colname_default`.
+          Entries are fitted clones of `estimator`, fitted with arguments
+          as described above.
+        """
         row_ix, col_ix = self.get_iter_indices()
         if row_ix is None:
             row_ix = [rowname_default]

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -476,12 +476,29 @@ class VectorizedDF:
         vectorization slices of `self`. Row and column indices are the
         same as obtained from `get_iter_indices`.
 
-        For a row and column of the return, the entry is a clone of `estimator`,
-        where `fit` has been executed with the following arguments:
+        This function:
+
+        1. takes a single `sktime` estimator or a `pd.DataFrame` with estimator entries
+        2. calls `method` of estimator, with arguments as per `args`, `args_rowvec`
+        3. returns the result, a list or pd.DataFrame with estimator values
+
+        If `estimator` is a single estimator, it is broadcast to a `pd.DataFrame`.
+        Elements of `args`, `args_rowvec` can be `VectorizedDF`, in which case
+        they are broadcast in the application step 2.
+
+        For a row and column of the return,
+        the entry is `estimator` at the same entry (if `DataFrame`) or `estimator`,
+        where `method` has been executed with the following arguments:
+
         * `varname=value`, where `varname`/`value` are key-value pair of `kwargs`,
           and `value` is not an instance of `VectorizedDF`, for all such `value`
-        * `varname=value[i]`, where `varname`/`value` are key-value pair of `kwargs`,
-          and `i` is the iteration index corresponding to row/column,
+        * `varname=value.loc[row,col]`,
+          where `varname`/`value` are key-value pair of `kwargs` or `args`,
+          and `row` and `col` are `loc` indices corresponding to row/column,
+          and `value` is an instance of `VectorizedDF`, for all such `value`
+        * `varname=value.loc[row]`,
+          where `varname`/`value` are key-value pair of `args_rowvec`,
+          and `row` and `col` are `loc` indices corresponding to row/column,
           and `value` is an instance of `VectorizedDF`, for all such `value`
         * `varname_of_self=self`, if `varname_of_self` is not `None`. Here,
           `varname_of_self` should be read as the `str` value of that variable.
@@ -517,8 +534,8 @@ class VectorizedDF:
         pd.DataFrame, with rows and columns as the return of `get_iter_indices`.
           If rows or columns are not vectorized over, the single index
           will be `rowname_default` resp `colname_default`.
-          Entries are fitted clones of `estimator`, fitted with arguments
-          as described above.
+          Entries are identity references to entries of `estimator`,
+          after `method` executed with arguments as above.
         """
         if args is None:
             args = kwargs

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -239,6 +239,11 @@ class VectorizedDF:
         # if row_ix and col_ix are both not None
         return len(row_ix) * len(col_ix)
 
+    def __getitem__(self, i: int):
+        """Return the i-th element iterated over in vectorization."""
+        row_ind, col_ind = self._get_item_indexer(i=i)
+        return self._get_X_at_index(row_ind=row_ind, col_ind=col_ind)
+
     def _get_X_at_index(self, row_ind=None, col_ind=None, X=None):
         """Return subset of self, at row_ind and col_ind."""
         if X is None:
@@ -256,11 +261,6 @@ class VectorizedDF:
             res = X[col_ind].loc[row_ind]
         res = _enforce_index_freq(res)
         return res
-
-    def __getitem__(self, i: int):
-        """Return the i-th element iterated over in vectorization."""
-        row_ind, col_ind = self._get_item_indexer(i=i)
-        return self._get_X_at_index(row_ind=row_ind, col_ind=col_ind)
 
     def _get_item_indexer(self, i: int, X=None):
 
@@ -474,12 +474,12 @@ class VectorizedDF:
         if args_rowvec is None:
             args_rowvec = {}
 
-        row_ix, col_ix = self.get_iter_indices()
-        if row_ix is None:
-            row_ix = [rowname_default]
-        if col_ix is None:
-            col_ix = [colname_default]
-        result = pd.DataFrame(index=row_ix, columns=col_ix)
+        row_idx, col_idx = self.get_iter_indices()
+        if row_idx is None:
+            row_idx = [rowname_default]
+        if col_idx is None:
+            col_idx = [colname_default]
+        result = pd.DataFrame(index=row_idx, columns=col_idx)
 
         if varname_of_self is not None and isinstance(varname_of_self, str):
             kwargs[varname_of_self] = self

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -472,8 +472,10 @@ class VectorizedDF:
 
         def vec_dict(d, i, vectorize_cols=True):
 
-            fun = lambda v: self._vectorize_slice(v, i=i, vectorize_cols=vectorize_cols)
-            return {k: fun(v) for k, v in args.items()}
+            def fun(v):
+                return self._vectorize_slice(v, i=i, vectorize_cols=vectorize_cols)
+
+            return {k: fun(v) for k, v in d.items()}
 
         for i in range(len(self)):
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -476,7 +476,7 @@ class VectorizedDF:
             return {k: fun(v) for k, v in args.items()}
 
         for i in range(len(self)):
-            
+
             args_i = vec_dict(args, i=i, vectorize_cols=True)
             args_i_rowvec = vec_dict(args_rowvec, i=i, vectorize_cols=True)
             args_i.update(args_i_rowvec)

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -402,6 +402,7 @@ class VectorizedDF:
         estimator,
         rowname_default="estimators",
         colname_default="estimators",
+        varname_of_self=None,
         **kwargs,
     ):
 
@@ -412,11 +413,14 @@ class VectorizedDF:
             col_ix = [colname_default]
         result = pd.DataFrame(index=row_ix, columns=col_ix)
 
-        for i in len(self):
-            row_ind, col_ind = self._get_item_indexer(i=i, result=result)
+        if varname_of_self is not None and isinstance(varname_of_self, str):
+            kwargs[varname_of_self] = self
+
+        for i in range(len(self)):
+            row_ind, col_ind = self.get_iloc_indexer(i)
             args_i = {k: self._vectorize_slice(v, i=i) for k, v in kwargs.items()}
             est_clone = estimator.clone()
-            result[row_ind].loc[col_ind] = est_clone.fit(**args_i)
+            result.iloc[row_ind].iloc[col_ind] = est_clone.fit(**args_i)
 
         return result
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -431,7 +431,7 @@ class VectorizedDF:
         varname_of_self=None,
         **kwargs,
     ):
-        """Fit multiple clones of estimator in broadcast shape, return in pd.DataFrame.
+        """Vectorize application of estimator method, return results DataFrame or list.
 
         This function returns a `pd.DataFrame` with `estimator` fitted on
         vectorization slices of `self`. Row and column indices are the
@@ -451,6 +451,8 @@ class VectorizedDF:
         ----------
         estimator : an sktime estimator object, instance of descendant of BaseEstimator
             clones of the estimator will be fitted to vectorized slices of self
+        method : str, optional, default="clone"
+            method of estimator to call with arguments in `args`, `args_rowvec`
         return_type : str, one of "pd.DataFrame" or "list"
         rowname_default : str, optional, default="estimators"
             used as index name of single row if no row vectorization is performed

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -457,12 +457,18 @@ def test_vectorize_fit(
 
     result = X_vect.vectorize_fit(NaiveForecaster(), **kwargs)
 
+    def _len(x):
+        if x is None:
+            return 1
+        else:
+            return len(x)
+
     # the result should be a pd.DataFrame
     # with entries being fitted NaiveForecaster clones
     rows, cols = X_vect.get_iter_indices()
-    n_rows = len(rows) if rows else 1
-    n_cols = len(cols) if cols else 1
+    n_rows = _len(rows)
+    n_cols = _len(cols)
     assert isinstance(result, pd.DataFrame)
     assert result.shape == (n_rows, n_cols)
-    is_fcst_frame = result.applymap(result, lambda x: isinstance(x, NaiveForecaster))
+    is_fcst_frame = result.applymap(lambda x: isinstance(x, NaiveForecaster))
     assert is_fcst_frame.all().all()

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -455,7 +455,8 @@ def test_vectorize_fit(
     else:
         kwargs["y"] = X_vect
 
-    result = X_vect.vectorize_fit(NaiveForecaster(), **kwargs)
+    est_clones = X_vect.vectorize_est(NaiveForecaster(), method="clone")
+    result = X_vect.vectorize_est(est_clones, method="fit", **kwargs)
 
     def _len(x):
         if x is None:

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -420,7 +420,7 @@ def test_enforce_index_freq(item, freq):
 def test_vectorize_fit(
     scitype, mtype, fixture_index, iterate_as, iterate_cols, varname_used
 ):
-    """Tests vectorize_fit method of VectorizeDF.
+    """Tests vectorize_est method of VectorizeDF, for method = clone, fit.
 
     Fixtures parameterized
     ----------------------

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -458,9 +458,11 @@ def test_vectorize_fit(
     result = X_vect.vectorize_fit(NaiveForecaster(), **kwargs)
 
     # the result should be a pd.DataFrame
-    # with entries being fittedd NaiveForecaster clones
+    # with entries being fitted NaiveForecaster clones
     rows, cols = X_vect.get_iter_indices()
+    n_rows = len(rows) if rows else 1
+    n_cols = len(cols) if cols else 1
     assert isinstance(result, pd.DataFrame)
-    assert result.shape == (len(rows), len(cols))
+    assert result.shape == (n_rows, n_cols)
     is_fcst_frame = result.applymap(result, lambda x: isinstance(x, NaiveForecaster))
     assert is_fcst_frame.all().all()

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -417,7 +417,7 @@ def test_enforce_index_freq(item, freq):
 
 
 @pytest.mark.parametrize("varname_used", [True, False])
-def test_vectorize_fit(
+def test_vectorize_est(
     scitype, mtype, fixture_index, iterate_as, iterate_cols, varname_used
 ):
     """Tests vectorize_est method of VectorizeDF, for method = clone, fit.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -39,7 +39,6 @@ __author__ = ["mloning", "big-o", "fkiraly", "sveameyer13", "miraep8"]
 __all__ = ["BaseForecaster"]
 
 from copy import deepcopy
-from itertools import product
 from warnings import warn
 
 import numpy as np

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1714,14 +1714,14 @@ class BaseForecaster(BaseEstimator):
             "predict_var",
         ]
 
-        # retrieve data arguments
-        y = kwargs.pop("y", None)
-        X = kwargs.pop("X", None)
-
         if methodname == "fit":
-            self.forecasters_ = y.vectorize_fit(self, **kwargs)
+            self.forecasters_ = kwargs["y"].vectorize_fit(self, **kwargs)
 
         elif methodname in FIT_METHODS:
+            # retrieve data arguments
+            y = kwargs.pop("y", None)
+            X = kwargs.pop("X", None)
+
             # create container for clones
             self._yvec = y
 
@@ -1749,6 +1749,10 @@ class BaseForecaster(BaseEstimator):
             return self
 
         elif methodname in PREDICT_METHODS:
+            # retrieve data arguments
+            y = kwargs.pop("y", None)
+            X = kwargs.pop("X", None)
+
             n = len(self.forecasters_.index)
             m = len(self.forecasters_.columns)
 

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1715,7 +1715,9 @@ class BaseForecaster(BaseEstimator):
         ]
 
         if methodname == "fit":
-            self.forecasters_ = kwargs["y"].vectorize_fit(self, **kwargs)
+            y = kwargs["y"]
+            self._yvec = y
+            self.forecasters_ = y.vectorize_fit(self, **kwargs)
 
         elif methodname in FIT_METHODS:
             # retrieve data arguments

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1723,38 +1723,24 @@ class BaseForecaster(BaseEstimator):
             dX = {"X": X}
 
             if methodname == "fit":
-                forecasters_ = y.vectorize_est(self, method="clone")
+                forecasters_ = y.vectorize_est(
+                    self,
+                    method="clone",
+                    rowname_default="forecasters",
+                    colname_default="forecasters",
+                )
             else:
                 forecasters_ = self.forecasters_
+
             self.forecasters_ = y.vectorize_est(
-                forecasters_, method=methodname, y=y, args_rowvec=dX, **kwargs
+                forecasters_,
+                method=methodname,
+                y=y,
+                args_rowvec=dX,
+                rowname_default="forecasters",
+                colname_default="forecasters",
+                **kwargs,
             )
-
-        elif methodname in FIT_METHODS:
-            # create container for clones
-            self._yvec = y
-
-            row_idx, col_idx = y.get_iter_indices()
-            ys = y.as_list()
-
-            if X is None:
-                Xs = [None] * len(ys)
-            else:
-                Xs = X.as_list()
-
-            if row_idx is None:
-                row_idx = ["forecasters"]
-            if col_idx is None:
-                col_idx = ["forecasters"]
-
-            if methodname == "fit":
-                self.forecasters_ = pd.DataFrame(index=row_idx, columns=col_idx)
-            for ix in range(len(ys)):
-                i, j = y.get_iloc_indexer(ix)
-                if methodname == "fit":
-                    self.forecasters_.iloc[i].iloc[j] = self.clone()
-                method = getattr(self.forecasters_.iloc[i].iloc[j], methodname)
-                method(y=ys[ix], X=Xs[i], **kwargs)
             return self
 
         elif methodname in PREDICT_METHODS:

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1718,10 +1718,17 @@ class BaseForecaster(BaseEstimator):
         X = kwargs.pop("X", None)
         y = kwargs.pop("y", None)
 
-        if methodname == "fit":
+        if methodname in FIT_METHODS:
             self._yvec = y
             dX = {"X": X}
-            self.forecasters_ = y.vectorize_fit(self, y=y, args_rowvec=dX, **kwargs)
+
+            if methodname == "fit":
+                forecasters_ = y.vectorize_est(self, method="clone")
+            else:
+                forecasters_ = self.forecasters_
+            self.forecasters_ = y.vectorize_est(
+                forecasters_, method=methodname, y=y, args_rowvec=dX, **kwargs
+            )
 
         elif methodname in FIT_METHODS:
             # create container for clones

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -39,6 +39,7 @@ __author__ = ["mloning", "big-o", "fkiraly", "sveameyer13", "miraep8"]
 __all__ = ["BaseForecaster"]
 
 from copy import deepcopy
+from itertools import product
 from warnings import warn
 
 import numpy as np

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1717,42 +1717,35 @@ class BaseForecaster(BaseEstimator):
         # retrieve data arguments
         X = kwargs.pop("X", None)
         y = kwargs.get("y", None)
-        kwargs["args_rowvec"] = {"X": X}
 
+        # add some common arguments to kwargs
+        kwargs["args_rowvec"] = {"X": X}
+        kwargs["rowname_default"] = "forecasters"
+        kwargs["colname_default"] = "forecasters"
+
+        # fit-like methods: write y to self._yvec; then run method; clone first if fit
         if methodname in FIT_METHODS:
             self._yvec = y
 
             if methodname == "fit":
-                forecasters_ = y.vectorize_est(
-                    self,
-                    method="clone",
-                    rowname_default="forecasters",
-                    colname_default="forecasters",
-                )
+                forecasters_ = y.vectorize_est(self, method="clone")
             else:
                 forecasters_ = self.forecasters_
 
             self.forecasters_ = y.vectorize_est(
-                forecasters_,
-                method=methodname,
-                rowname_default="forecasters",
-                colname_default="forecasters",
-                **kwargs,
+                forecasters_, method=methodname, **kwargs,
             )
             return self
 
+        # predict-like methods: return as list, then run through reconstruct
+        # to obtain a pandas based container in one of the pandas mtype formats
         elif methodname in PREDICT_METHODS:
 
             if methodname == "update_predict_single":
                 self._yvec = y
 
             y_preds = self._yvec.vectorize_est(
-                self.forecasters_,
-                method=methodname,
-                rowname_default="forecasters",
-                colname_default="forecasters",
-                return_type="list",
-                **kwargs,
+                self.forecasters_, method=methodname, return_type="list", **kwargs,
             )
 
             # if we vectorize over columns,

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1718,7 +1718,10 @@ class BaseForecaster(BaseEstimator):
         y = kwargs.pop("y", None)
         X = kwargs.pop("X", None)
 
-        if methodname in FIT_METHODS:
+        if methodname == "fit":
+            self.forecasters_ = y.vectorize_fit(self, **kwargs)
+
+        elif methodname in FIT_METHODS:
             # create container for clones
             self._yvec = y
 

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1714,16 +1714,16 @@ class BaseForecaster(BaseEstimator):
             "predict_var",
         ]
 
+        # retrieve data arguments
+        X = kwargs.pop("X", None)
+        y = kwargs.pop("y", None)
+
         if methodname == "fit":
-            y = kwargs["y"]
             self._yvec = y
-            self.forecasters_ = y.vectorize_fit(self, **kwargs)
+            dX = {"X": X}
+            self.forecasters_ = y.vectorize_fit(self, y=y, args_rowvec=dX, **kwargs)
 
         elif methodname in FIT_METHODS:
-            # retrieve data arguments
-            y = kwargs.pop("y", None)
-            X = kwargs.pop("X", None)
-
             # create container for clones
             self._yvec = y
 
@@ -1751,9 +1751,6 @@ class BaseForecaster(BaseEstimator):
             return self
 
         elif methodname in PREDICT_METHODS:
-            # retrieve data arguments
-            y = kwargs.pop("y", None)
-            X = kwargs.pop("X", None)
 
             n = len(self.forecasters_.index)
             m = len(self.forecasters_.columns)

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1760,44 +1760,6 @@ class BaseForecaster(BaseEstimator):
                 y_pred.columns = y_pred.columns.droplevel(1)
             return y_pred
 
-        elif methodname in PREDICT_METHODS:
-
-            n = len(self.forecasters_.index)
-            m = len(self.forecasters_.columns)
-
-            if X is None:
-                Xs = [None] * n * m
-            elif isinstance(X, VectorizedDF):
-                Xs = X.as_list()
-            else:
-                Xs = [X]
-
-            if methodname == "update_predict_single":
-                self._yvec = y
-                ys = y.as_list()
-
-            y_preds = []
-            ix = -1
-            for i, j in product(range(n), range(m)):
-                ix += 1
-                method = getattr(self.forecasters_.iloc[i].iloc[j], methodname)
-
-                if methodname != "update_predict_single":
-                    y_preds += [method(X=Xs[i], **kwargs)]
-                else:
-                    y_preds += [method(y=ys[ix], X=Xs[i], **kwargs)]
-
-            # if we vectorize over columns,
-            #   we need to replace top column level with variable names - part 1
-            col_multiindex = "multiindex" if m > 1 else "none"
-            y_pred = self._yvec.reconstruct(
-                y_preds, overwrite_index=True, col_multiindex=col_multiindex
-            )
-            # if vectorize over columns replace top column level with variable names
-            if col_multiindex == "multiindex":
-                y_pred.columns = y_pred.columns.droplevel(1)
-            return y_pred
-
     def _fit(self, y, X=None, fh=None):
         """Fit forecaster to training data.
 

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1733,7 +1733,7 @@ class BaseForecaster(BaseEstimator):
                 forecasters_ = self.forecasters_
 
             self.forecasters_ = y.vectorize_est(
-                forecasters_, method=methodname, **kwargs,
+                forecasters_, method=methodname, **kwargs
             )
             return self
 
@@ -1745,7 +1745,7 @@ class BaseForecaster(BaseEstimator):
                 self._yvec = y
 
             y_preds = self._yvec.vectorize_est(
-                self.forecasters_, method=methodname, return_type="list", **kwargs,
+                self.forecasters_, method=methodname, return_type="list", **kwargs
             )
 
             # if we vectorize over columns,

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1088,7 +1088,7 @@ class BaseTransformer(BaseEstimator):
             else:
                 transformers_ = self.transformers_
 
-            self.transformers_ = y.vectorize_est(
+            self.transformers_ = X.vectorize_est(
                 transformers_, method=methodname, **kwargs
             )
             return self

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1096,11 +1096,10 @@ class BaseTransformer(BaseEstimator):
         if methodname in TRAFO_METHODS:
             # loop through fitted transformers one-by-one, and transform series/panels
             if not self.get_tag("fit_is_empty"):
-
+                # if not fit_is_empty: check index compatibility, get fitted trafos
                 n_trafos = len(X)
                 n, m = self.transformers_.shape
                 n_fit = n * m
-
                 if n_trafos != n_fit:
                     raise RuntimeError(
                         "found different number of instances in transform than in fit. "
@@ -1108,30 +1107,18 @@ class BaseTransformer(BaseEstimator):
                         f"number of instances seen in transform: {n_trafos}"
                     )
 
-                # transform the i-th series/panel with the i-th stored transformer
-                Xts = X.vectorize_est(
-                    self.transformers_, method=methodname, return_type="list", **kwargs
-                )
-                Xt = X.reconstruct(Xts, overwrite_index=False)
+                transformers_ = self.transformers_
 
-            # if fit_is_empty: don't store transformers, run fit/transform in one
             else:
+                # if fit_is_empty: don't store transformers, run fit/transform in one
                 transformers_ = X.vectorize_est(self, method="clone")
                 transformers_ = X.vectorize_est(transformers_, method="fit", **kwargs)
-                Xts = X.vectorize_est(
-                    transformers_, method=methodname, return_type="list", **kwargs
-                )
-                Xt = X.reconstruct(Xts, overwrite_index=False)
 
-            # # one more thing before returning:
-            #
-            # if methodname == "inverse_transform":
-            #         output_scitype = self.get_tag("scitype:transform-input")
-            #     else:
-            #         output_scitype = self.get_tag("scitype:transform-output")
-            # if output_scitype == "Primitives" and :
-            #         Xt = pd.concat(Xt)
-            #         Xt = Xt.reset_index(drop=True)
+            # transform the i-th series/panel with the i-th stored transformer
+            Xts = X.vectorize_est(
+                transformers_, method=methodname, return_type="list", **kwargs
+            )
+            Xt = X.reconstruct(Xts, overwrite_index=False)
 
             return Xt
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -49,7 +49,6 @@ __all__ = [
     "_PanelToPanelTransformer",
 ]
 
-from itertools import product
 from typing import Union
 
 import numpy as np
@@ -705,7 +704,7 @@ class BaseTransformer(BaseEstimator):
         # transformers contains a pd.DataFrame with the individual transformers
         transformers = self.transformers_
 
-        # return forecasters in the "forecasters" param
+        # return transformers in the "transformers" param
         fitted_params["transformers"] = transformers
 
         # populate fitted_params with ftransformers and their parameters
@@ -1070,58 +1069,35 @@ class BaseTransformer(BaseEstimator):
     def _vectorize(self, methodname, **kwargs):
         """Vectorized/iterated loop over method of BaseTransformer.
 
-        Uses transformers_ attribute to store one forecaster per loop index.
+        Uses transformers_ attribute to store one transformer per loop index.
         """
-
-        def unwrap(kwargs):
-            """Unwrap kwargs to X, y, and reusable results of some method calls."""
-            X = kwargs.pop("X")
-            y = kwargs.pop("y", None)
-
-            row_idx, col_idx = X.get_iter_indices()
-            if row_idx is None:
-                row_idx = ["transformers"]
-            if col_idx is None:
-                col_idx = ["transformers"]
-
-            Xs = X.as_list()
-            n = len(Xs)
-
-            if y is None:
-                ys = [None] * n
-            else:
-                ys = y.as_list()
-
-            return X, y, Xs, ys, n, row_idx, col_idx
+        X = kwargs.get("X")
+        y = kwargs.pop("y", None)
+        kwargs["args_rowvec"] = {"y": y}
+        kwargs["rowname_default"] = "transformers"
+        kwargs["colname_default"] = "transformers"
 
         FIT_METHODS = ["fit", "update"]
         TRAFO_METHODS = ["transform", "inverse_transform"]
 
+        # fit-like methods: run method; clone first if fit
         if methodname in FIT_METHODS:
-            X, _, Xs, ys, n, row_idx, col_idx = unwrap(kwargs)
-
-            # if fit is called, create container of transformers, but not in update
             if methodname == "fit":
-                self.transformers_ = pd.DataFrame(index=row_idx, columns=col_idx)
-                for ix in range(n):
-                    i, j = X.get_iloc_indexer(ix)
-                    self.transformers_.iloc[i].iloc[j] = self.clone()
+                transformers_ = X.vectorize_est(self, method="clone")
+            else:
+                transformers_ = self.transformers_
 
-            # fit/update the ix-th transformer with the ix-th series/panel
-            for ix in range(n):
-                i, j = X.get_iloc_indexer(ix)
-                method = getattr(self.transformers_.iloc[i].iloc[j], methodname)
-                method(X=Xs[ix], y=ys[i], **kwargs)
-
+            self.transformers_ = y.vectorize_est(
+                transformers_, method=methodname, **kwargs
+            )
             return self
 
         if methodname in TRAFO_METHODS:
             # loop through fitted transformers one-by-one, and transform series/panels
             if not self.get_tag("fit_is_empty"):
-                X, _, Xs, ys, n_trafos, _, _ = unwrap(kwargs)
 
-                n = len(self.transformers_.index)
-                m = len(self.transformers_.columns)
+                n_trafos = len(X)
+                n, m = self.transformers_.shape
                 n_fit = n * m
 
                 if n_trafos != n_fit:
@@ -1132,25 +1108,18 @@ class BaseTransformer(BaseEstimator):
                     )
 
                 # transform the i-th series/panel with the i-th stored transformer
-                Xts = []
-                ix = -1
-                for i, j in product(range(n), range(m)):
-                    ix += 1
-                    method = getattr(self.transformers_.iloc[i].iloc[j], methodname)
-                    Xts += [method(X=Xs[ix], y=ys[i], **kwargs)]
+                Xts = X.vectorize_est(
+                    self.transformers_, method=methodname, return_type="list", **kwargs
+                )
                 Xt = X.reconstruct(Xts, overwrite_index=False)
 
             # if fit_is_empty: don't store transformers, run fit/transform in one
             else:
-                X, _, Xs, ys, n, _, _ = unwrap(kwargs)
-
-                # fit/transform the i-th series/panel with a new clone of self
-                Xts = []
-                for ix in range(n):
-                    i, j = X.get_iloc_indexer(ix)
-                    transformer = self.clone().fit(X=Xs[ix], y=ys[i], **kwargs)
-                    method = getattr(transformer, methodname)
-                    Xts += [method(X=Xs[ix], y=ys[i], **kwargs)]
+                transformers_ = X.vectorize_est(self, method="clone")
+                transformers_ = X.vectorize_est(transformers_, method="fit", **kwargs)
+                transformers_ = X.vectorize_est(
+                    transformers_, method=methodname, return_type="list", **kwargs
+                )
                 Xt = X.reconstruct(Xts, overwrite_index=False)
 
             # # one more thing before returning:

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -49,6 +49,7 @@ __all__ = [
     "_PanelToPanelTransformer",
 ]
 
+from itertools import product
 from typing import Union
 
 import numpy as np

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1118,7 +1118,7 @@ class BaseTransformer(BaseEstimator):
             else:
                 transformers_ = X.vectorize_est(self, method="clone")
                 transformers_ = X.vectorize_est(transformers_, method="fit", **kwargs)
-                transformers_ = X.vectorize_est(
+                Xts = X.vectorize_est(
                     transformers_, method=methodname, return_type="list", **kwargs
                 )
                 Xt = X.reconstruct(Xts, overwrite_index=False)


### PR DESCRIPTION
This PR moves functionality for broadcast/vectorized application of estimator methods to `VectorizedDF`, to a new method called `vectorize_est`. It also serves to explore refactor end states.

Reasons to move broadcast/vectorized application to `VectorizedDF`:

* duplication between transformers and forecasters which have very similar logic implemented
* current state can be seen as a violation of the law of Demeter; target state improves cohesion, reduces coupling between base classes and `VectorizedDF`
* localized logic in `VectorizedDF` seems to be a more natural starting point for adding `dask` and scaling/distributed features, see https://github.com/sktime/sktime/issues/4013

Also contains a direct unit test for `vectorize_est`.
Note that the new method `vectorize_est` is also indirectly covered by tests for vectorization functionality in transformers and forecasters, which also covers the external points of the refactor in `BaseForecaster` and `BaseTransformer`.

Question for reviewers:

* API design
* can this be further simplified?
* any feedback considering the constraints of refactor, and future `dask` integration, see #4013