### PR TITLE
[ENH] parameter estimators for stationarity - ADF and KPSS

### DIFF
--- a/sktime/param_est/stationarity.py
+++ b/sktime/param_est/stationarity.py
@@ -147,7 +147,7 @@ class StationarityADF(BaseParamFitter):
             "maxlag": 5,
             "regression": "ctt",
             "autolag": "t-stat",
-         }
+        }
 
         return [params1, params2]
 

--- a/sktime/param_est/stationarity.py
+++ b/sktime/param_est/stationarity.py
@@ -278,6 +278,6 @@ class StationarityKPSS(BaseParamFitter):
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
         params1 = {}
-        params2 = {"p_threshold": 0.1, "regression": "ctt", "lags": 5}
+        params2 = {"p_threshold": 0.1, "regression": "ctt", "nlags": 5}
 
         return [params1, params2]

--- a/sktime/param_est/stationarity.py
+++ b/sktime/param_est/stationarity.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Parameter estimators for stationarity."""
+
+__author__ = ["fkiraly"]
+__all__ = ["StationarityADF", "StationarityKPSS"]
+
+from sktime.param_est.base import BaseParamFitter
+
+
+class StationarityADF(BaseParamFitter):
+    """Test for stationarity via the Augmented Dickey-Fuller Unit Root Test (ADF).
+
+    Uses `statsmodels.tsa.stattools.adfuller` as a test for unit roots,
+    and derives a boolean statement whether a series is stationary.
+
+    Also returns test results for the unit root test as fitted parameters.
+
+    Parameters
+    ----------
+    p_threshold : float, optional, default=0.05
+        significance threshold to apply in tesing for stationarity
+    maxlag : int or None, optional, default=None
+        Maximum lag which is included in test, default value of
+        12*(nobs/100)^{1/4} is used when ``None``.
+    regression : str, one of {"c","ct","ctt","n"}, optional, default="c"
+        Constant and trend order to include in regression.
+
+        * "c" : constant only (default).
+        * "ct" : constant and trend.
+        * "ctt" : constant, and linear and quadratic trend.
+        * "n" : no constant, no trend.
+
+    autolag : one of {"AIC", "BIC", "t-stat", None}, optional, default="AIC"
+        Method to use when automatically determining the lag length among the
+        values 0, 1, ..., maxlag.
+
+        * If "AIC" (default) or "BIC", then the number of lags is chosen
+          to minimize the corresponding information criterion.
+        * "t-stat" based choice of maxlag.  Starts with maxlag and drops a
+          lag until the t-statistic on the last lag length is significant
+          using a 5%-sized test.
+        * If None, then the number of included lags is set to maxlag.
+
+    Attributes
+    ----------
+    stationary_ : bool, whether the series in `fit` is stationary according to the test
+        more precisely, whether the null of the ADF test is rejected at `p_threshold`
+    test_statistic_ : float
+        The ADF test statistic, of running `adfuller` on `y` in `fit`
+    pvalue_ : float : float
+        MacKinnon's approximate p-value based on MacKinnon (1994, 2010),
+        obtained when running `adfuller` on `y` in `fit`
+    usedlag_ : int
+        The number of lags used in the test.
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.param_est.stationarity import StationarityADF
+    >>>
+    >>> X = load_airline()  # doctest: +SKIP
+    >>> sty_est = StationarityADF()  # doctest: +SKIP
+    >>> sty_est.fit(X)  # doctest: +SKIP
+    StationarityADF(...)
+    >>> sp_est.get_fitted_params()["stationary"]  # doctest: +SKIP
+    False
+    """
+
+    _tags = {
+        "X_inner_mtype": "pd.Series",  # which types do _fit/_predict, support for X?
+        "scitype:X": "Series",  # which X scitypes are supported natively?
+        "capability:missing_values": False,  # can estimator handle missing data?
+        "capability:multivariate": False,  # can estimator handle multivariate data?
+        "python_dependencies": "statsmodels",
+    }
+
+    def __init__(
+        self,
+        p_threshold=0.05,
+        maxlag=None,
+        regression="c",
+        autolag="AIC",
+    ):
+        self.p_threshold = p_threshold
+        self.maxlag = maxlag
+        self.regression = regression
+        self.autolag = autolag
+        super(StationarityADF, self).__init__()
+
+    def _fit(self, X):
+        """Fit estimator and estimate parameters.
+
+        private _fit containing the core logic, called from fit
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            Time series to which to fit the estimator.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        from statsmodels.tsa.stattools import adfuller
+
+        p_threshold = self.p_threshold
+
+        res = adfuller(
+            x=X,
+            maxlag=self.maxlag,
+            regression=self.regression,
+            autolag=self.autolag,
+        )
+        self.test_statistic_ = res[0]
+        self.pvalue_ = res[1]
+        self.stationary_ = res[1] <= p_threshold
+        self.used_lag_ = res[2]
+
+        return self
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for transformers.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params1 = {}
+        params2 = {
+            "p_threshold": 0.1, "maxlag": 5, "regression": "ctt", "autolag": "t-stat"
+        }
+
+        return [params1, params2]
+
+
+class StationarityKPSS(BaseParamFitter):
+    """Test for stationarity via the Kwiatkowski-Phillips-Schmidt-Shin Test.
+
+    Uses `statsmodels.tsa.stattools.kpss` as a test for trend-stationairty,
+    and derives a boolean statement whether a series is (trend-)stationary.
+
+    Also returns test results for the trend-stationarity test as fitted parameters.
+
+    Parameters
+    ----------
+    p_threshold : float, optional, default=0.05
+        significance threshold to apply in tesing for stationarity
+    regression : str, one of {"c","ct","ctt","n"}, optional, default="c"
+        Constant and trend order to include in regression.
+
+        * "c" : constant only (default).
+        * "ct" : constant and trend.
+        * "ctt" : constant, and linear and quadratic trend.
+        * "n" : no constant, no trend.
+
+    nlags : str or int, optional, default="auto". If int, must be positive.
+        Indicates the number of lags to be used internally in `kpss`.
+        If "auto", lags is calculated using the data-dependent method of Hobijn et al
+        (1998). See also Andrews (1991), Newey & West (1994), and Schwert (1989).
+        If "legacy", uses int(12 * (n / 100)**(1 / 4)) , as outlined in Schwert (1989).
+        If int, uses that exact number.
+
+    Attributes
+    ----------
+    stationary_ : bool, whether the series in `fit` is stationary according to the test
+        more precisely, whether the null of the KPSS test is accepted at `p_threshold`
+    test_statistic_ : float
+        The KPSS test statistic, of running `kpss` on `y` in `fit`
+    pvalue_ : float : float
+        The p-value of the KPSS test, of running `kpss` on `y` in `fit`.
+        The p-value is interpolated from Table 1 in Kwiatkowski et al. (1992),
+        and a boundary point is returned if the test statistic is outside the table of
+        critical values, that is, if the p-value is outside the interval (0.01, 0.1).
+    lags_ : int
+        The truncation lag parameter.
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.param_est.stationarity import StationarityKPSS
+    >>>
+    >>> X = load_airline()  # doctest: +SKIP
+    >>> sty_est = StationarityKPSS()  # doctest: +SKIP
+    >>> sty_est.fit(X)  # doctest: +SKIP
+    StationarityKPSS(...)
+    >>> sp_est.get_fitted_params()["stationary"]  # doctest: +SKIP
+    False
+    """
+
+    _tags = {
+        "X_inner_mtype": "pd.Series",  # which types do _fit/_predict, support for X?
+        "scitype:X": "Series",  # which X scitypes are supported natively?
+        "capability:missing_values": False,  # can estimator handle missing data?
+        "capability:multivariate": False,  # can estimator handle multivariate data?
+        "python_dependencies": "statsmodels",
+    }
+
+    def __init__(
+        self,
+        p_threshold=0.05,
+        regression="c",
+        nlags="auto",
+    ):
+        self.p_threshold = p_threshold
+        self.regression = regression
+        self.nlags = nlags
+        super(StationarityKPSS, self).__init__()
+
+    def _fit(self, X):
+        """Fit estimator and estimate parameters.
+
+        private _fit containing the core logic, called from fit
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            Time series to which to fit the estimator.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        from statsmodels.tsa.stattools import kpss
+
+        p_threshold = self.p_threshold
+
+        res = kpss(
+            x=X,
+            regression=self.regression,
+            nlags=self.nlags,
+        )
+        self.test_statistic_ = res[0]
+        self.pvalue_ = res[1]
+        self.stationary_ = res[1] > p_threshold
+        self.lags_ = res[2]
+
+        return self
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for transformers.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params1 = {}
+        params2 = {"p_threshold": 0.1, "regression": "ctt", "lags": 5}
+
+        return [params1, params2]

--- a/sktime/param_est/stationarity.py
+++ b/sktime/param_est/stationarity.py
@@ -143,8 +143,11 @@ class StationarityADF(BaseParamFitter):
         """
         params1 = {}
         params2 = {
-            "p_threshold": 0.1, "maxlag": 5, "regression": "ctt", "autolag": "t-stat"
-        }
+            "p_threshold": 0.1,
+            "maxlag": 5,
+            "regression": "ctt",
+            "autolag": "t-stat",
+         }
 
         return [params1, params2]
 

