### PR TITLE
[MNT] addressing `pytest` failure - downgrade `coverage`, `dash`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,8 @@ all_extras = [
 
 dev = [
     "backoff",
+    "coverage<7.2.2",
+    "dash<2.9.0",
     "httpx",
     "pre-commit",
     "pytest",


### PR DESCRIPTION
Attempted/diagnostic fix to #4349 - attempt is downgrading packages to last known working versions: `coverage` to 7.2.1, from 7.2.2, and `dash` to 2.8.1 from 2.9.0