### PR TITLE
[MNT] add silent dependencies to core dependency set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "deprecated>=1.2.13",
     "numpy>=1.21.0,<1.25",
     "pandas>=1.1.0,<2.0.0",
+    "packaging",
     "scikit-base<0.5.0",
     "scikit-learn>=0.24.0,<1.3.0",
     "scipy<2.0.0,>=1.2.0",


### PR DESCRIPTION
This PR adds all formerly silent dependencies to the core dependency set.

A silent dependency is:

* an indirect dependency, i.e., a dependency of a core dependency, or an indirect dependency of a core dependency
* not a core dependency as per `pyproject.toml`
* imported directly from `sktime`

This is potentially problematic, as the dependency may decide to drop the dependency, which results in instant failure of `sktime` based CI.

An example of this in the past is the failure that https://github.com/sktime/sktime/pull/4450 fixed, where `pytest` dropped `attrs`, but `attrs`.

With https://github.com/sktime/sktime/issues/4544 in addition, it has become clear that we need to manage all silent dependencies and turn them into core dependencies.

This PR does that, as per the detection mechanism in https://github.com/sktime/sktime/pull/4548.