### PR TITLE
[ENH] rewrite of `_StatsForecastAdapter` in a generic way to support other models than `AutoARIMA`

### DIFF
--- a/sktime/forecasting/base/adapters/__init__.py
+++ b/sktime/forecasting/base/adapters/__init__.py
@@ -8,9 +8,13 @@ __all__ = [
     "_TbatsAdapter",
     "_PmdArimaAdapter",
     "_StatsForecastAdapter",
+    "_GeneralisedStatsForecastAdapter",
 ]
 
 from sktime.forecasting.base.adapters._fbprophet import _ProphetAdapter
+from sktime.forecasting.base.adapters._generalised_statsforecast import (
+    _GeneralisedStatsForecastAdapter,
+)
 from sktime.forecasting.base.adapters._pmdarima import _PmdArimaAdapter
 from sktime.forecasting.base.adapters._statsforecast import _StatsForecastAdapter
 from sktime.forecasting.base.adapters._statsmodels import _StatsModelsAdapter

--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Implements adapter for StatsForecast models."""
+import pandas
+
+from sktime.forecasting.base import BaseForecaster
+
+__all__ = ["_GeneralisedStatsForecastAdapter"]
+__author__ = ["yarnabrina"]
+
+
+class _GeneralisedStatsForecastAdapter(BaseForecaster):
+    """Base adapter class for StatsForecast models."""
+
+    _tags = {
+        "y_inner_mtype": "pd.Series",
+        "X_inner_mtype": "pd.DataFrame",
+        "scitype:y": "univariate",
+        "requires-fh-in-fit": False,
+        # "X-y-must-have-same-index": True,  # TODO: need to check (how?)
+        # "enforce_index_type": None,  # TODO: need to check (how?)
+        "handles-missing-data": False,
+        "python_version": ">=3.7",  # TODO: change to 3.8 (when?)
+        "python_dependencies": ["statsforecast"],
+    }
+
+    def __init__(self):
+        super().__init__()
+
+        self._forecaster = None
+
+    def _instantiate_model(self):
+        raise NotImplementedError("abstract method")
+
+    def _fit(self, y, X=None, fh=None):
+        """Fit forecaster to training data.
+
+        private _fit containing the core logic, called from fit
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        y : sktime time series object
+            guaranteed to be of an mtype in self.get_tag("y_inner_mtype")
+            Time series to which to fit the forecaster.
+            if self.get_tag("scitype:y")=="univariate":
+                guaranteed to have a single column/variable
+            if self.get_tag("scitype:y")=="multivariate":
+                guaranteed to have 2 or more columns
+            if self.get_tag("scitype:y")=="both": no restrictions apply
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            Required (non-optional) here if self.get_tag("requires-fh-in-fit")==True
+            Otherwise, if not passed in _fit, guaranteed to be passed in _predict
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series to fit to.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        del fh  # avoid being detected as unused by ``vulture`` like tools
+
+        self._forecaster = self._instantiate_model()
+
+        y_fit_input = y.to_numpy(copy=False)
+
+        X_fit_input = X
+        if X_fit_input is not None:
+            X_fit_input = X.to_numpy(copy=False)
+
+        self._forecaster.fit(y_fit_input, X=X_fit_input)
+
+        return self
+
+    def _predict_in_or_out_of_sample(self, fh, fh_type, X=None, levels=None):
+        maximum_forecast_horizon = fh.to_relative(self.cutoff)[-1]
+
+        absolute_horizons = fh.to_absolute_index(self.cutoff)
+        horizon_positions = fh.to_indexer(self.cutoff)
+
+        level_arguments = None if levels is None else [100 * level for level in levels]
+
+        if fh_type == "in-sample":
+            predictions = self._forecaster.predict_in_sample(level=level_arguments)
+            point_predictions = predictions["fitted"]
+        elif fh_type == "out-of-sample":
+            predictions = self._forecaster.predict(
+                maximum_forecast_horizon, X=X, level=level_arguments
+            )
+            point_predictions = predictions["mean"]
+
+        if isinstance(point_predictions, pandas.Series):
+            point_predictions = point_predictions.to_numpy()
+
+        final_point_predictions = pandas.Series(
+            point_predictions[horizon_positions], index=absolute_horizons
+        )
+
+        if levels is None:
+            return final_point_predictions
+
+        interval_predictions_indices = pandas.MultiIndex.from_product(
+            [["Coverage"], levels, ["lower", "upper"]]
+        )
+        interval_predictions = pandas.DataFrame(
+            index=absolute_horizons, columns=interval_predictions_indices
+        )
+
+        if fh_type == "out-of-sample":
+            column_prefix = ""
+        elif fh_type == "in-sample":
+            column_prefix = "fitted-"
+
+        for level, level_argument in zip(levels, level_arguments):
+            lower_interval_predictions = predictions[
+                f"{column_prefix}lo-{level_argument}"
+            ]
+            if isinstance(lower_interval_predictions, pandas.Series):
+                lower_interval_predictions = lower_interval_predictions.to_numpy()
+
+            upper_interval_predictions = predictions[
+                f"{column_prefix}hi-{level_argument}"
+            ]
+            if isinstance(upper_interval_predictions, pandas.Series):
+                upper_interval_predictions = upper_interval_predictions.to_numpy()
+
+            interval_predictions[
+                ("Coverage", level, "lower")
+            ] = lower_interval_predictions[horizon_positions]
+            interval_predictions[
+                ("Coverage", level, "upper")
+            ] = upper_interval_predictions[horizon_positions]
+
+        return interval_predictions
+
+    def _split_horizon(self, fh):
+        in_sample_horizon = fh.to_in_sample(self.cutoff)
+        out_of_sample_horizon = fh.to_out_of_sample(self.cutoff)
+
+        return in_sample_horizon, out_of_sample_horizon
+
+    def _predict(self, fh, X=None):
+        """Forecast time series at future horizon.
+
+        private _predict containing the core logic, called from predict
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            If not passed in _fit, guaranteed to be passed here
+        X : sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series for the forecast
+
+        Returns
+        -------
+        y_pred : sktime time series object
+            should be of the same type as seen in _fit, as in "y_inner_mtype" tag
+            Point predictions
+        """
+        X_predict_input = X.to_numpy(copy=False) if X is not None else X
+
+        in_sample_horizon, out_of_sample_horizon = self._split_horizon(fh)
+
+        point_predictions = []
+
+        if in_sample_horizon:
+            in_sample_point_predictions = self._predict_in_or_out_of_sample(
+                in_sample_horizon, "in-sample"
+            )
+            point_predictions.append(in_sample_point_predictions)
+
+        if out_of_sample_horizon:
+            out_of_sample_point_predictions = self._predict_in_or_out_of_sample(
+                out_of_sample_horizon, "out-of-sample", X=X_predict_input
+            )
+            point_predictions.append(out_of_sample_point_predictions)
+
+        final_point_predictions = pandas.concat(point_predictions, copy=False)
+        final_point_predictions.name = self._y.name
+
+        return final_point_predictions
+
+    def _predict_interval(self, fh, X=None, coverage=None):
+        """Compute/return prediction quantiles for a forecast.
+
+        private _predict_interval containing the core logic,
+            called from predict_interval and possibly predict_quantiles
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon
+            The forecasting horizon with the steps ahead to to predict.
+        X :  sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series for the forecast
+        coverage : list of float (guaranteed not None and floats in [0,1] interval)
+           nominal coverage(s) of predictive interval(s)
+
+        Returns
+        -------
+        pred_int : pd.DataFrame
+            Column has multi-index: first level is variable name from y in fit,
+                second level coverage fractions for which intervals were computed.
+                    in the same order as in input `coverage`.
+                Third level is string "lower" or "upper", for lower/upper interval end.
+            Row index is fh, with additional (upper) levels equal to instance levels,
+                from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
+            Entries are forecasts of lower/upper interval end,
+                for var in col index, at nominal coverage in second col index,
+                lower/upper depending on third col index, for the row index.
+                Upper/lower interval end forecasts are equivalent to
+                quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
+        """
+        X_predict_input = X if X is None else X.to_numpy(copy=False)
+
+        in_sample_horizon, out_of_sample_horizon = self._split_horizon(fh)
+
+        interval_predictions = []
+
+        if in_sample_horizon:
+            in_sample_interval_predictions = self._predict_in_or_out_of_sample(
+                in_sample_horizon, "in-sample", levels=coverage
+            )
+            interval_predictions.append(in_sample_interval_predictions)
+
+        if out_of_sample_horizon:
+            out_of_sample_interval_predictions = self._predict_in_or_out_of_sample(
+                out_of_sample_horizon,
+                "out-of-sample",
+                X=X_predict_input,
+                levels=coverage,
+            )
+            interval_predictions.append(out_of_sample_interval_predictions)
+
+        final_interval_predictions = pandas.concat(interval_predictions, copy=False)
+
+        return final_interval_predictions

