### PR TITLE
[DOC] Improve Docstring for MAPE Metrics

### DIFF
--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1735,15 +1735,8 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     MeanSquaredPercentageError
     MedianSquaredPercentageError
 
-    Notes
-    -----
-    In some literature sources, sMAPE is also known as Adjusted MAPE because
-    ,in some cases, over- and under-forecasts are not really penalised equally. [1]_
-
     References
     ----------
-    .. [1] Goodwin.P and Lawton.R (1999) "On the asymmetry of the symmetric MAPE".
-
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
     forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
 
@@ -1868,15 +1861,8 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     MeanSquaredPercentageError
     MedianSquaredPercentageError
 
-    Notes
-    -----
-    In some literature sources, sMdAPE is also known as Adjusted MdAPE because
-    ,in some cases, over- and under-forecasts are not penalised equally. [1]_
-
     References
     ----------
-    .. [1] Goodwin.P and Lawton.R (1999) "On the asymmetry of the symmetric MAPE".
-
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
     forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
 

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1684,7 +1684,7 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n`,
     at time indices :math:`t_1, \dots, t_n`,
     `evaluate` or call returns the Mean Absolute Percentage Error,
-    :math:`\frac{1}{n}\sum_{i=1}^n |\frac{y_i - \widehat{y}_i}{y_i}|`.
+    :math:`\frac{1}{n} \sum_{i=1}^n \left|\frac{y_i - \widehat{y}_i}{y_i} \right|`.
     (the time indices are not used)
 
     if `symmetric` is True then calculates
@@ -1708,7 +1708,7 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
 
     `evaluate_by_index` returns, at a time index :math:`t_i`,
     the abolute percentage error at that time index,
-    :math:`|\frac{y_i - \widehat{y}_i}{y_i}|`,
+    :math:`\left| \frac{y_i - \widehat{y}_i}{y_i} \right|`,
     or :math:`\frac{2|y_i - \widehat{y}_i|}{|y_i| + |\widehat{y}_i|}`,
     the symmetric version, if `symmetric` is True, for all time indices
     :math:`t_1, \dots, t_n` in the input.
@@ -1814,7 +1814,7 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n`,
     at time indices :math:`t_1, \dots, t_n`,
     `evaluate` or call returns the Median Absolute Percentage Error,
-    :math:`median(|\frac{y_i - \widehat{y}_i}{y_i}|)`.
+    :math:`median(\left|\frac{y_i - \widehat{y}_i}{y_i} \right|)`.
     (the time indices are not used)
 
     if `symmetric` is True then calculates

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1684,15 +1684,16 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n`,
     at time indices :math:`t_1, \dots, t_n`,
     `evaluate` or call returns the Mean Absolute Percentage Error,
-    :math:`\frac{100\%}{n}\sum_{i=1}^n |\frac{y_i - \widehat{y}_i}{y_i}|`.
+    :math:`\frac{1}{n}\sum_{i=1}^n |\frac{y_i - \widehat{y}_i}{y_i}|`.
     (the time indices are not used)
 
     if `symmetric` is True then calculates
     symmetric mean absolute percentage error (sMAPE), defined as
-    :math:`\frac{200\%}{n} \sum_{i=1}^n \frac{|y_i - \widehat{y}_i|}
+    :math:`\frac{2}{n} \sum_{i=1}^n \frac{|y_i - \widehat{y}_i|}
     {|y_i| + |\widehat{y}_i|}`.
 
-    Both MAPE and sMAPE output is non-negative floating point. The best value is 0.0.
+    Both MAPE and sMAPE output non-negative floating point which is in fractional units
+    rather than percentage. The best value is 0.0.
 
     sMAPE is measured in percentage error relative to the test data. Because it
     takes the absolute value rather than square the percentage forecast
@@ -1707,7 +1708,7 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
 
     `evaluate_by_index` returns, at a time index :math:`t_i`,
     the abolute percentage error at that time index,
-    :math:`100\%|\frac{y_i - \widehat{y}_i}{y_i}|`,
+    :math:`|\frac{y_i - \widehat{y}_i}{y_i}|`,
     for all time indices :math:`t_1, \dots, t_n` in the input.
 
     Parameters
