### PR TITLE
[ENH] remove superfluous implementation checks in `_predict_interval` and `_predict_quantiles` of `BaseForecaster`

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -2055,9 +2055,8 @@ class BaseForecaster(BaseEstimator):
                 at quantile probability in second col index, for the row index.
         """
         implements_interval = self._has_implementation_of("_predict_interval")
-        implements_quantiles = self._has_implementation_of("_predict_quantiles")
         implements_proba = self._has_implementation_of("_predict_proba")
-        can_do_proba = implements_interval or implements_quantiles or implements_proba
+        can_do_proba = implements_interval or implements_proba
 
         if not can_do_proba:
             raise RuntimeError(

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1986,10 +1986,9 @@ class BaseForecaster(BaseEstimator):
                 Upper/lower interval end forecasts are equivalent to
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
-        implements_interval = self._has_implementation_of("_predict_interval")
         implements_quantiles = self._has_implementation_of("_predict_quantiles")
         implements_proba = self._has_implementation_of("_predict_proba")
-        can_do_proba = implements_interval or implements_quantiles or implements_proba
+        can_do_proba = implements_quantiles or implements_proba
 
         if not can_do_proba:
             raise RuntimeError(


### PR DESCRIPTION
In the existing implementation of `_predict_interval` in `BaseForecaster`, first it checks whether any of `_predict_interval`, `_predict_quantiles` or `_predict_proba` is overridden or not. But the check on `_predict_interval` would never evaluate to `True` when called from an inherited forecaster, as if it is indeed overridden, that overridden method would have been called, and not that of the `BaseForecaster`.

(Edit: stroked out no-more-affected areas by PR, because of update as suggested below)

~~On the other hand, even if `_predict_proba` is implemented, as of current implementation it is not used to generate prediction interval in case `_predict_interval` is not implemented. Plus presence of this check can possibly lead to `NameError` from `return pred_int` line, in case `_predict_quantiles` is not implemented.~~

~~Because of the above reasons, the check with `can_do_proba` inside `_predict_interval` is equivalent to check with `implements_quantiles`, and that can simplify the next indented block by avoiding the check because of `raise` before this.~~

Similar arguments of can be made for `_predict_quantiles` in `BaseForecaster` as well, where using `_predict_interval` is sufficient.

This PR attempts to solve the above arguments by removing these unnecessary checks.