### PR TITLE
[MNT] address deprecation of automatic drop on `DataFrame.agg` on non-numeric columns

### DIFF
--- a/sktime/benchmarking/evaluation.py
+++ b/sktime/benchmarking/evaluation.py
@@ -121,7 +121,10 @@ class Evaluator:
             metrics_by_strategy_dataset, how="outer"
         )
         # aggregate over cv folds and datasets
-        metrics_by_strategy = metrics_by_strategy_dataset.groupby(
+        metrics_by_strategy_dataset_wo_ds = metrics_by_strategy_dataset.drop(
+            columns=["dataset"],
+        )
+        metrics_by_strategy = metrics_by_strategy_dataset_wo_ds.groupby(
             ["strategy"], as_index=False
         ).agg(np.mean)
         self._metrics_by_strategy = self._metrics_by_strategy.merge(


### PR DESCRIPTION
Prior to `pandas 2`, `DataFrame.agg` would automatically drop non-numeric columns for numeric aggregations.

That is no longer the case from `pandas 2` and causes exceptions.

This PR addresses the deprecation by manually dropping respective columns.