### PR TITLE
[BUG] fix erroneous `int` coercion of `TrendForecaster` and `PolynomialTrendForecaster` on `DatetimeIndex`

### DIFF
--- a/sktime/forecasting/tests/test_trend.py
+++ b/sktime/forecasting/tests/test_trend.py
@@ -2,7 +2,7 @@
 """Test trend forecasters."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = ["mloning"]
+__author__ = ["mloning", "fkiraly"]
 __all__ = ["get_expected_polynomial_coefs"]
 
 import numpy as np
@@ -11,9 +11,9 @@ import pytest
 
 from sktime.datasets import load_airline
 from sktime.forecasting.trend import (
-    _get_X_numpy_int_from_pandas,
     PolynomialTrendForecaster,
     TrendForecaster,
+    _get_X_numpy_int_from_pandas,
 )
 from sktime.utils._testing.forecasting import make_forecasting_problem
 

--- a/sktime/forecasting/tests/test_trend.py
+++ b/sktime/forecasting/tests/test_trend.py
@@ -16,7 +16,10 @@ from sktime.utils._testing.forecasting import make_forecasting_problem
 
 def get_expected_polynomial_coefs(y, degree, with_intercept=True):
     """Compute expected coefficients from polynomial regression."""
-    poly_matrix = np.vander(np.arange(len(y)), degree + 1)
+    from sktime.forecasting.trend import _get_X_numpy_int_from_pandas
+
+    t_ix = _get_X_numpy_int_from_pandas(y.index).reshape(-1)
+    poly_matrix = np.vander(t_ix, degree + 1)
     if not with_intercept:
         poly_matrix = poly_matrix[:, :-1]
     return np.linalg.lstsq(poly_matrix, y.to_numpy(), rcond=None)[0]

--- a/sktime/forecasting/tests/test_trend.py
+++ b/sktime/forecasting/tests/test_trend.py
@@ -42,6 +42,7 @@ def test_get_X_numpy():
     assert np.isin(intdiffs, [30, 31, 28, 29]).all()
 
     # testing pd.DatetimeIndex with hourly frequency
+    # diffs should be 1/24, since this is converted to float, days since 1970
     df_hourly = pd.DataFrame(
         data=[10, 5, 4, 2, 10],
         index=pd.date_range(start="2000-01-01", periods=5, freq="H"),

--- a/sktime/forecasting/tests/test_trend.py
+++ b/sktime/forecasting/tests/test_trend.py
@@ -10,7 +10,7 @@ import pandas as pd
 import pytest
 
 from sktime.datasets import load_airline
-from sktime.forecasting.trend import PolynomialTrendForecaster
+from sktime.forecasting.trend import PolynomialTrendForecaster, TrendForecaster
 from sktime.utils._testing.forecasting import make_forecasting_problem
 
 
@@ -64,5 +64,8 @@ def test_trendforecaster_with_datetimeindex():
     df = load_airline()
     df.index = df.index.to_timestamp()
 
-    trafo = PolynomialTrendForecaster()
-    trafo.fit(df)
+    f = PolynomialTrendForecaster()
+    f.fit(df)
+
+    f = TrendForecaster()
+    f.fit(df)

--- a/sktime/forecasting/tests/test_trend.py
+++ b/sktime/forecasting/tests/test_trend.py
@@ -56,8 +56,6 @@ def test_get_X_numpy():
     # testing integer index
     int_ix = pd.Index([1, 3, 5, 7])
     X_idx_int = _get_X_numpy_int_from_pandas(int_ix)
-    intdiffs = (np.diff(X_idx_int.reshape(-1))).astype(int)
-    assert np.isin(intdiffs, [30, 31, 28, 29]).all()
 
     # testing pd.IntegerIndex
     # this should be an 2D integer array with entries identical to int_ix

--- a/sktime/forecasting/tests/test_trend.py
+++ b/sktime/forecasting/tests/test_trend.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from sktime.datasets import load_airline
 from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.utils._testing.forecasting import make_forecasting_problem
 
@@ -37,15 +38,18 @@ def _test_trend(degree, with_intercept):
 @pytest.mark.parametrize("degree", [1, 3])
 @pytest.mark.parametrize("with_intercept", [True, False])
 def test_trend(degree, with_intercept):
+    """Test PolynomialTrendForecaster coefficients."""
     _test_trend(degree, with_intercept)
 
 
 # zero trend does not work without intercept
 def test_zero_trend():
+    """Test PolynomialTrendForecaster with degree zero."""
     _test_trend(degree=0, with_intercept=True)
 
 
 def test_constant_trend():
+    """Test expected output from constant trend."""
     y = pd.Series(np.arange(30))
     fh = -np.arange(30)  # in-sample fh
 
@@ -53,3 +57,12 @@ def test_constant_trend():
     y_pred = forecaster.fit(y).predict(fh)
 
     np.testing.assert_array_almost_equal(y, y_pred)
+
+
+def test_trendforecaster_with_datetimeindex():
+    """Test PolyonmialTrendForecaster with DatetimeIndex, see #4131."""
+    df = load_airline()
+    df.index = df.index.to_timestamp()
+
+    trafo = PolynomialTrendForecaster()
+    trafo.fit(df)

