### PR TITLE
[ENH] Forecaster that forecasts prescribed known or expert forecast values

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -78,8 +78,8 @@ Use ``make_reduction`` for easy specification.
     DirRecTabularRegressionForecaster
     DirRecTimeSeriesRegressionForecaster
 
-Naive forecaster
-----------------
+Naive forecasters
+-----------------
 
 .. currentmodule:: sktime.forecasting.naive
 
@@ -88,6 +88,14 @@ Naive forecaster
     :template: class.rst
 
     NaiveForecaster
+
+.. currentmodule:: sktime.forecasting.dummy
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ForecastKnownValues
 
 Prediction intervals
 --------------------

--- a/sktime/forecasting/dummy.py
+++ b/sktime/forecasting/dummy.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Dummy forecasters."""
+
+__author__ = ["fkiraly"]
+
+
+from sktime.forecasting.base import BaseForecaster
+
+
+class ForecastKnownValues(BaseForecaster):
+    """Custom forecaster. todo: write docstring.
+
+    todo: describe your custom forecaster here
+
+    Parameters
+    ----------
+    y_known : pd.DataFrame
+        should contain known values that the forecaster will replay in predict
+    """
+
+    _tags = {
+        "y_inner_mtype": "pd.DataFrame",
+        "X_inner_mtype": "pd.DataFrame",
+        "scitype:y": "both",
+        "ignores-exogeneous-X": True,
+        "requires-fh-in-fit": False,
+    }
+
+    # todo: add any hyper-parameters and components to constructor
+    def __init__(self, y_known):
+
+        self.y_known = y_known
+
+        super(ForecastKnownValues, self).__init__()
+
+    def _fit(self, y, X=None, fh=None):
+        """Fit forecaster to training data.
+
+        private _fit containing the core logic, called from fit
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
+            Time series to which to fit the forecaster.
+            if self.get_tag("scitype:y")=="univariate":
+                guaranteed to have a single column/variable
+            if self.get_tag("scitype:y")=="multivariate":
+                guaranteed to have 2 or more columns
+            if self.get_tag("scitype:y")=="both": no restrictions apply
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            Required (non-optional) here if self.get_tag("requires-fh-in-fit")==True
+            Otherwise, if not passed in _fit, guaranteed to be passed in _predict
+        X : optional (default=None)
+            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            Exogeneous time series to fit to.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        # no fitting, we already know the forecast values
+        return self
+
+    def _predict(self, fh, X=None):
+        """Forecast time series at future horizon.
+
+        private _predict containing the core logic, called from predict
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            If not passed in _fit, guaranteed to be passed here
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
+
+        Returns
+        -------
+        y_pred : Point predictions
+        """
+        fh_abs = fh.to_absolute(self.cutoff).to_pandas()
+
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for forecasters.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+
+        # todo: set the testing parameters for the estimators
+        # Testing parameters can be dictionary or list of dictionaries.
+        # Testing parameter choice should cover internal cases well.
+        #   for "simple" extension, ignore the parameter_set argument.
+        #
+        # this method can, if required, use:
+        #   class properties (e.g., inherited); parent class test case
+        #   imported objects such as estimators from sktime or sklearn
+        # important: all such imports should be *inside get_test_params*, not at the top
+        #            since imports are used only at testing time
+        #
+        # A good parameter set should primarily satisfy two criteria,
+        #   1. Chosen set of parameters should have a low testing time,
+        #      ideally in the magnitude of few seconds for the entire test suite.
+        #       This is vital for the cases where default values result in
+        #       "big" models which not only increases test time but also
+        #       run into the risk of test workers crashing.
+        #   2. There should be a minimum two such parameter sets with different
+        #      sets of values to ensure a wide range of code coverage is provided.
+        #
+        # example 1: specify params as dictionary
+        # any number of params can be specified
+        # params = {"est": value0, "parama": value1, "paramb": value2}
+        #
+        # example 2: specify params as list of dictionary
+        # note: Only first dictionary will be used by create_test_instance
+        # params = [{"est": value1, "parama": value2},
+        #           {"est": value3, "parama": value4}]
+        #
+        # return params

--- a/sktime/forecasting/dummy.py
+++ b/sktime/forecasting/dummy.py
@@ -52,7 +52,7 @@ class ForecastKnownValues(BaseForecaster):
     ForecastKnownValues(...)
 
     The forecast "plays back" the known/prescribed values from y_known
-    >>> fcst.predict()
+    >>> y_pred = fcst.predict()
     """
 
     _tags = {

--- a/sktime/forecasting/dummy.py
+++ b/sktime/forecasting/dummy.py
@@ -49,6 +49,7 @@ class ForecastKnownValues(BaseForecaster):
     >>>
     >>> fcst = ForecastKnownValues(y_known)
     >>> fcst.fit(y_train, fh=[1, 2, 3])
+    ForecastKnownValues(...)
 
     The forecast "plays back" the known/prescribed values from y_known
     >>> fcst.predict()

--- a/sktime/forecasting/dummy.py
+++ b/sktime/forecasting/dummy.py
@@ -9,9 +9,17 @@ from sktime.forecasting.base import BaseForecaster
 
 
 class ForecastKnownValues(BaseForecaster):
-    """Custom forecaster. todo: write docstring.
+    """Forecaster that plays back known or prescribed values as forecasts.
 
-    todo: describe your custom forecaster here
+    Takes a data set of "known future values" to produces these in the sktime interface.
+
+    Common use cases for this forecaster:
+
+    * as a dummy or naive forecaster with a known baseline expectation
+    * as a forecaster with (non-naive) expert forecasts, "known" values as per expert
+    * as a counterfactual in benchmarking experiments, "what if we knew the truth"
+    * to pass forecast data values in a composite used for postprocessing,
+      e.g., in combination with ReconcilerForecaster for an isolated reconciliation step
 
     Parameters
     ----------


### PR DESCRIPTION
This adds a forecaster, `ForecastKnownValues`, that produces forecasts from a set of known or prescribed values passed to it in construction.

use cases include:

* as a dummy or naive forecaster with a known baseline expectation
* as a forecaster with (non-naive) expert forecasts, "known" values as per expert
* as a counterfactual in benchmarking experiments, "what if we knew the truth"
* to pass forecast data values in a composite used for postprocessing,
  e.g., in combination with `ReconcilerForecaster` for an isolated reconciliation step, as discussed in https://github.com/sktime/sktime/issues/4239

FYI @ajdin2022
