### PR TITLE
[BUG] fix wrong `alpha` sorting in `BaseDistribution` `quantile` return

### DIFF
--- a/sktime/proba/base.py
+++ b/sktime/proba/base.py
@@ -423,7 +423,9 @@ class BaseDistribution(BaseObject):
 
         qres = pd.concat(qdfs, axis=1, keys=alpha)
         qres = qres.reorder_levels([1, 0], axis=1)
-        quantiles = qres.sort_index(axis=1)
+
+        cols = pd.MultiIndex.from_product([self.columns, alpha])
+        quantiles = qres.loc[:, cols]
         return quantiles
 
     def sample(self, n_samples=None):


### PR DESCRIPTION
This PR fixes an unreported bug where the `alpha` returned in the columns of the return of `BaseDistribution.quantiles` were not sorted in the same order as `alpha` of `quantiles`, in the rare case where the input `alpha` were not already ascendingly sorted.

This violates the assumption on the `predict_quantiles` interface per the default using `predict_proba` - however, as that default was never used, it did not show up as a test failure.

This is fixed, and is tested as part of `skpro` PR https://github.com/sktime/skpro/pull/18 (although `sktime` does not depend on it yet)