### PR TITLE
[MNT] isolate `statsmodels` in `HierarchyEnsembleForecaster` docstring

### DIFF
--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -58,9 +58,9 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
     Examples
     --------
     >>> from sktime.forecasting.compose import HierarchyEnsembleForecaster
-    >>> from sktime.forecasting.exp_smoothing import ExponentialSmoothing
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.forecasting.theta import ThetaForecaster
+    >>> from sktime.forecasting.trend import TrendForecaster
     >>> from sktime.utils._testing.hierarchical import _bottom_hier_datagen
     >>> y = _bottom_hier_datagen(
     ...         no_bottom_nodes=7,
@@ -70,8 +70,8 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
 
     >>> # Example of by = 'level'
     >>> forecasters = [
-    ...     ( 'naive', NaiveForecaster(), 0),
-    ...     ('exps' ,ExponentialSmoothing(trend='add'), 1)
+    ...     ('naive', NaiveForecaster(), 0),
+    ...     ('trend', TrendForecaster(), 1)
     ... ]
     >>> forecaster = HierarchyEnsembleForecaster(
     ...                 forecasters=forecasters,
@@ -83,8 +83,8 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
 
     >>> # Example of by = 'node'
     >>> forecasters = [
-    ...     ('exps', ExponentialSmoothing(), [("__total", "__total")]),
-    ...    ('theta', ThetaForecaster(), [('l2_node01', 'l1_node01')]),
+    ...     ('trend', TrendForecaster(), [("__total", "__total")]),
+    ...     ('theta', ThetaForecaster(), [('l2_node01', 'l1_node01')]),
     ... ]
     >>> forecaster = HierarchyEnsembleForecaster(
     ...                 forecasters=forecasters,


### PR DESCRIPTION
An unisolated instance of `statsmodels` accidentally made it onto `main` after making `statsmodels` a softdep: in the `HierarchyEnsembleForecaster` docstring.

This is now remedied by replacing a `statsmodels` dependent estimator with an `sktime` native one.

Also fixes some formatting issues in the docstring example.