### PR TITLE
[BUG] fix informative error message on `y` input type check in `BaseTransformer`

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -980,10 +980,12 @@ class BaseTransformer(BaseEstimator):
             elif X_scitype == "Hierarchical":
                 y_possible_scitypes = ["Panel", "Hierarchical"]
 
-            y_valid, _, y_metadata = check_is_scitype(
+            y_valid, msg, y_metadata = check_is_scitype(
                 y, scitype=y_possible_scitypes, return_metadata=[], var_name="y"
             )
             if not y_valid:
+                for mtype, err in msg.items():
+                    msg_invalid_input += f" [{mtype}: {err}] "
                 raise TypeError("y " + msg_invalid_input)
 
             y_scitype = y_metadata["scitype"]


### PR DESCRIPTION
This PR fixes an unreported bug where the `y` input type check in `BaseTransformer` would not return additional information on failure reasons for the check. The failure reasons were accidentally not appended to the failure string.