### PR TITLE
[ENH] fix warnings in make sphinx - language (`conf.py`) and `dists_kernels.rst` wrong imports

### DIFF
--- a/docs/source/api_reference/dists_kernels.rst
+++ b/docs/source/api_reference/dists_kernels.rst
@@ -117,6 +117,8 @@ Dynamic Time Warping Distances
 Time warping distances can also be obtained by composing ``DistFromAligner`` with
 a time warping aligner, see docstring of ``DistFromAligner``:
 
+.. currentmodule:: sktime.dists_kernels.compose_from_align
+
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,7 +82,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

changed  `language = None` to `language = "en"`  along with fixing import errors in confy.py