### PR TITLE
[MNT] replace emergency `dash` bound by exclusion of failing version 2.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 [project.optional-dependencies]
 all_extras = [
     "cloudpickle",
-    "dash<2.9.0",
+    "dash!=2.9.0",
     "dask",
     "dtw-python",
     "esig==0.9.7; python_version < '3.10'",


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4354.

CI runs, which means we can revert the temporary emergency measure in https://github.com/sktime/sktime/pull/4353.