### PR TITLE
[BUG] fix race condition in `tsfile` tests

### DIFF
--- a/sktime/datasets/tests/test_data_io.py
+++ b/sktime/datasets/tests/test_data_io.py
@@ -6,7 +6,6 @@ __author__ = ["SebasKoel", "Emiliathewolf", "TonyBagnall", "jasonlines", "achiev
 __all__ = []
 
 import os
-import shutil
 import tempfile
 
 import numpy as np
@@ -44,24 +43,23 @@ _TO_DISABLE = ["pd-long", "pd-wide", "numpyflat"]
 
 @pytest.mark.parametrize("dataset_name", ["UnitTest", "BasicMotions"])
 @pytest.mark.parametrize("return_type", ["nested_univ", "numpy3d"])
-def test_write_panel_to_tsfile_equal_length(dataset_name, return_type):
+def test_write_panel_to_tsfile_equal_length(dataset_name, return_type, tmpdir):
     """Test function to write a dataset.
 
     Loads equal and unequal length problems into both data frames and numpy arrays,
     writes locally, reloads, then compares all class labels. It then delete the files.
     """
     X, y = _load_provided_dataset(dataset_name, split="TRAIN", return_type=return_type)
-    write_panel_to_tsfile(data=X, path="./Temp", target=y, problem_name=dataset_name)
-    load_path = f"./Temp/{dataset_name}/{dataset_name}.ts"
+    write_panel_to_tsfile(data=X, path=tmpdir, target=y, problem_name=dataset_name)
+    load_path = tmpdir / dataset_name / f"{dataset_name}.ts"
     newX, newy = load_from_tsfile(
         full_file_path_and_name=load_path, return_data_type=return_type
     )
     assert np.array_equal(y, newy)
-    shutil.rmtree("./Temp")
 
 
 @pytest.mark.parametrize("dataset_name", ["PLAID", "JapaneseVowels"])
-def test_write_panel_to_tsfile_unequal_length(dataset_name):
+def test_write_panel_to_tsfile_unequal_length(dataset_name, tmpdir):
     """Test function to write a dataset.
 
     Loads equal and unequal length problems into both data frames and numpy arrays,
@@ -70,15 +68,12 @@ def test_write_panel_to_tsfile_unequal_length(dataset_name):
     X, y = _load_provided_dataset(
         dataset_name, split="TRAIN", return_type="nested_univ"
     )
-    write_panel_to_tsfile(
-        data=X, path=f"./Temp{dataset_name}/", target=y, problem_name=dataset_name
-    )
-    load_path = f"./Temp{dataset_name}/{dataset_name}/{dataset_name}.ts"
+    write_panel_to_tsfile(data=X, path=tmpdir, target=y, problem_name=dataset_name)
+    load_path = tmpdir / dataset_name / f"{dataset_name}.ts"
     newX, newy = load_from_tsfile(
         full_file_path_and_name=load_path, return_data_type="nested_univ"
     )
     assert np.array_equal(y, newy)
-    shutil.rmtree(f"./Temp{dataset_name}")
 
 
 @pytest.mark.parametrize("return_X_y", [True, False])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Split out of https://github.com/sktime/sktime/pull/4140


#### What does this implement/fix? Explain your changes.
This fixes a race condition in tests, if run in parallel. The "./Temp" dir might get deleted while another test is relying on its presence. This fix replaces the explicit creation of a temp dir with a fixture, unique to each test execution.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
