### PR TITLE
[BUG] Fixes incorrect window indexing in `HampelFilter`

### DIFF
--- a/sktime/transformations/series/outlier_detection.py
+++ b/sktime/transformations/series/outlier_detection.py
@@ -7,6 +7,7 @@ __author__ = ["aiwalter"]
 __all__ = ["HampelFilter"]
 
 import warnings
+from math import ceil
 
 import numpy as np
 import pandas as pd
@@ -183,7 +184,7 @@ def _hampel_filter(Z, cv, n_sigma, half_window_length, k):
             if cv.window_length % 2 == 0:
                 start_end_win = half_window_length
             else:
-                start_end_win = half_window_length + 1
+                start_end_win = ceil(cv.window_length / 2)
             idx_range = range(len(Z) - start_end_win, len(Z))
         else:
             idx_range = [cv_window[0] + half_window_length]

--- a/sktime/transformations/series/outlier_detection.py
+++ b/sktime/transformations/series/outlier_detection.py
@@ -126,7 +126,10 @@ class HampelFilter(BaseTransformer):
             )
 
         cv = SlidingWindowSplitter(
-            window_length=self.window_length, step_length=1, start_with_window=True
+            fh=0,
+            window_length=self.window_length,
+            step_length=1,
+            start_with_window=True,
         )
         half_window_length = int(self.window_length / 2)
 
@@ -172,28 +175,20 @@ def _hampel_filter(Z, cv, n_sigma, half_window_length, k):
         cv_median = np.nanmedian(Z[cv_window])
         cv_sigma = k * np.nanmedian(np.abs(Z[cv_window] - cv_median))
 
-        # find outliers at start and end of z
-        if (
-            cv_window[0] <= half_window_length
-            or cv_window[-1] >= len(Z) - half_window_length
-        ) and (cv_window[0] in [0, len(Z) - cv.window_length - 1]):
-
-            # first half of the first window
-            if cv_window[0] <= half_window_length:
-                idx_range = range(cv_window[0], half_window_length + 1)
-
-            # last half of the last window
+        is_start_window = cv_window[-1] == cv.window_length - 1
+        is_end_window = cv_window[-1] == len(Z) - 1
+        if is_start_window:
+            idx_range = range(cv_window[0], half_window_length + 1)
+        elif is_end_window:
+            if cv.window_length % 2 == 0:
+                start_end_win = half_window_length
             else:
-                idx_range = range(len(Z) - half_window_length - 1, len(Z))
-            for j in idx_range:
-                Z.iloc[j] = _compare(
-                    value=Z.iloc[j],
-                    cv_median=cv_median,
-                    cv_sigma=cv_sigma,
-                    n_sigma=n_sigma,
-                )
+                start_end_win = half_window_length + 1
+            idx_range = range(len(Z) - start_end_win, len(Z))
         else:
-            idx = cv_window[0] + half_window_length
+            idx_range = [cv_window[0] + half_window_length]
+
+        for idx in idx_range:
             Z.iloc[idx] = _compare(
                 value=Z.iloc[idx],
                 cv_median=cv_median,


### PR DESCRIPTION
#### Reference Issues/PRs
Not found any

#### What does this implement/fix? Explain your changes.
Consists on two fixes:

1. SlidingWindowSplitter split assumes a default forecasting horizon of 1 which leaves one datapoint out for test.  
   - Impact: all the datapoints checked for outlier in the last window have miscalculated stats since the window is shifted by 1 position, leaving the last datapoint out.
    - Solution: changed SlidingWindowSplitter forecasting horizon to 0, this creates an additional window including the missing datapoint, thus ensuring the calculations for the last window are accurate.

2. Current way of finding the start and end where the window is incomplete is not accurate for odd-sized windows
    - Impact: for an odd-sized window, the datapoint n - floor(half_window_length) - 2 is not being considered as an outlier.
    - Solution: changed the logic to identify where the window is incomplete at the start and end of the series making the code more explicit, and added different logic to handle the even-sized and odd-sized windows.
  
See screenshot below which gives an overview of the issue and the proposed fix.
![image](https://user-images.githubusercontent.com/29917556/236674762-262714bb-047c-4d27-9301-ec5978c43df8.png)



#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?


#### Did you add any tests for the change?
No

#### Any other comments?

#### PR checklist


##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.


<!--
Thanks for contributing!
-->
