### PR TITLE
[ENH] improved/fixed `scoring` argument for forecasting tuners

### DIFF
--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -325,7 +325,7 @@ class ForecastingGridSearchCV(BaseGridSearch):
         "refit" = forecaster is refitted to each training window
         "update" = forecaster is updated with training window data, in sequence provided
         "no-update_params" = fit to first training window, re-used without fit or update
-    update_behaviour: str, optional, default = "full_refit"
+    update_behaviour : str, optional, default = "full_refit"
         one of {"full_refit", "inner_only", "no_update"}
         behaviour of the forecaster when calling update
         "full_refit" = both tuning parameters and inner estimator refit on all data seen
@@ -333,24 +333,27 @@ class ForecastingGridSearchCV(BaseGridSearch):
         "no_update" = neither tuning parameters nor inner estimator are updated
     param_grid : dict or list of dictionaries
         Model tuning parameters of the forecaster to evaluate
-    scoring: function, optional (default=None)
-        Function to score models for evaluation of optimal parameters
+    scoring : sktime metric, BaseMetric descendant, or callable, optional (default=None)
+        scoring metric to use in tuning the forecaster
+        if callable, must have signature
+        `(y_true: 1D np.ndarray, y_pred: 1D np.ndarray) -> float`,
+        assuming np.ndarrays being of the same length, and lower being better.
     n_jobs: int, optional (default=None)
         Number of jobs to run in parallel.
         None means 1 unless in a joblib.parallel_backend context.
         -1 means using all processors.
-    refit: bool, optional (default=True)
+    refit : bool, optional (default=True)
         True = refit the forecaster with the best parameters on the entire data in fit
         False = best forecaster remains fitted on the last fold in cv
     verbose: int, optional (default=0)
-    return_n_best_forecasters: int, default=1
+    return_n_best_forecasters : int, default=1
         In case the n best forecaster should be returned, this value can be set
         and the n best forecasters will be assigned to n_best_forecasters_
-    pre_dispatch: str, optional (default='2*n_jobs')
-    error_score: numeric value or the str 'raise', optional (default=np.nan)
+    pre_dispatch : str, optional (default='2*n_jobs')
+    error_score : numeric value or the str 'raise', optional (default=np.nan)
         The test score returned when a forecaster fails to be fitted.
-    return_train_score: bool, optional (default=False)
-    backend: str, optional (default="loky")
+    return_train_score : bool, optional (default=False)
+    backend : str, optional (default="loky")
         Specify the parallelisation backend implementation in joblib, where
         "loky" is used by default.
     error_score : "raise" or numeric, default=np.nan
@@ -582,27 +585,30 @@ class ForecastingRandomizedSearchCV(BaseGridSearch):
     n_iter : int, default=10
         Number of parameter settings that are sampled. n_iter trades
         off runtime vs quality of the solution.
-    scoring: function, optional (default=None)
-        Function to score models for evaluation of optimal parameters
-    n_jobs: int, optional (default=None)
+    scoring : sktime metric, BaseMetric descendant, or callable, optional (default=None)
+        scoring metric to use in tuning the forecaster
+        if callable, must have signature
+        `(y_true: 1D np.ndarray, y_pred: 1D np.ndarray) -> float`,
+        assuming np.ndarrays being of the same length, and lower being better.
+    n_jobs : int, optional (default=None)
         Number of jobs to run in parallel.
         None means 1 unless in a joblib.parallel_backend context.
         -1 means using all processors.
-    refit: bool, optional (default=True)
+    refit : bool, optional (default=True)
         True = refit the forecaster with the best parameters on the entire data in fit
         False = best forecaster remains fitted on the last fold in cv
-    verbose: int, optional (default=0)
+    verbose : int, optional (default=0)
     return_n_best_forecasters: int, default=1
         In case the n best forecaster should be returned, this value can be set
         and the n best forecasters will be assigned to n_best_forecasters_
-    pre_dispatch: str, optional (default='2*n_jobs')
+    pre_dispatch : str, optional (default='2*n_jobs')
     random_state : int, RandomState instance or None, default=None
         Pseudo random number generator state used for random uniform sampling
         from lists of possible values instead of scipy.stats distributions.
         Pass an int for reproducible output across multiple
         function calls.
