### PR TITLE
[ENH] informative error messages for forecasting pipeline constructors, for `steps` arg

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -5,8 +5,9 @@
 __author__ = ["mloning", "aiwalter"]
 __all__ = ["TransformedTargetForecaster", "ForecastingPipeline", "ForecastX"]
 
-import pandas as pd
 from warnings import warn
+
+import pandas as pd
 
 from sktime.base import _HeterogenousMetaEstimator
 from sktime.datatypes import ALL_TIME_SERIES_MTYPES


### PR DESCRIPTION
This adds informative error messages and warnings to cover cases in https://github.com/sktime/sktime/issues/4370.

Fixes #4370 by adding informative user feedback.