### PR TITLE
[BUG] `AutoETS`, `UnobservedComponents`: fix `predict_interval` for integer based index not starting at zero

### DIFF
--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -450,9 +450,10 @@ class AutoETS(_StatsModelsAdapter):
                 Upper/lower interval end forecasts are equivalent to
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
+        start, end = fh.to_absolute_int(self._y.index[0], self.cutoff)[[0, -1]]
+
         valid_indices = fh.to_absolute(self.cutoff).to_pandas()
 
-        start, end = valid_indices[[0, -1]]
         prediction_results = self._fitted_forecaster.get_prediction(
             start=start, end=end, random_state=self.random_state
         )

--- a/sktime/forecasting/structural.py
+++ b/sktime/forecasting/structural.py
@@ -364,9 +364,10 @@ class UnobservedComponents(_StatsModelsAdapter):
         --------
         statsmodels.tsa.statespace.mlemodel.PredictionResults.summary_frame
         """
+        start, end = fh.to_absolute_int(self._y.index[0], self.cutoff)[[0, -1]]
+
         valid_indices = fh.to_absolute(self.cutoff).to_pandas()
 
-        start, end = valid_indices[[0, -1]]
         prediction_results = self._fitted_forecaster.get_prediction(
             start=start, end=end, exog=X
         )

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -352,6 +352,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
             #     pred_errors.values[1:].round(4) >= pred_errors.values[:-1].round(4)
             # )
 
+    @pytest.mark.parametrize("index_type", [None, "range"])
     @pytest.mark.parametrize(
         "coverage", TEST_ALPHAS, ids=[f"alpha={a}" for a in TEST_ALPHAS]
     )
@@ -359,14 +360,16 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         "fh_int_oos", TEST_OOS_FHS, ids=[f"fh={fh}" for fh in TEST_OOS_FHS]
     )
     def test_predict_interval(
-        self, estimator_instance, n_columns, fh_int_oos, coverage
+        self, estimator_instance, n_columns, index_type, fh_int_oos, coverage
     ):
         """Check prediction intervals returned by predict.
 
         Arguments
         ---------
-        Forecaster: BaseEstimator class descendant, forecaster to test
-        fh: ForecastingHorizon, fh at which to test prediction
+        estimator_instance : BaseEstimator class descendant instance, forecaster to test
+        n_columns : number of columns for the test data
+        index_type : index type of the test data
+        fh_int_oos : forecasting horizon to test the forecaster at, all out of sample
         coverage: float, coverage at which to make prediction intervals
 
         Raises
@@ -376,7 +379,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         AssertionError - if Forecaster test instance does not have "capability:pred_int"
                 and no NotImplementedError is raised when asking predict for pred.int
         """
-        y_train = _make_series(n_columns=n_columns)
+        y_train = _make_series(n_columns=n_columns, index_type=index_type)
         estimator_instance.fit(y_train, fh=fh_int_oos)
         if estimator_instance.get_tag("capability:pred_int"):
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -37,7 +37,8 @@ EXCLUDE_ESTIMATORS = [
 
 EXCLUDED_TESTS = {
     # issue when predicting residuals, see #3479
-    "SquaringResiduals": ["test_predict_residuals"],
+    # known issue with prediction intervals that needs fixing, tracked in #4181
+    "SquaringResiduals": ["test_predict_residuals", "test_predict_interval"],
     # known issue when X is passed, wrong time indices are returned, #1364
     "StackingForecaster": ["test_predict_time_index_with_X"],
     # known side effects on multivariate arguments, #2072
@@ -122,10 +123,11 @@ EXCLUDED_TESTS = {
         "test_inheritance",
         "test_create_test_instance",
     ],
-    "SAX": "test_fit_transform_output",  # SAX returns strange output format
+    # SAX returns strange output format
     # this needs to be fixed, was not tested previously due to legacy exception
-    "Prophet": ":test_hierarchical_with_exogeneous",
+    "SAX": "test_fit_transform_output",  
     # Prophet does not support datetime indices, see #2475 for the known issue
+    "Prophet": ":test_hierarchical_with_exogeneous",
 }
 
 # We use estimator tags in addition to class hierarchies to further distinguish

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -125,7 +125,7 @@ EXCLUDED_TESTS = {
     ],
     # SAX returns strange output format
     # this needs to be fixed, was not tested previously due to legacy exception
-    "SAX": "test_fit_transform_output",  
+    "SAX": "test_fit_transform_output",
     # Prophet does not support datetime indices, see #2475 for the known issue
     "Prophet": ":test_hierarchical_with_exogeneous",
 }


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4173, the index generation in `AutoETS` and `UnobservedComponents` was wrong.

Also extends the `test_predict_interval` to test integer based indices (the default `_make_series` output starts at 3, not 0).

This covers the fix - it has also highlighed the same buggy behaviour in `SquaringResiduals` which seems to have a different cause.
As this is a different bug, it has been added to the bug tracker here https://github.com/sktime/sktime/issues/4181, and is excepted from tests temporarily.