### PR TITLE
[ENH] Improve vectorized metric calculation and deprecate VectorizedDF.__getitem__ and VectorizedDF.get_iloc_indexer

### DIFF
--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -48,6 +48,8 @@ class VectorizedDF:
         as pandas.DataFrame with Index or MultiIndex (in sktime pandas format)
     len(self) or self.__len__()
         returns number of Series/Panels in X
+    get_iter_indices()
+        Returns pandas.(Multi)Index that are iterated over
     reconstruct(self, df_list, convert_back=False)
         Takes iterable df_list and returns as an object of is_scitype.
         Used to obtain original format after applying operations to self iterated
@@ -185,7 +187,7 @@ class VectorizedDF:
 
     # TODO: remove in v0.18.0
     @deprecated(
-        version="0.16.1",
+        version="0.16.2",
         reason="get_iloc_indexer will be removed in v0.18.0",
         category=FutureWarning,
     )
@@ -230,7 +232,7 @@ class VectorizedDF:
 
     # TODO: remove in v0.18.0
     @deprecated(
-        version="0.16.1",
+        version="0.16.2",
         reason="__getitem__ will be removed in v0.18.0",
         category=FutureWarning,
     )

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -8,6 +8,7 @@ import itertools
 
 import numpy as np
 import pandas as pd
+from deprecated.sphinx import deprecated
 
 from sktime.datatypes._check import check_is_scitype, mtype
 from sktime.datatypes._convert import convert_to
@@ -220,6 +221,16 @@ class VectorizedDF:
                 iterate_as=self.iterate_as, iterate_cols=self.iterate_cols
             )
         )
+
+    # TODO: remove in v0.18.0
+    @deprecated(
+        version="0.16.1",
+        reason="__getitem__ will be removed in v0.18.0",
+        category=FutureWarning,
+    )
+    def __getitem__(self, i: int):
+        """Return the i-th element iterated over in vectorization."""
+        return next(itertools.islice(self, i, None))
 
     def items(self, iterate_as=None, iterate_cols=None):
         """Iterate over (group name, column name, instance) tuples.

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -183,6 +183,12 @@ class VectorizedDF:
         """
         return self.iter_indices
 
+    # TODO: remove in v0.18.0
+    @deprecated(
+        version="0.16.1",
+        reason="get_iloc_indexer will be removed in v0.18.0",
+        category=FutureWarning,
+    )
     def get_iloc_indexer(self, i: int):
         """Get iloc row/column indexer for i-th list element.
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -230,12 +230,6 @@ class VectorizedDF:
             )
         )
 
-    # TODO: remove in v0.18.0
-    @deprecated(
-        version="0.16.2",
-        reason="__getitem__ will be removed in v0.18.0",
-        category=FutureWarning,
-    )
     def __getitem__(self, i: int):
         """Return the i-th element iterated over in vectorization."""
         return next(itertools.islice(self, i, None))

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -42,13 +42,11 @@ class VectorizedDF:
 
     Methods
     -------
-    self[i] or self.__getitem__(i)
-        Returns i-th Series/Panel (depending on iterate_as) in X
+    iter(self) or self.__iter__()
+        Iterates over each Series/Panel (depending on iterate_as) in X
         as pandas.DataFrame with Index or MultiIndex (in sktime pandas format)
-    len(self) or self.__len__
-        returns number of Series/Panel in X
-    get_iter_indices()
-        Returns pandas.(Multi)Index that are iterated over
+    len(self) or self.__len__()
+        returns number of Series/Panels in X
     reconstruct(self, df_list, convert_back=False)
         Takes iterable df_list and returns as an object of is_scitype.
         Used to obtain original format after applying operations to self iterated
@@ -336,7 +334,7 @@ class VectorizedDF:
 
         Parameters
         ----------
-        df_list : iterable of objects of same type and sequence as __getitem__ returns.
+        df_list : iterable of objects of same type and sequence as __iter__ returns.
             can be self, but will in general be another object to be useful.
             Example: [some_operation(df) for df in self] that leaves types the same
         convert_back : bool, optional, default = False
@@ -505,7 +503,7 @@ class VectorizedDF:
         return_type : str, one of "pd.DataFrame" or "list"
             the return will be of this type;
             if `pd.DataFrame`, with row/col indices being `self.get_iter_indices()`
-            if `list`, entries in sequence corresponding to `self__getitem__`
+            if `list`, entries in sequence corresponding to `self__iter__`
         rowname_default : str, optional, default="estimators"
             used as index name of single row if no row vectorization is performed
         colname_default : str, optional, default="estimators"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Followup to #4195
Contributes to https://github.com/sktime/sktime/issues/4139


#### What does this implement/fix? Explain your changes.
This PR implements `BaseForecastingErrorMetric._evaluate_vectorized` using `VectorizedDF.vectorize_est`.
Further, by removing with it the last reference to `VectorizedDF.__getitem__`, it deprecates this method. Random access is not needed, and developers should use `__iter__` for iteration instead (implemented in #4195).
Also, unused method `get_iloc_indexer` is marked as deprecated for the same reason.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
