### PR TITLE
[ENH] changing Union[int | float] to float as per issue #4379

### DIFF
--- a/sktime/distances/_lower_bounding_numba.py
+++ b/sktime/distances/_lower_bounding_numba.py
@@ -244,7 +244,7 @@ def numba_create_bounding_matrix(
     x: np.ndarray,
     y: np.ndarray,
     window: float = -1.0,
-    itakura_max_slope: Union[float, int] = -1.0,
+    itakura_max_slope: float = -1.0,
 ) -> np.ndarray:
     """Numba compiled way of creating bounding matrix.
 

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1314,8 +1314,8 @@ class SingleWindowSplitter(BaseSplitter):
 def temporal_train_test_split(
     y: ACCEPTED_Y_TYPES,
     X: Optional[pd.DataFrame] = None,
-    test_size: Optional[Union[int, float]] = None,
-    train_size: Optional[Union[int, float]] = None,
+    test_size: Optional[float] = None,
+    train_size: Optional[float] = None,
     fh: Optional[FORECASTING_HORIZON_TYPES] = None,
 ) -> SPLIT_TYPE:
     """Split arrays or matrices into sequential train and test subsets.

--- a/sktime/transformations/series/fourier.py
+++ b/sktime/transformations/series/fourier.py
@@ -6,7 +6,7 @@ __author__ = ["ltsaprounis", "blazingbhavneek"]
 
 import warnings
 from distutils.log import warn
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -38,7 +38,7 @@ class FourierFeatures(BaseTransformer):
 
     Parameters
     ----------
-    sp_list : List[Union[int, float]]
+    sp_list : List[float]
         list of seasonal periods
     fourier_terms_list : List[int]
         list of number of fourier terms (K) for each seasonal period.
@@ -110,7 +110,7 @@ class FourierFeatures(BaseTransformer):
 
     def __init__(
         self,
-        sp_list: List[Union[int, float]],
+        sp_list: List[float],
         fourier_terms_list: List[int],
         freq: Optional[str] = None,
         keep_original_columns: Optional[bool] = False,

--- a/sktime/transformations/series/hidalgo.py
+++ b/sktime/transformations/series/hidalgo.py
@@ -7,7 +7,6 @@ __all__ = ["Hidalgo"]
 
 
 from functools import reduce
-from typing import Union
 
 import numpy as np
 from sklearn.neighbors import NearestNeighbors
@@ -720,7 +719,7 @@ class Hidalgo(BaseTransformer):
         }
 
 
-def binom(N: Union[int, float], q: Union[int, float]):
+def binom(N: float, q: float):
     """Calculate the binomial coefficient.
 
     Parameters

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -306,7 +306,7 @@ class Imputer(BaseTransformer):
 
         Returns
         -------
-        Callable[[Optional[int]], Union[int, float]]
+        Callable[[Optional[int]], float]
             Random (discrete) uniform distribution between min and max of series
         """
         rng = check_random_state(self.random_state)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #4379 

in type annotations, replaces all instances of `Union[int | float]` (either way round) with `float`

#### What does this implement/fix? Explain your changes.
This is my first contribution.
replacing Union[int | float] to just float

