### PR TITLE
[ENH] turn off all unnecessary input checks in current base class boilerplate

### DIFF
--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -67,6 +67,15 @@ class BaseClassifier(BaseEstimator, ABC):
         "requires_cython": False,  # whether C compiler is required in env, e.g., gcc
     }
 
+    # convenience constant to control which metadata of input data
+    # are regularly retrieved in input checks
+    METADATA_REQ_IN_CHECKS = [
+        "n_instances",
+        "has_nans",
+        "is_univariate",
+        "is_equal_length",
+    ]
+
     def __init__(self):
         # reserved attributes written to in fit
         self.classes_ = []  # classes seen in y, unique labels
@@ -154,7 +163,9 @@ class BaseClassifier(BaseEstimator, ABC):
         # convenience conversions to allow user flexibility:
         # if X is 2D array, convert to 3D, if y is Series, convert to numpy
         X, y = self._internal_convert(X, y)
-        X_metadata = self._check_classifier_input(X, y)
+        X_metadata = self._check_classifier_input(
+            X, y, return_metadata=self.METADATA_REQ_IN_CHECKS
+        )
         missing = X_metadata["has_nans"]
         multivariate = not X_metadata["is_univariate"]
         unequal = not X_metadata["is_equal_length"]
@@ -333,7 +344,9 @@ class BaseClassifier(BaseEstimator, ABC):
 
         # we now know that cv is an sklearn splitter
         X, y = self._internal_convert(X, y)
-        X_metadata = self._check_classifier_input(X, y)
+        X_metadata = self._check_classifier_input(
+            X, y, return_metadata=self.METADATA_REQ_IN_CHECKS
+        )
         missing = X_metadata["has_nans"]
         multivariate = not X_metadata["is_univariate"]
         unequal = not X_metadata["is_equal_length"]
@@ -427,7 +440,10 @@ class BaseClassifier(BaseEstimator, ABC):
 
     def _single_class_y_pred(self, X, method="predict"):
         """Handle the prediction case where only single class label was seen in fit."""
-        _, _, X_meta = check_is_scitype(X, scitype="Panel", return_metadata=True)
+        X_meta_required = ["n_instances"]
+        _, _, X_meta = check_is_scitype(
+            X, scitype="Panel", return_metadata=X_meta_required
+        )
         n_instances = X_meta["n_instances"]
         if method == "predict":
             return np.repeat(list(self._class_dictionary.keys()), n_instances)
@@ -590,7 +606,9 @@ class BaseClassifier(BaseEstimator, ABC):
         ValueError if the capabilities in self._tags do not handle the data.
         """
         X = self._internal_convert(X)
-        X_metadata = self._check_classifier_input(X)
+        X_metadata = self._check_classifier_input(
+            X, return_metadata=self.METADATA_REQ_IN_CHECKS
+        )
         missing = X_metadata["has_nans"]
         multivariate = not X_metadata["is_univariate"]
         unequal = not X_metadata["is_equal_length"]
@@ -670,7 +688,9 @@ class BaseClassifier(BaseEstimator, ABC):
         )
         return X
 
-    def _check_classifier_input(self, X, y=None, enforce_min_instances=1):
+    def _check_classifier_input(
+        self, X, y=None, enforce_min_instances=1, return_metadata=True
+    ):
         """Check whether input X and y are valid formats with minimum data.
 
         Raises a ValueError if the input is not valid.
@@ -681,6 +701,8 @@ class BaseClassifier(BaseEstimator, ABC):
         y : check whether a pd.Series or np.array
         enforce_min_instances : int, optional (default=1)
             check there are a minimum number of instances.
+        return_metadata : bool, str, or list of str
+            metadata fields to return with X_metadata, input to check_is_scitype
 
         Returns
         -------
@@ -693,7 +715,7 @@ class BaseClassifier(BaseEstimator, ABC):
         """
         # Check X is valid input type and recover the data characteristics
         X_valid, _, X_metadata = check_is_scitype(
-            X, scitype="Panel", return_metadata=True
+            X, scitype="Panel", return_metadata=return_metadata
         )
         if not X_valid:
             raise TypeError(

--- a/sktime/classification/early_classification/base.py
+++ b/sktime/classification/early_classification/base.py
@@ -63,6 +63,15 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
         "capability:multithreading": False,
     }
 
+    # convenience constant to control which metadata of input data
+    # are regularly retrieved in input checks
+    METADATA_REQ_IN_CHECKS = [
+        "n_instances",
+        "has_nans",
+        "is_univariate",
+        "is_equal_length",
+    ]
+
     def __init__(self):
         self.classes_ = []
         self.n_classes_ = 0

--- a/sktime/classification/early_classification/base.py
+++ b/sktime/classification/early_classification/base.py
@@ -621,7 +621,9 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
         _convert_X = BaseClassifier._convert_X
         return _convert_X(self, X)
 
-    def _check_classifier_input(self, X, y=None, enforce_min_instances=1):
+    def _check_classifier_input(
+        self, X, y=None, enforce_min_instances=1, return_metadata=True
+    ):
         """Check whether input X and y are valid formats with minimum data.
 
         Raises a ValueError if the input is not valid.
@@ -632,6 +634,8 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
         y : check whether a pd.Series or np.array
         enforce_min_instances : int, optional (default=1)
             check there are a minimum number of instances.
+        return_metadata : bool, str, or list of str
+            metadata fields to return with X_metadata, input to check_is_scitype
 
         Returns
         -------
@@ -643,7 +647,9 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
             If y or X is invalid input data type, or there is not enough data
         """
         _check_classifier_input = BaseClassifier._check_classifier_input
-        return _check_classifier_input(self, X, y, enforce_min_instances)
+        return _check_classifier_input(
+            self, X, y, enforce_min_instances, return_metadata
+        )
 
     def _internal_convert(self, X, y=None):
         """Convert X and y if necessary as a user convenience.

