### PR TITLE
[DOC] `TimeSeriesKMeans` - correct `init_algorithm` default in docstring 

### DIFF
--- a/sktime/clustering/k_means.py
+++ b/sktime/clustering/k_means.py
@@ -20,7 +20,7 @@ class TimeSeriesKMeans(TimeSeriesLloyds):
     n_clusters: int, defaults = 8
         The number of clusters to form as well as the number of
         centroids to generate.
-    init_algorithm: str, defaults = 'forgy'
+    init_algorithm: str, defaults = 'random'
         Method for initializing cluster centers. Any of the following are valid:
         ['kmeans++', 'random', 'forgy']
     metric: str or Callable, defaults = 'dtw'


### PR DESCRIPTION
The documentation says that TimeSeriesKMeans defaults to `forgy`. However, in the actual code, it defaults to `random`.
Here is the incorrect line: https://github.com/sktime/sktime/blob/main/sktime/clustering/k_means.py#L23