### PR TITLE
[MNT] resolve circular imports in `forecasting.base`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,8 +13,6 @@ by default, this is off, including for default local runs of pytest
 
 __author__ = ["fkiraly"]
 
-from sktime.tests import test_all_estimators
-
 
 def pytest_addoption(parser):
     """Pytest command line parser options adder."""
@@ -27,5 +25,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     """Pytest configuration preamble."""
+    from sktime.tests import test_all_estimators
+
     if config.getoption("--matrixdesign") in [True, "True"]:
         test_all_estimators.MATRIXDESIGN = True

--- a/sktime/forecasting/base/__init__.py
+++ b/sktime/forecasting/base/__init__.py
@@ -8,5 +8,5 @@ __all__ = [
     "BaseForecaster",
 ]
 
-from sktime.forecasting.base._fh import ForecastingHorizon
 from sktime.forecasting.base._base import BaseForecaster
+from sktime.forecasting.base._fh import ForecastingHorizon

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -55,7 +55,7 @@ from sktime.datatypes import (
     scitype_to_mtype,
     update_data,
 )
-from sktime.forecasting.base import ForecastingHorizon
+from sktime.forecasting.base._fh import ForecastingHorizon
 from sktime.utils.datetime import _shift
 from sktime.utils.validation._dependencies import (
     _check_dl_dependencies,


### PR DESCRIPTION
PR https://github.com/sktime/sktime/pull/4319 has highlighted a potential issue with a circular import in `forecasting.base`.

`forecasting.base` was importing `BaseForecaster` from `forecasting.base._base`, which was importing `ForecastingHorizon` from `forecasting.base`, resulting in a circular import. Fixed by importing `ForecastingHorizon` from its direct location.