--- a/sktime/forecasting/base/adapters/_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_statsforecast.py
@@ -1,33 +1,37 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Implements adapter for StatsForecast models."""
-import pandas
+"""Implements adapter for StatsForecast forecasters to be used in sktime framework."""
+
+__author__ = ["FedericoGarza"]
+__all__ = ["_StatsForecastAdapter"]
+
+
+import pandas as pd
 
 from sktime.forecasting.base import BaseForecaster
-
-__all__ = ["_StatsForecastAdapter"]
-__author__ = ["yarnabrina"]
+from sktime.forecasting.base._base import DEFAULT_ALPHA
 
 
 class _StatsForecastAdapter(BaseForecaster):
-    """Base adapter class for StatsForecast models."""
+    """Base class for interfacing StatsForecast."""
 
     _tags = {
-        "y_inner_mtype": "pd.Series",
-        "X_inner_mtype": "pd.DataFrame",
-        "scitype:y": "univariate",
-        "requires-fh-in-fit": False,
-        # "X-y-must-have-same-index": True,  # TODO: need to check (how?)
-        # "enforce_index_type": None,  # TODO: need to check (how?)
-        "handles-missing-data": False,
-        "python_version": ">=3.7",  # TODO: change to 3.8 (when?)
-        "python_dependencies": ["statsforecast"],
+        "scitype:y": "univariate",  # which y are fine? univariate/multivariate/both
+        "ignores-exogeneous-X": False,  # does estimator ignore the exogeneous X?
+        "handles-missing-data": False,  # can estimator handle missing data?
+        "y_inner_mtype": "pd.Series",  # which types do _fit, _predict, assume for y?
+        "X_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for X?
+        "requires-fh-in-fit": False,  # is forecasting horizon already required in fit?
+        "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
+        "enforce_index_type": None,  # index type that needs to be enforced in X/y
+        "capability:pred_int": True,  # does forecaster implement predict_quantiles?
+        "capability:pred_int:insample": True,
+        "python_dependencies": "statsforecast",
     }
 
     def __init__(self):
-        super().__init__()
-
         self._forecaster = None
+        super(_StatsForecastAdapter, self).__init__()
 
     def _instantiate_model(self):
         raise NotImplementedError("abstract method")
@@ -42,8 +46,7 @@ class _StatsForecastAdapter(BaseForecaster):
 
         Parameters
         ----------
-        y : sktime time series object
-            guaranteed to be of an mtype in self.get_tag("y_inner_mtype")
+        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
             Time series to which to fit the forecaster.
             if self.get_tag("scitype:y")=="univariate":
                 guaranteed to have a single column/variable
@@ -54,91 +57,18 @@ class _StatsForecastAdapter(BaseForecaster):
             The forecasting horizon with the steps ahead to to predict.
             Required (non-optional) here if self.get_tag("requires-fh-in-fit")==True
             Otherwise, if not passed in _fit, guaranteed to be passed in _predict
-        X :  sktime time series object, optional (default=None)
-            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+        X : optional (default=None)
+            guaranteed to be of a type in self.get_tag("X_inner_mtype")
             Exogeneous time series to fit to.
 
         Returns
         -------
         self : reference to self
         """
