### PR TITLE
[DOC] add example for `ForecastX` forecasting only some exogeneous variables

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -1220,6 +1220,18 @@ class ForecastX(BaseForecaster):
     >>> pipe = pipe.fit(y, X=X, fh=fh)  # doctest: +SKIP
     >>> # this now works without X from the future of y!
     >>> y_pred = pipe.predict(fh=fh)  # doctest: +SKIP
+
+    to forecast only some columns, use the `columns` arg,
+    and pass known columns to `predict`:
+    >>> columns = ["ARMED", "POP"]
+    >>> pipe = ForecastX(  # doctest: +SKIP
+    ...     forecaster_X=VAR(),
+    ...     forecaster_y=SARIMAX(),
+    ...     columns=columns,
+    ... )
+    >>> pipe = pipe.fit(y_train, X=X_train, fh=fh)  # doctest: +SKIP
+    >>> # dropping ["ARMED", "POP"] = columns where we expect not to have future values
+    >>> y_pred = pipe.predict(fh=fh, X=X_test.drop(columns=columns))  # doctest: +SKIP
     """
 
     _tags = {


### PR DESCRIPTION
This PR adds an example in the docstring of `ForecastX` that shows how to use it to forecast only some columns.

Related to https://github.com/sktime/sktime/issues/4386, as this is @yarnabrina's use case.