### PR TITLE
[ENH] remove monotonicity requirement from quantile prediction contract

### DIFF
--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -428,9 +428,10 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
             )
 
             # check if values are monotonically increasing
-            for var in pred_quantiles.columns.levels[0]:
-                for index in range(len(pred_quantiles.index)):
-                    assert pred_quantiles[var].iloc[index].is_monotonic_increasing
+            # commented out until #4431 is resolved
+            # for var in pred_quantiles.columns.levels[0]:
+            #     for index in range(len(pred_quantiles.index)):
+            #        assert pred_quantiles[var].iloc[index].is_monotonic_increasing
 
     @pytest.mark.parametrize(
         "alpha", TEST_ALPHAS, ids=[f"alpha={a}" for a in TEST_ALPHAS]

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -139,10 +139,6 @@ EXCLUDED_TESTS = {
         "test_predict_quantiles",
         "test_predict_proba",
     ],
-    # stochastic failure of quantile prediction monotonicity, refer to #4420, #4431
-    "VAR": ["test_predict_quantiles"],
-    "Prophet": ["test_predict_quantiles"],
-    "VECM": ["test_predict_quantiles"],
 }
 
 # We use estimator tags in addition to class hierarchies to further distinguish


### PR DESCRIPTION
This PR removes the monotonicity requirement from the quantile and interval prediction contract, and from the test `test_predict_quantiles`.

Related issue: https://github.com/sktime/sktime/issues/4431

Also removes the test skips from estimators sporadically failing monotonicity.