### PR TITLE
[MNT] remove RNN related failure from main

### DIFF
--- a/sktime/classification/deep_learning/rnn.py
+++ b/sktime/classification/deep_learning/rnn.py
@@ -52,10 +52,7 @@ class SimpleRNNClassifier(BaseDeepClassifier):
         self.use_bias = use_bias
         self.optimizer = optimizer
         self.history = None
-        self._network = RNNNetwork(
-            batch_size=self.batch_size,
-            units=self.units,
-        )
+        self._network = RNNNetwork(random_state=random_state, units=units)
 
     def build_model(self, input_shape, **kwargs):
         """

--- a/sktime/classification/deep_learning/rnn.py
+++ b/sktime/classification/deep_learning/rnn.py
@@ -94,7 +94,7 @@ class SimpleRNNClassifier(BaseDeepClassifier):
         model.compile(loss=self.loss, optimizer=self.optimizer_, metrics=metrics)
         return model
 
-    def fit(self, X, y, input_checks=True):
+    def _fit(self, X, y):
         """
         Fit the regressor on the training set (X, y).
 
@@ -106,8 +106,6 @@ class SimpleRNNClassifier(BaseDeepClassifier):
             n_dimensions is assumed to be 1.
         y : array-like, shape = [n_instances]
             The training data class labels.
-        input_checks : boolean
-            whether to check the X and y parameters
 
         Returns
         -------

--- a/sktime/regression/deep_learning/rnn.py
+++ b/sktime/regression/deep_learning/rnn.py
@@ -53,10 +53,7 @@ class SimpleRNNRegressor(BaseDeepRegressor):
         self.use_bias = use_bias
         self.optimizer = optimizer
         self.history = None
-        self._network = RNNNetwork(
-            batch_size=self.batch_size,
-            units=self.units,
-        )
+        self._network = RNNNetwork(random_state=random_state, units=units)
 
     def build_model(self, input_shape, **kwargs):
         """

--- a/sktime/regression/deep_learning/rnn.py
+++ b/sktime/regression/deep_learning/rnn.py
@@ -90,7 +90,7 @@ class SimpleRNNRegressor(BaseDeepRegressor):
         model.compile(loss=self.loss, optimizer=self.optimizer_, metrics=metrics)
         return model
 
-    def fit(self, X, y, input_checks=True):
+    def _fit(self, X, y):
         """
         Fit the regressor on the training set (X, y).
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -33,6 +33,8 @@ EXCLUDE_ESTIMATORS = [
     "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
     "LSTMFCNClassifier",  # unknown cause, see bug report #4033
     "TimeSeriesLloyds",  # an abstract class, but does not follow naming convention
+    "SimpleRNNRegressor",
+    "SimpleRNNClassifier",
 ]
 
 


### PR DESCRIPTION
Due to a merge accident, a failure related to RNN made it to main.

This fixes fixture construction bugs and removes the estimators from testing temporarily.

The full fix will be developed in https://github.com/sktime/sktime/pull/4527, which is dependent on this PR (and removes the test skips).