### PR TITLE
[MNT] except `Prophet` from `test_predict_quantiles` due to sporadic failures

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -139,8 +139,9 @@ EXCLUDED_TESTS = {
         "test_predict_quantiles",
         "test_predict_proba",
     ],
-    # random quantile monotonicity issue in VAR, refer to #4420
+    # stochastic failure of quantile prediction monotonicity, refer to #4420, #4431
     "VAR": ["test_predict_quantiles"],
+    "Prophet": ["test_predict_quantiles"],
 }
 
 # We use estimator tags in addition to class hierarchies to further distinguish


### PR DESCRIPTION
Excepts `Prophet` from `test_predict_quantiles` due to sporadic failures of the current test (quantile prediction monotonocity), see https://github.com/sktime/sktime/issues/4431