### PR TITLE
[ENH] allow inclusive/exclusive bounds in `get_slice`

### DIFF
--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -605,7 +605,7 @@ def get_slice(obj, start=None, end=None, start_inclusive=True, end_inclusive=Fal
         elif end:
             slice_select = get_end_cond()
         elif start:
-            slice_select = get_start_cond
+            slice_select = get_start_cond()
 
         obj_subset = obj.iloc[slice_select]
         return convert_to(obj_subset, obj_in_mtype)


### PR DESCRIPTION
This PR adds two arguments to `get_slice` to allow exclusive/inclusive bounding at either and of the slice.

The default of the two new arguments leads to current behaviour, so no deprecation is necessary.

This will be useful as a utility, and also for fixing https://github.com/sktime/sktime/pull/3667