### PR TITLE
[ENH] add default kernel to `TimeSeriesSVC` - mean RBF kernel

### DIFF
--- a/sktime/classification/kernel_based/_svc.py
+++ b/sktime/classification/kernel_based/_svc.py
@@ -283,13 +283,13 @@ class TimeSeriesSVC(BaseClassifier):
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
         # testing that callables/classes can be passed
-        from sktime.dists_kernels.compose_tab_to_panel import AggrDist, FlatDist
+        from sktime.dists_kernels.compose_tab_to_panel import FlatDist
 
         # probability must be True, or predict_proba will not work
         dist1 = FlatDist.create_test_instance()
         params1 = {"kernel": dist1, "probability": True}
 
-        dist2 = AggrDist.create_test_instance()
-        params2 = {"kernel": dist2, "probability": True}
+        # testing the default kernel
+        params2 = {"probability": True}
 
         return [params1, params2]

--- a/sktime/classification/kernel_based/_svc.py
+++ b/sktime/classification/kernel_based/_svc.py
@@ -40,8 +40,8 @@ class TimeSeriesSVC(BaseClassifier):
     kernel_params : dict, optional. default = None.
         dictionary for distance parameters, in case that distance is a callable
     kernel_mtype : str, or list of str optional. default = None.
-        mtype that distance expects for X and X2, if a callable
-        only set this if distance is not ``BasePairwiseTransformerPanel`` descendant
+        mtype that ``kernel`` expects for X and X2, if a callable
+        only set this if ``kernel`` is not ``BasePairwiseTransformerPanel`` descendant
     C : float, default=1.0
         Regularization parameter. The strength of the regularization is
         inversely proportional to C. Must be strictly positive. The penalty
@@ -50,9 +50,9 @@ class TimeSeriesSVC(BaseClassifier):
         Whether to use the shrinking heuristic.
     probability : bool, default=False
         Whether to enable probability estimates. This must be enabled prior
-        to calling `fit`, will slow down that method as it internally uses
-        5-fold cross-validation, and `predict_proba` may be inconsistent with
-        `predict`. Read more in the :ref:`User Guide <scores_probabilities>`.
+        to calling ``fit``, will slow down that method as it internally uses
+        5-fold cross-validation, and ``predict_proba`` may be inconsistent with
+        ``predict``.
     tol : float, default=1e-3
         Tolerance for stopping criterion.
     cache_size : float, default=200

--- a/sktime/classification/kernel_based/_svc.py
+++ b/sktime/classification/kernel_based/_svc.py
@@ -29,17 +29,19 @@ class TimeSeriesSVC(BaseClassifier):
 
     Parameters
     ----------
-    kernel : pairwise panel transformer or callable
-        pairwise panel transformer inheriting from BasePairwiseTransformerPanel, or
-        callable, must be of signature (X: Panel, X2: Panel) -> np.ndarray
-            output must be mxn array if X is Panel of m Series, X2 of n Series
-            if distance_mtype is not set, must be able to take
-                X, X2 which are pd_multiindex and numpy3D mtype
+    kernel : pairwise panel transformer or callable, optional, default see below
+        pairwise panel transformer inheriting from ``BasePairwiseTransformerPanel``, or
+        callable, must be of signature ``(X: Panel, X2: Panel) -> np.ndarray``
+        output must be mxn array if ``X`` is Panel of m Series, ``X``2 of n Series
+        if ``distance_mtype`` is not set, must be able to take
+        ``X``, ``X2`` which are ``pd_multiindex`` and ``numpy3D`` mtype
+        default = mean Euclidean kernel, same as ``AggrDist(DotProduct())``,
+        where ``AggrDist`` is from ``sktime`` and ``DotProduct`` from ``sklearn``
     kernel_params : dict, optional. default = None.
         dictionary for distance parameters, in case that distance is a callable
     kernel_mtype : str, or list of str optional. default = None.
         mtype that distance expects for X and X2, if a callable
