### PR TITLE
[MNT] remove private imports from `sklearn`

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -64,9 +64,9 @@ from copy import deepcopy
 from skbase.base import BaseObject as _BaseObject
 from sklearn import clone
 from sklearn.base import BaseEstimator as _BaseEstimator
-from sklearn.ensemble._base import _set_random_states
 
 from sktime.exceptions import NotFittedError
+from sktime.utils.random_state import set_random_state
 
 
 class BaseObject(_BaseObject):
@@ -508,6 +508,6 @@ def _clone_estimator(base_estimator, random_state=None):
     estimator = clone(base_estimator)
 
     if random_state is not None:
-        _set_random_states(estimator, random_state)
+        set_random_state(estimator, random_state)
 
     return estimator

--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -269,7 +269,7 @@ class ProbabilityThresholdEarlyClassifier(BaseClassifier):
 
     def _fit_estimator(self, X, y, i):
         rs = 255 if self.random_state == 0 else self.random_state
-        rs = None if self.random_state is None else rs * 37 * (i + 1)
+        rs = None if self.random_state is None else rs * 37 * (i + 1) % 2**31
         rng = check_random_state(rs)
 
         estimator = _clone_estimator(

--- a/sktime/classification/early_classification/_teaser.py
+++ b/sktime/classification/early_classification/_teaser.py
@@ -430,7 +430,7 @@ class TEASER(BaseEarlyClassifier):
 
     def _predict_proba_for_estimator(self, X, i):
         rs = 255 if self.random_state == 0 else self.random_state
-        rs = None if self.random_state is None else rs * 37 * (i + 1)
+        rs = None if self.random_state is None else rs * 37 * (i + 1) % 2**31
         rng = check_random_state(rs)
 
         probas = self._estimators[i].predict_proba(

--- a/sktime/classification/early_classification/_teaser.py
+++ b/sktime/classification/early_classification/_teaser.py
@@ -352,7 +352,7 @@ class TEASER(BaseEarlyClassifier):
 
     def _fit_estimator(self, X, y, i):
         rs = 255 if self.random_state == 0 else self.random_state
-        rs = None if self.random_state is None else rs * 37 * (i + 1)
+        rs = None if self.random_state is None else rs * 37 * (i + 1) % 2**31
         rng = check_random_state(rs)
 
         default = (

--- a/sktime/classification/kernel_based/_arsenal.py
+++ b/sktime/classification/kernel_based/_arsenal.py
@@ -229,7 +229,8 @@ class Arsenal(BaseClassifier):
                             if self.random_state is None
                             else (255 if self.random_state == 0 else self.random_state)
                             * 37
-                            * (i + 1) % 2**31,
+                            * (i + 1)
+                            % 2**31,
                         ),
                         X,
                         y,
@@ -253,7 +254,8 @@ class Arsenal(BaseClassifier):
                         if self.random_state is None
                         else (255 if self.random_state == 0 else self.random_state)
                         * 37
-                        * (i + 1) % 2**31,
+                        * (i + 1)
+                        % 2**31,
                     ),
                     X,
                     y,

--- a/sktime/classification/kernel_based/_arsenal.py
+++ b/sktime/classification/kernel_based/_arsenal.py
@@ -229,7 +229,7 @@ class Arsenal(BaseClassifier):
                             if self.random_state is None
                             else (255 if self.random_state == 0 else self.random_state)
                             * 37
-                            * (i + 1),
+                            * (i + 1) % 2**31,
                         ),
                         X,
                         y,
@@ -253,7 +253,7 @@ class Arsenal(BaseClassifier):
                         if self.random_state is None
                         else (255 if self.random_state == 0 else self.random_state)
                         * 37
-                        * (i + 1),
+                        * (i + 1) % 2**31,
                     ),
                     X,
                     y,

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -11,7 +11,6 @@ import numpy as np
 import pandas as pd
 from sklearn import clone
 from sklearn.utils import check_random_state
