### PR TITLE
[DOC] improve docstring for `VectorizedDF.items` and `.__iter__`

### DIFF
--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -318,7 +318,9 @@ class VectorizedDF:
 
         Returns
         -------
-        An generator over all instances
+        A generator over all slices/instances iterated over.
+        i-th element corresponds to i-th vectorization slice, rows first then cols
+        Same as iterating over 2nd tuple element of self.items()
         """
         return (
             group

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -4,6 +4,10 @@
 
 Contains VectorizedDF class.
 """
+
+__author__ = ["fkiraly", "hoesler"]
+
+
 import itertools
 from itertools import product
 
@@ -314,7 +318,7 @@ class VectorizedDF:
 
         Returns
         -------
-        An iterator over all instances
+        An generator over all instances
         """
         return (
             group
@@ -347,7 +351,8 @@ class VectorizedDF:
 
         Returns
         -------
-        An iterator over all (row name, column name, instance) tuples.
+        A generator returning (row index, col index instance) tuples for vectorization.
+        i-th element is i-th
         """
         if iterate_as is None:
             iterate_as = self.iterate_as

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -351,8 +351,11 @@ class VectorizedDF:
 
         Returns
         -------
-        A generator returning (row index, col index instance) tuples for vectorization.
-        i-th element is i-th
+        A generator returning (row index, col index, instance) tuples for vectorization.
+        i-th element corresponds to i-th vectorization slice, rows first then cols
+        2nd tuple element is X row sub-set to 0-th tuple element, col sub-set to 1-st
+        if no sub-setting takes place for row, 0-th tuple element is None
+        if no sub-setting takes place for col, 1-st tuple element is None
         """
         if iterate_as is None:
             iterate_as = self.iterate_as


### PR DESCRIPTION
This improves the docstringd for `VectorizedDF.items` and `.__iter__`, see discussion in https://github.com/sktime/sktime/pull/4195

FYI @hoesler, comments and suggestions are appreciated.