-            only set this if distance is not BasePairwiseTransformerPanel descendant
+        only set this if distance is not ``BasePairwiseTransformerPanel`` descendant
     C : float, default=1.0
         Regularization parameter. The strength of the regularization is
         inversely proportional to C. Must be strictly positive. The penalty
@@ -68,7 +70,7 @@ class TimeSeriesSVC(BaseClassifier):
         properly in a multithreaded context.
     max_iter : int, default=-1
         Hard limit on iterations within solver, or -1 for no limit.
-    decision_function_shape : {'ovo', 'ovr'}, default='ovr'
+    decision_function_shape : ``{'ovo', 'ovr'}``, default='ovr'
         Whether to return a one-vs-rest ('ovr') decision function of shape
         (n_samples, n_classes) as all other classifiers, or the original
         one-vs-one ('ovo') decision function of libsvm which has shape
@@ -85,7 +87,6 @@ class TimeSeriesSVC(BaseClassifier):
         Controls the pseudo random number generation for shuffling the data for
         probability estimates. Ignored when `probability` is False.
         Pass an int for reproducible output across multiple function calls.
-        See :term:`Glossary <random_state>`.
 
     Examples
     --------
@@ -128,7 +129,7 @@ class TimeSeriesSVC(BaseClassifier):
 
     def __init__(
         self,
-        kernel,
+        kernel=None,
         kernel_params=None,
         kernel_mtype=None,
         C=1,
@@ -179,6 +180,13 @@ class TimeSeriesSVC(BaseClassifier):
         kernel_params = self.kernel_params
         if kernel_params is None:
             kernel_params = {}
+
+        if kernel is None:
+            from sklearn.gaussian_process.kernels import DotProduct
+
+            from sktime.dists_kernels.compose_tab_to_panel import AggrDist
+
+            kernel = AggrDist(DotProduct())
 
         if X2 is not None:
             return kernel(X, X2, **kernel_params)

--- a/sktime/classification/kernel_based/_svc.py
+++ b/sktime/classification/kernel_based/_svc.py
@@ -35,8 +35,8 @@ class TimeSeriesSVC(BaseClassifier):
         output must be mxn array if ``X`` is Panel of m Series, ``X``2 of n Series
         if ``distance_mtype`` is not set, must be able to take
         ``X``, ``X2`` which are ``pd_multiindex`` and ``numpy3D`` mtype
-        default = mean Euclidean kernel, same as ``AggrDist(DotProduct())``,
-        where ``AggrDist`` is from ``sktime`` and ``DotProduct`` from ``sklearn``
+        default = mean Euclidean kernel, same as ``AggrDist(RBF())``,
+        where ``AggrDist`` is from ``sktime`` and ``RBF`` from ``sklearn``
     kernel_params : dict, optional. default = None.
         dictionary for distance parameters, in case that distance is a callable
     kernel_mtype : str, or list of str optional. default = None.
@@ -182,11 +182,11 @@ class TimeSeriesSVC(BaseClassifier):
             kernel_params = {}
 
         if kernel is None:
-            from sklearn.gaussian_process.kernels import DotProduct
+            from sklearn.gaussian_process.kernels import RBF
 
             from sktime.dists_kernels.compose_tab_to_panel import AggrDist
 
-            kernel = AggrDist(DotProduct())
+            kernel = AggrDist(RBF())
 
         if X2 is not None:
             return kernel(X, X2, **kernel_params)


### PR DESCRIPTION
This adds a default kernel to `TimeSeriesSVC`, the `kernel` argument, which previously had no default.

The new default is the mean Euclidean kernel, same as ``AggrDist(RBF())``, where ``AggrDist`` is from ``sktime`` and ``RBF`` from ``sklearn``.

This is in analogy to the same default in `sklearn`'s `SVC` (with the mean added).

This PR also makes minor improvements to the docstring of `TimeSeriesSVC`.

As adding a default that did not previously exist does not break any existing dependent code, no deprecation is needed.