### PR TITLE
[MNT] except forecasters failing proba prediction tests (previously masked by buggy tests)

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -127,6 +127,10 @@ EXCLUDED_TESTS = {
     # SAX returns strange output format
     # this needs to be fixed, was not tested previously due to legacy exception
     "SAX": "test_fit_transform_output",
+    # known bug in BaggingForecaster, returns wrong index, #4363
+    "BaggingForecaster": ["test_predict_quantiles", "test_predict_proba"],
+    # known bug in DynamicFactor, returns wrong index, #4362
+    "DynamicFactor": ["test_predict_quantiles", "test_predict_proba"],
 }
 
 # We use estimator tags in addition to class hierarchies to further distinguish


### PR DESCRIPTION
This PR excepts the forecasters with failures in the probabilistic prediction tests that were masked due to bugs in said tests https://github.com/sktime/sktime/pull/4361.

This is a temporary measure until fixes for the forecasters are found, to allow fixing of the test.

The failures of the forecasters are tracked here:

* `BaggingForecaster` https://github.com/sktime/sktime/issues/4363
* `DynamicFactor` https://github.com/sktime/sktime/issues/4362