### PR TITLE
[BUG] fix for `get_fitted_params` in `_HeterogenousMetaEstimator`

### DIFF
--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -113,12 +113,16 @@ class _HeterogenousMetaEstimator:
             estimators = [(x[0], x[1]) for x in estimators]
             out.update(estimators)
             for name, estimator in estimators:
-                # checks estimator has get_params resp get_fitted_params
-                if hasattr(estimator, methodd):
-                    # checks estimator is fitted before get_fitted_params call
-                    if not fitted or estimator.is_fitted:
-                        for key, value in getattr(estimator, methodd)(**deepkw).items():
-                            out["%s__%s" % (name, key)] = value
+                # checks estimator has the method we want to call
+                cond1 = hasattr(estimator, methodd)
+                # checks estimator is fitted if calling get_fitted_params
+                is_fitted = hasattr(estimator, "is_fitted") and estimator.is_fitted
+                # if we call get_params and not get_fitted_params, this is True
+                cond2 = not fitted or is_fitted
+                # check both conditions together
+                if cond1 and cond2:
+                    for key, value in getattr(estimator, methodd)(**deepkw).items():
+                        out["%s__%s" % (name, key)] = value
         return out
 
     def _set_params(self, attr, **params):

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -100,9 +100,11 @@ class _HeterogenousMetaEstimator:
 
         if fitted:
             method = "_get_fitted_params"
+            method_d = "get_fitted_params"
             deepkw = {}
         else:
             method = "get_params"
+            method_d = "get_params"
             deepkw = {"deep": deep}
 
         out = getattr(super(), method)(**deepkw)
@@ -111,8 +113,8 @@ class _HeterogenousMetaEstimator:
             estimators = [(x[0], x[1]) for x in estimators]
             out.update(estimators)
             for name, estimator in estimators:
-                if hasattr(estimator, "get_params"):
-                    for key, value in getattr(estimator, method)(**deepkw).items():
+                if hasattr(estimator, method):
+                    for key, value in getattr(estimator, method_d)(deep=True).items():
                         out["%s__%s" % (name, key)] = value
         return out
 

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -114,7 +114,7 @@ class _HeterogenousMetaEstimator:
             out.update(estimators)
             for name, estimator in estimators:
                 # checks estimator has get_params resp get_fitted_params
-                if hasattr(estimator, method):
+                if hasattr(estimator, methodd):
                     # checks estimator is fitted before get_fitted_params call
                     if not fitted or estimator.is_fitted:
                         for key, value in getattr(estimator, methodd)(**deepkw).items():

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -100,11 +100,11 @@ class _HeterogenousMetaEstimator:
 
         if fitted:
             method = "_get_fitted_params"
-            method_d = "get_fitted_params"
+            methodd = "get_fitted_params"
             deepkw = {}
         else:
             method = "get_params"
-            method_d = "get_params"
+            methodd = "get_params"
             deepkw = {"deep": deep}
 
         out = getattr(super(), method)(**deepkw)
@@ -113,9 +113,12 @@ class _HeterogenousMetaEstimator:
             estimators = [(x[0], x[1]) for x in estimators]
             out.update(estimators)
             for name, estimator in estimators:
+                # checks estimator has get_params resp get_fitted_params
                 if hasattr(estimator, method):
-                    for key, value in getattr(estimator, method_d)(deep=True).items():
-                        out["%s__%s" % (name, key)] = value
+                    # checks estimator is fitted before get_fitted_params call
+                    if not fitted or estimator.is_fitted:
+                        for key, value in getattr(estimator, methodd)(**deepkw).items():
+                            out["%s__%s" % (name, key)] = value
         return out
 
     def _set_params(self, attr, **params):

--- a/sktime/forecasting/base/tests/test_base_bugs.py
+++ b/sktime/forecasting/base/tests/test_base_bugs.py
@@ -23,7 +23,6 @@ from sktime.utils.validation._dependencies import _check_estimator_deps
 )
 def test_vectorization_series_to_panel(mtype):
     """Regression test for bugfix #4574, related to get_fitted_params."""
-
     y = _make_hierarchical(hierarchy_levels=(2, 2), min_timepoints=7, max_timepoints=7)
     agg = Aggregator()
     y_agg = agg.fit_transform(y)

