### PR TITLE
[DOC] remove forgotten `legacy_interface` reference from `check_is_scitype` docstring

### DIFF
--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -352,14 +352,9 @@ def check_is_scitype(
     Returns
     -------
     valid: bool - whether obj is a valid object of mtype/scitype
-    msg:
-        if legacy_interface=False:
-        dict[str, str] or None - error messages if object is not valid, otherwise None
+    msg: dict[str, str] or None
+        error messages if object is not valid, otherwise None
         keys are all mtypes tested, value for key is error message for that key
-        if legacy_interface=True:
-        str or list of str - error messages if object is not valid, otherwise None
-        str if mtype is str; list of len(mtype) with message per mtype if list
-        returned only if return_metadata is True
     metadata: dict - metadata about obj if valid, otherwise None
             returned only if return_metadata is True
         Fields depend on scitpe.


### PR DESCRIPTION
This PR removes a `legacy_interface` reference from `check_is_scitype` docstring that should have been removed in carrying out a deprecation action but was forgotten.