@@ -1734,7 +1735,7 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
 
     Notes
     -----
-    In some literatures, sMAPE is also known as Adjusted MAPE because
+    In some literature sources, sMAPE is also known as Adjusted MAPE because
     ,in some cases, over- and under-forecasts are not really penalised equally. [1]_
 
     References
@@ -1818,13 +1819,12 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n`,
     at time indices :math:`t_1, \dots, t_n`,
     `evaluate` or call returns the Median Absolute Percentage Error,
-    :math:`median(100\%|\frac{y_i - \widehat{y}_i}{y_i}|)`.
+    :math:`median(|\frac{y_i - \widehat{y}_i}{y_i}|)`.
     (the time indices are not used)
 
     if `symmetric` is True then calculates
     symmetric Median Absolute Percentage Error (sMdAPE), defined as
-    :math:`median(\frac{200\%|y_i-\widehat{y}_i|}
-    {|y_i|+|\widehat{y}_i|})`.
+    :math:`median(\frac{2|y_i-\widehat{y}_i|}{|y_i|+|\widehat{y}_i|})`.
 
     Both MdAPE and sMdAPE output is non-negative floating point. The best value is 0.0.
 
@@ -1842,11 +1842,6 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
 
     `multioutput` and `multilevel` control averaging across variables and
     hierarchy indices, see below.
-
-    `evaluate_by_index` returns, at a time index :math:`t_i`,
-    the abolute percentage error at that time index,
-    :math:`100\%|\frac{y_i - \widehat{y}_i}{y_i}|`,
-    for all time indices :math:`t_1, \dots, t_n` in the input.
 
     Parameters
     ----------
@@ -1872,7 +1867,7 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
 
     Notes
     -----
-    In some literatures, sMdAPE is also known as Adjusted MdAPE because
+    In some literature sources, sMdAPE is also known as Adjusted MdAPE because
     ,in some cases, over- and under-forecasts are not penalised equally. [1]_
 
     References

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1677,20 +1677,20 @@ class GeometricMeanSquaredError(BaseForecastingErrorMetricFunc):
 
 
 class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
-    r"""Mean absolute percentage error (MAPE) or symmetric version.
+    """Mean absolute percentage error (MAPE) or symmetric version.
 
     For a univariate, non-hierarchical sample
-    of true values :math:`y_1, \dots, y_n` and
-    predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n`,
-    at time indices :math:`t_1, \dots, t_n`,
+    of true values :math:`y_1, \\dots, y_n` and
+    predicted values :math:`\\widehat{y}_1, \\dots, \\widehat{y}_n`,
+    at time indices :math:`t_1, \\dots, t_n`,
     `evaluate` or call returns the Mean Absolute Percentage Error,
-    :math:`\frac{1}{n} \sum_{i=1}^n \left|\frac{y_i - \widehat{y}_i}{y_i} \right|`.
+    :math:`\\frac{1}{n} \\sum_{i=1}^n \\left|\\frac{y_i-\\widehat{y}_i}{y_i} \\right|`.
     (the time indices are not used)
 
     if `symmetric` is True then calculates
     symmetric mean absolute percentage error (sMAPE), defined as
-    :math:`\frac{2}{n} \sum_{i=1}^n \frac{|y_i - \widehat{y}_i|}
-    {|y_i| + |\widehat{y}_i|}`.
+    :math:`\\frac{2}{n} \\sum_{i=1}^n \\frac{|y_i - \\widehat{y}_i|}
+    {|y_i| + |\\widehat{y}_i|}`.
 
     Both MAPE and sMAPE output non-negative floating point which is in fractional units
     rather than percentage. The best value is 0.0.
@@ -1708,10 +1708,10 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
 
     `evaluate_by_index` returns, at a time index :math:`t_i`,
     the abolute percentage error at that time index,
