### PR TITLE
[MNT] add `InceptionTimeClassifier` and `LSTMFCNClassifier` to API docs and as direct export

### DIFF
--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -35,6 +35,7 @@ Deep learning
 
     CNNClassifier
     FCNClassifier
+    LSTMFCNClassifier
     InceptionTimeClassifier
     MLPClassifier
     TapNetClassifier

--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -35,6 +35,7 @@ Deep learning
 
     CNNClassifier
     FCNClassifier
+    InceptionTimeClassifier
     MLPClassifier
     TapNetClassifier
 

--- a/sktime/classification/deep_learning/__init__.py
+++ b/sktime/classification/deep_learning/__init__.py
@@ -3,6 +3,7 @@
 __all__ = [
     "CNNClassifier",
     "FCNClassifier",
+    "InceptionTimeClassifier",
     "LSTMFCNClassifier",
     "MLPClassifier",
     "TapNetClassifier",
@@ -10,6 +11,7 @@ __all__ = [
 
 from sktime.classification.deep_learning.cnn import CNNClassifier
 from sktime.classification.deep_learning.fcn import FCNClassifier
+from sktime.classification.deep_learning.inceptiontime import InceptionTimeClassifier
 from sktime.classification.deep_learning.lstmfcn import LSTMFCNClassifier
 from sktime.classification.deep_learning.mlp import MLPClassifier
 from sktime.classification.deep_learning.tapnet import TapNetClassifier


### PR DESCRIPTION
This PR adds the `InceptionTimeClassifier` and `LSTMFCNClassifier` to API docs. It also ensures all DL classifiers are consistently direct exports in the `deep_learning` module.