### PR TITLE
[ENH] variable subsetting dunder `[...]` for distances and kernels

### DIFF
--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -349,6 +349,28 @@ class BasePairwiseTransformerPanel(BaseEstimator):
         else:
             return NotImplemented
 
+    def __getitem__(self, key):
+        """Magic [...] method, return column subsetted transformer.
+
+        Pairwise transformer (e.g., distance kernel) subsetted to the index.
+
+        Keys must be valid inputs for `columns` in `ColumnSubset`.
+
+        Parameters
+        ----------
+        key: valid input for `columns` in `ColumnSubset`, or pair thereof
+            keys can also be a :-slice, in which case it is considered as not passed
+
+        Returns
+        -------
+        the following TransformerPipeline object:
+            ColumnSubset(columns) * self
+            where `columns` only item in `key`
+        """
+        from sktime.transformations.series.subset import ColumnSelect
+
+        return ColumnSelect(key) * self
+
     def transform(self, X, X2=None):
         """Compute distance/kernel matrix.
 

--- a/sktime/dists_kernels/tests/test_dist_kernels_dunders.py
+++ b/sktime/dists_kernels/tests/test_dist_kernels_dunders.py
@@ -165,3 +165,28 @@ def test_dunders_with_constants(constant):
 
     mtimesc = ttimesc.transform(X1, X2)
     assert np.allclose(m * constant, mtimesc)
+
+
+def test_getitem_dunder():
+    """Tests creation of pairwise panel trafo pipeliens using mul dunder."""
+    t = EditDist()
+
+    idx_sub = ["var_1", "var_2"]
+
+    X1_sub = X1.loc[:, idx_sub]
+    X2_sub = X2.loc[:, idx_sub]
+
+    # compare manual subsetting with dunder subsetting
+    t_sub = t[idx_sub]
+
+    # manual: subset then transform
+    m_manual = t.transform(X1_sub, X2_sub)
+
+    # dunder: apply the subsetted transformer
+    m_dunder = t_sub.transform(X1, X2)
+
+    assert np.allclose(m_manual, m_dunder)
+
+    # this should not be the same as distance on all columns
+    m = t.transform(X1, X2)
+    assert not np.allclose(m_dunder, m)

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -327,7 +327,7 @@ class BaseTransformer(BaseEstimator):
     def __getitem__(self, key):
         """Magic [...] method, return column subsetted transformer.
 
-        First index does intput subsetting, second index does output subsetting.
+        First index does input subsetting, second index does output subsetting.
 
         Keys must be valid inputs for `columns` in `ColumnSubset`.
 


### PR DESCRIPTION
This adds variable subsetting functionality to the `__getitem__` dunder of distances and kernels, i.e., to `BasePairwiseTransformerPanel`.

This is in analogy to the same dunder of ordinary transformers.

Also includes a test.