### PR TITLE
[ENH] add test for `all_estimators` tag filter

### DIFF
--- a/sktime/registry/tests/test_lookup.py
+++ b/sktime/registry/tests/test_lookup.py
@@ -238,14 +238,16 @@ def test_all_estimators_tag_filter(pred_int):
     PROBA_EXAMPLE = "ARIMA"
 
     res = all_estimators("forecaster", filter_tags={"capability:pred_int": pred_int})
-    names, _ = zip(res)
+    names, ests = zip(*res)
 
     if pred_int:
         assert PROBA_EXAMPLE in names
         assert NOPROBA_EXAMPLE not in names
+        assert [est.get_class_tag("capability:pred_int") for est in ests]
     else:
         assert PROBA_EXAMPLE not in names
         assert NOPROBA_EXAMPLE in names
+        assert [not est.get_class_tag("capability:pred_int") for est in ests]
 
 
 @pytest.mark.parametrize("estimator_scitype", BASE_CLASS_SCITYPE_LIST)

--- a/sktime/registry/tests/test_lookup.py
+++ b/sktime/registry/tests/test_lookup.py
@@ -231,6 +231,23 @@ def test_all_estimators_return_tags_bad_arg(return_tags):
         _ = all_estimators(return_tags=return_tags)
 
 
+@pytest.mark.parametrize("pred_int", [True, False])
+def test_all_estimators_tag_filter(pred_int):
+    """Test that tag filtering returns estimators as expected."""
+    NOPROBA_EXAMPLE = "TrendForecaster"
+    PROBA_EXAMPLE = "ARIMA"
+
+    res = all_estimators("forecaster", filter_tags={"capability:pred_int": pred_int})
+    names, _ = zip(res)
+
+    if pred_int:
+        assert PROBA_EXAMPLE in names
+        assert NOPROBA_EXAMPLE not in names
+    else:
+        assert PROBA_EXAMPLE not in names
+        assert NOPROBA_EXAMPLE in names
+
+
 @pytest.mark.parametrize("estimator_scitype", BASE_CLASS_SCITYPE_LIST)
 def test_scitype_inference(estimator_scitype):
     """Check that scitype inverts _check_estimator_types."""


### PR DESCRIPTION
This adds a test for the tag filter parameter of `all_estimators`, i.e., that only the filtered estimators are returned, and the filtered estimators are returned.