### PR TITLE
[ENH] shift `ForecastingHorizon`-`BaseForecaster` `cutoff` interface to rely on public point

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1624,7 +1624,7 @@ class BaseForecaster(BaseEstimator):
         cutoff : pandas compatible index element, or None
             pandas compatible index element, if cutoff has been set; None otherwise
         """
-        if hasattr(self, "_cutoff"):
+        if not hasattr(self, "_cutoff"):
             return None
         else:
             return self._cutoff

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1624,7 +1624,7 @@ class BaseForecaster(BaseEstimator):
         cutoff : pandas compatible index element, or None
             pandas compatible index element, if cutoff has been set; None otherwise
         """
-        if self._cutoff is None:
+        if self.hasattr("_cutoff"):
             return None
         else:
             return self._cutoff

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1624,7 +1624,7 @@ class BaseForecaster(BaseEstimator):
         cutoff : pandas compatible index element, or None
             pandas compatible index element, if cutoff has been set; None otherwise
         """
-        if self.hasattr("_cutoff"):
+        if hasattr(self, "_cutoff"):
             return None
         else:
             return self._cutoff

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -159,8 +159,8 @@ def _check_freq(obj):
     """
     if isinstance(obj, pd.offsets.BaseOffset):
         return obj
-    elif hasattr(obj, "_cutoff"):
-        return _check_freq(obj._cutoff)
+    elif hasattr(obj, "cutoff"):
+        return _check_freq(obj.cutoff)
     elif isinstance(obj, (pd.Period, pd.Index)):
         return _extract_freq_from_cutoff(obj)
     elif isinstance(obj, str) or obj is None:


### PR DESCRIPTION
In 0.16.0, the `BaseForecaster.cutoff` has changed from being an index element to `pandas.Index`, the `pandas.Index` version was available only as the private element `_cutoff` previously.

The `ForecastingHorizon` object's interface to `BaseForecaster` was still pointing to the private element, but can now be pointed to the public interface point which is `pandas.Index` since 0.16.0, see https://github.com/sktime/sktime/pull/3678.

Further, the `BaseForecaster.cutoff` getter has been made safer, i.e., it can also be called on non-fitted forecasters now (and will return `None`).