### PR TITLE
[ENH] `BaseObject` boilerplate to set parameters to `self` at start of `__init__`

### DIFF
--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -165,13 +165,16 @@ class MyForecaster(BaseForecaster):
         # estimators should precede parameters
         #  if estimators have default values, set None and initalize below
 
-        # todo: write any hyper-parameters and components to self
-        self.est = est
-        self.parama = parama
-        self.paramb = paramb
-        self.paramc = paramc
+        # this should be the first line and not change
+        self._set_params_from(locals())
+        # convenience function that does self.est = est, self.parama = parama, etc
+        # parameters of same name as __init__ args should never be overwritten!
+        # if parameters are generated, write to other attr names, such as self._parama
+        # estimators of same name as __init__ args should never be mutated!
+        # for internal use, make a clone later, e.g., self._est = est.clone()
 
         # todo: change "MyForecaster" to the name of the class
+        # this should be the second line and not be changed except the class name
         super(MyForecaster, self).__init__()
 
         # todo: optional, parameter checking logic (if applicable) should happen here

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -114,12 +114,14 @@ class MyForecaster(BaseForecaster):
     # todo: add any hyper-parameters and components to constructor
     def __init__(self, parama, paramb="default", paramc=None):
 
-        # todo: write any hyper-parameters to self
-        self.parama = parama
-        self.paramb = paramb
-        self.paramc = paramc
+        # this should be the first line and not change
+        self._set_params_from(locals())
+        # convenience function that does self.parama = parama, self.paramb=paramb etc
+        # parameters of same name as __init__ args should never be overwritten!
+        # if parameters are generated, write to other attr names, such as self._parama
 
         # todo: change "MyForecaster" to the name of the class
+        # this should be the second line and not be changed except the class name
         super(MyForecaster, self).__init__()
 
         # todo: optional, parameter checking logic (if applicable) should happen here

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -72,8 +72,44 @@ from sktime.exceptions import NotFittedError
 class BaseObject(_BaseObject):
     """Base class for parametric objects with tags in sktime.
 
-    Extends skbase BaseObject with additional features.
+    Extends ``skbase`` ``BaseObject`` with additional features.
     """
