### PR TITLE
[ENH] address deprecation of `"mad"` option on `DataFrame.agg` and `Series.agg`

### DIFF
--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -701,7 +701,7 @@ class SummaryTransformer(BaseTransformer):
                 summary_value = X.agg(non_mad)
                 if "mad" in summary_function:
                     summary_value = pd.concat([summary_value, mad_value])
-                    summary_value = summary_value.loc[summary_function]
+                    summary_value = summary_value.loc[list(summary_function)]
             else:
                 summary_value = mad_value
 

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -685,7 +685,23 @@ class SummaryTransformer(BaseTransformer):
         quantiles = _check_quantiles(self.quantiles)
 
         if summary_function is not None:
-            summary_value = X.agg(summary_function)
+            # pandas has deprecated "mad"
+            # so we need to replicate the functionality here
+            if "mad" in summary_function:
+                mad_value = (X - X.mean()).abs().mean()
+                mad_value = type(X)(mad_value)
+                mad_value.index = ["mad"]
+                non_mad = set(summary_function).difference(["mad"])
+                non_mad = list(non_mad)
+            else:
+                non_mad = summary_function
+            if len(non_mad) > 0:
+                summary_value = X.agg(non_mad)
+                if "mad" in summary_function:
+                    summary_value = pd.concat([summary_value, mad_value])
+                    summary_value = summary_value.loc[summary_function]
+            else:
+                summary_value = mad_value
 
         if quantiles is not None:
             quantile_value = X.quantile(quantiles)
@@ -729,7 +745,8 @@ class SummaryTransformer(BaseTransformer):
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
         params1 = {}
-        params2 = {"summary_function": ["mean", "std", "skew"], "quantiles": None}
-        params3 = {"summary_function": None, "quantiles": (0.1, 0.2, 0.25)}
+        params2 = {"summary_function": ["mean", "mad", "skew"], "quantiles": None}
+        params3 = {"summary_function": ["mad"], "quantiles": (0.7,)}
+        params4 = {"summary_function": None, "quantiles": (0.1, 0.2, 0.25)}
 
-        return [params1, params2, params3]
+        return [params1, params2, params3, params4]

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -690,6 +690,8 @@ class SummaryTransformer(BaseTransformer):
             if "mad" in summary_function:
                 mad_value = (X - X.mean()).abs().mean()
                 mad_value = type(X)(mad_value)
+                if isinstance(X, pd.DataFrame):
+                    mad_value = mad_value.T
                 mad_value.index = ["mad"]
                 non_mad = set(summary_function).difference(["mad"])
                 non_mad = list(non_mad)


### PR DESCRIPTION
The `"mad"` option in the `pandas` `agg` methods has been deprecated and removed from `pandas` 2.

This is a problem as it is available in `SummaryTransformer`.

This PR replaces the deprecated functionality with a manual replicate as recommended in the deprecation message from `pandas`, allowing to keep the option in `SummaryTransformer`.
Test cases to cover the special logic are added.