### PR TITLE
[DOC] clarified requirement for `get_test_params` in extension templates

### DIFF
--- a/extension_templates/annotation.py
+++ b/extension_templates/annotation.py
@@ -26,7 +26,7 @@ Mandatory implements:
 Optional implements:
     updating        - _update(self, X, Y=None)
 
-Testing - implement if sktime forecaster (not needed locally):
+Testing - required for sktime test framework and check_estimator usage:
     get default parameters for test instance(s) - get_test_params()
 
 copyright: sktime developers, BSD-3-Clause License (see LICENSE file)

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -30,7 +30,7 @@ Optional implements:
     fitted parameter inspection           - _get_fitted_params()
     predicting class probabilities        - _predict_proba(self, X)
 
-Testing - implement if sktime classifier (not needed locally):
+Testing - required for sktime test framework and check_estimator usage:
     get default parameters for test instance(s) - get_test_params()
 
 copyright: sktime developers, BSD-3-Clause License (see LICENSE file)

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -28,7 +28,7 @@ Optional implements:
     cluster assignment          -  _predict(self, X)
     fitted parameter inspection -  _get_fitted_params()
 
-Testing - implement if sktime forecaster (not needed locally):
+Testing - required for sktime test framework and check_estimator usage:
     get default parameters for test instance(s) - get_test_params()
 
 copyright: sktime developers, BSD-3-Clause License (see LICENSE file)

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -19,7 +19,7 @@ How to use this:
 Mandatory implements:
     transforming    - _transform(self, X, X2=None)
 
-Testing - implement if sktime forecaster (not needed locally):
+Testing - required for sktime test framework and check_estimator usage:
     get default parameters for test instance(s) - get_test_params()
 
 copyright: sktime developers, BSD-3-Clause License (see LICENSE file)

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -19,7 +19,7 @@ How to use this:
 Mandatory implements:
     transforming    - _transform(self, X, X2=None)
 
-Testing - implement if sktime forecaster (not needed locally):
+Testing - required for sktime test framework and check_estimator usage:
     get default parameters for test instance(s) - get_test_params()
 
 copyright: sktime developers, BSD-3-Clause License (see LICENSE file)

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -31,7 +31,7 @@ Optional implements:
     predicting class probabilities        - _predict_proba(self, X)
     updating probability predictions      - _update_predict_proba(self, X)
 
-Testing - implement if sktime early classifier (not needed locally):
+Testing - required for sktime test framework and check_estimator usage:
     get default parameters for test instance(s) - get_test_params()
 
 copyright: sktime developers, BSD-3-Clause License (see LICENSE file)

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -34,7 +34,7 @@ Optional implements:
     distribution forecast       - _predict_proba(self, fh, X=None)
     fitted parameter inspection - _get_fitted_params()
 
-Testing - implement if sktime forecaster (not needed locally):
+Testing - required for sktime test framework and check_estimator usage:
     get default parameters for test instance(s) - get_test_params()
 """
 # todo: write an informative docstring for the file or module, remove the above

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -31,7 +31,7 @@ Mandatory implements:
     fitting         - _fit(self, y, X=None, fh=None)
     forecasting     - _predict(self, fh=None, X=None)
 
-Testing - implement if sktime forecaster (not needed locally):
+Testing - required for sktime test framework and check_estimator usage:
     get default parameters for test instance(s) - get_test_params()
 """
 # todo: write an informative docstring for the file or module, remove the above

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -31,7 +31,7 @@ Optional implements:
     update                      - _update(self, X, y=None)
     fitted parameter inspection - _get_fitted_params()
 
-Testing - implement if sktime transformer (not needed locally):
+Testing - required for sktime test framework and check_estimator usage:
     get default parameters for test instance(s) - get_test_params()
 """
 # todo: write an informative docstring for the file or module, remove the above

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -31,7 +31,7 @@ Mandatory implements:
     fitting         - _fit(self, X, y=None)
     transformation  - _transform(self, X, y=None)
 
-Testing - implement if sktime transformer (not needed locally):
+Testing - required for sktime test framework and check_estimator usage:
     get default parameters for test instance(s) - get_test_params()
 """
 # todo: write an informative docstring for the file or module, remove the above


### PR DESCRIPTION
This PR makes the same small change to all extension templates, clarifying the cases where `get_test_params` should be implemented - contribution to `sktime` *and* for use with `check_estimator`. The latter has been incorrectly omitted from the extension templates.