-        del fh  # avoid being detected as unused by ``vulture`` like tools
-
         self._forecaster = self._instantiate_model()
-
-        y_fit_input = y.to_numpy(copy=False)
-        X_fit_input = X.to_numpy(copy=False) if X is not None else X
-
-        self._forecaster.fit(y_fit_input, X=X_fit_input)
+        self._forecaster.fit(y.values, X.values if X is not None else X)
 
         return self
-
-    def _predict_in_or_out_of_sample(self, fh, fh_type, X=None, levels=None):
-        maximum_forecast_horizon = fh.to_relative(self.cutoff)[-1]
-
-        absolute_horizons = fh.to_absolute(self.cutoff).to_pandas()
-        horizon_positions = fh.to_indexer(self.cutoff)
-
-        level_arguments = None if levels is None else [100 * level for level in levels]
-
-        if fh_type == "in-sample":
-            predictions = self._forecaster.predict_in_sample(level=level_arguments)
-            point_predictions = predictions["fitted"]
-        elif fh_type == "out-of-sample":
-            predictions = self._forecaster.predict(
-                maximum_forecast_horizon, X=X, level=level_arguments
-            )
-            point_predictions = predictions["mean"]
-
-        if isinstance(point_predictions, pandas.Series):
-            point_predictions = point_predictions.to_numpy()
-
-        final_point_predictions = pandas.Series(
-            point_predictions[horizon_positions], index=absolute_horizons
-        )
-
-        if levels is None:
-            return final_point_predictions
-
-        interval_predictions_indices = pandas.MultiIndex.from_product(
-            [["Coverage"], levels, ["lower", "upper"]]
-        )
-        interval_predictions = pandas.DataFrame(
-            index=absolute_horizons, columns=interval_predictions_indices
-        )
-
-        if fh_type == "out-of-sample":
-            column_prefix = ""
-        elif fh_type == "in-sample":
-            column_prefix = "fitted-"
-
-        for level, level_argument in zip(levels, level_arguments):
-            lower_interval_predictions = predictions[
-                f"{column_prefix}lo-{level_argument}"
-            ]
-            if isinstance(lower_interval_predictions, pandas.Series):
-                lower_interval_predictions = lower_interval_predictions.to_numpy()
-
-            upper_interval_predictions = predictions[
-                f"{column_prefix}hi-{level_argument}"
-            ]
-            if isinstance(upper_interval_predictions, pandas.Series):
-                upper_interval_predictions = upper_interval_predictions.to_numpy()
-
-            interval_predictions[
-                ("Coverage", level, "lower")
-            ] = lower_interval_predictions[horizon_positions]
-            interval_predictions[
-                ("Coverage", level, "upper")
-            ] = upper_interval_predictions[horizon_positions]
-
-        return interval_predictions
-
-    def _split_horizon(self, fh):
-        in_sample_horizon = fh.to_in_sample(self.cutoff)
-        out_of_sample_horizon = fh.to_out_of_sample(self.cutoff)
-
-        return in_sample_horizon, out_of_sample_horizon
 
     def _predict(self, fh, X=None):
         """Forecast time series at future horizon.
@@ -157,59 +87,135 @@ class _StatsForecastAdapter(BaseForecaster):
         fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
             The forecasting horizon with the steps ahead to to predict.
             If not passed in _fit, guaranteed to be passed here
-        X : sktime time series object, optional (default=None)
-            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
-            Exogeneous time series for the forecast
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
 
         Returns
         -------
-        y_pred : sktime time series object
-            should be of the same type as seen in _fit, as in "y_inner_mtype" tag
+        y_pred : pd.Series
             Point predictions
         """
