### PR TITLE
[DOC] improved reducer docstring formatting

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1359,53 +1359,54 @@ def make_reduction(
         ``*`` = observations, past or future, neither part of window nor forecast.
 
         Assume we have the following training data (14 observations):
-        |----------------------------|
-        | * * * * * * * * * * * * * *|
-        |----------------------------|
+            |----------------------------|
+            | * * * * * * * * * * * * * *|
+            |----------------------------|
 
         And want to forecast with `window_length = 9` and `fh = [2, 4]`.
 
         By construction, a recursive reducer always targets the first data point after
         the window, irrespective of the forecasting horizons requested.
         In the example the following 5 windows are created:
-        |--------------------------- |
-        | x x x x x x x x x y * * * *|
-        | * x x x x x x x x x y * * *|
-        | * * x x x x x x x x x y * *|
-        | * * * x x x x x x x x x y *|
-        | * * * * x x x x x x x x x y|
-        |----------------------------|
+            |--------------------------- |
+            | x x x x x x x x x y * * * *|
+            | * x x x x x x x x x y * * *|
+            | * * x x x x x x x x x y * *|
+            | * * * x x x x x x x x x y *|
+            | * * * * x x x x x x x x x y|
+            |----------------------------|
 
         Direct Reducers will create multiple models, one for each forecasting horizon.
         With the argument `windows_identical = True` (default) the windows used to train
         the model are defined by the maximum forecasting horizon.
         Only two complete windows can be defined in this example:
         `fh = 4` (maxium of `fh = [2, 4]`)
-        |--------------------------- |
-        | x x x x x x x x x * * * y *|
-        | * x x x x x x x x x * * * y|
-        |----------------------------|
-        All other forecasting horizon will also use those two windows.
+            |--------------------------- |
+            | x x x x x x x x x * * * y *|
+            | * x x x x x x x x x * * * y|
+            |----------------------------|
+
+        All other forecasting horizons will also use those two (maximal) windows.
         `fh = 2`
-        |--------------------------- |
-        | x x x x x x x x x * y * * *|
-        | * x x x x x x x x x * y * *|
-        |----------------------------|
+            |--------------------------- |
+            | x x x x x x x x x * y * * *|
+            | * x x x x x x x x x * y * *|
+            |----------------------------|
         With `windows_identical = False` we drop the requirement to use the same windows
         for each of the direct models, so more windows can be created for horizons other
         than the maximum forecasting horizon:
         `fh = 2`
-        |--------------------------- |
-        | x x x x x x x x x * y * * *|
-        | * x x x x x x x x x * y * *|
-        | * * x x x x x x x x x * y *|
-        | * * * x x x x x x x x x * y|
-        |----------------------------|
+            |--------------------------- |
+            | x x x x x x x x x * y * * *|
+            | * x x x x x x x x x * y * *|
+            | * * x x x x x x x x x * y *|
+            | * * * x x x x x x x x x * y|
+            |----------------------------|
         `fh = 4`
-        |--------------------------- |
-        | x x x x x x x x x * * * y *|
-        | * x x x x x x x x x * * * y|
-        |----------------------------|
+            |--------------------------- |
+            | x x x x x x x x x * * * y *|
+            | * x x x x x x x x x * * * y|
+            |----------------------------|
 
         Use `windows_identical = True` if you want to compare the forecasting
         performance across different horizons, since all models trained will use the

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1328,10 +1328,25 @@ def temporal_train_test_split(
 
     Parameters
     ----------
-    y : pd.Series
-        Target series
-    X : pd.DataFrame, optional (default=None)
-        Exogenous data
+    y : time series in sktime compatible data container format
+    X : time series in sktime compatible data container format, optional, default=None
+        y and X can be in one of the following formats:
+        Series scitype: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
+            for vanilla forecasting, one time series
+        Panel scitype: pd.DataFrame with 2-level row MultiIndex,
+            3D np.ndarray, list of Series pd.DataFrame, or nested pd.DataFrame
+            for global or panel forecasting
+        Hierarchical scitype: pd.DataFrame with 3 or more level row MultiIndex
+            for hierarchical forecasting
+        Number of columns admissible depend on the "scitype:y" tag:
+            if self.get_tag("scitype:y")=="univariate":
+                y must have a single column/variable
+            if self.get_tag("scitype:y")=="multivariate":
+                y must have 2 or more columns
+            if self.get_tag("scitype:y")=="both": no restrictions on columns apply
+        For further details:
+            on usage, see forecasting tutorial examples/01_forecasting.ipynb
+            on specification of formats, examples/AA_datatypes_and_datasets.ipynb
     test_size : float, int or None, optional (default=None)
         If float, should be between 0.0 and 1.0 and represent the proportion
         of the dataset to include in the test split. If int, represents the


### PR DESCRIPTION
Fixes #4158.

The solution is via indentation, in which case the symbol table is rendered as a code block incl newlines.