### PR TITLE
[MNT] addressing `pytest` failure - exclude `pytest-xdist` 3.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dev = [
     "pytest-cov",
     "pytest-randomly",
     "pytest-timeout",
-    "pytest-xdist!=3.2.1",
+    "pytest-xdist<3.2.0",
     "wheel",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dev = [
     "pytest-cov",
     "pytest-randomly",
     "pytest-timeout",
-    "pytest-xdist",
+    "pytest-xdist!=3.2.1",
     "wheel",
 ]
 


### PR DESCRIPTION
Since a couple hours, CI fails with `pytest-xdist` workers crashing, see https://github.com/sktime/sktime/issues/4349

Hypothesis: this is coming from the recent release 3.2.1 of `pytest-xdist` (fixes https://github.com/sktime/sktime/issues/4349)

this PR is an attempted fix (and hypothesis check) by excluding version 3.2.1 from `pyproject`.