### PR TITLE
[MNT] addressing `pytest` failure - remove `pytest-xdist`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,9 @@ test_softdeps: ## Run unit tests to check soft dependency handling in estimators
 	mkdir -p ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
 	cd ${TEST_DIR}
-	python -m pytest -v -n auto --showlocals --durations=20 -k 'test_all_estimators' $(PYTESTOPTIONS) --pyargs sktime.registry
-	python -m pytest -v -n auto --showlocals --durations=20 -k 'test_check_estimator_does_not_raise' $(PYTESTOPTIONS) --pyargs sktime.utils.tests
-	python -m pytest -v -n auto --showlocals --durations=20 $(PYTESTOPTIONS) --pyargs sktime.tests.test_softdeps
+	python -m pytest -v --showlocals --durations=20 -k 'test_all_estimators' $(PYTESTOPTIONS) --pyargs sktime.registry
+	python -m pytest -v --showlocals --durations=20 -k 'test_check_estimator_does_not_raise' $(PYTESTOPTIONS) --pyargs sktime.utils.tests
+	python -m pytest -v --showlocals --durations=20 $(PYTESTOPTIONS) --pyargs sktime.tests.test_softdeps
 
 test_softdeps_full: ## Run all non-suite unit tests without soft dependencies
 	-rm -rf ${TEST_DIR}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ dev = [
     "pytest-cov",
     "pytest-randomly",
     "pytest-timeout",
-    "pytest-xdist",
     "wheel",
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ addopts =
     --cov-report html
     --showlocals
     --matrixdesign True
-    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
Since a couple hours, CI fails with `pytest-xdist` workers crashing, see https://github.com/sktime/sktime/issues/4349

Hypothesis: this is coming from some interaction with `pytest-xdist`.

this PR is an attempted fix (and partial hypothesis check) by removing `pytest-xdist` as a dependency (fixes #4349 tentatively)