--- a/sktime/forecasting/tests/test_trend.py
+++ b/sktime/forecasting/tests/test_trend.py
@@ -24,7 +24,7 @@ def test_get_X_numpy():
     X_idx = _get_X_numpy_int_from_pandas(y.index)
 
     # testing pd.PeriodIndex
-    # this should be a 2D.ndnp array, with diffs being 1 (month)
+    # this should be a 2D nd.nparray, with diffs being 1 (month)
     # because month is the periodicity
     assert isinstance(X_idx, np.ndarray)
     assert X_idx.shape == (len(y), 1)
@@ -46,7 +46,7 @@ def test_get_X_numpy():
     X_idx_int = _get_X_numpy_int_from_pandas(int_ix)
 
     # testing pd.IntegerIndex
-    # this should be an integer array with entries identical to int_ix
+    # this should be an 2D integer array with entries identical to int_ix
     assert isinstance(X_idx_int, np.ndarray)
     assert X_idx_int.shape == (len(int_ix), 1)
     assert (X_idx_int.reshape(-1) == int_ix.to_numpy()).all()

--- a/sktime/forecasting/tests/test_trend.py
+++ b/sktime/forecasting/tests/test_trend.py
@@ -24,7 +24,7 @@ def test_get_X_numpy():
     X_idx = _get_X_numpy_int_from_pandas(y.index)
 
     # testing pd.PeriodIndex
-    # this should be a 2D nd.nparray, with diffs being 1 (month)
+    # this should be a 2D np.dparray, with diffs being 1 (month)
     # because month is the periodicity
     assert isinstance(X_idx, np.ndarray)
     assert X_idx.shape == (len(y), 1)
@@ -41,9 +41,22 @@ def test_get_X_numpy():
     intdiffs = (np.diff(X_idx_datetime.reshape(-1))).astype(int)
     assert np.isin(intdiffs, [30, 31, 28, 29]).all()
 
+    # testing pd.DatetimeIndex with hourly frequency
+    df_hourly = pd.DataFrame(
+        data=[10, 5, 4, 2, 10],
+        index=pd.date_range(start="2000-01-01", periods=5, freq="H"),
+    )
+    X_idx_hourly = _get_X_numpy_int_from_pandas(df_hourly.index)
+    assert isinstance(X_idx_hourly, np.ndarray)
+    assert X_idx_hourly.shape == (len(df_hourly), 1)
+    hourdiffs = np.diff(X_idx_hourly.reshape(-1))
+    assert np.allclose(hourdiffs, np.repeat([1 / 24], len(df_hourly) - 1))
+
     # testing integer index
     int_ix = pd.Index([1, 3, 5, 7])
     X_idx_int = _get_X_numpy_int_from_pandas(int_ix)
+    intdiffs = (np.diff(X_idx_int.reshape(-1))).astype(int)
+    assert np.isin(intdiffs, [30, 31, 28, 29]).all()
 
     # testing pd.IntegerIndex
     # this should be an 2D integer array with entries identical to int_ix

--- a/sktime/forecasting/tests/test_trend.py
+++ b/sktime/forecasting/tests/test_trend.py
@@ -71,7 +71,7 @@ def _test_trend(degree, with_intercept):
     # intercept is added in reverse order
     actual = forecaster.regressor_.steps[-1][1].coef_[::-1]
     expected = get_expected_polynomial_coefs(y, degree, with_intercept)
-    np.testing.assert_allclose(actual, expected)
+    np.testing.assert_allclose(actual, expected, rtol=1e-5)
 
 
 @pytest.mark.parametrize("degree", [1, 3])

--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -41,7 +41,7 @@ class TrendForecaster(BaseForecaster):
     Default for `regressor` is linear regression = `sklearn` `LinearRegression` default.
 
     If time stamps are `pd.DatetimeIndex`, fitted coefficients are in units