--- a/sktime/clustering/base.py
+++ b/sktime/clustering/base.py
@@ -372,7 +372,10 @@ class BaseClusterer(BaseEstimator):
         X = self._initial_conversion(X)
 
         X_metadata_required = [
-            "n_instances", "has_nans", "is_univariate", "is_equal_length"
+            "n_instances",
+            "has_nans",
+            "is_univariate",
+            "is_equal_length",
         ]
         X_valid, _, X_metadata = check_is_scitype(
             X, scitype="Panel", return_metadata=X_metadata_required

--- a/sktime/clustering/base.py
+++ b/sktime/clustering/base.py
@@ -371,8 +371,11 @@ class BaseClusterer(BaseEstimator):
         """
         X = self._initial_conversion(X)
 
+        X_metadata_required = [
+            "n_instances", "has_nans", "is_univariate", "is_equal_length"
+        ]
         X_valid, _, X_metadata = check_is_scitype(
-            X, scitype="Panel", return_metadata=True
+            X, scitype="Panel", return_metadata=X_metadata_required
         )
         if not X_valid:
             raise TypeError(

--- a/sktime/datatypes/_adapter/dask_to_pd.py
+++ b/sktime/datatypes/_adapter/dask_to_pd.py
@@ -16,7 +16,8 @@ index is replaced by a string index where tuples are replaced with str coerced e
 """
 import pandas as pd
 
-from sktime.datatypes._common import _req, _ret as ret
+from sktime.datatypes._common import _req
+from sktime.datatypes._common import _ret as ret
 
 
 def _is_mi_col(x):

--- a/sktime/datatypes/_adapter/dask_to_pd.py
+++ b/sktime/datatypes/_adapter/dask_to_pd.py
@@ -16,6 +16,8 @@ index is replaced by a string index where tuples are replaced with str coerced e
 """
 import pandas as pd
 
+from sktime.datatypes._common import _req, _ret as ret
+
 
 def _is_mi_col(x):
     return isinstance(x, str) and x.startswith("__index__")
@@ -132,11 +134,6 @@ def check_dask_frame(
 
     metadata = {}
 
-    def ret(valid, msg, metadata, return_metadata):
-        if return_metadata:
-            return valid, msg, metadata
-        return valid
-
     if not isinstance(obj, dask.dataframe.core.DataFrame):
         msg = f"{var_name} must be a dask DataFrame, found {type(obj)}"
         return ret(False, msg, None, return_metadata)
@@ -174,8 +171,10 @@ def check_dask_frame(
         # dask series should have at most one __index__ col
         return ret(False, cols_msg, None, return_metadata)
 
-    metadata["is_empty"] = len(obj.index) < 1 or len(obj.columns) < 1
-    metadata["is_univariate"] = len(obj.columns) == 1
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(obj.index) < 1 or len(obj.columns) < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = len(obj.columns) == 1
 
     # check that columns are unique
     if not obj.columns.is_unique:
@@ -205,17 +204,20 @@ def check_dask_frame(
 
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
-    if return_metadata:
+    if _req("is_equally_spaced", return_metadata):
         # todo: logic for equal spacing
         metadata["is_equally_spaced"] = True
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isnull().values.any().compute()
 
-    if return_metadata and scitype in ["Panel", "Hierarchical"]:
-        instance_cols = index_cols[:-1]
-        metadata["n_instances"] = len(obj[instance_cols].drop_duplicates())
+    if scitype in ["Panel", "Hierarchical"]:
+        if _req("n_instances", return_metadata):
+            instance_cols = index_cols[:-1]
+            metadata["n_instances"] = len(obj[instance_cols].drop_duplicates())
 
-    if return_metadata and scitype in ["Hierarchical"]:
-        panel_cols = index_cols[:-2]
-        metadata["n_panels"] = len(obj[panel_cols].drop_duplicates())
+    if scitype in ["Hierarchical"]:
+        if _req("n_panels", return_metadata):
+            panel_cols = index_cols[:-2]
+            metadata["n_panels"] = len(obj[panel_cols].drop_duplicates())
 
     return ret(True, None, metadata, return_metadata)

--- a/sktime/datatypes/_alignment/_check.py
+++ b/sktime/datatypes/_alignment/_check.py
@@ -37,6 +37,8 @@ __all__ = ["check_dict"]
 import numpy as np
 import pandas as pd
 
+from sktime.datatypes._common import _ret
+
 check_dict = dict()
 
 
@@ -108,10 +110,7 @@ def check_alignment_alignment(obj, return_metadata=False, var_name="obj"):
     """Check whether object has mtype `alignment` for scitype `Alignment`."""
     valid, msg = check_align(obj, name=var_name, index="iloc")
 
-    if return_metadata:
-        return valid, msg, dict()
-    else:
-        return valid
+    return _ret(valid, msg, {}, return_metadata)
 
 
 check_dict[("alignment", "Alignment")] = check_alignment_alignment
@@ -121,10 +120,7 @@ def check_alignment_loc_alignment(obj, return_metadata=False, var_name="obj"):
     """Check whether object has mtype `alignment_loc` for scitype `Alignment`."""
     valid, msg = check_align(obj, name=var_name, index="loc")
 
-    if return_metadata:
-        return valid, msg, dict()
-    else:
-        return valid
+    return _ret(valid, msg, {}, return_metadata)
 
 
 check_dict[("alignment_loc", "Alignment")] = check_alignment_loc_alignment

--- a/sktime/datatypes/_alignment/_check.py
+++ b/sktime/datatypes/_alignment/_check.py
@@ -17,6 +17,7 @@ obj - object to check
 return_metadata - bool, optional, default=False
     if False, returns only "valid" return
     if True, returns all three return objects
+    if str, list of str, metadata return dict is subset to keys in return_metadata
 var_name: str, optional, default="obj" - name of input in error messages
 
 Returns

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -110,9 +110,10 @@ def check_is_mtype(
     scitype: str, optional, scitype to check obj as; default = inferred from mtype
         if inferred from mtype, list elements of mtype need not have same scitype
         valid mtype strings are in datatypes.SCITYPE_REGISTER (1st column)
-    return_metadata - bool, optional, default=False
+    return_metadata - bool, str, or list of str, optional, default=False
         if False, returns only "valid" return
         if True, returns all three return objects
+        if str, list of str, metadata return dict is subset to keys in return_metadata
     var_name: str, optional, default="obj" - name of input in error messages
 
     Returns
@@ -120,9 +121,9 @@ def check_is_mtype(
     valid: bool - whether obj is a valid object of mtype/scitype
     msg: str or list of str - error messages if object is not valid, otherwise None
             str if mtype is str; list of len(mtype) with message per mtype if list
-            returned only if return_metadata is True
+            returned only if return_metadata is True or str, list of str
     metadata: dict - metadata about obj if valid, otherwise None
-            returned only if return_metadata is True
+            returned only if return_metadata is True or str, list of str
         Keys populated depend on (assumed, otherwise identified) scitype of obj.
         Always returned:
             "mtype": str, mtype of obj (assumed or inferred)
@@ -241,7 +242,7 @@ def check_raise(obj, mtype: str, scitype: str = None, var_name: str = "input"):
         obj=obj_long_name_for_avoiding_linter_clash,
         mtype=mtype,
         scitype=scitype,
-        return_metadata=True,
+        return_metadata=[],
         var_name=var_name,
     )
 
@@ -306,7 +307,7 @@ def mtype(
             obj,
             mtype=m_plus_scitype[0],
             scitype=m_plus_scitype[1],
-            return_metadata=True,
+            return_metadata=[],
         )
         if valid:
             mtypes_positive += [m_plus_scitype[0]]
@@ -349,6 +350,7 @@ def check_is_scitype(
     return_metadata - bool, optional, default=False
         if False, returns only "valid" return
         if True, returns all three return objects
+        if str, list of str, metadata return dict is subset to keys in return_metadata
     var_name: str, optional, default="obj" - name of input in error messages
     exclude_mtypes : list of str, default = AMBIGUOUS_MTYPES
         which mtypes to ignore in inferring mtype, default = ambiguous ones

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -29,6 +29,7 @@ from typing import List, Union
 import numpy as np
 
 from sktime.datatypes._alignment import check_dict_Alignment
+from sktime.datatypes._common import _ret
 from sktime.datatypes._hierarchical import check_dict_Hierarchical
 from sktime.datatypes._panel import check_dict_Panel
 from sktime.datatypes._proba import check_dict_Proba
@@ -55,13 +56,6 @@ def _check_scitype_valid(scitype: str = None):
 
     if scitype is not None and scitype not in valid_scitypes:
         raise TypeError(scitype + " is not a supported scitype")
-
-
-def _ret(valid, msg, metadata, return_metadata):
-    if return_metadata:
-        return valid, msg, metadata
-    else:
-        return valid
 
 
 def _coerce_list_of_str(obj, var_name="obj"):

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -170,7 +170,7 @@ def check_is_mtype(
 
         res = check_dict[key](obj, return_metadata=return_metadata, var_name=var_name)
 
-        if return_metadata:
+        if not isinstance(return_metadata, bool) or return_metadata:
             check_passed = res[0]
         else:
             check_passed = res
@@ -179,7 +179,7 @@ def check_is_mtype(
             found_mtype.append(m)
             found_scitype.append(scitype_of_m)
             final_result = res
-        elif return_metadata:
+        elif not isinstance(return_metadata, bool) or return_metadata:
             msg.append(res[1])
 
     # there are three options on the result of check_is_mtype:
@@ -190,7 +190,7 @@ def check_is_mtype(
         )
     # b. one mtype is found - then return that mtype
     elif len(found_mtype) == 1:
-        if return_metadata:
+        if not isinstance(return_metadata, bool) or return_metadata:
             # add the mtype return to the metadata
             final_result[2]["mtype"] = found_mtype[0]
             final_result[2]["scitype"] = found_scitype[0]
@@ -418,7 +418,7 @@ def check_is_scitype(
             final_result = res
             found_mtype.append(key[0])
             found_scitype.append(key[1])
-        elif return_metadata:
+        elif not isinstance(return_metadata, bool) or return_metadata:
             msg[key[0]] = res[1]
 
     # there are three options on the result of check_is_mtype:
@@ -429,7 +429,7 @@ def check_is_scitype(
         )
     # b. one mtype is found - then return that mtype
     elif len(found_mtype) == 1:
-        if return_metadata:
+        if not isinstance(return_metadata, bool) or return_metadata:
             # add the mtype return to the metadata
             final_result[2]["mtype"] = found_mtype[0]
             # add the scitype return to the metadata

--- a/sktime/datatypes/_common.py
+++ b/sktime/datatypes/_common.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Common private utilities for checkers and converters."""
+
+__author__ = ["fkiraly"]
+
+
+def _ret(valid, msg, metadata, return_metadata):
+    """Return switch for checker functions."""
+    if return_metadata:
+        return valid, msg, metadata
+    else:
+        return valid
+
+
+def _req(key, return_metadata):
+    """Return whether metadata key is requested, boolean."""
+    if isinstance(return_metadata, bool):
+        return return_metadata
+    elif isinstance(return_metadata, str) and not isinstance(key, list):
+        return return_metadata == key
+    elif isinstance(return_metadata, str) and isinstance(key, list):
+        return return_metadata in key
+    elif isinstance(return_metadata, list) and not isinstance(key, list):
+        return key in return_metadata
+    elif isinstance(return_metadata, list) and isinstance(key, list):
+        return len(set(key).intersection(return_metadata)) > 0
+    else:
+        return False
+
+
+def _wr(d, key, val, return_metadata):
+    """Metadata write switch for checker functions."""
+    if _req(key, return_metadata):
+        d[key] = val
+
+    return d

--- a/sktime/datatypes/_common.py
+++ b/sktime/datatypes/_common.py
@@ -7,7 +7,7 @@ __author__ = ["fkiraly"]
 
 def _ret(valid, msg, metadata, return_metadata):
     """Return switch for checker functions."""
-    if return_metadata:
+    if not isinstance(return_metadata, bool) or return_metadata:
         return valid, msg, metadata
     else:
         return valid

--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -17,6 +17,7 @@ obj - object to check
 return_metadata - bool, optional, default=False
     if False, returns only "valid" return
     if True, returns all three return objects
+    if str, list of str, metadata return dict is subset to keys in return_metadata
 var_name: str, optional, default="obj" - name of input in error messages
 
 Returns

--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -68,13 +68,6 @@ def _list_all_equal(obj):
 check_dict = dict()
 
 
-def _ret(valid, msg, metadata, return_metadata):
-    if return_metadata:
-        return valid, msg, metadata
-    else:
-        return valid
-
-
 def check_pdmultiindex_hierarchical(obj, return_metadata=False, var_name="obj"):
 
     ret = check_pdmultiindex_panel(

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -17,6 +17,7 @@ obj - object to check
 return_metadata - bool, optional, default=False
     if False, returns only "valid" return
     if True, returns all three return objects
+    if str, list of str, metadata return dict is subset to keys in return_metadata
 var_name: str, optional, default="obj" - name of input in error messages
 
 Returns

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -44,6 +44,7 @@ import numpy as np
 import pandas as pd
 from pandas.core.dtypes.cast import is_nested_object
 
+from sktime.datatypes._common import _req, _ret
 from sktime.datatypes._series._check import (
     _index_equally_spaced,
     check_pddataframe_series,
@@ -58,13 +59,6 @@ VALID_INDEX_TYPES = (pd.RangeIndex, pd.PeriodIndex, pd.DatetimeIndex)
 def is_in_valid_multiindex_types(x) -> bool:
     """Check that the input type belongs to the valid multiindex types."""
     return isinstance(x, VALID_MULTIINDEX_TYPES) or is_integer_index(x)
-
-
-def _ret(valid, msg, metadata, return_metadata):
-    if return_metadata:
-        return valid, msg, metadata
-    else:
-        return valid
 
 
 def _list_all_equal(obj):
@@ -108,18 +102,28 @@ def check_dflist_panel(obj, return_metadata=False, var_name="obj"):
         return _ret(False, msg, None, return_metadata)
 
     metadata = dict()
-    metadata["is_univariate"] = np.all([res[2]["is_univariate"] for res in check_res])
-    metadata["is_equally_spaced"] = np.all(
-        [res[2]["is_equally_spaced"] for res in check_res]
-    )
-    metadata["is_equal_length"] = _list_all_equal([len(s) for s in obj])
-    metadata["is_empty"] = np.any([res[2]["is_empty"] for res in check_res])
-    metadata["has_nans"] = np.any([res[2]["has_nans"] for res in check_res])
-    metadata["is_one_series"] = n == 1
-    metadata["n_panels"] = 1
-    metadata["is_one_panel"] = True
-
-    metadata["n_instances"] = n
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = np.all(
+            [res[2]["is_univariate"] for res in check_res]
+        )
+    if _req("is_equally_spaced", return_metadata):
+        metadata["is_equally_spaced"] = np.all(
+            [res[2]["is_equally_spaced"] for res in check_res]
+        )
+    if _req("is_equal_length", return_metadata):
+        metadata["is_equal_length"] = _list_all_equal([len(s) for s in obj])
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = np.any([res[2]["is_empty"] for res in check_res])
+    if _req("has_nans", return_metadata):
+        metadata["has_nans"] = np.any([res[2]["has_nans"] for res in check_res])
+    if _req("is_one_series", return_metadata):
+        metadata["is_one_series"] = n == 1
+    if _req("n_panels", return_metadata):
+        metadata["n_panels"] = 1
+    if _req("is_one_panel", return_metadata):
+        metadata["is_one_panel"] = True
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = n
 
     return _ret(True, None, metadata, return_metadata)
 
@@ -138,19 +142,27 @@ def check_numpy3d_panel(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a 3D np.ndarray
     metadata = dict()
-    metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1 or obj.shape[2] < 1
-    metadata["is_univariate"] = obj.shape[1] < 2
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1 or obj.shape[2] < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = obj.shape[1] < 2
     # np.arrays are considered equally spaced and equal length by assumption
-    metadata["is_equally_spaced"] = True
-    metadata["is_equal_length"] = True
+    if _req("is_equally_spaced", return_metadata):
+        metadata["is_equally_spaced"] = True
+    if _req("is_equal_length", return_metadata):
+        metadata["is_equal_length"] = True
 
-    metadata["n_instances"] = obj.shape[0]
-    metadata["is_one_series"] = obj.shape[0] == 1
-    metadata["n_panels"] = 1
-    metadata["is_one_panel"] = True
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = obj.shape[0]
+    if _req("is_one_series", return_metadata):
+        metadata["is_one_series"] = obj.shape[0] == 1
+    if _req("n_panels", return_metadata):
+        metadata["n_panels"] = 1
+    if _req("is_one_panel", return_metadata):
+        metadata["is_one_panel"] = True
 
     # check whether there any nans; only if requested
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = pd.isnull(obj).any()
 
     return _ret(True, None, metadata, return_metadata)
@@ -227,30 +239,48 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj", panel=T
 
     metadata = dict()
 
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = len(obj.columns) < 2
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
+    if _req("has_nans", return_metadata):
+        metadata["has_nans"] = obj.isna().values.any()
+
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
-    if return_metadata:
+    requires_series_grps = [
+        "n_instances", "is_one_series", "is_equal_length", "is_equally_spaced"
+    ]
+    if _req(requires_series_grps, return_metadata):
         series_groups = obj.groupby(level=list(range(index.nlevels - 1)), sort=False)
         n_series = series_groups.ngroups
 
+        if _req("n_instances", return_metadata):
+            metadata["n_instances"] = n_series
+        if _req("is_one_series", return_metadata):
+            metadata["is_one_series"] = n_series == 1
+        if _req("is_equal_length", return_metadata):
+            metadata["is_equal_length"] = _list_all_equal(
+                series_groups.size().to_numpy()
+            )
+        if _req("is_equally_spaced", return_metadata):
+            metadata["is_equally_spaced"] = all(
+                _index_equally_spaced(group.index.get_level_values(-1))
+                for _, group in series_groups
+            )
+
+    requires_panel_grps = ["n_panels", "is_one_panel"]
+    if _req(requires_panel_grps, return_metadata):
         if panel:
             n_panels = 1
         else:
             panel_groups = obj.groupby(level=list(range(index.nlevels - 2)), sort=False)
             n_panels = panel_groups.ngroups
 
-        metadata["is_univariate"] = len(obj.columns) < 2
-        metadata["is_equally_spaced"] = all(
-            _index_equally_spaced(group.index.get_level_values(-1))
-            for _, group in series_groups
-        )
-        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
-        metadata["n_panels"] = n_panels
-        metadata["is_one_panel"] = n_panels == 1
-        metadata["n_instances"] = n_series
-        metadata["is_one_series"] = n_series == 1
-        metadata["has_nans"] = obj.isna().values.any()
-        metadata["is_equal_length"] = _list_all_equal(series_groups.size().to_numpy())
+        if _req("n_panels", return_metadata):
+            metadata["n_panels"] = n_panels
+        if _req("is_one_panel", return_metadata):
+            metadata["is_one_panel"] = n_panels == 1
 
     return _ret(True, None, metadata, return_metadata)
 
@@ -371,18 +401,26 @@ def is_nested_dataframe(obj, return_metadata=False, var_name="obj"):
         return _ret(False, msg, None, return_metadata)
 
     metadata = dict()
-    metadata["is_univariate"] = obj.shape[1] < 2
-    metadata["n_instances"] = len(obj)
-    metadata["is_one_series"] = len(obj) == 1
-    metadata["n_panels"] = 1
-    metadata["is_one_panel"] = True
-    if return_metadata:
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = obj.shape[1] < 2
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = len(obj)
+    if _req("is_one_series", return_metadata):
+        metadata["is_one_series"] = len(obj) == 1
+    if _req("n_panels", return_metadata):
+        metadata["n_panels"] = 1
+    if _req("is_one_panel", return_metadata):
+        metadata["is_one_panel"] = True
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = _nested_dataframe_has_nans(obj)
+    if _req("is_equal_length", return_metadata):
         metadata["is_equal_length"] = not _nested_dataframe_has_unequal(obj)
 
     # todo: this is temporary override, proper is_empty logic needs to be added
-    metadata["is_empty"] = False
-    metadata["is_equally_spaced"] = True
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = False
+    if _req("is_equally_spaced", return_metadata):
+        metadata["is_equally_spaced"] = True
     # end hacks
 
     return _ret(True, None, metadata, return_metadata)
@@ -402,18 +440,24 @@ def check_numpyflat_Panel(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a 3D np.ndarray
     metadata = dict()
-    metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
-    metadata["is_univariate"] = True
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = True
     # np.arrays are considered equally spaced, equal length, by assumption
-    metadata["is_equally_spaced"] = True
-    metadata["is_equal_length"] = True
-    metadata["n_instances"] = obj.shape[0]
-    metadata["is_one_series"] = obj.shape[0] == 1
-    metadata["n_panels"] = 1
-    metadata["is_one_panel"] = True
-
-    # check whether there any nans; only if requested
-    if return_metadata:
+    if _req("is_equally_spaced", return_metadata):
+        metadata["is_equally_spaced"] = True
+    if _req("is_equal_length", return_metadata):
+        metadata["is_equal_length"] = True
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = obj.shape[0]
+    if _req("is_one_series", return_metadata):
+        metadata["is_one_series"] = obj.shape[0] == 1
+    if _req("n_panels", return_metadata):
+        metadata["n_panels"] = 1
+    if _req("is_one_panel", return_metadata):
+        metadata["is_one_panel"] = True
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = np.isnan(obj).any()
 
     return _ret(True, None, metadata, return_metadata)

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -249,7 +249,10 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj", panel=T
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
     requires_series_grps = [
-        "n_instances", "is_one_series", "is_equal_length", "is_equally_spaced"
+        "n_instances",
+        "is_one_series",
+        "is_equal_length",
+        "is_equally_spaced",
     ]
     if _req(requires_series_grps, return_metadata):
         series_groups = obj.groupby(level=list(range(index.nlevels - 1)), sort=False)

--- a/sktime/datatypes/_proba/_check.py
+++ b/sktime/datatypes/_proba/_check.py
@@ -40,18 +40,14 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
+from sktime.datatypes._common import _req, _ret as ret
+
 check_dict = dict()
 
 
 def check_pred_quantiles_proba(obj, return_metadata=False, var_name="obj"):
 
     metadata = dict()
-
-    def ret(valid, msg, metadata, return_metadata):
-        if return_metadata:
-            return valid, msg, metadata
-        else:
-            return valid
 
     # check if the input is a dataframe
     if not isinstance(obj, pd.DataFrame):
@@ -60,7 +56,8 @@ def check_pred_quantiles_proba(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a pd.DataFrame
     index = obj.index
-    metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
 
     # check that column indices are unique
     if not len(set(obj.columns)) == len(obj.columns):
@@ -100,8 +97,9 @@ def check_pred_quantiles_proba(obj, return_metadata=False, var_name="obj"):
         return ret(False, msg, None, return_metadata)
 
     # compute more metadata, only if needed
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
+    if _req("is_univariate", return_metadata):
         metadata["is_univariate"] = len(colidx.get_level_values(0).unique()) == 1
 
     return ret(True, None, metadata, return_metadata)
@@ -114,12 +112,6 @@ def check_pred_interval_proba(obj, return_metadata=False, var_name="obj"):
 
     metadata = dict()
 
-    def ret(valid, msg, metadata, return_metadata):
-        if return_metadata:
-            return valid, msg, metadata
-        else:
-            return valid
-
     # check if the input is a dataframe
     if not isinstance(obj, pd.DataFrame):
         msg = f"{var_name} should be a pd.DataFrame"
@@ -127,7 +119,8 @@ def check_pred_interval_proba(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a pd.DataFrame
     index = obj.index
-    metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
 
     # check that column indices are unique
     if not len(set(obj.columns)) == len(obj.columns):
@@ -171,8 +164,9 @@ def check_pred_interval_proba(obj, return_metadata=False, var_name="obj"):
         return ret(False, msg, None, return_metadata)
 
     # compute more metadata, only if needed
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
+    if _req("is_univariate", return_metadata):
         metadata["is_univariate"] = len(colidx.get_level_values(0).unique()) == 1
 
     return ret(True, None, metadata, return_metadata)

--- a/sktime/datatypes/_proba/_check.py
+++ b/sktime/datatypes/_proba/_check.py
@@ -17,6 +17,7 @@ obj - object to check
 return_metadata - bool, optional, default=False
     if False, returns only "valid" return
     if True, returns all three return objects
+    if str, list of str, metadata return dict is subset to keys in return_metadata
 var_name: str, optional, default="obj" - name of input in error messages
 
 Returns

--- a/sktime/datatypes/_proba/_check.py
+++ b/sktime/datatypes/_proba/_check.py
@@ -40,7 +40,8 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
-from sktime.datatypes._common import _req, _ret as ret
+from sktime.datatypes._common import _req
+from sktime.datatypes._common import _ret as ret
 
 check_dict = dict()
 

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -40,7 +40,8 @@ __all__ = ["check_dict"]
 import numpy as np
 import pandas as pd
 
-from sktime.datatypes._common import _req, _ret as ret
+from sktime.datatypes._common import _req
+from sktime.datatypes._common import _ret as ret
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 from sktime.utils.validation.series import is_in_valid_index_types
 

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -17,6 +17,7 @@ obj - object to check
 return_metadata - bool, optional, default=False
     if False, returns only "valid" return
     if True, returns all three return objects
+    if str, list of str, metadata return dict is subset to keys in return_metadata
 var_name: str, optional, default="obj" - name of input in error messages
 
 Returns

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -40,6 +40,7 @@ __all__ = ["check_dict"]
 import numpy as np
 import pandas as pd
 
+from sktime.datatypes._common import _req, _ret as ret
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 from sktime.utils.validation.series import is_in_valid_index_types
 
@@ -56,20 +57,16 @@ def check_pddataframe_series(obj, return_metadata=False, var_name="obj"):
 
     metadata = dict()
 
-    def ret(valid, msg, metadata, return_metadata):
-        if return_metadata:
-            return valid, msg, metadata
-        else:
-            return valid
-
     if not isinstance(obj, pd.DataFrame):
         msg = f"{var_name} must be a pandas.DataFrame, found {type(obj)}"
         return ret(False, msg, None, return_metadata)
 
     # we now know obj is a pd.DataFrame
     index = obj.index
-    metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
-    metadata["is_univariate"] = len(obj.columns) < 2
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = len(obj.columns) < 2
 
     # check that columns are unique
     if not obj.columns.is_unique:
@@ -104,8 +101,9 @@ def check_pddataframe_series(obj, return_metadata=False, var_name="obj"):
 
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
-    if return_metadata:
+    if _req("is_equally_spaced", return_metadata):
         metadata["is_equally_spaced"] = _index_equally_spaced(index)
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
 
     return ret(True, None, metadata, return_metadata)
@@ -118,20 +116,16 @@ def check_pdseries_series(obj, return_metadata=False, var_name="obj"):
 
     metadata = dict()
 
-    def ret(valid, msg, metadata, return_metadata):
-        if return_metadata:
-            return valid, msg, metadata
-        else:
-            return valid
-
     if not isinstance(obj, pd.Series):
         msg = f"{var_name} must be a pandas.Series, found {type(obj)}"
         return ret(False, msg, None, return_metadata)
 
     # we now know obj is a pd.Series
     index = obj.index
-    metadata["is_empty"] = len(index) < 1
-    metadata["is_univariate"] = True
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = True
 
     # check that dtype is not object
     if "object" == obj.dtypes:
@@ -161,8 +155,9 @@ def check_pdseries_series(obj, return_metadata=False, var_name="obj"):
 
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
-    if return_metadata:
+    if _req("is_equally_spaced", return_metadata):
         metadata["is_equally_spaced"] = _index_equally_spaced(index)
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
 
     return ret(True, None, metadata, return_metadata)
@@ -175,33 +170,32 @@ def check_numpy_series(obj, return_metadata=False, var_name="obj"):
 
     metadata = dict()
 
-    def ret(valid, msg, metadata, return_metadata):
-        if return_metadata:
-            return valid, msg, metadata
-        else:
-            return valid
-
     if not isinstance(obj, np.ndarray):
         msg = f"{var_name} must be a numpy.ndarray, found {type(obj)}"
         return ret(False, msg, None, return_metadata)
 
     if len(obj.shape) == 2:
         # we now know obj is a 2D np.ndarray
-        metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
-        metadata["is_univariate"] = obj.shape[1] < 2
+        if _req("is_empty", return_metadata):
+            metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
+        if _req("is_univariate", return_metadata):
+            metadata["is_univariate"] = obj.shape[1] < 2
     elif len(obj.shape) == 1:
         # we now know obj is a 1D np.ndarray
-        metadata["is_empty"] = len(obj) < 1
-        metadata["is_univariate"] = True
+        if _req("is_empty", return_metadata):
+            metadata["is_empty"] = len(obj) < 1
+        if _req("is_univariate", return_metadata):
+            metadata["is_univariate"] = True
     else:
         msg = f"{var_name} must be 1D or 2D numpy.ndarray, but found {len(obj.shape)}D"
         return ret(False, msg, None, return_metadata)
 
     # np.arrays are considered equally spaced by assumption
-    metadata["is_equally_spaced"] = True
+    if _req("is_equally_spaced", return_metadata):
+        metadata["is_equally_spaced"] = True
 
     # check whether there any nans; compute only if requested
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = pd.isnull(obj).any()
 
     return ret(True, None, metadata, return_metadata)
@@ -262,11 +256,6 @@ if _check_soft_dependencies("xarray", severity="none"):
     def check_xrdataarray_series(obj, return_metadata=False, var_name="obj"):
         metadata = {}
 
-        def ret(valid, msg, metadata, return_metadata):
-            if return_metadata:
-                return valid, msg, metadata
-            return valid
-
         if not isinstance(obj, xr.DataArray):
             msg = f"{var_name} must be a xarray.DataArray, found {type(obj)}"
             return ret(False, msg, None, return_metadata)
@@ -279,9 +268,11 @@ if _check_soft_dependencies("xarray", severity="none"):
         # The first dimension is the index of the time series in sktimelen
         index = obj.indexes[obj.dims[0]]
 
-        metadata["is_empty"] = len(index) < 1 or len(obj.values) < 1
+        if _req("is_empty", return_metadata):
+            metadata["is_empty"] = len(index) < 1 or len(obj.values) < 1
         # The second dimension is the set of columns
-        metadata["is_univariate"] = len(obj.dims) == 1 or len(obj[obj.dims[1]]) < 2
+        if _req("is_univariate", return_metadata):
+            metadata["is_univariate"] = len(obj.dims) == 1 or len(obj[obj.dims[1]]) < 2
 
         # check that columns are unique
         if not len(obj.dims) == len(set(obj.dims)):
@@ -316,8 +307,9 @@ if _check_soft_dependencies("xarray", severity="none"):
 
         # check whether index is equally spaced or if there are any nans
         #   compute only if needed
-        if return_metadata:
+        if _req("is_equally_spaced", return_metadata):
             metadata["is_equally_spaced"] = _index_equally_spaced(index)
+        if _req("has_nans", return_metadata):
             metadata["has_nans"] = obj.isnull().values.any()
 
         return ret(True, None, metadata, return_metadata)

--- a/sktime/datatypes/_table/_check.py
+++ b/sktime/datatypes/_table/_check.py
@@ -40,17 +40,12 @@ __all__ = ["check_dict"]
 import numpy as np
 import pandas as pd
 
+from sktime.datatypes._common import _req, _ret
+
 check_dict = dict()
 
 
 PRIMITIVE_TYPES = (float, int, str)
-
-
-def _ret(valid, msg, metadata, return_metadata):
-    if return_metadata:
-        return valid, msg, metadata
-    else:
-        return valid
 
 
 def check_pddataframe_table(obj, return_metadata=False, var_name="obj"):
@@ -63,13 +58,13 @@ def check_pddataframe_table(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a pd.DataFrame
     index = obj.index
-    metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
-    metadata["is_univariate"] = len(obj.columns) < 2
-    metadata["n_instances"] = len(index)
-
-    # check whether there are any nans
-    #   compute only if needed
-    if return_metadata:
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = len(obj.columns) < 2
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = len(index)
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
 
     # check that no dtype is object
@@ -93,9 +88,12 @@ def check_pdseries_table(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a pd.Series
     index = obj.index
-    metadata["is_empty"] = len(index) < 1
-    metadata["is_univariate"] = True
-    metadata["n_instances"] = len(index)
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(index) < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = True
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = len(index)
 
     # check that dtype is not object
     if "object" == obj.dtypes:
@@ -104,7 +102,7 @@ def check_pdseries_table(obj, return_metadata=False, var_name="obj"):
 
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
 
     return _ret(True, None, metadata, return_metadata)
@@ -126,12 +124,15 @@ def check_numpy1d_table(obj, return_metadata=False, var_name="obj"):
         return _ret(False, msg, None, return_metadata)
 
     # we now know obj is a 1D np.ndarray
-    metadata["is_empty"] = len(obj) < 1
-    metadata["n_instances"] = len(obj)
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(obj) < 1
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = len(obj)
     # 1D numpy arrays are considered univariate
-    metadata["is_univariate"] = True
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = True
     # check whether there any nans; compute only if requested
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = pd.isnull(obj).any()
 
     return _ret(True, None, metadata, return_metadata)
@@ -153,11 +154,14 @@ def check_numpy2d_table(obj, return_metadata=False, var_name="obj"):
         return _ret(False, msg, None, return_metadata)
 
     # we now know obj is a 2D np.ndarray
-    metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
-    metadata["is_univariate"] = obj.shape[1] < 2
-    metadata["n_instances"] = obj.shape[0]
+    if _req("is_empty", return_metadata):
+        metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
+    if _req("is_univariate", return_metadata):
+        metadata["is_univariate"] = obj.shape[1] < 2
+    if _req("n_instances", return_metadata):
+        metadata["n_instances"] = obj.shape[0]
     # check whether there any nans; compute only if requested
-    if return_metadata:
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = pd.isnull(obj).any()
 
     return _ret(True, None, metadata, return_metadata)
@@ -191,7 +195,7 @@ def check_list_of_dict_table(obj, return_metadata=False, var_name="obj"):
 
     # we now know obj is a list of dict
     # check whether there any nans; compute only if requested
-    if return_metadata:
+    if _req("is_univariate", return_metadata):
         multivariate_because_one_row = np.any([len(x) > 1 for x in obj])
         if not multivariate_because_one_row:
             all_keys = np.unique([key for d in obj for key in d.keys()])
@@ -200,10 +204,13 @@ def check_list_of_dict_table(obj, return_metadata=False, var_name="obj"):
         else:
             multivariate = multivariate_because_one_row
         metadata["is_univariate"] = not multivariate
+    if _req("has_nans", return_metadata):
         metadata["has_nans"] = np.any(
             [pd.isnull(d[key]) for d in obj for key in d.keys()]
         )
+    if _req("is_empty", return_metadata):
         metadata["is_empty"] = len(obj) < 1 or np.all([len(x) < 1 for x in obj])
+    if _req("n_instances", return_metadata):
         metadata["n_instances"] = len(obj)
 
     return _ret(True, None, metadata, return_metadata)

--- a/sktime/datatypes/tests/test_check.py
+++ b/sktime/datatypes/tests/test_check.py
@@ -174,9 +174,10 @@ def test_check_metadata_inference(scitype, mtype, fixture_index):
     # is_equal_index is not fully supported yet in inference
     EXCLUDE_KEYS = ["is_equal_index"]
 
-    expected_metadata = expected_metadata.copy()
-    subset_keys = set(expected_metadata.keys()).difference(EXCLUDE_KEYS)
-    expected_metadata = {key: expected_metadata[key] for key in subset_keys}
+    if metadata_provided:
+        expected_metadata = expected_metadata.copy()
+        subset_keys = set(expected_metadata.keys()).difference(EXCLUDE_KEYS)
+        expected_metadata = {key: expected_metadata[key] for key in subset_keys}
 
     # check fixtures that exist against checks that exist, full metadata query
     if fixture is not None and check_is_defined and metadata_provided:

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -473,7 +473,7 @@ class BasePairwiseTransformerPanel(BaseEstimator):
             usually df-list, list of pd.DataFrame, unless overridden
         """
         check_res = check_is_scitype(
-            X, ["Series", "Panel"], return_metadata=True, var_name=var_name
+            X, ["Series", "Panel"], return_metadata=[], var_name=var_name
         )
         X_valid = check_res[0]
         metadata = check_res[2]

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1342,11 +1342,11 @@ class BaseForecaster(BaseEstimator):
 
         # checking y
         if y is not None:
-            y_metadata_keys = ["is_univariate"]
+            y_metadata_required = ["is_univariate"]
             y_valid, _, y_metadata = check_is_scitype(
                 y,
                 scitype=ALLOWED_SCITYPES,
-                return_metadata=y_metadata_keys,
+                return_metadata=y_metadata_required,
                 var_name="y"
             )
             msg = (

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1347,7 +1347,7 @@ class BaseForecaster(BaseEstimator):
                 y,
                 scitype=ALLOWED_SCITYPES,
                 return_metadata=y_metadata_required,
-                var_name="y"
+                var_name="y",
             )
             msg = (
                 "y must be in an sktime compatible format, "

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1342,7 +1342,13 @@ class BaseForecaster(BaseEstimator):
 
         # checking y
         if y is not None:
-            y_metadata_required = ["is_univariate"]
+            # request only required metadata from checks
+            y_metadata_required = []
+            if self.get_tag("scitype:y") != "both":
+                y_metadata_required += ["is_univariate"]
+            if not self.get_tag("handles-missing-data"):
+                y_metadata_required += ["has_nans"]
+
             y_valid, _, y_metadata = check_is_scitype(
                 y,
                 scitype=ALLOWED_SCITYPES,
@@ -1392,8 +1398,16 @@ class BaseForecaster(BaseEstimator):
 
         # checking X
         if X is not None:
+            # request only required metadata from checks
+            X_metadata_required = []
+            if not self.get_tag("handles-missing-data"):
+                X_metadata_required += ["has_nans"]
+
             X_valid, _, X_metadata = check_is_scitype(
-                X, scitype=ALLOWED_SCITYPES, return_metadata=[], var_name="X"
+                X,
+                scitype=ALLOWED_SCITYPES,
+                return_metadata=X_metadata_required,
+                var_name="X",
             )
 
             msg = (

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1342,8 +1342,12 @@ class BaseForecaster(BaseEstimator):
 
         # checking y
         if y is not None:
+            y_metadata_keys = ["is_univariate"]
             y_valid, _, y_metadata = check_is_scitype(
-                y, scitype=ALLOWED_SCITYPES, return_metadata=True, var_name="y"
+                y,
+                scitype=ALLOWED_SCITYPES,
+                return_metadata=y_metadata_keys,
+                var_name="y"
             )
             msg = (
                 "y must be in an sktime compatible format, "
@@ -1389,7 +1393,7 @@ class BaseForecaster(BaseEstimator):
         # checking X
         if X is not None:
             X_valid, _, X_metadata = check_is_scitype(
-                X, scitype=ALLOWED_SCITYPES, return_metadata=True, var_name="X"
+                X, scitype=ALLOWED_SCITYPES, return_metadata=[], var_name="X"
             )
 
             msg = (

--- a/sktime/param_est/base.py
+++ b/sktime/param_est/base.py
@@ -257,7 +257,7 @@ class BaseParamFitter(BaseEstimator):
 
         # checking X
         X_valid, _, X_metadata = check_is_scitype(
-            X, scitype=ALLOWED_SCITYPES, return_metadata=True, var_name="X"
+            X, scitype=ALLOWED_SCITYPES, return_metadata=[], var_name="X"
         )
         msg = (
             "X must be in an sktime compatible format, "

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -62,6 +62,15 @@ class BaseRegressor(BaseEstimator, ABC):
         "capability:multithreading": False,
     }
 
+    # convenience constant to control which metadata of input data
+    # are regularly retrieved in input checks
+    METADATA_REQ_IN_CHECKS = [
+        "n_instances",
+        "has_nans",
+        "is_univariate",
+        "is_equal_length",
+    ]
+
     def __init__(self):
         self.fit_time_ = 0
         self._class_dictionary = {}
@@ -142,7 +151,9 @@ class BaseRegressor(BaseEstimator, ABC):
         # convenience conversions to allow user flexibility:
         # if X is 2D array, convert to 3D, if y is Series, convert to numpy
         X, y = _internal_convert(X, y)
-        X_metadata = _check_regressor_input(X, y)
+        X_metadata = _check_regressor_input(
+            X, y, return_metadata=self.METADATA_REQ_IN_CHECKS
+        )
         self._X_metadata = X_metadata
         missing = X_metadata["has_nans"]
         multivariate = not X_metadata["is_univariate"]
@@ -289,7 +300,9 @@ class BaseRegressor(BaseEstimator, ABC):
         ValueError if the capabilities in self._tags do not handle the data.
         """
         X = _internal_convert(X)
-        X_metadata = _check_regressor_input(X)
+        X_metadata = _check_regressor_input(
+            X, return_metadata=self.METADATA_REQ_IN_CHECKS
+        )
         missing = X_metadata["has_nans"]
         multivariate = not X_metadata["is_univariate"]
         unequal = not X_metadata["is_equal_length"]
@@ -374,6 +387,7 @@ def _check_regressor_input(
     X,
     y=None,
     enforce_min_instances=1,
+    return_metadata=True,
 ):
     """Check whether input X and y are valid formats with minimum data.
 
@@ -385,6 +399,8 @@ def _check_regressor_input(
     y : check whether a pd.Series or np.array
     enforce_min_instances : int, optional (default=1)
         check there are a minimum number of instances.
+    return_metadata : bool, str, or list of str
+        metadata fields to return with X_metadata, input to check_is_scitype
 
     Returns
     -------
@@ -396,7 +412,9 @@ def _check_regressor_input(
         If y or X is invalid input data type, or there is not enough data
     """
     # Check X is valid input type and recover the data characteristics
-    X_valid, _, X_metadata = check_is_scitype(X, scitype="Panel", return_metadata=True)
+    X_valid, _, X_metadata = check_is_scitype(
+        X, scitype="Panel", return_metadata=return_metadata
+    )
     if not X_valid:
         raise TypeError(
             f"X is not of a supported input data type."

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -916,10 +916,11 @@ class BaseTransformer(BaseEstimator):
         ALLOWED_MTYPES = self.ALLOWED_INPUT_MTYPES
 
         # checking X
+        X_metadata_required = ["is_univariate"]
         X_valid, msg, X_metadata = check_is_scitype(
             X,
             scitype=ALLOWED_SCITYPES,
-            return_metadata=True,
+            return_metadata=X_metadata_required,
             var_name="X",
         )
 
@@ -980,7 +981,7 @@ class BaseTransformer(BaseEstimator):
                 y_possible_scitypes = ["Panel", "Hierarchical"]
 
             y_valid, _, y_metadata = check_is_scitype(
-                y, scitype=y_possible_scitypes, return_metadata=True, var_name="y"
+                y, scitype=y_possible_scitypes, return_metadata=[], var_name="y"
             )
             if not y_valid:
                 raise TypeError("y " + msg_invalid_input)


### PR DESCRIPTION
This PR aims to turn off all unnecessary input checks in base class boilerplate.

Relies on https://github.com/sktime/sktime/pull/4389 for granular control on metadata computation.

The blanket strategy is controlling the input checks at the level of the interface between base classes and `check_is_scitype` or `check_is_mtype`. An argument `return_metadata=True` is replaced by `return_metadata=` the list of metadata fields that is subsequently actually used in the current code.

This typically avoids the most expensive metadata calculations such as index checks, and should therefore speed up computation time substantially for cases where that turns out to be the bottleneck.