-    :math:`\left| \frac{y_i - \widehat{y}_i}{y_i} \right|`,
-    or :math:`\frac{2|y_i - \widehat{y}_i|}{|y_i| + |\widehat{y}_i|}`,
+    :math:`\\left| \\frac{y_i - \\widehat{y}_i}{y_i} \\right|`,
+    or :math:`\\frac{2|y_i - \\widehat{y}_i|}{|y_i| + |\\widehat{y}_i|}`,
     the symmetric version, if `symmetric` is True, for all time indices
-    :math:`t_1, \dots, t_n` in the input.
+    :math:`t_1, \\dots, t_n` in the input.
 
     Parameters
     ----------
@@ -1808,18 +1808,18 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
 
 
 class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
-    r"""Median absolute percentage error (MdAPE) or symmetric version.
+    """Median absolute percentage error (MdAPE) or symmetric version.
 
-    For a univariate, non-hierarchical sample of true values :math:`y_1, \dots, y_n` and
-    predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n`,
-    at time indices :math:`t_1, \dots, t_n`,
+    For a univariate, non-hierarchical sample of true values :math:`y_1, \\dots, y_n`
+    and predicted values :math:`\\widehat{y}_1, \\dots, \\widehat{y}_n`,
+    at time indices :math:`t_1, \\dots, t_n`,
     `evaluate` or call returns the Median Absolute Percentage Error,
-    :math:`median(\left|\frac{y_i - \widehat{y}_i}{y_i} \right|)`.
+    :math:`median(\\left|\\frac{y_i - \\widehat{y}_i}{y_i} \\right|)`.
     (the time indices are not used)
 
     if `symmetric` is True then calculates
     symmetric Median Absolute Percentage Error (sMdAPE), defined as
-    :math:`median(\frac{2|y_i-\widehat{y}_i|}{|y_i|+|\widehat{y}_i|})`.
+    :math:`median(\\frac{2|y_i-\\widehat{y}_i|}{|y_i|+|\\widehat{y}_i|})`.
 
     Both MdAPE and sMdAPE output non-negative floating point which is in fractional
     units rather than percentage. The best value is 0.0.

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1677,18 +1677,19 @@ class GeometricMeanSquaredError(BaseForecastingErrorMetricFunc):
 
 
 class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
-    """Mean absolute percentage error (MAPE) or symmetric version.
-    
-    For a univariate, non-hierarchical sample of true values :math:`y_1, \dots, y_n` and
+    r"""Mean absolute percentage error (MAPE) or symmetric version.
+
+    For a univariate, non-hierarchical sample
+    of true values :math:`y_1, \dots, y_n` and
     predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n`,
     at time indices :math:`t_1, \dots, t_n`,
     `evaluate` or call returns the Mean Absolute Percentage Error,
-    :math:`\frac{100%}{n}\sum_{i=1}^n |\frac{y_i - \widehat{y}_i}{y_i}|`.
+    :math:`\frac{100\%}{n}\sum_{i=1}^n |\frac{y_i - \widehat{y}_i}{y_i}|`.
     (the time indices are not used)
 
     if `symmetric` is True then calculates
     symmetric mean absolute percentage error (sMAPE), defined as