-    of days since start of 1970.  If time stamps are `pd.PeriodIndex`,
+    of days since start of 1970. If time stamps are `pd.PeriodIndex`,
     coefficients are in units of (full) periods since start of 1970.
 
     Parameters
@@ -171,7 +171,7 @@ class PolynomialTrendForecaster(BaseForecaster):
     Default for `regressor` is linear regression = `sklearn` `LinearRegression` default.
 
     If time stamps are `pd.DatetimeIndex`, fitted coefficients are in units
-    of days since start of 1970.  If time stamps are `pd.PeriodIndex`,
+    of days since start of 1970. If time stamps are `pd.PeriodIndex`,
     coefficients are in units of (full) periods since start of 1970.
 
     Parameters

--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -161,7 +161,7 @@ class PolynomialTrendForecaster(BaseForecaster):
     and :math:`p` is the polynomial feature transform with degree `degree`,
     and with/without intercept depending on `with_intercept`,
     fits an `sklearn` model :math:`v_i = f(p(t_i)) + \epsilon_i`, where `f` is
-    the model fitted when `regressor.fit` is passed `X` = vector of :math:`t_i`,
+    the model fitted when `regressor.fit` is passed `X` = vector of :math:`p(t_i)`,
     and `y` = vector of :math:`v_i`.
 
     In `predict`, for a new time point :math:`t_*`, predicts :math:`f(p(t_*))`,

--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -15,7 +15,6 @@ from sklearn.preprocessing import PolynomialFeatures
 from sktime.forecasting.base import BaseForecaster
 
 
-
 def _get_X_numpy_int_from_pandas(x):
     """Convert pandas index to an sklearn compatible X, 2D np.ndarray, int type."""
     return x.astype("int64").to_numpy().reshape(-1, 1)

--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -223,7 +223,7 @@ class PolynomialTrendForecaster(BaseForecaster):
         """
         # use relative fh as time index to predict
         fh = self.fh.to_absolute(self.cutoff)
-        X_sklearn = self._get_X_numpy_int_from_pandas(fh)
+        X_sklearn = self._get_X_numpy_int_from_pandas(fh.to_pandas())
         y_pred = self.regressor_.predict(X_sklearn)
         return pd.Series(y_pred, index=self.fh.to_absolute(self.cutoff))
 

--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -153,7 +153,7 @@ class PolynomialTrendForecaster(BaseForecaster):
 
     Uses a `sklearn` regressor `regressor` to regress values of time series on index,
     after extraction of polynomial features.
-    Same as pipeline of `TrendForecaster` with transformation step
+    Same `TrendForecaster` where `regressor` is pipelined with transformation step
     `PolynomialFeatures(degree, with_intercept)` applied to time, at the start.
 
     In `fit`, for input time series :math:`(v_i, p(t_i)), i = 1, \dots, T`,

--- a/sktime/forecasting/trend.py
+++ b/sktime/forecasting/trend.py
@@ -164,7 +164,7 @@ class PolynomialTrendForecaster(BaseForecaster):
         self.regressor_ = self.regressor
         super(PolynomialTrendForecaster, self).__init__()
 
-    def _get_X_numpy_int_from_pandas(x):
+    def _get_X_numpy_int_from_pandas(self, x):
         """Convert pandas index to an sklearn compatible X, 2D np.ndarray, int type."""
         return x.astype("int64").to_numpy().reshape(-1, 1)
 


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4131 and a parallel issue for `TrendForecaster` which is the cause of #3230 (also fixes #3230).

Erroneous coercion caused huge arrays to be allocated when the input data had a `DatetimeIndex`.

Also, previously, any time stamp based fits and coefficients were related to a reset index (naive replacement with `RangeIndex`) rather than the time stamp.

This has been changed to periods since start of 1970 (with correct time stamp conversion). I've now added a clarifying docstring on what the coefficients mean, and changed it consistently to periods since start of 1970.

Since this was subject to a bug previously (and, likely, confusion), we don't need deprecation for this change.

Contains new and updated tests:
*  `test_trendforecaster_with_datetimeindex`, a test for the failure case in #4131, and parallel case.
* The existing test `test_trend` was failing with the bugfix due to the erroneous conversion to `int`. The test has been modified to cover the time stamp case corretly, by using time stamp converted indices in the Vandermonde matrix rather than the `RangeIndex` based indices.
* a test for the time stamp to integer/float conversion logic now used under the hood