--- a/sktime/param_est/tests/test_seasonality.py
+++ b/sktime/param_est/tests/test_seasonality.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Tests for seasonality tansformers."""
+"""Tests for seasonality parameter estimators."""
 
 __author__ = ["fkiraly"]
 

--- a/sktime/param_est/tests/test_stationarity.py
+++ b/sktime/param_est/tests/test_stationarity.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for stationarity parameter estimators."""
+
+__author__ = ["fkiraly"]
+
+import pytest
+
+from sktime.datasets import load_airline
+from sktime.param_est.stationarity import StationarityADF, StationarityKPSS
+from sktime.utils.validation._dependencies import _check_estimator_deps
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(StationarityADF, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+def test_stationarity_adf():
+    """Test StationarityADF on airline data, identical to docstring example."""
+    X = load_airline()
+    sty_est = StationarityADF()
+    sty_est.fit(X)
+    assert not sty_est.get_fitted_params()["stationary"]
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(StationarityKPSS, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+def test_stationarity_kpss():
+    """Test StationarityKPSS on airline data, identical to docstring example."""
+    X = load_airline()
+    sty_est = StationarityKPSS()
+    sty_est.fit(X)
+    assert not sty_est.get_fitted_params()["stationary"]

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -23,12 +23,12 @@ class TabularToSeriesAdaptor(BaseTransformer):
     If fit_in_transform = False and X is a series (pd.DataFrame, pd.Series, np.ndarray):
         ``fit(X)`` fits a clone of ``transformer`` to X (considered as a table)
         ``transform(X)`` applies transformer.transform to X and returns the result
-        ``inverse_transform(X)`` applies tansformer.inverse_transform to X
+        ``inverse_transform(X)`` applies transformer.inverse_transform to X
     If fit_in_transform = True and X is a series (pd.DataFrame, pd.Series, np.ndarray):
         ``fit`` is empty
-        ``transform(X)`` applies transformer.fit(X).transform.(X) to X,
+        ``transform(X)`` applies transformer.fit(X).transform(X) to X,
             considered as a table, and returns the result
-        ``inverse_transform(X)`` applies tansformer(X).inverse_transform(X) to X
+        ``inverse_transform(X)`` applies transformer.fit(X).inverse_transform(X) to X
 
     If fit_in_transform = False, and X is of a panel/hierarchical type:
         ``fit(X)`` fits a clone of ``transformer`` for each individual series x in X


### PR DESCRIPTION
This PR adds two parameter estimators for stationarity - ADF (Augmented Dickey-Fuller) and KPSS (Kwiatkowski-Phillips-Schmidt-Shin) tests, directly interfacing `statsmodels.tsa.stattools`.

Besides exposing them in the unified `sktime` interface, a fitted parameter `stationary` is added which tells the user whether the test considers the time series stationary.

This can be used, for instance, for conditional differencing in a pipeline where the boolean can be forwarded to an `OptionalPassthrough`.

This PR also contains some docstring fixes discovered elsewhere, in the context of this piece of work.

FYI @ngupta23, you might find this useful. I'll add a pipeline example to the docstring once all PR it would be conditional on are merged.

It would be apprecated if reviewers could check the logic - especially behind the boolean. E.g., as it is currently coded, one of the tests has "stationarity" as rejection, one as accepting the null - this is intentionally inconsistent.