### PR TITLE
[MNT] excepting `FCNClassifier` from CI to prevent memouts until bugfix

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -33,6 +33,8 @@ EXCLUDE_ESTIMATORS = [
     "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
     "LSTMFCNClassifier",  # unknown cause, see bug report #4033
     "TimeSeriesLloyds",  # an abstract class, but does not follow naming convention
+    # DL classifier suspected to cause hangs and memouts, see #4610 
+    "FCNClassifier",
 ]
 
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -33,7 +33,7 @@ EXCLUDE_ESTIMATORS = [
     "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
     "LSTMFCNClassifier",  # unknown cause, see bug report #4033
     "TimeSeriesLloyds",  # an abstract class, but does not follow naming convention
-    # DL classifier suspected to cause hangs and memouts, see #4610 
+    # DL classifier suspected to cause hangs and memouts, see #4610
     "FCNClassifier",
 ]
 


### PR DESCRIPTION
Temporary measure to address sporadic memouts caused by `FCNClassifier`.

See https://github.com/sktime/sktime/issues/4610