### PR TITLE
[MNT] ensure all elements in test matrix complete runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,6 +142,7 @@ jobs:
     needs: test-nosoftdeps
     runs-on: windows-2019
     strategy:
+      fail-fast: false  # to not fail all combinations if just one fail
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
@@ -183,6 +184,7 @@ jobs:
   test-unix:
     needs: test-nosoftdeps
     strategy:
+      fail-fast: false  # to not fail all combinations if just one fail
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-20.04, macOS-11]


### PR DESCRIPTION
This PR modifies the CI test matrix to ensure that all elements run, by using the `fail-fast` element, inspired by this discussion with @yarnabrina: https://github.com/sktime/sktime/discussions/4453#discussioncomment-5571043

As I see it:

* this is no major drawback, as in teh current test schema, all matrix elements start simultaneously and have similar duration. Failing the first usually shuts down runs that were almost finished.
* as we distribute estimators across matrix elements, a single failure may mask other estimator failures, if `fail-fast` is on.