### PR TITLE
[MNT] bound `tensorflow-probability` to `<0.20.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ all_extras = [
     "statsmodels>=0.12.1",
     "stumpy>=1.5.1; python_version < '3.11'",
     "tbats>=1.1.0",
-    "tensorflow-probability; python_version < '3.11'",
+    "tensorflow-probability<0.20.0; python_version < '3.11'",
     "tensorflow; python_version < '3.11'",
     "tsfresh>=0.17.0; python_version < '3.10'",
     "tslearn>=0.5.2; python_version < '3.11'",


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4566 temporarily by bounding `tensorflow-probability` to `<0.20.0`.