-    :math:`\frac{100%}{n}\sum_{i=1}^n \frac{2|y_i - \widehat{y}_i|}
+    :math:`\frac{200\%}{n} \sum_{i=1}^n \frac{|y_i - \widehat{y}_i|}
     {|y_i| + |\widehat{y}_i|}`.
 
     Both MAPE and sMAPE output is non-negative floating point. The best value is 0.0.
@@ -1701,15 +1702,12 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     values are close to zero. In such cases the function returns a large value
     instead of `inf`.
 
-    Notes: In some literatures, sMAPE is also known as Adjusted MAPE because
-    ,in some cases, over- and under-forecasts are not treated equally. [1]_
-
     `multioutput` and `multilevel` control averaging across variables and
     hierarchy indices, see below.
 
     `evaluate_by_index` returns, at a time index :math:`t_i`,
     the abolute percentage error at that time index,
-    :math:`100%|\frac{y_i - \widehat{y}_i}{y_i}|`,
+    :math:`100\%|\frac{y_i - \widehat{y}_i}{y_i}|`,
     for all time indices :math:`t_1, \dots, t_n` in the input.
 
     Parameters
@@ -1723,16 +1721,21 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
     multilevel : {'raw_values', 'uniform_average', 'uniform_average_time'}
-    Defines how to aggregate metric for hierarchical data (with levels).
-    If 'uniform_average' (default), errors are mean-averaged across levels.
-    If 'uniform_average_time', errors are mean-averaged across rows.
-    If 'raw_values', does not average errors across levels, hierarchy is retained.
+        Defines how to aggregate metric for hierarchical data (with levels).
+        If 'uniform_average' (default), errors are mean-averaged across levels.
+        If 'uniform_average_time', errors are mean-averaged across rows.
+        If 'raw_values', does not average errors across levels, hierarchy is retained.
 
     See Also
     --------
     MedianAbsolutePercentageError
     MeanSquaredPercentageError
     MedianSquaredPercentageError
+
+    Notes
+    -----
+    In some literatures, sMAPE is also known as Adjusted MAPE because
+    ,in some cases, over- and under-forecasts are not really penalised equally. [1]_
 
     References
     ----------
@@ -1809,18 +1812,18 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
 
 
 class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
-    """Median absolute percentage error (MdAPE) or symmetric version.
+    r"""Median absolute percentage error (MdAPE) or symmetric version.
 
     For a univariate, non-hierarchical sample of true values :math:`y_1, \dots, y_n` and
     predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n`,
     at time indices :math:`t_1, \dots, t_n`,
     `evaluate` or call returns the Median Absolute Percentage Error,
-    :math:`median(|\frac{y_i - \widehat{y}_i}{y_i}|)`.
+    :math:`median(100\%|\frac{y_i - \widehat{y}_i}{y_i}|)`.
     (the time indices are not used)
 
     if `symmetric` is True then calculates
     symmetric Median Absolute Percentage Error (sMdAPE), defined as
