### PR TITLE
[MNT] address some warnings and deprecation messages from dependencies

### DIFF
--- a/sktime/dists_kernels/dist_to_kern.py
+++ b/sktime/dists_kernels/dist_to_kern.py
@@ -238,7 +238,7 @@ class DistFromKernel(BasePairwiseTransformerPanel):
         mat2 = mat2.transpose()
 
         distmat = mat1 + mat2 - 2 * kernelmat
-        distmat = np.sqrt(distmat)
+        distmat = np.sqrt(np.abs(distmat))
 
         return distmat
 

--- a/sktime/forecasting/squaring_residuals.py
+++ b/sktime/forecasting/squaring_residuals.py
@@ -349,7 +349,7 @@ class SquaringResiduals(BaseForecaster):
         fh_abs = fh.to_absolute(self.cutoff)
         fh_rel = fh.to_relative(self.cutoff)
         fh_rel_index = fh_rel.to_pandas()
-        pred_var = pd.Series(index=fh_rel_index)
+        pred_var = pd.Series(index=fh_rel_index, dtype="float64")
         for el in fh_rel:
             pred_var.at[el] = self._res_forecasters[el].predict(fh=el)[0]
         if self.strategy == "square":

--- a/sktime/transformations/series/kinematic.py
+++ b/sktime/transformations/series/kinematic.py
@@ -161,7 +161,7 @@ class KinematicFeatures(BaseTransformer):
             cross_term = (v_frame.values * a_frame.values).sum(axis=1) ** 2
             cross_term = cross_term.reshape(-1, 1)
             curv_arr = (curv_arr - cross_term) / (vsq_frame.values**3)
-            curv_arr = curv_arr**0.5
+            curv_arr = np.abs(curv_arr)**0.5
             curv_frame = pd.DataFrame(curv_arr, columns=["curv"], index=X.index)
             res = pd.concat([res, curv_frame], axis=1)
 

--- a/sktime/transformations/series/kinematic.py
+++ b/sktime/transformations/series/kinematic.py
@@ -161,7 +161,7 @@ class KinematicFeatures(BaseTransformer):
             cross_term = (v_frame.values * a_frame.values).sum(axis=1) ** 2
             cross_term = cross_term.reshape(-1, 1)
             curv_arr = (curv_arr - cross_term) / (vsq_frame.values**3)
-            curv_arr = np.abs(curv_arr)**0.5
+            curv_arr = np.abs(curv_arr) ** 0.5
             curv_frame = pd.DataFrame(curv_arr, columns=["curv"], index=X.index)
             res = pd.concat([res, curv_frame], axis=1)
 

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -84,7 +84,7 @@ class IndexSubset(BaseTransformer):
             Xt = X.loc[ind_X_and_y]
         elif index_treatment == "keep":
             Xt = X.loc[ind_X_and_y]
-            y_idx_frame = type(X)(index=y.index)
+            y_idx_frame = type(X)(index=y.index, dtype="float64")
             Xt = Xt.combine_first(y_idx_frame)
         else:
             raise ValueError(


### PR DESCRIPTION
This PR addresses some warnings deprecation messages from dependencies:

* default `dtype` set explicitly in `pandas` constructors to `float64`
* adding `np.abs` to prevent negative values in square roots