### PR TITLE
[BUG] BaseGridCV ranking sorted wrongly

### DIFF
--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -243,7 +243,8 @@ class BaseGridSearch(_DelegatedForecaster):
 
         # Sort values according to rank
         results = results.sort_values(
-            by=f"rank_{scoring_name}", ascending=scoring.get_tag("lower_is_better")
+            by=f"rank_{scoring_name}",
+            ascending=True,
         )
         # Select n best forecaster
         self.n_best_forecasters_ = []


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

While I was working on my `skopforecastingCV`, I noticed a little tiny bug in BaseGridCV. On line 221, a rank column is populated based on scoring tag `lower_is_better`. A few lines of code later, BaseGridCV updates its n_best_scores and n_best_forecasters. so to do this, the same table is then sorted based on the rank column created in line 221, but with ascending order following the scoring tag again. This works well for metrics where lower is better, which is the case for all forecasting metrics as far as I know lol  (minimum is better). However, it would be incorrect for the opposite case. To give you an example:

| column_1  | rank |
| ----------- | ---- |
| 0.527870   | 2.0  |
| 0.677122   | 1.0  |
|  0.060541  | 3.0  |

if ascending = False, the tag for when higher is better, the algorithm is fitting the n **worst**  forecaster rather. 
| column_1  | rank |
| ----------- | ---- |
|  0.060541  | 3.0  |
| 0.527870   | 2.0  |
| 0.677122   | 1.0  |