### PR TITLE
[BUG] fix `predict_quantiles` in `_PmdArimaAdapter` and `_StatsForecastAdapter` post 0.17.1

### DIFF
--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -222,7 +222,9 @@ class _PmdArimaAdapter(BaseForecaster):
                 )
                 pred_int = result[1]
                 pred_int = pd.DataFrame(
-                    pred_int[fh_idx, :], index=fh_abs, columns=["lower", "upper"]
+                    pred_int[fh_idx, :],
+                    index=fh_abs.to_pandas(),
+                    columns=["lower", "upper"],
                 )
                 pred_ints.append(pred_int)
             return result[0], pred_ints

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -165,9 +165,7 @@ class _PmdArimaAdapter(BaseForecaster):
         if return_pred_int:
             pred_ints = []
             for a in alpha:
-                pred_int = pd.DataFrame(
-                    index=fh_abs.to_pandas(), columns=["lower", "upper"]
-                )
+                pred_int = pd.DataFrame(index=fh_abs, columns=["lower", "upper"])
                 result = self._forecaster.predict_in_sample(
                     start=start,
                     end=end,
@@ -224,9 +222,7 @@ class _PmdArimaAdapter(BaseForecaster):
                 )
                 pred_int = result[1]
                 pred_int = pd.DataFrame(
-                    pred_int[fh_idx, :],
-                    index=fh_abs.to_pandas(),
-                    columns=["lower", "upper"],
+                    pred_int[fh_idx, :], index=fh_abs, columns=["lower", "upper"]
                 )
                 pred_ints.append(pred_int)
             return result[0], pred_ints

--- a/sktime/forecasting/base/adapters/_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_statsforecast.py
@@ -145,9 +145,7 @@ class _StatsForecastAdapter(BaseForecaster):
         if return_pred_int:
             pred_ints = []
             for a in alpha:
-                pred_int = pd.DataFrame(
-                    index=fh_abs.to_pandas(), columns=["lower", "upper"]
-                )
+                pred_int = pd.DataFrame(index=fh_abs, columns=["lower", "upper"])
                 result = self._forecaster.predict_in_sample(level=int(100 * a))
                 pred_int.loc[fh_abs] = result.drop("mean", axis=1).values[fh_idx, :]
                 pred_ints.append(pred_int)

--- a/sktime/forecasting/tests/test_pmdarima.py
+++ b/sktime/forecasting/tests/test_pmdarima.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""Tests for the ARIMA estimator and _PmdArimaAdapter."""
+
+import pytest
+
+from sktime.datasets import load_airline
+from sktime.forecasting.arima import ARIMA
+from sktime.utils.validation._dependencies import _check_estimator_deps
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(ARIMA, severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_ARIMA_pred_quantiles_insample():
+    """Test ARIMA predict_quantiles with in-sample fh. Failure condition of #4468."""
+    y = load_airline()
+    forecaster = ARIMA(order=(1, 1, 0), seasonal_order=(0, 1, 0, 12))
+    forecaster.fit(y)
+    forecaster.predict_quantiles(fh=y.index, X=None, alpha=[0.05, 0.95])


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4468.

An accident in the `pandas 2` upgrade in 0.17.1 broke the `predict_quantiles` method of the `_PmdArimaAdapter` and the `_StatsForecastAdapter`.

That this went undetected is due to quantile predictions not being tested in-sample, we need to add tests for that.