### PR TITLE
[ENH] remove test for output values in `test_FeatureUnion_pipeline`

### DIFF
--- a/sktime/transformations/tests/test_pipeline.py
+++ b/sktime/transformations/tests/test_pipeline.py
@@ -41,7 +41,7 @@ def test_FeatureUnion_pipeline():
     y_pred = clf.predict(X_test)
 
     assert y_pred.shape[0] == y_test.shape[0]
-    np.testing.assert_array_equal(np.unique(y_pred), np.unique(y_test))
+    # np.testing.assert_array_equal(np.unique(y_pred), np.unique(y_test))
 
 
 def test_FeatureUnion():


### PR DESCRIPTION
This removes one test for output values in `test_FeatureUnion_pipeline`, as this is sporadically no longer satisfied.
This is due to the refactor https://github.com/sktime/sktime/pull/4267 changing how random seeds map onto estimator states, and the test in question only testing validity of the pipeline.