### PR TITLE
[ENH] test for `get_test_params`, and reserved parameters

### DIFF
--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -117,6 +117,7 @@ class BaseForecastingErrorMetric(BaseMetric):
         "lower_is_better": True,
         # "y_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"]
         "inner_implements_multilevel": False,
+        "reserved_params": ["multioutput", "multilevel"],
     }
 
     def __init__(self, multioutput="uniform_average", multilevel="uniform_average"):

--- a/sktime/performance_metrics/forecasting/probabilistic/_classes.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/_classes.py
@@ -36,6 +36,7 @@ class _BaseProbaForecastingErrorMetric(BaseForecastingErrorMetric):
     """
 
     _tags = {
+        "reserved_params": ["multioutput", "score_average"],
         "scitype:y_pred": "pred_quantiles",
         "lower_is_better": True,
     }

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -366,6 +366,12 @@ ESTIMATOR_TAG_REGISTER = [
         "str",
         "distribution type of data as str",
     ),
+    (
+        "reserved_params",
+        "estimator",
+        ("list", "str"),
+        "parameters reserved by the base class and present in all child estimators",
+    ),
 ]
 
 ESTIMATOR_TAG_TABLE = pd.DataFrame(ESTIMATOR_TAG_REGISTER)

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -799,17 +799,22 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
 
         key_list = [x.keys() for x in param_list]
 
-        reserved_errs = [set(x).intersection(reserved_set) for x in key_list]
+        # commenting out "no reserved params in test params for now"
+        # probably cannot ask for that, e.g., index/columns in BaseDistribution
 
-        assert all([len(x) == 0 for x in reserved_errs]), (
-            "get_test_params return dict keys must be valid parameter names, "
-            "i.e., names of arguments of __init__ that are not reserved, "
-            f"but found the following reserved parameters as keys: {reserved_errs}"
-        )
+        # reserved_errs = [set(x).intersection(reserved_set) for x in key_list]
+        # reserved_errs = [x for x in reserved_errs if len(x) > 0]
+
+        # assert len(reserved_errs) == 0, (
+        #     "get_test_params return dict keys must be valid parameter names, "
+        #     "i.e., names of arguments of __init__ that are not reserved, "
+        #     f"but found the following reserved parameters as keys: {reserved_errs}"
+        # )
 
         notfound_errs = [set(x).difference(param_names) for x in key_list]
+        notfound_errs = [x for x in notfound_errs if len(x) > 0]
 
-        assert all([len(x) == 0 for x in notfound_errs]), (
+        assert len(notfound_errs) == 0, (
             "get_test_params return dict keys must be valid parameter names, "
             "i.e., names of arguments of __init__, "
             f"but found some parameters that are not __init__ args: {notfound_errs}"

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -977,6 +977,10 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         if not isinstance(test_params, list):
             test_params = [test_params]
 
+        reserved_params = estimator_class.get_class_tag(
+            "reserved_params", tag_value_default=None
+        )
+
         for params in test_params:
             # we construct the full parameter set for params
             # params may only have parameters that are deviating from defaults
@@ -988,8 +992,12 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             est_after_set = estimator.set_params(**params_full)
             assert est_after_set is estimator, msg
 
+            def unreserved(params):
+                return {p: v for p, v in params.items() if p not in reserved_params}
+
+            est_params = estimator.get_params(deep=False)
             is_equal, equals_msg = deep_equals(
-                estimator.get_params(deep=False), params_full, return_msg=True
+                unreserved(est_params), unreserved(params_full), return_msg=True
             )
             msg = (
                 f"get_params result of {estimator_class.__name__} (x) does not match "

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -789,11 +789,11 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             else:
                 return []
 
-        reserved_param_names = estimator_class.get_class_tag(
-            "reserved_params", tag_value_default=None
-        )
-        reserved_param_names = _coerce_to_list_of_str(reserved_param_names)
-        reserved_set = set(reserved_param_names)
+        # reserved_param_names = estimator_class.get_class_tag(
+        #     "reserved_params", tag_value_default=None
+        # )
+        # reserved_param_names = _coerce_to_list_of_str(reserved_param_names)
+        # reserved_set = set(reserved_param_names)
 
         param_names = estimator_class.get_param_names()
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -978,7 +978,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
             test_params = [test_params]
 
         reserved_params = estimator_class.get_class_tag(
-            "reserved_params", tag_value_default=None
+            "reserved_params", tag_value_default=[]
         )
 
         for params in test_params:


### PR DESCRIPTION
This PR introduces:

* an interface test for the `get_test_params` method of `BaseObject` descendants. It tests whether the return has the expected type.
* introduces the concept of "reserved parameters", i.e., constructor parameters that are not object parameters but type modifying and therefore cannot be tested in the same way as ordinary parameters. Examples are the existing `multioutput` and `multilevel` parameters, which change the logical type of the metric. This is implemented as a tag `reserved_params`.
* adds the `reserved_params` tag in the base metric classes