-    :math:`median(\frac{2|y_i-\widehat{y}_i|}
+    :math:`median(\frac{200\%|y_i-\widehat{y}_i|}
     {|y_i|+|\widehat{y}_i|})`.
 
     Both MdAPE and sMdAPE output is non-negative floating point. The best value is 0.0.
@@ -1837,15 +1840,12 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     values are close to zero. In such cases the function returns a large value
     instead of `inf`.
 
-    Notes: In some literatures, sMdAPE is also known as Adjusted MdAPE because
-    ,in some cases, over- and under-forecasts are not treated equally. [1]_
-
     `multioutput` and `multilevel` control averaging across variables and
     hierarchy indices, see below.
 
     `evaluate_by_index` returns, at a time index :math:`t_i`,
     the abolute percentage error at that time index,
-    :math:`100%|\frac{y_i - \widehat{y}_i}{y_i}|`,
+    :math:`100\%|\frac{y_i - \widehat{y}_i}{y_i}|`,
     for all time indices :math:`t_1, \dots, t_n` in the input.
 
     Parameters
@@ -1870,10 +1870,15 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     MeanSquaredPercentageError
     MedianSquaredPercentageError
 
+    Notes
+    -----
+    In some literatures, sMdAPE is also known as Adjusted MdAPE because
+    ,in some cases, over- and under-forecasts are not penalised equally. [1]_
+
     References
     ----------
     .. [1] Goodwin.P and Lawton.R (1999) "On the asymmetry of the symmetric MAPE".
-    
+
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
     forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
 

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1826,7 +1826,8 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     symmetric Median Absolute Percentage Error (sMdAPE), defined as
     :math:`median(\frac{2|y_i-\widehat{y}_i|}{|y_i|+|\widehat{y}_i|})`.
 
-    Both MdAPE and sMdAPE output is non-negative floating point. The best value is 0.0.
+    Both MdAPE and sMdAPE output non-negative floating point which is in fractional
+    units rather than percentage. The best value is 0.0.
 
     MdAPE and sMdAPE are measured in percentage error relative to the test data.
     Because it takes the absolute value rather than square the percentage forecast

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1699,9 +1699,9 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     takes the absolute value rather than square the percentage forecast
     error, it penalizes large errors less than MSPE, RMSPE, MdSPE or RMdSPE.
 
-    There is no limit on how large the error can be, particulalrly when `y_true`
+    MAPE has no limit on how large the error can be, particulalrly when `y_true`
     values are close to zero. In such cases the function returns a large value
-    instead of `inf`.
+    instead of `inf`. While sMAPE is bounded at 2.
 
     `multioutput` and `multilevel` control averaging across variables and
     hierarchy indices, see below.
@@ -1709,7 +1709,9 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     `evaluate_by_index` returns, at a time index :math:`t_i`,
     the abolute percentage error at that time index,
     :math:`|\frac{y_i - \widehat{y}_i}{y_i}|`,
-    for all time indices :math:`t_1, \dots, t_n` in the input.
+    or :math:`\frac{2|y_i - \widehat{y}_i|}{|y_i| + |\widehat{y}_i|}`,
+    the symmetric version, if `symmetric` is True, for all time indices
+    :math:`t_1, \dots, t_n` in the input.
 
     Parameters
     ----------
@@ -1837,9 +1839,9 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     makes this metric more robust to error outliers since the median tends
     to be a more robust measure of central tendency in the presence of outliers.
 
-    There is no limit on how large the error can be, particulalrly when `y_true`
+    MAPE has no limit on how large the error can be, particulalrly when `y_true`
     values are close to zero. In such cases the function returns a large value
-    instead of `inf`.
+    instead of `inf`. While sMAPE is bounded at 2.
 
     `multioutput` and `multilevel` control averaging across variables and
     hierarchy indices, see below.

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1717,7 +1717,7 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     ----------
     symmetric : bool, default = False
         Whether to calculate the symmetric version of the percentage metric
-    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape (n_outputs,), default='uniform_average' # noqa: E501
+    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape (n_outputs,), default='uniform_average'
         Defines how to aggregate metric for multivariate (multioutput) data.
         If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
@@ -1769,7 +1769,7 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     >>> smape = MeanAbsolutePercentageError(multioutput=[0.3, 0.7], symmetric=True)
     >>> smape(y_true, y_pred)
     0.5668686868686869
-    """
+    """  # noqa: E501
 
     func = mean_absolute_percentage_error
 
@@ -1841,7 +1841,7 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     ----------
     symmetric : bool, default = False
         Whether to calculate the symmetric version of the percentage metric
-    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape (n_outputs,) , default='uniform_average' # noqa: E501
+    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape (n_outputs,) , default='uniform_average'
         Defines how to aggregate metric for multivariate (multioutput) data.
         If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
@@ -1893,7 +1893,7 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     >>> smdape = MedianAbsolutePercentageError(multioutput=[0.3, 0.7], symmetric=True)
     >>> smdape(y_true, y_pred)
     0.5066666666666666
-    """
+    """  # noqa: E501
 
     func = median_absolute_percentage_error
 

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1717,7 +1717,8 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     ----------
     symmetric : bool, default = False
         Whether to calculate the symmetric version of the percentage metric
-    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape (n_outputs,), default='uniform_average'
+    multioutput : str or 1D array-like (n_outputs,), default='uniform_average'
+        if str, must be one of {'raw_values', 'uniform_average'}
         Defines how to aggregate metric for multivariate (multioutput) data.
         If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
@@ -1769,7 +1770,7 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     >>> smape = MeanAbsolutePercentageError(multioutput=[0.3, 0.7], symmetric=True)
     >>> smape(y_true, y_pred)
     0.5668686868686869
-    """  # noqa: E501
+    """
 
     func = mean_absolute_percentage_error
 
@@ -1841,7 +1842,8 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     ----------
     symmetric : bool, default = False
         Whether to calculate the symmetric version of the percentage metric
-    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape (n_outputs,) , default='uniform_average'
+    multioutput : str or 1D array-like (n_outputs,), default='uniform_average'
+        if str, must be one of {'raw_values', 'uniform_average'}
         Defines how to aggregate metric for multivariate (multioutput) data.
         If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1717,8 +1717,7 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     ----------
     symmetric : bool, default = False
         Whether to calculate the symmetric version of the percentage metric
-    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape (n_outputs,)
-    , default='uniform_average'
+    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape (n_outputs,), default='uniform_average' # noqa: E501
         Defines how to aggregate metric for multivariate (multioutput) data.
         If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
@@ -1842,8 +1841,7 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     ----------
     symmetric : bool, default = False
         Whether to calculate the symmetric version of the percentage metric
-    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape (n_outputs,)
-    , default='uniform_average'
+    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape (n_outputs,) , default='uniform_average' # noqa: E501
         Defines how to aggregate metric for multivariate (multioutput) data.
         If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1678,10 +1678,20 @@ class GeometricMeanSquaredError(BaseForecastingErrorMetricFunc):
 
 class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     """Mean absolute percentage error (MAPE) or symmetric version.
+    
+    For a univariate, non-hierarchical sample of true values :math:`y_1, \dots, y_n` and
+    predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n`,
+    at time indices :math:`t_1, \dots, t_n`,
+    `evaluate` or call returns the Mean Absolute Percentage Error,
+    :math:`\frac{100%}{n}\sum_{i=1}^n |\frac{y_i - \widehat{y}_i}{y_i}|`.
+    (the time indices are not used)
 
