### PR TITLE
[MNT] addressing `pytest` failure - downgrade `dash` to <2.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
 [project.optional-dependencies]
 all_extras = [
     "cloudpickle",
+    "dash<2.9.0",
     "dask",
     "dtw-python",
     "esig==0.9.7; python_version < '3.10'",


### PR DESCRIPTION
Attempted/diagnostic fix to #4349 - attempt is downgrading packages to last known working versions: `dash` to 2.8.1, from 2.9.0