### PR TITLE
[ENH] Adds `_predict_interval` to `SARIMAX` to support `predict_interval` and `predict_quantiles`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2144,7 +2144,8 @@
       "profile": "https://github.com/yarnabrina/",
       "contributions": [
         "bug",
-        "code"
+        "code",
+        "test"
       ]
     }
   ]

--- a/sktime/forecasting/sarimax.py
+++ b/sktime/forecasting/sarimax.py
@@ -116,6 +116,7 @@ class SARIMAX(_StatsModelsAdapter):
 
     _tags = {
         "ignores-exogeneous-X": False,
+        "capability:pred_int": True,
     }
 
     def __init__(

--- a/sktime/forecasting/tests/test_sarimax.py
+++ b/sktime/forecasting/tests/test_sarimax.py
@@ -4,6 +4,7 @@ __author__ = ["TNTran92"]
 
 import pytest
 from numpy.testing import assert_allclose
+from pandas.testing import assert_frame_equal
 
 from sktime.forecasting.sarimax import SARIMAX
 from sktime.utils._testing.forecasting import make_forecasting_problem
@@ -28,3 +29,64 @@ def test_SARIMAX_against_statsmodels():
     stats_fit = stats.fit()
     stats_pred = stats_fit.predict(df.index[0])
     assert_allclose(y_pred.tolist(), stats_pred.tolist())
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_SARIMAX_single_interval_against_statsmodels():
+    """Compares Sktime's and Statsmodel's SARIMAX.
+
+    Notes
+    -----
+
+    * Predict confidence intervals using underlying estimator and the wrapper.
+    * Predicts for a single coverage.
+    * Uses a non-default value of 97.5% to test inputs are actually being respected.
+    """
+    from statsmodels.tsa.api import SARIMAX as _SARIMAX
+
+    sktime_model = SARIMAX(order=(1, 0, 0), trend="t", seasonal_order=(1, 0, 0, 6))
+    sktime_model.fit(df)
+    sktime_pred_int = sktime_model.predict_interval(df.index, coverage=0.975)
+    sktime_pred_int = sktime_pred_int.xs(("Coverage", 0.975), axis="columns")
+
+    stats = _SARIMAX(endog=df, order=(1, 0, 0), trend="t", seasonal_order=(1, 0, 0, 6))
+    stats_fit = stats.fit()
+    stats_pred_int = stats_fit.get_prediction(df.index[0]).conf_int(alpha=0.025)
+    stats_pred_int.columns = ["lower", "upper"]
+
+    assert_frame_equal(sktime_pred_int, stats_pred_int)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_SARIMAX_single_intervals_against_statsmodels():
+    """Compares Sktime's and Statsmodel's SARIMAX.
+
+    Notes
+    -----
+
+    * Predict confidence intervals using underlying estimator and the wrapper.
+    * Predicts for multiple coverage values, viz. 70% and 80%.
+    """
+    from statsmodels.tsa.api import SARIMAX as _SARIMAX
+
+    sktime_model = SARIMAX(order=(1, 0, 0), trend="t", seasonal_order=(1, 0, 0, 6))
+    sktime_model.fit(df)
+    sktime_pred_int = sktime_model.predict_interval(df.index, coverage=[0.70, 0.80])
+    sktime_pred_int_70 = sktime_pred_int.xs(("Coverage", 0.70), axis="columns")
+    sktime_pred_int_80 = sktime_pred_int.xs(("Coverage", 0.80), axis="columns")
+
+    stats = _SARIMAX(endog=df, order=(1, 0, 0), trend="t", seasonal_order=(1, 0, 0, 6))
+    stats_fit = stats.fit()
+    stats_pred_int_70 = stats_fit.get_prediction(df.index[0]).conf_int(alpha=0.30)
+    stats_pred_int_70.columns = ["lower", "upper"]
+    stats_pred_int_80 = stats_fit.get_prediction(df.index[0]).conf_int(alpha=0.20)
+    stats_pred_int_80.columns = ["lower", "upper"]
+
+    assert_frame_equal(sktime_pred_int_70, stats_pred_int_70)
+    assert_frame_equal(sktime_pred_int_80, stats_pred_int_80)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #4301.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Before this PR, `SARIMAX` did not support prediction of confidence intervals and quantiles. This PR adds those functionalities, and tests to check that results match with underlying `statsmodels` estimator.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
Yes.

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
`SARIMAX` in `statsmodels` has a boolean argument `simple_differencing`. If it's set to be `True`, the forecasts and predictions are about the differenced series. It can be considered to add handling of that, similar to [how `pmdarima` does it](https://github.com/alkaline-ml/pmdarima/blob/18cbe34d62bf7ec2508509b0590ff0962f00af3e/pmdarima/arima/arima.py#LL168-L171).

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
