### PR TITLE
[MNT] carry out forgotten deprecation for `ContractableBOSS` `typed_dict` parameter

### DIFF
--- a/sktime/classification/dictionary_based/_cboss.py
+++ b/sktime/classification/dictionary_based/_cboss.py
@@ -11,7 +11,6 @@ __all__ = ["ContractableBOSS", "pairwise_distances"]
 
 import math
 import time
-import warnings
 
 import numpy as np
 from sklearn.utils import check_random_state
@@ -63,15 +62,6 @@ class ContractableBOSS(BaseClassifier):
     contract_max_n_parameter_samples : int, default=np.inf
         Max number of parameter combinations to consider when time_limit_in_minutes is
         set.
-    typed_dict : bool, default="deprecated"
-        Use a numba TypedDict to store word counts. May increase memory usage, but will
-        be faster for larger datasets. As the Dict cannot be pickled currently, there
-        will be some overhead converting it to a python dict with multiple threads and
-        pickling.
-
-        .. deprecated:: 0.13.3
-            ``typed_dict`` was deprecated in version 0.13.3 and will be removed in 0.15.
-
     save_train_predictions : bool, default=False
         Save the ensemble member train predictions in fit for use in _get_train_probs
         leave-one-out cross-validation.
@@ -156,7 +146,6 @@ class ContractableBOSS(BaseClassifier):
         min_window=10,
         time_limit_in_minutes=0.0,
         contract_max_n_parameter_samples=np.inf,
-        typed_dict="deprecated",
         save_train_predictions=False,
         feature_selection="none",
         n_jobs=1,
@@ -169,7 +158,6 @@ class ContractableBOSS(BaseClassifier):
 
         self.time_limit_in_minutes = time_limit_in_minutes
         self.contract_max_n_parameter_samples = contract_max_n_parameter_samples
-        self.typed_dict = typed_dict
         self.save_train_predictions = save_train_predictions
         self.n_jobs = n_jobs
         self.random_state = random_state
@@ -217,13 +205,6 @@ class ContractableBOSS(BaseClassifier):
 
         self.estimators_ = []
         self.weights_ = []
-
-        if self.typed_dict != "deprecated":
-            warnings.warn(
-                "``typed_dict`` was deprecated in version 0.13.3 and "
-                "will be removed in 0.15.",
-                stacklevel=2,
-            )
 
         # Window length parameter space dependent on series length
         max_window_searches = self.series_length_ / 4


### PR DESCRIPTION
This PR carries out a forgotten depreation (scheduled for 0.15.0), of the `typed_dict` parameter in `ContractableBOSS`.

Fixes #4313