### PR TITLE
[DOC] updated `PULL_REQUEST_TEMPLATE.md`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,13 +44,13 @@ Please go through the checklist below. Please feel free to remove points if they
 -->
 
 ##### For all contributions
-- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
-- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
-- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.
+- [ ] I've added myself to the list of contributors. How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory. Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).
+- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
+- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or dicstrings.
 
 ##### For new estimators
-- [ ] I've added the estimator to the online documentation.
-- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.
+- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
+- [ ] I've added an example to the docstring, in a pydocstyle compliant `Examples` section.
 
 
 <!--


### PR DESCRIPTION
This updates the PR template, mostly with explanations and clarifications on "how to".

It also makes one changes, it no longer asks for creation of new notebooks to showcase estimators, instead it asks to write a docstring example - as that is the de-facto common and desired location for estimator specific example code (rather than notebooks) since a long time already.