### PR TITLE
[MNT] bound `holidays` to avoid error in `Prophet`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ all_extras = [
     "filterpy>=1.4.5; python_version < '3.11'",
     "h5py",
     "hmmlearn>=0.2.7; python_version < '3.11'",
+    "holidays<0.25",
     "gluonts>=0.9.0",
     "keras-self-attention; python_version < '3.11'",
     "kotsu>=0.3.1",


### PR DESCRIPTION
This fixes a new CI problem which seems to come from `holidays`, see https://github.com/sktime/sktime/pull/4589#issuecomment-1549991608