### PR TITLE
[MNT] except `VECM` from `test_predict_quantiles` due to sporadic failures

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -142,6 +142,7 @@ EXCLUDED_TESTS = {
     # stochastic failure of quantile prediction monotonicity, refer to #4420, #4431
     "VAR": ["test_predict_quantiles"],
     "Prophet": ["test_predict_quantiles"],
+    "VECM": ["test_predict_quantiles"],
 }
 
 # We use estimator tags in addition to class hierarchies to further distinguish


### PR DESCRIPTION
Excepts `VECM` from `test_predict_quantiles` due to sporadic failures of the current test (quantile prediction monotonocity), see https://github.com/sktime/sktime/issues/4431