### PR TITLE
DRAFT [ENH] experimental: datasets as objects

### DIFF
--- a/sktime/datasets/base/__init__.py
+++ b/sktime/datasets/base/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Base class for datasets."""
+
+__all__ = ["BaseDataset"]
+
+from sktime.datasets.base._base import BaseDataset

--- a/sktime/datasets/base/_base.py
+++ b/sktime/datasets/base/_base.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""
+Base class template for data sets.
+
+    class name: BaseDataset
+
+Scitype defining methods:
+    loading dataset              - load()
+    loading object from dataset  - load(*args)
+
+Inspection methods:
+    hyper-parameter inspection   - get_params()
+"""
+
+__author__ = ["fkiraly"]
+
+__all__ = ["BaseDataset"]
+
+from sktime.base import BaseObject
+
+from sktime.utils.validation._dependencies import _check_estimator_deps
+
+
+class BaseDataset(BaseObject):
+    """Base class for datasets."""
+
+    # default tag values - these typically make the "safest" assumption
+    _tags = {}
+
+    def __init__(self):
+
+        super(BaseDataset, self).__init__()
+        _check_estimator_deps(self)
+
+    def __call__(self, *args, **kwargs):
+        """Load the dataset, same as calling load."""
+        return self.load(*args, **kwargs)

--- a/sktime/datasets/classification/_base.py
+++ b/sktime/datasets/classification/_base.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Base classes for classification datasets."""
+
+__author__ = ["fkiraly"]
+
+from inspect import isfunction
+
+from sktime.datasets.base import BaseDataset
+
+
+class BaseClassificationDataset(BaseDataset):
+    """Base class for classification datasets."""
+
+    def __init__(self, return_mtype="pd-multiindex"):
+
+        self.return_mtype = return_mtype
+        super(BaseClassificationDataset, self).__init__()
+
+    def load(self, *args):
+        pass
+
+
+def _coerce_to_list_of_str(obj):
+    if not isinstance(obj, list):
+        return [obj]
+    else:
+        return obj
+
+
+class ClassificationDatasetFromLoader(BaseClassificationDataset):
+
+    loader_func = None
+
+    def _encode_args(self, code):
+        kwargs = {}
+        if code in ["X", "y"]:
+            split = None
+        elif code in ["X_train", "y_train"]:
+            split = "TRAIN"
+        elif code in ["X_test", "y_test"]:
+            split = "TRAIN"
+        else:
+            split = None
+        kwargs = {"split": split, "return_type": self.return_mtype}
+        return kwargs
+
+    def load(self, *args):
+        """Load the dataset.
+
+        Parameters
+        ----------
+        *args: tuple of strings that specify what to load
+            "X": full panel data set of instnaces to classify
+            "y": full set of class labels
+            "X_train": training instances only, for fixed single split
+            "y_train": training labels only, for fixed single split
+            "X_test": test instances only, for fixed single split
+            "y_test": test labels only, for fixed single split
+
+        Returns
+        -------
+        dataset, if args is empty or length one
+            data container corresponding to string in args (see above)
+        tuple, of same length as args, if args is length 2 or longer
+            data containers corresponding to strings in args, in same order
+        """
+        # calls class variable loader_func, if available, or dynamic (object) variable
+        # we need to call type since we store func as a class attribute
+        if hasattr(type(self), "loader_func") and isfunction(type(self).loader_func):
+            loader = type(self).loader_func
+        else:
+            loader = self.loader_func
+
+        if len(args) == 0:
+            args = ("X", "y")
+
+        cache = {}
+        if "X" in args or "y" in args:
+            X, y = loader(**self._encode_args("X"))
+            cache["X"] = X
+            cache["y"] = y
+        if "X_train" in args or "y_train" in args:
+            X, y = loader(**self._encode_args("X_train"))
+            cache["X_train"] = X
+            cache["y_train"] = y
+        if "X_test" in args or "y_test" in args:
+            X, y = loader(**self._encode_args("X_test"))
+            cache["X_test"] = X
+            cache["y_test"] = y
+
+        res = [cache[key] for key in args]
+        res = tuple(res)
+
+        return res

--- a/sktime/datasets/classification/plaid.py
+++ b/sktime/datasets/classification/plaid.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Plaid dataset."""
+
+from sktime.datasets._single_problem_loaders import load_plaid
+from sktime.datasets.classification._base import ClassificationDatasetFromLoader
+
+
+class PLAID(ClassificationDatasetFromLoader):
+    """PLAID time series classification problem.
+
+    Example of a univariate problem with unequal length series.
+
+    Parameters
+    ----------
+    return_mtype: valid Panel mtype str or None, optional (default=None="pd-multiindex")
+        Memory data format specification to return X in, None = "nested_univ" type.
+        str can be any supported sktime Panel mtype,
+            for list of mtypes, see datatypes.MTYPE_REGISTER
+            for specifications, see examples/AA_datatypes_and_datasets.ipynb
+        commonly used specifications:
+            "pd-multiindex": pd.DataFrame with 2-level (instance, time) MultiIndex
+            "numpy3D"/"numpy3d"/"np3D": 3D np.ndarray (instance, variable, time index)
+            "numpy2d"/"np2d"/"numpyflat": 2D np.ndarray (instance, time index)
+            "nested_univ: nested pd.DataFrame, pd.Series in cells
+        Exception is raised if the data cannot be stored in the requested type.
+
+    Examples
+    --------
+    >>> from sktime.datasets.classification.plaid import PLAID
+    >>> X, y = PLAID().load()
+    """
+
+    _tags = {
+        "is_univariate": True,
+        "is_one_series": False,
+        "n_panels": 1,
+        "is_one_panel": True,
+        "is_equally_spaced": True,
+        "is_equal_length": False,
+        "is_equal_index": False,
+        "is_empty": False,
+        "has_nans": False,
+        "n_instances": 3,
+        "n_instances_train": 537,
+        "n_instances_test": 537,
+        "n_classes": 11,
+    }
+
+    loader_func = load_plaid