-from sklearn.utils._testing import set_random_state
 
 from sktime.datatypes._utilities import update_data
 from sktime.forecasting.base import BaseForecaster
@@ -22,6 +21,7 @@ from sktime.transformations.bootstrap import (
     STLBootstrapTransformer,
 )
 from sktime.utils.estimators import MockForecaster
+from sktime.utils.random_state import set_random_state
 
 
 class BaggingForecaster(BaseForecaster):

--- a/sktime/series_as_features/base/estimators/_ensemble.py
+++ b/sktime/series_as_features/base/estimators/_ensemble.py
@@ -14,7 +14,6 @@ import pandas as pd
 from joblib import Parallel, delayed
 from numpy import float64 as DOUBLE
 from sklearn.base import clone
-from sklearn.ensemble._base import _set_random_states
 from sklearn.ensemble._forest import (
     MAX_INT,
     BaseForest,
@@ -25,6 +24,7 @@ from sklearn.exceptions import DataConversionWarning
 from sklearn.utils import check_array, check_random_state, compute_sample_weight
 
 from sktime.transformations.panel.summarize import RandomIntervalFeatureExtractor
+from sktime.utils.random_state import set_random_state
 
 
 def _parallel_build_trees(
@@ -112,7 +112,7 @@ class BaseTimeSeriesForest(BaseForest):
         estimator.set_params(**{p: getattr(self, p) for p in self.estimator_params})
 
         if random_state is not None:
-            _set_random_states(estimator, random_state)
+            set_random_state(estimator, random_state)
 
         if append:
             self.estimators_.append(estimator)

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -18,7 +18,6 @@ import joblib
 import numpy as np
 import pandas as pd
 import pytest
-from sklearn.utils._testing import set_random_state
 from sklearn.utils.estimator_checks import (
     check_get_params_invariance as _check_get_params_invariance,
 )
@@ -55,6 +54,7 @@ from sktime.utils._testing.estimator_checks import (
     _list_required_methods,
 )
 from sktime.utils._testing.scenarios_getter import retrieve_scenarios
+from sktime.utils.random_state import set_random_state
 from sktime.utils.sampling import random_partition
 from sktime.utils.validation._dependencies import (
     _check_dl_dependencies,

--- a/sktime/utils/random_state.py
+++ b/sktime/utils/random_state.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""Utilities for handling the random_state variable."""
+# copied from scikit-learn to avoid dependency on sklearn private methods
+
+import numpy as np
+from sklearn.utils import check_random_state
+
+
+def set_random_state(estimator, random_state=0):
+    """Set fixed random_state parameters for an estimator.
+
+    Finds all parameters ending ``random_state`` and sets them to integers
+    derived from ``random_state``.
+
+    Parameters
+    ----------
+    estimator : estimator supporting get_params, set_params
+        Estimator with potential randomness managed by random_state parameters.
+
+    random_state : int, RandomState instance or None, default=None
+        Pseudo-random number generator to control the generation of the random
+        integers. Pass an int for reproducible output across multiple function calls.
+
+    Notes
+    -----
+    This does not necessarily set *all* ``random_state`` attributes that
+    control an estimator's randomness, only those accessible through
+    ``estimator.get_params()``.
+    """
+    random_state = check_random_state(random_state)
+    to_set = {}
+    for key in sorted(estimator.get_params(deep=True)):
+        if key == "random_state" or key.endswith("__random_state"):
+            to_set[key] = random_state.randint(np.iinfo(np.int32).max)
+
+    if to_set:
+        estimator.set_params(**to_set)


### PR DESCRIPTION
Towards https://github.com/sktime/sktime/issues/4670

Eliminates private imports from `sklearn`:

* `set_random_state` and `_set_random_states` imports replaced by an `sktime` local `set_random_state` (consensus replacement)
* fixes an unreported bug where internal random state seeds could under some conditions exceed the max permissible in `numpy`, of `2**32 -1`

Todo:
* `_partition_estimators` imports
* `from sklearn.ensemble._forest import`-s