### PR TITLE
[BUG] `ForecastingHorizon` constructor - override erroneously inferred `freq` attribute from regular `DatetimeIndex` based horizon

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -287,11 +287,12 @@ class ForecastingHorizon:
 
         # infer freq from values, if available
         # if not, infer from freq argument, if available
-        if hasattr(values, "index") and hasattr(values.index, "freq"):
+        if freq is not None:
+            self.freq = freq
+        elif hasattr(values, "index") and hasattr(values.index, "freq"):
             self.freq = values.index.freq
         elif hasattr(values, "freq"):
             self.freq = values.freq
-        self.freq = freq
 
         # infer self._is_relative from is_relative, and type of values
         # depending on type of values, is_relative is inferred


### PR DESCRIPTION
This PR fixes the bug https://github.com/sktime/sktime/issues/4462 as follows.

The reason for #4462 is `freq` from two sources clashing when converting a relative `ForecastingHorizon` to absolute in a case where the internal representation ends up being `DatetimeIndex`, and the horizon is equally spaced but not at the same spacing as the data.

In this case, `pandas` automatically infers the spacing of the `DatetimeIndex`, and the `ForecastingHorizon` constructor obtains that as an input via `values.freq`, as well as an explicit `freq` input, which end up clashing and setting off a consistency check.

The fix changes the behaviour in case of clashing `freq` attributes: if `freq` is explicitly passed to the `ForecastingHorizon` constructor, it overrides the one from the `values` argument in case of a clash, instead of raising an error.

We should check thouroughly and think carefully whether this has any unintended side effects. As none of the current tests set off the exception, and one would expect that only the exception condition is affected by this fix, it seems fine (but this is not logical proof)