### PR TITLE
[BUG] allow unfitted estimators as fitted parameters in `get_fitted_params`

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -386,7 +386,7 @@ class BaseEstimator(BaseObject):
         """Get fitted parameters.
 
         State required:
-            Requires state to be "fitted".
+            Requires state to be "fitted". If not, returns empty dict.
 
         Parameters
         ----------
@@ -412,12 +412,11 @@ class BaseEstimator(BaseObject):
               all parameters of `componentname` appear as `paramname` with its value
             * if `deep=True`, also contains arbitrary levels of component recursion,
               e.g., `[componentname]__[componentcomponentname]__[paramname]`, etc
+
+            If estimator is not fitted, will return an empty dict.
         """
         if not self.is_fitted:
-            raise NotFittedError(
-                f"estimator of type {type(self).__name__} has not been "
-                "fitted yet, please call fit on data before get_fitted_params"
-            )
+            return {}
 
         # collect non-nested fitted params of self
         fitted_params = self._get_fitted_params()

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1224,7 +1224,7 @@ class BaseForecaster(BaseEstimator):
         """Get fitted parameters.
 
         State required:
-            Requires state to be "fitted".
+            Requires state to be "fitted". If not, returns empty dict.
 
         Parameters
         ----------
@@ -1250,6 +1250,8 @@ class BaseForecaster(BaseEstimator):
               all parameters of `componentname` appear as `paramname` with its value
             * if `deep=True`, also contains arbitrary levels of component recursion,
               e.g., `[componentname]__[componentcomponentname]__[paramname]`, etc
+
+            If estimator is not fitted, will return an empty dict.
         """
         # if self is not vectorized, run the default get_fitted_params
         if not getattr(self, "_is_vectorized", False):

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -759,7 +759,7 @@ class BaseTransformer(BaseEstimator):
         """Get fitted parameters.
 
         State required:
-            Requires state to be "fitted".
+            Requires state to be "fitted". If not, returns empty dict.
 
         Parameters
         ----------
@@ -785,6 +785,8 @@ class BaseTransformer(BaseEstimator):
               all parameters of `componentname` appear as `paramname` with its value
             * if `deep=True`, also contains arbitrary levels of component recursion,
               e.g., `[componentname]__[componentcomponentname]__[paramname]`, etc
+
+            If estimator is not fitted, will return an empty dict.
         """
         # if self is not vectorized, run the default get_fitted_params
         if not getattr(self, "_is_vectorized", False):


### PR DESCRIPTION
The `get_fitted_params` method would terminate with an exception if a fitted parameter was an estimator, but not fitted - as it would attempt to call its `get_fitted_params` which would then error out.

However, it is perfectly sensible - even if rare - for a fitted parameter to be an estimator, so this should be possible.

This PR solves this by not raising an exception when `get_fitted_params` is called on an unfitted estimator, but returning an empty `dict`.

Deprecation is not necessary, as it removes an exception case upon nothing hinges in downstream code.

Reviewers should focus on whether this interface change is sensible.

Fixes #4574, and adds it as a test case.