### PR TITLE
[ENH] `PluginParamsForecaster` to accept any estimator, conformal tuned fast example

### DIFF
--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -276,12 +276,9 @@ def get_cutoff(
         if not return_index:
             return idx[ix]
         res = idx[[ix]]
-        if hasattr(idx, "freq"):
-            if idx.freq is None:
-                res.freq = pd.infer_freq(idx)
-            else:
-                if res.freq != idx.freq:
-                    res.freq = idx.freq
+        if hasattr(idx, "freq") and idx.freq is not None:
+            if res.freq != idx.freq:
+                res.freq = idx.freq
         return res
 
     if isinstance(obj, pd.Series):

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -276,9 +276,12 @@ def get_cutoff(
         if not return_index:
             return idx[ix]
         res = idx[[ix]]
-        if hasattr(idx, "freq") and idx.freq is not None:
-            if res.freq != idx.freq:
-                res.freq = idx.freq
+        if hasattr(idx, "freq"):
+            if idx.freq is None:
+                res.freq = pd.infer_freq(idx)
+            else:
+                if res.freq != idx.freq:
+                    res.freq = idx.freq
         return res
 
     if isinstance(obj, pd.Series):

--- a/sktime/datatypes/tests/test_utils.py
+++ b/sktime/datatypes/tests/test_utils.py
@@ -241,7 +241,7 @@ def test_get_cutoff_inferred_freq():
 
     past_data = pd.DataFrame(
         {
-            "time_identifier": pandas.to_datetime(
+            "time_identifier": pd.to_datetime(
                 [
                     "2024-01-01",
                     "2024-01-02",

--- a/sktime/datatypes/tests/test_utils.py
+++ b/sktime/datatypes/tests/test_utils.py
@@ -232,6 +232,36 @@ def test_get_cutoff_wrong_input(bad_inputs):
         get_cutoff(bad_inputs, check_input=True)
 
 
+def test_get_cutoff_inferred_freq():
+    """Tests that get_cutoff infers the freq in a case where it is not directly set.
+
+    Ensures that the bug in #4405 does not occur, combined with the forecaster contract.
+    """
+    np.random.seed(seed=0)
+
+    past_data = pd.DataFrame(
+        {
+            "time_identifier": pandas.to_datetime(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-04",
+                    "2024-01-05",
+                    "2024-01-06",
+                    "2024-01-07",
+                    "2024-01-08",
+                ],
+                format="%Y-%m-%d",
+            ),
+            "series_data": np.random.random(size=8),
+        }
+    )
+    past_data = past_data.set_index(["time_identifier"])
+    cutoff = get_cutoff(past_data, return_index=True)
+    assert cutoff.freq == "D"
+
+
 @pytest.mark.parametrize("window_length, lag", [(2, 0), (None, 0), (4, 1)])
 @pytest.mark.parametrize("scitype,mtype", SCITYPE_MTYPE_PAIRS)
 def test_get_window_output_type(scitype, mtype, window_length, lag):

--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -86,6 +86,36 @@ class ConformalIntervals(BaseForecaster):
     >>> conformal_forecaster.fit(y, fh=[1,2,3])
     ConformalIntervals(...)
     >>> pred_int = conformal_forecaster.predict_interval()
+
+    recommended use of ConformalIntervals together with ForecastingGridSearch
+    is by 1. first running grid search, 2. then ConformalIntervals on the tuned params
+    otherwise, nested sliding windows will cause high compute requirement
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.conformal import ConformalIntervals
+    >>> from sktime.forecasting.naive import NaiveForecaster
+    >>> from sktime.forecasting.model_selection import ForecastingGridSearchCV
+    >>> from sktime.forecasting.model_selection import ExpandingWindowSplitter
+    >>> from sktime.param_est.plugin import PluginParamsForecaster
+    >>> # part 1 = grid search
+    >>> cv = ExpandingWindowSplitter(fh=[1,2,3])
+    >>> forecaster = NaiveForecaster()
+    >>> param_grid = {"strategy" : ["last", "mean", "drift"]}
+    >>> gscv = ForecastingGridSearchCV(
+    ...     forecaster=forecaster,
+    ...     param_grid=param_grid,
+    ...     cv=cv,
+    ... )
+    >>> # part 2 = plug in results of grid search into conformal intervals estimator
+    >>> conformal_with_fallback = ConformalIntervals(NaiveForecaster())
+    >>> gscv_with_conformal = PluginParamsForecaster(
+    ...     gscv,
+    ...     conformal_with_fallback,
+    ...     params={"best_forecaster": "forecaster"},
+    ... )
+    >>> y = load_airline()
+    >>> gscv_with_conformal.fit(y, fh=[1, 2, 3])
+    PluginParamsForecaster(...)
+    >>> y_pred_quantiles = gscv_with_conformal.predict_quantiles()
     """
 
     _tags = {

--- a/sktime/param_est/plugin.py
+++ b/sktime/param_est/plugin.py
@@ -149,7 +149,7 @@ class PluginParamsForecaster(_DelegatedForecaster):
         # y is passed always
         # X is passed if param_est fit has at least two arguments
         # fh is passed if any remaining argument is fh
-        inner_params = list(signature(param_est).parameters.keys())
+        inner_params = list(signature(param_est.fit).parameters.keys())
         fit_kwargs = {}
         if len(inner_params) > 1:
             fit_kwargs[inner_params[1]] = X

--- a/sktime/param_est/plugin.py
+++ b/sktime/param_est/plugin.py
@@ -5,22 +5,36 @@
 __author__ = ["fkiraly"]
 __all__ = ["PluginParamsForecaster"]
 
+from inspect import signature
+
 from sktime.forecasting.base._delegate import _DelegatedForecaster
 
 
 class PluginParamsForecaster(_DelegatedForecaster):
     """Plugs parameters from a parameter estimator into a forecaster.
 
-    In `fit`, first fits `param_est` to data.
+    In `fit`, first fits `param_est` to data passed:
+
+    * `y` of `fit` is passed as the first arg to `param_est.fit`
+    * `X` of `fit` is passed as the second arg, if `param_est.fit` has a second arg
+    * `fh` of `fit` is passed as `fh`, if any remaining arg of `param_est.fit` is `fh`
+
     Then, does `forecaster.set_params` with desired/selected parameters.
-    After that, behaves as `forecaster` with those parameters set.
+    Parameters of the fitted `param_est` are passed on to `forecaster`,
+    from/to pairs are as specified by the `params` parameter of `self`, see below.
+
+    Then, fits `forecaster` to the data passed in `fit`.
+
+    After that, behaves identically to `forecaster` with those parameters set.
+    `update` behaviour is controlled by the `update_params` parameter.
 
     Example: `param_est` seasonality test to determine `sp` parameter;
         `forecaster` being any forecaster with an `sp` parameter.
 
     Parameters
     ----------
-    param_est : parameter estimator, i.e., estimator inheriting from BaseParamFitter
+    param_est : sktime estimator object with a fit method, inheriting from BaseEstimator
+        e.g., estimator inheriting from BaseParamFitter or forecaster
         this is a "blueprint" estimator, state does not change when `fit` is called
     forecaster : sktime forecaster, i.e., estimator inheriting from BaseForecaster
         this is a "blueprint" estimator, state does not change when `fit` is called
@@ -130,7 +144,19 @@ class PluginParamsForecaster(_DelegatedForecaster):
 
         # fit the parameter estimator to y
         param_est = self.param_est_
-        param_est.fit(y)
+
+        # map args y, X, fh onto inner signature
+        # y is passed always
+        # X is passed if param_est fit has at least two arguments
+        # fh is passed if any remaining argument is fh
+        inner_params = list(signature(param_est).parameters.keys())
+        fit_kwargs = {}
+        if len(inner_params) > 1:
+            fit_kwargs[inner_params[1]] = X
+            if "fh" in inner_params[2:]:
+                fit_kwargs["fh"] = fh
+
+        param_est.fit(y, **fit_kwargs)
         fitted_params = param_est.get_fitted_params()
 
         # obtain the mapping restricted to param names that are available


### PR DESCRIPTION
This PR enables `PluginParamsForecaster` to accept any fittable estimator as `estimator`.
This enables use of exogeneous data when said parameter estimator is a forecaster.

What this also enables is combining conformal interval estimators and tuners according to the comment https://github.com/sktime/sktime/issues/4218#issuecomment-1488122851, this partially covers #4218 when nesting can be avoided by sequencing.

An example for the `ConformalIntervals` wrapper is added, how to use the `PluginParamsForecaster` to enable conformal intervals together with tuning, without incurring the high computational cost from nesting.

FYI @bethrice44, @adoherty21.

Accidentally contains https://github.com/sktime/sktime/pull/4406 due to wrong branching - but that should not be an issue since we'll merge #4406 first.
NOTE: do not merge before #4406.