### PR TITLE
[BUG] prevent discovery of abstract `TimeSeriesLloyds` by contract tests

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -32,6 +32,7 @@ EXCLUDE_ESTIMATORS = [
     "TapNetClassifier",
     "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
     "LSTMFCNClassifier",  # unknown cause, see bug report #4033
+    "TimeSeriesLloyds",  # an abstract class, but does not follow naming convention
 ]
 
 


### PR DESCRIPTION
This PR prevents discovery of abstract `TimeSeriesLloyds` by interface contract tests (which fail since the class is abstract), which surfaces in clean package crawls, see, e.g., https://github.com/sktime/sktime/pull/4208