### PR TITLE
& hoesler [ENH] granular control of mtype metadata computation, avoid computation when not needed

### DIFF
--- a/sktime/datatypes/_adapter/dask_to_pd.py
+++ b/sktime/datatypes/_adapter/dask_to_pd.py
@@ -16,7 +16,8 @@ index is replaced by a string index where tuples are replaced with str coerced e
 """
 import pandas as pd
 
-from sktime.datatypes._common import _req, _ret as ret
+from sktime.datatypes._common import _req
+from sktime.datatypes._common import _ret as ret
 
 
 def _is_mi_col(x):

--- a/sktime/datatypes/_adapter/dask_to_pd.py
+++ b/sktime/datatypes/_adapter/dask_to_pd.py
@@ -16,6 +16,8 @@ index is replaced by a string index where tuples are replaced with str coerced e
 """
 import pandas as pd
 
+from sktime.datatypes._common import _req, _ret as ret
+
 
 def _is_mi_col(x):
     return isinstance(x, str) and x.startswith("__index__")
@@ -132,11 +134,6 @@ def check_dask_frame(
 
     metadata = {}
 
-    def ret(valid, msg, metadata, return_metadata):
-        if return_metadata:
-            return valid, msg, metadata
-        return valid
-
     if not isinstance(obj, dask.dataframe.core.DataFrame):
         msg = f"{var_name} must be a dask DataFrame, found {type(obj)}"
         return ret(False, msg, None, return_metadata)
@@ -174,8 +171,10 @@ def check_dask_frame(
         # dask series should have at most one __index__ col
         return ret(False, cols_msg, None, return_metadata)
 
-    metadata["is_empty"] = len(obj.index) < 1 or len(obj.columns) < 1
-    metadata["is_univariate"] = len(obj.columns) == 1
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(obj.index) < 1 or len(obj.columns) < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = len(obj.columns) == 1
 
     # check that columns are unique
     if not obj.columns.is_unique:
@@ -205,17 +204,20 @@ def check_dask_frame(
 
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
-    if return_metadata:
+    if _req("is_equally_spaced", return_metadata):
         # todo: logic for equal spacing
         metadata["is_equally_spaced"] = True
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isnull().values.any().compute()
 
-    if return_metadata and scitype in ["Panel", "Hierarchical"]:
-        instance_cols = index_cols[:-1]
-        metadata["n_instances"] = len(obj[instance_cols].drop_duplicates())
+    if scitype in ["Panel", "Hierarchical"]:
+        if _req("n_instances", return_metadata):
+            instance_cols = index_cols[:-1]
+            metadata["n_instances"] = len(obj[instance_cols].drop_duplicates())
 
-    if return_metadata and scitype in ["Hierarchical"]:
-        panel_cols = index_cols[:-2]
-        metadata["n_panels"] = len(obj[panel_cols].drop_duplicates())
+    if scitype in ["Hierarchical"]:
+        if _req("n_panels", return_metadata):
+            panel_cols = index_cols[:-2]
+            metadata["n_panels"] = len(obj[panel_cols].drop_duplicates())
 
     return ret(True, None, metadata, return_metadata)

--- a/sktime/datatypes/_alignment/_check.py
+++ b/sktime/datatypes/_alignment/_check.py
@@ -37,6 +37,8 @@ __all__ = ["check_dict"]
 import numpy as np
 import pandas as pd
 
+from sktime.datatypes._common import _ret
+
 check_dict = dict()
 
 
@@ -108,10 +110,7 @@ def check_alignment_alignment(obj, return_metadata=False, var_name="obj"):
     """Check whether object has mtype `alignment` for scitype `Alignment`."""
     valid, msg = check_align(obj, name=var_name, index="iloc")
 
-    if return_metadata:
-        return valid, msg, dict()
-    else:
-        return valid
+    return _ret(valid, msg, {}, return_metadata)
 
 
 check_dict[("alignment", "Alignment")] = check_alignment_alignment
@@ -121,10 +120,7 @@ def check_alignment_loc_alignment(obj, return_metadata=False, var_name="obj"):
     """Check whether object has mtype `alignment_loc` for scitype `Alignment`."""
     valid, msg = check_align(obj, name=var_name, index="loc")
 
-    if return_metadata:
-        return valid, msg, dict()
-    else:
-        return valid
+    return _ret(valid, msg, {}, return_metadata)
 
 
 check_dict[("alignment_loc", "Alignment")] = check_alignment_loc_alignment

--- a/sktime/datatypes/_alignment/_check.py
+++ b/sktime/datatypes/_alignment/_check.py
@@ -17,6 +17,7 @@ obj - object to check
 return_metadata - bool, optional, default=False
     if False, returns only "valid" return
     if True, returns all three return objects
+    if str, list of str, metadata return dict is subset to keys in return_metadata
 var_name: str, optional, default="obj" - name of input in error messages
 
 Returns

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -110,9 +110,10 @@ def check_is_mtype(
     scitype: str, optional, scitype to check obj as; default = inferred from mtype
         if inferred from mtype, list elements of mtype need not have same scitype
         valid mtype strings are in datatypes.SCITYPE_REGISTER (1st column)
-    return_metadata - bool, optional, default=False
+    return_metadata - bool, str, or list of str, optional, default=False
         if False, returns only "valid" return
         if True, returns all three return objects
+        if str, list of str, metadata return dict is subset to keys in return_metadata
     var_name: str, optional, default="obj" - name of input in error messages
 
     Returns
@@ -120,9 +121,9 @@ def check_is_mtype(
     valid: bool - whether obj is a valid object of mtype/scitype
     msg: str or list of str - error messages if object is not valid, otherwise None
             str if mtype is str; list of len(mtype) with message per mtype if list
-            returned only if return_metadata is True
+            returned only if return_metadata is True or str, list of str
     metadata: dict - metadata about obj if valid, otherwise None
-            returned only if return_metadata is True
+            returned only if return_metadata is True or str, list of str
         Keys populated depend on (assumed, otherwise identified) scitype of obj.
         Always returned:
             "mtype": str, mtype of obj (assumed or inferred)
@@ -241,7 +242,7 @@ def check_raise(obj, mtype: str, scitype: str = None, var_name: str = "input"):
         obj=obj_long_name_for_avoiding_linter_clash,
         mtype=mtype,
         scitype=scitype,
-        return_metadata=True,
+        return_metadata=[],
         var_name=var_name,
     )
 
@@ -306,7 +307,7 @@ def mtype(
             obj,
             mtype=m_plus_scitype[0],
             scitype=m_plus_scitype[1],
-            return_metadata=True,
+            return_metadata=[],
         )
         if valid:
             mtypes_positive += [m_plus_scitype[0]]
@@ -349,6 +350,7 @@ def check_is_scitype(
     return_metadata - bool, optional, default=False
         if False, returns only "valid" return
         if True, returns all three return objects
+        if str, list of str, metadata return dict is subset to keys in return_metadata
     var_name: str, optional, default="obj" - name of input in error messages
     exclude_mtypes : list of str, default = AMBIGUOUS_MTYPES
         which mtypes to ignore in inferring mtype, default = ambiguous ones

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -29,6 +29,7 @@ from typing import List, Union
 import numpy as np
 
 from sktime.datatypes._alignment import check_dict_Alignment
+from sktime.datatypes._common import _ret
 from sktime.datatypes._hierarchical import check_dict_Hierarchical
 from sktime.datatypes._panel import check_dict_Panel
 from sktime.datatypes._proba import check_dict_Proba
@@ -55,13 +56,6 @@ def _check_scitype_valid(scitype: str = None):
 
     if scitype is not None and scitype not in valid_scitypes:
         raise TypeError(scitype + " is not a supported scitype")
-
-
-def _ret(valid, msg, metadata, return_metadata):
-    if return_metadata:
-        return valid, msg, metadata
-    else:
-        return valid
 
 
 def _coerce_list_of_str(obj, var_name="obj"):

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -170,7 +170,7 @@ def check_is_mtype(
 
         res = check_dict[key](obj, return_metadata=return_metadata, var_name=var_name)
 
-        if return_metadata:
+        if not isinstance(return_metadata, bool) or return_metadata:
             check_passed = res[0]
         else:
             check_passed = res
@@ -179,7 +179,7 @@ def check_is_mtype(
             found_mtype.append(m)
             found_scitype.append(scitype_of_m)
             final_result = res
-        elif return_metadata:
+        elif not isinstance(return_metadata, bool) or return_metadata:
             msg.append(res[1])
 
     # there are three options on the result of check_is_mtype:
@@ -190,7 +190,7 @@ def check_is_mtype(
         )
     # b. one mtype is found - then return that mtype
     elif len(found_mtype) == 1:
-        if return_metadata:
+        if not isinstance(return_metadata, bool) or return_metadata:
             # add the mtype return to the metadata
             final_result[2]["mtype"] = found_mtype[0]
             final_result[2]["scitype"] = found_scitype[0]
@@ -418,7 +418,7 @@ def check_is_scitype(
             final_result = res
             found_mtype.append(key[0])
             found_scitype.append(key[1])
-        elif return_metadata:
+        elif not isinstance(return_metadata, bool) or return_metadata:
             msg[key[0]] = res[1]
 
     # there are three options on the result of check_is_mtype:
@@ -429,7 +429,7 @@ def check_is_scitype(
         )
     # b. one mtype is found - then return that mtype
     elif len(found_mtype) == 1:
-        if return_metadata:
+        if not isinstance(return_metadata, bool) or return_metadata:
             # add the mtype return to the metadata
             final_result[2]["mtype"] = found_mtype[0]
             # add the scitype return to the metadata

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -29,7 +29,7 @@ from typing import List, Union
 import numpy as np
 
 from sktime.datatypes._alignment import check_dict_Alignment
-from sktime.datatypes._common import _ret
+from sktime.datatypes._common import _metadata_requested, _ret
 from sktime.datatypes._hierarchical import check_dict_Hierarchical
 from sktime.datatypes._panel import check_dict_Panel
 from sktime.datatypes._proba import check_dict_Proba
@@ -170,7 +170,7 @@ def check_is_mtype(
 
         res = check_dict[key](obj, return_metadata=return_metadata, var_name=var_name)
 
-        if not isinstance(return_metadata, bool) or return_metadata:
+        if _metadata_requested(return_metadata):
             check_passed = res[0]
         else:
             check_passed = res
@@ -179,7 +179,7 @@ def check_is_mtype(
             found_mtype.append(m)
             found_scitype.append(scitype_of_m)
             final_result = res
-        elif not isinstance(return_metadata, bool) or return_metadata:
+        elif _metadata_requested(return_metadata):
             msg.append(res[1])
 
     # there are three options on the result of check_is_mtype:
@@ -190,7 +190,7 @@ def check_is_mtype(
         )
     # b. one mtype is found - then return that mtype
     elif len(found_mtype) == 1:
-        if not isinstance(return_metadata, bool) or return_metadata:
+        if _metadata_requested(return_metadata):
             # add the mtype return to the metadata
             final_result[2]["mtype"] = found_mtype[0]
             final_result[2]["scitype"] = found_scitype[0]
@@ -409,7 +409,7 @@ def check_is_scitype(
     for key in keys:
         res = check_dict[key](obj, return_metadata=return_metadata, var_name=var_name)
 
-        if return_metadata:
+        if _metadata_requested(return_metadata):
             check_passed = res[0]
         else:
             check_passed = res
@@ -418,7 +418,7 @@ def check_is_scitype(
             final_result = res
             found_mtype.append(key[0])
             found_scitype.append(key[1])
-        elif not isinstance(return_metadata, bool) or return_metadata:
+        elif _metadata_requested(return_metadata):
             msg[key[0]] = res[1]
 
     # there are three options on the result of check_is_mtype:
@@ -429,7 +429,7 @@ def check_is_scitype(
         )
     # b. one mtype is found - then return that mtype
     elif len(found_mtype) == 1:
-        if not isinstance(return_metadata, bool) or return_metadata:
+        if _metadata_requested(return_metadata):
             # add the mtype return to the metadata
             final_result[2]["mtype"] = found_mtype[0]
             # add the scitype return to the metadata

--- a/sktime/datatypes/_common.py
+++ b/sktime/datatypes/_common.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Common private utilities for checkers and converters."""
+
+__author__ = ["fkiraly"]
+
+
+def _ret(valid, msg, metadata, return_metadata):
+    """Return switch for checker functions."""
+    if return_metadata:
+        return valid, msg, metadata
+    else:
+        return valid
+
+
+def _req(key, return_metadata):
+    """Return whether metadata key is requested, boolean."""
+    if isinstance(return_metadata, bool):
+        return return_metadata
+    elif isinstance(return_metadata, str) and not isinstance(key, list):
+        return return_metadata == key
+    elif isinstance(return_metadata, str) and isinstance(key, list):
+        return return_metadata in key
+    elif isinstance(return_metadata, list) and not isinstance(key, list):
+        return key in return_metadata
+    elif isinstance(return_metadata, list) and isinstance(key, list):
+        return len(set(key).intersection(return_metadata)) > 0
+    else:
+        return False
+
+
+def _wr(d, key, val, return_metadata):
+    """Metadata write switch for checker functions."""
+    if _req(key, return_metadata):
+        d[key] = val
+
+    return d

--- a/sktime/datatypes/_common.py
+++ b/sktime/datatypes/_common.py
@@ -7,7 +7,7 @@ __author__ = ["fkiraly"]
 
 def _ret(valid, msg, metadata, return_metadata):
     """Return switch for checker functions."""
-    if return_metadata:
+    if not isinstance(return_metadata, bool) or return_metadata:
         return valid, msg, metadata
     else:
         return valid

--- a/sktime/datatypes/_common.py
+++ b/sktime/datatypes/_common.py
@@ -5,9 +5,14 @@
 __author__ = ["fkiraly"]
 
 
+def _metadata_requested(return_metadata):
+    """Return whether some metadata has been requested."""
+    return not isinstance(return_metadata, bool) or return_metadata
+
+
 def _ret(valid, msg, metadata, return_metadata):
     """Return switch for checker functions."""
-    if not isinstance(return_metadata, bool) or return_metadata:
+    if _metadata_requested(return_metadata):
         return valid, msg, metadata
     else:
         return valid

--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -17,6 +17,7 @@ obj - object to check
 return_metadata - bool, optional, default=False
     if False, returns only "valid" return
     if True, returns all three return objects
+    if str, list of str, metadata return dict is subset to keys in return_metadata
 var_name: str, optional, default="obj" - name of input in error messages
 
 Returns

--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -68,13 +68,6 @@ def _list_all_equal(obj):
 check_dict = dict()
 
 
-def _ret(valid, msg, metadata, return_metadata):
-    if return_metadata:
-        return valid, msg, metadata
-    else:
-        return valid
-
-
 def check_pdmultiindex_hierarchical(obj, return_metadata=False, var_name="obj"):
 
     ret = check_pdmultiindex_panel(

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -17,6 +17,7 @@ obj - object to check
 return_metadata - bool, optional, default=False
     if False, returns only "valid" return
     if True, returns all three return objects
+    if str, list of str, metadata return dict is subset to keys in return_metadata
 var_name: str, optional, default="obj" - name of input in error messages
 
 Returns

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -44,6 +44,7 @@ import numpy as np
 import pandas as pd
 from pandas.core.dtypes.cast import is_nested_object
 
+from sktime.datatypes._common import _req, _ret
 from sktime.datatypes._series._check import (
     _index_equally_spaced,
     check_pddataframe_series,
@@ -58,13 +59,6 @@ VALID_INDEX_TYPES = (pd.RangeIndex, pd.PeriodIndex, pd.DatetimeIndex)
 def is_in_valid_multiindex_types(x) -> bool:
     """Check that the input type belongs to the valid multiindex types."""
     return isinstance(x, VALID_MULTIINDEX_TYPES) or is_integer_index(x)
-
-
-def _ret(valid, msg, metadata, return_metadata):
-    if return_metadata:
-        return valid, msg, metadata
-    else:
-        return valid
 
 
 def _list_all_equal(obj):
@@ -108,18 +102,28 @@ def check_dflist_panel(obj, return_metadata=False, var_name="obj"):
         return _ret(False, msg, None, return_metadata)
 
     metadata = dict()
-    metadata["is_univariate"] = np.all([res[2]["is_univariate"] for res in check_res])
-    metadata["is_equally_spaced"] = np.all(
-        [res[2]["is_equally_spaced"] for res in check_res]
-    )
-    metadata["is_equal_length"] = _list_all_equal([len(s) for s in obj])
-    metadata["is_empty"] = np.any([res[2]["is_empty"] for res in check_res])
-    metadata["has_nans"] = np.any([res[2]["has_nans"] for res in check_res])
-    metadata["is_one_series"] = n == 1
-    metadata["n_panels"] = 1
-    metadata["is_one_panel"] = True
-
-    metadata["n_instances"] = n
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = np.all(
+            [res[2]["is_univariate"] for res in check_res]
+        )
+    if _req("is_equally_spaced", return_metadata):
+        metadata["is_equally_spaced"] = np.all(
+            [res[2]["is_equally_spaced"] for res in check_res]
+        )
+    if _req("is_equal_length", return_metadata):
+        metadata["is_equal_length"] = _list_all_equal([len(s) for s in obj])
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = np.any([res[2]["is_empty"] for res in check_res])
+    if _req("has_nans", return_metadata):
+        metadata["has_nans"] = np.any([res[2]["has_nans"] for res in check_res])
+    if _req("is_one_series", return_metadata):
+        metadata["is_one_series"] = n == 1
+    if _req("n_panels", return_metadata):
+        metadata["n_panels"] = 1
+    if _req("is_one_panel", return_metadata):
+        metadata["is_one_panel"] = True
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = n
 
     return _ret(True, None, metadata, return_metadata)
 
@@ -138,19 +142,27 @@ def check_numpy3d_panel(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a 3D np.ndarray
     metadata = dict()
-    metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1 or obj.shape[2] < 1
-    metadata["is_univariate"] = obj.shape[1] < 2
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1 or obj.shape[2] < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = obj.shape[1] < 2
     # np.arrays are considered equally spaced and equal length by assumption
-    metadata["is_equally_spaced"] = True
-    metadata["is_equal_length"] = True
+    if _req("is_equally_spaced", return_metadata):
+        metadata["is_equally_spaced"] = True
+    if _req("is_equal_length", return_metadata):
+        metadata["is_equal_length"] = True
 
-    metadata["n_instances"] = obj.shape[0]
-    metadata["is_one_series"] = obj.shape[0] == 1
-    metadata["n_panels"] = 1
-    metadata["is_one_panel"] = True
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = obj.shape[0]
+    if _req("is_one_series", return_metadata):
+        metadata["is_one_series"] = obj.shape[0] == 1
+    if _req("n_panels", return_metadata):
+        metadata["n_panels"] = 1
+    if _req("is_one_panel", return_metadata):
+        metadata["is_one_panel"] = True
 
     # check whether there any nans; only if requested
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = pd.isnull(obj).any()
 
     return _ret(True, None, metadata, return_metadata)
@@ -227,30 +239,48 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj", panel=T
 
     metadata = dict()
 
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = len(obj.columns) < 2
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
+    if _req("has_nans", return_metadata):
+        metadata["has_nans"] = obj.isna().values.any()
+
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
-    if return_metadata:
+    requires_series_grps = [
+        "n_instances", "is_one_series", "is_equal_length", "is_equally_spaced"
+    ]
+    if _req(requires_series_grps, return_metadata):
         series_groups = obj.groupby(level=list(range(index.nlevels - 1)), sort=False)
         n_series = series_groups.ngroups
 
+        if _req("n_instances", return_metadata):
+            metadata["n_instances"] = n_series
+        if _req("is_one_series", return_metadata):
+            metadata["is_one_series"] = n_series == 1
+        if _req("is_equal_length", return_metadata):
+            metadata["is_equal_length"] = _list_all_equal(
+                series_groups.size().to_numpy()
+            )
+        if _req("is_equally_spaced", return_metadata):
+            metadata["is_equally_spaced"] = all(
+                _index_equally_spaced(group.index.get_level_values(-1))
+                for _, group in series_groups
+            )
+
+    requires_panel_grps = ["n_panels", "is_one_panel"]
+    if _req(requires_panel_grps, return_metadata):
         if panel:
             n_panels = 1
         else:
             panel_groups = obj.groupby(level=list(range(index.nlevels - 2)), sort=False)
             n_panels = panel_groups.ngroups
 
-        metadata["is_univariate"] = len(obj.columns) < 2
-        metadata["is_equally_spaced"] = all(
-            _index_equally_spaced(group.index.get_level_values(-1))
-            for _, group in series_groups
-        )
-        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
-        metadata["n_panels"] = n_panels
-        metadata["is_one_panel"] = n_panels == 1
-        metadata["n_instances"] = n_series
-        metadata["is_one_series"] = n_series == 1
-        metadata["has_nans"] = obj.isna().values.any()
-        metadata["is_equal_length"] = _list_all_equal(series_groups.size().to_numpy())
+        if _req("n_panels", return_metadata):
+            metadata["n_panels"] = n_panels
+        if _req("is_one_panel", return_metadata):
+            metadata["is_one_panel"] = n_panels == 1
 
     return _ret(True, None, metadata, return_metadata)
 
@@ -371,18 +401,26 @@ def is_nested_dataframe(obj, return_metadata=False, var_name="obj"):
         return _ret(False, msg, None, return_metadata)
 
     metadata = dict()
-    metadata["is_univariate"] = obj.shape[1] < 2
-    metadata["n_instances"] = len(obj)
-    metadata["is_one_series"] = len(obj) == 1
-    metadata["n_panels"] = 1
-    metadata["is_one_panel"] = True
-    if return_metadata:
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = obj.shape[1] < 2
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = len(obj)
+    if _req("is_one_series", return_metadata):
+        metadata["is_one_series"] = len(obj) == 1
+    if _req("n_panels", return_metadata):
+        metadata["n_panels"] = 1
+    if _req("is_one_panel", return_metadata):
+        metadata["is_one_panel"] = True
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = _nested_dataframe_has_nans(obj)
+    if _req("is_equal_length", return_metadata):
         metadata["is_equal_length"] = not _nested_dataframe_has_unequal(obj)
 
     # todo: this is temporary override, proper is_empty logic needs to be added
-    metadata["is_empty"] = False
-    metadata["is_equally_spaced"] = True
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = False
+    if _req("is_equally_spaced", return_metadata):
+        metadata["is_equally_spaced"] = True
     # end hacks
 
     return _ret(True, None, metadata, return_metadata)
@@ -402,18 +440,24 @@ def check_numpyflat_Panel(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a 3D np.ndarray
     metadata = dict()
-    metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
-    metadata["is_univariate"] = True
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = True
     # np.arrays are considered equally spaced, equal length, by assumption
-    metadata["is_equally_spaced"] = True
-    metadata["is_equal_length"] = True
-    metadata["n_instances"] = obj.shape[0]
-    metadata["is_one_series"] = obj.shape[0] == 1
-    metadata["n_panels"] = 1
-    metadata["is_one_panel"] = True
-
-    # check whether there any nans; only if requested
-    if return_metadata:
+    if _req("is_equally_spaced", return_metadata):
+        metadata["is_equally_spaced"] = True
+    if _req("is_equal_length", return_metadata):
+        metadata["is_equal_length"] = True
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = obj.shape[0]
+    if _req("is_one_series", return_metadata):
+        metadata["is_one_series"] = obj.shape[0] == 1
+    if _req("n_panels", return_metadata):
+        metadata["n_panels"] = 1
+    if _req("is_one_panel", return_metadata):
+        metadata["is_one_panel"] = True
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = np.isnan(obj).any()
 
     return _ret(True, None, metadata, return_metadata)

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -249,7 +249,10 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj", panel=T
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
     requires_series_grps = [
-        "n_instances", "is_one_series", "is_equal_length", "is_equally_spaced"
+        "n_instances",
+        "is_one_series",
+        "is_equal_length",
+        "is_equally_spaced",
     ]
     if _req(requires_series_grps, return_metadata):
         series_groups = obj.groupby(level=list(range(index.nlevels - 1)), sort=False)

--- a/sktime/datatypes/_proba/_check.py
+++ b/sktime/datatypes/_proba/_check.py
@@ -40,18 +40,14 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
+from sktime.datatypes._common import _req, _ret as ret
+
 check_dict = dict()
 
 
 def check_pred_quantiles_proba(obj, return_metadata=False, var_name="obj"):
 
     metadata = dict()
-
-    def ret(valid, msg, metadata, return_metadata):
-        if return_metadata:
-            return valid, msg, metadata
-        else:
-            return valid
 
     # check if the input is a dataframe
     if not isinstance(obj, pd.DataFrame):
@@ -60,7 +56,8 @@ def check_pred_quantiles_proba(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a pd.DataFrame
     index = obj.index
-    metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
 
     # check that column indices are unique
     if not len(set(obj.columns)) == len(obj.columns):
@@ -100,8 +97,9 @@ def check_pred_quantiles_proba(obj, return_metadata=False, var_name="obj"):
         return ret(False, msg, None, return_metadata)
 
     # compute more metadata, only if needed
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
+    if _req("is_univariate", return_metadata):
         metadata["is_univariate"] = len(colidx.get_level_values(0).unique()) == 1
 
     return ret(True, None, metadata, return_metadata)
@@ -114,12 +112,6 @@ def check_pred_interval_proba(obj, return_metadata=False, var_name="obj"):
 
     metadata = dict()
 
-    def ret(valid, msg, metadata, return_metadata):
-        if return_metadata:
-            return valid, msg, metadata
-        else:
-            return valid
-
     # check if the input is a dataframe
     if not isinstance(obj, pd.DataFrame):
         msg = f"{var_name} should be a pd.DataFrame"
@@ -127,7 +119,8 @@ def check_pred_interval_proba(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a pd.DataFrame
     index = obj.index
-    metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
 
     # check that column indices are unique
     if not len(set(obj.columns)) == len(obj.columns):
@@ -171,8 +164,9 @@ def check_pred_interval_proba(obj, return_metadata=False, var_name="obj"):
         return ret(False, msg, None, return_metadata)
 
     # compute more metadata, only if needed
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
+    if _req("is_univariate", return_metadata):
         metadata["is_univariate"] = len(colidx.get_level_values(0).unique()) == 1
 
     return ret(True, None, metadata, return_metadata)

--- a/sktime/datatypes/_proba/_check.py
+++ b/sktime/datatypes/_proba/_check.py
@@ -17,6 +17,7 @@ obj - object to check
 return_metadata - bool, optional, default=False
     if False, returns only "valid" return
     if True, returns all three return objects
+    if str, list of str, metadata return dict is subset to keys in return_metadata
 var_name: str, optional, default="obj" - name of input in error messages
 
 Returns

--- a/sktime/datatypes/_proba/_check.py
+++ b/sktime/datatypes/_proba/_check.py
@@ -40,7 +40,8 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
-from sktime.datatypes._common import _req, _ret as ret
+from sktime.datatypes._common import _req
+from sktime.datatypes._common import _ret as ret
 
 check_dict = dict()
 

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -40,7 +40,8 @@ __all__ = ["check_dict"]
 import numpy as np
 import pandas as pd
 
-from sktime.datatypes._common import _req, _ret as ret
+from sktime.datatypes._common import _req
+from sktime.datatypes._common import _ret as ret
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 from sktime.utils.validation.series import is_in_valid_index_types
 

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -17,6 +17,7 @@ obj - object to check
 return_metadata - bool, optional, default=False
     if False, returns only "valid" return
     if True, returns all three return objects
+    if str, list of str, metadata return dict is subset to keys in return_metadata
 var_name: str, optional, default="obj" - name of input in error messages
 
 Returns

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -40,6 +40,7 @@ __all__ = ["check_dict"]
 import numpy as np
 import pandas as pd
 
+from sktime.datatypes._common import _req, _ret as ret
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 from sktime.utils.validation.series import is_in_valid_index_types
 
@@ -56,20 +57,16 @@ def check_pddataframe_series(obj, return_metadata=False, var_name="obj"):
 
     metadata = dict()
 
-    def ret(valid, msg, metadata, return_metadata):
-        if return_metadata:
-            return valid, msg, metadata
-        else:
-            return valid
-
     if not isinstance(obj, pd.DataFrame):
         msg = f"{var_name} must be a pandas.DataFrame, found {type(obj)}"
         return ret(False, msg, None, return_metadata)
 
     # we now know obj is a pd.DataFrame
     index = obj.index
-    metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
-    metadata["is_univariate"] = len(obj.columns) < 2
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = len(obj.columns) < 2
 
     # check that columns are unique
     if not obj.columns.is_unique:
@@ -104,8 +101,9 @@ def check_pddataframe_series(obj, return_metadata=False, var_name="obj"):
 
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
-    if return_metadata:
+    if _req("is_equally_spaced", return_metadata):
         metadata["is_equally_spaced"] = _index_equally_spaced(index)
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
 
     return ret(True, None, metadata, return_metadata)
@@ -118,20 +116,16 @@ def check_pdseries_series(obj, return_metadata=False, var_name="obj"):
 
     metadata = dict()
 
-    def ret(valid, msg, metadata, return_metadata):
-        if return_metadata:
-            return valid, msg, metadata
-        else:
-            return valid
-
     if not isinstance(obj, pd.Series):
         msg = f"{var_name} must be a pandas.Series, found {type(obj)}"
         return ret(False, msg, None, return_metadata)
 
     # we now know obj is a pd.Series
     index = obj.index
-    metadata["is_empty"] = len(index) < 1
-    metadata["is_univariate"] = True
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = True
 
     # check that dtype is not object
     if "object" == obj.dtypes:
@@ -161,8 +155,9 @@ def check_pdseries_series(obj, return_metadata=False, var_name="obj"):
 
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
-    if return_metadata:
+    if _req("is_equally_spaced", return_metadata):
         metadata["is_equally_spaced"] = _index_equally_spaced(index)
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
 
     return ret(True, None, metadata, return_metadata)
@@ -175,33 +170,32 @@ def check_numpy_series(obj, return_metadata=False, var_name="obj"):
 
     metadata = dict()
 
-    def ret(valid, msg, metadata, return_metadata):
-        if return_metadata:
-            return valid, msg, metadata
-        else:
-            return valid
-
     if not isinstance(obj, np.ndarray):
         msg = f"{var_name} must be a numpy.ndarray, found {type(obj)}"
         return ret(False, msg, None, return_metadata)
 
     if len(obj.shape) == 2:
         # we now know obj is a 2D np.ndarray
-        metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
-        metadata["is_univariate"] = obj.shape[1] < 2
+        if _req("is_empty", return_metadata):
+            metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
+        if _req("is_univariate", return_metadata):
+            metadata["is_univariate"] = obj.shape[1] < 2
     elif len(obj.shape) == 1:
         # we now know obj is a 1D np.ndarray
-        metadata["is_empty"] = len(obj) < 1
-        metadata["is_univariate"] = True
+        if _req("is_empty", return_metadata):
+            metadata["is_empty"] = len(obj) < 1
+        if _req("is_univariate", return_metadata):
+            metadata["is_univariate"] = True
     else:
         msg = f"{var_name} must be 1D or 2D numpy.ndarray, but found {len(obj.shape)}D"
         return ret(False, msg, None, return_metadata)
 
     # np.arrays are considered equally spaced by assumption
-    metadata["is_equally_spaced"] = True
+    if _req("is_equally_spaced", return_metadata):
+        metadata["is_equally_spaced"] = True
 
     # check whether there any nans; compute only if requested
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = pd.isnull(obj).any()
 
     return ret(True, None, metadata, return_metadata)
@@ -262,11 +256,6 @@ if _check_soft_dependencies("xarray", severity="none"):
     def check_xrdataarray_series(obj, return_metadata=False, var_name="obj"):
         metadata = {}
 
-        def ret(valid, msg, metadata, return_metadata):
-            if return_metadata:
-                return valid, msg, metadata
-            return valid
-
         if not isinstance(obj, xr.DataArray):
             msg = f"{var_name} must be a xarray.DataArray, found {type(obj)}"
             return ret(False, msg, None, return_metadata)
@@ -279,9 +268,11 @@ if _check_soft_dependencies("xarray", severity="none"):
         # The first dimension is the index of the time series in sktimelen
         index = obj.indexes[obj.dims[0]]
 
-        metadata["is_empty"] = len(index) < 1 or len(obj.values) < 1
+        if _req("is_empty", return_metadata):
+            metadata["is_empty"] = len(index) < 1 or len(obj.values) < 1
         # The second dimension is the set of columns
-        metadata["is_univariate"] = len(obj.dims) == 1 or len(obj[obj.dims[1]]) < 2
+        if _req("is_univariate", return_metadata):
+            metadata["is_univariate"] = len(obj.dims) == 1 or len(obj[obj.dims[1]]) < 2
 
         # check that columns are unique
         if not len(obj.dims) == len(set(obj.dims)):
@@ -316,8 +307,9 @@ if _check_soft_dependencies("xarray", severity="none"):
 
         # check whether index is equally spaced or if there are any nans
         #   compute only if needed
-        if return_metadata:
+        if _req("is_equally_spaced", return_metadata):
             metadata["is_equally_spaced"] = _index_equally_spaced(index)
+        if _req("has_nans", return_metadata):
             metadata["has_nans"] = obj.isnull().values.any()
 
         return ret(True, None, metadata, return_metadata)

--- a/sktime/datatypes/_table/_check.py
+++ b/sktime/datatypes/_table/_check.py
@@ -40,17 +40,12 @@ __all__ = ["check_dict"]
 import numpy as np
 import pandas as pd
 
+from sktime.datatypes._common import _req, _ret
+
 check_dict = dict()
 
 
 PRIMITIVE_TYPES = (float, int, str)
-
-
-def _ret(valid, msg, metadata, return_metadata):
-    if return_metadata:
-        return valid, msg, metadata
-    else:
-        return valid
 
 
 def check_pddataframe_table(obj, return_metadata=False, var_name="obj"):
@@ -63,13 +58,13 @@ def check_pddataframe_table(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a pd.DataFrame
     index = obj.index
-    metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
-    metadata["is_univariate"] = len(obj.columns) < 2
-    metadata["n_instances"] = len(index)
-
-    # check whether there are any nans
-    #   compute only if needed
-    if return_metadata:
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = len(obj.columns) < 2
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = len(index)
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
 
     # check that no dtype is object
@@ -93,9 +88,12 @@ def check_pdseries_table(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a pd.Series
     index = obj.index
-    metadata["is_empty"] = len(index) < 1
-    metadata["is_univariate"] = True
-    metadata["n_instances"] = len(index)
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = True
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = len(index)
 
     # check that dtype is not object
     if "object" == obj.dtypes:
@@ -104,7 +102,7 @@ def check_pdseries_table(obj, return_metadata=False, var_name="obj"):
 
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
 
     return _ret(True, None, metadata, return_metadata)
@@ -126,12 +124,15 @@ def check_numpy1d_table(obj, return_metadata=False, var_name="obj"):
         return _ret(False, msg, None, return_metadata)
 
     # we now know obj is a 1D np.ndarray
-    metadata["is_empty"] = len(obj) < 1
-    metadata["n_instances"] = len(obj)
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(obj) < 1
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = len(obj)
     # 1D numpy arrays are considered univariate
-    metadata["is_univariate"] = True
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = True
     # check whether there any nans; compute only if requested
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = pd.isnull(obj).any()
 
     return _ret(True, None, metadata, return_metadata)
@@ -153,11 +154,14 @@ def check_numpy2d_table(obj, return_metadata=False, var_name="obj"):
         return _ret(False, msg, None, return_metadata)
 
     # we now know obj is a 2D np.ndarray
-    metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
-    metadata["is_univariate"] = obj.shape[1] < 2
-    metadata["n_instances"] = obj.shape[0]
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = obj.shape[1] < 2
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = obj.shape[0]
     # check whether there any nans; compute only if requested
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = pd.isnull(obj).any()
 
     return _ret(True, None, metadata, return_metadata)
@@ -191,7 +195,7 @@ def check_list_of_dict_table(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a list of dict
     # check whether there any nans; compute only if requested
-    if return_metadata:
+    if _req("is_univariate", return_metadata):
         multivariate_because_one_row = np.any([len(x) > 1 for x in obj])
         if not multivariate_because_one_row:
             all_keys = np.unique([key for d in obj for key in d.keys()])
@@ -200,10 +204,13 @@ def check_list_of_dict_table(obj, return_metadata=False, var_name="obj"):
         else:
             multivariate = multivariate_because_one_row
         metadata["is_univariate"] = not multivariate
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = np.any(
             [pd.isnull(d[key]) for d in obj for key in d.keys()]
         )
+    if _req("is_empty", return_metadata):
         metadata["is_empty"] = len(obj) < 1 or np.all([len(x) < 1 for x in obj])
+    if _req("n_instances", return_metadata):
         metadata["n_instances"] = len(obj)
 
     return _ret(True, None, metadata, return_metadata)

--- a/sktime/datatypes/tests/test_check.py
+++ b/sktime/datatypes/tests/test_check.py
@@ -5,7 +5,12 @@ __author__ = ["fkiraly"]
 
 import numpy as np
 
-from sktime.datatypes._check import AMBIGUOUS_MTYPES, check_dict, check_is_mtype
+from sktime.datatypes._check import (
+    AMBIGUOUS_MTYPES,
+    check_dict,
+    check_is_mtype,
+    check_is_scitype
+)
 from sktime.datatypes._check import mtype as infer_mtype
 from sktime.datatypes._check import scitype as infer_scitype
 from sktime.datatypes._examples import get_examples
@@ -145,6 +150,55 @@ def test_check_positive(scitype, mtype, fixture_index):
         assert check_result[0], msg
 
 
+def test_check_positive_check_scitype(scitype, mtype, fixture_index):
+    """Tests that check_is_scitype correctly confirms the scitype of examples.
+
+    Parameters
+    ----------
+    scitype : str - scitype of fixture
+    mtype : str - mtype of fixture
+    fixture_index : int - index of fixture tuple with that scitype and mtype
+
+    Raises
+    ------
+    RuntimeError if scitype is not defined or has no mtypes or examples
+    AssertionError if examples are not correctly identified
+    error if check itself raises an error
+    """
+    if mtype in AMBIGUOUS_MTYPES:
+        return None
+
+    # retrieve fixture for checking
+    fixture = get_examples(mtype=mtype, as_scitype=scitype).get(fixture_index)
+
+    # todo: possibly remove this once all checks are defined
+    check_is_defined = (mtype, scitype) in check_dict.keys()
+
+    # check fixtures that exist against checks that exist, when full metadata is queried
+    if fixture is not None and check_is_defined:
+        check_result = check_is_scitype(fixture, scitype, return_metadata=True)
+        if not check_result[0]:
+            msg = (
+                f"check_is_scitype returns False on scitype {scitype}, mtype {mtype} "
+                f"fixture {fixture_index}, message: "
+            )
+            msg = msg + str(check_result[1])
+        assert check_result[0], msg
+        assert check_result[2]["mtype"] == mtype
+
+    # check fixtures that exist against checks that exist, when no metadata is queried
+    if fixture is not None and check_is_defined:
+        check_result = check_is_scitype(fixture, scitype, return_metadata=[])
+        if not check_result[0]:
+            msg = (
+                f"check_is_scitype returns False on scitype {scitype}, mtype {mtype} "
+                f"fixture {fixture_index}, message: "
+            )
+            msg = msg + str(check_result[1])
+        assert check_result[0], msg
+        assert check_result[2]["mtype"] == mtype
+
+
 def test_check_metadata_inference(scitype, mtype, fixture_index):
     """Tests that check_is_mtype correctly infers metadata of examples.
 
@@ -271,6 +325,16 @@ def test_check_negative(scitype, mtype):
                     f"on {wrong_mtype} fixture {i}"
                 )
 
+            # check fixtures that exist against checks that exist
+            if fixture_wrong_type is not None and check_is_defined:
+                result = check_is_mtype(
+                    fixture_wrong_type, mtype, scitype, return_metadata=[]
+                )[0]
+                assert not result, (
+                    f"check_is_mtype {mtype} returns True "
+                    f"on {wrong_mtype} fixture {i}"
+                )
+
 
 def test_mtype_infer(scitype, mtype, fixture_index):
     """Tests that mtype correctly infers the mtype of examples.
@@ -302,6 +366,16 @@ def test_mtype_infer(scitype, mtype, fixture_index):
         assert mtype == infer_mtype(
             fixture, as_scitype=scitype, exclude_mtypes=[]
         ), f"mtype {mtype} not correctly identified for fixture {fixture_index}"
+
+    # check indirect mtype inference via check_is_scitype
+    if fixture is not None and check_is_defined:
+        scitype_res = check_is_scitype(
+            fixture, scitype=scitype, exclude_mtypes=[], return_metadata=[]
+        )
+        inferred_mtype = scitype_res[2]["mtype"]
+        assert mtype == inferred_mtype, (
+            f"mtype {mtype} not correctly identified for fixture {fixture_index}"
+        )
 
 
 # exclude these scitypes in inference of scitype test
@@ -339,4 +413,4 @@ def test_scitype_infer(scitype, mtype, fixture_index):
     if fixture is not None and check_is_defined:
         assert scitype == infer_scitype(
             fixture, candidate_scitypes=SCITYPES_FOR_INFER_TEST
-        ), f"mtype {mtype} not correctly identified for fixture {fixture_index}"
+        ), f"scitype {scitype} not correctly identified for fixture {fixture_index}"

--- a/sktime/datatypes/tests/test_check.py
+++ b/sktime/datatypes/tests/test_check.py
@@ -9,7 +9,7 @@ from sktime.datatypes._check import (
     AMBIGUOUS_MTYPES,
     check_dict,
     check_is_mtype,
-    check_is_scitype
+    check_is_scitype,
 )
 from sktime.datatypes._check import mtype as infer_mtype
 from sktime.datatypes._check import scitype as infer_scitype
@@ -373,9 +373,9 @@ def test_mtype_infer(scitype, mtype, fixture_index):
             fixture, scitype=scitype, exclude_mtypes=[], return_metadata=[]
         )
         inferred_mtype = scitype_res[2]["mtype"]
-        assert mtype == inferred_mtype, (
-            f"mtype {mtype} not correctly identified for fixture {fixture_index}"
-        )
+        assert (
+            mtype == inferred_mtype
+        ), f"mtype {mtype} not correctly identified for fixture {fixture_index}"
 
 
 # exclude these scitypes in inference of scitype test

--- a/sktime/datatypes/tests/test_check.py
+++ b/sktime/datatypes/tests/test_check.py
@@ -174,9 +174,10 @@ def test_check_metadata_inference(scitype, mtype, fixture_index):
     # is_equal_index is not fully supported yet in inference
     EXCLUDE_KEYS = ["is_equal_index"]
 
-    expected_metadata = expected_metadata.copy()
-    subset_keys = set(expected_metadata.keys()).difference(EXCLUDE_KEYS)
-    expected_metadata = {key: expected_metadata[key] for key in subset_keys}
+    if metadata_provided:
+        expected_metadata = expected_metadata.copy()
+        subset_keys = set(expected_metadata.keys()).difference(EXCLUDE_KEYS)
+        expected_metadata = {key: expected_metadata[key] for key in subset_keys}
 
     # check fixtures that exist against checks that exist, full metadata query
     if fixture is not None and check_is_defined and metadata_provided:


### PR DESCRIPTION
This PR:

* adds granular control of metadata computation requests for all mtypes. This is controlled by allowing `return_metadata` to not just be boolean, but str or list of str. If the latter, controls exactly the fields of metadata that are requested. If empty list, no metadata are computed - but the error messages are still returned.
* As a consequence, we can implement the idea in @hoesler's https://github.com/sktime/sktime/pull/4191 without losing the informative error messages, which should also speed up thet input checks.
* refactors some common functions into a new `datatypes._common` module. Deals with the proliferation of `ret`/`_ret` functions all over the place.

Crediting @hoesler for this due to the idea in #4191 for speed-up (second bullet point).