### PR TITLE
[ENH] refactoring segmentation transformers to use `pandas` native data types

### DIFF
--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -43,6 +43,9 @@ def get_time_index(X):
         # nested_univ
         elif isinstance(X, pd.DataFrame) and isinstance(X.iloc[0, 0], pd.DataFrame):
             return _get_index(X.iloc[0, 0])
+        # nested_univ
+        elif isinstance(X, pd.DataFrame) and isinstance(X.iloc[0, 0], pd.Series):
+            return _get_index(X.iloc[0, 0])
         # pd.Series or pd.DataFrame
         else:
             return X.index

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -4,6 +4,10 @@
 
 Contains VectorizedDF class.
 """
+
+__author__ = ["fkiraly", "hoesler"]
+
+
 import itertools
 from itertools import product
 
@@ -314,7 +318,9 @@ class VectorizedDF:
 
         Returns
         -------
-        An iterator over all instances
+        A generator over all slices/instances iterated over.
+        i-th element corresponds to i-th vectorization slice, rows first then cols
+        Same as iterating over 2nd tuple element of self.items()
         """
         return (
             group
@@ -347,7 +353,11 @@ class VectorizedDF:
 
         Returns
         -------
-        An iterator over all (row name, column name, instance) tuples.
+        A generator returning (row index, col index, instance) tuples for vectorization.
+        i-th element corresponds to i-th vectorization slice, rows first then cols
+        2nd tuple element is X row sub-set to 0-th tuple element, col sub-set to 1-st
+        if no sub-setting takes place for row, 0-th tuple element is None
+        if no sub-setting takes place for col, 1-st tuple element is None
         """
         if iterate_as is None:
             iterate_as = self.iterate_as

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from sklearn.utils import check_random_state
 
-from sktime.datatypes._panel._convert import _get_time_index
+from sktime.datatypes._utilities import get_time_index
 from sktime.transformations.base import BaseTransformer
 from sktime.utils.validation import check_window_length
 
@@ -42,7 +42,6 @@ class IntervalSegmenter(BaseTransformer):
     def __init__(self, intervals=10):
         self.intervals = intervals
         self._time_index = []
-        self.input_shape_ = ()
         super(IntervalSegmenter, self).__init__()
 
     def _fit(self, X, y=None):
@@ -62,7 +61,6 @@ class IntervalSegmenter(BaseTransformer):
         self : an instance of self.
         """
         n_timepoints = X.shape[0]
-        self.input_shape_ = n_timepoints
 
         self._time_index = np.arange(n_timepoints)
 
@@ -183,7 +181,7 @@ class RandomIntervalSegmenter(IntervalSegmenter):
     """
 
     _tags = {
-        "X_inner_mtype": "nested_univ",  # which mtypes do _fit/_predict support for X?
+        "X_inner_mtype": "pd-multiindex",  # which mtype do _fit/_predict support for X?
         "y_inner_mtype": "pd_Series_Table",
         # which mtypes do _fit/_predict support for y?
     }
@@ -232,11 +230,9 @@ class RandomIntervalSegmenter(IntervalSegmenter):
             if not min_length < self.max_length:
                 raise ValueError("`max_length` must be bigger than `min_length`.")
 
-        self.input_shape_ = X.shape
-
         # Retrieve time-series indexes from each column.
         # TODO generalise to columns with series of unequal length
-        self._time_index = _get_time_index(X)
+        self._time_index = get_time_index(X)
 
         # Compute random intervals for each column.
         # TODO if multiple columns are passed, introduce option to compute

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -106,11 +106,14 @@ class IntervalSegmenter(BaseTransformer):
         """
         segments = []
 
-        for interval in self.intervals_:
-            start, end = interval[0], interval[-1]
+        for start, end in self.intervals_:
             nlevels = X.index.nlevels
             seg = X.groupby(level=list(range(nlevels - 1)))
-            seg = seg.apply(lambda x: x.iloc[start:end].reset_index(drop=True))
+
+            def subset(x):
+                return x.iloc[start:end].reset_index(drop=True)
+
+            seg = seg.apply(subset)
             seg.columns = [f"{X.columns[0]}_{start}_{end}"]
 
             segments = segments + [seg]

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -107,8 +107,8 @@ class IntervalSegmenter(BaseTransformer):
 
         for interval in self.intervals_:
             start, end = interval[0], interval[-1]
-            seg = X.groupby(level=0).apply(lambda x: x.iloc[start:end]).droplevel(0)
-            seg = seg.reset_index(drop=True)
+            seg = X.groupby(level=0)
+            seg = seg.apply(lambda x: x.iloc[start:end].reset_index(drop=True))
             seg.columns = [f"{X.columns[0]}_{start}_{end}"]
 
             segments = segments + [seg]

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -432,7 +432,7 @@ class SlidingWindowSegmenter(BaseTransformer):
 
         df = pd.DataFrame(subsequences)
 
-        return df
+        return df.transpose()
 
     def _extract_subsequences(self, instance, n_timepoints):
         """Extract a set of subsequences from a list of instances.

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -111,7 +111,7 @@ class IntervalSegmenter(BaseTransformer):
             seg = X.groupby(level=list(range(nlevels - 1)))
 
             def subset(x):
-                return x.iloc[start:end].reset_index(drop=True)
+                return x.iloc[start:end].reset_index(drop=True)  # noqa B023
 
             seg = seg.apply(subset)
             seg.columns = [f"{X.columns[0]}_{start}_{end}"]

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -375,15 +375,10 @@ class SlidingWindowSegmenter(BaseTransformer):
 
     Parameters
     ----------
-        window_length : int, optional, default=5.
-            length of sliding window interval
+    window_length : int, optional, default=5.
+        length of sliding window interval
 
-    Returns
-    -------
-        df : pandas dataframe of shape
-             [n_instances, n_timepoints]
-
-    Proposed in the ShapeDTW algorithm.
+    Used by the ShapeDTW algorithm.
     """
 
     _tags = {

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -423,7 +423,7 @@ class SlidingWindowSegmenter(BaseTransformer):
         padded_data = np.zeros(n_timepoints + (2 * pad_amnt))
 
         # Pad both ends of X
-        padded_data = np.pad(X, pad_amnt, mode="edge")
+        padded_data = np.pad(X_np1d, pad_amnt, mode="edge")
 
         subsequences = np.zeros((n_timepoints, self.window_length))
 

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -9,7 +9,6 @@ from sklearn.utils import check_random_state
 from sktime.datatypes._panel._convert import _get_time_index
 from sktime.transformations.base import BaseTransformer
 from sktime.utils.validation import check_window_length
-from sktime.utils.validation.panel import check_X
 
 
 class IntervalSegmenter(BaseTransformer):

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -109,7 +109,7 @@ class IntervalSegmenter(BaseTransformer):
         for interval in self.intervals_:
             start, end = interval[0], interval[-1]
             nlevels = X.index.nlevels
-            seg = X.groupby(level=list(range(nlevels-1)))
+            seg = X.groupby(level=list(range(nlevels - 1)))
             seg = seg.apply(lambda x: x.iloc[start:end].reset_index(drop=True))
             seg.columns = [f"{X.columns[0]}_{start}_{end}"]
 
@@ -139,7 +139,8 @@ class IntervalSegmenter(BaseTransformer):
         """
         # small number of intervals for testing
         params = {"intervals": 2}
-        return params
+        params2 = {}
+        return [params, params2]
 
 
 class RandomIntervalSegmenter(_DelegatedTransformer):

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -259,20 +259,20 @@ class RandomIntervalSegmenter(_DelegatedTransformer):
                     "Setting `min_length` or `max_length` is not yet "
                     "implemented for `n_intervals='random'`."
                 )
-            self.intervals_ = _rand_intervals_rand_n(
+            rand_intervals = _rand_intervals_rand_n(
                 self._time_index, random_state=self.random_state
             )
         else:
-            self.intervals_ = _rand_intervals_fixed_n(
+            rand_intervals = _rand_intervals_fixed_n(
                 self._time_index,
                 n_intervals=self.n_intervals,
                 min_length=min_length,
                 max_length=self.max_length,
                 random_state=self.random_state,
             )
+        self.intervals_ = np.unique(rand_intervals, axis=0)
 
         self.interval_segmenter_ = IntervalSegmenter(self.intervals_)
-
         self.interval_segmenter_.fit(X=X, y=y)
 
         return self

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -24,6 +24,15 @@ class IntervalSegmenter(BaseTransformer):
         - If ndarray, 2d np.ndarray [n_intervals, 2] with rows giving
         intervals, the first column giving start points,
         and the second column giving end points of intervals
+
+    Examples
+    --------
+    >>> from sktime.utils._testing.panel import _make_panel
+    >>> from sktime.transformations.panel.segment import IntervalSegmenter
+
+    >>> X = _make_panel()
+    >>> t = IntervalSegmenter()
+    >>> Xt = t.fit_transform(X)
     """
 
     _tags = {
@@ -75,7 +84,9 @@ class IntervalSegmenter(BaseTransformer):
                     "The number of intervals must be half the number of time points"
                     " or less"
                 )
-            self.intervals_ = np.array_split(self._time_index, self.intervals)
+            ints = np.array_split(self._time_index, self.intervals)
+            ints = [x[[0, -1]] for x in ints]
+            self.intervals_ = ints
 
         else:
             raise ValueError(
@@ -142,7 +153,7 @@ class IntervalSegmenter(BaseTransformer):
         """
         # small number of intervals for testing
         params = {"intervals": 2}
-        params2 = {}
+        params2 = {"intervals": 3}
         return [params, params2]
 
 

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -33,7 +33,8 @@ class IntervalSegmenter(BaseTransformer):
         "scitype:transform-output": "Series",
         # what scitype is returned: Primitives, Series, Panel
         "scitype:instancewise": True,  # is this an instance-wise transform?
-        "X_inner_mtype": "pd-multiindex",  # which mtypes do _fit/_predict support for X?
+        "X_inner_mtype": ["pd-multiindex", "pd_multiindex_hier"],
+        # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for X?
         "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
         "capability:unequal_length:removes": True,
@@ -107,7 +108,8 @@ class IntervalSegmenter(BaseTransformer):
 
         for interval in self.intervals_:
             start, end = interval[0], interval[-1]
-            seg = X.groupby(level=0)
+            nlevels = X.index.nlevels
+            seg = X.groupby(level=list(range(nlevels-1)))
             seg = seg.apply(lambda x: x.iloc[start:end].reset_index(drop=True))
             seg.columns = [f"{X.columns[0]}_{start}_{end}"]
 

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -186,6 +186,15 @@ class RandomIntervalSegmenter(_DelegatedTransformer):
         # which mtype do _fit/_predict support for X?
         "y_inner_mtype": "pd_Series_Table",
         # which mtypes do _fit/_predict support for y?
+        "univariate-only": True,
+        "scitype:transform-input": "Series",
+        # what is the scitype of X: Series, or Panel
+        "scitype:transform-output": "Series",
+        # what scitype is returned: Primitives, Series, Panel
+        "scitype:instancewise": True,  # is this an instance-wise transform?
+        "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
+        "capability:unequal_length:removes": True,
+        # is transform result always guaranteed to be equal length (and series)?
     }
 
     # attribute for _DelegatedTransformer, which then delegates

--- a/sktime/transformations/panel/summarize/_extract.py
+++ b/sktime/transformations/panel/summarize/_extract.py
@@ -243,7 +243,7 @@ class RandomIntervalFeatureExtractor(BaseTransformer):
         )
         self._interval_segmenter.fit(X, y)
         self.intervals_ = self._interval_segmenter.intervals_
-        self.input_shape_ = self._interval_segmenter.input_shape_
+        self.input_shape_ = X.shape
         self._time_index = self._interval_segmenter._time_index
         return self
 


### PR DESCRIPTION
This refactors three segmentation transformers, `RandomIntervalSegmenter`, `SlidingWindowSegmenter` and `IntervalSegmenter` to the `pandas` native mtype, `pd-multiindex`, from the deprecated mtype `nested_univ` which had nested pandas objects.

As a consequence, this also fixes https://github.com/sktime/sktime/issues/4266 for which the use of the nested data type seems to have been the cause.

This seems to cause a substantial improvement in runtime too (ca 25% reduction in the example in #4266), we may like to benchmark.

Relies on bugfix https://github.com/sktime/sktime/pull/4270 for an unreported bug was discovered through this.