### PR TITLE
[BUG] fix error messages in `BaseDistribution` if default methods are not implemented

### DIFF
--- a/sktime/proba/base.py
+++ b/sktime/proba/base.py
@@ -237,7 +237,7 @@ class BaseDistribution(BaseObject):
 
     def cdf(self, x):
         """Cumulative distribution function."""
-        N = self.APPROX_SPL
+        N = self.get_tag("approx_spl")
         approx_method = (
             "by approximating the expected value by the indicator function on "
             f"{N} samples"
@@ -252,7 +252,7 @@ class BaseDistribution(BaseObject):
 
     def ppf(self, p):
         """Quantile function = percent point function = inverse cdf."""
-        raise NotImplementedError(self._method_error_msg("cdf", "error"))
+        raise NotImplementedError(self._method_error_msg("ppf", "error"))
 
     def energy(self, x=None):
         r"""Energy of self, w.r.t. self or a constant frame x.
@@ -285,7 +285,7 @@ class BaseDistribution(BaseObject):
         )
         warn(self._method_error_msg("energy", fill_in=approx_method))
 
-        # splx, sply = i.i.d. samples of X - Y of size N = self.APPROX_ENERGY_SPL
+        # splx, sply = i.i.d. samples of X - Y of size N = approx_spl_size
         N = approx_spl_size
         if x is None:
             splx = self.sample(N)

--- a/sktime/proba/base.py
+++ b/sktime/proba/base.py
@@ -193,7 +193,7 @@ class BaseDistribution(BaseObject):
             warn(self._method_error_msg("pdf", fill_in=approx_method))
             return self.log_pdf(x=x).applymap(np.exp)
 
-        raise NotImplementedError(self._method_err_msg("pdf", "error"))
+        raise NotImplementedError(self._method_error_msg("pdf", "error"))
 
     def log_pdf(self, x):
         r"""Logarithmic probability density function.
@@ -233,7 +233,7 @@ class BaseDistribution(BaseObject):
 
             return self.pdf(x=x).applymap(np.log)
 
-        raise NotImplementedError(self._method_err_msg("log_pdf", "error"))
+        raise NotImplementedError(self._method_error_msg("log_pdf", "error"))
 
     def cdf(self, x):
         """Cumulative distribution function."""
@@ -252,7 +252,7 @@ class BaseDistribution(BaseObject):
 
     def ppf(self, p):
         """Quantile function = percent point function = inverse cdf."""
-        raise NotImplementedError(self._method_err_msg("cdf", "error"))
+        raise NotImplementedError(self._method_error_msg("cdf", "error"))
 
     def energy(self, x=None):
         r"""Energy of self, w.r.t. self or a constant frame x.
@@ -457,7 +457,7 @@ class BaseDistribution(BaseObject):
                 df_spl = pd.concat(pd_smpl, keys=range(n_samples))
                 return df_spl
 
-        raise NotImplementedError(self._method_err_msg("sample", "error"))
+        raise NotImplementedError(self._method_error_msg("sample", "error"))
 
 
 class _Indexer:

--- a/sktime/proba/normal.py
+++ b/sktime/proba/normal.py
@@ -151,35 +151,6 @@ class Normal(BaseDistribution):
         icdf_arr = d.mu + d.sigma * np.sqrt(2) * erfinv(2 * p.values - 1)
         return pd.DataFrame(icdf_arr, index=p.index, columns=p.columns)
 
-    def sample(self, n_samples=None):
-        """Sample from the distribution.
-
-        Parameters
-        ----------
-        n_samples : int, optional, default = None
-
-        Returns
-        -------
-        if `n_samples` is `None`:
-        returns a sample that contains a single sample from `self`,
-        in `pd.DataFrame` mtype format convention, with `index` and `columns` as `self`
-        if n_samples is `int`:
-        returns a `pd.DataFrame` that contains `n_samples` i.i.d. samples from `self`,
-        in `pd-multiindex` mtype format convention, with same `columns` as `self`,
-        and `MultiIndex` that is product of `RangeIndex(n_samples)` and `self.index`
-        """
-
-        def gen_unif():
-            np_unif = np.random.uniform(size=self.shape)
-            return pd.DataFrame(np_unif, index=self.index, columns=self.columns)
-
-        if n_samples is None:
-            return self.ppf(gen_unif())
-        else:
-            pd_smpl = [self.ppf(gen_unif()) for _ in range(n_samples)]
-            df_spl = pd.concat(pd_smpl, keys=range(n_samples))
-            return df_spl
-
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator."""


### PR DESCRIPTION
Fixes error messages in `BaseDistribution` if default methods are not implemented - this was calling a function that did not exist.

Also removes the redundant `sample` in `Normal` with defaulting to the parent class.