### PR TITLE
[MNT] address deprecation of `pandas.DataFrame.iteritems`

### DIFF
--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -711,7 +711,7 @@ def from_multi_index_to_nested(
     x_nested = pd.DataFrame()
 
     # Loop the dimensions (columns) of multi-index DataFrame
-    for _label, _series in multi_ind_dataframe.iteritems():  # noqa
+    for _label, _series in multi_ind_dataframe.items():  # noqa
         # for _label in multi_ind_dataframe.columns:
         #    _series = multi_ind_dataframe.loc[:, _label]
         # Slice along the instance dimension to return list of series for each case

--- a/sktime/transformations/panel/channel_selection.py
+++ b/sktime/transformations/panel/channel_selection.py
@@ -384,7 +384,7 @@ class ElbowClassPairwise(BaseTransformer):
         obj = _distance_matrix()
         self.distance_frame_ = obj.distance(df)
 
-        for pairdistance in self.distance_frame_.iteritems():
+        for pairdistance in self.distance_frame_.items():
             distance = pairdistance[1].sort_values(ascending=False).values
             indices = pairdistance[1].sort_values(ascending=False).index
 


### PR DESCRIPTION
`pandas.DataFrame.iteritems` has been deprecated in favour of ``pandas.DataFrame.items`, this PR replaces all occurrences.