### PR TITLE
[MNT] Bump isort to 5.12.0 in pre-commit config

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2053,6 +2053,15 @@
         "example",
         "test"
       ]
-    }
+    },
+    {
+			"login": "snnbotchway",
+			"name": "Solomon Botchway",
+			"avatar_url": "https://avatars.githubusercontent.com/u/62394255?v=4",
+			"profile": "https://www.linkedin.com/in/solomon-botchway-a1383821b/",
+			"contributions": [
+				"maintenance"
+			]
+		}
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2055,13 +2055,13 @@
       ]
     },
     {
-			"login": "snnbotchway",
-			"name": "Solomon Botchway",
-			"avatar_url": "https://avatars.githubusercontent.com/u/62394255?v=4",
-			"profile": "https://www.linkedin.com/in/solomon-botchway-a1383821b/",
-			"contributions": [
-				"maintenance"
-			]
-		}
+      "login": "snnbotchway",
+      "name": "Solomon Botchway",
+      "avatar_url": "https://avatars.githubusercontent.com/u/62394255?v=4",
+      "profile": "https://www.linkedin.com/in/solomon-botchway-a1383821b/",
+      "contributions": [
+      "maintenance"
+      ]
+    }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2060,7 +2060,7 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/62394255?v=4",
       "profile": "https://www.linkedin.com/in/solomon-botchway-a1383821b/",
       "contributions": [
-      "maintenance"
+        "maintenance"
       ]
     }
   ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,12 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort
+
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
@@ -53,6 +59,16 @@ repos:
     hooks:
       - id: pydocstyle
         args: ["--config=setup.cfg"]
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        require_serial: true
+        name: isort
+        args: ["--profile", "black"]
+        stages: [commit]
+        exclude: ^legacy-backend.*$
 
   # We use the Python version instead of the original version which seems to require Docker
   # https://github.com/koalaman/shellcheck-precommit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,16 +60,6 @@ repos:
       - id: pydocstyle
         args: ["--config=setup.cfg"]
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        require_serial: true
-        name: isort
-        args: ["--profile", "black"]
-        stages: [commit]
-        exclude: ^legacy-backend.*$
-
   # We use the Python version instead of the original version which seems to require Docker
   # https://github.com/koalaman/shellcheck-precommit
   - repo: https://github.com/shellcheck-py/shellcheck-py


### PR DESCRIPTION
I updated the sort version in pre-commit to stop pre-commit checks from failing.

Closes #4162