+
+    def _set_params_from(self, locals):
+        """Set parameters to self from locals.
+
+        Convenience method for estimator authors and developers.
+
+        Writing ``self._set_params_from(locals())`` is
+        equivalent to writing ``self.paramname = paramname`` for all
+        variables ``paramname` in the current locals scope.
+
+        This is simpler, and less error prone (e.g., to typos of ``paramname``)
+        to write out ``self.param1 = param1, self.param2 = param2`` and so on,
+        as is required to satisfy the ``sklearn`` and ``sktime`` extension contracts,
+        at the start of ``__init__`.
+
+        Developer notes:
+
+        * the only case this should be used is at the start of ``__init__``,
+          as the single line ``self._set_params_from(locals())``
+        * ``__init__`` parameters written to ``self`` should never be overwritten,
+          not in ``__init__`` after this call and not in other methods
+
+        Parameters
+        ----------
+        locals : dict, should be ``locals()`` directly at start of ``__init__``     
+
+        Returns
+        -------
+        self   
+        """
+        if isinstance(locals, dict):
+            for param in self.get_param_names():
+                if param in locals.keys():
+                    setattr(self, param, locals[param])
+
+        return self
 
     def __eq__(self, other):
         """Equality dunder. Checks equal class and parameters.

--- a/sktime/forecasting/ardl.py
+++ b/sktime/forecasting/ardl.py
@@ -209,6 +209,7 @@ class ARDL(_StatsModelsAdapter):
 
     def __init__(
         self,
+        # Model Params
         lags=None,
         order=None,
         fixed=None,
@@ -219,47 +220,22 @@ class ARDL(_StatsModelsAdapter):
         hold_back=None,
         period=None,
         missing="none",
+        # Fit Params
         cov_type="nonrobust",
         cov_kwds=None,
         use_t=True,
+        # Auto ARDL params
         auto_ardl=False,
         maxlag=None,
         maxorder=None,
         ic="bic",
         glob=False,
+        # Predict Params
         fixed_oos=None,
         X_oos=None,
         dynamic=False,
     ):
-
-        # Model Params
-        self.lags = lags
-        self.order = order
-        self.fixed = fixed
-        self.causal = causal
-        self.trend = trend
-        self.seasonal = seasonal
-        self.deterministic = deterministic
-        self.hold_back = hold_back
-        self.period = period
-        self.missing = missing
-
-        # Fit Params
-        self.cov_type = cov_type
-        self.cov_kwds = cov_kwds
-        self.use_t = use_t
-
-        # Predict Params
-        self.fixed_oos = fixed_oos
-        self.X_oos = X_oos
-        self.dynamic = dynamic
-
-        # Auto ARDL params
-        self.auto_ardl = auto_ardl
-        self.maxlag = maxlag
-        self.ic = ic
-        self.glob = glob
-        self.maxorder = maxorder
+        self._set_params_from(locals())
 
         if not self.auto_ardl:
             assert self.lags is not None

--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -267,17 +267,6 @@ class AutoARIMA(_PmdArimaAdapter):
 
     _tags = {"handles-missing-data": True}
 
-    SARIMAX_KWARGS_KEYS = [
-        "time_varying_regression",
-        "enforce_stationarity",
-        "enforce_invertibility",
-        "simple_differencing",
-        "measurement_error",
-        "mle_regression",
-        "hamilton_representation",
-        "concentrate_scale",
-    ]
-
     def __init__(
         self,
         start_p=2,
@@ -328,48 +317,7 @@ class AutoARIMA(_PmdArimaAdapter):
         hamilton_representation=False,
         concentrate_scale=False,
     ):
-
-        self.start_p = start_p
-        self.d = d
-        self.start_q = start_q
-        self.max_p = max_p
-        self.max_d = max_d
-        self.max_q = max_q
-        self.start_P = start_P
-        self.D = D
-        self.start_Q = start_Q
-        self.max_P = max_P
-        self.max_D = max_D
-        self.max_Q = max_Q
-        self.max_order = max_order
-        self.sp = sp
-        self.seasonal = seasonal
-        self.stationary = stationary
-        self.information_criterion = information_criterion
-        self.alpha = alpha
-        self.test = test
-        self.seasonal_test = seasonal_test
-        self.stepwise = stepwise
-        self.n_jobs = n_jobs
-        self.start_params = start_params
-        self.trend = trend
-        self.method = method
-        self.maxiter = maxiter
-        self.offset_test_args = offset_test_args
-        self.seasonal_test_args = seasonal_test_args
-        self.suppress_warnings = suppress_warnings
-        self.error_action = error_action
-        self.trace = trace
-        self.random = random
-        self.random_state = random_state
-        self.n_fits = n_fits
-        self.out_of_sample_size = out_of_sample_size
-        self.scoring = scoring
-        self.scoring_args = scoring_args
-        self.with_intercept = with_intercept
-        self.update_pdq = update_pdq
-        for key in self.SARIMAX_KWARGS_KEYS:
-            setattr(self, key, eval(key))
+        self._set_params_from(locals())
 
         super(AutoARIMA, self).__init__()
 
@@ -379,49 +327,10 @@ class AutoARIMA(_PmdArimaAdapter):
         # import inside method to avoid hard dependency
         from pmdarima.arima import AutoARIMA as _AutoARIMA  # type: ignore
 
-        sarimax_kwargs = {key: getattr(self, key) for key in self.SARIMAX_KWARGS_KEYS}
+        params_same = set(self.get_param_names()).difference(["update_pdq", "sp"])
+        sarimax_kwargs = {key: getattr(self, key) for key in params_same}
 
-        return _AutoARIMA(
-            start_p=self.start_p,
-            d=self.d,
-            start_q=self.start_q,
-            max_p=self.max_p,
-            max_d=self.max_d,
-            max_q=self.max_q,
-            start_P=self.start_P,
-            D=self.D,
-            start_Q=self.start_Q,
-            max_P=self.max_P,
-            max_D=self.max_D,
-            max_Q=self.max_Q,
-            max_order=self.max_order,
-            m=self._sp,
-            seasonal=self.seasonal,
-            stationary=self.stationary,
-            information_criterion=self.information_criterion,
-            alpha=self.alpha,
-            test=self.test,
-            seasonal_test=self.seasonal_test,
-            stepwise=self.stepwise,
-            n_jobs=self.n_jobs,
-            start_params=None,
-            trend=self.trend,
-            method=self.method,
-            maxiter=self.maxiter,
-            offset_test_args=self.offset_test_args,
-            seasonal_test_args=self.seasonal_test_args,
-            suppress_warnings=self.suppress_warnings,
-            error_action=self.error_action,
-            trace=self.trace,
-            random=self.random,
-            random_state=self.random_state,
-            n_fits=self.n_fits,
-            out_of_sample_size=self.out_of_sample_size,
-            scoring=self.scoring,
-            scoring_args=self.scoring_args,
-            with_intercept=self.with_intercept,
-            **sarimax_kwargs,
-        )
+        return _AutoARIMA(m=self._sp, **sarimax_kwargs)
 
     def _update(self, y, X=None, update_params=True):
         """Update model with data.
