### PR TITLE
[MNT] addressing `pytest` failure - downgrade `coverage`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ all_extras = [
 
 dev = [
     "backoff",
+    "coverage<7.2.2",
     "httpx",
     "pre-commit",
     "pytest",


### PR DESCRIPTION
Attempted/diagnostic fix to #4349 - attempt is downgrading packages to last known working versions: `coverage` to 7.2.1, from 7.2.2