### PR TITLE
[MNT] address passing of unsupported `random_state` parameter in `_StatsModelsAdapter`

### DIFF
--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -190,12 +190,14 @@ class _StatsModelsAdapter(BaseForecaster):
 
         get_prediction_arguments = {"start": start, "end": end}
 
-        if hasattr(self, "random_state"):
+        def _pred_has_arg(x):
+            get_pred_args = inspect.signature(self._fitted_forecaster.get_prediction)
+            return x in get_pred_args.parameters.keys()
+
+        if hasattr(self, "random_state") and _pred_has_arg("random_state"):
             get_prediction_arguments["random_state"] = self.random_state
 
-        if inspect.signature(self._fitted_forecaster.get_prediction).parameters.get(
-            "exog"
-        ):
+        if _pred_has_arg("exog"):
             get_prediction_arguments["exog"] = X
 
         prediction_results = self._fitted_forecaster.get_prediction(

--- a/sktime/forecasting/structural.py
+++ b/sktime/forecasting/structural.py
@@ -277,7 +277,18 @@ class UnobservedComponents(_StatsModelsAdapter):
         self.flags = flags
         self.low_memory = low_memory
 
-        super(UnobservedComponents, self).__init__(random_state=random_state)
+        if random_state is not None:
+            from warnings import warn
+
+            msg = (
+                "the random_state parameter of UnobservedComponents does not "
+                "have any effect, it is deprecated in sktime and will be removed "
+                "in 0.20.0, "
+                "as statsmodels UnobservedComponents does not have this parameter"
+            )
+            warn("", stacklevel=2)
+
+        super(UnobservedComponents, self).__init__()
 
     def _fit_forecaster(self, y, X=None):
         """Fit to training data.

--- a/sktime/forecasting/structural.py
+++ b/sktime/forecasting/structural.py
@@ -276,22 +276,8 @@ class UnobservedComponents(_StatsModelsAdapter):
         self.optim_hessian = optim_hessian
         self.flags = flags
         self.low_memory = low_memory
-        self.random_state = random_state
 
-        # todo 0.20.0: remove random_state parameter
-        # also docstring references and logic
-        if random_state is not None:
-            from warnings import warn
-
-            msg = (
-                "the random_state parameter of UnobservedComponents does not "
-                "have any effect, it is deprecated in sktime and will be removed "
-                "in 0.20.0, "
-                "as statsmodels UnobservedComponents does not have this parameter"
-            )
-            warn("", stacklevel=2)
-
-        super(UnobservedComponents, self).__init__()
+        super(UnobservedComponents, self).__init__(random_state=random_state)
 
     def _fit_forecaster(self, y, X=None):
         """Fit to training data.

--- a/sktime/forecasting/structural.py
+++ b/sktime/forecasting/structural.py
@@ -276,7 +276,10 @@ class UnobservedComponents(_StatsModelsAdapter):
         self.optim_hessian = optim_hessian
         self.flags = flags
         self.low_memory = low_memory
+        self.random_state = random_state
 
+        # todo 0.20.0: remove random_state parameter
+        # also docstring references and logic
         if random_state is not None:
             from warnings import warn
 


### PR DESCRIPTION
This PR addresses a deprecation warning from `statsmodels`.

The `_StatsModelsAdapter` may pass a `random_state` parameter that does nothing. This was accepted as `kwargs`, but will raise an exception in the future, and raises a deprecation warning currently.

This PR prevents it from being passed by `_StatsModelsAdapter` if it isn't a recognized parameter.