### PR TITLE
[ENH] Extend forecasting benchmarking framework to multiple metrics, add test coverage

### DIFF
--- a/sktime/benchmarking/forecasting.py
+++ b/sktime/benchmarking/forecasting.py
@@ -36,10 +36,9 @@ def forecasting_validation(
     """
     y = dataset_loader()
     results = {}
+    scores_df = evaluate(forecaster=estimator, y=y, cv=cv_splitter, scoring=scorers)
     for scorer in scorers:
         scorer_name = scorer.name
-        # TODO re-write evaluate to allow multiple scorers, to avoid recomputation
-        scores_df = evaluate(forecaster=estimator, y=y, cv=cv_splitter, scoring=scorer)
         for ix, row in scores_df.iterrows():
             results[f"{scorer_name}_fold_{ix}_test"] = row[f"test_{scorer_name}"]
         results[f"{scorer_name}_mean"] = scores_df[f"test_{scorer_name}"].mean()

--- a/sktime/benchmarking/tests/test_forecasting.py
+++ b/sktime/benchmarking/tests/test_forecasting.py
@@ -7,8 +7,42 @@ import pytest
 from sktime.benchmarking import forecasting
 from sktime.forecasting.model_selection import ExpandingWindowSplitter
 from sktime.forecasting.naive import NaiveForecaster
-from sktime.performance_metrics.forecasting import MeanSquaredPercentageError
+from sktime.performance_metrics.forecasting import (
+    MeanAbsoluteError,
+    MeanAbsolutePercentageError,
+    MeanSquaredPercentageError,
+)
 from sktime.utils.validation._dependencies import _check_soft_dependencies
+
+expected_results_df_1 = pd.DataFrame(
+    data={
+        "validation_id": "[dataset=data_loader_simple]_"
+        + "[cv_splitter=ExpandingWindowSplitter]-v1",
+        "model_id": "NaiveForecaster-v1",
+        "MeanSquaredPercentageError_fold_0_test": 0.0,
+        "MeanSquaredPercentageError_fold_1_test": 0.111,
+        "MeanSquaredPercentageError_mean": 0.0555,
+        "MeanSquaredPercentageError_std": 0.0785,
+    },
+    index=[0],
+)
+
+expected_results_df_2 = pd.DataFrame(
+    data={
+        "validation_id": "[dataset=data_loader_simple]_"
+        + "[cv_splitter=ExpandingWindowSplitter]-v1",
+        "model_id": "NaiveForecaster-v1",
+        "MeanAbsolutePercentageError_fold_0_test": 0.0,
+        "MeanAbsolutePercentageError_fold_1_test": 0.333,
+        "MeanAbsolutePercentageError_mean": 0.1666,
+        "MeanAbsolutePercentageError_std": 0.2357,
+        "MeanAbsoluteError_fold_0_test": 0.0,
+        "MeanAbsoluteError_fold_1_test": 1.0,
+        "MeanAbsoluteError_mean": 0.5,
+        "MeanAbsoluteError_std": 0.7071,
+    },
+    index=[0],
+)
 
 
 def data_loader_simple() -> pd.DataFrame:
@@ -20,7 +54,14 @@ def data_loader_simple() -> pd.DataFrame:
     not _check_soft_dependencies("kotsu", severity="none"),
     reason="skip test if required soft dependencies not available",
 )
-def test_forecastingbenchmark(tmp_path):
+@pytest.mark.parametrize(
+    "expected_results_df, scorers",
+    [
+        (expected_results_df_1, [MeanSquaredPercentageError()]),
+        (expected_results_df_2, [MeanAbsolutePercentageError(), MeanAbsoluteError()]),
+    ],
+)
+def test_forecastingbenchmark(tmp_path, expected_results_df, scorers):
     """Test benchmarking a forecaster estimator."""
     benchmark = forecasting.ForecastingBenchmark()
 
@@ -31,36 +72,12 @@ def test_forecastingbenchmark(tmp_path):
         step_length=1,
         fh=1,
     )
-    benchmark.add_task(data_loader_simple, cv_splitter, [MeanSquaredPercentageError()])
+    benchmark.add_task(data_loader_simple, cv_splitter, scorers)
 
     results_file = tmp_path / "results.csv"
     results_df = benchmark.run(results_file)
 
     results_df = results_df.drop(columns=["runtime_secs"])
-
-    expected_results_df = pd.DataFrame(
-        [
-            (
-                (
-                    "[dataset=data_loader_simple]_"
-                    "[cv_splitter=ExpandingWindowSplitter]-v1"
-                ),
-                "NaiveForecaster-v1",
-                0.0,
-                0.111,
-                0.0555,
-                0.0785,
-            )
-        ],
-        columns=[
-            "validation_id",
-            "model_id",
-            "MeanSquaredPercentageError_fold_0_test",
-            "MeanSquaredPercentageError_fold_1_test",
-            "MeanSquaredPercentageError_mean",
-            "MeanSquaredPercentageError_std",
-        ],
-    )
 
     pd.testing.assert_frame_equal(
         expected_results_df, results_df, check_exact=False, atol=0, rtol=0.001


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->
#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

I recently looked through the changes made to the benchmarking module in sktime because I'm interested in extending sktime benchmarking with `kotsu`.  As I went through the codebase, I noticed a comment below in the code 

> TODO re-write evaluate to allow multiple scorers, to avoid recomputation

that there was a need to rewrite `evaluate` to handle multiple metrics but `evaluate` indeed already supports this. we just need to give the scoring argument as a list of `BaseMetric` and it will compute multiple metrics without having to refit a model n number of times for n metrics.

I've also added an extra test coverage to ensure this works properly. 

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

@alex-hh @DBCerigo @TNTran92 @fkiraly 
Please confirm that this changes tackle the `todo` comment