### PR TITLE
[ENH] remove warning for length 1 forecasting pipelines

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -5,8 +5,6 @@
 __author__ = ["mloning", "aiwalter"]
 __all__ = ["TransformedTargetForecaster", "ForecastingPipeline", "ForecastX"]
 
-from warnings import warn
-
 import pandas as pd
 
 from sktime.base import _HeterogenousMetaEstimator

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -81,15 +81,6 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
             )
             raise TypeError(msg)
 
-        if len(estimators) == 1:
-            msg = (
-                f"in {self_name}, found steps of length 1, "
-                f"this will result in the same behaviour "
-                f"as not wrapping the single step in a pipeline. "
-                f"Consider not wrapping steps in {self_name} as it is redundant."
-            )
-            warn(msg)
-
         estimator_tuples = self._get_estimator_tuples(estimators, clone_ests=True)
         names, estimators = zip(*estimator_tuples)
 


### PR DESCRIPTION
This PR removes the warning at construction of length 1 forecasting pipelines.

While helpful to the user if they explicitly construct the pipeline via the constructor, it is also raised when constructing pipelines via the dunder, or the `make_pipeline` utility, in which case it confuses the user.

As there is no way currently to evoke different behaviour in these two cases, we should remove it instead.

Side consideration: I have thought whether the config system and https://github.com/sktime/sktime/pull/4536 could be used for this - but for this, the config would have to be set before construction, which is currently not possible, not even with #4536.