### PR TITLE
[ENH] turn `BKFilter` into a direct interface

### DIFF
--- a/sktime/transformations/series/bkfilter.py
+++ b/sktime/transformations/series/bkfilter.py
@@ -140,5 +140,6 @@ class BKFilter(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        params = {"low": 6, "high": 24, "K": 12}
-        return params
+        params1 = {"low": 5, "high": 24, "K": 4}
+        params2 = {}
+        return [params1, params2]

--- a/sktime/transformations/series/bkfilter.py
+++ b/sktime/transformations/series/bkfilter.py
@@ -118,25 +118,10 @@ class BKFilter(BaseTransformer):
         -------
         transformed cyclical version of X
         """
-        from scipy.signal import fftconvolve
-        from statsmodels.tools.validation import PandasWrapper, array_like
+        from statsmodels.tsa.filters.bk_filter import bkfilter
 
-        pw = PandasWrapper(X)
-        X = array_like(X, "X", maxdim=2)
-        omega_1 = 2.0 * np.pi / self.high
-        omega_2 = 2.0 * np.pi / self.low
-        bweights = np.zeros(2 * self.K + 1)
-        bweights[self.K] = (omega_2 - omega_1) / np.pi
-        j = np.arange(1, int(self.K) + 1)
-        weights = 1 / (np.pi * j) * (np.sin(omega_2 * j) - np.sin(omega_1 * j))
-        bweights[self.K + j] = weights
-        bweights[: self.K] = weights[::-1]
-        bweights -= bweights.mean()
-        if X.ndim == 2:
-            bweights = bweights[:, None]
-        X = fftconvolve(X, bweights, mode="valid")
-
-        return pw.wrap(X, append="cycle", trim_start=self.K, trim_end=self.K)
+        kwargs = {"low": self.low, "high": self.high, "K": self.K}
+        return bkfilter(X, **kwargs)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/transformations/series/bkfilter.py
+++ b/sktime/transformations/series/bkfilter.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-Implements Baxter-King bandpass filter transformation.
+Interface to Baxter-King bandpass filter from `statsmodels`.
 
-Please see the original library
-(https://github.com/statsmodels/statsmodels/blob/main/statsmodels/tsa/filters/bk_filter.py)
+Interfaces `bk_filter` from `statsmodels.tsa.filters`.
 """
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
@@ -11,7 +10,6 @@ __author__ = ["klam-data", "pyyim", "mgorlin"]
 __all__ = ["BKFilter"]
 
 
-import numpy as np
 import pandas as pd
 
 from sktime.transformations.base import BaseTransformer
@@ -23,8 +21,8 @@ _check_soft_dependencies("statsmodels", severity="warning")
 class BKFilter(BaseTransformer):
     """Filter a times series using the Baxter-King filter.
 
-    This is a wrapper around statsmodels' bkfilter function
-    (see 'sm.tsa.filters.bk_filter.bkfilter').
+    This is a wrapper around the `bkfilter` function from `statsmodels`.
+    (see `statsmodels.tsa.filters.bk_filter.bkfilter`).
 
     The Baxter-King filter is intended for economic and econometric time series
     data and deals with the periodicity of the business cycle. Applying their


### PR DESCRIPTION
Following discussion in https://github.com/sktime/sktime/pull/4342, I noticed that the `BKFilter` did not interface, but in fact copy the code from `statmodels`.

This was an oversight in review, apologies. The code should interface (not copy) the statsmodels function, to avoid duplication and forking.

The fix should not change any functionality.

Also adds a second set of test parameters.