### PR TITLE
[ENH] test that forecasters preserve `name` attr of `pd.Series`

### DIFF
--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -333,7 +333,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         y_train = _make_series(n_timepoints=15)
         y_train.name = "foo"
 
-        estimator_instance.fit(y, fh=[1, 2, 3])
+        estimator_instance.fit(y_train, fh=[1, 2, 3])
         y_pred = estimator_instance.predict()
 
         _assert_correct_columns(y_pred, y_train)

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -328,6 +328,16 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         except NotImplementedError:
             pass
 
+    def test_predict_series_name_preserved(self, estimator_instance):
+        """Test that fit/predict preserves name attribute and type of pd.Series."""
+        y_train = _make_series(n_timepoints=15)
+        y_train.name = "foo"
+
+        estimator_instance.fit(y, fh=[1, 2, 3])
+        y_pred = estimator_instance.predict()
+
+        _assert_correct_columns(y_pred, y_train)
+
     def _check_pred_ints(
         self, pred_ints: pd.DataFrame, y_train: pd.Series, y_pred: pd.Series, fh_int
     ):

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -330,6 +330,11 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
 
     def test_predict_series_name_preserved(self, estimator_instance):
         """Test that fit/predict preserves name attribute and type of pd.Series."""
+        # skip this test if estimator needs multivariate data
+        # because then it does not take pd.Series at all
+        if estimator_instance.get_tag("scitype:y") == "multivariate":
+            return None
+
         y_train = _make_series(n_timepoints=15)
         y_train.name = "foo"
 


### PR DESCRIPTION
Adds a test, `test_predict_series_name_preserved`, to the forecasting test suite, to test that the `name` attribute of `pd.Series` is preserved in `fit`/`predict`.

A test for detecting the general issue at the root of https://github.com/sktime/sktime/issues/4144, which currently was not covered by the forecasting test suite, as the scenarios containing `pd.Series` with non-None `name` attribute did not interact with the tests in which the time index and name were checked for consistency via `_assert_correct_pred_time_index`.

If this works, this should surface a number of cases with the problem, among them `NaiveForecaster` (where this surfaced through manual testing in the context of https://github.com/sktime/sktime/pull/4150 failures)