### PR TITLE
[BUG] fixes merge accident in `_tags`

### DIFF
--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -210,9 +210,9 @@ ESTIMATOR_TAG_REGISTER = [
         "forecaster",
         "bool",
         "can the forecaster make in-sample predictions in predict_interval/quantiles?",
-        "capability:predict_proba",
     ),
     (
+        "capability:predict_proba",
         "classifier",
         "bool",
         "does the classifier implement a non-default predict_proba, "


### PR DESCRIPTION
FIxes a merge accident in the `_tags` registry that made it to `main`.