### PR TITLE
[BUG] fix incorrect values returned by `DateTimeFeatures` `'month_of_quarter'` feature

### DIFF
--- a/sktime/transformations/series/date.py
+++ b/sktime/transformations/series/date.py
@@ -267,7 +267,7 @@ def _calendar_dummies(x, funcs):
     elif funcs == "week_of_month":
         cd = (date_sequence.day - 1) // 7 + 1
     elif funcs == "month_of_quarter":
-        cd = (np.floor(date_sequence.month / 4) + 1).astype(np.int64)
+        cd = (date_sequence.month.astype(np.int64) + 2) % 3 + 1
     elif funcs == "week_of_quarter":
         col_names = x.columns
         x_columns = col_names.intersection(["year", "quarter", "week"]).to_list()

--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from sktime.datasets import load_PBS_dataset, load_airline, load_longley
+from sktime.datasets import load_airline, load_longley, load_PBS_dataset
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.transformations.series.date import DateTimeFeatures
 from sktime.utils._testing.hierarchical import _make_hierarchical
@@ -281,7 +281,7 @@ def test_month_of_quarter(df_panel):
     """Test month_of_quarter for correctness, failure case of bug #4541."""
     y = load_PBS_dataset()
 
-    FEATURES = ['month_of_quarter']
+    FEATURES = ["month_of_quarter"]
     t = DateTimeFeatures(manual_selection=FEATURES)
 
     yt = t.fit_transform(y)[:13]

--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -3,11 +3,12 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file).
 """Unit tests of DateTimeFeatures functionality."""
 
+import numpy as np
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from sktime.datasets import load_airline, load_longley
+from sktime.datasets import load_PBS_dataset, load_airline, load_longley
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.transformations.series.date import DateTimeFeatures
 from sktime.utils._testing.hierarchical import _make_hierarchical
@@ -270,3 +271,19 @@ def test_keep_original_columns(df_panel):
         },
     )
     assert_frame_equal(Xt, expected)
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(DateTimeFeatures, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+def test_month_of_quarter(df_panel):
+    """Test month_of_quarter for correctness, failure case of bug #4541."""
+    y = load_PBS_dataset()
+
+    FEATURES = ['month_of_quarter']
+    t = DateTimeFeatures(manual_selection=FEATURES)
+
+    yt = t.fit_transform(y)[:13]
+    expected = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1])
+    assert (expected == yt.values).all()


### PR DESCRIPTION
Fixes #4541. As the issue states, the formula with the modulos was broken, this is fixed now.

Also adds the example case as a test.