### PR TITLE
[ENH] ensure `predict_proba` calls in `mlflow` forecasting interface explicitly call `legacy_interface`

### DIFF
--- a/examples/mlflow.ipynb
+++ b/examples/mlflow.ipynb
@@ -378,7 +378,7 @@
     }
    ],
    "source": [
-    "y_pred_dist = loaded_model.predict_proba(X=X)\n",
+    "y_pred_dist = loaded_model.predict_proba(X=X, legacy_interface=True)\n",
     "y_pred_dist_quantiles = pd.DataFrame(y_pred_dist.quantile(quantiles))\n",
     "y_pred_dist_quantiles.columns = [f\"Quantiles_{q}\" for q in quantiles]\n",
     "y_pred_dist_quantiles.index = y_pred_dist.parameters[\"loc\"].index\n",
@@ -812,7 +812,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "sktime-skbase-310",
    "language": "python",
    "name": "python3"
   },
@@ -826,7 +826,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.10.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "1ab6896984b6aa500b8009633c692bca601cfe3e50e0ab79a8a59539ceef9c7a"
+   }
   }
  },
  "nbformat": 4,

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -741,7 +741,9 @@ class _SktimeModelWrapper:
                     ]["marginal"]
                 )
 
-                y_pred_dist = self.sktime_model.predict_proba(X=X, marginal=marginal)
+                y_pred_dist = self.sktime_model.predict_proba(
+                    X=X, marginal=marginal, legacy_interface=True
+                )
                 y_pred_dist_quantiles = pd.DataFrame(y_pred_dist.quantile(quantiles))
                 y_pred_dist_quantiles.columns = [f"Quantiles_{q}" for q in quantiles]
                 y_pred_dist_quantiles.index = y_pred_dist.parameters["loc"].index

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -195,7 +195,7 @@ def test_auto_arima_model_pyfunc_with_params_output(auto_arima_model, model_path
     model_predict = auto_arima_model.predict()
     model_predict_interval = auto_arima_model.predict_interval(coverage=[0.1, 0.9])
     model_predict_interval.columns = flatten_multiindex(model_predict_interval)
-    model_predict_proba_dist = auto_arima_model.predict_proba()
+    model_predict_proba_dist = auto_arima_model.predict_proba(legacy_interface=True)
     model_predict_proba = pd.DataFrame(model_predict_proba_dist.quantile([0.1, 0.9]))
     model_predict_proba.index = model_predict_proba_dist.parameters["loc"].index
     model_predict_quantiles = auto_arima_model.predict_quantiles(alpha=[0.1, 0.9])
@@ -249,7 +249,7 @@ def test_auto_arima_model_pyfunc_without_params_output(auto_arima_model, model_p
     model_predict = auto_arima_model.predict()
     model_predict_interval = auto_arima_model.predict_interval()
     model_predict_interval.columns = flatten_multiindex(model_predict_interval)
-    model_predict_proba_dist = auto_arima_model.predict_proba()
+    model_predict_proba_dist = auto_arima_model.predict_proba(legacy_interface=True)
     model_predict_proba = pd.DataFrame(model_predict_proba_dist.quantile([0.1, 0.9]))
     model_predict_proba.index = model_predict_proba_dist.parameters["loc"].index
     model_predict_quantiles = auto_arima_model.predict_quantiles()


### PR DESCRIPTION
This makes the `mlflow` forecasting interface safe from the default interface changes to the `predict_proba` in 0.18.0, by ensuring that `predict_proba` calls in `mlflow` forecasting interface explicitly call `legacy_interface`.

This is fine for now, as the `mlflow` interface explicitly says that it does not support `predict_proba` (it just returns quantiles obtained from the distribution object).

We will need to change these calls to use the new interface, but that will be a separate issue.

Towards the 0.18.0 release action of deprecating the legacy interface.