@@ -665,17 +574,6 @@ class ARIMA(_PmdArimaAdapter):
 
     _tags = {"handles-missing-data": True}
 
-    SARIMAX_KWARGS_KEYS = [
-        "time_varying_regression",
-        "enforce_stationarity",
-        "enforce_invertibility",
-        "simple_differencing",
-        "measurement_error",
-        "mle_regression",
-        "hamilton_representation",
-        "concentrate_scale",
-    ]
-
     def __init__(
         self,
         order=(1, 0, 0),
@@ -698,20 +596,7 @@ class ARIMA(_PmdArimaAdapter):
         hamilton_representation=False,
         concentrate_scale=False,
     ):
-
-        self.order = order
-        self.seasonal_order = seasonal_order
-        self.start_params = start_params
-        self.method = method
-        self.maxiter = maxiter
-        self.suppress_warnings = suppress_warnings
-        self.out_of_sample_size = out_of_sample_size
-        self.scoring = scoring
-        self.scoring_args = scoring_args
-        self.trend = trend
-        self.with_intercept = with_intercept
-        for key in self.SARIMAX_KWARGS_KEYS:
-            setattr(self, key, eval(key))
+        self._set_params_from(locals())
 
         super(ARIMA, self).__init__()
 
@@ -719,22 +604,9 @@ class ARIMA(_PmdArimaAdapter):
         # import inside method to avoid hard dependency
         from pmdarima.arima.arima import ARIMA as _ARIMA
 
-        sarimax_kwargs = {key: getattr(self, key) for key in self.SARIMAX_KWARGS_KEYS}
+        sarimax_kwargs = self.get_params()
 
-        return _ARIMA(
-            order=self.order,
-            seasonal_order=self.seasonal_order,
-            start_params=self.start_params,
-            method=self.method,
-            maxiter=self.maxiter,
-            suppress_warnings=self.suppress_warnings,
-            out_of_sample_size=self.out_of_sample_size,
-            scoring=self.scoring,
-            scoring_args=self.scoring_args,
-            trend=self.trend,
-            with_intercept=self.with_intercept,
-            **sarimax_kwargs,
-        )
+        return _ARIMA(**sarimax_kwargs)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -152,12 +152,8 @@ class ConformalIntervals(BaseForecaster):
                 f"method must be one of {self.ALLOWED_METHODS}, but found {method}"
             )
 
-        self.forecaster = forecaster
-        self.method = method
-        self.verbose = verbose
-        self.initial_window = initial_window
-        self.sample_frac = sample_frac
-        self.n_jobs = n_jobs
+        self._set_params_from(locals())
+
         self.forecasters_ = []
 
         super(ConformalIntervals, self).__init__()

--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -140,12 +140,14 @@ class DynamicFactor(_StatsModelsAdapter):
 
     def __init__(
         self,
+        # Model Params
         k_factors=1,
         factor_order=1,
         error_cov_type="diagonal",
         error_order=0,
         error_var=False,
         enforce_stationarity=True,
+        # Fit Params
         start_params=None,
         transformed=True,
         includes_fixed=False,
@@ -163,31 +165,7 @@ class DynamicFactor(_StatsModelsAdapter):
         flags=None,
         low_memory=False,
     ):
