### PR TITLE
[BUG] fix `pandas` write error in probabilistic forecasts of `BaggingForecaster`

### DIFF
--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -262,7 +262,6 @@ class BaggingForecaster(BaseForecaster):
         """
         # X is ignored
         y_pred = self.forecaster_.predict(fh=fh, X=None)
-
         return _calculate_data_quantiles(y_pred, alpha)
 
     def _update(self, y, X=None, update_params=True):
@@ -338,8 +337,7 @@ def _calculate_data_quantiles(df: pd.DataFrame, alpha: List[float]) -> pd.DataFr
     index = pd.MultiIndex.from_product([["Quantiles"], alpha])
     pred_quantiles = pd.DataFrame(columns=index)
     for a in alpha:
-        pred_quantiles[("Quantiles", a)] = (
-            df.groupby(level=-1, as_index=True).quantile(a).squeeze()
-        )
+        quant_a = df.groupby(level=-1, as_index=True).quantile(a)
+        pred_quantiles[[("Quantiles", a)]] = quant_a
 
     return pred_quantiles

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -127,12 +127,6 @@ EXCLUDED_TESTS = {
     # SAX returns strange output format
     # this needs to be fixed, was not tested previously due to legacy exception
     "SAX": "test_fit_transform_output",
-    # known bug in BaggingForecaster, returns wrong index, #4363
-    "BaggingForecaster": [
-        "test_predict_interval",
-        "test_predict_quantiles",
-        "test_predict_proba",
-    ],
     # known bug in DynamicFactor, returns wrong index, #4362
     "DynamicFactor": [
         "test_predict_interval",


### PR DESCRIPTION
Fixes #4363, probabilistic forecasts of `BaggingForecaster`.

The probabilistic methods of `BaggingForecaster` would break, the reason being an unsafe dataframe column write.
Plausible reason may be a break through a `pandas` update which was not detected due to lacking test coverage before the proba prediction tests were updated.

The unsafe write has been replaced with a column write that does actually work under current `pandas 1` version.