### PR TITLE
[DOC] Update of roles - community council

### DIFF
--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -25,7 +25,7 @@ Community Council
    * - Marc Rovira
      - :user:`marrov`
 
-(interim, subject to `widening of governance model <https://github.com/sktime/sktime/issues/4234>`_)
+(interim, subject to `widening of governance model <https://github.com/sktime/community-org/issues/46>`_)
 
 Community Council Observers
 ---------------------------

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -14,8 +14,18 @@ Community Council
 
    * - Name
      - GitHub ID
+   * - Jonathan Bechtel
+     - :user:`jonathanb`
    * - Franz Király
      - :user:`fkiraly`
+   * - Ryan Kuhns
+     - :user:`rnkuhns`
+   * - Kiril Ralinovski
+     - :user:`kirilral`
+   * - Marc Rovira
+     - :user:`marrov`
+
+(interim subject to `widening of governance model <https://github.com/sktime/sktime/issues/4234>`_)
 
 Community Council Observers
 ---------------------------
@@ -25,6 +35,8 @@ Community Council Observers
 
    * - Name
      - GitHub ID
+   * - Jana Schmidberger
+     - :user:`janasberger`
    * - Lovkush Agarwal
      - :user:`lovkush-a`
    * - Mirae Parker
@@ -40,6 +52,8 @@ Code of Conduct Committee
      - GitHub ID
    * - Franz Király
      - :user:`fkiraly`
+   * - Marc Rovira
+     - :user:`marrov`
 
 Core Developers
 ---------------

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -25,7 +25,7 @@ Community Council
    * - Marc Rovira
      - :user:`marrov`
 
-(interim subject to `widening of governance model <https://github.com/sktime/sktime/issues/4234>`_)
+(interim, subject to `widening of governance model <https://github.com/sktime/sktime/issues/4234>`_)
 
 Community Council Observers
 ---------------------------

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -15,7 +15,7 @@ Community Council
    * - Name
      - GitHub ID
    * - Jonathan Bechtel
-     - :user:`jonathanb`
+     - :user:`jonathanbechtel`
    * - Franz Király
      - :user:`fkiraly`
    * - Ryan Kuhns


### PR DESCRIPTION
This PR updates the "roles" page on the documentation with the status quo.

The following individuals are joining the community council: @jonathanbechtel, @kirilral, @marrov, @RNKuhns,

subject to planned widening of governance to include users and the community of early career contributors in formal decision making (see https://github.com/sktime/community-org/issues/46)