### PR TITLE
[BUG] fix unreported probabilistic prediction bugs detected through #4393

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -185,6 +185,7 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                     y = pd.concat(yt, axis=1)
                     flipcols = [n - 1] + list(range(n - 1))
                     y.columns = y.columns.reorder_levels(flipcols)
+                    y = y.loc[:, idx]
                 else:
                     raise ValueError('mode arg must be None or "proba"')
         return y


### PR DESCRIPTION
This PR fixes a number of unreported probabilistic prediction bugs detected through https://github.com/sktime/sktime/pull/4393:

* `TransformedTargetForecaster` would return colums of a prediction interval forecast in unexpected order. This is fixed by reordering.