### PR TITLE
[MNT] 0.19.0 release action - `pandas 2` bound

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,3 +230,32 @@ jobs:
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v3
+
+  test-unix-pandas1:
+    needs: test-nosoftdeps
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install sktime and dependencies
+        run: |
+          python -m pip install .[all_extras,dev,pandas1] --no-cache-dir
+
+      - name: Show dependencies
+        run: python -m pip list
+
+      - name: Run tests
+        run: make test
+
+      - name: Publish code coverage
+        uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ mlflow_tests = [
 
 binder = [
     "jupyter",
+    "pandas<2.0.0",
 ]
 
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,10 @@ dl = [
     "tensorflow-probability",
 ]
 
+pandas1 = [
+    "pandas<2.0.0",
+]
+
 [project.urls]
 Homepage = "https://www.sktime.net"
 Repository = "https://github.com/sktime/sktime"


### PR DESCRIPTION
PR for planned release action to release `pandas 2` bound in 0.19.0.

This relaxes the `pandas 2` bound for the package (main dependency sets), and:

* leaves the `pandas<2` bound in the `binder` dependency set which is used for `binder`, notebook tests, and required for some dependencies, e.g., `statsforecast`
* adds a `pandas1` dependency set which restricts `pandas<2`, and a full set of tests on ubuntu with `pandas1`

See https://github.com/sktime/sktime/issues/4441 for a discussion of the release strategy.