### PR TITLE
[BUG] fix `BATS` and `TBATS` `_predict_interval` interface

### DIFF
--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -229,9 +229,7 @@ class _TbatsAdapter(BaseForecaster):
         fh_out = fh.to_out_of_sample(cutoff=self.cutoff)
         steps = fh_out.to_pandas().max()
 
-        _, tbats_ci = self._forecaster.forecast(
-            steps=steps, confidence_level=conf_lev
-        )
+        _, tbats_ci = self._forecaster.forecast(steps=steps, confidence_level=conf_lev)
         out = pd.DataFrame(tbats_ci)
 
         # pred_int

--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -323,39 +323,6 @@ class _TbatsAdapter(BaseForecaster):
         """Get names of fitted parameters."""
         return self._fitted_param_names
 
-    def _get_pred_int(self, lower, upper):
-        """Combine lower/upper bounds of pred.intervals, slice on fh.
-
-        Parameters
-        ----------
-        lower : pd.Series
-            Lower bound (can contain also in-sample bound)
-        upper : pd.Series
-            Upper bound (can contain also in-sample bound)
-
-        Returns
-        -------
-        pd.DataFrame
-            pred_int, prediction intervals (out-sample, sliced by fh)
-        """
-        pred_int = pd.DataFrame({"lower": lower, "upper": upper})
-        # Out-sample fh
-        fh_out = self.fh.to_out_of_sample(cutoff=self.cutoff)
-        # If pred_int contains in-sample prediction intervals
-        if len(pred_int) > len(self._y):
-            len_out = len(pred_int) - len(self._y)
-            # Workaround for slicing with negative index
-            pred_int["idx"] = [x for x in range(-len(self._y), len_out)]
-        # If pred_int does not contain in-sample prediction intervals
-        else:
-            pred_int["idx"] = [x for x in range(len(pred_int))]
-        pred_int = pred_int.loc[
-            pred_int["idx"].isin(fh_out.to_indexer(self.cutoff).values)
-        ]
-        pred_int.index = fh_out.to_absolute(self.cutoff).to_pandas()
-        pred_int = pred_int.drop(columns=["idx"])
-        return pred_int
-
 
 def nans(length):
     """Return a vector of NaNs, of length `length`."""

--- a/sktime/forecasting/tests/test_tbats.py
+++ b/sktime/forecasting/tests/test_tbats.py
@@ -18,7 +18,6 @@ from sktime.utils.validation._dependencies import _check_estimator_deps
 )
 def test_tbats_long_fh():
     """Test TBATS with long fh, checks for failure condition in bug #4491."""
-    np.random.seed(42)
     LEN_HISTORY = 50
     train = pd.Series(data=np.random.randint(1, 100, LEN_HISTORY))
 

--- a/sktime/forecasting/tests/test_tbats.py
+++ b/sktime/forecasting/tests/test_tbats.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Tests for TBATS."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+__author__ = ["fkiraly", "ngupta23"]
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sktime.forecasting.tbats import TBATS
+from sktime.utils.validation._dependencies import _check_estimator_deps
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(TBATS, severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_tbats_long_fh():
+    """Test TBATS with long fh, checks for failure condition in bug #4491."""
+    np.random.seed(42)
+    LEN_HISTORY = 50
+    train = pd.Series(data=np.random.randint(1, 100, LEN_HISTORY))
+
+    # train model
+    estimator = TBATS(
+        use_box_cox=False,
+        use_trend=True,
+        use_damped_trend=False,
+        sp=10,
+        use_arma_errors=False,
+    )
+    estimator.fit(train)
+
+    # failure condition is fh being longer than training data
+    long_fh = np.array(range(1, LEN_HISTORY + 2))
+
+    fcst = estimator.predict_interval(coverage=0.8, fh=long_fh)
+    assert len(fcst) == len(long_fh)

--- a/sktime/forecasting/tests/test_theta.py
+++ b/sktime/forecasting/tests/test_theta.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Tests for ThetaForecaster.
-
+"""Tests for ThetaForecaster."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
 
 __author__ = ["big-o", "kejsitake"]
 


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4491

The `_predict_interval` interface in `_TbatsAdapter` was a bit of a mess.

There was also really strange code that triggered specifically whenever the `fh` was longer than the training data, I was unable to understand why that condition should be the same as "contains in-sample prediction intervals".

This is the code:
```python
        # If pred_int contains in-sample prediction intervals
        if len(pred_int) > len(self._y):
            len_out = len(pred_int) - len(self._y)
            # Workaround for slicing with negative index
            pred_int["idx"] = [x for x in range(-len(self._y), len_out)]
```

It explains @ngupta23's issues in #4491, but I don't get why this was there in the first place.

Either way, I just completely rewrote the interface to prediction intervals from scratch.
The logic was simple, it is producing `nan` for insample predictions.

Contains the failure case from https://github.com/sktime/sktime/issues/4491 as a test.