### PR TITLE
[MNT] integrate parameter estimators with `check_estimator`

### DIFF
--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -123,6 +123,7 @@ def check_estimator(
         TestAllPanelTransformers,
     )
     from sktime.forecasting.tests.test_all_forecasters import TestAllForecasters
+    from sktime.param_est.tests.test_all_param_est import TestAllParamFitters
     from sktime.registry import scitype
     from sktime.regression.tests.test_all_regressors import TestAllRegressors
     from sktime.tests.test_all_estimators import TestAllEstimators, TestAllObjects
@@ -148,6 +149,7 @@ def check_estimator(
     testclass_dict["classifier"] = TestAllClassifiers
     testclass_dict["early_classifier"] = TestAllEarlyClassifiers
     testclass_dict["forecaster"] = TestAllForecasters
+    testclass_dict["param_est"] = TestAllParamFitters
     testclass_dict["regressor"] = TestAllRegressors
     testclass_dict["transformer"] = TestAllTransformers
     testclass_dict["transformer-pairwise"] = TestAllPairwiseTransformers


### PR DESCRIPTION
This PR integrates parameter estimators with `check_estimator`.

Previously, `check_estimator` would run only generic `skbase` interface tests, but not the parameter estimator speicific ones.
This PR adds parameter estimator specific ones that are already run by the test suite.