### PR TITLE
[BUG] fix `WeightedEnsembleClassifier._predict_proba` to work with `pandas` based mtypes

### DIFF
--- a/sktime/classification/compose/_ensemble.py
+++ b/sktime/classification/compose/_ensemble.py
@@ -754,13 +754,16 @@ class WeightedEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
         y : array-like, shape = [n_instances, n_classes_]
             Predicted probabilities using the ordering in classes_.
         """
-        dists = np.zeros((X.shape[0], self.n_classes_))
+        dists = None
 
         # Call predict proba on each classifier, multiply the probabilities by the
         # classifiers weight then add them to the current HC2 probabilities
         for clf_name, clf in self.classifiers_:
             y_proba = clf.predict_proba(X=X)
-            dists += y_proba * self.weights_[clf_name]
+            if dists is None:
+                dists = y_proba * self.weights_[clf_name]
+            else:
+                dists += y_proba * self.weights_[clf_name]
 
         # Make each instances probability array sum to 1 and return
         y_proba = dists / dists.sum(axis=1, keepdims=True)


### PR DESCRIPTION
This fixes an unreported bug where `WeightedEnsembleClassifier._predict_proba` would not work with `pandas` multiindex based mtypes. This is due to an array initialization that assumes `X.shape[0]` as axis 0 length for an array (number instances), which is not correct for the multiindex based mtype.