--- a/sktime/forecasting/base/tests/test_base_bugs.py
+++ b/sktime/forecasting/base/tests/test_base_bugs.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for bugfixes related to base class related functionality."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+import pytest
+
+from sktime.forecasting.compose import ForecastByLevel, TransformedTargetForecaster
+from sktime.forecasting.exp_smoothing import ExponentialSmoothing
+from sktime.forecasting.model_selection import (
+    ForecastingGridSearchCV,
+    ExpandingWindowSplitter,
+)
+from sktime.forecasting.reconcile import ReconcilerForecaster
+from sktime.forecasting.trend import PolynomialTrendForecaster
+from sktime.transformations.hierarchical.aggregate import Aggregator
+from sktime.utils._testing.hierarchical import _make_hierarchical
+from sktime.utils.validation._dependencies import _check_estimator_deps
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(ExponentialSmoothing, severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_vectorization_series_to_panel(mtype):
+    """Regression test for bugfix #4574, related to get_fitted_params."""
+
+    y = _make_hierarchical(hierarchy_levels=(2, 2), min_timepoints=7, max_timepoints=7)
+    agg = Aggregator()
+    y_agg = agg.fit_transform(y)
+
+    param_grid = [
+        {
+            "forecaster": [ExponentialSmoothing()],
+            "forecaster__trend": ["add", "mul"],
+        },
+        {
+            "forecaster": [PolynomialTrendForecaster()],
+            "forecaster__degree": [1, 2],
+        },
+    ]
+
+    pipe = TransformedTargetForecaster(steps=[("forecaster", ExponentialSmoothing())])
+
+    N_cv_fold = 2
+    step_cv = 1
+    fh = [1, 2]
+
+    N_t = len(y_agg.index.get_level_values(2).unique())
+    initial_window_cv_len = N_t - (N_cv_fold - 1) * step_cv - fh[-1]
+
+    cv = ExpandingWindowSplitter(
+        initial_window=initial_window_cv_len,
+        step_length=step_cv,
+        fh=fh,
+    )
+
+    gscv = ForecastingGridSearchCV(forecaster=pipe, param_grid=param_grid, cv=cv)
+    gscv_bylevel = ForecastByLevel(gscv, 'local')
+    reconciler = ReconcilerForecaster(gscv_bylevel, method="ols")
+
+    reconciler.fit(y_agg)
+    reconciler.get_fitted_params()  # triggers an error pre-fix

--- a/sktime/forecasting/base/tests/test_base_bugs.py
+++ b/sktime/forecasting/base/tests/test_base_bugs.py
@@ -21,7 +21,7 @@ from sktime.utils.validation._dependencies import _check_estimator_deps
     not _check_estimator_deps(ExponentialSmoothing, severity="none"),
     reason="skip test if required soft dependency not available",
 )
-def test_vectorization_series_to_panel(mtype):
+def test_heterogeneous_get_fitted_params():
     """Regression test for bugfix #4574, related to get_fitted_params."""
     y = _make_hierarchical(hierarchy_levels=(2, 2), min_timepoints=7, max_timepoints=7)
     agg = Aggregator()

--- a/sktime/forecasting/base/tests/test_base_bugs.py
+++ b/sktime/forecasting/base/tests/test_base_bugs.py
@@ -7,8 +7,8 @@ import pytest
 from sktime.forecasting.compose import ForecastByLevel, TransformedTargetForecaster
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.model_selection import (
-    ForecastingGridSearchCV,
     ExpandingWindowSplitter,
+    ForecastingGridSearchCV,
 )
 from sktime.forecasting.reconcile import ReconcilerForecaster
 from sktime.forecasting.trend import PolynomialTrendForecaster
@@ -55,7 +55,7 @@ def test_vectorization_series_to_panel(mtype):
     )
 
     gscv = ForecastingGridSearchCV(forecaster=pipe, param_grid=param_grid, cv=cv)
-    gscv_bylevel = ForecastByLevel(gscv, 'local')
+    gscv_bylevel = ForecastByLevel(gscv, "local")
     reconciler = ReconcilerForecaster(gscv_bylevel, method="ols")
 
     reconciler.fit(y_agg)


### PR DESCRIPTION
This fixes a bug in `get_fitted_params` of `_HeterogenousMetaEstimator`, which is at the root of https://github.com/sktime/sktime/issues/4574. Also fixes #4574.

`get_fitted_params` of `_HeterogenousMetaEstimator` was accidentally calling the private interface point of components rather than the public interface point that it should have.

For reviewers: the first call should be to `_get_fitted_params` of the base class, which is correct. Subsequent calls to components should be to the public interface, `get_fitted_params`.

Contains a regression test for #4574.