-        X_predict_input = X.to_numpy(copy=False) if X is not None else X
+        # distinguish between in-sample and out-of-sample prediction
+        fh_oos = fh.to_out_of_sample(self.cutoff)
+        fh_ins = fh.to_in_sample(self.cutoff)
 
-        in_sample_horizon, out_of_sample_horizon = self._split_horizon(fh)
+        # all values are out-of-sample
+        if fh.is_all_out_of_sample(self.cutoff):
+            y_pred = self._predict_fixed_cutoff(fh_oos, X=X)
 
-        point_predictions = []
+        # all values are in-sample
+        elif fh.is_all_in_sample(self.cutoff):
+            y_pred = self._predict_in_sample(fh_ins, X=X)
 
-        if in_sample_horizon:
-            in_sample_point_predictions = self._predict_in_or_out_of_sample(
-                in_sample_horizon, "in-sample"
-            )
-            point_predictions.append(in_sample_point_predictions)
+        # both in-sample and out-of-sample values
+        else:
+            y_ins = self._predict_in_sample(fh_ins, X=X)
+            y_oos = self._predict_fixed_cutoff(fh_oos, X=X)
+            y_pred = pd.concat([y_ins, y_oos])
 
-        if out_of_sample_horizon:
-            out_of_sample_point_predictions = self._predict_in_or_out_of_sample(
-                out_of_sample_horizon, "out-of-sample", X=X_predict_input
-            )
-            point_predictions.append(out_of_sample_point_predictions)
+        # ensure that name is not added nor removed
+        # otherwise this may upset conversion to pd.DataFrame
+        y_pred.name = self._y.name
+        return y_pred
 
