### PR TITLE
[ENH] remove remaining soft dependency related module import warnings

### DIFF
--- a/sktime/classification/deep_learning/rnn.py
+++ b/sktime/classification/deep_learning/rnn.py
@@ -12,8 +12,6 @@ from sktime.classification.deep_learning.base import BaseDeepClassifier
 from sktime.networks.rnn import RNNNetwork
 from sktime.utils.validation._dependencies import _check_dl_dependencies
 
-_check_dl_dependencies(severity="warning")
-
 
 class SimpleRNNClassifier(BaseDeepClassifier):
     """Simple recurrent neural network.

--- a/sktime/networks/inceptiontime.py
+++ b/sktime/networks/inceptiontime.py
@@ -5,8 +5,6 @@ __author__ = "James Large, Withington"
 from sktime.networks.base import BaseDeepNetwork
 from sktime.utils.validation._dependencies import _check_dl_dependencies
 
-_check_dl_dependencies("tensorflow", severity="warning")
-
 
 class InceptionTimeNetwork(BaseDeepNetwork):
     """InceptionTime adapted from the implementation from Fawaz et al.

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -136,7 +136,9 @@ def all_estimators(
     ----------
     Modified version from scikit-learn's `all_estimators()`.
     """
-    MODULES_TO_IGNORE = ("tests", "setup", "contrib", "benchmarking", "utils", "all")
+    MODULES_TO_IGNORE = (
+        "tests", "setup", "contrib", "benchmarking", "utils", "all", "plotting"
+    )
 
     result = []
     ROOT = str(Path(__file__).parent.parent)  # sktime package root directory

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -137,7 +137,13 @@ def all_estimators(
     Modified version from scikit-learn's `all_estimators()`.
     """
     MODULES_TO_IGNORE = (
-        "tests", "setup", "contrib", "benchmarking", "utils", "all", "plotting"
+        "tests",
+        "setup",
+        "contrib",
+        "benchmarking",
+        "utils",
+        "all",
+        "plotting",
     )
 
     result = []

--- a/sktime/regression/deep_learning/cnn.py
+++ b/sktime/regression/deep_learning/cnn.py
@@ -12,8 +12,6 @@ from sktime.networks.cnn import CNNNetwork
 from sktime.regression.deep_learning.base import BaseDeepRegressor
 from sktime.utils.validation._dependencies import _check_dl_dependencies
 
-_check_dl_dependencies(severity="warning")
-
 
 class CNNRegressor(BaseDeepRegressor):
     """Time Series Convolutional Neural Network (CNN), as described in [1].

--- a/sktime/regression/deep_learning/rnn.py
+++ b/sktime/regression/deep_learning/rnn.py
@@ -12,8 +12,6 @@ from sktime.networks.rnn import RNNNetwork
 from sktime.regression.deep_learning.base import BaseDeepRegressor
 from sktime.utils.validation._dependencies import _check_dl_dependencies
 
-_check_dl_dependencies(severity="warning")
-
 
 class SimpleRNNRegressor(BaseDeepRegressor):
     """


### PR DESCRIPTION
This removes a number of remaining import warnings from module imports, these are raised for example when running `all_estimators`.

Completes the work and dependency handling requirements from https://github.com/sktime/sktime/pull/4398 - most of the remaining warnings are from PR which were still in progress when #4398 was merged.