-        # Model Params
-        self.k_factors = k_factors
-        self.factor_order = factor_order
-        self.error_cov_type = error_cov_type
-        self.error_order = error_order
-        self.error_var = error_var
-        self.enforce_stationarity = enforce_stationarity
-
-        # Fit Params
-        self.start_params = start_params
-        self.transformed = transformed
-        self.includes_fixed = includes_fixed
-        self.cov_type = cov_type
-        self.cov_kwds = cov_kwds
-        self.method = method
-        self.maxiter = maxiter
-        self.full_output = full_output
-        self.disp = disp
-        self.callback = callback
-        self.return_params = return_params
-        self.optim_score = optim_score
-        self.optim_complex_step = optim_complex_step
-        self.optim_hessian = optim_hessian
-        self.flags = flags
-        self.low_memory = low_memory
+        self._set_params_from(locals())
 
         super(DynamicFactor, self).__init__()
 

--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -144,25 +144,7 @@ class ExponentialSmoothing(_StatsModelsAdapter):
         random_state=None,
     ):
         # Model params
-        self.trend = trend
-        self.damped_trend = damped_trend
-        self.seasonal = seasonal
-        self.sp = sp
-        self.use_boxcox = use_boxcox
-        self.initial_level = initial_level
-        self.initial_trend = initial_trend
-        self.initial_seasonal = initial_seasonal
-        self.initialization_method = initialization_method
-        self.smoothing_level = smoothing_level
-        self.smoothing_trend = smoothing_trend
-        self.smoothing_seasonal = smoothing_seasonal
-        self.damping_trend = damping_trend
-        self.optimized = optimized
-        self.remove_bias = remove_bias
-        self.start_params = start_params
-        self.method = method
-        self.minimize_kwargs = minimize_kwargs
-        self.use_brute = use_brute
+        self._set_params_from(locals())
 
         super().__init__(random_state=random_state)
 

--- a/sktime/forecasting/fbprophet.py
+++ b/sktime/forecasting/fbprophet.py
@@ -160,29 +160,7 @@ class Prophet(_ProphetAdapter):
         stan_backend=None,
         verbose=0,
     ):
-        self.freq = freq
-        self.add_seasonality = add_seasonality
-        self.add_country_holidays = add_country_holidays
-
-        self.growth = growth
-        self.growth_floor = growth_floor
-        self.growth_cap = growth_cap
-        self.changepoints = changepoints
-        self.n_changepoints = n_changepoints
-        self.changepoint_range = changepoint_range
-        self.yearly_seasonality = yearly_seasonality
-        self.weekly_seasonality = weekly_seasonality
-        self.daily_seasonality = daily_seasonality
-        self.holidays = holidays
-        self.seasonality_mode = seasonality_mode
-        self.seasonality_prior_scale = seasonality_prior_scale
-        self.changepoint_prior_scale = changepoint_prior_scale
-        self.holidays_prior_scale = holidays_prior_scale
-        self.mcmc_samples = mcmc_samples
-        self.alpha = alpha
-        self.uncertainty_samples = uncertainty_samples
-        self.stan_backend = stan_backend
-        self.verbose = verbose
+        self._set_params_from(locals())
 
         super(Prophet, self).__init__()
 

--- a/sktime/forecasting/sarimax.py
+++ b/sktime/forecasting/sarimax.py
@@ -143,24 +143,7 @@ class SARIMAX(_StatsModelsAdapter):
         validate_specification=True,
         random_state=None,
     ):
-
-        self.order = order
-        self.seasonal_order = seasonal_order
-        self.trend = trend
-        self.measurement_error = measurement_error
-        self.time_varying_regression = time_varying_regression
-        self.mle_regression = mle_regression
-        self.simple_differencing = simple_differencing
-        self.enforce_stationarity = enforce_stationarity
-        self.enforce_invertibility = enforce_invertibility
-        self.hamilton_representation = hamilton_representation
-        self.concentrate_scale = concentrate_scale
-        self.trend_offset = trend_offset
-        self.use_exact_diffuse = use_exact_diffuse
-        self.dates = dates
-        self.freq = freq
-        self.missing = missing
-        self.validate_specification = validate_specification
+        self._set_params_from(locals())
 
         super().__init__(random_state=random_state)
 

--- a/sktime/forecasting/statsforecast.py
+++ b/sktime/forecasting/statsforecast.py
@@ -196,39 +196,7 @@ class StatsForecastAutoARIMA(_StatsForecastAdapter):
         biasadj: bool = False,
         parallel: bool = False,
     ):
