### PR TITLE
[ENH] consistent internal removal of `pd.Series` name

### DIFF
--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -54,6 +54,24 @@ for tp in MTYPE_LIST_SERIES:
     convert_dict[(tp, tp, "Series")] = convert_identity
 
 
+def handle_UvS_as_Series_nameattr(obj: pd.Series, store=None) -> pd.DataFrame:
+
+    if not isinstance(obj, pd.Series):
+        raise TypeError("input must be a pd.Series")
+
+    res = obj.copy(deep=False)
+
+    if isinstance(store, dict) and "name" in store.keys():
+        res.name = store["name"]
+    if isinstance(store, dict) and "name" not in store.keys():
+        store["name"] = obj.name
+
+    return res
+
+
+convert_dict[("pd.Series", "pd.Series", "Series")] = handle_UvS_as_Series_nameattr
+
+
 def convert_UvS_to_MvS_as_Series(obj: pd.Series, store=None) -> pd.DataFrame:
 
     if not isinstance(obj, pd.Series):


### PR DESCRIPTION
This is an alternative fix, fixes #4144.

The fixing strategy is to always remove the `name` attribute of `pd.Series` when entering the `fit` conversion, and adding it back, at back-conversion.

Experimental, to see what happens.