### PR TITLE
[DOC] README and docs update - tasks table, typos, lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Questions and feedback are extremely welcome! Please understand that we won't be
 | :woman_technologist: **Usage Questions**          | [GitHub Discussions] · [Stack Overflow] |
 | :speech_balloon: **General Discussion**        | [GitHub Discussions] |
 | :factory: **Contribution & Development** | contributors channel · [Discord] |
-| :globe_with_meridians: **Community collaboration session** | [Discord] - Fridays 4pm UTC, dev/meet-ups channel |
+| :globe_with_meridians: **Community collaboration session** | [Discord] - Fridays 3pm UTC, dev/meet-ups channel |
 
 [github issue tracker]: https://github.com/sktime/sktime/issues
 [github discussions]: https://github.com/sktime/sktime/discussions
@@ -73,13 +73,15 @@ For **deep learning**, see our companion package: [sktime-dl](https://github.com
 
 | Module | Status | Links |
 |---|---|---|
-| **[Forecasting]** | stable | [Tutorial](https://www.sktime.net/en/latest/examples/01_forecasting.html) · [API Reference](https://www.sktime.net/en/latest/api_reference.html#sktime-forecasting-time-series-forecasting) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting.py)  |
-| **[Time Series Classification]** | stable | [Tutorial](https://github.com/sktime/sktime/blob/main/examples/02_classification.ipynb) · [API Reference](https://www.sktime.net/en/latest/api_reference.html#sktime-classification-time-series-classification) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/classification.py) |
-| **[Time Series Regression]** | stable | [API Reference](https://www.sktime.net/en/latest/api_reference.html#sktime-classification-time-series-regression) |
-| **[Transformations]** | stable | [API Reference](https://www.sktime.net/en/latest/api_reference.html#sktime-transformations-time-series-transformers) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/transformer.py)  |
-| **[Time Series Clustering]** | maturing | [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/clustering.py) |
-| **[Time Series Distances/Kernels]** | experimental | [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/dist_kern_panel.py) |
+| **[Forecasting]** | stable | [Tutorial](https://www.sktime.net/en/latest/examples/01_forecasting.html) · [API Reference](https://www.sktime.net/en/latest/api_reference/forecasting.html) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/forecasting.py)  |
+| **[Time Series Classification]** | stable | [Tutorial](https://github.com/sktime/sktime/blob/main/examples/02_classification.ipynb) · [API Reference](https://www.sktime.net/en/latest/api_reference/classification.html) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/classification.py) |
+| **[Time Series Regression]** | stable | [API Reference](https://www.sktime.net/en/latest/api_reference/regression.html) |
+| **[Transformations]** | stable | [Tutorial](https://github.com/sktime/sktime/blob/main/examples/03_transformers.ipynb) · [API Reference](https://www.sktime.net/en/latest/api_reference/transformations.html) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/transformer.py)  |
+| **[Parameter fitting]** | maturing | [API Reference](https://www.sktime.net/en/latest/api_reference/param_est.html) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/transformer.py)  |
+| **[Time Series Clustering]** | maturing | [API Reference](https://www.sktime.net/en/latest/api_reference/clustering.html) ·  [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/clustering.py) |
+| **[Time Series Distances/Kernels]** | maturing | [Tutorial](https://github.com/sktime/sktime/blob/main/examples/03_transformers.ipynb) · [API Reference](https://www.sktime.net/en/latest/api_reference/dists_kernels.html) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/dist_kern_panel.py) |
 | **[Annotation]** | experimental | [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/annotation.py) |
+| **[Distributions and simulation]** | experimental |  |
 
 [forecasting]: https://github.com/sktime/sktime/tree/main/sktime/forecasting
 [time series classification]: https://github.com/sktime/sktime/tree/main/sktime/classification
@@ -88,6 +90,8 @@ For **deep learning**, see our companion package: [sktime-dl](https://github.com
 [annotation]: https://github.com/sktime/sktime/tree/main/sktime/annotation
 [time series distances/kernels]: https://github.com/sktime/sktime/tree/main/sktime/dists_kernels
 [transformations]: https://github.com/sktime/sktime/tree/main/sktime/transformations
+[distributions and simulation]: https://github.com/sktime/sktime/tree/main/sktime/proba
+[parameter fitting]: https://github.com/sktime/sktime/tree/main/sktime/param_est
 
 
 ## :hourglass_flowing_sand: Install sktime

--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -5,7 +5,7 @@ Time series classification
 
 The :mod:`sktime.classification` module contains algorithms and composition tools for time series classification.
 
-All classifiers in ``sktime``can be listed using the ``sktime.registry.all_estimators`` utility,
+All classifiers in ``sktime`` can be listed using the ``sktime.registry.all_estimators`` utility,
 using ``estimator_types="classifier"``, optionally filtered by tags.
 Valid tags can be listed using ``sktime.registry.all_tags``.
 

--- a/docs/source/api_reference/clustering.rst
+++ b/docs/source/api_reference/clustering.rst
@@ -6,7 +6,7 @@ Time series clustering
 
 The :mod:`sktime.clustering` module contains algorithms for time series clustering.
 
-All clusterers in ``sktime``can be listed using the ``sktime.registry.all_estimators`` utility,
+All clusterers in ``sktime`` can be listed using the ``sktime.registry.all_estimators`` utility,
 using ``estimator_types="clusterer"``, optionally filtered by tags.
 Valid tags can be listed using ``sktime.registry.all_tags``.
 

--- a/docs/source/api_reference/dists_kernels.rst
+++ b/docs/source/api_reference/dists_kernels.rst
@@ -14,7 +14,7 @@ Below, we list separately pairwise transformers for time series, and pairwise tr
    :no-members:
    :no-inherited-members:
 
-All time series distances and kernels in ``sktime``can be listed using the ``sktime.registry.all_estimators`` utility,
+All time series distances and kernels in ``sktime`` can be listed using the ``sktime.registry.all_estimators`` utility,
 using ``estimator_types="transformer-pairwise-panel"``, optionally filtered by tags.
 Valid tags can be listed using ``sktime.registry.all_tags``.
 

--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -6,7 +6,7 @@ Forecasting
 
 The :mod:`sktime.forecasting` module contains algorithms and composition tools for forecasting.
 
-All clusterers in ``sktime``can be listed using the ``sktime.registry.all_estimators`` utility,
+All clusterers in ``sktime`` can be listed using the ``sktime.registry.all_estimators`` utility,
 using ``estimator_types="forecaster"``, optionally filtered by tags.
 Valid tags can be listed using ``sktime.registry.all_tags``.
 

--- a/docs/source/api_reference/param_est.rst
+++ b/docs/source/api_reference/param_est.rst
@@ -9,6 +9,11 @@ seasonality, and utilities for plugging the estimated parameters into other esti
 For example, seasonality estimators can be combined with any seasonal forecaster
 to an auto-seasonality version.
 
+All parameter estimators in ``sktime`` can be listed using the
+``sktime.registry.all_estimators`` utility,
+using ``estimator_types="param_est"``, optionally filtered by tags.
+Valid tags can be listed using ``sktime.registry.all_tags``.
+
 .. automodule:: sktime.param_est
     :no-members:
     :no-inherited-members:

--- a/docs/source/api_reference/regression.rst
+++ b/docs/source/api_reference/regression.rst
@@ -5,7 +5,7 @@ Time series regression
 
 The :mod:`sktime.regression` module contains algorithms and composition tools for time series regression.
 
-All regressors in ``sktime``can be listed using the ``sktime.registry.all_estimators`` utility,
+All regressors in ``sktime`` can be listed using the ``sktime.registry.all_estimators`` utility,
 using ``estimator_types="regressor"``, optionally filtered by tags.
 Valid tags can be listed using ``sktime.registry.all_tags``.
 

--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -10,7 +10,7 @@ transformations.
    :no-members:
    :no-inherited-members:
 
-All (simple) transformers in ``sktime``can be listed using the ``sktime.registry.all_estimators`` utility,
+All (simple) transformers in ``sktime`` can be listed using the ``sktime.registry.all_estimators`` utility,
 using ``estimator_types="regressor"``, optionally filtered by tags.
 Valid tags can be listed using ``sktime.registry.all_tags``.
 


### PR DESCRIPTION
This PR makes various improvements to the README and adjacent docs.

* in the "tasks" table in the README, adds parameter estimatino as maturing and distributions/simulations as experimental
* in the "tasks" table in the README, changes partially valid API reference links to valid direct links into the respective subsections
* in the "overview" table, changes the time for the community meetup from 4pm UTC to 3pm UTC (daylight saving time change)
* fixes a systematic typo in API references where a space was missing
* adds the lookup paragraph present in other API reference sub-pages on the parameter estimator API reference page