### PR TITLE
[ENH] temporarily replace `sktime.org` links by `readthedocs` links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,5 +3,5 @@ contact_links:
     url: https://discord.com/invite/gqSab2K
     about: Chat with the sktime community on Discord
   - name: "\u2709\uFE0F Code of Conduct incident reporting"
-    url: https://www.sktime-backup.readthedocs.io/en/latest/get_involved/code_of_conduct.html#incident-reporting-guidelines
+    url: https://sktime-backup.readthedocs.io/en/latest/get_involved/code_of_conduct.html#incident-reporting-guidelines
     about: Report an incident to the Code of Conduct committee

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,5 +3,5 @@ contact_links:
     url: https://discord.com/invite/gqSab2K
     about: Chat with the sktime community on Discord
   - name: "\u2709\uFE0F Code of Conduct incident reporting"
-    url: https://www.sktime.org/en/latest/get_involved/code_of_conduct.html#incident-reporting-guidelines
+    url: https://www.sktime-backup.readthedocs.io/en/latest/get_involved/code_of_conduct.html#incident-reporting-guidelines
     about: Report an incident to the Code of Conduct committee

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changelog
 
-You can find the sktime changelog on our [website](https://www.sktime-backup.readthedocs.io/en/latest/changelog.html).
+You can find the sktime changelog on our [website](https://sktime-backup.readthedocs.io/en/latest/changelog.html).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changelog
 
-You can find the sktime changelog on our [website](https://www.sktime.org/en/latest/changelog.html).
+You can find the sktime changelog on our [website](https://www.sktime-backup.readthedocs.io/en/latest/changelog.html).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-You can find our Code of Conduct on our [website](https://www.sktime.org/en/latest/get_involved/code_of_conduct.html).
+You can find our Code of Conduct on our [website](https://www.sktime-backup.readthedocs.io/en/latest/get_involved/code_of_conduct.html).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-You can find our Code of Conduct on our [website](https://www.sktime-backup.readthedocs.io/en/latest/get_involved/code_of_conduct.html).
+You can find our Code of Conduct on our [website](https://sktime-backup.readthedocs.io/en/latest/get_involved/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing guide
 
-You can find our contributing guide on our [website](https://www.sktime-backup.readthedocs.io/en/latest/get_involved/contributing.html).
+You can find our contributing guide on our [website](https://sktime-backup.readthedocs.io/en/latest/get_involved/contributing.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing guide
 
-You can find our contributing guide on our [website](https://www.sktime.org/en/latest/get_involved/contributing.html).
+You can find our contributing guide on our [website](https://www.sktime-backup.readthedocs.io/en/latest/get_involved/contributing.html).

--- a/ESTIMATOR_OVERVIEW.md
+++ b/ESTIMATOR_OVERVIEW.md
@@ -1,5 +1,5 @@
 This file is outdated and present only for downwards compatibility of links.
 
 Please visit instead:
-* the [sktime API reference](https://www.sktime.org/en/stable/api_reference.html)
-* the [tabular estimator overview](https://www.sktime.org/en/stable/estimator_overview.html)
+* the [sktime API reference](https://www.sktime-backup.readthedocs.io/en/stable/api_reference.html)
+* the [tabular estimator overview](https://www.sktime-backup.readthedocs.io/en/stable/estimator_overview.html)

--- a/ESTIMATOR_OVERVIEW.md
+++ b/ESTIMATOR_OVERVIEW.md
@@ -1,5 +1,5 @@
 This file is outdated and present only for downwards compatibility of links.
 
 Please visit instead:
-* the [sktime API reference](https://www.sktime-backup.readthedocs.io/en/stable/api_reference.html)
-* the [tabular estimator overview](https://www.sktime-backup.readthedocs.io/en/stable/estimator_overview.html)
+* the [sktime API reference](https://sktime-backup.readthedocs.io/en/stable/api_reference.html)
+* the [tabular estimator overview](https://sktime-backup.readthedocs.io/en/stable/estimator_overview.html)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,3 +1,3 @@
 # Governance
 
-You can find our governance guidelines on our [website](https://www.sktime-backup.readthedocs.io/en/latest/get_involved/governance.html).
+You can find our governance guidelines on our [website](https://sktime-backup.readthedocs.io/en/latest/get_involved/governance.html).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,3 +1,3 @@
 # Governance
 
-You can find our governance guidelines on our [website](https://www.sktime.org/en/latest/get_involved/governance.html).
+You can find our governance guidelines on our [website](https://www.sktime-backup.readthedocs.io/en/latest/get_involved/governance.html).

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-<a href="https://sktime.org"><img src="https://github.com/sktime/sktime/blob/main/docs/source/images/sktime-logo.jpg?raw=true)" width="175" align="right" /></a>
+<a href="https://sktime-backup.readthedocs.io"><img src="https://github.com/sktime/sktime/blob/main/docs/source/images/sktime-logo.jpg?raw=true)" width="175" align="right" /></a>
 
 # Welcome to sktime
 
 > A unified interface for machine learning with time series
 
-:rocket: **Version 0.16.1 out now!** [Check out the release notes here](https://www.sktime.org/en/latest/changelog.html).
+:rocket: **Version 0.16.1 out now!** [Check out the release notes here](https://www.sktime-backup.readthedocs.io/en/latest/changelog.html).
 
-sktime is a library for time series analysis in Python. It provides a unified interface for multiple time series learning tasks. Currently, this includes time series classification, regression, clustering, annotation and forecasting. It comes with [time series algorithms](https://www.sktime.org/en/stable/estimator_overview.html) and [scikit-learn] compatible tools to build, tune and validate time series models.
+sktime is a library for time series analysis in Python. It provides a unified interface for multiple time series learning tasks. Currently, this includes time series classification, regression, clustering, annotation and forecasting. It comes with [time series algorithms](https://www.sktime-backup.readthedocs.io/en/stable/estimator_overview.html) and [scikit-learn] compatible tools to build, tune and validate time series models.
 
 [scikit-learn]: https://scikit-learn.org/stable/
 
 | Overview | |
 |---|---|
-| **CI/CD** | [![github-actions](https://img.shields.io/github/actions/workflow/status/sktime/sktime/wheels.yml?logo=github)](https://github.com/sktime/sktime/actions/workflows/wheels.yml) [![!codecov](https://img.shields.io/codecov/c/github/sktime/sktime?label=codecov&logo=codecov)](https://codecov.io/gh/sktime/sktime) [![readthedocs](https://img.shields.io/readthedocs/sktime?logo=readthedocs)](https://www.sktime.org/en/latest/?badge=latest) [![platform](https://img.shields.io/conda/pn/conda-forge/sktime)](https://github.com/sktime/sktime) |
+| **CI/CD** | [![github-actions](https://img.shields.io/github/actions/workflow/status/sktime/sktime/wheels.yml?logo=github)](https://github.com/sktime/sktime/actions/workflows/wheels.yml) [![!codecov](https://img.shields.io/codecov/c/github/sktime/sktime?label=codecov&logo=codecov)](https://codecov.io/gh/sktime/sktime) [![readthedocs](https://img.shields.io/readthedocs/sktime?logo=readthedocs)](https://www.sktime-backup.readthedocs.io/en/latest/?badge=latest) [![platform](https://img.shields.io/conda/pn/conda-forge/sktime)](https://github.com/sktime/sktime) |
 | **Code** |  [![!pypi](https://img.shields.io/pypi/v/sktime?color=orange)](https://pypi.org/project/sktime/) [![!conda](https://img.shields.io/conda/vn/conda-forge/sktime)](https://anaconda.org/conda-forge/sktime) [![!python-versions](https://img.shields.io/pypi/pyversions/sktime)](https://www.python.org/) [![!black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/sktime/sktime/main?filepath=examples) |
 | **Downloads**| [![Downloads](https://static.pepy.tech/personalized-badge/sktime?period=week&units=international_system&left_color=grey&right_color=blue&left_text=weekly%20(pypi))](https://pepy.tech/project/sktime) [![Downloads](https://static.pepy.tech/personalized-badge/sktime?period=month&units=international_system&left_color=grey&right_color=blue&left_text=monthly%20(pypi))](https://pepy.tech/project/sktime) [![Downloads](https://static.pepy.tech/personalized-badge/sktime?period=total&units=international_system&left_color=grey&right_color=blue&left_text=cumulative%20(pypi))](https://pepy.tech/project/sktime) |
 | **Community** | [![!discord](https://img.shields.io/static/v1?logo=discord&label=discord&message=chat&color=lightgreen)](https://discord.com/invite/gqSab2K) [![!slack](https://img.shields.io/static/v1?logo=linkedin&label=LinkedIn&message=news&color=lightblue)](https://www.linkedin.com/company/sktime/) [![!twitter](https://img.shields.io/static/v1?logo=twitter&label=Twitter&message=news&color=lightblue)](https://twitter.com/sktime_toolbox) [![!youtube](https://img.shields.io/static/v1?logo=youtube&label=YouTube&message=tutorials&color=red)](https://www.youtube.com/playlist?list=PLKs3UgGjlWHqNzu0LEOeLKvnjvvest2d0) |
@@ -32,14 +32,14 @@ sktime is a library for time series analysis in Python. It provides a unified in
 | :deciduous_tree: **[Roadmap]**          | sktime's software and community development plan.                                   |
 | :pencil: **[Related Software]**          | A list of related software. |
 
-[tutorials]: https://www.sktime.org/en/latest/tutorials.html
+[tutorials]: https://www.sktime-backup.readthedocs.io/en/latest/tutorials.html
 [binder notebooks]: https://mybinder.org/v2/gh/sktime/sktime/main?filepath=examples
-[user guides]: https://www.sktime.org/en/latest/user_guide.html
+[user guides]: https://www.sktime-backup.readthedocs.io/en/latest/user_guide.html
 [video tutorial]: https://github.com/sktime/sktime-tutorial-pydata-global-2021
-[api reference]: https://www.sktime.org/en/latest/api_reference.html
-[changelog]: https://www.sktime.org/en/latest/changelog.html
-[roadmap]: https://www.sktime.org/en/latest/roadmap.html
-[related software]: https://www.sktime.org/en/latest/related_software.html
+[api reference]: https://www.sktime-backup.readthedocs.io/en/latest/api_reference.html
+[changelog]: https://www.sktime-backup.readthedocs.io/en/latest/changelog.html
+[roadmap]: https://www.sktime-backup.readthedocs.io/en/latest/roadmap.html
+[related software]: https://www.sktime-backup.readthedocs.io/en/latest/related_software.html
 
 ## :speech_balloon: Where to ask questions
 
@@ -60,7 +60,7 @@ Questions and feedback are extremely welcome! Please understand that we won't be
 [discord]: https://discord.com/invite/gqSab2K
 
 ## :dizzy: Features
-Our aim is to make the time series analysis ecosystem more interoperable and usable as a whole. sktime provides a __unified interface for distinct but related time series learning tasks__. It features [__dedicated time series algorithms__](https://www.sktime.org/en/stable/estimator_overview.html) and __tools for composite model building__ including pipelining, ensembling, tuning and reduction that enables users to apply an algorithm for one task to another.
+Our aim is to make the time series analysis ecosystem more interoperable and usable as a whole. sktime provides a __unified interface for distinct but related time series learning tasks__. It features [__dedicated time series algorithms__](https://www.sktime-backup.readthedocs.io/en/stable/estimator_overview.html) and __tools for composite model building__ including pipelining, ensembling, tuning and reduction that enables users to apply an algorithm for one task to another.
 
 sktime also provides **interfaces to related libraries**, for example [scikit-learn], [statsmodels], [tsfresh], [PyOD] and [fbprophet], among others.
 
@@ -73,10 +73,10 @@ For **deep learning**, see our companion package: [sktime-dl](https://github.com
 
 | Module | Status | Links |
 |---|---|---|
-| **[Forecasting]** | stable | [Tutorial](https://www.sktime.org/en/latest/examples/01_forecasting.html) · [API Reference](https://www.sktime.org/en/latest/api_reference.html#sktime-forecasting-time-series-forecasting) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting.py)  |
-| **[Time Series Classification]** | stable | [Tutorial](https://github.com/sktime/sktime/blob/main/examples/02_classification.ipynb) · [API Reference](https://www.sktime.org/en/latest/api_reference.html#sktime-classification-time-series-classification) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/classification.py) |
-| **[Time Series Regression]** | stable | [API Reference](https://www.sktime.org/en/latest/api_reference.html#sktime-classification-time-series-regression) |
-| **[Transformations]** | stable | [API Reference](https://www.sktime.org/en/latest/api_reference.html#sktime-transformations-time-series-transformers) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/transformer.py)  |
+| **[Forecasting]** | stable | [Tutorial](https://www.sktime-backup.readthedocs.io/en/latest/examples/01_forecasting.html) · [API Reference](https://www.sktime-backup.readthedocs.io/en/latest/api_reference.html#sktime-forecasting-time-series-forecasting) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting.py)  |
+| **[Time Series Classification]** | stable | [Tutorial](https://github.com/sktime/sktime/blob/main/examples/02_classification.ipynb) · [API Reference](https://www.sktime-backup.readthedocs.io/en/latest/api_reference.html#sktime-classification-time-series-classification) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/classification.py) |
+| **[Time Series Regression]** | stable | [API Reference](https://www.sktime-backup.readthedocs.io/en/latest/api_reference.html#sktime-classification-time-series-regression) |
+| **[Transformations]** | stable | [API Reference](https://www.sktime-backup.readthedocs.io/en/latest/api_reference.html#sktime-transformations-time-series-transformers) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/transformer.py)  |
 | **[Time Series Clustering]** | maturing | [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/clustering.py) |
 | **[Time Series Distances/Kernels]** | experimental | [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/dist_kern_panel.py) |
 | **[Annotation]** | experimental | [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/annotation.py) |
@@ -91,7 +91,7 @@ For **deep learning**, see our companion package: [sktime-dl](https://github.com
 
 
 ## :hourglass_flowing_sand: Install sktime
-For trouble shooting and detailed installation instructions, see the [documentation](https://www.sktime.org/en/latest/installation.html).
+For trouble shooting and detailed installation instructions, see the [documentation](https://www.sktime-backup.readthedocs.io/en/latest/installation.html).
 
 - **Operating system**: macOS X · Linux · Windows 8.1 or higher
 - **Python version**: Python 3.7, 3.8, 3.9, 3.10, and 3.11 (only 64 bit)
@@ -180,16 +180,16 @@ There are many ways to join the sktime community. We follow the [all-contributor
 | :money_with_wings: **[Donate]** | Fund sktime maintenance and development. |
 | :classical_building: **[Governance]** | How and by whom decisions are made in sktime's community.   |
 
-[contribute]: https://www.sktime.org/en/latest/get_involved/contributing.html
+[contribute]: https://www.sktime-backup.readthedocs.io/en/latest/get_involved/contributing.html
 [donate]: https://opencollective.com/sktime
 [extension templates]: https://github.com/sktime/sktime/tree/main/extension_templates
-[developer guides]: https://www.sktime.org/en/latest/developer_guide.html
+[developer guides]: https://www.sktime-backup.readthedocs.io/en/latest/developer_guide.html
 [contributors]: https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md
-[governance]: https://www.sktime.org/en/latest/governance.html
+[governance]: https://www.sktime-backup.readthedocs.io/en/latest/governance.html
 [mentoring]: https://github.com/sktime/mentoring
 [meetings]: https://calendar.google.com/calendar/u/0/embed?src=sktime.toolbox@gmail.com&ctz=UTC
 [enhancement proposals]: https://github.com/sktime/enhancement-proposals
-[roles]: https://www.sktime.org/en/latest/about/team.html
+[roles]: https://www.sktime-backup.readthedocs.io/en/latest/about/team.html
 
 ## :bulb: Project vision
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 > A unified interface for machine learning with time series
 
-:rocket: **Version 0.16.1 out now!** [Check out the release notes here](https://www.sktime-backup.readthedocs.io/en/latest/changelog.html).
+:rocket: **Version 0.16.1 out now!** [Check out the release notes here](https://sktime-backup.readthedocs.io/en/latest/changelog.html).
 
-sktime is a library for time series analysis in Python. It provides a unified interface for multiple time series learning tasks. Currently, this includes time series classification, regression, clustering, annotation and forecasting. It comes with [time series algorithms](https://www.sktime-backup.readthedocs.io/en/stable/estimator_overview.html) and [scikit-learn] compatible tools to build, tune and validate time series models.
+sktime is a library for time series analysis in Python. It provides a unified interface for multiple time series learning tasks. Currently, this includes time series classification, regression, clustering, annotation and forecasting. It comes with [time series algorithms](https://sktime-backup.readthedocs.io/en/stable/estimator_overview.html) and [scikit-learn] compatible tools to build, tune and validate time series models.
 
 [scikit-learn]: https://scikit-learn.org/stable/
 
 | Overview | |
 |---|---|
-| **CI/CD** | [![github-actions](https://img.shields.io/github/actions/workflow/status/sktime/sktime/wheels.yml?logo=github)](https://github.com/sktime/sktime/actions/workflows/wheels.yml) [![!codecov](https://img.shields.io/codecov/c/github/sktime/sktime?label=codecov&logo=codecov)](https://codecov.io/gh/sktime/sktime) [![readthedocs](https://img.shields.io/readthedocs/sktime?logo=readthedocs)](https://www.sktime-backup.readthedocs.io/en/latest/?badge=latest) [![platform](https://img.shields.io/conda/pn/conda-forge/sktime)](https://github.com/sktime/sktime) |
+| **CI/CD** | [![github-actions](https://img.shields.io/github/actions/workflow/status/sktime/sktime/wheels.yml?logo=github)](https://github.com/sktime/sktime/actions/workflows/wheels.yml) [![!codecov](https://img.shields.io/codecov/c/github/sktime/sktime?label=codecov&logo=codecov)](https://codecov.io/gh/sktime/sktime) [![readthedocs](https://img.shields.io/readthedocs/sktime?logo=readthedocs)](https://sktime-backup.readthedocs.io/en/latest/?badge=latest) [![platform](https://img.shields.io/conda/pn/conda-forge/sktime)](https://github.com/sktime/sktime) |
 | **Code** |  [![!pypi](https://img.shields.io/pypi/v/sktime?color=orange)](https://pypi.org/project/sktime/) [![!conda](https://img.shields.io/conda/vn/conda-forge/sktime)](https://anaconda.org/conda-forge/sktime) [![!python-versions](https://img.shields.io/pypi/pyversions/sktime)](https://www.python.org/) [![!black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/sktime/sktime/main?filepath=examples) |
 | **Downloads**| [![Downloads](https://static.pepy.tech/personalized-badge/sktime?period=week&units=international_system&left_color=grey&right_color=blue&left_text=weekly%20(pypi))](https://pepy.tech/project/sktime) [![Downloads](https://static.pepy.tech/personalized-badge/sktime?period=month&units=international_system&left_color=grey&right_color=blue&left_text=monthly%20(pypi))](https://pepy.tech/project/sktime) [![Downloads](https://static.pepy.tech/personalized-badge/sktime?period=total&units=international_system&left_color=grey&right_color=blue&left_text=cumulative%20(pypi))](https://pepy.tech/project/sktime) |
 | **Community** | [![!discord](https://img.shields.io/static/v1?logo=discord&label=discord&message=chat&color=lightgreen)](https://discord.com/invite/gqSab2K) [![!slack](https://img.shields.io/static/v1?logo=linkedin&label=LinkedIn&message=news&color=lightblue)](https://www.linkedin.com/company/sktime/) [![!twitter](https://img.shields.io/static/v1?logo=twitter&label=Twitter&message=news&color=lightblue)](https://twitter.com/sktime_toolbox) [![!youtube](https://img.shields.io/static/v1?logo=youtube&label=YouTube&message=tutorials&color=red)](https://www.youtube.com/playlist?list=PLKs3UgGjlWHqNzu0LEOeLKvnjvvest2d0) |
@@ -32,14 +32,14 @@ sktime is a library for time series analysis in Python. It provides a unified in
 | :deciduous_tree: **[Roadmap]**          | sktime's software and community development plan.                                   |
 | :pencil: **[Related Software]**          | A list of related software. |
 
-[tutorials]: https://www.sktime-backup.readthedocs.io/en/latest/tutorials.html
+[tutorials]: https://sktime-backup.readthedocs.io/en/latest/tutorials.html
 [binder notebooks]: https://mybinder.org/v2/gh/sktime/sktime/main?filepath=examples
-[user guides]: https://www.sktime-backup.readthedocs.io/en/latest/user_guide.html
+[user guides]: https://sktime-backup.readthedocs.io/en/latest/user_guide.html
 [video tutorial]: https://github.com/sktime/sktime-tutorial-pydata-global-2021
-[api reference]: https://www.sktime-backup.readthedocs.io/en/latest/api_reference.html
-[changelog]: https://www.sktime-backup.readthedocs.io/en/latest/changelog.html
-[roadmap]: https://www.sktime-backup.readthedocs.io/en/latest/roadmap.html
-[related software]: https://www.sktime-backup.readthedocs.io/en/latest/related_software.html
+[api reference]: https://sktime-backup.readthedocs.io/en/latest/api_reference.html
+[changelog]: https://sktime-backup.readthedocs.io/en/latest/changelog.html
+[roadmap]: https://sktime-backup.readthedocs.io/en/latest/roadmap.html
+[related software]: https://sktime-backup.readthedocs.io/en/latest/related_software.html
 
 ## :speech_balloon: Where to ask questions
 
@@ -60,7 +60,7 @@ Questions and feedback are extremely welcome! Please understand that we won't be
 [discord]: https://discord.com/invite/gqSab2K
 
 ## :dizzy: Features
-Our aim is to make the time series analysis ecosystem more interoperable and usable as a whole. sktime provides a __unified interface for distinct but related time series learning tasks__. It features [__dedicated time series algorithms__](https://www.sktime-backup.readthedocs.io/en/stable/estimator_overview.html) and __tools for composite model building__ including pipelining, ensembling, tuning and reduction that enables users to apply an algorithm for one task to another.
+Our aim is to make the time series analysis ecosystem more interoperable and usable as a whole. sktime provides a __unified interface for distinct but related time series learning tasks__. It features [__dedicated time series algorithms__](https://sktime-backup.readthedocs.io/en/stable/estimator_overview.html) and __tools for composite model building__ including pipelining, ensembling, tuning and reduction that enables users to apply an algorithm for one task to another.
 
 sktime also provides **interfaces to related libraries**, for example [scikit-learn], [statsmodels], [tsfresh], [PyOD] and [fbprophet], among others.
 
@@ -73,10 +73,10 @@ For **deep learning**, see our companion package: [sktime-dl](https://github.com
 
 | Module | Status | Links |
 |---|---|---|
-| **[Forecasting]** | stable | [Tutorial](https://www.sktime-backup.readthedocs.io/en/latest/examples/01_forecasting.html) · [API Reference](https://www.sktime-backup.readthedocs.io/en/latest/api_reference.html#sktime-forecasting-time-series-forecasting) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting.py)  |
-| **[Time Series Classification]** | stable | [Tutorial](https://github.com/sktime/sktime/blob/main/examples/02_classification.ipynb) · [API Reference](https://www.sktime-backup.readthedocs.io/en/latest/api_reference.html#sktime-classification-time-series-classification) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/classification.py) |
-| **[Time Series Regression]** | stable | [API Reference](https://www.sktime-backup.readthedocs.io/en/latest/api_reference.html#sktime-classification-time-series-regression) |
-| **[Transformations]** | stable | [API Reference](https://www.sktime-backup.readthedocs.io/en/latest/api_reference.html#sktime-transformations-time-series-transformers) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/transformer.py)  |
+| **[Forecasting]** | stable | [Tutorial](https://sktime-backup.readthedocs.io/en/latest/examples/01_forecasting.html) · [API Reference](https://sktime-backup.readthedocs.io/en/latest/api_reference.html#sktime-forecasting-time-series-forecasting) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting.py)  |
+| **[Time Series Classification]** | stable | [Tutorial](https://github.com/sktime/sktime/blob/main/examples/02_classification.ipynb) · [API Reference](https://sktime-backup.readthedocs.io/en/latest/api_reference.html#sktime-classification-time-series-classification) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/classification.py) |
+| **[Time Series Regression]** | stable | [API Reference](https://sktime-backup.readthedocs.io/en/latest/api_reference.html#sktime-classification-time-series-regression) |
+| **[Transformations]** | stable | [API Reference](https://sktime-backup.readthedocs.io/en/latest/api_reference.html#sktime-transformations-time-series-transformers) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/transformer.py)  |
 | **[Time Series Clustering]** | maturing | [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/clustering.py) |
 | **[Time Series Distances/Kernels]** | experimental | [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/dist_kern_panel.py) |
 | **[Annotation]** | experimental | [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/annotation.py) |
@@ -91,7 +91,7 @@ For **deep learning**, see our companion package: [sktime-dl](https://github.com
 
 
 ## :hourglass_flowing_sand: Install sktime
-For trouble shooting and detailed installation instructions, see the [documentation](https://www.sktime-backup.readthedocs.io/en/latest/installation.html).
+For trouble shooting and detailed installation instructions, see the [documentation](https://sktime-backup.readthedocs.io/en/latest/installation.html).
 
 - **Operating system**: macOS X · Linux · Windows 8.1 or higher
 - **Python version**: Python 3.7, 3.8, 3.9, 3.10, and 3.11 (only 64 bit)
@@ -180,16 +180,16 @@ There are many ways to join the sktime community. We follow the [all-contributor
 | :money_with_wings: **[Donate]** | Fund sktime maintenance and development. |
 | :classical_building: **[Governance]** | How and by whom decisions are made in sktime's community.   |
 
-[contribute]: https://www.sktime-backup.readthedocs.io/en/latest/get_involved/contributing.html
+[contribute]: https://sktime-backup.readthedocs.io/en/latest/get_involved/contributing.html
 [donate]: https://opencollective.com/sktime
 [extension templates]: https://github.com/sktime/sktime/tree/main/extension_templates
-[developer guides]: https://www.sktime-backup.readthedocs.io/en/latest/developer_guide.html
+[developer guides]: https://sktime-backup.readthedocs.io/en/latest/developer_guide.html
 [contributors]: https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md
-[governance]: https://www.sktime-backup.readthedocs.io/en/latest/governance.html
+[governance]: https://sktime-backup.readthedocs.io/en/latest/governance.html
 [mentoring]: https://github.com/sktime/mentoring
 [meetings]: https://calendar.google.com/calendar/u/0/embed?src=sktime.toolbox@gmail.com&ctz=UTC
 [enhancement proposals]: https://github.com/sktime/enhancement-proposals
-[roles]: https://www.sktime-backup.readthedocs.io/en/latest/about/team.html
+[roles]: https://sktime-backup.readthedocs.io/en/latest/about/team.html
 
 ## :bulb: Project vision
 

--- a/build_tools/make_release.py
+++ b/build_tools/make_release.py
@@ -30,7 +30,7 @@ class URLs:
     DOCS_LOCAL = "file://" + os.path.realpath(
         os.path.join(ROOT_DIR, "docs/_build/html/index.html")
     )
-    DOCS_ONLINE = "https://www.sktime-backup.readthedocs.io"
+    DOCS_ONLINE = "https://sktime-backup.readthedocs.io"
     PYPI = f"https://pypi.org/simple/{PACKAGE_NAME}/"
 
 

--- a/build_tools/make_release.py
+++ b/build_tools/make_release.py
@@ -30,7 +30,7 @@ class URLs:
     DOCS_LOCAL = "file://" + os.path.realpath(
         os.path.join(ROOT_DIR, "docs/_build/html/index.html")
     )
-    DOCS_ONLINE = "https://www.sktime.org"
+    DOCS_ONLINE = "https://www.sktime-backup.readthedocs.io"
     PYPI = f"https://pypi.org/simple/{PACKAGE_NAME}/"
 
 

--- a/build_tools/make_release.py
+++ b/build_tools/make_release.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """
-Do-nothing script for making a release
+Do-nothing script for making a release.
 
 This idea comes from here:
 - https://blog.danslimmon.com/2019/07/15/do-nothing-scripting-the-key-to
@@ -13,7 +13,7 @@ The script is adapted from:
 /make_release.py
 """
 
-__author__ = ["Markus Löning"]
+__author__ = ["mloning"]
 
 import codecs
 import os
@@ -27,6 +27,8 @@ PACKAGE_NAME = "sktime"
 
 
 class URLs:
+    """Container class for URLs."""
+
     DOCS_LOCAL = "file://" + os.path.realpath(
         os.path.join(ROOT_DIR, "docs/_build/html/index.html")
     )
@@ -35,6 +37,7 @@ class URLs:
 
 
 def read(*parts):
+    """Read from parts."""
     # intentionally *not* adding an encoding option to open, See:
     #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
     with codecs.open(os.path.join(ROOT_DIR, *parts), "r") as fp:
@@ -42,6 +45,7 @@ def read(*parts):
 
 
 def find_version(*file_paths):
+    """Find version string."""
     version_file = read(*file_paths)
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
@@ -51,10 +55,12 @@ def find_version(*file_paths):
 
 
 def open_website(website):
+    """Open website."""
     webbrowser.open(website, new=1)
 
 
 def colored(msg, color=None, style=None):
+    """Print message with colors."""
     colors = {
         "red": colorama.Fore.RED,
         "green": colorama.Fore.GREEN,
@@ -74,23 +80,29 @@ def colored(msg, color=None, style=None):
 
 
 def cprint(msg, color=None, style=None):
-    """Coloured printing"""
+    """Coloured printing."""
     print(colored(msg, color=color, style=style))  # noqa
 
 
 def wait_for_enter():
+    """Wait for Enter."""
     input(colored("\nPress Enter to continue", style="dim"))
     print()  # noqa
 
 
 class Step:
+    """Abstraction for release step."""
+
     def pre(self, context):
+        """Pre-step."""
         pass
 
     def post(self, context):
+        """Post-step."""
         wait_for_enter()
 
     def run(self, context):
+        """Run step."""
         try:
             self.pre(context)
             self.action(context)
@@ -101,31 +113,39 @@ class Step:
 
     @staticmethod
     def instruct(msg):
+        """Instruction."""
         cprint(msg, color="green")
 
     def print_run(self, msg):
+        """Print run step."""
         cprint("Run:", color="cyan", style="bright")
         self.print_cmd(msg)
 
     @staticmethod
     def print_cmd(msg):
+        """Print cmd step."""
         cprint("\t" + msg, color="cyan", style="bright")
 
     @staticmethod
     def do_cmd(cmd):
+        """Wait for confirmation."""
         cprint(f"Going to run: {cmd}", color="magenta", style="bright")
         wait_for_enter()
         os.system(cmd)
 
     def action(self, context):
+        """Carry out action."""
         raise NotImplementedError("abstract method")
 
 
 class ConfirmGitStatus(Step):
+    """Confirm git status."""
+
     def __init__(self, branch):
         self.branch = branch
 
     def action(self, context):
+        """Carry out action."""
         self.instruct(
             f"Make sure you're on: {self.branch}, you're local "
             f"branch is up-to-date, and all new changes are merged "
@@ -136,48 +156,73 @@ class ConfirmGitStatus(Step):
 
 
 class UpdateChangelog(Step):
+    """Update the changelog."""
+
     def action(self, context):
+        """Carry out action."""
         self.instruct(f"Update CHANGELOG for version: {context['version']}")
 
 
 class UpdateReadme(Step):
+    """Update the readme."""
+
     def action(self, context):
+        """Carry out action."""
         self.instruct(f"Update README for version: {context['version']}")
 
 
 class UpdateVersion(Step):
+    """Update sktime version."""
+
     def action(self, context):
+        """Carry out action."""
         self.instruct("Update __init__.py with new version")
 
     def post(self, context):
+        """Post-action step."""
         wait_for_enter()
         context["version"] = find_version(context["package_name"], "__init__.py")
 
 
 class MakeClean(Step):
+    """Make clean."""
+
     def action(self, context):
+        """Carry out action."""
         self.do_cmd("make clean")
 
 
 class MakeDocs(Step):
+    """Make docs."""
+
     def action(self, context):
+        """Carry out action."""
         self.do_cmd("make docs")
 
 
 class MakeDist(Step):
+    """Make dist."""
+
     def action(self, context):
+        """Carry out action."""
         self.do_cmd("make dist")
 
 
 class UploadToTestPyPI(Step):
+    """Upload to test pypi."""
+
     def action(self, context):
+        """Carry out action."""
         self.instruct("Upload to TestPyPI")
         cmd = "twine upload --repository-url https://test.pypi.org/legacy/ dist/*"
         self.do_cmd(cmd)
 
 
 class InstallFromTestPyPI(Step):
+    """Install from test pypi."""
+
     def action(self, context):
+        """Carry out action."""
         self.instruct("Check installation from TestPyPI")
         self.do_cmd(
             f"sh build_tools/check_install_from_test_pypi.sh {context['version']}"
@@ -185,7 +230,10 @@ class InstallFromTestPyPI(Step):
 
 
 class CheckVersionNumber(Step):
+    """Check version number."""
+
     def action(self, context):
+        """Carry out action."""
         self.instruct(
             f"Ensure that the following command gives version: {context['version']}"
         )
@@ -196,51 +244,76 @@ class CheckVersionNumber(Step):
 
 
 class GitTagRelease(Step):
+    """Git tag release."""
+
     def action(self, context):
+        """Carry out action."""
         self.instruct("Tag version as a release")
         self.do_cmd(f"git tag v{context['version']}")
 
 
 class GitTagPreRelease(Step):
+    """Git tag prerelease."""
+
     def action(self, context):
+        """Carry out action."""
         self.instruct("Tag version as a pre-release (increment as needed)")
         self.print_run(f"git tag v{context['version']}-rc.1")
 
 
 class PushToGitHub(Step):
+    """Push to GitHub."""
+
     def action(self, context):
+        """Carry out action."""
         self.instruct("Add and commit to git, then push to GitHub")
 
 
 class CheckCIStatus(Step):
+    """Check CI status."""
+
     def action(self, context):
+        """Carry out action."""
         self.instruct("Wait for CI to complete and check status")
 
 
 class CheckOnlineDocs(Step):
+    """Check online docs."""
+
     def action(self, context):
+        """Carry out action."""
         self.instruct("Check online docs")
         open_website(URLs.DOCS_ONLINE)
 
 
 class CheckLocalDocs(Step):
+    """Check local docs."""
+
     def action(self, context):
+        """Carry out action."""
         self.instruct("Check local docs")
         open_website(URLs.DOCS_LOCAL)
 
 
 class CheckPyPIFiles(Step):
+    """Check pypi files."""
+
     def action(self, context):
+        """Carry out action."""
         self.instruct("Check PyPI files")
         open_website(URLs.PYPI)
 
 
 class PushTagToGitHub(Step):
+    """Push tag to GitHub."""
+
     def action(self, context):
+        """Carry out action."""
         self.do_cmd(f"git push origin v{context['version']}")
 
 
 def main():
+    """Run release, main script."""
     colorama.init()
     steps = [
         # prepare and run final checks

--- a/docs/source/api_reference/file_specifications/ts.rst
+++ b/docs/source/api_reference/file_specifications/ts.rst
@@ -348,4 +348,4 @@ This concludes how to create string identifiers for ``.ts``  format. To learn mo
 .. _issue: https://github.com/alan-turing-institute/sktime/issues
 .. _tsregression: http://tseregression.org/
 .. _timeseriesclassification.com: http://www.timeseriesclassification.com/index.php
-.. _tutorials: https://www.sktime.org/en/stable/tutorials.html
+.. _tutorials: https://www.sktime-backup.readthedocs.io/en/stable/tutorials.html

--- a/docs/source/api_reference/file_specifications/ts.rst
+++ b/docs/source/api_reference/file_specifications/ts.rst
@@ -348,4 +348,4 @@ This concludes how to create string identifiers for ``.ts``  format. To learn mo
 .. _issue: https://github.com/alan-turing-institute/sktime/issues
 .. _tsregression: http://tseregression.org/
 .. _timeseriesclassification.com: http://www.timeseriesclassification.com/index.php
-.. _tutorials: https://www.sktime-backup.readthedocs.io/en/stable/tutorials.html
+.. _tutorials: https://sktime-backup.readthedocs.io/en/stable/tutorials.html

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2963,7 +2963,7 @@ Highlights
 * probabilistic forecasting: ``predict_var`` (variance forecast) and ``predict_proba`` (full distribution forecast) interfaces; performance metrics for interval and quantile forecasts (:pr:`2100`, :pr:`2130`, :pr:`2232`) :user:`eenticott-shell` :user:`fkiraly` :user:`kejsitake`
 * dunder methods for transformer and classifier pipelines: write ``my_trafo1 * my_trafo2`` for pipeline, ``my_trafo1 + my_trafo2`` for ``FeatureUnion`` (:pr:`2090`, :pr:`2251`) :user:`fkiraly`
 * Frequently requested: ``AutoARIMA`` from ``statsforecast`` package available as ``StatsforecastAutoARIMA`` (:pr:`2251`) :user:`FedericoGarza`
-* for extenders: detailed `"creating sktime compatible estimator" guide <https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html>`_
+* for extenders: detailed `"creating sktime compatible estimator" guide <https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html>`_
 * for extenders: simplified extension templates for forecasters and transformers (:pr:`2161`) :user:`fkiraly`
 
 Dependency changes
@@ -3918,8 +3918,8 @@ Highlights
 * :code:`conda-forge` metapackage for installing `sktime` with all extras :user:`freddyaboulton`
 * framework support for multivariate forecasting (:pr:`980` :pr:`1195` :pr:`1286` :pr:`1301` :pr:`1306` :pr:`1311` :pr:`1401` :pr:`1410`) :user:`aiwalter` :user:`fkiraly` :user:`thayeylolu`
 * consolidated lookup of estimators and tags using :code:`registry.all_estimators` and :code:`registry.all_tags` (:pr:`1196`) :user:`fkiraly`
-* [DOC] major overhaul of :code:`sktime`'s `online documentation <https://www.sktime-backup.readthedocs.io/en/latest/>`_
-* [DOC] `searchable, auto-updating estimators register <https://www.sktime-backup.readthedocs.io/en/latest/estimator_overview.html>`_ in online documentation (:pr:`930` :pr:`1138`) :user:`afzal442` :user:`mloning`
+* [DOC] major overhaul of :code:`sktime`'s `online documentation <https://sktime-backup.readthedocs.io/en/latest/>`_
+* [DOC] `searchable, auto-updating estimators register <https://sktime-backup.readthedocs.io/en/latest/estimator_overview.html>`_ in online documentation (:pr:`930` :pr:`1138`) :user:`afzal442` :user:`mloning`
 * [MNT] working Binder in-browser notebook showcase (:pr:`1266`) :user:`corvusrabus`
 * [DOC] tutorial notebook for in-memory data format conventions, validation, and conversion (:pr:`1232`) :user:`fkiraly`
 * easy conversion functionality for estimator inputs, series and panel data (:pr:`1061` :pr:`1187` :pr:`1201` :pr:`1225`) :user:`fkiraly`

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2963,7 +2963,7 @@ Highlights
 * probabilistic forecasting: ``predict_var`` (variance forecast) and ``predict_proba`` (full distribution forecast) interfaces; performance metrics for interval and quantile forecasts (:pr:`2100`, :pr:`2130`, :pr:`2232`) :user:`eenticott-shell` :user:`fkiraly` :user:`kejsitake`
 * dunder methods for transformer and classifier pipelines: write ``my_trafo1 * my_trafo2`` for pipeline, ``my_trafo1 + my_trafo2`` for ``FeatureUnion`` (:pr:`2090`, :pr:`2251`) :user:`fkiraly`
 * Frequently requested: ``AutoARIMA`` from ``statsforecast`` package available as ``StatsforecastAutoARIMA`` (:pr:`2251`) :user:`FedericoGarza`
-* for extenders: detailed `"creating sktime compatible estimator" guide <https://www.sktime.org/en/stable/developer_guide/add_estimators.html>`_
+* for extenders: detailed `"creating sktime compatible estimator" guide <https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html>`_
 * for extenders: simplified extension templates for forecasters and transformers (:pr:`2161`) :user:`fkiraly`
 
 Dependency changes
@@ -3918,8 +3918,8 @@ Highlights
 * :code:`conda-forge` metapackage for installing `sktime` with all extras :user:`freddyaboulton`
 * framework support for multivariate forecasting (:pr:`980` :pr:`1195` :pr:`1286` :pr:`1301` :pr:`1306` :pr:`1311` :pr:`1401` :pr:`1410`) :user:`aiwalter` :user:`fkiraly` :user:`thayeylolu`
 * consolidated lookup of estimators and tags using :code:`registry.all_estimators` and :code:`registry.all_tags` (:pr:`1196`) :user:`fkiraly`
-* [DOC] major overhaul of :code:`sktime`'s `online documentation <https://www.sktime.org/en/latest/>`_
-* [DOC] `searchable, auto-updating estimators register <https://www.sktime.org/en/latest/estimator_overview.html>`_ in online documentation (:pr:`930` :pr:`1138`) :user:`afzal442` :user:`mloning`
+* [DOC] major overhaul of :code:`sktime`'s `online documentation <https://www.sktime-backup.readthedocs.io/en/latest/>`_
+* [DOC] `searchable, auto-updating estimators register <https://www.sktime-backup.readthedocs.io/en/latest/estimator_overview.html>`_ in online documentation (:pr:`930` :pr:`1138`) :user:`afzal442` :user:`mloning`
 * [MNT] working Binder in-browser notebook showcase (:pr:`1266`) :user:`corvusrabus`
 * [DOC] tutorial notebook for in-memory data format conventions, validation, and conversion (:pr:`1232`) :user:`fkiraly`
 * easy conversion functionality for estimator inputs, series and panel data (:pr:`1061` :pr:`1187` :pr:`1201` :pr:`1225`) :user:`fkiraly`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -364,7 +364,7 @@ def _make_estimator_overview(app):
         clean_path = ".".join(list(filter(_does_not_start_with_underscore, path_parts)))
         # adds html link reference
         modname = str(
-            '<a href="https://www.sktime.org/en/latest/api_reference'
+            '<a href="https://www.sktime-backup.readthedocs.io/en/latest/api_reference'
             + "/auto_generated/"
             + clean_path
             + '.html">'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -364,7 +364,7 @@ def _make_estimator_overview(app):
         clean_path = ".".join(list(filter(_does_not_start_with_underscore, path_parts)))
         # adds html link reference
         modname = str(
-            '<a href="https://www.sktime-backup.readthedocs.io/en/latest/api_reference'
+            '<a href="https://sktime-backup.readthedocs.io/en/latest/api_reference'
             + "/auto_generated/"
             + clean_path
             + '.html">'

--- a/docs/source/contributing/reporting_bugs.rst
+++ b/docs/source/contributing/reporting_bugs.rst
@@ -26,4 +26,4 @@ rules before submitting:
 .. note::
 
    To find out more about how to take part in sktime’s community, check out our `governance
-   guidelines <https://www.sktime-backup.readthedocs.io/en/latest/governance.html>`__.
+   guidelines <https://sktime-backup.readthedocs.io/en/latest/governance.html>`__.

--- a/docs/source/contributing/reporting_bugs.rst
+++ b/docs/source/contributing/reporting_bugs.rst
@@ -26,4 +26,4 @@ rules before submitting:
 .. note::
 
    To find out more about how to take part in sktime’s community, check out our `governance
-   guidelines <https://www.sktime.org/en/latest/governance.html>`__.
+   guidelines <https://www.sktime-backup.readthedocs.io/en/latest/governance.html>`__.

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -18,7 +18,7 @@ New developers should:
 * install a development version of ``sktime``, see :ref:`installation`
 * set up CI tests locally and ensure they know how to check them remotely, see :ref:`continuous_integration`
 * get familiar with the git workflow (:ref:`git_workflow`) and coding standards (:ref:`coding_standards`)
-* feel free, at any point in time, to post questions on Discord, or ask core developers for help (see here for a `list of core developers <https://www.sktime.org/en/stable/about/team.html>`_)
+* feel free, at any point in time, to post questions on Discord, or ask core developers for help (see here for a `list of core developers <https://www.sktime-backup.readthedocs.io/en/stable/about/team.html>`_)
 
 * feel free to join the collaborative coding sessions for pair programming or getting help on developer set-up
 

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -18,7 +18,7 @@ New developers should:
 * install a development version of ``sktime``, see :ref:`installation`
 * set up CI tests locally and ensure they know how to check them remotely, see :ref:`continuous_integration`
 * get familiar with the git workflow (:ref:`git_workflow`) and coding standards (:ref:`coding_standards`)
-* feel free, at any point in time, to post questions on Discord, or ask core developers for help (see here for a `list of core developers <https://www.sktime-backup.readthedocs.io/en/stable/about/team.html>`_)
+* feel free, at any point in time, to post questions on Discord, or ask core developers for help (see here for a `list of core developers <https://sktime-backup.readthedocs.io/en/stable/about/team.html>`_)
 
 * feel free to join the collaborative coding sessions for pair programming or getting help on developer set-up
 

--- a/docs/source/developer_guide/add_estimators.rst
+++ b/docs/source/developer_guide/add_estimators.rst
@@ -16,7 +16,7 @@ The high-level steps to implement ``sktime`` compatible estimators are as follow
 1.  identify the type of the estimator: forecaster, classifier, etc
 2.  copy the extension template for that kind of estimator to its intended location
 3.  complete the extension template
-4.  run the ``sktime`` test suite and/or the ``check_estimator`` utility (see `here <https://www.sktime.org/en/latest/developer_guide/add_estimators.html#using-the-check-estimator-utility>`__)
+4.  run the ``sktime`` test suite and/or the ``check_estimator`` utility (see `here <https://www.sktime-backup.readthedocs.io/en/latest/developer_guide/add_estimators.html#using-the-check-estimator-utility>`__)
 5.  if the test suite highlights bugs or issues, fix them and go to 4
 
 For more guidance on how to implement your own estimator, see this `tutorial at pydata <https://github.com/sktime/sktime-workshop-pydata-london-2022>`__ on testing interface conformance.

--- a/docs/source/developer_guide/add_estimators.rst
+++ b/docs/source/developer_guide/add_estimators.rst
@@ -16,7 +16,7 @@ The high-level steps to implement ``sktime`` compatible estimators are as follow
 1.  identify the type of the estimator: forecaster, classifier, etc
 2.  copy the extension template for that kind of estimator to its intended location
 3.  complete the extension template
-4.  run the ``sktime`` test suite and/or the ``check_estimator`` utility (see `here <https://www.sktime-backup.readthedocs.io/en/latest/developer_guide/add_estimators.html#using-the-check-estimator-utility>`__)
+4.  run the ``sktime`` test suite and/or the ``check_estimator`` utility (see `here <https://sktime-backup.readthedocs.io/en/latest/developer_guide/add_estimators.html#using-the-check-estimator-utility>`__)
 5.  if the test suite highlights bugs or issues, fix them and go to 4
 
 For more guidance on how to implement your own estimator, see this `tutorial at pydata <https://github.com/sktime/sktime-workshop-pydata-london-2022>`__ on testing interface conformance.

--- a/docs/source/developer_guide/continuous_integration.rst
+++ b/docs/source/developer_guide/continuous_integration.rst
@@ -8,7 +8,7 @@ if new pull requests do not break anything and meet code quality
 standards such as a common `coding style <#Coding-style>`__.
 Before setting up Continuous Integration, be sure that you have set
 up your developer environment, and installed a
-`developement version <https://www.sktime-backup.readthedocs.io/en/stable/installation.html>`__
+`developement version <https://sktime-backup.readthedocs.io/en/stable/installation.html>`__
  of sktime.
 
 .. contents::
@@ -53,7 +53,7 @@ development version of sktime and all extra dependencies.
 .. note::
 
    For trouble shooting on different operating systems, please see our detailed
-   `installation instructions <https://www.sktime-backup.readthedocs.io/en/latest/installation.html>`__.
+   `installation instructions <https://sktime-backup.readthedocs.io/en/latest/installation.html>`__.
 
 2. To run all unit tests, run:
 

--- a/docs/source/developer_guide/continuous_integration.rst
+++ b/docs/source/developer_guide/continuous_integration.rst
@@ -8,7 +8,7 @@ if new pull requests do not break anything and meet code quality
 standards such as a common `coding style <#Coding-style>`__.
 Before setting up Continuous Integration, be sure that you have set
 up your developer environment, and installed a
-`developement version <https://www.sktime.org/en/stable/installation.html>`__
+`developement version <https://www.sktime-backup.readthedocs.io/en/stable/installation.html>`__
  of sktime.
 
 .. contents::
@@ -53,7 +53,7 @@ development version of sktime and all extra dependencies.
 .. note::
 
    For trouble shooting on different operating systems, please see our detailed
-   `installation instructions <https://www.sktime.org/en/latest/installation.html>`__.
+   `installation instructions <https://www.sktime-backup.readthedocs.io/en/latest/installation.html>`__.
 
 2. To run all unit tests, run:
 

--- a/docs/source/developer_guide/documentation.rst
+++ b/docs/source/developer_guide/documentation.rst
@@ -171,9 +171,9 @@ MeanAbsoluteScaledError_
 
 .. _numpydoc: https://numpydoc.readthedocs.io/en/latest/index.html
 .. _pydocstyle: http://www.pydocstyle.org/en/stable/
-.. _BOSSEnsemble: https://www.sktime.org/en/latest/api_reference/auto_generated/sktime.classification.dictionary_based.BOSSEnsemble.html#sktime.classification.dictionary_based.BOSSEnsemble
-.. _ContractableBOSS: https://www.sktime.org/en/latest/api_reference/auto_generated/sktime.classification.dictionary_based.ContractableBOSS.html#sktime.classification.dictionary_based.ContractableBOSS
-.. _MeanAbsoluteScaledError: https://www.sktime.org/en/latest/api_reference/auto_generated/sktime.performance_metrics.forecasting.MeanAbsoluteScaledError.html
+.. _BOSSEnsemble: https://www.sktime-backup.readthedocs.io/en/latest/api_reference/auto_generated/sktime.classification.dictionary_based.BOSSEnsemble.html#sktime.classification.dictionary_based.BOSSEnsemble
+.. _ContractableBOSS: https://www.sktime-backup.readthedocs.io/en/latest/api_reference/auto_generated/sktime.classification.dictionary_based.ContractableBOSS.html#sktime.classification.dictionary_based.ContractableBOSS
+.. _MeanAbsoluteScaledError: https://www.sktime-backup.readthedocs.io/en/latest/api_reference/auto_generated/sktime.performance_metrics.forecasting.MeanAbsoluteScaledError.html
 
 .. _sphinx: https://www.sphinx-doc.org/
 .. _readthedocs: https://readthedocs.org/projects/sktime/
@@ -182,7 +182,7 @@ Documentation Build
 -------------------
 
 We use `sphinx`_ to build our documentation and `readthedocs`_ to host it.
-You can find our latest documentation `here <https://www.sktime.org/en/latest/>`_.
+You can find our latest documentation `here <https://www.sktime-backup.readthedocs.io/en/latest/>`_.
 
 The source files can be found
 in `docs/source/ <https://github.com/sktime/sktime/tree/main/docs/source>`_.

--- a/docs/source/developer_guide/documentation.rst
+++ b/docs/source/developer_guide/documentation.rst
@@ -171,9 +171,9 @@ MeanAbsoluteScaledError_
 
 .. _numpydoc: https://numpydoc.readthedocs.io/en/latest/index.html
 .. _pydocstyle: http://www.pydocstyle.org/en/stable/
-.. _BOSSEnsemble: https://www.sktime-backup.readthedocs.io/en/latest/api_reference/auto_generated/sktime.classification.dictionary_based.BOSSEnsemble.html#sktime.classification.dictionary_based.BOSSEnsemble
-.. _ContractableBOSS: https://www.sktime-backup.readthedocs.io/en/latest/api_reference/auto_generated/sktime.classification.dictionary_based.ContractableBOSS.html#sktime.classification.dictionary_based.ContractableBOSS
-.. _MeanAbsoluteScaledError: https://www.sktime-backup.readthedocs.io/en/latest/api_reference/auto_generated/sktime.performance_metrics.forecasting.MeanAbsoluteScaledError.html
+.. _BOSSEnsemble: https://sktime-backup.readthedocs.io/en/latest/api_reference/auto_generated/sktime.classification.dictionary_based.BOSSEnsemble.html#sktime.classification.dictionary_based.BOSSEnsemble
+.. _ContractableBOSS: https://sktime-backup.readthedocs.io/en/latest/api_reference/auto_generated/sktime.classification.dictionary_based.ContractableBOSS.html#sktime.classification.dictionary_based.ContractableBOSS
+.. _MeanAbsoluteScaledError: https://sktime-backup.readthedocs.io/en/latest/api_reference/auto_generated/sktime.performance_metrics.forecasting.MeanAbsoluteScaledError.html
 
 .. _sphinx: https://www.sphinx-doc.org/
 .. _readthedocs: https://readthedocs.org/projects/sktime/
@@ -182,7 +182,7 @@ Documentation Build
 -------------------
 
 We use `sphinx`_ to build our documentation and `readthedocs`_ to host it.
-You can find our latest documentation `here <https://www.sktime-backup.readthedocs.io/en/latest/>`_.
+You can find our latest documentation `here <https://sktime-backup.readthedocs.io/en/latest/>`_.
 
 The source files can be found
 in `docs/source/ <https://github.com/sktime/sktime/tree/main/docs/source>`_.

--- a/docs/source/events/gsoc_2022.md
+++ b/docs/source/events/gsoc_2022.md
@@ -22,7 +22,7 @@ The deadline to complete all of these is **April 19, 18:00 (UTC)**.
 
 1. Entrance task. Make a pull request (PR) to sktime to show you are able to contribute meaningfully.
     - Your PR does not need to be merged at the time of application.
-    - To find out how to contribute to sktime, look at our [new contributor starter issue](https://github.com/sktime/sktime/issues/1147) and [developer guide](https://www.sktime.org/en/latest/developer_guide.html).
+    - To find out how to contribute to sktime, look at our [new contributor starter issue](https://github.com/sktime/sktime/issues/1147) and [developer guide](https://www.sktime-backup.readthedocs.io/en/latest/developer_guide.html).
     - Alternatively, if you are already experienced in using git and GitHub in a collaborative environment, you can skip this step. In this case, in the form in step 2 below, please provide a link to publicly visible evidence for your experience.
 2. Fill in and submit the sktime application form at (https://forms.gle/MVcf9Q45Ui1ByMxM8).
     - You should have completed your entrance task (point 1 above) before submitting the form, since you need to provide a link to it in the form.
@@ -89,7 +89,7 @@ Our expectations for GSoC participants before GSoC starts:
 
 Our expectations for GSoC participants during GSoC:
 
-- You follow our [Code of Conduct](https://www.sktime.org/en/stable/get_involved/code_of_conduct.html).
+- You follow our [Code of Conduct](https://www.sktime-backup.readthedocs.io/en/stable/get_involved/code_of_conduct.html).
 - You work full time on your GSoC project.
 - You maintain daily contact with your mentor(s).
 - You engage with the sktime community and other GSoC participants.
@@ -101,7 +101,7 @@ Our expectations for GSoC participants during GSoC:
 
 The expectations on you are high, but you can expect just as much from us. You should expect:
 
-- We follow the [Code of Conduct](https://www.sktime.org/en/stable/get_involved/code_of_conduct.html).
+- We follow the [Code of Conduct](https://www.sktime-backup.readthedocs.io/en/stable/get_involved/code_of_conduct.html).
 - 1-1 mentoring with an experienced contributor, with weekly meetings.
 - Regular feedback and help on your efforts, including blog posts, with quick responses from us (usually respond within 2 working days).
 - 'Agile' ways of working, used throughout the tech industry, e.g. daily standups.

--- a/docs/source/events/gsoc_2022.md
+++ b/docs/source/events/gsoc_2022.md
@@ -22,7 +22,7 @@ The deadline to complete all of these is **April 19, 18:00 (UTC)**.
 
 1. Entrance task. Make a pull request (PR) to sktime to show you are able to contribute meaningfully.
     - Your PR does not need to be merged at the time of application.
-    - To find out how to contribute to sktime, look at our [new contributor starter issue](https://github.com/sktime/sktime/issues/1147) and [developer guide](https://www.sktime-backup.readthedocs.io/en/latest/developer_guide.html).
+    - To find out how to contribute to sktime, look at our [new contributor starter issue](https://github.com/sktime/sktime/issues/1147) and [developer guide](https://sktime-backup.readthedocs.io/en/latest/developer_guide.html).
     - Alternatively, if you are already experienced in using git and GitHub in a collaborative environment, you can skip this step. In this case, in the form in step 2 below, please provide a link to publicly visible evidence for your experience.
 2. Fill in and submit the sktime application form at (https://forms.gle/MVcf9Q45Ui1ByMxM8).
     - You should have completed your entrance task (point 1 above) before submitting the form, since you need to provide a link to it in the form.
@@ -89,7 +89,7 @@ Our expectations for GSoC participants before GSoC starts:
 
 Our expectations for GSoC participants during GSoC:
 
-- You follow our [Code of Conduct](https://www.sktime-backup.readthedocs.io/en/stable/get_involved/code_of_conduct.html).
+- You follow our [Code of Conduct](https://sktime-backup.readthedocs.io/en/stable/get_involved/code_of_conduct.html).
 - You work full time on your GSoC project.
 - You maintain daily contact with your mentor(s).
 - You engage with the sktime community and other GSoC participants.
@@ -101,7 +101,7 @@ Our expectations for GSoC participants during GSoC:
 
 The expectations on you are high, but you can expect just as much from us. You should expect:
 
-- We follow the [Code of Conduct](https://www.sktime-backup.readthedocs.io/en/stable/get_involved/code_of_conduct.html).
+- We follow the [Code of Conduct](https://sktime-backup.readthedocs.io/en/stable/get_involved/code_of_conduct.html).
 - 1-1 mentoring with an experienced contributor, with weekly meetings.
 - Regular feedback and help on your efforts, including blog posts, with quick responses from us (usually respond within 2 working days).
 - 'Agile' ways of working, used throughout the tech industry, e.g. daily standups.

--- a/docs/source/get_involved/contributing.rst
+++ b/docs/source/get_involved/contributing.rst
@@ -25,11 +25,11 @@ and people who are looking to learn and develop their skills.
 Recommended steps for first time contributors, or to get started with regular contributions:
 
 1. Say hello (in the lobby on `Discord`_)!
-2. Get set up for development, see `instructions in the developer guide <https://www.sktime-backup.readthedocs.io/en/stable/developer_guide.html>`_.
+2. Get set up for development, see `instructions in the developer guide <https://sktime-backup.readthedocs.io/en/stable/developer_guide.html>`_.
 3. Pick a good first issue to work on, see a collection `in this summary issue <https://github.com/sktime/sktime/issues/1147>`_ , or from `this list <https://github.com/sktime/sktime/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22>`_
    suggestion: pick something small with simple content to learn the “process”
 4. Feel free to attend the regular community collab sessions or one of the topic specific stand-ups and tech sessions (see schedule on `Discord`_)
-5. Once your first PR is merged and you’ve seen how things work, you could consider contributing more regularly: optionally, continue attending the Friday community collaboration sessions and stand-ups; or, optionally, `apply for mentoring <https://www.sktime-backup.readthedocs.io/en/stable/get_involved/mentoring.html#mentoring>`_
+5. Once your first PR is merged and you’ve seen how things work, you could consider contributing more regularly: optionally, continue attending the Friday community collaboration sessions and stand-ups; or, optionally, `apply for mentoring <https://sktime-backup.readthedocs.io/en/stable/get_involved/mentoring.html#mentoring>`_
 
 .. _Discord: https://discord.com/invite/gqSab2K
 

--- a/docs/source/get_involved/contributing.rst
+++ b/docs/source/get_involved/contributing.rst
@@ -25,11 +25,11 @@ and people who are looking to learn and develop their skills.
 Recommended steps for first time contributors, or to get started with regular contributions:
 
 1. Say hello (in the lobby on `Discord`_)!
-2. Get set up for development, see `instructions in the developer guide <https://www.sktime.org/en/stable/developer_guide.html>`_.
+2. Get set up for development, see `instructions in the developer guide <https://www.sktime-backup.readthedocs.io/en/stable/developer_guide.html>`_.
 3. Pick a good first issue to work on, see a collection `in this summary issue <https://github.com/sktime/sktime/issues/1147>`_ , or from `this list <https://github.com/sktime/sktime/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22>`_
    suggestion: pick something small with simple content to learn the “process”
 4. Feel free to attend the regular community collab sessions or one of the topic specific stand-ups and tech sessions (see schedule on `Discord`_)
-5. Once your first PR is merged and you’ve seen how things work, you could consider contributing more regularly: optionally, continue attending the Friday community collaboration sessions and stand-ups; or, optionally, `apply for mentoring <https://www.sktime.org/en/stable/get_involved/mentoring.html#mentoring>`_
+5. Once your first PR is merged and you’ve seen how things work, you could consider contributing more regularly: optionally, continue attending the Friday community collaboration sessions and stand-ups; or, optionally, `apply for mentoring <https://www.sktime-backup.readthedocs.io/en/stable/get_involved/mentoring.html#mentoring>`_
 
 .. _Discord: https://discord.com/invite/gqSab2K
 

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -191,7 +191,7 @@ to the continued development of the project through ongoing engagement
 with the community.
 
 Current core developers are listed in the `core-developers
-team <https://www.sktime.org/en/stable/about/team.html>`__
+team <https://www.sktime-backup.readthedocs.io/en/stable/about/team.html>`__
 within the sktime organisation on GitHub.
 
 .. _rights-and-responsibilities-1:
@@ -263,7 +263,7 @@ CoC committee members
 
 CoC members are contributors with special rights and responsibilities.
 The current members of the CoC committee are listed in the
-`CoC <https://www.sktime.org/en/stable/about/team.html>`__.
+`CoC <https://www.sktime-backup.readthedocs.io/en/stable/about/team.html>`__.
 
 .. _rights-and-responsibilities-2:
 
@@ -311,7 +311,7 @@ responsibilities to avoid deadlocks and ensure a smooth progress of the
 project.
 
 Current CC members are listed in the `community-council
-team <https://www.sktime.org/en/stable/about/team.html>`__
+team <https://www.sktime-backup.readthedocs.io/en/stable/about/team.html>`__
 within the sktime organisation on GitHub.
 
 .. _rights-and-responsibilities-3:
@@ -391,7 +391,7 @@ CC observers
 
 CC (community council) observers are core developers with additional rights and
 responsibilities. Current CC observers are listed in the `community-council
-observers <https://www.sktime.org/en/stable/about/team.html>`__ .
+observers <https://www.sktime-backup.readthedocs.io/en/stable/about/team.html>`__ .
 
 .. _rights-and-responsibilities-4:
 
@@ -691,7 +691,7 @@ References
 Our governance model is inspired by various existing governance
 structures. In particular, we’d like to acknowledge:
 
-* scikit-learn’s `governance model <https://www.sktime.org/en/latest/governance.html>`__
+* scikit-learn’s `governance model <https://www.sktime-backup.readthedocs.io/en/latest/governance.html>`__
 * `The Turing Way <https://github.com/alan-turing-institute/the-turing-way>`__ project
 * `The Art of Community <https://www.jonobacon.com/books/artofcommunity/>`__ by Jono Bacon
 * The `astropy <https://www.astropy.org>`__ project

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -191,7 +191,7 @@ to the continued development of the project through ongoing engagement
 with the community.
 
 Current core developers are listed in the `core-developers
-team <https://www.sktime-backup.readthedocs.io/en/stable/about/team.html>`__
+team <https://sktime-backup.readthedocs.io/en/stable/about/team.html>`__
 within the sktime organisation on GitHub.
 
 .. _rights-and-responsibilities-1:
@@ -263,7 +263,7 @@ CoC committee members
 
 CoC members are contributors with special rights and responsibilities.
 The current members of the CoC committee are listed in the
-`CoC <https://www.sktime-backup.readthedocs.io/en/stable/about/team.html>`__.
+`CoC <https://sktime-backup.readthedocs.io/en/stable/about/team.html>`__.
 
 .. _rights-and-responsibilities-2:
 
@@ -311,7 +311,7 @@ responsibilities to avoid deadlocks and ensure a smooth progress of the
 project.
 
 Current CC members are listed in the `community-council
-team <https://www.sktime-backup.readthedocs.io/en/stable/about/team.html>`__
+team <https://sktime-backup.readthedocs.io/en/stable/about/team.html>`__
 within the sktime organisation on GitHub.
 
 .. _rights-and-responsibilities-3:
@@ -391,7 +391,7 @@ CC observers
 
 CC (community council) observers are core developers with additional rights and
 responsibilities. Current CC observers are listed in the `community-council
-observers <https://www.sktime-backup.readthedocs.io/en/stable/about/team.html>`__ .
+observers <https://sktime-backup.readthedocs.io/en/stable/about/team.html>`__ .
 
 .. _rights-and-responsibilities-4:
 
@@ -691,7 +691,7 @@ References
 Our governance model is inspired by various existing governance
 structures. In particular, we’d like to acknowledge:
 
-* scikit-learn’s `governance model <https://www.sktime-backup.readthedocs.io/en/latest/governance.html>`__
+* scikit-learn’s `governance model <https://sktime-backup.readthedocs.io/en/latest/governance.html>`__
 * `The Turing Way <https://github.com/alan-turing-institute/the-turing-way>`__ project
 * `The Art of Community <https://www.jonobacon.com/books/artofcommunity/>`__ by Jono Bacon
 * The `astropy <https://www.astropy.org>`__ project

--- a/examples/01_forecasting.ipynb
+++ b/examples/01_forecasting.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "To run this notebook as intended, ensure that `sktime` with basic dependency requirements is installed in your python environment.\n",
     "\n",
-    "To run this notebook with a local development version of sktime, an editable developer installation is recommended, see the [sktime developer install guide](https://www.sktime.org/en/stable/installation.html#development-versions) for instructions."
+    "To run this notebook with a local development version of sktime, an editable developer installation is recommended, see the [sktime developer install guide](https://www.sktime-backup.readthedocs.io/en/stable/installation.html#development-versions) for instructions."
    ]
   },
   {
@@ -6765,7 +6765,7 @@
     "\n",
     "To get started:\n",
     "\n",
-    "* Follow the [\"implementing estimator\" developer guide](https://www.sktime.org/en/stable/developer_guide/add_estimators.html)\n",
+    "* Follow the [\"implementing estimator\" developer guide](https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html)\n",
     "* Use the [simple forecasting extension template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting_simple.py) for forecasters without stream, probabilistic, or hierarchical functionality\n",
     "* Use the [advanced forecasting extension template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting.py) for forecasters with stream, probabilistic or hierarchical functionality\n",
     "* For probabilistic and hierarchical forecasters, it is recommended to familiarize yourself with the interfaces via the tutorials\n",

--- a/examples/01_forecasting.ipynb
+++ b/examples/01_forecasting.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "To run this notebook as intended, ensure that `sktime` with basic dependency requirements is installed in your python environment.\n",
     "\n",
-    "To run this notebook with a local development version of sktime, an editable developer installation is recommended, see the [sktime developer install guide](https://www.sktime-backup.readthedocs.io/en/stable/installation.html#development-versions) for instructions."
+    "To run this notebook with a local development version of sktime, an editable developer installation is recommended, see the [sktime developer install guide](https://sktime-backup.readthedocs.io/en/stable/installation.html#development-versions) for instructions."
    ]
   },
   {
@@ -6765,7 +6765,7 @@
     "\n",
     "To get started:\n",
     "\n",
-    "* Follow the [\"implementing estimator\" developer guide](https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html)\n",
+    "* Follow the [\"implementing estimator\" developer guide](https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html)\n",
     "* Use the [simple forecasting extension template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting_simple.py) for forecasters without stream, probabilistic, or hierarchical functionality\n",
     "* Use the [advanced forecasting extension template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting.py) for forecasters with stream, probabilistic or hierarchical functionality\n",
     "* For probabilistic and hierarchical forecasters, it is recommended to familiarize yourself with the interfaces via the tutorials\n",

--- a/examples/01b_forecasting_proba.ipynb
+++ b/examples/01b_forecasting_proba.ipynb
@@ -1606,7 +1606,7 @@
     "\n",
     "Getting started:\n",
     "\n",
-    "* follow the [\"implementing estimator\" developer guide](https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html)\n",
+    "* follow the [\"implementing estimator\" developer guide](https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html)\n",
     "* use the advanced [forecasting extension template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting.py)\n",
     "\n",
     "Extension template = python \"fill-in\" template with to-do blocks that allow you to implement your own, sktime-compatible forecasting algorithm.\n",

--- a/examples/01b_forecasting_proba.ipynb
+++ b/examples/01b_forecasting_proba.ipynb
@@ -1606,7 +1606,7 @@
     "\n",
     "Getting started:\n",
     "\n",
-    "* follow the [\"implementing estimator\" developer guide](https://www.sktime.org/en/stable/developer_guide/add_estimators.html)\n",
+    "* follow the [\"implementing estimator\" developer guide](https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html)\n",
     "* use the advanced [forecasting extension template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting.py)\n",
     "\n",
     "Extension template = python \"fill-in\" template with to-do blocks that allow you to implement your own, sktime-compatible forecasting algorithm.\n",

--- a/examples/01c_forecasting_hierarchical_global.ipynb
+++ b/examples/01c_forecasting_hierarchical_global.ipynb
@@ -4395,7 +4395,7 @@
     "\n",
     "Getting started:\n",
     "\n",
-    "* follow the [\"implementing estimator\" developer guide](https://www.sktime.org/en/stable/developer_guide/add_estimators.html)\n",
+    "* follow the [\"implementing estimator\" developer guide](https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html)\n",
     "* use the advanced [forecasting extension template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting.py)\n",
     "\n",
     "Extension template = python \"fill-in\" template with to-do blocks that allow you to implement your own, sktime-compatible forecasting algorithm.\n",

--- a/examples/01c_forecasting_hierarchical_global.ipynb
+++ b/examples/01c_forecasting_hierarchical_global.ipynb
@@ -4395,7 +4395,7 @@
     "\n",
     "Getting started:\n",
     "\n",
-    "* follow the [\"implementing estimator\" developer guide](https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html)\n",
+    "* follow the [\"implementing estimator\" developer guide](https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html)\n",
     "* use the advanced [forecasting extension template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting.py)\n",
     "\n",
     "Extension template = python \"fill-in\" template with to-do blocks that allow you to implement your own, sktime-compatible forecasting algorithm.\n",

--- a/examples/03_transformers.ipynb
+++ b/examples/03_transformers.ipynb
@@ -1184,7 +1184,7 @@
     "\n",
     "To get started:\n",
     "\n",
-    "* Follow the [\"implementing estimator\" developer guide](https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html)\n",
+    "* Follow the [\"implementing estimator\" developer guide](https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html)\n",
     "* Use the [simple forecasting extension template](https://github.com/sktime/sktime/blob/main/extension_templates/transformer_simple.py) for transformers without stream, probabilistic, or hierarchical functionality\n",
     "* Use the [advanced forecasting extension template](https://github.com/sktime/sktime/blob/main/extension_templates/transformer.py) for transformers with stream, probabilistic or hierarchical functionality\n",
     "* For pairwise transformers, use the [time series pairwise transformer extension template](https://github.com/sktime/sktime/blob/main/extension_templates/dist_kern_panel.py) or the [scalar/tabular pairwise transformer extension template](https://github.com/sktime/sktime/blob/main/extension_templates/dist_kern_tab.py)\n",

--- a/examples/03_transformers.ipynb
+++ b/examples/03_transformers.ipynb
@@ -1184,7 +1184,7 @@
     "\n",
     "To get started:\n",
     "\n",
-    "* Follow the [\"implementing estimator\" developer guide](https://www.sktime.org/en/stable/developer_guide/add_estimators.html)\n",
+    "* Follow the [\"implementing estimator\" developer guide](https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html)\n",
     "* Use the [simple forecasting extension template](https://github.com/sktime/sktime/blob/main/extension_templates/transformer_simple.py) for transformers without stream, probabilistic, or hierarchical functionality\n",
     "* Use the [advanced forecasting extension template](https://github.com/sktime/sktime/blob/main/extension_templates/transformer.py) for transformers with stream, probabilistic or hierarchical functionality\n",
     "* For pairwise transformers, use the [time series pairwise transformer extension template](https://github.com/sktime/sktime/blob/main/extension_templates/dist_kern_panel.py) or the [scalar/tabular pairwise transformer extension template](https://github.com/sktime/sktime/blob/main/extension_templates/dist_kern_tab.py)\n",

--- a/extension_templates/annotation.py
+++ b/extension_templates/annotation.py
@@ -16,7 +16,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, X, Y=None)

--- a/extension_templates/annotation.py
+++ b/extension_templates/annotation.py
@@ -16,7 +16,8 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details:
+  https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, X, Y=None)

--- a/extension_templates/annotation.py
+++ b/extension_templates/annotation.py
@@ -16,7 +16,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime.org/en/stable/developer_guide/add_estimators.html
+- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, X, Y=None)

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -18,7 +18,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime.org/en/stable/developer_guide/add_estimators.html
+- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting                 - _fit(self, X, y)

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -18,7 +18,8 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details:
+  https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting                 - _fit(self, X, y)

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -18,7 +18,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting                 - _fit(self, X, y)

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -18,7 +18,8 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by testing clustering/tests
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details:
+  https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting            - _fit(self, X)

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -18,7 +18,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by testing clustering/tests
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting            - _fit(self, X)

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -18,7 +18,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by testing clustering/tests
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime.org/en/stable/developer_guide/add_estimators.html
+- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting            - _fit(self, X)

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -13,7 +13,7 @@ How to use this:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime.org/en/stable/developer_guide/add_estimators.html
+- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     transforming    - _transform(self, X, X2=None)

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -13,7 +13,8 @@ How to use this:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details:
+  https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     transforming    - _transform(self, X, X2=None)

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -13,7 +13,7 @@ How to use this:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     transforming    - _transform(self, X, X2=None)

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -13,7 +13,7 @@ How to use this:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime.org/en/stable/developer_guide/add_estimators.html
+- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     transforming    - _transform(self, X, X2=None)

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -13,7 +13,8 @@ How to use this:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details:
+  https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     transforming    - _transform(self, X, X2=None)

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -13,7 +13,7 @@ How to use this:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     transforming    - _transform(self, X, X2=None)

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -16,7 +16,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime.org/en/stable/developer_guide/add_estimators.html
+- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting                 - _fit(self, X, y)

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -16,7 +16,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting                 - _fit(self, X, y)

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -16,7 +16,8 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details:
+  https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting                 - _fit(self, X, y)

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -19,7 +19,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, y, X=None, fh=None)

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -19,7 +19,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime.org/en/stable/developer_guide/add_estimators.html
+- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, y, X=None, fh=None)

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -19,7 +19,8 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details:
+  https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, y, X=None, fh=None)

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -24,7 +24,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime.org/en/stable/developer_guide/add_estimators.html
+- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, y, X=None, fh=None)

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -24,7 +24,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, y, X=None, fh=None)

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -24,7 +24,8 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details:
+  https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, y, X=None, fh=None)

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -19,7 +19,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, X, y=None)

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -19,7 +19,8 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details:
+  https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, X, y=None)

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -19,7 +19,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime.org/en/stable/developer_guide/add_estimators.html
+- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, X, y=None)

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -24,7 +24,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime.org/en/stable/developer_guide/add_estimators.html
+- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, X, y=None)

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -24,7 +24,8 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details:
+  https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, X, y=None)

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -24,7 +24,7 @@ How to use this implementation template to implement a new estimator:
 - change docstrings for functions and the file
 - ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
 - once complete: use as a local library, or contribute to sktime via PR
-- more details: https://www.sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
+- more details: https://sktime-backup.readthedocs.io/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
     fitting         - _fit(self, X, y=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,12 +125,12 @@ dl = [
 ]
 
 [project.urls]
-Homepage = "https://www.sktime-backup.readthedocs.io"
+Homepage = "https://sktime-backup.readthedocs.io"
 Repository = "https://github.com/sktime/sktime"
-Documentation = "https://www.sktime-backup.readthedocs.io"
+Documentation = "https://sktime-backup.readthedocs.io"
 Download = "https://pypi.org/project/sktime/#files"
-"API Reference" = "https://www.sktime-backup.readthedocs.io/en/stable/api_reference.html"
-"Release Notes" = "https://www.sktime-backup.readthedocs.io/en/stable/changelog.html"
+"API Reference" = "https://sktime-backup.readthedocs.io/en/stable/api_reference.html"
+"Release Notes" = "https://sktime-backup.readthedocs.io/en/stable/changelog.html"
 
 [project.license]
 file = "LICENSE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,12 +125,12 @@ dl = [
 ]
 
 [project.urls]
-Homepage = "https://www.sktime.org"
+Homepage = "https://www.sktime-backup.readthedocs.io"
 Repository = "https://github.com/sktime/sktime"
-Documentation = "https://www.sktime.org"
+Documentation = "https://www.sktime-backup.readthedocs.io"
 Download = "https://pypi.org/project/sktime/#files"
-"API Reference" = "https://www.sktime.org/en/stable/api_reference.html"
-"Release Notes" = "https://www.sktime.org/en/stable/changelog.html"
+"API Reference" = "https://www.sktime-backup.readthedocs.io/en/stable/api_reference.html"
+"Release Notes" = "https://www.sktime-backup.readthedocs.io/en/stable/changelog.html"
 
 [project.license]
 file = "LICENSE"


### PR DESCRIPTION
This temporarily replaces `sktime.org` links in the repository by `readthedocs` links, see issue https://github.com/sktime/sktime/issues/4237

Also lints all affected files.