### PR TITLE
[ENH] add more test parameter sets to `AutoETS`

### DIFF
--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -466,12 +466,14 @@ class AutoETS(_StatsModelsAdapter):
         -------
         params : dict or list of dict
         """
+        # default setting, non-auto
         params1 = {}
-        params2 = {
-            "sp": 2,
-            "auto": True,
+        # "auto-ets"
+        params2 = {"sp": 2, "auto": True}
+        # ets (non-auto) with some non-default parameters
+        params3 = {
             "information_criterion": "bic",
             "trend": "add",
             "damped_trend": True,
         }
-        return [params1, params2]
+        return [params1, params2, params3]

--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -450,3 +450,28 @@ class AutoETS(_StatsModelsAdapter):
         https://www.statsmodels.org/dev/examples/notebooks/generated/ets.html
         """
         return self._fitted_forecaster.summary()
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+
+        Returns
+        -------
+        params : dict or list of dict
+        """
+        params1 = {}
+        params2 = {
+            "sp": 12,
+            "auto": True,
+            "information_criterion": "bic",
+            "trend": "add",
+            "damped_trend": True,
+        }
+        return [params1, params2]

--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -468,7 +468,7 @@ class AutoETS(_StatsModelsAdapter):
         """
         params1 = {}
         params2 = {
-            "sp": 12,
+            "sp": 2,
             "auto": True,
             "information_criterion": "bic",
             "trend": "add",


### PR DESCRIPTION
This adds a second test parameter set to `AutoETS`.

Towards https://github.com/sktime/sktime/issues/3429

Related: https://github.com/sktime/sktime/issues/4587, as the second set has `auto=True`

