### PR TITLE
&marrov [BUG] fix `Settingwithcopywarning` when using custom error metric in `evaluate`

### DIFF
--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -470,11 +470,11 @@ def evaluate(
     if isinstance(scoring, List):
         for s in scoring[1:]:
             results[f"test_{s.name}"] = np.nan
-            for row in range(len(results)):
-                results[f"test_{s.name}"].iloc[row] = s(
-                    results["y_test"].iloc[row],
-                    results["y_pred"].iloc[row],
-                    y_train=results["y_train"].iloc[row],
+            for row in results.index:
+                results.loc[row, f"test_{s.name}"] = s(
+                    results["y_test"].loc[row],
+                    results["y_pred"].loc[row],
+                    y_train=results["y_train"].loc[row],
                 )
 
     if not return_data:

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -467,6 +467,7 @@ def evaluate(
         )
         results = pd.concat(results)
 
+    results = results.reset_index(drop=True)
     if isinstance(scoring, List):
         for s in scoring[1:]:
             results[f"test_{s.name}"] = np.nan
@@ -479,6 +480,6 @@ def evaluate(
 
     if not return_data:
         results = results.drop(columns=["y_train", "y_test", "y_pred"])
-    results = results.astype({"len_train_window": int}).reset_index(drop=True)
+    results = results.astype({"len_train_window": int})
 
     return results


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4292

@marrov, thanks, I think you've correctly identified the source location of the bug!

I'm not quite clear why we are dealing with a `DataFrame` that has repeated index (zero??), but I've fixed it now by chaging the chained double access to single `loc` access with two indices, and ensuring the multiple indexp roblem does not occur.

Perhaps @topher-lo has a piece of wisdom to offer what eactly was happening there with the index...