### PR TITLE
[MNT] reintroduce `pandas<2.0.0` bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "deprecated>=1.2.13",
     "numba>=0.53; python_version < '3.11'",
     "numpy>=1.21.0,<1.25",
-    "pandas>=1.1.0,<2.1.0",
+    "pandas>=1.1.0,<2.0.0",
     "scikit-learn>=0.24.0,<1.3.0",
     "scipy<2.0.0,>=1.2.0",
 ]


### PR DESCRIPTION
Reintroduces the `pandas` 2 bound given compatibility issues, see https://github.com/sktime/sktime/issues/4426

Will relax again if issues can be resolved quickly for 0.17.0