-        self.start_p = start_p
-        self.d = d
-        self.start_q = start_q
-        self.max_p = max_p
-        self.max_d = max_d
-        self.max_q = max_q
-        self.start_P = start_P
-        self.D = D
-        self.start_Q = start_Q
-        self.max_P = max_P
-        self.max_D = max_D
-        self.max_Q = max_Q
-        self.max_order = max_order
-        self.sp = sp
-        self.seasonal = seasonal
-        self.stationary = stationary
-        self.information_criterion = information_criterion
-        self.test = test
-        self.seasonal_test = seasonal_test
-        self.stepwise = stepwise
-        self.n_jobs = n_jobs
-        self.trend = trend
-        self.method = method
-        self.offset_test_args = offset_test_args
-        self.seasonal_test_args = seasonal_test_args
-        self.trace = trace
-        self.n_fits = n_fits
-        self.with_intercept = with_intercept
-        self.approximation = approximation
-        self.truncate = truncate
-        self.blambda = blambda
-        self.biasadj = biasadj
-        self.parallel = parallel
+        self._set_params_from(locals())
 
         super(StatsForecastAutoARIMA, self).__init__()
 

--- a/sktime/forecasting/var.py
+++ b/sktime/forecasting/var.py
@@ -96,14 +96,7 @@ class VAR(_StatsModelsAdapter):
         random_state=None,
     ):
         # Model params
-        self.trend = trend
-        self.maxlags = maxlags
-        self.method = method
-        self.verbose = verbose
-        self.missing = missing
-        self.dates = dates
-        self.freq = freq
-        self.ic = ic
+        self._set_params_from(locals())
 
         super(VAR, self).__init__(random_state=random_state)
 

--- a/sktime/forecasting/varmax.py
+++ b/sktime/forecasting/varmax.py
@@ -250,33 +250,7 @@ class VARMAX(_StatsModelsAdapter):
         suppress_warnings=False,
     ):
         # Model parameters
-        self.order = order
-        self.trend = trend
-        self.error_cov_type = error_cov_type
-        self.measurement_error = measurement_error
-        self.enforce_stationarity = enforce_stationarity
-        self.enforce_invertibility = enforce_invertibility
-        self.trend_offset = trend_offset
-        self.start_params = start_params
-        self.transformed = transformed
-        self.includes_fixed = includes_fixed
-        self.cov_type = cov_type
-        self.cov_kwds = cov_kwds
-        self.method = method
-        self.maxiter = maxiter
-        self.full_output = full_output
-        self.disp = disp
-        self.callback = callback
-        self.return_params = return_params
-        self.optim_score = optim_score
-        self.optim_complex_step = optim_complex_step
-        self.optim_hessian = optim_hessian
-        self.flags = flags
-        self.low_memory = low_memory
-        self.dynamic = dynamic
-        self.information_set = information_set
-        self.signal_only = signal_only
-        self.suppress_warnings = suppress_warnings
+        self._set_params_from(locals())
 
         super(VARMAX, self).__init__()
 

--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -102,18 +102,7 @@ class VECM(_StatsModelsAdapter):
         exog_coint=None,
         exog_coint_fc=None,
     ):
-
-        self.dates = dates
-        self.freq = freq
-        self.missing = missing
-        self.k_ar_diff = k_ar_diff
-        self.coint_rank = coint_rank
-        self.deterministic = deterministic
-        self.seasons = seasons
-        self.first_season = first_season
-        self.method = method
-        self.exog_coint = exog_coint
-        self.exog_coint_fc = exog_coint_fc
+        self._set_params_from(locals())
 
         super(VECM, self).__init__()
 


### PR DESCRIPTION
This PR simplifies `__init__` boilerplate and extension templates as follows.

The `sklearn` and `sktime` contracts requires that all `__init__` parameters are written to `self` in `__init__`, and never be mutated, e.g., `self.a=a`, `self.b=b` etc.

This can become cumbersome, error-prone, and hard to review if there are dozens of parameters.
That is not a hypothetical case, but the state of affairs for many, if not most `sktime` estimators, especially those interfacing `statsmodels` or time series classifiers that are highly composite.

This PR proposes to reduce boilerplate and simplifies the extender contract by using the same line everywhere, `self._set_params_from(locals())`, which never needs to be changed.

As a demonstration, this refactors a larger number of problematic forecasters, and changes the extension templates for forecasters.

If this is agreed, I'd finish the work for other learning tasks, and eventually we may like to port this functionality into `scikit-base`.