-    If `symmetric` is False then calculates MAPE and if `symmetric` is True
-    then calculates symmetric mean absolute percentage error (sMAPE). Both
-    MAPE and sMAPE output is non-negative floating point. The best value is 0.0.
+    if `symmetric` is True then calculates
+    symmetric mean absolute percentage error (sMAPE), defined as
+    :math:`\frac{100%}{n}\sum_{i=1}^n \frac{2|y_i - \widehat{y}_i|}
+    {|y_i| + |\widehat{y}_i|}`.
+
+    Both MAPE and sMAPE output is non-negative floating point. The best value is 0.0.
 
     sMAPE is measured in percentage error relative to the test data. Because it
     takes the absolute value rather than square the percentage forecast
@@ -1690,6 +1700,17 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     There is no limit on how large the error can be, particulalrly when `y_true`
     values are close to zero. In such cases the function returns a large value
     instead of `inf`.
+
+    Notes: In some literatures, sMAPE is also known as Adjusted MAPE because
+    ,in some cases, over- and under-forecasts are not treated equally. [1]_
+
+    `multioutput` and `multilevel` control averaging across variables and
+    hierarchy indices, see below.
+
+    `evaluate_by_index` returns, at a time index :math:`t_i`,
+    the abolute percentage error at that time index,
+    :math:`100%|\frac{y_i - \widehat{y}_i}{y_i}|`,
+    for all time indices :math:`t_1, \dots, t_n` in the input.
 
     Parameters
     ----------
@@ -1701,6 +1722,11 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
         If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
+    multilevel : {'raw_values', 'uniform_average', 'uniform_average_time'}
+    Defines how to aggregate metric for hierarchical data (with levels).
+    If 'uniform_average' (default), errors are mean-averaged across levels.
+    If 'uniform_average_time', errors are mean-averaged across rows.
+    If 'raw_values', does not average errors across levels, hierarchy is retained.
 
     See Also
     --------
@@ -1710,6 +1736,8 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
 
     References
     ----------
+    .. [1] Goodwin.P and Lawton.R (1999) "On the asymmetry of the symmetric MAPE".
+
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
     forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
 
