### PR TITLE
[ENH] faster test for forecasters' `predict_residuals`

### DIFF
--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -224,17 +224,20 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         cutoff = get_cutoff(y_train, return_index=True)
         fh = _make_fh(cutoff, fh_int, fh_type, is_relative)
 
-        estimator_instance.fit(y_train, fh=fh)
-        y_pred = estimator_instance.predict()
-        _assert_correct_pred_time_index(y_pred.index, cutoff, fh=fh_int)
-        _assert_correct_columns(y_pred, y_train)
+        try:
+            estimator_instance.fit(y_train, fh=fh)
+            y_pred = estimator_instance.predict()
+            _assert_correct_pred_time_index(y_pred.index, cutoff, fh=fh_int)
+            _assert_correct_columns(y_pred, y_train)
 
-        y_test = _make_series(
-            n_columns=n_columns, index_type=index_type, n_timepoints=len(y_pred)
-        )
-        y_test.index = y_pred.index
-        y_res = estimator_instance.predict_residuals(y_test)
-        _assert_correct_pred_time_index(y_res.index, cutoff, fh=fh)
+            y_test = _make_series(
+                n_columns=n_columns, index_type=index_type, n_timepoints=len(y_pred)
+            )
+            y_test.index = y_pred.index
+            y_res = estimator_instance.predict_residuals(y_test)
+            _assert_correct_pred_time_index(y_res.index, cutoff, fh=fh)
+        except NotImplementedError:
+            pass
 
     @pytest.mark.parametrize(
         "index_fh_comb", VALID_INDEX_FH_COMBINATIONS, ids=index_fh_comb_names

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -206,7 +206,10 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
     def test_predict_time_index(
         self, estimator_instance, n_columns, index_fh_comb, fh_int
     ):
-        """Check that predicted time index matches forecasting horizon."""
+        """Check that predicted time index matches forecasting horizon.
+
+        Tests predicted time index for predict and predict_residuals.
+        """
         index_type, fh_type, is_relative = index_fh_comb
         if fh_type == "timedelta":
             return None
@@ -221,48 +224,17 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         cutoff = get_cutoff(y_train, return_index=True)
         fh = _make_fh(cutoff, fh_int, fh_type, is_relative)
 
-        try:
-            estimator_instance.fit(y_train, fh=fh)
-            y_pred = estimator_instance.predict()
-            _assert_correct_pred_time_index(y_pred.index, cutoff, fh=fh_int)
-            _assert_correct_columns(y_pred, y_train)
-        except NotImplementedError:
-            pass
+        estimator_instance.fit(y_train, fh=fh)
+        y_pred = estimator_instance.predict()
+        _assert_correct_pred_time_index(y_pred.index, cutoff, fh=fh_int)
+        _assert_correct_columns(y_pred, y_train)
 
-    @pytest.mark.parametrize(
-        "index_fh_comb", VALID_INDEX_FH_COMBINATIONS, ids=index_fh_comb_names
-    )
-    @pytest.mark.parametrize("fh_int", TEST_FHS, ids=[f"fh={fh}" for fh in TEST_FHS])
-    def test_predict_residuals(
-        self, estimator_instance, n_columns, index_fh_comb, fh_int
-    ):
-        """Check that predict_residuals method works as expected."""
-        index_type, fh_type, is_relative = index_fh_comb
-        if fh_type == "timedelta":
-            # workaround to ensure check_estimator without breaking e.g. debugging
-            return None
-            # todo: ensure check_estimator works with pytest.skip like below
-            # pytest.skip(
-            #    "ForecastingHorizon with timedelta values "
-            #     "is currently experimental and not supported everywhere"
-            # )
-        y_train = _make_series(
-            n_columns=n_columns, index_type=index_type, n_timepoints=50
+        y_test = _make_series(
+            n_columns=n_columns, index_type=index_type, n_timepoints=len(y_pred)
         )
-        cutoff = get_cutoff(y_train, return_index=True)
-        fh = _make_fh(cutoff, fh_int, fh_type, is_relative)
-        try:
-            estimator_instance.fit(y_train, fh=fh)
-            y_pred = estimator_instance.predict()
-
-            y_test = _make_series(
-                n_columns=n_columns, index_type=index_type, n_timepoints=len(y_pred)
-            )
-            y_test.index = y_pred.index
-            y_res = estimator_instance.predict_residuals(y_test)
-            _assert_correct_pred_time_index(y_res.index, cutoff, fh=fh)
-        except NotImplementedError:
-            pass
+        y_test.index = y_pred.index
+        y_res = estimator_instance.predict_residuals(y_test)
+        _assert_correct_pred_time_index(y_res.index, cutoff, fh=fh)
 
     @pytest.mark.parametrize(
         "index_fh_comb", VALID_INDEX_FH_COMBINATIONS, ids=index_fh_comb_names


### PR DESCRIPTION
The tests `test_predict_time_index` and `test_predict_residuals` were duplicative - a lot of `fit` calls for the same data.
Merging the tests reduces the runtime by a factor of 2 (of the runtime arising from said tests).