### PR TITLE
[BUG] fix input check error message in `BasePairwiseTransformerPanel`

### DIFF
--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -478,8 +478,6 @@ class BasePairwiseTransformerPanel(BaseEstimator):
         X_valid = check_res[0]
         metadata = check_res[2]
 
-        X_scitype = metadata["scitype"]
-
         if not X_valid:
             msg = (
                 "X and X2 must be in an sktime compatible format, "
@@ -489,6 +487,8 @@ class BasePairwiseTransformerPanel(BaseEstimator):
                 " See the data format tutorial examples/AA_datatypes_and_datasets.ipynb"
             )
             raise TypeError(msg)
+
+        X_scitype = metadata["scitype"]
 
         # if the input is a single series, convert it to a Panel
         if X_scitype == "Series":


### PR DESCRIPTION
This PR fixes an unreported bug where the informative error message from a failed input check in `BasePairwiseTransformerPanel` would not be displaye, instead a cryptic exception about `NoneType` would be raised.

The failure is due to a return of `check_is_mtype` being `None` in the case where the check fails, but being treated as a `dict` erroneously (which it is in the success case). This was fixed.