### PR TITLE
[BUG] fix broken `ComposableTimeSeriesRegressor`

### DIFF
--- a/sktime/regression/compose/_ensemble.py
+++ b/sktime/regression/compose/_ensemble.py
@@ -373,6 +373,10 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
 
         self.oob_score_ /= self.n_outputs_
 
+    # TODO - Implement this abstract method properly.
+    def _set_oob_score_and_attributes(self, X, y):
+        raise NotImplementedError("Not implemented.")
+
     def _validate_y_class_weight(self, y):
         # in regression, we don't validate class weights
         # TODO remove from regression

--- a/sktime/regression/compose/_ensemble.py
+++ b/sktime/regression/compose/_ensemble.py
@@ -214,6 +214,7 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
             warm_start=warm_start,
             max_samples=max_samples,
         )
+        BaseRegressor.__init__(self)
 
         # We need to add is-fitted state when inheriting from scikit-learn
         self._is_fitted = False

--- a/sktime/regression/compose/_ensemble.py
+++ b/sktime/regression/compose/_ensemble.py
@@ -44,14 +44,14 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
         and a decision tree regressor as final estimator.
     n_estimators : integer, optional (default=100)
         The number of trees in the forest.
-    criterion : string, optional (default="mse")
-        The function to measure the quality of a split. Supported criteria
-        are "mse" for the mean squared error, which is equal to variance
-        reduction as feature selection criterion and minimizes the L2 loss
-        using the mean of each terminal node, "friedman_mse", which uses mean
-        squared error with Friedman's improvement score for potential splits,
-        and "mae" for the mean absolute error, which minimizes the L1 loss
-        using the median of each terminal node.
+    criterion : string, optional (default="squared_error")
+        The function to measure the quality of a split. Supported criteria are
+        "squared_error" for the mean squared error, which is equal to variance reduction
+        as feature selection criterion and minimizes the L2 loss using the mean of each
+        terminal node, "friedman_mse", which uses mean squared error with Friedman’s
+        improvement score for potential splits, "absolute_error" for the mean absolute
+        error, which minimizes the L1 loss using the median of each terminal node,
+        and "poisson" which uses reduction in Poisson deviance to find splits.
     max_depth : integer or None, optional (default=None)
         The maximum depth of the tree. If None, then nodes are expanded until
         all leaves are pure or until all leaves contain less than
@@ -171,7 +171,7 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
         self,
         estimator=None,
         n_estimators=100,
-        criterion="mse",
+        criterion="squared_error",
         max_depth=None,
         min_samples_split=2,
         min_samples_leaf=1,

--- a/sktime/regression/compose/_ensemble.py
+++ b/sktime/regression/compose/_ensemble.py
@@ -252,7 +252,7 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
                 ),
                 ("clf", DecisionTreeRegressor(random_state=self.random_state)),
             ]
-            self.estimator_ = Pipeline(steps)
+            self._estimator = Pipeline(steps)
 
         else:
             # else check given estimator is a pipeline with prior
@@ -263,7 +263,7 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
                 raise ValueError(
                     "Last step in `estimator` must be DecisionTreeRegressor."
                 )
-            self.estimator_ = self.estimator
+            self._estimator = self.estimator
 
         # Set parameters according to naming in pipeline
         estimator_params = {
@@ -277,7 +277,7 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
             "min_impurity_decrease": self.min_impurity_decrease,
             "min_impurity_split": self.min_impurity_split,
         }
-        final_estimator = self.estimator_.steps[-1][0]
+        final_estimator = self._estimator.steps[-1][0]
         self.estimator_params = {
             f"{final_estimator}__{pname}": pval
             for pname, pval in estimator_params.items()

--- a/sktime/regression/compose/_ensemble.py
+++ b/sktime/regression/compose/_ensemble.py
@@ -104,9 +104,6 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
         left child, and ``N_t_R`` is the number of samples in the right child.
         ``N``, ``N_t``, ``N_t_R`` and ``N_t_L`` all refer to the weighted sum,
         if ``sample_weight`` is passed.
-    min_impurity_split : float, (default=1e-7)
-        Threshold for early stopping in tree growth. A node will split
-        if its impurity is above the threshold, otherwise it is a leaf.
     bootstrap : boolean, optional (default=True)
         Whether bootstrap samples are used when building trees.
     oob_score : bool (default=False)
@@ -182,7 +179,6 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
         max_features=None,
         max_leaf_nodes=None,
         min_impurity_decrease=0.0,
-        min_impurity_split=None,
         bootstrap=False,
         oob_score=False,
         n_jobs=None,
@@ -203,7 +199,6 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
         self.max_features = max_features
         self.max_leaf_nodes = max_leaf_nodes
         self.min_impurity_decrease = min_impurity_decrease
-        self.min_impurity_split = min_impurity_split
         self.max_samples = max_samples
 
         # Pass on params.
@@ -275,7 +270,6 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
             "max_features": self.max_features,
             "max_leaf_nodes": self.max_leaf_nodes,
             "min_impurity_decrease": self.min_impurity_decrease,
-            "min_impurity_split": self.min_impurity_split,
         }
         final_estimator = self._estimator.steps[-1][0]
         self.estimator_params = {

--- a/sktime/series_as_features/base/estimators/_ensemble.py
+++ b/sktime/series_as_features/base/estimators/_ensemble.py
@@ -368,10 +368,3 @@ class BaseTimeSeriesForest(BaseForest):
             fis /= fis_count
 
         return fis
-
-    def _get_fitted_params(self):
-
-        return {
-            "classes": self.classes_,
-            "estimators": self.estimators_,
-        }

--- a/sktime/utils/_testing/estimator_checks.py
+++ b/sktime/utils/_testing/estimator_checks.py
@@ -195,7 +195,11 @@ def _has_capability(est, method: str) -> bool:
                 tag_name=tag_name, tag_value_default=tag_value_default
             )
         else:
-            return est.get_tag(tag_name=tag_name, tag_value_default=tag_value_default)
+            return est.get_tag(
+                tag_name=tag_name,
+                tag_value_default=tag_value_default,
+                raise_error=False,
+            )
 
     if not hasattr(est, method):
         return False


### PR DESCRIPTION
Partially fixes https://github.com/sktime/sktime/issues/4220 for `ComposableTimeSeriesRegressor`. This is done by:

* doing the same as in the existing `ComposableTimeSeriesClassifier`, introducing a dummy abstract method that satisfies the abstract parent class
* renaming the reserved `estimator_` attribute (by the `sklearn` parent class) to `_estimator`
* fix parameters inconsistent with underlying `sklearn` decision tree/forest