### PR TITLE
[MNT] test for isolation of `pytest`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,26 @@ jobs:
         run: build_tools/run_examples.sh
         shell: bash
 
+  test-nodevdeps:
+    needs: code-quality
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install sktime and dependencies
+        run: |
+          python -m pip install .
+
+      - name: Install sktime and dependencies
+        run: |
+          python sktime/_nopytest_tests.py
+
   test-nosoftdeps:
     needs: code-quality
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           python -m pip install .
 
-      - name: Install sktime and dependencies
+      - name: Run pytest-free tests
         run: |
           python sktime/_nopytest_tests.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "deprecated>=1.2.13",
     "numpy>=1.21.0,<1.25",
     "pandas>=1.1.0,<2.0.0",
+    "packaging",
     "scikit-base<0.5.0",
     "scikit-learn>=0.24.0,<1.3.0",
     "scipy<2.0.0,>=1.2.0",

--- a/sktime/_nopytest_tests.py
+++ b/sktime/_nopytest_tests.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Tests to run without pytest, to check pytest isolation."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+from sktime.registry import all_estimators
+
+# all_estimators crawls all modules excepting pytest test files
+# if it encounters an unisolated import, it will throw an exception
+results = all_estimators()


### PR DESCRIPTION
Resolves https://github.com/sktime/sktime/issues/4544, i.e., testing that `pytest` is isolated in a plain `sktime` install (which does not have `pytest` as a declared core dependency).

The approach is as follows:

* addition of a new GHA job
* only `sktime` plain is installed, no `dev` dependencies
* a test file `_nopytest_tests` is added, which can contain `pytest`-free checks
* currently, `all_estimators` plain is executed. As this crawls all modules (except tests and a few others), it will spot unisolated `pytest` imports, or imports of other packages.
* further checks can be added later

Depends on https://github.com/sktime/sktime/pull/4551