### PR TITLE
[ENH] transformer compositor to apply by panel or instance

### DIFF
--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -66,6 +66,7 @@ Pipeline building
     Id
     YtoX
     IxToX
+    TransformByLevel
     TransformIf
 
 .. currentmodule:: sktime.transformations.panel.compose

--- a/sktime/transformations/compose/__init__.py
+++ b/sktime/transformations/compose/__init__.py
@@ -8,6 +8,7 @@ from sktime.transformations.compose._column import (
 )
 from sktime.transformations.compose._featureunion import FeatureUnion
 from sktime.transformations.compose._fitintransform import FitInTransform
+from sktime.transformations.compose._grouped import TransformByLevel
 from sktime.transformations.compose._id import Id
 from sktime.transformations.compose._invert import InvertTransform
 from sktime.transformations.compose._ixtox import IxToX
@@ -29,6 +30,7 @@ __all__ = [
     "MultiplexTransformer",
     "OptionalPassthrough",
     "TransformerPipeline",
+    "TransformByLevel",
     "TransformIf",
     "YtoX",
 ]

--- a/sktime/transformations/compose/_grouped.py
+++ b/sktime/transformations/compose/_grouped.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Implements compositors for performing transformations by group."""
+
+from sktime.datatypes import ALL_TIME_SERIES_MTYPES, mtype_to_scitype
+from sktime.transformations._delegate import _DelegatedTransformer
+
+__author__ = ["fkiraly"]
+__all__ = ["TransformByLevel"]
+
+
+class TransformByLevel(_DelegatedTransformer):
+    """Transform by instance or panel.
+
+    Used to apply multiple copies of `transformer` by instance or by panel.
+
+    If `groupby="global"`, behaves like `transformer`.
+    If `groupby="local"`, fits a clone of `transformer` per time series instance.
+    If `groupby="panel"`, fits a clone of `transformer` by panel (first non-time level).
+
+    The fitted transformers can be accessed in the `transformers_` attribute,
+    if more than one clone is fitted, otherwise in the `transformer_` attribute.
+
+    Parameters
+    ----------
+    transformer : sktime transformer used in TransformByLevel
+        A "blueprint" transformer, state does not change when `fit` is called.
+    groupby : str, one of ["local", "global", "panel"], optional, default="local"
+        level on which data are grouped to fit clones of `transformer`
+        "local" = unit/instance level, one reduced model per lowest hierarchy level
+        "global" = top level, one reduced model overall, on pooled data ignoring levels
+        "panel" = second lowest level, one reduced model per panel level (-2)
+        if there are 2 or less levels, "global" and "panel" result in the same
+        if there is only 1 level (single time series), all three settings agree
+
+    Attributes
+    ----------
+    transformer_ : sktime transformer, present only if `groupby` is "global"
+        clone of `transformer` used for fitting and transformation
+    transformers_ : pd.DataFrame of sktime transformer, present otherwise
+        entries are clones of `transformer` used for fitting and transformation
+
+    Examples
+    --------
+    >>> from sktime.transformations.hierarchical.reconcile import Reconciler
+    >>> from sktime.utils._testing.hierarchical import _make_hierarchical
+    >>> X = _make_hierarchical()
+    >>> f = TransformByLevel(Reconciler(), groupby="panel")
+    >>> f.fit(X)
+    TransformByLevel(...)
+    """
+
+    _tags = {
+        "requires-fh-in-fit": False,
+        "handles-missing-data": True,
+        "X_inner_mtype": ALL_TIME_SERIES_MTYPES,
+        "y_inner_mtype": ALL_TIME_SERIES_MTYPES,
+        "fit_is_empty": False,
+    }
+
+    # attribute for _DelegatedTrafoer, which then delegates
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
+    #     see further details in _DelegatedTrafoer docstring
+    _delegate_name = "transformer_"
+
+    def __init__(self, transformer, groupby="local"):
+
+        self.transformer = transformer
+        self.groupby = groupby
+
+        self.transformer_ = transformer.clone()
+
+        super(TransformByLevel, self).__init__()
+
+        self.clone_tags(self.transformer_)
+        self.set_tags(**{"fit_is_empty": False})
+
+        if groupby == "local":
+            scitypes = ["Series"]
+        elif groupby == "global":
+            scitypes = ["Series", "Panel", "Hierarchical"]
+        elif groupby == "panel":
+            scitypes = ["Series", "Panel"]
+        else:
+            raise ValueError(
+                "groupby in TransformByLevel must be one of"
+                ' "local", "global", "panel", '
+                f"but found {groupby}"
+            )
+
+        mtypes = [x for x in ALL_TIME_SERIES_MTYPES if mtype_to_scitype(x) in scitypes]
+
+        # this ensures that we convert in the inner estimator
+        # but vectorization/broadcasting happens at the level of groupby
+        self.set_tags(**{"X_inner_mtype": mtypes})
+        if self.transformer_.get_tag("y_inner_mtype") != "None":
+            self.set_tags(**{"y_inner_mtype": mtypes})
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict
+        """
+        from sktime.transformations.series.time_since import TimeSince
+
+        groupbys = ["local", "panel", "global"]
+
+        t = TimeSince()
+
+        params = [{"transformer": t, "groupby": g} for g in groupbys]
+
+        return params

--- a/sktime/transformations/compose/_grouped.py
+++ b/sktime/transformations/compose/_grouped.py
@@ -75,6 +75,7 @@ class TransformByLevel(_DelegatedTransformer):
 
         self.transformer = transformer
         self.groupby = groupby
+        self.raise_warnings = raise_warnings
 
         self.transformer_ = transformer.clone()
 


### PR DESCRIPTION
This PR adds a `TransformByLevel` transformer, which applies a transformer by panel or instance.

This allows to add to any transformer that does not have granular control on whether to apply it by level or not the option to apply it by panel or instance.