-        final_point_predictions = pandas.concat(point_predictions, copy=False)
-        final_point_predictions.name = self._y.name
+    def _predict_in_sample(
+        self, fh, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA
+    ):
+        """Generate in sample predictions.
 
-        return final_point_predictions
+        Parameters
+        ----------
+        fh : array-like
+            The forecasters horizon with the steps ahead to to predict.
+            Default is
+            one-step ahead forecast, i.e. np.array([1]).
 
-    def _predict_interval(self, fh, X=None, coverage=None):
+        Returns
+        -------
+        y_pred : pandas.Series
+            Returns series of predicted values.
+        """
+        # initialize return objects
+        fh_abs = fh.to_absolute(self.cutoff).to_numpy()
+        fh_idx = fh.to_indexer(self.cutoff, from_cutoff=True)
+        y_pred = pd.Series(index=fh_abs, dtype="float64")
+
+        result = self._forecaster.predict_in_sample()
+        y_pred.loc[fh_abs] = result["mean"].values[fh_idx]
+
+        if return_pred_int:
+            pred_ints = []
+            for a in alpha:
+                pred_int = pd.DataFrame(index=fh_abs, columns=["lower", "upper"])
+                result = self._forecaster.predict_in_sample(level=int(100 * a))
+                pred_int.loc[fh_abs] = result.drop("mean", axis=1).values[fh_idx, :]
+                pred_ints.append(pred_int)
+            return y_pred, pred_ints
+
+        return y_pred
+
+    def _predict_fixed_cutoff(
+        self, fh, X=None, return_pred_int=False, alpha=DEFAULT_ALPHA
+    ):
+        """Make predictions out of sample.
+
+        Parameters
+        ----------
+        fh : array-like
+            The forecasters horizon with the steps ahead to to predict.
+            Default is
+            one-step ahead forecast, i.e. np.array([1]).
+
+        Returns
+        -------
+        y_pred : pandas.Series
+        Returns series of predicted values.
+        """
+        n_periods = int(fh.to_relative(self.cutoff)[-1])
+        result = self._forecaster.predict(
+            h=n_periods,
+            X=X.values if X is not None else X,
+        )
+
+        fh_abs = fh.to_absolute(self.cutoff)
+        fh_idx = fh.to_indexer(self.cutoff)
+        mean = pd.Series(result["mean"].values[fh_idx], index=fh_abs.to_pandas())
+        if return_pred_int:
+            pred_ints = []
+            for a in alpha:
+                result = self._forecaster.predict(
+                    h=n_periods,
+                    X=X.values if X is not None else X,
+                    level=int(100 * a),
+                )
+                pred_int = result.drop("mean", axis=1).values
+                pred_int = pd.DataFrame(
+                    pred_int[fh_idx, :],
+                    index=fh_abs.to_pandas(),
+                    columns=["lower", "upper"],
+                )
+                pred_ints.append(pred_int)
+            return mean, pred_ints
+        else:
+            return pd.Series(mean, index=fh_abs.to_pandas())
+
+    def _predict_interval(self, fh, X=None, coverage=0.90):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
             called from predict_interval and possibly predict_quantiles