@@ -1783,9 +1811,19 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
 class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     """Median absolute percentage error (MdAPE) or symmetric version.
 
-    If `symmetric` is False then calculates MdAPE and if `symmetric` is True
-    then calculates symmetric median absolute percentage error (sMdAPE). Both
-    MdAPE and sMdAPE output is non-negative floating point. The best value is 0.0.
+    For a univariate, non-hierarchical sample of true values :math:`y_1, \dots, y_n` and
+    predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n`,
+    at time indices :math:`t_1, \dots, t_n`,
+    `evaluate` or call returns the Median Absolute Percentage Error,
+    :math:`median(|\frac{y_i - \widehat{y}_i}{y_i}|)`.
+    (the time indices are not used)
+
+    if `symmetric` is True then calculates
+    symmetric Median Absolute Percentage Error (sMdAPE), defined as
+    :math:`median(\frac{2|y_i-\widehat{y}_i|}
+    {|y_i|+|\widehat{y}_i|})`.
+
+    Both MdAPE and sMdAPE output is non-negative floating point. The best value is 0.0.
 
     MdAPE and sMdAPE are measured in percentage error relative to the test data.
     Because it takes the absolute value rather than square the percentage forecast
@@ -1799,6 +1837,17 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     values are close to zero. In such cases the function returns a large value
     instead of `inf`.
 
+    Notes: In some literatures, sMdAPE is also known as Adjusted MdAPE because
+    ,in some cases, over- and under-forecasts are not treated equally. [1]_
+
+    `multioutput` and `multilevel` control averaging across variables and
+    hierarchy indices, see below.
+
+    `evaluate_by_index` returns, at a time index :math:`t_i`,
+    the abolute percentage error at that time index,
+    :math:`100%|\frac{y_i - \widehat{y}_i}{y_i}|`,
+    for all time indices :math:`t_1, \dots, t_n` in the input.
+
     Parameters
     ----------
     symmetric : bool, default = False
@@ -1809,6 +1858,11 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
         If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
         If 'uniform_average', errors of all outputs are averaged with uniform weight.
+    multilevel : {'raw_values', 'uniform_average', 'uniform_average_time'}
+        Defines how to aggregate metric for hierarchical data (with levels).
+        If 'uniform_average' (default), errors are mean-averaged across levels.
+        If 'uniform_average_time', errors are mean-averaged across rows.
+        If 'raw_values', does not average errors across levels, hierarchy is retained.
 
     See Also
     --------
@@ -1818,6 +1872,8 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
 
     References
     ----------
+    .. [1] Goodwin.P and Lawton.R (1999) "On the asymmetry of the symmetric MAPE".
+    
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
     forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
 

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1677,20 +1677,20 @@ class GeometricMeanSquaredError(BaseForecastingErrorMetricFunc):
 
 
 class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
-    """Mean absolute percentage error (MAPE) or symmetric version.
+    r"""Mean absolute percentage error (MAPE) or symmetric version.
 
     For a univariate, non-hierarchical sample
-    of true values :math:`y_1, \\dots, y_n` and
-    predicted values :math:`\\widehat{y}_1, \\dots, \\widehat{y}_n`,
-    at time indices :math:`t_1, \\dots, t_n`,
+    of true values :math:`y_1, \dots, y_n` and
+    predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n`,
+    at time indices :math:`t_1, \dots, t_n`,
     `evaluate` or call returns the Mean Absolute Percentage Error,
-    :math:`\\frac{1}{n} \\sum_{i=1}^n \\left|\\frac{y_i-\\widehat{y}_i}{y_i} \\right|`.
+    :math:`\frac{1}{n} \sum_{i=1}^n \left|\frac{y_i-\widehat{y}_i}{y_i} \right|`.
     (the time indices are not used)
 
     if `symmetric` is True then calculates
     symmetric mean absolute percentage error (sMAPE), defined as
-    :math:`\\frac{2}{n} \\sum_{i=1}^n \\frac{|y_i - \\widehat{y}_i|}
-    {|y_i| + |\\widehat{y}_i|}`.
+    :math:`\frac{2}{n} \sum_{i=1}^n \frac{|y_i - \widehat{y}_i|}
+    {|y_i| + |\widehat{y}_i|}`.
 
     Both MAPE and sMAPE output non-negative floating point which is in fractional units
     rather than percentage. The best value is 0.0.
@@ -1708,17 +1708,17 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
 
     `evaluate_by_index` returns, at a time index :math:`t_i`,
     the abolute percentage error at that time index,
-    :math:`\\left| \\frac{y_i - \\widehat{y}_i}{y_i} \\right|`,
-    or :math:`\\frac{2|y_i - \\widehat{y}_i|}{|y_i| + |\\widehat{y}_i|}`,
+    :math:`\left| \frac{y_i - \widehat{y}_i}{y_i} \right|`,
+    or :math:`\frac{2|y_i - \widehat{y}_i|}{|y_i| + |\widehat{y}_i|}`,
     the symmetric version, if `symmetric` is True, for all time indices
-    :math:`t_1, \\dots, t_n` in the input.
+    :math:`t_1, \dots, t_n` in the input.
 
     Parameters
     ----------
     symmetric : bool, default = False
         Whether to calculate the symmetric version of the percentage metric
-    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
-            (n_outputs,), default='uniform_average'
+    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape (n_outputs,)
+    , default='uniform_average'
         Defines how to aggregate metric for multivariate (multioutput) data.
         If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
@@ -1743,8 +1743,7 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     Examples
     --------
     >>> import numpy as np
-    >>> from sktime.performance_metrics.forecasting import \
-    MeanAbsolutePercentageError
+    >>> from sktime.performance_metrics.forecasting import MeanAbsolutePercentageError
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> mape = MeanAbsolutePercentageError(symmetric=False)
@@ -1808,18 +1807,18 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
 
 
 class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
-    """Median absolute percentage error (MdAPE) or symmetric version.
+    r"""Median absolute percentage error (MdAPE) or symmetric version.
 
-    For a univariate, non-hierarchical sample of true values :math:`y_1, \\dots, y_n`
-    and predicted values :math:`\\widehat{y}_1, \\dots, \\widehat{y}_n`,
-    at time indices :math:`t_1, \\dots, t_n`,
+    For a univariate, non-hierarchical sample of true values :math:`y_1, \dots, y_n`
+    and predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n`,
+    at time indices :math:`t_1, \dots, t_n`,
     `evaluate` or call returns the Median Absolute Percentage Error,
-    :math:`median(\\left|\\frac{y_i - \\widehat{y}_i}{y_i} \\right|)`.
+    :math:`median(\left|\frac{y_i - \widehat{y}_i}{y_i} \right|)`.
     (the time indices are not used)
 
     if `symmetric` is True then calculates
     symmetric Median Absolute Percentage Error (sMdAPE), defined as
-    :math:`median(\\frac{2|y_i-\\widehat{y}_i|}{|y_i|+|\\widehat{y}_i|})`.
+    :math:`median(\frac{2|y_i-\widehat{y}_i|}{|y_i|+|\widehat{y}_i|})`.
 
     Both MdAPE and sMdAPE output non-negative floating point which is in fractional
     units rather than percentage. The best value is 0.0.
@@ -1843,8 +1842,8 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     ----------
     symmetric : bool, default = False
         Whether to calculate the symmetric version of the percentage metric
-    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \
-            (n_outputs,), default='uniform_average'
+    multioutput : {'raw_values', 'uniform_average'}  or array-like of shape (n_outputs,)
+    , default='uniform_average'
         Defines how to aggregate metric for multivariate (multioutput) data.
         If array-like, values used as weights to average the errors.
         If 'raw_values', returns a full set of errors in case of multioutput input.
@@ -1869,8 +1868,7 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     Examples
     --------
     >>> import numpy as np
-    >>> from sktime.performance_metrics.forecasting import \
-    MedianAbsolutePercentageError
+    >>> from sktime.performance_metrics.forecasting import MedianAbsolutePercentageError
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> mdape = MedianAbsolutePercentageError(symmetric=False)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #4457. See also #4303 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
1. Added adjusted vs symmetric clarifications for sMAPE.
2. Improved docstring documentation to include a mathematical summary of the metric and additional parameters that the metric class currently supports.

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->


#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
This isn't directly related to the PR, but I ran the documentation build locally to confirm that the changes were displayed correctly. During the process, I noticed that it took a while to build the HTML docs. It would be great if this process could be sped up a bit. Maybe consider `sphinx-autobuild` extension to automatically detect changes in docs with live-reload in the browser during local development.


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.


<!--
Thanks for contributing!
-->