--- a/sktime/registry/_base_classes.py
+++ b/sktime/registry/_base_classes.py
@@ -64,6 +64,7 @@ from sktime.base import BaseEstimator, BaseObject
 from sktime.classification.base import BaseClassifier
 from sktime.classification.early_classification import BaseEarlyClassifier
 from sktime.clustering.base import BaseClusterer
+from sktime.datasets.base import BaseDataset
 from sktime.dists_kernels._base import (
     BasePairwiseTransformer,
     BasePairwiseTransformerPanel,
@@ -88,6 +89,7 @@ BASE_CLASS_REGISTER = [
     ("aligner", BaseAligner, "time series aligner or sequence aligner"),
     ("classifier", BaseClassifier, "time series classifier"),
     ("clusterer", BaseClusterer, "time series clusterer"),
+    ("dataset", BaseDataset, "data set"),
     ("early_classifier", BaseEarlyClassifier, "early time series classifier"),
     ("forecaster", BaseForecaster, "forecaster"),
     ("metric", BaseMetric, "performance metric"),

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -372,6 +372,84 @@ ESTIMATOR_TAG_REGISTER = [
         ("list", "str"),
         "parameters reserved by the base class and present in all child estimators",
     ),
+    (
+        "is_univariate",
+        "dataset",
+        "bool",
+        "is the dataset univariate?",
+    ),
+    (
+        "is_one_series",
+        "dataset",
+        "bool",
+        "does the data consist of a single series?",
+    ),
+    (
+        "n_panels",
+        "dataset",
+        "int",
+        "number of panels in the dataset",
+    ),
+    (
+        "is_one_panel",
+        "dataset",
+        "bool",
+        "does the dataset consist of a single panel?",
+    ),
+    (
+        "is_equally_spaced",
+        "dataset",
+        "bool",
+        "are the series in the dataset equally spaced?",
+    ),
+    (
+        "is_equal_length",
+        "dataset",
+        "bool",
+        "are the series in the dataset of equal length?",
+    ),
+    (
+        "is_equal_index",
+        "dataset",
+        "bool",
+        "do the series in the dataset have equal index set?",
+    ),
+    (
+        "is_empty",
+        "dataset",
+        "bool",
+        "is the dataset empty?",
+    ),
+    (
+        "has_nans",
+        "dataset",
+        "bool",
+        "does the dataset contain nans?",
+    ),
+    (
+        "n_instances",
+        "dataset",
+        "int",
+        "number of instances in the dataset",
+    ),
+    (
+        "n_instances_train",
+        "dataset",
+        "int",
+        "number of training instances in the dataset",
+    ),
+    (
+        "n_instances_test",
+        "dataset",
+        "int",
+        "number of test instances in the dataset",
+    ),
+    (
+        "n_classes",
+        "dataset",
+        "int",
+        "number of classes in the dataset",
+    ),
 ]
 
 ESTIMATOR_TAG_TABLE = pd.DataFrame(ESTIMATOR_TAG_REGISTER)


### PR DESCRIPTION
This is a prototype draft refining some ideas of @JonathanBechtel in #4314.
See #4332.

This introduces a `BaseDataset` class and classification specific descendants, and showcases using the example of the `PLAID` dataset how datasets could be tagged and made be discoverable using `all_estimators`.