-
         State required:
             Requires state to be "fitted".
-
         Accesses in self:
             Fitted model attributes ending in "_"
             self.cutoff
 
         Parameters
         ----------
-        fh : guaranteed to be ForecastingHorizon
-            The forecasting horizon with the steps ahead to to predict.
-        X :  sktime time series object, optional (default=None)
-            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
-            Exogeneous time series for the forecast
+        fh : int, list, np.array or ForecastingHorizon
+            Forecasting horizon, default = y.index (in-sample forecast)
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
         coverage : list of float (guaranteed not None and floats in [0,1] interval)
            nominal coverage(s) of predictive interval(s)
 
@@ -220,35 +226,47 @@ class _StatsForecastAdapter(BaseForecaster):
                 second level coverage fractions for which intervals were computed.
                     in the same order as in input `coverage`.
                 Third level is string "lower" or "upper", for lower/upper interval end.
-            Row index is fh, with additional (upper) levels equal to instance levels,
-                from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
-            Entries are forecasts of lower/upper interval end,
+            Row index is fh. Entries are forecasts of lower/upper interval end,
                 for var in col index, at nominal coverage in second col index,
                 lower/upper depending on third col index, for the row index.
                 Upper/lower interval end forecasts are equivalent to
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
-        X_predict_input = X if X is None else X.to_numpy(copy=False)
+        # initializaing cutoff and fh related info
+        cutoff = self.cutoff
+        fh_oos = fh.to_out_of_sample(cutoff)
+        fh_ins = fh.to_in_sample(cutoff)
+        fh_is_in_sample = fh.is_all_in_sample(cutoff)
+        fh_is_oosample = fh.is_all_out_of_sample(cutoff)
 
-        in_sample_horizon, out_of_sample_horizon = self._split_horizon(fh)
+        # prepare the return DataFrame - empty with correct cols
+        var_names = ["Coverage"]
+        int_idx = pd.MultiIndex.from_product([var_names, coverage, ["lower", "upper"]])
+        pred_int = pd.DataFrame(columns=int_idx)
 
-        interval_predictions = []
+        kwargs = {"X": X, "return_pred_int": True, "alpha": coverage}
+        # all values are out-of-sample
+        if fh_is_oosample:
+            _, y_pred_int = self._predict_fixed_cutoff(fh_oos, **kwargs)
 
-        if in_sample_horizon:
-            in_sample_interval_predictions = self._predict_in_or_out_of_sample(
-                in_sample_horizon, "in-sample", levels=coverage
-            )
-            interval_predictions.append(in_sample_interval_predictions)
+        # all values are in-sample
+        elif fh_is_in_sample:
+            _, y_pred_int = self._predict_in_sample(fh_ins, **kwargs)
 
-        if out_of_sample_horizon:
-            out_of_sample_interval_predictions = self._predict_in_or_out_of_sample(
-                out_of_sample_horizon,
-                "out-of-sample",
-                X=X_predict_input,
-                levels=coverage,
-            )
-            interval_predictions.append(out_of_sample_interval_predictions)
+        # if all in-sample/out-of-sample, we put y_pred_int in the required format
+        if fh_is_in_sample or fh_is_oosample:
+            # needs to be replaced, also seems duplicative, identical to part A
+            for intervals, a in zip(y_pred_int, coverage):
+                pred_int[("Coverage", a, "lower")] = intervals["lower"]
+                pred_int[("Coverage", a, "upper")] = intervals["upper"]
+            return pred_int
 
