### PR TITLE
[DOC] API reference for parameter estimator module

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -22,6 +22,7 @@ For a scientific manual, see the :ref:`user_guide`.
     api_reference/regression
     api_reference/clustering
     api_reference/dists_kernels
+    api_reference/param_est
     api_reference/performance_metrics
     api_reference/series_as_features
     api_reference/annotation

--- a/docs/source/api_reference/param_est.rst
+++ b/docs/source/api_reference/param_est.rst
@@ -1,0 +1,60 @@
+
+.. _param_est_ref:
+
+Parameter estimation
+====================
+
+The :mod:`sktime.param_est` module contains parameter estimators, e.g., for
+seasonality, and utilities for plugging the estimated parameters into other estimators.
+For example, seasonality estimators can be combined with any seasonal forecaster
+to an auto-seasonality version.
+
+.. automodule:: sktime.param_est
+    :no-members:
+    :no-inherited-members:
+
+Parameter estimators
+--------------------
+
+Composition
+~~~~~~~~~~~
+
+.. currentmodule:: sktime.param_est.compose
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ParamFitterPipeline
+
+.. currentmodule:: sktime.param_est.plugin
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    PluginParamsForecaster
+
+Naive
+~~~~~
+
+.. currentmodule:: sktime.param_est.fixed
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    FixedParams
+
+Seasonality estimators
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: sktime.param_est.seasonality
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    SeasonalityACF
+    SeasonalityACFqstat
+    SeasonalityPeriodogram

--- a/docs/source/api_reference/param_est.rst
+++ b/docs/source/api_reference/param_est.rst
@@ -58,3 +58,15 @@ Seasonality estimators
     SeasonalityACF
     SeasonalityACFqstat
     SeasonalityPeriodogram
+
+Stationarity estimators
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: sktime.param_est.stationarity
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    StationarityADF
+    StationarityKPSS


### PR DESCRIPTION
This PR adds the API reference page for the parameter estimator module, which contains, e.g., seasonality estimators and auto-seasonality plugin forecasters.