### PR TITLE
[ENH] Clustering plot function now supports alpha (transparency) value for individual timeseries lines

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2146,6 +2146,15 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "Aylr",
+      "name": "Taylor Miller",
+      "avatar_url": "https://avatars.githubusercontent.com/u/928247?v=4",
+      "profile": "https://github.com/Aylr",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,6 +35,8 @@ sktime/classification/shapelet_based/_stc.py @ABostrom @MatthewMiddlehurst @Tony
 sktime/classification/sklearn/_continuous_interval_tree.py @MatthewMiddlehurst
 sktime/classification/sklearn/_rotation_forest.py @MatthewMiddlehurst
 
+sktime/clustering/utils/plotting/_plot_partitions.py @Aylr
+
 sktime/transformations/panel/dictionary_based/_paa.py @patrickzib @MatthewMiddlehurst
 sktime/transformations/panel/dictionary_based/_sax.py @patrickzib @MatthewMiddlehurst
 sktime/transformations/panel/dictionary_based/_sfa.py @patrickzib @MatthewMiddlehurst

--- a/sktime/clustering/utils/plotting/_plot_partitions.py
+++ b/sktime/clustering/utils/plotting/_plot_partitions.py
@@ -13,10 +13,10 @@ from sktime.datatypes import convert_to
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 
-def _plot(cluster_values, center, axes):
+def _plot(cluster_values, center, axes, alpha: float = 1.0):
     for cluster_series in cluster_values:
         for cluster in cluster_series:
-            axes.plot(cluster, color="b")
+            axes.plot(cluster, color="b", alpha=alpha)
     axes.plot(center[0], color="r")
 
 
@@ -58,7 +58,12 @@ def plot_series(X: TimeSeriesInstances):
     plt.show()
 
 
-def plot_cluster_algorithm(model: TimeSeriesLloyds, X: TimeSeriesInstances, k: int):
+def plot_cluster_algorithm(
+    model: TimeSeriesLloyds,
+    X: TimeSeriesInstances,
+    k: int,
+    timeseries_alpha: float = 1.0,
+):
     """Plot the results from a univariate partitioning algorithm.
 
     Parameters
@@ -69,6 +74,8 @@ def plot_cluster_algorithm(model: TimeSeriesLloyds, X: TimeSeriesInstances, k: i
         The series to predict the values for
     k: int
         Number of centers
+    timeseries_alpha: float
+        Alpha (transparency) value for the individual timeseries lines.
     """
     _check_soft_dependencies("matplotlib")
     import matplotlib.patches as mpatches
@@ -86,7 +93,7 @@ def plot_cluster_algorithm(model: TimeSeriesLloyds, X: TimeSeriesInstances, k: i
 
     fig, axes = plt.subplots(nrows=k, ncols=1)
     for i in range(k):
-        _plot(series_values[i], centers[i], axes[i])
+        _plot(series_values[i], centers[i], axes[i], alpha=timeseries_alpha)
 
     blue_patch = mpatches.Patch(color="blue", label="Series that belong to the cluster")
     red_patch = mpatches.Patch(color="red", label="Cluster centers")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

A user with large numbers of time series using the existing clustering plotting function `plot_cluster_algorithm` can suffer from  [over plotting](https://www.quanthub.com/how-do-you-fix-overplotting/). This is easily solved with the addition of transparency.

This PR introduces an optional argument that allows a user to customize the transparency of the individual time series plots.

**Before:**

```python
plot_cluster_algorithm(k_means, df, k_means.n_clusters)
```
<img width="532" alt="Screen Shot 2023-03-28 at 9 59 19 AM" src="https://user-images.githubusercontent.com/928247/228298275-036c3823-2fe9-4fa6-806b-06f3a3f7d567.png">

**After:**

```python
plot_cluster_algorithm(k_means, df, k_means.n_clusters, alpha=0.2)
```
<img width="530" alt="Screen Shot 2023-03-28 at 9 59 47 AM" src="https://user-images.githubusercontent.com/928247/228298470-ebc752e0-6484-45e9-beaf-851a45d7c2d7.png">


#### Does your contribution introduce a new dependency? If yes, which one?

No.
<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

No.

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [x] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
