### PR TITLE
[BUG] in forecasting test framework, fix ineffective assertion for correct time index check

### DIFF
--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -517,7 +517,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         y_pred = estimator_instance.update_predict_single(
             y_test, update_params=update_params
         )
-        cutoff = get_cutoff(y_train, return_index=True)
+        cutoff = get_cutoff(y_test, return_index=True)
         _assert_correct_pred_time_index(y_pred.index, cutoff, fh_int_oos)
         _assert_correct_columns(y_pred, y_train)
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -127,6 +127,10 @@ EXCLUDED_TESTS = {
     # SAX returns strange output format
     # this needs to be fixed, was not tested previously due to legacy exception
     "SAX": "test_fit_transform_output",
+    # known bug in BaggingForecaster, returns wrong index, #4363
+    "BaggingForecaster": ["test_predict_quantiles", "test_predict_proba"],
+    # known bug in DynamicFactor, returns wrong index, #4362
+    "DynamicFactor": ["test_predict_quantiles", "test_predict_proba"],
 }
 
 # We use estimator tags in addition to class hierarchies to further distinguish

--- a/sktime/utils/_testing/forecasting.py
+++ b/sktime/utils/_testing/forecasting.py
@@ -133,7 +133,7 @@ def _assert_correct_pred_time_index(y_pred_index, cutoff, fh):
     assert isinstance(y_pred_index, pd.Index)
     fh = check_fh(fh)
     expected = fh.to_absolute(cutoff).to_pandas()
-    y_pred_index.equals(expected)
+    assert y_pred_index.equals(expected)
 
 
 def _assert_correct_columns(y_pred, y_train):


### PR DESCRIPTION
This PR fixes unreported bugs in the contract testing framework for forecasters:

* an ancient part of legacy code, `_assert_correct_pred_time_index` was supposed to check whether the time index of forecasts is correct. Instead of checking, the code did nothing, as it was missing an `assert`. Fixed.
* `test_update_predict_single` was using the wrong expected time index for the check (which was not detected because the check was broken), also fixed

This is expected to surface bugs, such as in `DynamicFactor`, see
https://github.com/sktime/sktime/actions/runs/4457787440/jobs/7829202210

Relies on https://github.com/sktime/sktime/pull/4364 which excepts the failing tests after they have been turned into bug reports.