### PR TITLE
[MNT] emergency fix for precommit CI failure - remove `isort`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           output: " "
       - name: List changed files
         run: echo '${{ steps.file_changes.outputs.files}}'
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v3.0.0
         with:
           extra_args: --files ${{ steps.file_changes.outputs.files}}
       - name: Check for missing init files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
           output: " "
       - name: List changed files
         run: echo '${{ steps.file_changes.outputs.files}}'
+      - uses: pre-commit/action@v2.0.0
+        with:
+          extra_args: --files ${{ steps.file_changes.outputs.files}}
       - name: Check for missing init files
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,6 @@ jobs:
           output: " "
       - name: List changed files
         run: echo '${{ steps.file_changes.outputs.files}}'
-      - uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: --files ${{ steps.file_changes.outputs.files}}
       - name: Check for missing init files
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
         name: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,6 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
-    hooks:
-      - id: isort
-        name: isort
-
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:


### PR DESCRIPTION
Temporary workaround for #4162 to allow other development and release.

Removes the `isort` pre-commit step to which the problem can be isolated.

