### PR TITLE
Release 0.17.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > A unified interface for machine learning with time series
 
-:rocket: **Version 0.17.0 out now!** [Check out the release notes here](https://www.sktime.net/en/latest/changelog.html).
+:rocket: **Version 0.17.1 out now!** [Check out the release notes here](https://www.sktime.net/en/latest/changelog.html).
 
 sktime is a library for time series analysis in Python. It provides a unified interface for multiple time series learning tasks. Currently, this includes time series classification, regression, clustering, annotation and forecasting. It comes with [time series algorithms](https://www.sktime.net/en/stable/estimator_overview.html) and [scikit-learn] compatible tools to build, tune and validate time series models.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,17 +23,17 @@ Version 0.17.1 - 2023-04-11
 
 User feedback and ``pandas`` 2 compatibility issues are appreciated in :issue:`4426`.
 
-Deprecations and removals
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Dependencies
-^^^^^^^^^^^^
+Dependency changes
+~~~~~~~~~~~~~~~~~~
 
 * the version bound ``pandas<2.0.0`` will be relaxed to ``pandas<2.1.0`` in ``sktime 0.19.0``
-* option 1: to keep using ``pandas 1.X`` from ``0.19.0`` onwards, simply introduce the ``pandas<2.0.0`` bound in downstream requirements
-* option 2: to upgrade safely to ``pandas 2.X``, follow the upgrade and testing instructions below
-* neither option impacts public interfaces of ``sktime``, i.e., there are no removals, deprecations,
-  or changes of contract besides the change of ``pandas`` bound in ``sktime`` requirements
+
+  * option 1: to keep using ``pandas 1.X`` from ``0.19.0`` onwards, simply introduce the ``pandas<2.0.0`` bound in downstream requirements
+  * option 2: to upgrade safely to ``pandas 2.X``, follow the upgrade and testing instructions below
+  * neither option impacts public interfaces of ``sktime``, i.e., there are no removals, deprecations,
+    or changes of contract besides the change of ``pandas`` bound in ``sktime`` requirements
+
+* ``attrs`` changes from an implied (non-explicit) soft dependency to an explicit soft dependency (in ``all_extras``)
 
 ``pandas 2`` upgrade and testing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,14 +14,16 @@ For upcoming changes and next releases, see our `milestones <https://github.com/
 For our long-term plan, see our :ref:`roadmap`.
 
 
-Version 0.17.1 - 2023-04-11
+Version 0.17.1 - 2023-04-10
 ---------------------------
 
-* ``pandas`` 2 compatibility patch
-* experimental support for ``pandas`` 2 with testing and upgrade instructions for users
-* ``sktime`` will continue to support ``pandas`` 1 versions
+Maintenance patch (``pandas 2``, ``attrs``). For last content update, see 0.17.0.
 
-User feedback and ``pandas`` 2 compatibility issues are appreciated in :issue:`4426`.
+* ``pandas 2`` compatibility patch
+* experimental support for ``pandas 2`` with testing and upgrade instructions for users
+* ``sktime`` will continue to support ``pandas 1`` versions
+
+User feedback and ``pandas 2`` compatibility issues are appreciated in :issue:`4426`.
 
 Dependency changes
 ~~~~~~~~~~~~~~~~~~
@@ -57,6 +59,17 @@ Dependency changes
   * ``sktime`` will aim to be compatible with ``pandas 2`` (any version), as well as ``pandas 1, >=1.1.0``
   * users choose their preferred ``pandas`` version by requirements on their downstream environment
   * the bug and issue trackers should be used as normal
+
+List of PR
+~~~~~~~~~~
+
+* [MNT] address deprecation of ``"mad"`` option on ``DataFrame.agg`` and ``Series.agg`` (:pr:`4435`) :user:`fkiraly`
+* [MNT] address deprecation of automatic drop on ``DataFrame.agg`` on non-numeric columns (:pr:`4436`) :user:`fkiraly`
+* [MNT] resolve ``freq`` related deprecations and ``pandas 2`` failures in reducers (:pr:`4438`) :user:`fkiraly`
+* [MNT] except ``Prophet`` from ``test_predict_quantiles`` due to sporadic failures (:pr:`4432`) :user:`fkiraly`
+* [MNT] except ``VECM`` from ``test_predict_quantiles`` due to sporadic failures (:pr:`4442`) :user:`fkiraly`
+* [MNT] fix and sharpen soft dependency isolation logic for ``statsmodels`` and ``pmdarima`` (:pr:`4443`) :user:`fkiraly`
+* [MNT] isolating ``attrs`` imports (:pr:`4450`) :user:`fkiraly`
 
 Version 0.17.0 - 2023-04-03
 ---------------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,50 @@ For upcoming changes and next releases, see our `milestones <https://github.com/
 For our long-term plan, see our :ref:`roadmap`.
 
 
+Version 0.17.1 - 2023-04-11
+---------------------------
+
+* ``pandas`` 2 compatibility patch
+* experimental support for ``pandas`` 2 with testing and upgrade instructions for users
+* ``sktime`` will continue to support ``pandas`` 1 versions
+
+User feedback and ``pandas`` 2 compatibility issues are appreciated in :issue:`4426`.
+
+Deprecations and removals
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Dependencies
+^^^^^^^^^^^^
+
+* the version bound ``pandas<2.0.0`` will be relaxed to ``pandas<2.1.0`` in ``sktime 0.19.0``
+* option 1: to keep using ``pandas 1.X`` from ``0.19.0`` onwards, simply introduce the ``pandas<2.0.0`` bound in downstream requirements
+* option 2: to upgrade safely to ``pandas 2.X``, follow the upgrade and testing instructions below
+* neither option impacts public interfaces of ``sktime``, i.e., there are no removals, deprecations,
+  or changes of contract besides the change of ``pandas`` bound in ``sktime`` requirements
+
+``pandas 2`` upgrade and testing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* support for ``pandas 2`` will be introduced gradually:
+
+  * experimental support period until 0.19.0 (all 0.17.X and 0.18.X versions)
+  * full support from 0.19.0 (0.19.0, 0.19.X and onwards)
+
+* in the experimental period (0.17.1-0.18.last):
+
+  * ``sktime`` will have a dependency bound of ``pandas<2.0.0``
+  * ``sktime`` will aim to be compatible with ``pandas 2.0.X`` as well as ``pandas 1, >=1.1.0``,
+  * ``sktime`` can be run and tested with ``pandas 2.0.X`` by force-installing ``pandas 2.0.X``
+  * estimators can be tested for ``pandas 2`` compatibility via ``check_estimator`` under force-installed ``pandas 2.0.X``
+  * reports on compatibility issues are appreciated in :issue:`4426` (direct input or link from)
+
+* in the full support period (0.19.0-onwards):
+
+  * ``sktime`` requirements will allow ``pandas 2.0.X`` and extend support with ``pandas`` releases
+  * ``sktime`` will aim to be compatible with ``pandas 2`` (any version), as well as ``pandas 1, >=1.1.0``
+  * users choose their preferred ``pandas`` version by requirements on their downstream environment
+  * the bug and issue trackers should be used as normal
+
 Version 0.17.0 - 2023-04-03
 ---------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sktime"
-version = "0.17.0"
+version = "0.17.1"
 description = "A unified framework for machine learning with time series"
 authors = [
     {name = "sktime developers", email = "sktime.toolbox@gmail.com"},

--- a/sktime/__init__.py
+++ b/sktime/__init__.py
@@ -2,7 +2,7 @@
 
 """sktime."""
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"
 
 __all__ = ["show_versions"]
 


### PR DESCRIPTION
Release PR for 0.17.1

* version number bump
* changelog
* instructions for `pandas 2` upgrade (if desired) and `pandas 1` continuity

NOTE: this is a patch focused on `pandas 2` compatibility and upgrade.
