### PR TITLE
[MNH] address `kulsinski` deprecation in `scipy`

### DIFF
--- a/sktime/dists_kernels/scipy_dist.py
+++ b/sktime/dists_kernels/scipy_dist.py
@@ -26,7 +26,9 @@ class ScipyDist(BasePairwiseTransformer):
     metric : string or function, as in cdist; default = 'euclidean'
         if string, one of: 'braycurtis', 'canberra', 'chebyshev', 'cityblock',
             'correlation', 'cosine', 'dice', 'euclidean', 'hamming', 'jaccard',
-            'jensenshannon', 'kulsinski', 'mahalanobis', 'matching', 'minkowski',
+            'jensenshannon',
+            'kulsinski' (< scipy 1.11) or 'kulczynski1' (from scipy 1.11),
+            'mahalanobis', 'matching', 'minkowski',
             'rogerstanimoto', 'russellrao', 'seuclidean', 'sokalmichener',
             'sokalsneath', 'sqeuclidean', 'yule'
         if function, should have signature 1D-np.array x 1D-np.array -> float

--- a/sktime/dists_kernels/tests/test_scipy_dist.py
+++ b/sktime/dists_kernels/tests/test_scipy_dist.py
@@ -52,7 +52,7 @@ def _get_kul_name():
         one of "kulsinski" (if scipy < 1.11.0) and "kulczynski1" (if scipy >= 1.11.0)
     """
     try:
-        from scipy.spatial.distance import kulczynski1
+        from scipy.spatial.distance import kulczynski1  # noqa: F401
 
         name = "kulczynski1"
     except Exception:

--- a/sktime/dists_kernels/tests/test_scipy_dist.py
+++ b/sktime/dists_kernels/tests/test_scipy_dist.py
@@ -41,9 +41,15 @@ X2_df = make_transformer_problem(
 
 
 def _get_kul_name():
-    """Utility to bridge deprecation of kulsinski distance in scipy.
+    """Get name of kul... distance.
 
-    Name pre-1.11.0 is kulsinski, and from 1.11.0 it is kulcynski1
+    Utility to bridge deprecation of kulsinski distance in scipy.
+    Name pre-1.11.0 is kulsinski, and from 1.11.0 it is kulczynski1.
+
+    Returns
+    -------
+    name : str
+        one of "kulsinski" (if scipy < 1.11.0) and "kulczynski1" (if scipy >= 1.11.0)
     """
     try:
         from scipy.spatial.distance import kulczynski1

--- a/sktime/dists_kernels/tests/test_scipy_dist.py
+++ b/sktime/dists_kernels/tests/test_scipy_dist.py
@@ -40,6 +40,21 @@ X2_df = make_transformer_problem(
 )
 
 
+def _get_kul_name():
+    """Utility to bridge deprecation of kulsinski distance in scipy.
+
+    Name pre-1.11.0 is kulsinski, and from 1.11.0 it is kulcynski1
+    """
+    try:
+        from scipy.spatial.distance import kulczynski1
+
+        name = "kulczynski1"
+    except Exception:
+        name = "kulsinski"
+
+    return name
+
+
 # potential parameters
 METRIC_VALUES = [
     "braycurtis",
@@ -53,7 +68,7 @@ METRIC_VALUES = [
     "hamming",
     "jaccard",
     "jensenshannon",
-    "kulsinski",
+    _get_kul_name(),
     "mahalanobis",
     "matching",
     "minkowski",


### PR DESCRIPTION
This PR addresses the `kulsinski` deprecation in `scipy` by ensuring the tests use the distance of the right name, depending on `scipy` version.