-    pre_dispatch: str, optional (default='2*n_jobs')
-    backend: str, optional (default="loky")
+    pre_dispatch : str, optional (default='2*n_jobs')
+    backend : str, optional (default="loky")
         Specify the parallelisation backend implementation in joblib, where
         "loky" is used by default.
     error_score : "raise" or numeric, default=np.nan

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -146,7 +146,7 @@ class BaseGridSearch(_DelegatedForecaster):
         """
         cv = check_cv(self.cv)
 
-        scoring = check_scoring(self.scoring)
+        scoring = check_scoring(self.scoring, obj=self)
         scoring_name = f"test_{scoring.name}"
 
         parallel = Parallel(
@@ -524,7 +524,10 @@ class ForecastingGridSearchCV(BaseGridSearch):
         from sktime.forecasting.model_selection._split import SingleWindowSplitter
         from sktime.forecasting.naive import NaiveForecaster
         from sktime.forecasting.trend import PolynomialTrendForecaster
-        from sktime.performance_metrics.forecasting import MeanAbsolutePercentageError
+        from sktime.performance_metrics.forecasting import (
+            MeanAbsolutePercentageError,
+            mean_absolute_percentage_error,
+        )
 
         params = {
             "forecaster": NaiveForecaster(strategy="mean"),
@@ -536,7 +539,7 @@ class ForecastingGridSearchCV(BaseGridSearch):
             "forecaster": PolynomialTrendForecaster(),
             "cv": SingleWindowSplitter(fh=1),
             "param_grid": {"degree": [1, 2]},
-            "scoring": MeanAbsolutePercentageError(symmetric=True),
+            "scoring": mean_absolute_percentage_error,
             "update_behaviour": "inner_only",
         }
         return [params, params2]

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -333,7 +333,7 @@ class ForecastingGridSearchCV(BaseGridSearch):
         "no_update" = neither tuning parameters nor inner estimator are updated
     param_grid : dict or list of dictionaries
         Model tuning parameters of the forecaster to evaluate
-    scoring : sktime metric, BaseMetric descendant, or callable, optional (default=None)
+    scoring : sktime metric object (BaseMetric), or callable, optional (default=None)
         scoring metric to use in tuning the forecaster
         if callable, must have signature
         `(y_true: 1D np.ndarray, y_pred: 1D np.ndarray) -> float`,
@@ -588,7 +588,7 @@ class ForecastingRandomizedSearchCV(BaseGridSearch):
     n_iter : int, default=10
         Number of parameter settings that are sampled. n_iter trades
         off runtime vs quality of the solution.
-    scoring : sktime metric, BaseMetric descendant, or callable, optional (default=None)
+    scoring : sktime metric object (BaseMetric), or callable, optional (default=None)
         scoring metric to use in tuning the forecaster
         if callable, must have signature
         `(y_true: 1D np.ndarray, y_pred: 1D np.ndarray) -> float`,

--- a/sktime/utils/validation/forecasting.py
+++ b/sktime/utils/validation/forecasting.py
@@ -18,7 +18,6 @@ __all__ = [
 __author__ = ["mloning", "@big-o", "khrapovs"]
 
 from datetime import timedelta
-from inspect import isclass
 from typing import Optional, Union
 
 import numpy as np
@@ -394,7 +393,7 @@ def check_scoring(scoring, allow_y_pred_benchmark=False, obj=None):
     ----------
     scoring : object to validate. For successful validation, must be one of
 
-        * sktime metric, descendant of `BaseMetric`
+        * sktime metric object, instance of descendant of `BaseMetric`
         * a callable with signature
           `(y_true: 1D np.ndarray, y_pred: 1D np.ndarray) -> float`,
           assuming `np.ndarray`-s being of the same length, and lower being better.
@@ -408,7 +407,7 @@ def check_scoring(scoring, allow_y_pred_benchmark=False, obj=None):
 
     Returns
     -------
-    scoring : input `scoring` coerced to sktime `BaseMetric` descendant
+    scoring : input `scoring` coerced to instance of sktime `BaseMetric` descendant
 
         * if `scoring` was sktime metric, returns `scoring`
         * if `scoring` was `None`, returns `MeanAbsolutePercentageError()`
@@ -417,11 +416,12 @@ def check_scoring(scoring, allow_y_pred_benchmark=False, obj=None):
 
     Raises
     ------
-    TypeError, if `scorin`
+    TypeError, if `scoring` is not a callable
     NotImplementedError
-        if metric requires y_pred_benchmark to be passed
+        if allow_y_pred_benchmark=False and metric requires y_pred_benchmark argument
     """
     # Note symmetric=True is default arg for MeanAbsolutePercentageError
+    from sktime.performance_metrics.base import BaseMetric
     from sktime.performance_metrics.forecasting import (
         MeanAbsolutePercentageError,
         make_forecasting_scorer,
@@ -447,7 +447,7 @@ def check_scoring(scoring, allow_y_pred_benchmark=False, obj=None):
     if not callable(scoring):
         raise TypeError(msg)
 
-    if not isclass(scoring):
+    if not isinstance(scoring, BaseMetric):
         scoring = make_forecasting_scorer(func=scoring, greater_is_better=False)
 
     if hasattr(scoring, "get_class_tag"):

--- a/sktime/utils/validation/forecasting.py
+++ b/sktime/utils/validation/forecasting.py
@@ -431,9 +431,7 @@ def check_scoring(scoring, allow_y_pred_benchmark=False, obj=None):
         return MeanAbsolutePercentageError()
 
     if obj is not None:
-        if not isclass(obj):
-            obj = type(obj)
-        obj_str = f" of {obj.__name__}"
+        obj_str = f" of {str(obj)}"
     else:
         obj_str = ""
 

--- a/sktime/utils/validation/forecasting.py
+++ b/sktime/utils/validation/forecasting.py
@@ -448,11 +448,7 @@ def check_scoring(scoring, allow_y_pred_benchmark=False, obj=None):
         raise TypeError(msg)
 
     if not isclass(scoring):
-        scoring = make_forecasting_scorer(
-            func=scoring,
-            name=scoring.__name__,
-            greater_is_better=False,
-        )
+        scoring = make_forecasting_scorer(func=scoring, greater_is_better=False)
 
     if hasattr(scoring, "get_class_tag"):
         scoring_req_bench = scoring.get_class_tag("requires-y-pred-benchmark", False)


### PR DESCRIPTION
This improves the `scoring` argument for forecasting tuners and fixes the incorrect docstring.
Fixes https://github.com/sktime/sktime/issues/4149

Context: the docstring of forecasting tuners claims that `scoring` should be a function, but current checker methods only allow `BaseMetric` descendants through. This is at least a wrong docstring, but I think both classes and functions (like in sklearn) should be allowed.

Improvements:

* the `scoring` arguments of `BaseGridSearch` and descendants are changed so that *both* functions and `BaseMetric` desendant classes are allowed.
* this is achieved by a change in `check_scoring`, which coerces functions to scorer classes, and now raises an informative error message.

Fixes:

* the `scoring` docstrings of the tuners (grid and random search) were wrong. These have been fixed.
* the docstring of `check_scoring` was wrong. This has been fixed.

Testing: done by changing one of the test cases to be passed a function rather than a class.