### PR TITLE
&achieveordie [BUG] fix bug from clash between `ABC` inheritance and RNN `fit` override

### DIFF
--- a/sktime/classification/deep_learning/rnn.py
+++ b/sktime/classification/deep_learning/rnn.py
@@ -52,10 +52,7 @@ class SimpleRNNClassifier(BaseDeepClassifier):
         self.use_bias = use_bias
         self.optimizer = optimizer
         self.history = None
-        self._network = RNNNetwork(
-            batch_size=self.batch_size,
-            units=self.units,
-        )
+        self._network = RNNNetwork(random_state=random_state, units=units)
 
     def build_model(self, input_shape, **kwargs):
         """

--- a/sktime/classification/deep_learning/rnn.py
+++ b/sktime/classification/deep_learning/rnn.py
@@ -94,7 +94,7 @@ class SimpleRNNClassifier(BaseDeepClassifier):
         model.compile(loss=self.loss, optimizer=self.optimizer_, metrics=metrics)
         return model
 
-    def fit(self, X, y, input_checks=True):
+    def _fit(self, X, y):
         """
         Fit the regressor on the training set (X, y).
 
@@ -106,8 +106,6 @@ class SimpleRNNClassifier(BaseDeepClassifier):
             n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
             The training data class labels.
-        input_checks : boolean
-            whether to check the X and y parameters
 
         Returns
         -------

--- a/sktime/networks/rnn.py
+++ b/sktime/networks/rnn.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Time Recurrent Neural Network (RNN) (minus the final output layer)."""
 
-__author__ = "James Large, Withington, Tony Bagnall"
+__authors__ = ["JamesLarge", "Withington", "TonyBagnall", "achieveordie"]
 
 from sktime.networks.base import BaseDeepNetwork
 
@@ -27,8 +27,10 @@ class RNNNetwork(BaseDeepNetwork):
 
         Parameters
         ----------
-        input_shape : tuple
-            The shape of the data fed into the input layer, should be (m,d)
+        input_shape : int or tuple
+            The shape of the data fed into the input layer. It should either
+            have dimensions of (m, d) or m. In case an int is passed,
+            1 is appended for d.
 
         Returns
         -------
@@ -36,11 +38,28 @@ class RNNNetwork(BaseDeepNetwork):
         """
         from tensorflow import keras
 
-        input_layer = keras.layers.Input((input_shape, 1))
+        if isinstance(input_shape, int):
+            input_layer = keras.layers.Input((input_shape, 1))
+        elif isinstance(input_shape, tuple):
+            if len(input_shape) == 2:
+                input_layer = keras.layers.Input(input_shape)
+            elif len(input_shape) == 1:
+                input_layer = keras.layers.Input((*input_shape, 1))
+            else:
+                raise ValueError(
+                    "If `input_shape` is a tuple, it must either be "
+                    f"of length 1 or 2. Found length of be {len(input_shape)}"
+                )
+        else:
+            raise TypeError(
+                "`input_shape` should either be of type int or tuple. "
+                f"But found the type to be: {type(input_shape)}"
+            )
 
-        rnn = keras.layers.SimpleRNN(
-            units=self.units, return_sequences=True, input_shape=(input_shape, 1)
-        )(input_layer)
+        rnn = keras.layers.SimpleRNN(units=self.units, return_sequences=True)(
+            input_layer
+        )
+
         dense = keras.layers.Dense(units=1)(rnn)
 
         return input_layer, dense

--- a/sktime/regression/deep_learning/rnn.py
+++ b/sktime/regression/deep_learning/rnn.py
@@ -53,10 +53,7 @@ class SimpleRNNRegressor(BaseDeepRegressor):
         self.use_bias = use_bias
         self.optimizer = optimizer
         self.history = None
-        self._network = RNNNetwork(
-            batch_size=self.batch_size,
-            units=self.units,
-        )
+        self._network = RNNNetwork(random_state=random_state, units=units)
 
     def build_model(self, input_shape, **kwargs):
         """

--- a/sktime/regression/deep_learning/rnn.py
+++ b/sktime/regression/deep_learning/rnn.py
@@ -90,7 +90,7 @@ class SimpleRNNRegressor(BaseDeepRegressor):
         model.compile(loss=self.loss, optimizer=self.optimizer_, metrics=metrics)
         return model
 
-    def fit(self, X, y, input_checks=True):
+    def _fit(self, X, y):
         """
         Fit the regressor on the training set (X, y).
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -33,8 +33,6 @@ EXCLUDE_ESTIMATORS = [
     "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
     "LSTMFCNClassifier",  # unknown cause, see bug report #4033
     "TimeSeriesLloyds",  # an abstract class, but does not follow naming convention
-    "SimpleRNNRegressor",
-    "SimpleRNNClassifier",
 ]
 
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -33,6 +33,8 @@ EXCLUDE_ESTIMATORS = [
     "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
     "LSTMFCNClassifier",  # unknown cause, see bug report #4033
     "TimeSeriesLloyds",  # an abstract class, but does not follow naming convention
+    "SimpleRNNRegressor",
+    "SimpleRNNClassifier",
 ]
 
 


### PR DESCRIPTION
By accident, we merged https://github.com/sktime/sktime/pull/4185 without re-running the tests - this masked a bug. Which is not too grave as it is post-release, and the release CI has all passed.

Details: on the new `main`, the merge caused a clash with the `ABC` inheritance in `BaseRegressor` as one of the methods was not overridden. Also, `fit` should be `_fit`, which is also fixed.