-        final_interval_predictions = pandas.concat(interval_predictions, copy=False)
+        # both in-sample and out-of-sample values (we reach this line only then)
+        # in this case, we additionally need to concat in and out-of-sample returns
+        _, y_ins_pred_int = self._predict_in_sample(fh_ins, **kwargs)
+        _, y_oos_pred_int = self._predict_fixed_cutoff(fh_oos, **kwargs)
+        for ins_int, oos_int, a in zip(y_ins_pred_int, y_oos_pred_int, coverage):
+            pred_int[("Coverage", a, "lower")] = pd.concat([ins_int, oos_int])["lower"]
+            pred_int[("Coverage", a, "upper")] = pd.concat([ins_int, oos_int])["upper"]
 
-        return final_interval_predictions
+        return pred_int

--- a/sktime/forecasting/statsforecast.py
+++ b/sktime/forecasting/statsforecast.py
@@ -160,6 +160,12 @@ class StatsForecastAutoARIMA(_StatsForecastAdapter):
     >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
     """
 
+    _tags = {
+        "ignores-exogeneous-X": False,
+        "capability:pred_int": True,
+        "capability:pred_int:insample": True,
+    }
+
     def __init__(
         self,
         start_p: int = 2,
@@ -234,7 +240,7 @@ class StatsForecastAutoARIMA(_StatsForecastAdapter):
 
     def _instantiate_model(self):
         # import inside method to avoid hard dependency
-        from statsforecast.arima import AutoARIMA as _AutoARIMA
+        from statsforecast.models import AutoARIMA as _AutoARIMA
 
         return _AutoARIMA(
             d=self.d,
@@ -269,7 +275,7 @@ class StatsForecastAutoARIMA(_StatsForecastAdapter):
             biasadj=self.biasadj,
             parallel=self.parallel,
             num_cores=self.n_jobs,
-            period=self.sp,
+            season_length=self.sp,
         )
 
     @classmethod

--- a/sktime/forecasting/statsforecast.py
+++ b/sktime/forecasting/statsforecast.py
@@ -8,10 +8,12 @@ __all__ = ["StatsForecastAutoARIMA"]
 
 from typing import Dict, Optional
 
-from sktime.forecasting.base.adapters._statsforecast import _StatsForecastAdapter
+from sktime.forecasting.base.adapters._generalised_statsforecast import (
+    _GeneralisedStatsForecastAdapter,
+)
 
 
-class StatsForecastAutoARIMA(_StatsForecastAdapter):
+class StatsForecastAutoARIMA(_GeneralisedStatsForecastAdapter):
     """StatsForecast AutoARIMA estimator.
 
     This implementation is inspired by Hyndman's forecast::auto.arima [1]_


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
See #4447 for discussions.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
The existing `_StatsForecastAdapter` was too specific for `AutoARIMA`, and it was not possible to use same base adapter class for other estimators, e.g. `AutoTheta`. This PR attempts to rewrite in a general way to avoid this problem.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* `copyright` part - not sure what to use
* `__author__` part - replaced `FedericoGarza` as I rewrote entirely, but since it's Nixtla's implementation, not sure if that's okay
* specification of tags `X-y-must-have-same-index` and `enforce_index_type` - not sure what is appropritae, skipped to use default
* introduced `fh_type`, which should only be either `in-sample` or `out-of-sample` - should this be an Enum, or normal check is fine?
* modified import for `StatsForecastAutoARIMA`, as `statsforecast.models` is publicly documented (and changed argument name as appropriate) - please look at #4598
* other code readability issues, if any
* other code generalisation issues, if any

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
No.

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
I tested the functionally locally by running this:

```sh
pytest -k "StatsForecastAutoARIMA" sktime/forecasting/tests/test_all_forecasters.py
```

All tests passed successfully. To test generalisation of the base adapter, I took the liberty of merging this PR branch into PR #4539 branch locally. Afterwards, all of these passed locally:

```sh
pytest -k "StatsForecastAutoTheta" sktime/forecasting/tests/test_all_forecasters.py
```

Hence, updated that branch remotely as well, and that PR can be checked to test generic nature of this adapter.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
