### PR TITLE
[BUG] Support multiple coverage values for VECM

### DIFF
--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -260,6 +260,7 @@ class VECM(_StatsModelsAdapter):
         )
         int_idx = pd.MultiIndex.from_product([var_names, coverage, ["lower", "upper"]])
 
+        all_values = []  # will store predicted intervals for each coverage value
         for c in coverage:
             alpha = 1 - c
             _, y_lower, y_upper = self._fitted_forecaster.predict(
@@ -273,8 +274,10 @@ class VECM(_StatsModelsAdapter):
                 values.append(y_lower[0][v_idx])
                 values.append(y_upper[0][v_idx])
 
+            all_values.extend(values)
+
         pred_int = pd.DataFrame(
-            [values], index=fh.to_absolute(self.cutoff), columns=int_idx
+            [all_values], index=fh.to_absolute(self.cutoff), columns=int_idx
         )
 
         return pred_int

--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -259,7 +259,6 @@ class VECM(_StatsModelsAdapter):
             else self._y.columns.values
         )
         int_idx = pd.MultiIndex.from_product([var_names, coverage, ["lower", "upper"]])
-        # pred_int = pd.DataFrame(index=int_idx)
 
         for c in coverage:
             alpha = 1 - c
@@ -273,8 +272,7 @@ class VECM(_StatsModelsAdapter):
             for v_idx in range(len(var_names)):
                 values.append(y_lower[0][v_idx])
                 values.append(y_upper[0][v_idx])
-                # pred_int.loc[(var_names[v_idx], c, "lower"), :] = (y_lower[0][v_idx])
-                # pred_int.loc[(var_names[v_idx], c, "upper"), :] = (y_upper[0][v_idx])
+
         pred_int = pd.DataFrame(
             [values], index=fh.to_absolute(self.cutoff), columns=int_idx
         )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
See also #4394 (relevant comment: https://github.com/sktime/sktime/pull/4394#issuecomment-1489052793).

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
The previous implementation of `VECM` caused `ValueError` when `coverage` was passed as a list of float to `predict_interval`. This was caused because lower/upper bounds determined for different coverages were not stored, and it was trying to match the last iteration with all columns generated independently. This PR addresses that by combining the results from all the different coverage values, and then creating the final results.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
No.

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
