### PR TITLE
[MNT] update pre commit hook versions and corresponding changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=1000"]
@@ -22,27 +22,27 @@ repos:
         name: isort
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
       - id: black
         language_version: python3
         # args: [--line-length 79]
 
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
         exclude: docs/conf.py
         additional_dependencies: [flake8-bugbear, flake8-print]
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.47"
+    rev: "0.49"
     hooks:
       - id: check-manifest
         stages: [manual]
 
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.2.2
+    rev: 1.7.0
     hooks:
       - id: nbqa-black
         args: [--nbqa-mutate, --nbqa-dont-skip-bad-cells]
@@ -55,7 +55,7 @@ repos:
         additional_dependencies: [flake8==3.8.3]
 
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         args: ["--config=setup.cfg"]
@@ -63,7 +63,7 @@ repos:
   # We use the Python version instead of the original version which seems to require Docker
   # https://github.com/koalaman/shellcheck-precommit
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.4
+    rev: v0.9.0.5
     hooks:
       - id: shellcheck
         name: shellcheck

--- a/build_tools/changelog.py
+++ b/build_tools/changelog.py
@@ -140,7 +140,6 @@ def render_changelog(prs, assigned):  # noqa
 
 
 if __name__ == "__main__":
-
     categories = [
         {"title": "Enhancements", "labels": ["feature", "enhancement"]},
         {"title": "Fixes", "labels": ["bug", "fix", "bugfix"]},

--- a/build_tools/make_release.py
+++ b/build_tools/make_release.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Do-nothing script for making a release.
+"""Do-nothing script for making a release.
 
 This idea comes from here:
 - https://blog.danslimmon.com/2019/07/15/do-nothing-scripting-the-key-to

--- a/docs/source/about/citation.md
+++ b/docs/source/about/citation.md
@@ -3,5 +3,5 @@
 If you use sktime in a scientific publication, we would appreciate
 citations to the following papers:
 
-* [Markus Löning, Anthony Bagnall, Sajaysurya Ganesh, Viktor Kazakov, Jason Lines, Franz Király (2019): “sktime: A Unified Interface for Machine Learning with Time Series”](http://learningsys.org/neurips19/assets/papers/sktime_ml_systems_neurips2019.pdf)
+* [Markus Löning, Anthony Bagnall, Sajaysurya Ganesh, Viktor Kazakov, Jason Lines, Franz Király (2019): "sktime: A Unified Interface for Machine Learning with Time Series"](http://learningsys.org/neurips19/assets/papers/sktime_ml_systems_neurips2019.pdf)
 * [Markus Löning, Tony Bagnall, Sajaysurya Ganesh, George Oastler, Jason Lines, ViktorKaz, …, Aadesh Deshmukh (2020). sktime/sktime. Zenodo. http://doi.org/10.5281/zenodo.3749000](http://doi.org/10.5281/zenodo.3749000)

--- a/docs/source/about/funding.rst
+++ b/docs/source/about/funding.rst
@@ -25,7 +25,7 @@ of the initial development under the UKRI Strategic Priorities Fund
 Systems <https://www.turing.ac.uk/events/tools-practices-and-systems-data-science-and-artificial-intelligence-scoping-workshop>`__
 theme within that grant.
 
-Markus Löning’s contributions between 2019 and 2021 were supported by:
+Markus Löning's contributions between 2019 and 2021 were supported by:
 
 * the `UK Economic and Social Research Council (ESRC) <https://esrc.ukri.org>`_,
 * the `Consumer Data Research Centre (CDRC) <https://www.cdrc.ac.uk>`_,

--- a/docs/source/about/showcase.rst
+++ b/docs/source/about/showcase.rst
@@ -14,7 +14,7 @@ Community Showcase
      -  Gives insights on importance of skime over scikit-learn, Proper Data Model for Time Series, and Highlights on unique features of sktime like sktime API, Code Examples of Time Series Models
      - :user:`Alexandra Amidon <lynnssi>`
    * - `Why start using sktime for forecasting? <https://medium.com/@jlenczuk/why-start-using-sktime-for-forecasting-8d6881c0a518>`_
-     - Overview of sktime’s features that distinguish it from other forecasting frameworks
+     - Overview of sktime's features that distinguish it from other forecasting frameworks
      - :user:`Joanna Lenczuk <joanlenczuk>`
    * - `Time Series Analysis with sktime on AWS SageMaker <https://datachef.co/blog/time-series-analysis-sktime-sagemaker/>`_
      - This guide explains the procedure of using sktime as a toolbox for time series analysis on the AWS SageMaker environment.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
 """Configuration file for the Sphinx documentation builder."""
 
 import os
@@ -305,8 +304,7 @@ def _make_estimator_overview(app):
     from sktime.registry import all_estimators
 
     def _process_author_info(author_info):
-        """
-        Process author information from source code files.
+        """Process author information from source code files.
 
         Parameters
         ----------

--- a/docs/source/contributing/enhancement_proposals.rst
+++ b/docs/source/contributing/enhancement_proposals.rst
@@ -11,7 +11,7 @@ Description
 An sktime enhancement proposal (STEP) is a software design document providing information to the sktime community.
 The proposal should provide a rationale and concise technical specification of proposed design.
 
-We collect and discuss proposals in sktime’s STEP `repository`_.
+We collect and discuss proposals in sktime's STEP `repository`_.
 
 .. _repository: https://github.com/sktime/enhancement-proposals
 

--- a/docs/source/contributing/reporting_bugs.rst
+++ b/docs/source/contributing/reporting_bugs.rst
@@ -25,5 +25,5 @@ rules before submitting:
 
 .. note::
 
-   To find out more about how to take part in sktime’s community, check out our `governance
+   To find out more about how to take part in sktime's community, check out our `governance
    guidelines <https://www.sktime.net/en/latest/governance.html>`__.

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -24,9 +24,9 @@ New developers should:
 
 Further special topics are listed below.
 
-sktime follows `scikit-learn <https://scikit-learn.org/stable/>`_\ ’s API whenever possible.
-If you’re new to scikit-learn, take a look at their `getting-started guide <https://scikit-learn.org/stable/getting_started.html>`_.
-If you’re already familiar with scikit-learn, you may still learn something new from their `developers’ guide <https://scikit-learn.org/stable/developers/index.html>`_.
+sktime follows `scikit-learn <https://scikit-learn.org/stable/>`_\ 's API whenever possible.
+If you're new to scikit-learn, take a look at their `getting-started guide <https://scikit-learn.org/stable/getting_started.html>`_.
+If you're already familiar with scikit-learn, you may still learn something new from their `developers' guide <https://scikit-learn.org/stable/developers/index.html>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/developer_guide/coding_standards.rst
+++ b/docs/source/developer_guide/coding_standards.rst
@@ -48,7 +48,7 @@ Additional configurations can be found in
 -  Avoid multiple statements on one line. Prefer a line return after a
    control flow statement (``if``/``for``).
 -  Use absolute imports for references inside sktime.
--  Don’t use ``import *`` in the source code. It is considered
+-  Don't use ``import *`` in the source code. It is considered
    harmful by the official Python recommendations. It makes the code
    harder to read as the origin of symbols is no longer explicitly
    referenced, but most important, it prevents using a static analysis
@@ -110,8 +110,8 @@ API design
 ============
 
 The general design approach of sktime is described in the
-paper `“Designing Machine Learning Toolboxes: Concepts, Principles and
-Patterns” <https://arxiv.org/abs/2101.04938>`__.
+paper `"Designing Machine Learning Toolboxes: Concepts, Principles and
+Patterns" <https://arxiv.org/abs/2101.04938>`__.
 
 .. note::
 

--- a/docs/source/developer_guide/git_workflow.rst
+++ b/docs/source/developer_guide/git_workflow.rst
@@ -3,7 +3,7 @@
 Git and GitHub workflow
 =======================
 
-The preferred workflow for contributing to sktime’s repository is to
+The preferred workflow for contributing to sktime's repository is to
 fork the `main
 repository <https://github.com/sktime/sktime/>`__ on
 GitHub, clone, and develop on a new branch.

--- a/docs/source/get_involved/code_of_conduct.rst
+++ b/docs/source/get_involved/code_of_conduct.rst
@@ -121,11 +121,11 @@ hope you will consider to be appropriate community guidelines:
    unsure whether your behaviour towards another person is welcome, ask
    them. If someone tells you to stop, do so.
 -  **Respect the privacy and safety of others**. Do not take photographs
-   of others without their permission. Do not share other participant’s
+   of others without their permission. Do not share other participant's
    personal experiences without their express permission. Note that
    posting (or threatening to post) personally identifying information
    of others without their consent ("doxing") is a form of harassment.
--  **Be considerate of others’ participation**. Everyone should have an
+-  **Be considerate of others' participation**. Everyone should have an
    opportunity to be heard. In update sessions, please keep comments
    succinct so as to allow maximum engagement by all participants. Do
    not interrupt others on the basis of disagreement; hold such comments
@@ -135,7 +135,7 @@ hope you will consider to be appropriate community guidelines:
    crucial for fairness and diversity of our community, as well as its scientific quality.
    Free speech and constant scrutiny directed at those in power is also essential to ensure
    accountability and fair operations of our community, and to prevent groupthink or in-group dynamics.
--  **Don’t be a bystander**. If you see something inappropriate
+-  **Don't be a bystander**. If you see something inappropriate
    happening, speak up. If you don't feel comfortable intervening but
    feel someone should, please feel free to ask a member of the Code of
    Conduct response team for support.

--- a/docs/source/get_involved/contributing.rst
+++ b/docs/source/get_involved/contributing.rst
@@ -27,9 +27,9 @@ Recommended steps for first time contributors, or to get started with regular co
 1. Say hello (in the lobby on `Discord`_)!
 2. Get set up for development, see `instructions in the developer guide <https://www.sktime.net/en/stable/developer_guide.html>`_.
 3. Pick a good first issue to work on, see a collection `in this summary issue <https://github.com/sktime/sktime/issues/1147>`_ , or from `this list <https://github.com/sktime/sktime/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22>`_
-   suggestion: pick something small with simple content to learn the “process”
+   suggestion: pick something small with simple content to learn the "process"
 4. Feel free to attend the regular community collab sessions or one of the topic specific stand-ups and tech sessions (see schedule on `Discord`_)
-5. Once your first PR is merged and you’ve seen how things work, you could consider contributing more regularly: optionally, continue attending the Friday community collaboration sessions and stand-ups; or, optionally, `apply for mentoring <https://www.sktime.net/en/stable/get_involved/mentoring.html#mentoring>`_
+5. Once your first PR is merged and you've seen how things work, you could consider contributing more regularly: optionally, continue attending the Friday community collaboration sessions and stand-ups; or, optionally, `apply for mentoring <https://www.sktime.net/en/stable/get_involved/mentoring.html#mentoring>`_
 
 .. _Discord: https://discord.com/invite/54ACzaFsn7
 

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -205,7 +205,7 @@ Rights and responsibilities
    * - Right/responsibility
      - Description
    * - Direct access
-     - Being a core developer allows contributors to more easily carry on with their project related activities by giving them direct access to the project’s repository.
+     - Being a core developer allows contributors to more easily carry on with their project related activities by giving them direct access to the project's repository.
    * - Issue/PR management
      - Core developers are responsible for reviewing and managing issues and pull requests. This includes commenting on issues, reviewing code contributions, merging approved pull requests, and closing issues once resolved.
    * - Decision making
@@ -228,7 +228,7 @@ they have been nominated, there will be a vote by the current core
 developers.
 
 Voting on appointments is one of the few activities that takes
-place on the project’s private communication channels. The vote will be
+place on the project's private communication channels. The vote will be
 anonymous.
 
 While it is expected that most votes will be unanimous, a 2/3 majority of
@@ -438,11 +438,11 @@ used by the sktime project. We clarify:
 * how decisions are made, and
 * who participates in the decision making.
 
-sktime’s decision-making process is designed to take into account
+sktime's decision-making process is designed to take into account
 feedback from all community members and strives to find consensus, while
 avoiding deadlocks when no consensus can be found.
 
-All discussion and votes takes place on the project’s `issue
+All discussion and votes takes place on the project's `issue
 tracker <https://github.com/sktime/sktime/issues>`__,
 `pull requests <https://github.com/sktime/sktime/pulls>`__ or an :ref:`steps`. Some
 sensitive discussions and appointment votes occur on private chats.
@@ -475,7 +475,7 @@ corresponding decision making process is described in more detail below.
 Stage 1: lazy consensus with veto right
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-sktime uses a “consensus seeking” process for making decisions. The
+sktime uses a "consensus seeking" process for making decisions. The
 community tries to find a resolution that has no open objections among
 core developers.
 
@@ -573,7 +573,7 @@ comparison with alternative solutions, as outlined in our
 A complete STEP must always include at least a high-level design for the proposed change,
 not just a wishlist of features.
 
-Usually, we collect and discuss proposals in sktime’s `repository for
+Usually, we collect and discuss proposals in sktime's `repository for
 enhancement-proposals <https://github.com/sktime/enhancement-proposals>`__.
 
 For smaller changes, such as punctual changes to the API or governance documents,
@@ -632,7 +632,7 @@ If algorithms require major dependencies, we encourage to create a
 separate companion repository. For smaller
 dependencies which are limited to a few files, we encourage to use soft
 dependencies, which are only required for particular modules, but not
-for most of sktime’s functionality and not for installing sktime.
+for most of sktime's functionality and not for installing sktime.
 
 .. _acknowledging-contributions:
 
@@ -644,11 +644,11 @@ developers, users, educators, and other stakeholders. We value all kinds
 of contributions and are committed to recognising each of them fairly.
 
 We follow the `all-contributors <https://allcontributors.org>`__
-specification to recognise all contributors, including those that don’t
+specification to recognise all contributors, including those that don't
 contribute code. Please see `our list of all
 contributors <https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md>`__.
 
-If you think, we’ve missed anything, please let us know or open a PR
+If you think, we've missed anything, please let us know or open a PR
 with the appropriate changes to
 `sktime/.all-contributorsrc <https://github.com/sktime/sktime/blob/main/.all-contributorsrc>`__.
 
@@ -659,7 +659,7 @@ All contributors acknowledge that they have all the rights to the code
 they contribute to make it available under this license.
 
 The project belongs to the sktime community, and all parts of it are
-always considered “work in progress” so that they can evolve over time
+always considered "work in progress" so that they can evolve over time
 with newer contributions.
 
 .. _outlook:
@@ -668,7 +668,7 @@ Outlook
 -------
 
 We are open to improvement suggestions for our governance model. Once
-the community grows more and sktime’s code base becomes more
+the community grows more and sktime's code base becomes more
 consolidated, we will consider the following changes:
 
 -  Allow for more time to discuss changes, and more time to cast vote
@@ -681,7 +681,7 @@ In addition, we plan to add more roles for managing/coordinating
 specific project:
 
 * Community manager (mentorship, outreach, social media, etc),
-* Sub-councils for project-specific technical leadership (e.g.  for documentation, learning tasks, continuous integration)
+* Sub-councils for project-specific technical leadership (e.g.  for documentation, learning tasks, continuous integration)
 
 .. _references:
 
@@ -689,9 +689,9 @@ References
 ----------
 
 Our governance model is inspired by various existing governance
-structures. In particular, we’d like to acknowledge:
+structures. In particular, we'd like to acknowledge:
 
-* scikit-learn’s `governance model <https://www.sktime.net/en/latest/governance.html>`__
+* scikit-learn's `governance model <https://www.sktime.net/en/latest/governance.html>`__
 * `The Turing Way <https://github.com/alan-turing-institute/the-turing-way>`__ project
 * `The Art of Community <https://www.jonobacon.com/books/artofcommunity/>`__ by Jono Bacon
 * The `astropy <https://www.astropy.org>`__ project

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -105,7 +105,7 @@ sktime.
 
     Tabular
         Is a setting where each :term:`timepoint` of the :term:`univariate time series` being measured for each instance are treated as features and
-        stored as a primitive data type in the DataFrame’s cells. E.g., there are N :term:`instances <instance>` of time series and each has T
+        stored as a primitive data type in the DataFrame's cells. E.g., there are N :term:`instances <instance>` of time series and each has T
         :term:`timepoints <timepoint>`, this would yield a pandas DataFrame with shape (N, T): N rows, T columns.
 
     Framework

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -15,7 +15,7 @@ To run the user guide notebooks interactively, you can
 `launch them on binder <https://mybinder.org/v2/gh/sktime/sktime/main?filepath=examples>`_
 without having to install anything.
 
-We assume basic familiarity with `scikit-learn`_. If you haven’t worked with scikit-learn before, check out their
+We assume basic familiarity with `scikit-learn`_. If you haven't worked with scikit-learn before, check out their
 `getting-started guide`_.
 
 The notebook files can be found `here <https://github.com/sktime/sktime/blob/main/examples>`_.

--- a/examples/feature_extraction_with_tsfresh.ipynb
+++ b/examples/feature_extraction_with_tsfresh.ipynb
@@ -224,7 +224,7 @@
     }
    ],
    "source": [
-    "#  binary classification task\n",
+    "#  binary classification task\n",
     "np.unique(y_train)"
    ]
   },
@@ -936,7 +936,7 @@
     }
    ],
    "source": [
-    "#  multivariate input data\n",
+    "#  multivariate input data\n",
     "X_train.head()"
    ]
   },

--- a/examples/minirocket.ipynb
+++ b/examples/minirocket.ipynb
@@ -471,7 +471,7 @@
     "\n",
     "\n",
     "### 4.1 Load japanese_vowels as unequal length dataset\n",
-    "Japanese vowels is a a UCI Archive dataset. 9 Japanese-male speakers were recorded saying the vowels ‘a’ and ‘e’. \n",
+    "Japanese vowels is a a UCI Archive dataset. 9 Japanese-male speakers were recorded saying the vowels 'a' and 'e'. \n",
     "The raw recordings are preprocessed to get a 12-dimensional (multivariate) classification probem. The series lengths are between 7 and 29. "
    ]
   },

--- a/examples/plateau_finder.ipynb
+++ b/examples/plateau_finder.ipynb
@@ -233,7 +233,7 @@
     }
    ],
    "source": [
-    "#  find plateaus\n",
+    "#  find plateaus\n",
     "t = PlateauFinder()\n",
     "Xt = t.fit_transform(X)\n",
     "Xt"

--- a/examples/segmentation_with_clasp.ipynb
+++ b/examples/segmentation_with_clasp.ipynb
@@ -355,7 +355,7 @@
    "source": [
     "# ClaSP - Window Size Selection\n",
     "\n",
-    "ClaSP takes the window size 𝑤 as a hyper-parameter. This parameter has data-dependent effects on ClaSP’s performance. When chosen too small, all windows tend to appear similar; when chosen too large, windows have a higher chance to overlap adjacent segments, blurring their discriminative power. \n",
+    "ClaSP takes the window size 𝑤 as a hyper-parameter. This parameter has data-dependent effects on ClaSP's performance. When chosen too small, all windows tend to appear similar; when chosen too large, windows have a higher chance to overlap adjacent segments, blurring their discriminative power. \n",
     "\n",
     "A simple, yet effective method for choosing the window size is the dominant frequency of the Fourier Transform."
    ]

--- a/examples/signature_method.ipynb
+++ b/examples/signature_method.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# The Signature Method with Sktime\n",
     "\n",
-    "The ‘signature method’ refers to a collection of feature extraction techniques for multimodal sequential data, derived from the theory of controlled differential equations. In recent years, a large number of modifications have been suggested to the signature method so as to improve some aspect of it. \n",
+    "The 'signature method' refers to a collection of feature extraction techniques for multimodal sequential data, derived from the theory of controlled differential equations. In recent years, a large number of modifications have been suggested to the signature method so as to improve some aspect of it. \n",
     "\n",
     "In the paper [\"A Generalised Signature Method for Time-Series\"](https://arxiv.org/abs/2006.00873) [1] the authors collated the vast majority of these modifications into a single document and ran a large hyper-parameter study over the multivariate UEA datasets to build a generic signature algorithm that is expected to work well on a wide range of datasets. We implement the best practice results from this study as the default starting values for our hyperparameters in the `SignatureClassifier` module. \n"
    ]

--- a/extension_templates/alignment.py
+++ b/extension_templates/alignment.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Extension template for unsupervised sequence aligners.
+"""Extension template for unsupervised sequence aligners.
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template

--- a/extension_templates/annotation.py
+++ b/extension_templates/annotation.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Extension template for series annotation.
+"""Extension template for series annotation.
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Extension template for time series classifiers.
+"""Extension template for time series classifiers.
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Extension template for clusterers.
+"""Extension template for clusterers.
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Extension template for pairwise distance or kernel between time series.
+"""Extension template for pairwise distance or kernel between time series.
 
 How to use this:
 - this is meant as a "fill in" template for easy extension

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Extension template for pairwise distance or kernel on tabular data.
+"""Extension template for pairwise distance or kernel on tabular data.
 
 How to use this:
 - this is meant as a "fill in" template for easy extension

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Extension template for early time series classifiers.
+"""Extension template for early time series classifiers.
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Extension template for forecasters.
+"""Extension template for forecasters.
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template
@@ -319,9 +318,9 @@ class MyForecaster(BaseForecaster):
     def _update_predict_single(self, y, fh, X=None, update_params=True):
         """Update forecaster and then make forecasts.
 
-        Implements default behaviour of calling update and predict
-        sequentially, but can be overwritten by subclasses
-        to implement more efficient updating algorithms when available.
+        Implements default behaviour of calling update and predict sequentially, but can
+        be overwritten by subclasses to implement more efficient updating algorithms
+        when available.
         """
         self.update(y, X, update_params=update_params)
         return self.predict(fh, X)

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -113,7 +113,6 @@ class MyForecaster(BaseForecaster):
 
     # todo: add any hyper-parameters and components to constructor
     def __init__(self, parama, paramb="default", paramc=None):
-
         # todo: write any hyper-parameters to self
         self.parama = parama
         self.paramb = paramb

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Extension template for forecasters, SIMPLE version.
+"""Extension template for forecasters, SIMPLE version.
 
 Contains only bare minimum of implementation requirements for a functional forecaster.
 Also assumes *no composition*, i.e., no forecaster or other estimator components.

--- a/extension_templates/param_est.py
+++ b/extension_templates/param_est.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Extension template for parameter estimators.
+"""Extension template for parameter estimators.
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Extension template for transformers.
+"""Extension template for transformers.
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -178,7 +178,6 @@ class MyTransformer(BaseTransformer):
 
     # todo: add any hyper-parameters and components to constructor
     def __init__(self, parama, paramb="default", paramc=None):
-
         # todo: write any hyper-parameters to self
         self.parama = parama
         self.paramb = paramb

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Extension template for transformers, SIMPLE version.
+"""Extension template for transformers, SIMPLE version.
 
 Contains only bare minimum of implementation requirements for a functional transformer.
 Also assumes *no composition*, i.e., no transformer or other estimator components.

--- a/sktime/__init__.py
+++ b/sktime/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """sktime."""
 
 __version__ = "0.19.1"

--- a/sktime/_contrib/__init__.py
+++ b/sktime/_contrib/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-A place for misc/incomplete developer code.
+"""A place for misc/incomplete developer code.
 
 This is not an official sktime package. The contents stored here are not guaranteed to
 be properly reviewed, and can change at any time with no deprecation.

--- a/sktime/_contrib/_plot_path.py
+++ b/sktime/_contrib/_plot_path.py
@@ -9,7 +9,6 @@ _check_soft_dependencies("matplotlib", severity="warning")
 
 
 def _path_mask(cost_matrix, path, ax, theme=None):
-
     _check_soft_dependencies("matplotlib")
 
     import matplotlib.colors as colorplt
@@ -55,7 +54,6 @@ def _plot_path(
     title: str = "",
     plot_over_pw: bool = False,
 ):
-
     _check_soft_dependencies("matplotlib")
 
     import matplotlib as plt
@@ -122,7 +120,6 @@ def _plot_path(
 
 
 def _plot_alignment(x, y, metric, dist_kwargs: dict = None, title: str = ""):
-
     _check_soft_dependencies("matplotlib")
 
     import matplotlib as plt

--- a/sktime/_contrib/classification_experiments.py
+++ b/sktime/_contrib/classification_experiments.py
@@ -67,9 +67,8 @@ def demo_loading():
 
 
 if __name__ == "__main__":
-    """
-    Example simple usage, with arguments input via script or hard coded for testing.
-    """
+    """Example simple usage, with arguments input via script or hard coded for
+    testing."""
     if sys.argv.__len__() > 1:  # cluster run, this is fragile
         print(sys.argv)
         data_dir = sys.argv[1]

--- a/sktime/_contrib/clustering_experiments.py
+++ b/sktime/_contrib/clustering_experiments.py
@@ -98,9 +98,8 @@ def tune_window(metric: str, train_X):
 
 
 if __name__ == "__main__":
-    """
-    Example simple usage, with arguments input via script or hard coded for testing.
-    """
+    """Example simple usage, with arguments input via script or hard coded for
+    testing."""
     clusterer = "kmeans"
     chris_config = True  # This is so chris doesn't have to change config each time
     tune = False

--- a/sktime/_contrib/distance_based/_proximity_forest.py
+++ b/sktime/_contrib/distance_based/_proximity_forest.py
@@ -1281,7 +1281,7 @@ class ProximityTree(BaseClassifier):
     def predict_class_label(self, query):
         """Predict the label of a query.
 
-        :param query: 
+        :param query:
         :return:
         """
         stump = self.root_stump

--- a/sktime/_contrib/distance_based/_proximity_forest.py
+++ b/sktime/_contrib/distance_based/_proximity_forest.py
@@ -2,7 +2,7 @@
 """Proximity Forest time series classifier.
 
 A decision tree forest which uses distance measures to partition data. B. Lucas and A.
-Shifaz, C. Pelletier, L. O’Neill, N. Zaidi, B. Goethals, F. Petitjean and G. Webb
+Shifaz, C. Pelletier, L. O'Neill, N. Zaidi, B. Goethals, F. Petitjean and G. Webb
 Proximity Forest: an effective and scalable distance-based classifier for time series,
 Data Mining and Knowledge Discovery, 33(3): 607-635, 2019
 """

--- a/sktime/_contrib/distance_based/_proximity_forest.py
+++ b/sktime/_contrib/distance_based/_proximity_forest.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 """Proximity Forest time series classifier.
 
-A decision tree forest which uses distance measures to partition data.
-B. Lucas and A. Shifaz, C. Pelletier, L. O’Neill, N. Zaidi, B. Goethals,
-F. Petitjean and G. Webb
-Proximity Forest: an effective and scalable distance-based classifier for
-time series,
+A decision tree forest which uses distance measures to partition data. B. Lucas and A.
+Shifaz, C. Pelletier, L. O’Neill, N. Zaidi, B. Goethals, F. Petitjean and G. Webb
+Proximity Forest: an effective and scalable distance-based classifier for time series,
 Data Mining and Knowledge Discovery, 33(3): 607-635, 2019
 """
 
@@ -101,7 +99,6 @@ class _CachedTransformer(_PanelToPanelTransformer):
     Attributes
     ----------
     cache       : location to store transforms seen before for fast look up
-
     """
 
     _required_parameters = ["transformer"]
@@ -116,8 +113,7 @@ class _CachedTransformer(_PanelToPanelTransformer):
         self.cache = {}
 
     def transform(self, X, y=None):
-        """
-        Fit transformer, creating a cache for transformation.
+        """Fit transformer, creating a cache for transformation.
 
         Parameters
         ----------
@@ -928,7 +924,7 @@ class ProximityStump(BaseClassifier):
         :param X: Array-like containing instances
         :param y: Array-like containing class labels
         :return: Returns a dictionary {Label: [sub_X]} in which sub_X contains all
-        instances that match that label
+                instances that match that label
         """
         split_class_x = dict()
         y_size = len(y)
@@ -1083,8 +1079,8 @@ class ProximityStump(BaseClassifier):
         """Find distance to exemplars.
 
         :param X: the dataset containing a list of instances
-        :return: 2d numpy array of distances from each instance to each
-        exemplar (instance by exemplar)
+        :return: 2d numpy array of distances from each instance to each         exemplar
+                (instance by exemplar)
         """
         check_X(X)
         if self.n_jobs > 1 or self.n_jobs < 0:
@@ -1285,7 +1281,7 @@ class ProximityTree(BaseClassifier):
     def predict_class_label(self, query):
         """Predict the label of a query.
 
-        :param query:
+        :param query: 
         :return:
         """
         stump = self.root_stump
@@ -1539,8 +1535,8 @@ class ProximityForest(BaseClassifier):
         """Find probability estimates for each class for all cases in X.
 
         :param predictions_per_tree: Array-like of shape
-        [n_instances,[n_tree_estimators,labels]] which contains an array of labels
-        predicted by each tree for each instance.
+                [n_instances,[n_tree_estimators,labels]] which contains an array of
+                labels         predicted by each tree for each instance.
         :param size: Size of X dataset containing the instances to predict
         :return:
         """

--- a/sktime/_contrib/distance_based/_proximity_forest.py
+++ b/sktime/_contrib/distance_based/_proximity_forest.py
@@ -1313,7 +1313,7 @@ class ProximityForest(BaseClassifier):
 
         title={Proximity Forest: an effective and scalable distance-based
         classifier for time series},
-        author={B. Lucas and A. Shifaz and C. Pelletier and L. O’Neill and N.
+        author={B. Lucas and A. Shifaz and C. Pelletier and L. O'Neill and N.
         Zaidi and B. Goethals and F. Petitjean and G. Webb},
          journal={Data Mining and Knowledge Discovery},
         volume={33},

--- a/sktime/_contrib/distance_based/_proximity_forest.py
+++ b/sktime/_contrib/distance_based/_proximity_forest.py
@@ -191,8 +191,8 @@ def numba_wrapper(distance_measure):
 
     (to 1 column per dimension format)
     :param distance_measure: distance measure to wrap
-    :return: a distance measure which automatically formats data for cython
-    distance measures
+    :return: a distance measure which automatically formats data for cython distance
+        measures
     """
 
     def distance(instance_a, instance_b, **params):
@@ -637,8 +637,8 @@ def setup_all_distance_measure_getter(proximity):
     def pick_rand_distance_measure(proximity):
         """Generate a distance measure from a range of parameters.
 
-        :param proximity: proximity object containing distance measures,
-        ranges and dataset
+        :param proximity: proximity object containing distance measures, ranges and
+            dataset
         :return: a distance measure with no parameters
         """
         random_state = proximity.random_state
@@ -924,7 +924,7 @@ class ProximityStump(BaseClassifier):
         :param X: Array-like containing instances
         :param y: Array-like containing class labels
         :return: Returns a dictionary {Label: [sub_X]} in which sub_X contains all
-                instances that match that label
+            instances that match that label
         """
         split_class_x = dict()
         y_size = len(y)
@@ -1079,8 +1079,8 @@ class ProximityStump(BaseClassifier):
         """Find distance to exemplars.
 
         :param X: the dataset containing a list of instances
-        :return: 2d numpy array of distances from each instance to each         exemplar
-                (instance by exemplar)
+        :return: 2d numpy array of distances from each instance to each exemplar
+            (instance by exemplar)
         """
         check_X(X)
         if self.n_jobs > 1 or self.n_jobs < 0:
@@ -1226,22 +1226,21 @@ class ProximityTree(BaseClassifier):
         """Build a Proximity Tree object.
 
         :param random_state: the random state
-        :param get_exemplars: get the exemplars from a given dataframe and
-        list of class labels
+        :param get_exemplars: get the exemplars from a given dataframe and list of class
+            labels
         :param distance_measure: distance measure to use
-        :param get_distance_measure: method to get the distance measure if
-        no already set
-        :param setup_distance_measure: method to setup the distance measures
-        based upon the dataset given
+        :param get_distance_measure: method to get the distance measure if no already
+            set
+        :param setup_distance_measure: method to setup the distance measures based upon
+            the dataset given
         :param get_gain: method to find the gain of a data split
         :param max_depth: maximum depth of the tree
         :param is_leaf: function to decide when to mark a node as a leaf node
         :param verbosity: number reflecting the verbosity of logging
         :param n_jobs: number of parallel threads to use while building
-        :param find_stump: method to find the best split of data / stump at
-        a node
-        :param n_stump_evaluations: number of stump evaluations to do if
-        find_stump method is None
+        :param find_stump: method to find the best split of data / stump at a node
+        :param n_stump_evaluations: number of stump evaluations to do if find_stump
+            method is None
         """
         super().__init__()
         self.verbosity = verbosity
@@ -1362,22 +1361,21 @@ class ProximityForest(BaseClassifier):
         """Build a Proximity Forest object.
 
         :param random_state: the random state
-        :param get_exemplars: get the exemplars from a given dataframe and
-        list of class labels
+        :param get_exemplars: get the exemplars from a given dataframe and list of class
+            labels
         :param distance_measure: distance measure to use
-        :param get_distance_measure: method to get the distance measure if
-        no already set
-        :param setup_distance_measure_getter: method to setup the distance
-        measures based upon the dataset given
+        :param get_distance_measure: method to get the distance measure if no already
+            set
+        :param setup_distance_measure_getter: method to setup the distance measures
+            based upon the dataset given
         :param get_gain: method to find the gain of a data split
         :param max_depth: maximum depth of the tree
         :param is_leaf: function to decide when to mark a node as a leaf node
         :param verbosity: number reflecting the verbosity of logging
         :param n_jobs: number of parallel threads to use while building
-        :param find_stump: method to find the best split of data / stump at
-        a node
-        :param n_stump_evaluations: number of stump evaluations to do if
-        find_stump method is None
+        :param find_stump: method to find the best split of data / stump at a node
+        :param n_stump_evaluations: number of stump evaluations to do if find_stump
+            method is None
         :param n_estimators: number of trees to construct
         """
         self.verbosity = verbosity
@@ -1535,8 +1533,8 @@ class ProximityForest(BaseClassifier):
         """Find probability estimates for each class for all cases in X.
 
         :param predictions_per_tree: Array-like of shape
-                [n_instances,[n_tree_estimators,labels]] which contains an array of
-                labels         predicted by each tree for each instance.
+            [n_instances,[n_tree_estimators,labels]] which contains an array of labels
+            predicted by each tree for each instance.
         :param size: Size of X dataset containing the instances to predict
         :return:
         """

--- a/sktime/_contrib/distance_based/elastic_ensemble_from_file.py
+++ b/sktime/_contrib/distance_based/elastic_ensemble_from_file.py
@@ -213,8 +213,7 @@ class ElasticEnsemblePostProcess:
         write_test=True,
         overwrite=False,
     ):
-        """
-        Write the results to file.
+        """Write the results to file.
 
         Probably could be replaced with data_io.write_results_UEA
 

--- a/sktime/_contrib/tests/test_experiments.py
+++ b/sktime/_contrib/tests/test_experiments.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Test Experiments.
 
-tests the experiments code works with all current valid classifiers.
-Loops through all classifiers in the list in experiments, trains,  Builds all.
+tests the experiments code works with all current valid classifiers. Loops through all
+classifiers in the list in experiments, trains,  Builds all.
 """
 
 __author__ = ["TonyBagnall"]

--- a/sktime/alignment/dtw_numba.py
+++ b/sktime/alignment/dtw_numba.py
@@ -133,7 +133,6 @@ class AlignerDtwNumba(BaseAligner):
         bounding_matrix: np.ndarray = None,
         g: float = 0.0,
     ):
-
         self.weighted = weighted
         self.derivative = derivative
         self.window = window

--- a/sktime/annotation/base/_base.py
+++ b/sktime/annotation/base/_base.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Base class template for annotator base type for time series stream.
+"""Base class template for annotator base type for time series stream.
 
     class name: BaseSeriesAnnotator
 

--- a/sktime/annotation/clasp.py
+++ b/sktime/annotation/clasp.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-
-"""
-ClaSP (Classification Score Profile) Segmentation.
+"""ClaSP (Classification Score Profile) Segmentation.
 
 Notes
 -----
@@ -340,7 +338,6 @@ class ClaSPSegmentation(BaseSeriesAnnotator):
         -------
         IntervalIndex:
             Segmentation based on found change pints
-
         """
         cps = np.array(found_cps)
         start = np.insert(cps, 0, 0)

--- a/sktime/annotation/datagen.py
+++ b/sktime/annotation/datagen.py
@@ -15,8 +15,7 @@ def piecewise_normal_multivariate(
     covariances: npt.ArrayLike = None,
     random_state: Union[int, np.random.RandomState] = None,
 ) -> npt.ArrayLike:
-    """
-    Generate multivariate series from segments.
+    """Generate multivariate series from segments.
 
     Each segment has length specified in ``lengths`` and data sampled from a
     multivariate normal distribution with a mean from ``means`` and covariance
@@ -89,7 +88,6 @@ def piecewise_normal_multivariate(
            [ 4.00389069,  3.95225998],
            [ 5.32264874,  5.05088075],
            [ 2.62479901,  6.08308546]])
-
     """
 
     def get_covariances(var):
@@ -139,8 +137,7 @@ def piecewise_normal(
     std_dev: Union[npt.ArrayLike, float] = 1.0,
     random_state: Union[int, np.random.RandomState] = None,
 ) -> npt.ArrayLike:
-    """
-    Generate series from segments.
+    """Generate series from segments.
 
     Each segment has length specified in ``lengths`` and data sampled from a normal
     distribution with a mean from ``means`` and standard deviation from ``std_dev``.
@@ -179,7 +176,6 @@ def piecewise_normal(
     array([1.        , 1.        , 2.32384427, 2.76151493, 1.88292331,
         1.88293152, 4.57921282, 3.76743473, 2.53052561, 3.54256004,
         2.53658231, 2.53427025, 3.24196227, 1.08671976])
-
     """
     rng = check_random_state(random_state)
     assert len(means) == len(lengths)
@@ -202,8 +198,7 @@ def piecewise_multinomial(
     p_vals: npt.ArrayLike,
     random_state: Union[int, np.random.RandomState] = None,
 ) -> npt.ArrayLike:
-    """
-    Generate series from segments.
+    """Generate series from segments.
 
     Each segment has length specified in ``lengths`` and data sampled from a multinomial
     distribution with a total number of experiments for each trial set from ``n_trials``
@@ -279,8 +274,7 @@ def piecewise_poisson(
     lengths: npt.ArrayLike,
     random_state: Union[int, np.random.RandomState] = None,
 ) -> npt.ArrayLike:
-    """
-    Generate series using Possion distribution.
+    """Generate series using Possion distribution.
 
     Each segment has length specified in ``lengths`` and data sampled from a Poisson
     distribution with expected lambda from ``lambdas``.
@@ -308,7 +302,6 @@ def piecewise_poisson(
     >>> from sktime.annotation.datagen import piecewise_poisson
     >>> piecewise_poisson(lambdas=[1,3,6],lengths=[2,4,8],random_state=42)#doctest:+SKIP
     array([1, 2, 1, 3, 3, 2, 5, 5, 6, 4, 4, 9, 3, 5])
-
     """
     rng = check_random_state(random_state)
 
@@ -339,8 +332,7 @@ def label_piecewise_normal(
     std_dev: Union[npt.ArrayLike, float] = 1.0,
     repeated_labels: bool = True,
 ) -> npt.ArrayLike:
-    """
-    Generate labels for a series composed of segments.
+    """Generate labels for a series composed of segments.
 
     Parameters
     ----------

--- a/sktime/annotation/eagglo.py
+++ b/sktime/annotation/eagglo.py
@@ -15,8 +15,7 @@ __all__ = ["EAgglo"]
 
 
 class EAgglo(BaseTransformer):
-    """
-    Hierarchical agglomerative estimation of multiple change points.
+    """Hierarchical agglomerative estimation of multiple change points.
 
     E-Agglo is a non-parametric clustering approach for multivariate timeseries[1]_,
     where neighboring segments are sequentially merged_ to maximize a goodness-of-fit
@@ -431,7 +430,7 @@ def len_penalty(x: pd.DataFrame) -> int:
 def mean_diff_penalty(x: pd.DataFrame) -> float:
     """Penalize goodness-of-fit statistic.
 
-    Favors segmentations with larger sizes, while taking into consideration
-    the size of the new segments.
+    Favors segmentations with larger sizes, while taking into consideration the size of
+    the new segments.
     """
     return np.mean(np.diff(np.sort(x)))

--- a/sktime/annotation/eagglo.py
+++ b/sktime/annotation/eagglo.py
@@ -134,9 +134,7 @@ class EAgglo(BaseTransformer):
             return list(
                 filter(
                     lambda v: v == v,
-                    self.progression[
-                        i,
-                    ],
+                    self.progression[i,],
                 )
             )
 

--- a/sktime/annotation/ggs.py
+++ b/sktime/annotation/ggs.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Greedy Gaussian Segmentation (GGS).
+"""Greedy Gaussian Segmentation (GGS).
 
 The method approximates solutions for the problem of breaking a
 multivariate time series into segments, where the data in each segment
@@ -54,8 +53,7 @@ def get_GGS():
 
     @define
     class GGS:
-        """
-        Greedy Gaussian Segmentation.
+        """Greedy Gaussian Segmentation.
 
         The method approxmates solutions for the problem of breaking a
         multivariate time series into segments, where the data in each segment
@@ -131,8 +129,7 @@ def get_GGS():
             self._intermediate_ll = []
 
         def log_likelihood(self, data: npt.ArrayLike) -> float:
-            """
-            Compute the GGS log-likelihood of the segmented Gaussian model.
+            """Compute the GGS log-likelihood of the segmented Gaussian model.
 
             Parameters
             ----------
@@ -157,8 +154,7 @@ def get_GGS():
         def cumulative_log_likelihood(
             self, data: npt.ArrayLike, change_points: List[int]
         ) -> float:
-            """
-            Calculate cumulative GGS log-likelihood for all segments.
+            """Calculate cumulative GGS log-likelihood for all segments.
 
             Args
             ----
@@ -181,8 +177,7 @@ def get_GGS():
             return log_likelihood
 
         def add_new_change_point(self, data: npt.ArrayLike) -> Tuple[int, float]:
-            """
-            Add change point.
+            """Add change point.
 
             This methods finds a new change point by that splits the segment and
             optimizes the objective function. See section 3.1 on split subroutine
@@ -249,8 +244,7 @@ def get_GGS():
         def adjust_change_points(
             self, data: npt.ArrayLike, change_points: List[int], new_index: List[int]
         ) -> List[int]:
-            """
-            Adjust change points.
+            """Adjust change points.
 
             This method adjusts the positions of all change points until the
             result is 1-OPT, i.e., no change of any one breakpoint improves

--- a/sktime/annotation/hmm.py
+++ b/sktime/annotation/hmm.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-"""
-HMM Annotation Estimator.
+"""HMM Annotation Estimator.
 
-Implements a basic Hidden Markov Model (HMM) as an annotation estimator.
-To read more about the algorithm, check out the `HMM wikipedia page
+Implements a basic Hidden Markov Model (HMM) as an annotation estimator. To read more
+about the algorithm, check out the `HMM wikipedia page
 <https://en.wikipedia.org/wiki/Hidden_Markov_model>`_.
 """
 import warnings

--- a/sktime/annotation/hmm_learn/base.py
+++ b/sktime/annotation/hmm_learn/base.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-
-"""
-Hidden Markov Model based annotation from hmmlearn.
+"""Hidden Markov Model based annotation from hmmlearn.
 
 This code provides a base interface template for models
 from hmmlearn for using that library for annotation of time series.

--- a/sktime/annotation/hmm_learn/gaussian.py
+++ b/sktime/annotation/hmm_learn/gaussian.py
@@ -124,7 +124,6 @@ class GaussianHMM(BaseHMMLearn):
         init_params: str = "stmc",
         implementation: str = "log",
     ):
-
         self.n_components = n_components
         self.covariance_type = covariance_type
         self.min_covar = min_covar

--- a/sktime/annotation/hmm_learn/gaussian.py
+++ b/sktime/annotation/hmm_learn/gaussian.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-
-"""
-Hidden Markov Model with Gaussian emissions.
+"""Hidden Markov Model with Gaussian emissions.
 
 Please see the original library
 (https://github.com/hmmlearn/hmmlearn/blob/main/lib/hmmlearn/hmm.py)

--- a/sktime/annotation/hmm_learn/gmm.py
+++ b/sktime/annotation/hmm_learn/gmm.py
@@ -133,7 +133,6 @@ class GMMHMM(BaseHMMLearn):
         init_params: str = "stmcw",
         implementation: str = "log",
     ):
-
         self.n_components = n_components
         self.n_mix = n_mix
         self.min_covar = min_covar

--- a/sktime/annotation/hmm_learn/gmm.py
+++ b/sktime/annotation/hmm_learn/gmm.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-
-"""
-Hidden Markov Model with Gaussian mixture emissions.
+"""Hidden Markov Model with Gaussian mixture emissions.
 
 Please see the original library
 (https://github.com/hmmlearn/hmmlearn/blob/main/lib/hmmlearn/hmm.py)
@@ -14,8 +12,7 @@ __all__ = ["GMMHMM"]
 
 
 class GMMHMM(BaseHMMLearn):
-    """
-    Hidden Markov Model with Gaussian mixture emissions.
+    """Hidden Markov Model with Gaussian mixture emissions.
 
     Parameters
     ----------

--- a/sktime/annotation/hmm_learn/poisson.py
+++ b/sktime/annotation/hmm_learn/poisson.py
@@ -99,7 +99,6 @@ class PoissonHMM(BaseHMMLearn):
         init_params: str = "stl",
         implementation: str = "log",
     ):
-
         self.n_components = n_components
         self.startprob_prior = startprob_prior
         self.transmat_prior = transmat_prior

--- a/sktime/annotation/hmm_learn/poisson.py
+++ b/sktime/annotation/hmm_learn/poisson.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-
-"""
-Hidden Markov Model with Poisson emissions.
+"""Hidden Markov Model with Poisson emissions.
 
 Please see the original library
 (https://github.com/hmmlearn/hmmlearn/blob/main/lib/hmmlearn/hmm.py)
@@ -14,8 +12,7 @@ __all__ = ["PoissonHMM"]
 
 
 class PoissonHMM(BaseHMMLearn):
-    """
-    Hidden Markov Model with Poisson emissions.
+    """Hidden Markov Model with Poisson emissions.
 
     Parameters
     ----------

--- a/sktime/annotation/igts.py
+++ b/sktime/annotation/igts.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Information Gain-based Temporal Segmentation.
+"""Information Gain-based Temporal Segmentation.
 
 Information Gain Temporal Segmentation (IGTS) is a method for segmenting
 multivariate time series based off reducing the entropy in each segment [1]_.
@@ -15,7 +14,6 @@ References
     "Information gain-based metric for recognizing transitions in human activities.",
     Pervasive and Mobile Computing, 38, 92-109, (2017).
     https://www.sciencedirect.com/science/article/abs/pii/S1574119217300081
-
 """
 
 from dataclasses import dataclass
@@ -110,8 +108,7 @@ def get_IGTS():
 
     @define
     class IGTS:
-        """
-        Information Gain based Temporal Segmentation (IGTS).
+        """Information Gain based Temporal Segmentation (IGTS).
 
         IGTS is a n unsupervised method for segmenting multivariate time series
         into non-overlapping segments by locating change points that for which
@@ -172,7 +169,6 @@ def get_IGTS():
         >>> from sktime.annotation.igts import InformationGainSegmentation
         >>> igts = InformationGainSegmentation(k_max=3, step=2)
         >>> y = igts.fit_predict(X_scaled)
-
         """
 
         # init attributes

--- a/sktime/annotation/plotting/utils.py
+++ b/sktime/annotation/plotting/utils.py
@@ -37,7 +37,6 @@ def plot_time_series_with_change_points(ts_name, ts, true_cps, font_size=16):
 
     axes : np.ndarray
         Array of the figure's Axe objects
-
     """
     # Checks availability of plotting libraries
     _check_soft_dependencies("matplotlib")
@@ -76,7 +75,8 @@ def plot_time_series_with_profiles(
     score_name="ClaSP Score",
     font_size=16,
 ):
-    """Plot the TS with the known and found change points and profiles from segmentation.
+    """Plot the TS with the known and found change points and profiles from
+    segmentation.
 
     Parameters
     ----------

--- a/sktime/annotation/plotting/utils.py
+++ b/sktime/annotation/plotting/utils.py
@@ -75,8 +75,7 @@ def plot_time_series_with_profiles(
     score_name="ClaSP Score",
     font_size=16,
 ):
-    """Plot the TS with the known and found change points and profiles from
-    segmentation.
+    """Plot TS with known and found change points and profiles from segmentation.
 
     Parameters
     ----------

--- a/sktime/annotation/stray.py
+++ b/sktime/annotation/stray.py
@@ -187,9 +187,7 @@ class STRAY(BaseTransformer):
         """
         r = np.shape(X)[0]
         idx_dropna = np.array([i for i in range(r) if not np.isnan(X[i]).any()])
-        X_dropna = X[
-            idx_dropna,
-        ]
+        X_dropna = X[idx_dropna,]
 
         n = np.shape(X_dropna)[0]
         outliers = self._find_outliers_kNN(X_dropna, n)

--- a/sktime/annotation/tests/test_all_annotators.py
+++ b/sktime/annotation/tests/test_all_annotators.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """Tests for sktime annotators."""
 
 __author__ = ["miraep8", "fkiraly", "klam-data", "pyyim", "mgorlin"]

--- a/sktime/annotation/tests/test_eagglo.py
+++ b/sktime/annotation/tests/test_eagglo.py
@@ -12,13 +12,11 @@ from sktime.annotation.eagglo import EAgglo
 def test_fit_default_params_univariate():
     """Test univariate data and defualt parameters.
 
-    These numbers are generated from the original implemention
-    in R, with the following code:
+    These numbers are generated from the original implemention in R, with the following
+    code:
 
-    set.seed(1234)
-    X <- c(rnorm(15, mean = -6), 0, rnorm(16, mean = 6))
-    X <- as.matrix(X[c(1,2,17,18)])
-    ret = e.agglo(X)
+    set.seed(1234) X <- c(rnorm(15, mean = -6), 0, rnorm(16, mean = 6)) X <-
+    as.matrix(X[c(1,2,17,18)]) ret = e.agglo(X)
     """
     X = pd.DataFrame([-7.207066, -5.722571, 5.889715, 5.488990])
 

--- a/sktime/base/__init__.py
+++ b/sktime/base/__init__.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-
 """Base classes for defining estimators and other objects in sktime."""
 
 __author__ = ["mloning", "RNKuhns", "fkiraly"]

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Base class template for objects and fittable objects.
+"""Base class template for objects and fittable objects.
 
 templates in this module:
 
@@ -78,8 +77,8 @@ class BaseObject(_BaseObject):
     def __eq__(self, other):
         """Equality dunder. Checks equal class and parameters.
 
-        Returns True iff result of get_params(deep=False)
-        results in equal parameter sets.
+        Returns True iff result of get_params(deep=False) results in equal parameter
+        sets.
 
         Nested BaseObject descendants from get_params are compared via __eq__ as well.
         """
@@ -180,20 +179,20 @@ class TagAliaserMixin:
     """Mixin class for tag aliasing and deprecation of old tags.
 
     To deprecate tags, add the TagAliaserMixin to BaseObject or BaseEstimator.
-    alias_dict contains the deprecated tags, and supports removal and renaming.
-        For removal, add an entry "old_tag_name": ""
-        For renaming, add an entry "old_tag_name": "new_tag_name"
-    deprecate_dict contains the version number of renaming or removal.
-        the keys in deprecate_dict should be the same as in alias_dict.
-        values in deprecate_dict should be strings, the version of removal/renaming.
+    alias_dict contains the deprecated tags, and supports removal and renaming.     For
+    removal, add an entry "old_tag_name": ""     For renaming, add an entry
+    "old_tag_name": "new_tag_name" deprecate_dict contains the version number of
+    renaming or removal.     the keys in deprecate_dict should be the same as in
+    alias_dict.     values in deprecate_dict should be strings, the version of
+    removal/renaming.
 
-    The class will ensure that new tags alias old tags and vice versa, during
-    the deprecation period. Informative warnings will be raised whenever the
-    deprecated tags are being accessed.
+    The class will ensure that new tags alias old tags and vice versa, during the
+    deprecation period. Informative warnings will be raised whenever the deprecated tags
+    are being accessed.
 
-    When removing tags, ensure to remove the removed tags from this class.
-    If no tags are deprecated anymore (e.g., all deprecated tags are removed/renamed),
-    ensure toremove this class as a parent of BaseObject or BaseEstimator.
+    When removing tags, ensure to remove the removed tags from this class. If no tags
+    are deprecated anymore (e.g., all deprecated tags are removed/renamed), ensure
+    toremove this class as a parent of BaseObject or BaseEstimator.
     """
 
     def __init__(self):

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -97,7 +97,6 @@ class _HeterogenousMetaEstimator:
         return True
 
     def _get_params(self, attr, deep=True, fitted=False):
-
         if fitted:
             method = "_get_fitted_params"
             methodd = "get_fitted_params"

--- a/sktime/base/_tagmanager.py
+++ b/sktime/base/_tagmanager.py
@@ -176,7 +176,7 @@ class _FlagManager:
         return self
 
     def _clone_flags(self, estimator, flag_names=None, flag_attr_name="_flags"):
-        """clone/mirror flags from another estimator as dynamic override.
+        """Clone/mirror flags from another estimator as dynamic override.
 
         Parameters
         ----------

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Tests for BaseObject universal base class.
+"""Tests for BaseObject universal base class.
 
 tests in this module:
 

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -44,13 +44,11 @@ from sktime.base import BaseEstimator, BaseObject
 
 # Fixture class for testing tag system
 class FixtureClassParent(BaseObject):
-
     _tags = {"A": "1", "B": 2, "C": 1234, 3: "D"}
 
 
 # Fixture class for testing tag system, child overrides tags
 class FixtureClassChild(FixtureClassParent):
-
     _tags = {"A": 42, 3: "E"}
 
 
@@ -203,7 +201,6 @@ def test_is_composite():
 
 
 class ResetTester(BaseObject):
-
     clsvar = 210
 
     def __init__(self, a, b=42):
@@ -331,7 +328,6 @@ def test_get_fitted_params():
 
 
 class ConfigTester(BaseObject):
-
     _config = {"foo_config": 42, "bar": "a"}
 
     clsvar = 210

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -38,7 +38,6 @@ class BaseBenchmark:
             Estimator to add to the benchmark.
         estimator_id : str, optional (default=None)
             Identifier for estimator. If none given then uses estimator's class name.
-
         """
         estimator_id = estimator_id or f"{estimator.__class__.__name__}-v1"
         estimator = estimator.clone()  # extra cautious

--- a/sktime/benchmarking/critical_difference.py
+++ b/sktime/benchmarking/critical_difference.py
@@ -14,8 +14,7 @@ _check_soft_dependencies("matplotlib", severity="warning")
 
 
 def _check_friedman(n_strategies, n_datasets, ranked_data, alpha):
-    """
-    Check whether Friedman test is significant.
+    """Check whether Friedman test is significant.
 
     Larger parts of code copied from scipy.
 
@@ -71,8 +70,7 @@ def plot_critical_difference(
     textspace=2.5,
     reverse=True,
 ):
-    """
-    Draw critical difference diagram.
+    """Draw critical difference diagram.
 
     Step 1 & 2: Calculate average ranks from data
     Step 3: Use Friedman test to check whether
@@ -122,8 +120,7 @@ def plot_critical_difference(
         return [a[n] for a in lst]
 
     def _lloc(lst, n):
-        """
-        List location in list of list structure.
+        """List location in list of list structure.
 
         Enable the use of negative locations:
         -1 is the last element, -2 second last...

--- a/sktime/benchmarking/evaluation.py
+++ b/sktime/benchmarking/evaluation.py
@@ -21,7 +21,6 @@ class Evaluator:
     """Analyze results of machine learning experiments."""
 
     def __init__(self, results):
-
         if not isinstance(results, BaseResults):
             raise ValueError("`results` must inherit from BaseResults")
         self.results = results

--- a/sktime/benchmarking/evaluation.py
+++ b/sktime/benchmarking/evaluation.py
@@ -62,9 +62,8 @@ class Evaluator:
     def evaluate(self, metric, train_or_test="test", cv_fold="all"):
         """Evaluate estimator performance.
 
-        Calculates the average prediction error per estimator as well as the
-        prediction error achieved by each
-        estimator on individual datasets.
+        Calculates the average prediction error per estimator as well as the prediction
+        error achieved by each estimator on individual datasets.
         """
         # check input
         if isinstance(cv_fold, int) and cv_fold >= 0:
@@ -162,8 +161,8 @@ class Evaluator:
     def rank(self, metric_name=None, ascending=False):
         """Determine estimator ranking.
 
-        Calculates the average ranks based on the performance of each
-        estimator on each dataset
+        Calculates the average ranks based on the performance of each estimator on each
+        dataset
         """
         self._check_is_evaluated()
         if not isinstance(ascending, bool):
@@ -398,11 +397,10 @@ class Evaluator:
     def nemenyi(self, metric_name=None):
         """Nemenyi test.
 
-        Post-hoc test run if the `friedman_test` reveals statistical
-        significance.
-        For more information see `Nemenyi test
-        <https://en.wikipedia.org/wiki/Nemenyi_test>`_.
-        Implementation used `scikit-posthocs
+        Post-hoc test run if the `friedman_test` reveals statistical significance. For
+        more information see
+        `Nemenyi test <https://en.wikipedia.org/wiki/Nemenyi_test>`_.
+         Implementation used `scikit-posthocs
         <https://github.com/maximtrp/scikit-posthocs>`_.
         """
         _check_soft_dependencies("scikit_posthocs")

--- a/sktime/benchmarking/experiments.py
+++ b/sktime/benchmarking/experiments.py
@@ -38,8 +38,7 @@ def run_clustering_experiment(
     resample_id=0,
     overwrite=True,
 ):
-    """
-    Run a clustering experiment and save the results to file.
+    """Run a clustering experiment and save the results to file.
 
     Method to run a basic experiment and write the results to files called
     testFold<resampleID>.csv and, if required, trainFold<resampleID>.csv. This
@@ -73,7 +72,6 @@ def run_clustering_experiment(
         Name of problem, written to the results file, ignored if None
     resample_id : int, default = 0
         Resample identifier, defaults to 0
-
     """
     if not overwrite:
         full_path = (

--- a/sktime/benchmarking/forecasting.py
+++ b/sktime/benchmarking/forecasting.py
@@ -63,9 +63,9 @@ def _factory_forecasting_validation(
 class ForecastingBenchmark(BaseBenchmark):
     """Forecasting benchmark.
 
-    Run a series of forecasters against a series of tasks defined via
-    dataset loaders, cross validation splitting strategies and performance metrics,
-    and return results as a df (as well as saving to file).
+    Run a series of forecasters against a series of tasks defined via dataset loaders,
+    cross validation splitting strategies and performance metrics, and return results as
+    a df (as well as saving to file).
     """
 
     def add_task(

--- a/sktime/benchmarking/orchestration.py
+++ b/sktime/benchmarking/orchestration.py
@@ -77,7 +77,6 @@ class Orchestrator:
             train_idx,
             _test_idx,
         ) in self._iter():
-
             # skip strategy, if overwrite is set to False and fitted
             # strategy already exists
             if (
@@ -134,7 +133,6 @@ class Orchestrator:
 
         # fitting and prediction
         for task, dataset, data, strategy, cv_fold, train_idx, test_idx in self._iter():
-
             # check which results already exist
             train_pred_exist = self.results.check_predictions_exist(
                 strategy.name, dataset.name, cv_fold, train_or_test="train"

--- a/sktime/benchmarking/results.py
+++ b/sktime/benchmarking/results.py
@@ -59,7 +59,6 @@ class RAMResults(BaseResults):
             timestamp when the estimator began making predictions
         predict_estimator_end_time : pandas timestamp (default=None)
             timestamp when the estimator finished making predictions
-
         """
         key = self._generate_key(strategy_name, dataset_name, cv_fold, train_or_test)
         index = np.asarray(index)
@@ -107,7 +106,10 @@ class RAMResults(BaseResults):
         return False
 
     def save(self):
-        """Save self. Method present for interface consistency."""
+        """Save self.
+
+        Method present for interface consistency.
+        """
         # in-memory results are currently not persisted (i.e saved to the disk)
         pass
 

--- a/sktime/benchmarking/strategies.py
+++ b/sktime/benchmarking/strategies.py
@@ -28,9 +28,8 @@ CASES = ("TSR", "TSC")
 class BaseStrategy(BaseEstimator):
     """Abstract base strategy class.
 
-    Implements attributes and operations shared by all strategies,
-    including input and compatibility checks between passed estimator,
-    data and task.
+    Implements attributes and operations shared by all strategies, including input and
+    compatibility checks between passed estimator, data and task.
     """
 
     def __init__(self, estimator, name=None):
@@ -185,8 +184,8 @@ class BaseSupervisedLearningStrategy(BaseStrategy):
 
     Accepts a low-level estimator to perform a given task.
 
-    Implements predict and internal fit methods for time series regression
-    and classification.
+    Implements predict and internal fit methods for time series regression and
+    classification.
     """
 
     def _fit(self, data):
@@ -231,8 +230,7 @@ class BaseSupervisedLearningStrategy(BaseStrategy):
 
 
 class TSCStrategy(BaseSupervisedLearningStrategy):
-    """
-    Strategy for time series classification.
+    """Strategy for time series classification.
 
     Parameters
     ----------
@@ -249,8 +247,7 @@ class TSCStrategy(BaseSupervisedLearningStrategy):
 
 
 class TSRStrategy(BaseSupervisedLearningStrategy):
-    """
-    Strategy for time series regression.
+    """Strategy for time series regression.
 
     Parameters
     ----------

--- a/sktime/benchmarking/tasks.py
+++ b/sktime/benchmarking/tasks.py
@@ -179,8 +179,7 @@ class BaseTask(BaseObject):
 
 
 class TSCTask(BaseTask):
-    """
-    Time series classification task.
+    """Time series classification task.
 
     A task encapsulates metadata information such as the feature and target
     variable
@@ -205,8 +204,7 @@ class TSCTask(BaseTask):
 
 
 class TSRTask(BaseTask):
-    """
-    Time series regression task.
+    """Time series regression task.
 
     A task encapsulates metadata information such as the feature and target
     variable

--- a/sktime/classification/_delegate.py
+++ b/sktime/classification/_delegate.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Delegator mixin that delegates all methods to wrapped classifiers.
 
-Useful for building estimators where all but one or a few methods are delegated.
-For that purpose, inherit from this estimator and then override only the methods
-    that are not delegated.
+Useful for building estimators where all but one or a few methods are delegated. For
+that purpose, inherit from this estimator and then override only the methods     that
+are not delegated.
 """
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Abstract base class for time series classifiers.
+"""Abstract base class for time series classifiers.
 
     class name: BaseClassifier
 

--- a/sktime/classification/compose/_column_ensemble.py
+++ b/sktime/classification/compose/_column_ensemble.py
@@ -100,9 +100,9 @@ class BaseColumnEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
     def _iter(self, replace_strings=False):
         """Generate (name, estimator, column) tuples.
 
-        If fitted=True, use the fitted transformations, else use the
-        user specified transformations updated with converted column names
-        and potentially appended with transformer for remainder.
+        If fitted=True, use the fitted transformations, else use the user specified
+        transformations updated with converted column names and potentially appended
+        with transformer for remainder.
         """
         if self.is_fitted:
             estimators = self.estimators_
@@ -140,7 +140,6 @@ class BaseColumnEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
 
         y : array-like, shape (n_samples, ...), optional
             Targets for supervised learning.
-
         """
         if self.estimators is None or len(self.estimators) == 0:
             raise AttributeError(
@@ -301,8 +300,7 @@ class ColumnEnsembleClassifier(BaseColumnEnsembleClassifier):
 
 
 def _get_column(X, key):
-    """
-    Get feature column(s) from input data X.
+    """Get feature column(s) from input data X.
 
     Supported input types (X): numpy arrays and DataFrames
 
@@ -319,7 +317,6 @@ def _get_column(X, key):
         - only supported for dataframes
         - So no keys other than strings are allowed (while in principle you
           can use any hashable object as key).
-
     """
     # check whether we have string column names or integers
     if _check_key_type(key, int):
@@ -355,8 +352,7 @@ def _get_column(X, key):
 
 
 def _check_key_type(key, superclass):
-    """
-    Check that scalar, list or slice is of a certain type.
+    """Check that scalar, list or slice is of a certain type.
 
     This is only used in _get_column and _get_column_indices to check
     if the `key` (column specification) is fully integer or fully string-like.
@@ -367,7 +363,6 @@ def _check_key_type(key, superclass):
         The column specification to check
     superclass : int or str
         The type for which to check the `key`
-
     """
     if isinstance(key, superclass):
         return True
@@ -387,11 +382,9 @@ def _check_key_type(key, superclass):
 
 
 def _get_column_indices(X, key):
-    """
-    Get feature column indices for input data X and key.
+    """Get feature column indices for input data X and key.
 
     For accepted values of `key`, see the docstring of _get_column
-
     """
     n_columns = X.shape[1]
 

--- a/sktime/classification/compose/_pipeline.py
+++ b/sktime/classification/compose/_pipeline.py
@@ -105,7 +105,6 @@ class ClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
     # no default tag values - these are set dynamically below
 
     def __init__(self, classifier, transformers):
-
         self.classifier = classifier
         self.classifier_ = classifier.clone()
         self.transformers = transformers
@@ -419,7 +418,6 @@ class SklearnClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
     # no default tag values - these are set dynamically below
 
     def __init__(self, classifier, transformers):
-
         from sklearn.base import clone
 
         self.classifier = classifier

--- a/sktime/classification/deep_learning/base.py
+++ b/sktime/classification/deep_learning/base.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Abstract base class for the Keras neural network classifiers.
+"""Abstract base class for the Keras neural network classifiers.
 
 The reason for this class between BaseClassifier and deep_learning classifiers is
 because we can generalise tags, _predict and _predict_proba
@@ -67,14 +66,12 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         ...
 
     def summary(self):
-        """
-        Summary function to return the losses/metrics for model fit.
+        """Summary function to return the losses/metrics for model fit.
 
         Returns
         -------
         history: dict or None,
             Dictionary containing model's train/validation losses and metrics
-
         """
         return self.history.history if self.history is not None else None
 

--- a/sktime/classification/deep_learning/lstmfcn.py
+++ b/sktime/classification/deep_learning/lstmfcn.py
@@ -13,9 +13,7 @@ from sktime.networks.lstmfcn import LSTMFCNNetwork
 
 
 class LSTMFCNClassifier(BaseDeepClassifier):
-    """
-
-    Implementation of LSTMFCNClassifier from Karim et al (2019) [1].
+    """Implementation of LSTMFCNClassifier from Karim et al (2019) [1].
 
     Overview
     --------
@@ -62,7 +60,6 @@ class LSTMFCNClassifier(BaseDeepClassifier):
     ----------
     .. [1] Karim et al. Multivariate LSTM-FCNs for Time Series Classification, 2019
     https://arxiv.org/pdf/1801.04503.pdf
-
     """
 
     _tags = {"python_dependencies": "tensorflow"}

--- a/sktime/classification/deep_learning/lstmfcn.py
+++ b/sktime/classification/deep_learning/lstmfcn.py
@@ -80,7 +80,6 @@ class LSTMFCNClassifier(BaseDeepClassifier):
         random_state=None,
         verbose=0,
     ):
-
         super(LSTMFCNClassifier, self).__init__()
 
         self.classes_ = None

--- a/sktime/classification/deep_learning/macnn.py
+++ b/sktime/classification/deep_learning/macnn.py
@@ -133,8 +133,7 @@ class MACNNClassifier(BaseDeepClassifier):
         )
 
     def build_model(self, input_shape, n_classes, **kwargs):
-        """
-        Construct a compiled, un-trained, keras model that is ready for training.
+        """Construct a compiled, un-trained, keras model that is ready for training.
 
         In sktime, time series are stored in numpy arrays of shape (d,m), where d
         is the number of dimensions, m is the series length. Keras/tensorflow assume
@@ -181,8 +180,7 @@ class MACNNClassifier(BaseDeepClassifier):
         return model
 
     def _fit(self, X, y):
-        """
-        Fit the classifier on the training set (X, y).
+        """Fit the classifier on the training set (X, y).
 
         Parameters
         ----------

--- a/sktime/classification/deep_learning/resnet.py
+++ b/sktime/classification/deep_learning/resnet.py
@@ -14,8 +14,7 @@ from sktime.utils.validation._dependencies import _check_dl_dependencies
 
 
 class ResNetClassifier(BaseDeepClassifier):
-    """
-    Residual Neural Network as described in [1].
+    """Residual Neural Network as described in [1].
 
     Parameters
     ----------

--- a/sktime/classification/deep_learning/rnn.py
+++ b/sktime/classification/deep_learning/rnn.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
-
 """Time Recurrent Neural Network (RNN) for classification."""
 
 __author__ = ["mloning"]
@@ -84,8 +83,7 @@ class SimpleRNNClassifier(BaseDeepClassifier):
         self._network = RNNNetwork(random_state=random_state, units=units)
 
     def build_model(self, input_shape, n_classes, **kwargs):
-        """
-        Construct a compiled, un-trained, keras model that is ready for training.
+        """Construct a compiled, un-trained, keras model that is ready for training.
 
         In sktime, time series are stored in numpy arrays of shape (d,m), where d
         is the number of dimensions, m is the series length. Keras/tensorflow assume
@@ -124,8 +122,7 @@ class SimpleRNNClassifier(BaseDeepClassifier):
         return model
 
     def _fit(self, X, y):
-        """
-        Fit the classifier on the training set (X, y).
+        """Fit the classifier on the training set (X, y).
 
         Parameters
         ----------

--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """BOSS classifiers.
 
-Dictionary based BOSS classifiers based on SFA transform. Contains a single
-BOSS and a BOSS ensemble.
+Dictionary based BOSS classifiers based on SFA transform. Contains a single BOSS and a
+BOSS ensemble.
 """
 
 __author__ = ["MatthewMiddlehurst", "patrickzib"]

--- a/sktime/classification/dictionary_based/_cboss.py
+++ b/sktime/classification/dictionary_based/_cboss.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """ContractableBOSS classifier.
 
-Dictionary based cBOSS classifier based on SFA transform. Improves the
-ensemble structure of the original BOSS algorithm.
+Dictionary based cBOSS classifier based on SFA transform. Improves the ensemble
+structure of the original BOSS algorithm.
 """
 
 __author__ = ["MatthewMiddlehurst", "BINAYKUMAR943"]

--- a/sktime/classification/dictionary_based/_muse.py
+++ b/sktime/classification/dictionary_based/_muse.py
@@ -142,7 +142,6 @@ class MUSE(BaseClassifier):
         n_jobs=1,
         random_state=None,
     ):
-
         # currently other values than 4 are not supported.
         self.alphabet_size = alphabet_size
 

--- a/sktime/classification/dictionary_based/_muse.py
+++ b/sktime/classification/dictionary_based/_muse.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """WEASEL+MUSE classifier.
 
-multivariate dictionary based classifier based on SFA transform, dictionaries
-and logistic regression.
+multivariate dictionary based classifier based on SFA transform, dictionaries and
+logistic regression.
 """
 
 __author__ = ["patrickzib", "BINAYKUMAR943"]

--- a/sktime/classification/dictionary_based/_tde.py
+++ b/sktime/classification/dictionary_based/_tde.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """TDE classifiers.
 
-Dictionary based TDE classifiers based on SFA transform. Contains a single
-IndividualTDE and TDE.
+Dictionary based TDE classifiers based on SFA transform. Contains a single IndividualTDE
+and TDE.
 """
 
 __author__ = ["MatthewMiddlehurst"]

--- a/sktime/classification/dictionary_based/_weasel.py
+++ b/sktime/classification/dictionary_based/_weasel.py
@@ -140,7 +140,6 @@ class WEASEL(BaseClassifier):
         support_probabilities=False,
         random_state=None,
     ):
-
         self.alphabet_size = alphabet_size
 
         # feature selection is applied based on the chi-squared test.

--- a/sktime/classification/dictionary_based/tests/test_boss.py
+++ b/sktime/classification/dictionary_based/tests/test_boss.py
@@ -10,8 +10,7 @@ from sktime.utils.validation._dependencies import _check_estimator_deps
 
 @pytest.fixture
 def dataset():
-    """
-    Load unit_test train and test data set from sktime.
+    """Load unit_test train and test data set from sktime.
 
     :return: tuple, (X_train, y_train, X_test, y_test).
     """

--- a/sktime/classification/distance_based/_elastic_ensemble.py
+++ b/sktime/classification/distance_based/_elastic_ensemble.py
@@ -267,7 +267,6 @@ class ElasticEnsemble(BaseClassifier):
             # If 100 parameter options are being considered per measure,
             # use a GridSearchCV
             if self.proportion_of_param_options == 1:
-
                 grid = GridSearchCV(
                     estimator=KNeighborsTimeSeriesClassifier(
                         distance=this_measure, n_neighbors=1

--- a/sktime/classification/distance_based/_proximity_forest.py
+++ b/sktime/classification/distance_based/_proximity_forest.py
@@ -144,8 +144,8 @@ def numba_wrapper(distance_measure):
     Converts to 1 column per dimension format. Really would be better if the whole thing
     worked directly with numpy arrays.
     :param distance_measure: distance measure to wrap
-    :returns: a distance measure which automatically formats data for numba
-    distance measures
+    :returns: a distance measure which automatically formats data for numba distance
+        measures
     """
 
     def distance(instance_a, instance_b, **params):
@@ -582,8 +582,8 @@ def setup_all_distance_measure_getter(proximity):
     def pick_rand_distance_measure(proximity):
         """Generate a distance measure from a range of parameters.
 
-        :param proximity: proximity object containing distance measures,
-        ranges and dataset
+        :param proximity: proximity object containing distance measures, ranges and
+            dataset
         :returns: a distance measure with no parameters
         """
         random_state = check_random_state(proximity.random_state)
@@ -804,8 +804,7 @@ class ProximityStump(BaseClassifier):
 
         :param exemplars: the exemplars to use
         :param instance: the instance to compare to each exemplar
-        :param distance_measure: the distance measure to provide similarity
-        values
+        :param distance_measure: the distance measure to provide similarity values
         :returns: list of distances to each exemplar
         """
         n_exemplars = len(exemplars)

--- a/sktime/classification/distance_based/_proximity_forest.py
+++ b/sktime/classification/distance_based/_proximity_forest.py
@@ -1513,6 +1513,7 @@ class ProximityForest(BaseClassifier):
 
 # start of util functions
 
+
 # find the index of the best value in the array
 def arg_bests(array, comparator):
     indices = [0]

--- a/sktime/classification/distance_based/_proximity_forest.py
+++ b/sktime/classification/distance_based/_proximity_forest.py
@@ -141,8 +141,8 @@ def distance_predefined_params(distance_measure, **params):
 def numba_wrapper(distance_measure):
     """Wrap a numba distance measure with numpy conversion.
 
-     Converts to 1 column per dimension format. Really would be better if the whole
-     thing worked directly with numpy arrays.
+    Converts to 1 column per dimension format. Really would be better if the whole thing
+    worked directly with numpy arrays.
     :param distance_measure: distance measure to wrap
     :returns: a distance measure which automatically formats data for numba
     distance measures
@@ -853,8 +853,7 @@ class ProximityStump(BaseClassifier):
         return distances
 
     def _fit(self, X, y):
-        """
-        Build the classifier on the training set (X, y).
+        """Build the classifier on the training set (X, y).
 
         Parameters
         ----------

--- a/sktime/classification/distance_based/_shape_dtw.py
+++ b/sktime/classification/distance_based/_shape_dtw.py
@@ -109,7 +109,6 @@ class ShapeDTW(BaseClassifier):
     .. [1] Jiaping Zhao and Laurent Itti, "shapeDTW: Shape Dynamic Time Warping",
         Pattern Recognition, 74, pp 171-184, 2018
         http://www.sciencedirect.com/science/article/pii/S0031320317303710,
-
     """
 
     _tags = {
@@ -302,9 +301,8 @@ class ShapeDTW(BaseClassifier):
     def _generate_shape_descriptors(self, data):
         """Generate shape descriptors.
 
-        This function is used to convert a list of
-        subsequences into a list of shape descriptors
-        to be used for classification.
+        This function is used to convert a list of subsequences into a list of shape
+        descriptors to be used for classification.
         """
         # Get the appropriate transformer objects
         if self.shape_descriptor_function != "compound":

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -1,19 +1,18 @@
 # -*- coding: utf-8 -*-
 """KNN time series classification.
 
-This class is a KNN classifier which supports time series distance measures.
-The class has hardcoded string references to numba based distances in sktime.distances.
-It can also be used with callables, or sktime (pairwise transformer) estimators.
+This class is a KNN classifier which supports time series distance measures. The class
+has hardcoded string references to numba based distances in sktime.distances. It can
+also be used with callables, or sktime (pairwise transformer) estimators.
 
-This is a direct wrap or sklearn KNeighbors, with added functionality that allows
-time series distances to be passed, and the sktime time series classifier interface.
+This is a direct wrap or sklearn KNeighbors, with added functionality that allows time
+series distances to be passed, and the sktime time series classifier interface.
 
-todo: add a utility method to set keyword args for distance measure parameters.
-(e.g.  handle the parameter name(s) that are passed as metric_params automatically,
-depending on what distance measure is used in the classifier (e.g. know that it is w
-for dtw, c for msm, etc.). Also allow long-format specification for
-non-standard/user-defined measures e.g. set_distance_params(measure_type=None,
-param_values_to_set=None,
+todo: add a utility method to set keyword args for distance measure parameters. (e.g.
+handle the parameter name(s) that are passed as metric_params automatically, depending
+on what distance measure is used in the classifier (e.g. know that it is w for dtw, c
+for msm, etc.). Also allow long-format specification for non-standard/user-defined
+measures e.g. set_distance_params(measure_type=None, param_values_to_set=None,
 param_names=None)
 """
 

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -69,7 +69,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
           containing the weights.
     algorithm : str, optional. default = 'brute'
         search method for neighbours
-        one of {'auto’, 'ball_tree', 'kd_tree', 'brute'}
+        one of {'auto', 'ball_tree', 'kd_tree', 'brute'}
     distance : str or callable, optional. default ='dtw'
         distance measure between time series
         if str, must be one of the following strings:
@@ -227,7 +227,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
             # if we do not want/need to pass train-train distances,
             #   we still need to pass a zeros matrix, this means "do not consider"
             # citing the sklearn KNeighborsClassifier docs on distance matrix input:
-            # "X may be a sparse graph, in which case only “nonzero” elements
+            # "X may be a sparse graph, in which case only "nonzero" elements
             #   may be considered neighbors."
             X_inner_mtype = self.get_tag("X_inner_mtype")
             _, _, X_meta = check_is_mtype(X, X_inner_mtype, return_metadata=True)

--- a/sktime/classification/early_classification/_teaser.py
+++ b/sktime/classification/early_classification/_teaser.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """TEASER early classifier.
 
-An early classifier using a one class SVM's to determine decision safety with a
-time series classifier.
+An early classifier using a one class SVM's to determine decision safety with a time
+series classifier.
 """
 
 __author__ = ["MatthewMiddlehurst", "patrickzib"]

--- a/sktime/classification/early_classification/_teaser.py
+++ b/sktime/classification/early_classification/_teaser.py
@@ -488,7 +488,6 @@ class TEASER(BaseEarlyClassifier):
     def _predict_oc_classifier(
         self, X_oc, n_consecutive_predictions, idx, estimator_preds, state_info
     ):
-
         # stores whether we have made a final decision on a prediction, if true
         # state info won't be edited in later time stamps
         finished = state_info[:, 1] >= n_consecutive_predictions

--- a/sktime/classification/early_classification/base.py
+++ b/sktime/classification/early_classification/base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Abstract base class for early time series classifiers.
+"""Abstract base class for early time series classifiers.
 
     class name: BaseEarlyClassifier
 
@@ -78,12 +77,12 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
         self.fit_time_ = 0
         self._class_dictionary = {}
         self._threads_to_use = 1
+        """An array containing the state info for each decision in X from update and
+        predict methods.
 
-        """
-        An array containing the state info for each decision in X from update and
-        predict methods. Contains classifier dependant information for future decisions
-        on the data and information on when a cases decision has been made. Each row
-        contains information for a case from the latest decision on its safety made in
+        Contains classifier dependant information for future decisions on the data and
+        information on when a cases decision has been made. Each row contains
+        information for a case from the latest decision on its safety made in
         update/predict. Successive updates are likely to remove rows from the
         state_info, as it will only store as many rows as there are input instances to
         update/predict.

--- a/sktime/classification/ensemble/_ctsf.py
+++ b/sktime/classification/ensemble/_ctsf.py
@@ -241,10 +241,10 @@ class ComposableTimeSeriesForestClassifier(BaseTimeSeriesForest, BaseClassifier)
     def fit(self, X, y, **kwargs):
         """Wrap fit to call BaseClassifier.fit.
 
-        This is a fix to get around the problem with multiple inheritance. The
-        problem is that if we just override _fit, this class inherits the fit from
-        the sklearn class BaseTimeSeriesForest. This is the simplest solution,
-        albeit a little hacky.
+        This is a fix to get around the problem with multiple inheritance. The problem
+        is that if we just override _fit, this class inherits the fit from the sklearn
+        class BaseTimeSeriesForest. This is the simplest solution, albeit a little
+        hacky.
         """
         return BaseClassifier.fit(self, X=X, y=y, **kwargs)
 

--- a/sktime/classification/ensemble/_ctsf.py
+++ b/sktime/classification/ensemble/_ctsf.py
@@ -198,7 +198,6 @@ class ComposableTimeSeriesForestClassifier(BaseTimeSeriesForest, BaseClassifier)
         class_weight=None,
         max_samples=None,
     ):
-
         self.estimator = estimator
 
         # Assign values, even though passed on to base estimator below,
@@ -261,7 +260,6 @@ class ComposableTimeSeriesForestClassifier(BaseTimeSeriesForest, BaseClassifier)
         BaseTimeSeriesForest._fit(self, X=X, y=y)
 
     def _validate_estimator(self):
-
         if not isinstance(self.n_estimators, numbers.Integral):
             raise ValueError(
                 "n_estimators must be an integer, "

--- a/sktime/classification/interval_based/_rise_numba.py
+++ b/sktime/classification/interval_based/_rise_numba.py
@@ -91,7 +91,6 @@ def matrix_acf(x, num_cases, max_lag):
     Returns
     -------
     y : array-like shape = [num_cases,max_lag]
-
     """
     y = np.empty(shape=(num_cases, max_lag))
     length = x.shape[1]

--- a/sktime/classification/interval_based/_stsf.py
+++ b/sktime/classification/interval_based/_stsf.py
@@ -300,9 +300,9 @@ class SupervisedTimeSeriesForest(BaseClassifier):
     ):
         """Recursive function for finding intervals for a feature using fisher score.
 
-        Given a start and end point the series is split in half and both intervals
-        are evaluated. The half with the higher score is retained and used as the new
-        start and end for a recursive call.
+        Given a start and end point the series is split in half and both intervals are
+        evaluated. The half with the higher score is retained and used as the new start
+        and end for a recursive call.
         """
         series_length = end - start
         if series_length < 4:

--- a/sktime/classification/interval_based/_tsf.py
+++ b/sktime/classification/interval_based/_tsf.py
@@ -105,10 +105,10 @@ class TimeSeriesForestClassifier(
     def fit(self, X, y, **kwargs):
         """Wrap fit to call BaseClassifier.fit.
 
-        This is a fix to get around the problem with multiple inheritance. The
-        problem is that if we just override _fit, this class inherits the fit from
-        the sklearn class BaseTimeSeriesForest. This is the simplest solution,
-        albeit a little hacky.
+        This is a fix to get around the problem with multiple inheritance. The problem
+        is that if we just override _fit, this class inherits the fit from the sklearn
+        class BaseTimeSeriesForest. This is the simplest solution, albeit a little
+        hacky.
         """
         return BaseClassifier.fit(self, X=X, y=y, **kwargs)
 

--- a/sktime/classification/kernel_based/_svc.py
+++ b/sktime/classification/kernel_based/_svc.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Support vector classifier using time series kernels..
 
-Direct wrap of sklearn SVC with added functionality that allows
-time series kernel to be passed, and uses the sktime time series classifier interface.
+Direct wrap of sklearn SVC with added functionality that allows time series kernel to be
+passed, and uses the sktime time series classifier interface.
 """
 
 __author__ = ["fkiraly"]

--- a/sktime/classification/sklearn/_continuous_interval_tree.py
+++ b/sktime/classification/sklearn/_continuous_interval_tree.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Continuous interval tree (CIT) vector classifier (aka Time Series Tree).
 
-Continuous Interval Tree aka Time Series Tree, base classifier originally used
-in the time series forest interval based classification algorithm. Fits sklearn
-conventions.
+Continuous Interval Tree aka Time Series Tree, base classifier originally used in the
+time series forest interval based classification algorithm. Fits sklearn conventions.
 """
 
 __author__ = ["MatthewMiddlehurst"]

--- a/sktime/classification/sklearn/_continuous_interval_tree_numba.py
+++ b/sktime/classification/sklearn/_continuous_interval_tree_numba.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Continuous interval tree (CIT) vector classifier (aka Time Series Tree).
 
-Continuous Interval Tree aka Time Series Tree, base classifier originally used
-in the time series forest interval based classification algorithm. Fits sklearn
-conventions.
+Continuous Interval Tree aka Time Series Tree, base classifier originally used in the
+time series forest interval based classification algorithm. Fits sklearn conventions.
 """
 
 __author__ = ["MatthewMiddlehurst"]

--- a/sktime/classification/sklearn/tests/__init__.py
+++ b/sktime/classification/sklearn/tests/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-"""sklearn classifier test code."""
+"""Sklearn classifier test code."""

--- a/sktime/classification/tests/test_all_classifiers.py
+++ b/sktime/classification/tests/test_all_classifiers.py
@@ -202,8 +202,8 @@ class TestAllClassifiers(ClassifierFixtureGenerator, QuickTester):
     def test_handles_single_class(self, estimator_instance):
         """Test that estimator handles fit when only single class label is seen.
 
-        This is important for compatibility with ensembles that sub-sample,
-        as sub-sampling stochastically produces training sets with single class label.
+        This is important for compatibility with ensembles that sub-sample, as sub-
+        sampling stochastically produces training sets with single class label.
         """
         X, y = make_classification_problem()
         y[:] = 42

--- a/sktime/clustering/compose/_pipeline.py
+++ b/sktime/clustering/compose/_pipeline.py
@@ -104,7 +104,6 @@ class ClustererPipeline(_HeterogenousMetaEstimator, BaseClusterer):
     # no default tag values - these are set dynamically below
 
     def __init__(self, clusterer, transformers):
-
         self.clusterer = clusterer
         self.clusterer_ = clusterer.clone()
         self.transformers = transformers
@@ -320,7 +319,6 @@ class ClustererPipeline(_HeterogenousMetaEstimator, BaseClusterer):
         params = params + [params1]
 
         if _check_estimator_deps(TimeSeriesKMeans, severity="none"):
-
             t1 = ExponentTransformer(power=2)
             t2 = ExponentTransformer(power=0.5)
             c = TimeSeriesKMeans(random_state=42)
@@ -428,7 +426,6 @@ class SklearnClustererPipeline(ClustererPipeline):
     # no default tag values - these are set dynamically below
 
     def __init__(self, clusterer, transformers):
-
         from sklearn.base import clone
 
         self.clusterer = clusterer

--- a/sktime/clustering/dbscan.py
+++ b/sktime/clustering/dbscan.py
@@ -84,7 +84,6 @@ class TimeSeriesDBSCAN(BaseClusterer):
         leaf_size=30,
         n_jobs=None,
     ):
-
         self.distance = distance
         self.eps = eps
         self.min_samples = min_samples

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -1411,8 +1411,7 @@ def write_tabular_transformation_to_arff(
     fold="",
     fit_transform=True,
 ):
-    """Transform a dataset using a tabular transformer and write the result to a arff
-    file.
+    """Transform dataset using a tabular transformer and write the result to arff file.
 
     Parameters
     ----------

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -65,8 +65,7 @@ def _alias_mtype_check(return_type):
 
 # time series classification data sets
 def _download_and_extract(url, extract_path=None):
-    """
-    Download and unzip datasets (helper function).
+    """Download and unzip datasets (helper function).
 
     This code was modified from
     https://github.com/tslearn-team/tslearn/blob
@@ -126,7 +125,6 @@ def _list_available_datasets(extract_path):
     -------
     datasets : List
         List of the names of datasets downloaded
-
     """
     if extract_path is None:
         data_dir = os.path.join(MODULE, "data")
@@ -1413,8 +1411,8 @@ def write_tabular_transformation_to_arff(
     fold="",
     fit_transform=True,
 ):
-    """
-    Transform a dataset using a tabular transformer and write the result to a arff file.
+    """Transform a dataset using a tabular transformer and write the result to a arff
+    file.
 
     Parameters
     ----------
@@ -1552,8 +1550,7 @@ def write_dataframe_to_tsfile(
     comment=None,
     fold="",
 ):
-    """
-    Output a dataset in dataframe format to .ts file.
+    """Output a dataset in dataframe format to .ts file.
 
     Parameters
     ----------
@@ -1663,8 +1660,7 @@ def write_ndarray_to_tsfile(
     comment=None,
     fold="",
 ):
-    """
-    Output a dataset in ndarray format to .ts file.
+    """Output a dataset in ndarray format to .ts file.
 
     Parameters
     ----------
@@ -1762,8 +1758,7 @@ def load_tsf_to_dataframe(
     value_column_name="series_value",
     return_type="pd_multiindex_hier",
 ):
-    """
-    Convert the contents in a .tsf file into a dataframe.
+    """Convert the contents in a .tsf file into a dataframe.
 
     This code was extracted from
     https://github.com/rakshitha123/TSForecasting/blob

--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -343,8 +343,7 @@ def load_italy_power_demand(split=None, return_X_y=True, return_type=None):
 
 
 def load_unit_test(split=None, return_X_y=True, return_type=None):
-    """
-    Load UnitTest data.
+    """Load UnitTest data.
 
     This is an equal length univariate time series classification problem. It is a
     stripped down version of the ChinaTown problem that is used in correctness tests
@@ -472,8 +471,7 @@ def load_japanese_vowels(split=None, return_X_y=True, return_type=None):
 
 
 def load_arrow_head(split=None, return_X_y=True, return_type=None):
-    """
-    Load the ArrowHead time series classification problem and returns X and y.
+    """Load the ArrowHead time series classification problem and returns X and y.
 
     Parameters
     ----------
@@ -598,8 +596,7 @@ def load_acsf1(split=None, return_X_y=True, return_type=None):
 
 
 def load_basic_motions(split=None, return_X_y=True, return_type=None):
-    """
-    Load the BasicMotions time series classification problem and returns X and y.
+    """Load the BasicMotions time series classification problem and returns X and y.
 
     This is an equal length multivariate time series classification problem. It loads a
     4 class classification problem with number of cases, n, where n = 80 (if
@@ -1039,8 +1036,7 @@ def load_PBS_dataset():
 
 
 def load_macroeconomic():
-    """
-    Load the US Macroeconomic Data [1]_.
+    """Load the US Macroeconomic Data [1]_.
 
     Returns
     -------
@@ -1087,8 +1083,7 @@ def load_macroeconomic():
 
 
 def load_unit_test_tsf():
-    """
-    Load tsf UnitTest dataset.
+    """Load tsf UnitTest dataset.
 
     Returns
     -------

--- a/sktime/datasets/tests/test_data_io.py
+++ b/sktime/datasets/tests/test_data_io.py
@@ -205,8 +205,7 @@ _CHECKS = {
 
 @pytest.mark.parametrize("dataset", sorted(_CHECKS.keys()))
 def test_data_loaders(dataset):
-    """
-    Assert if datasets are loaded correctly.
+    """Assert if datasets are loaded correctly.
 
     dataset: dictionary with values to assert against should contain:
         'columns' : list with column names in correct order,

--- a/sktime/datasets/tests/test_data_io.py
+++ b/sktime/datasets/tests/test_data_io.py
@@ -457,7 +457,6 @@ def test_load_from_tsfile_to_dataframe():
     fd, path = tempfile.mkstemp()
     try:
         with os.fdopen(fd, "w") as tmp_file:
-
             # Write the contents of the file
 
             file_contents = (
@@ -484,7 +483,6 @@ def test_load_from_tsfile_to_dataframe():
     fd, path = tempfile.mkstemp()
     try:
         with os.fdopen(fd, "w") as tmp_file:
-
             # Write the contents of the file
 
             file_contents = (
@@ -510,7 +508,6 @@ def test_load_from_tsfile_to_dataframe():
     fd, path = tempfile.mkstemp()
     try:
         with os.fdopen(fd, "w") as tmp_file:
-
             # Write the contents of the file
 
             file_contents = (
@@ -597,7 +594,6 @@ def test_load_from_tsfile_to_dataframe():
     fd, path = tempfile.mkstemp()
     try:
         with os.fdopen(fd, "w") as tmp_file:
-
             # Write the contents of the file
 
             file_contents = (
@@ -691,7 +687,6 @@ def test_load_from_tsfile_to_dataframe():
     fd, path = tempfile.mkstemp()
     try:
         with os.fdopen(fd, "w") as tmp_file:
-
             # Write the contents of the file
 
             file_contents = (
@@ -731,7 +726,6 @@ def test_load_from_tsfile_to_dataframe():
     fd, path = tempfile.mkstemp()
     try:
         with os.fdopen(fd, "w") as tmp_file:
-
             # Write the contents of the file
 
             file_contents = (
@@ -758,7 +752,6 @@ def test_load_from_tsfile_to_dataframe():
     fd, path = tempfile.mkstemp()
     try:
         with os.fdopen(fd, "w") as tmp_file:
-
             # Write the contents of the file
 
             file_contents = (
@@ -787,7 +780,6 @@ def test_load_from_tsfile_to_dataframe():
     fd, path = tempfile.mkstemp()
     try:
         with os.fdopen(fd, "w") as tmp_file:
-
             # Write the contents of the file
 
             file_contents = (
@@ -867,7 +859,6 @@ def test_load_from_tsfile_to_dataframe():
     fd, path = tempfile.mkstemp()
     try:
         with os.fdopen(fd, "w") as tmp_file:
-
             # Write the contents of the file
 
             file_contents = (
@@ -955,7 +946,6 @@ def test_load_from_tsfile_to_dataframe():
     fd, path = tempfile.mkstemp()
     try:
         with os.fdopen(fd, "w") as tmp_file:
-
             # Write the contents of the file
 
             file_contents = (

--- a/sktime/datasets/tsc_dataset_names.py
+++ b/sktime/datasets/tsc_dataset_names.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-
-"""
-List of datasets available from the timeseriesclassification.com archive.
+"""List of datasets available from the timeseriesclassification.com archive.
 
 There are four main distinctions: univariate/multivariate equal/unequal length.
 Array univariate lists the 128 UCR problems, as described in [1].
@@ -28,8 +26,7 @@ Learning on Temporal Data
 """
 
 __author__ = ["TonyBagnall"]
-
-""" 128 UCR univariatetime series classification problems [1]"""
+"""128 UCR univariatetime series classification problems [1]"""
 univariate = [
     "ACSF1",
     "Adiac",
@@ -161,8 +158,7 @@ univariate = [
     "WormsTwoClass",
     "IOError",
 ]
-
-""" 33 UEA multivariate time series classification problems [2]"""
+"""33 UEA multivariate time series classification problems [2]"""
 multivariate = [
     "ArticularyWordRecognition",
     "AsphaltObstaclesCoordinates",
@@ -198,7 +194,6 @@ multivariate = [
     "StandWalkJump",
     "UWaveGestureLibrary",
 ]
-
 """113 equal length/no missing univariate time series classification problems [3]"""
 univariate_equal_length = [
     "ACSF1",
@@ -315,7 +310,6 @@ univariate_equal_length = [
     "WormsTwoClass",
     "Yoga",
 ]
-
 """11 variable length univariate time series classification problems [3]"""
 univariate_variable_length = [
     "AllGestureWiimoteX",
@@ -330,15 +324,13 @@ univariate_variable_length = [
     "PLAID",
     "ShakeGestureWiimoteZ",
 ]
-
-"""4 fixed length univariate time series classification problems with missing values"""
+"""4 fixed length univariate time series classification problems with missing values."""
 univariate_missing_values = [
     "DodgerLoopDay",
     "DodgerLoopGame",
     "DodgerLoopWeekend",
     "MelbournePedestrian",
 ]
-
 """26 equal length multivariate time series classification problems [4]"""
 multivariate_equal_length = [
     "ArticularyWordRecognition",
@@ -368,7 +360,6 @@ multivariate_equal_length = [
     "StandWalkJump",
     "UWaveGestureLibrary",
 ]
-
 """7 variable length multivariate time series classification problems [4]"""
 multivariate_unequal_length = [
     "AsphaltObstaclesCoordinates",

--- a/sktime/datatypes/_adapter/gluonts_to_pd_multiindex.py
+++ b/sktime/datatypes/_adapter/gluonts_to_pd_multiindex.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 def convert_gluonts_result_to_multiindex(gluonts_result):
-    """
-
-    Back Convert from Gluonts to sktime.
+    """Back Convert from Gluonts to sktime.
 
     Convert the output of Gluonts's prediction to a multiindex
     dataframe compatible with sktime.
@@ -18,7 +16,6 @@ def convert_gluonts_result_to_multiindex(gluonts_result):
     Returns
     -------
     A MultiIndex DF mtype type compatible with sktime.
-
     """
     import pandas as pd
 

--- a/sktime/datatypes/_adapter/pd_multiindex_to_list_dataset.py
+++ b/sktime/datatypes/_adapter/pd_multiindex_to_list_dataset.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 def convert_from_multiindex_to_listdataset(trainDF, class_val_list=None):
-    """
-    Output a dataset in ListDataset format compatible with gluonts.
+    """Output a dataset in ListDataset format compatible with gluonts.
 
     Parameters
     ----------
@@ -20,7 +19,6 @@ def convert_from_multiindex_to_listdataset(trainDF, class_val_list=None):
     Returns
     -------
     A ListDataset mtype type to be used as input for gluonts models/estimators
-
     """
     import numpy as np
     import pandas as pd

--- a/sktime/datatypes/_convert_utils/_coerce.py
+++ b/sktime/datatypes/_convert_utils/_coerce.py
@@ -7,7 +7,6 @@ import pandas as pd
 
 
 def _is_nullable_numeric(dtype):
-
     return dtype in ["Int64", "Float64", "boolean"]
 
 

--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -70,7 +70,6 @@ check_dict = dict()
 
 
 def check_pdmultiindex_hierarchical(obj, return_metadata=False, var_name="obj"):
-
     ret = check_pdmultiindex_panel(
         obj, return_metadata=return_metadata, var_name=var_name, panel=False
     )
@@ -85,7 +84,6 @@ if _check_soft_dependencies("dask", severity="none"):
     from sktime.datatypes._adapter.dask_to_pd import check_dask_frame
 
     def check_dask_hierarchical(obj, return_metadata=False, var_name="obj"):
-
         return check_dask_frame(
             obj=obj,
             return_metadata=return_metadata,

--- a/sktime/datatypes/_hierarchical/_registry.py
+++ b/sktime/datatypes/_hierarchical/_registry.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-"""Registry of mtypes for Hierarchical scitype. See datatypes._registry for API."""
+"""Registry of mtypes for Hierarchical scitype.
+
+See datatypes._registry for API.
+"""
 
 import pandas as pd
 

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -49,7 +49,6 @@ convert_dict = dict()
 
 
 def convert_identity(obj, store=None):
-
     return obj
 
 
@@ -124,7 +123,6 @@ def _check_equal_index(X):
     indexes = []
     # Check index for each column separately.
     for c, col in enumerate(X.columns):
-
         # Get index from first row, can be either pd.Series or np.array.
         first_index = (
             X.iloc[0, c].index
@@ -180,7 +178,6 @@ def from_3d_numpy_to_2d_array(X):
 
 
 def from_3d_numpy_to_2d_array_adp(obj, store=None):
-
     return from_3d_numpy_to_2d_array(obj)
 
 
@@ -273,12 +270,10 @@ def from_nested_to_2d_array(X, return_numpy=False):
 
 
 def from_nested_to_pdwide(obj, store=None):
-
     return from_nested_to_2d_array(X=obj, return_numpy=False)
 
 
 def from_nested_to_2d_np_array(obj, store=None):
-
     return from_nested_to_2d_array(X=obj, return_numpy=True)
 
 
@@ -343,7 +338,6 @@ def from_2d_array_to_nested(
 
 
 def from_pd_wide_to_nested(obj, store=None):
-
     return from_2d_array_to_nested(X=obj)
 
 
@@ -497,7 +491,6 @@ def from_nested_to_long(
 
 
 def from_nested_to_long_adp(obj, store=None):
-
     return from_nested_to_long(
         X=obj,
         instance_column_name="case_id",
@@ -562,7 +555,6 @@ def from_long_to_nested(
 
 
 def from_long_to_nested_adp(obj, store=None):
-
     return from_long_to_nested(X_long=obj)
 
 
@@ -570,7 +562,6 @@ convert_dict[("pd-long", "nested_univ", "Panel")] = from_nested_to_long_adp
 
 
 def from_multiindex_to_long(obj, store=None):
-
     X_long = pd.melt(obj, value_vars=obj.columns, ignore_index=False)
     X_long = X_long.reset_index()
 
@@ -581,7 +572,6 @@ convert_dict[("pd-multiindex", "pd-long", "Panel")] = from_multiindex_to_long
 
 
 def from_long_to_multiindex(obj, store=None):
-
     ixcols = obj.columns[[0, 1]]
     Xmi = pd.pivot(obj, columns=obj.columns[2], values=obj.columns[3], index=ixcols)
 
@@ -624,7 +614,6 @@ def from_multi_index_to_3d_numpy(X):
 
 
 def from_multi_index_to_3d_numpy_adp(obj, store=None):
-
     obj = _coerce_df_dtypes(obj)
 
     res = from_multi_index_to_3d_numpy(X=obj)
@@ -778,7 +767,6 @@ def from_multi_index_to_nested(
 
 
 def from_multi_index_to_nested_adp(obj, store=None):
-
     obj = _coerce_df_dtypes(obj)
 
     if isinstance(store, dict):
@@ -849,7 +837,6 @@ def from_nested_to_multi_index(X, instance_index=None, time_index=None):
 
 
 def from_nested_to_multi_index_adp(obj, store=None):
-
     if isinstance(store, dict):
         store["instance_names"] = obj.index.names
 
@@ -917,7 +904,6 @@ def from_nested_to_3d_numpy(X):
 
 
 def from_nested_to_3d_numpy_adp(obj, store=None):
-
     return from_nested_to_3d_numpy(X=obj)
 
 
@@ -979,7 +965,6 @@ def from_3d_numpy_to_nested(X, column_names=None, cells_as_numpy=False):
 
 
 def from_3d_numpy_to_nested_adp(obj, store=None):
-
     return from_3d_numpy_to_nested(X=obj)
 
 
@@ -987,7 +972,6 @@ convert_dict[("numpy3D", "nested_univ", "Panel")] = from_3d_numpy_to_nested_adp
 
 
 def from_dflist_to_multiindex(obj, store=None):
-
     n = len(obj)
 
     mi = pd.concat(obj, axis=0, keys=range(n), names=["instances", "timepoints"])
@@ -1002,7 +986,6 @@ convert_dict[("df-list", "pd-multiindex", "Panel")] = from_dflist_to_multiindex
 
 
 def from_multiindex_to_dflist(obj, store=None):
-
     obj = _coerce_df_dtypes(obj)
 
     instance_index = obj.index.levels[0]
@@ -1019,7 +1002,6 @@ convert_dict[("pd-multiindex", "df-list", "Panel")] = from_multiindex_to_dflist
 
 
 def from_dflist_to_numpy3D(obj, store=None):
-
     if not isinstance(obj, list):
         raise TypeError("obj must be a list of pd.DataFrame")
 
@@ -1039,7 +1021,6 @@ convert_dict[("df-list", "numpy3D", "Panel")] = from_dflist_to_numpy3D
 
 
 def from_numpy3d_to_dflist(obj, store=None):
-
     if not isinstance(obj, np.ndarray) or len(obj.shape) != 3:
         raise TypeError("obj must be a 3D numpy.ndarray")
 
@@ -1053,7 +1034,6 @@ convert_dict[("numpy3D", "df-list", "Panel")] = from_numpy3d_to_dflist
 
 
 def from_nested_to_df_list_adp(obj, store=None):
-
     # this is not already implemented, so chain two conversions
     obj = from_nested_to_multi_index_adp(obj, store=store)
     return from_multiindex_to_dflist(obj, store=store)
@@ -1063,7 +1043,6 @@ convert_dict[("nested_univ", "df-list", "Panel")] = from_nested_to_df_list_adp
 
 
 def from_df_list_to_nested_adp(obj, store=None):
-
     # this is not already implemented, so chain two conversions
     obj = from_dflist_to_multiindex(obj, store=store)
     return from_multi_index_to_nested_adp(obj, store=store)
@@ -1073,7 +1052,6 @@ convert_dict[("df-list", "nested_univ", "Panel")] = from_df_list_to_nested_adp
 
 
 def from_numpy3d_to_numpyflat(obj, store=None):
-
     if not isinstance(obj, np.ndarray) or len(obj.shape) != 3:
         raise TypeError("obj must be a 3D numpy.ndarray")
 
@@ -1092,7 +1070,6 @@ convert_dict[("numpy3D", "numpyflat", "Panel")] = from_numpy3d_to_numpyflat
 
 
 def from_numpyflat_to_numpy3d(obj, store=None):
-
     if not isinstance(obj, np.ndarray) or len(obj.shape) != 2:
         raise TypeError("obj must be a 2D numpy.ndarray")
 

--- a/sktime/datatypes/_panel/_registry.py
+++ b/sktime/datatypes/_panel/_registry.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-"""Registry of mtypes for Panel scitype. See datatypes._registry for API."""
+"""Registry of mtypes for Panel scitype.
+
+See datatypes._registry for API.
+"""
 
 import pandas as pd
 

--- a/sktime/datatypes/_proba/_check.py
+++ b/sktime/datatypes/_proba/_check.py
@@ -48,7 +48,6 @@ check_dict = dict()
 
 
 def check_pred_quantiles_proba(obj, return_metadata=False, var_name="obj"):
-
     metadata = dict()
 
     # check if the input is a dataframe
@@ -111,7 +110,6 @@ check_dict[("pred_quantiles", "Proba")] = check_pred_quantiles_proba
 
 
 def check_pred_interval_proba(obj, return_metadata=False, var_name="obj"):
-
     metadata = dict()
 
     # check if the input is a dataframe

--- a/sktime/datatypes/_proba/_convert.py
+++ b/sktime/datatypes/_proba/_convert.py
@@ -44,7 +44,6 @@ convert_dict = dict()
 
 
 def convert_identity(obj, store=None):
-
     return obj
 
 
@@ -112,7 +111,6 @@ def convert_pred_interval_to_quantiles(y_pred, inplace=False):
 
 
 def convert_interval_to_quantiles(obj: pd.DataFrame, store=None) -> pd.DataFrame:
-
     return convert_pred_interval_to_quantiles(y_pred=obj)
 
 
@@ -175,7 +173,6 @@ def convert_pred_quantiles_to_interval(y_pred, inplace=False):
 
 
 def convert_quantiles_to_interval(obj: pd.DataFrame, store=None) -> pd.DataFrame:
-
     return convert_pred_quantiles_to_interval(y_pred=obj)
 
 

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -56,7 +56,6 @@ check_dict = dict()
 
 
 def check_pddataframe_series(obj, return_metadata=False, var_name="obj"):
-
     metadata = dict()
 
     if not isinstance(obj, pd.DataFrame):
@@ -115,7 +114,6 @@ check_dict[("pd.DataFrame", "Series")] = check_pddataframe_series
 
 
 def check_pdseries_series(obj, return_metadata=False, var_name="obj"):
-
     metadata = dict()
 
     if not isinstance(obj, pd.Series):
@@ -169,7 +167,6 @@ check_dict[("pd.Series", "Series")] = check_pdseries_series
 
 
 def check_numpy_series(obj, return_metadata=False, var_name="obj"):
-
     metadata = dict()
 
     if not isinstance(obj, np.ndarray):
@@ -323,7 +320,6 @@ if _check_soft_dependencies("dask", severity="none"):
     from sktime.datatypes._adapter.dask_to_pd import check_dask_frame
 
     def check_dask_series(obj, return_metadata=False, var_name="obj"):
-
         return check_dask_frame(
             obj=obj,
             return_metadata=return_metadata,

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -57,7 +57,6 @@ for tp in MTYPE_LIST_SERIES:
 
 
 def convert_UvS_to_MvS_as_Series(obj: pd.Series, store=None) -> pd.DataFrame:
-
     if not isinstance(obj, pd.Series):
         raise TypeError("input must be a pd.Series")
 
@@ -82,7 +81,6 @@ convert_dict[("pd.Series", "pd.DataFrame", "Series")] = convert_UvS_to_MvS_as_Se
 
 
 def convert_MvS_to_UvS_as_Series(obj: pd.DataFrame, store=None) -> pd.Series:
-
     if not isinstance(obj, pd.DataFrame):
         raise TypeError("input is not a pd.DataFrame")
 
@@ -108,7 +106,6 @@ convert_dict[("pd.DataFrame", "pd.Series", "Series")] = convert_MvS_to_UvS_as_Se
 
 
 def convert_MvS_to_np_as_Series(obj: pd.DataFrame, store=None) -> np.ndarray:
-
     if not isinstance(obj, pd.DataFrame):
         raise TypeError("input must be a pd.DataFrame")
 
@@ -125,7 +122,6 @@ convert_dict[("pd.DataFrame", "np.ndarray", "Series")] = convert_MvS_to_np_as_Se
 
 
 def convert_UvS_to_np_as_Series(obj: pd.Series, store=None) -> np.ndarray:
-
     if not isinstance(obj, pd.Series):
         raise TypeError("input must be a pd.Series")
 
@@ -142,7 +138,6 @@ convert_dict[("pd.Series", "np.ndarray", "Series")] = convert_UvS_to_np_as_Serie
 
 
 def convert_np_to_MvS_as_Series(obj: np.ndarray, store=None) -> pd.DataFrame:
-
     if not isinstance(obj, np.ndarray) and len(obj.shape) > 2:
         raise TypeError("input must be a np.ndarray of dim 1 or 2")
 
@@ -172,7 +167,6 @@ convert_dict[("np.ndarray", "pd.DataFrame", "Series")] = convert_np_to_MvS_as_Se
 
 
 def convert_np_to_UvS_as_Series(obj: np.ndarray, store=None) -> pd.Series:
-
     if not isinstance(obj, np.ndarray) or obj.ndim > 2:
         raise TypeError("input must be a one-column np.ndarray of dim 1 or 2")
 

--- a/sktime/datatypes/_series/_mtypes.py
+++ b/sktime/datatypes/_series/_mtypes.py
@@ -37,7 +37,6 @@ infer_mtype_dict = dict()
 
 
 def infer_mtype_Series(obj):
-
     obj_type = type(obj)
 
     infer_dict = {

--- a/sktime/datatypes/_series/_registry.py
+++ b/sktime/datatypes/_series/_registry.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-"""Registry of mtypes for Series scitype. See datatypes._registry for API."""
+"""Registry of mtypes for Series scitype.
+
+See datatypes._registry for API.
+"""
 
 import pandas as pd
 

--- a/sktime/datatypes/_table/_check.py
+++ b/sktime/datatypes/_table/_check.py
@@ -49,7 +49,6 @@ PRIMITIVE_TYPES = (float, int, str)
 
 
 def check_pddataframe_table(obj, return_metadata=False, var_name="obj"):
-
     metadata = dict()
 
     if not isinstance(obj, pd.DataFrame):
@@ -79,7 +78,6 @@ check_dict[("pd_DataFrame_Table", "Table")] = check_pddataframe_table
 
 
 def check_pdseries_table(obj, return_metadata=False, var_name="obj"):
-
     metadata = dict()
 
     if not isinstance(obj, pd.Series):
@@ -112,7 +110,6 @@ check_dict[("pd_Series_Table", "Table")] = check_pdseries_table
 
 
 def check_numpy1d_table(obj, return_metadata=False, var_name="obj"):
-
     metadata = dict()
 
     if not isinstance(obj, np.ndarray):
@@ -142,7 +139,6 @@ check_dict[("numpy1D", "Table")] = check_numpy1d_table
 
 
 def check_numpy2d_table(obj, return_metadata=False, var_name="obj"):
-
     metadata = dict()
 
     if not isinstance(obj, np.ndarray):
@@ -171,7 +167,6 @@ check_dict[("numpy2D", "Table")] = check_numpy2d_table
 
 
 def check_list_of_dict_table(obj, return_metadata=False, var_name="obj"):
-
     metadata = dict()
 
     if not isinstance(obj, list):

--- a/sktime/datatypes/_table/_convert.py
+++ b/sktime/datatypes/_table/_convert.py
@@ -45,7 +45,6 @@ convert_dict = dict()
 
 
 def convert_identity(obj, store=None):
-
     return obj
 
 
@@ -55,7 +54,6 @@ for tp in MTYPE_LIST_TABLE:
 
 
 def convert_1D_to_2D_numpy_as_Table(obj: np.ndarray, store=None) -> np.ndarray:
-
     if not isinstance(obj, np.ndarray):
         raise TypeError("input must be a np.ndarray")
 
@@ -71,7 +69,6 @@ convert_dict[("numpy1D", "numpy2D", "Table")] = convert_1D_to_2D_numpy_as_Table
 
 
 def convert_2D_to_1D_numpy_as_Table(obj: np.ndarray, store=None) -> np.ndarray:
-
     if not isinstance(obj, np.ndarray):
         raise TypeError("input must be a np.ndarray")
 
@@ -87,7 +84,6 @@ convert_dict[("numpy2D", "numpy1D", "Table")] = convert_2D_to_1D_numpy_as_Table
 
 
 def convert_df_to_2Dnp_as_Table(obj: pd.DataFrame, store=None) -> np.ndarray:
-
     if not isinstance(obj, pd.DataFrame):
         raise TypeError("input must be a pd.DataFrame")
 
@@ -101,7 +97,6 @@ convert_dict[("pd_DataFrame_Table", "numpy2D", "Table")] = convert_df_to_2Dnp_as
 
 
 def convert_df_to_1Dnp_as_Table(obj: pd.DataFrame, store=None) -> np.ndarray:
-
     return convert_df_to_2Dnp_as_Table(obj=obj, store=store).flatten()
 
 
@@ -109,7 +104,6 @@ convert_dict[("pd_DataFrame_Table", "numpy1D", "Table")] = convert_df_to_1Dnp_as
 
 
 def convert_2Dnp_to_df_as_Table(obj: np.ndarray, store=None) -> pd.DataFrame:
-
     if not isinstance(obj, np.ndarray) and len(obj.shape) != 2:
         raise TypeError("input must be a 2D np.ndarray")
 
@@ -132,7 +126,6 @@ convert_dict[("numpy2D", "pd_DataFrame_Table", "Table")] = convert_2Dnp_to_df_as
 
 
 def convert_1Dnp_to_df_as_Table(obj: np.ndarray, store=None) -> pd.DataFrame:
-
     if not isinstance(obj, np.ndarray) and len(obj.shape) != 1:
         raise TypeError("input must be a 1D np.ndarray")
 
@@ -154,7 +147,6 @@ convert_dict[("numpy1D", "pd_DataFrame_Table", "Table")] = convert_1Dnp_to_df_as
 
 
 def convert_s_to_df_as_table(obj: pd.Series, store=None) -> pd.DataFrame:
-
     if not isinstance(obj, pd.Series):
         raise TypeError("input must be a pd.Series")
 
@@ -176,7 +168,6 @@ convert_dict[
 
 
 def convert_df_to_s_as_table(obj: pd.DataFrame, store=None) -> pd.Series:
-
     if not isinstance(obj, pd.DataFrame):
         raise TypeError("input is not a pd.DataFrame")
 
@@ -198,7 +189,6 @@ convert_dict[
 
 
 def convert_list_of_dict_to_df_as_table(obj: list, store=None) -> pd.DataFrame:
-
     if not isinstance(obj, list):
         raise TypeError("input must be a list of dict")
 
@@ -223,7 +213,6 @@ convert_dict[
 
 
 def convert_df_to_list_of_dict_as_table(obj: pd.DataFrame, store=None) -> list:
-
     if not isinstance(obj, pd.DataFrame):
         raise TypeError("input is not a pd.DataFrame")
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -63,7 +63,6 @@ class VectorizedDF:
     def __init__(
         self, X, y=None, iterate_as="Series", is_scitype="Panel", iterate_cols=False
     ):
-
         self.X = X
 
         if is_scitype is None:
@@ -571,7 +570,7 @@ class VectorizedDF:
 
         ret = []
 
-        for ((group_name, col_name, group), args_i, args_i_rowvec, est_i) in zip(
+        for (group_name, col_name, group), args_i, args_i_rowvec, est_i in zip(
             self.items(),
             explode(args, iterate_as=self.iterate_as, iterate_cols=self.iterate_cols),
             explode(args_rowvec, iterate_as=self.iterate_as, iterate_cols=False),

--- a/sktime/datatypes/tests/test_check.py
+++ b/sktime/datatypes/tests/test_check.py
@@ -37,7 +37,6 @@ def _generate_scitype_mtype_combinations():
     sci_mtype_tuples = []
 
     for scitype in SCITYPES:
-
         mtypes = scitype_to_mtype(scitype)
 
         for mtype in mtypes:
@@ -311,7 +310,6 @@ def test_check_negative(scitype, mtype):
     for i in range(n_fixtures):
         # if mtype is not ambiguous, other mtypes are negative examples
         for wrong_mtype in list(set(mtypes).difference(set([mtype]))):
-
             # retrieve fixture for checking
             fixture_wrong_type = fixtures[wrong_mtype].get(i)
 

--- a/sktime/datatypes/tests/test_convert.py
+++ b/sktime/datatypes/tests/test_convert.py
@@ -21,7 +21,6 @@ def _generate_fixture_tuples():
     fixture_tuples = []
 
     for scitype in SCITYPES:
-
         # if we know there are no conversions defined, skip this scitype
         if scitype in SCITYPES_NO_CONVERSIONS:
             continue
@@ -112,7 +111,6 @@ def test_convert(scitype, from_mtype, to_mtype, fixture_index):
 
     # test that converted from-fixture equals to-fixture
     if cond1 and cond2 and cond3:
-
         converted_fixture_i = convert(
             obj=from_fixture[0],
             from_type=from_mtype,

--- a/sktime/datatypes/tests/test_panel_converters.py
+++ b/sktime/datatypes/tests/test_panel_converters.py
@@ -285,7 +285,6 @@ def test_from_multiindex_to_listdataset(n_instances, n_columns, n_timepoints):
     def _make_example_multiindex(
         n_instances, n_columns, n_timepoints, random_seed=42
     ) -> pd.DataFrame:
-
         import numpy as np
 
         start = pd.to_datetime("1750-01-01")

--- a/sktime/datatypes/tests/test_panel_converters.py
+++ b/sktime/datatypes/tests/test_panel_converters.py
@@ -261,13 +261,10 @@ def test_from_multiindex_to_listdataset(n_instances, n_columns, n_timepoints):
     ):
         """Generate random pd Datetime in the start to end range.
 
-        unix timestamp is in ns by default.
-        Divide the unix time value by 10**9 to make it seconds
-        (or 24*60*60*10**9 to make it days).
-        The corresponding unit variable is passed to the pd.to_datetime function.
-        Values for the (divide_by, unit) pair to select is defined by the out_format
-        parameter.
-        for 1 -> out_format='datetime'
+        unix timestamp is in ns by default. Divide the unix time value by 10**9 to make
+        it seconds (or 24*60*60*10**9 to make it days). The corresponding unit variable
+        is passed to the pd.to_datetime function. Values for the (divide_by, unit) pair
+        to select is defined by the out_format parameter. for 1 -> out_format='datetime'
         for 2 -> out_format=anything else.
         """
         np.random.seed(random_seed)

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -73,7 +73,6 @@ def _generate_scitype_mtype_combinations():
     sci_mtype_tuples = []
 
     for scitype in SCITYPES:
-
         mtypes = _get_all_mtypes_for_scitype(scitype)
 
         for mtype in mtypes:

--- a/sktime/distances/_ddtw.py
+++ b/sktime/distances/_ddtw.py
@@ -40,8 +40,8 @@ def average_of_slope_transform(X: np.ndarray) -> np.ndarray:
 class _DdtwDistance(NumbaDistance):
     """Derivative dynamic time warping (ddtw) between two time series.
 
-    Takes the slope based derivative of the series (using compute_derivative),
-    then applies DTW (using the _cost_matrix from _DtwDistance)
+    Takes the slope based derivative of the series (using compute_derivative), then
+    applies DTW (using the _cost_matrix from _DtwDistance)
     """
 
     def _distance_alignment_path_factory(

--- a/sktime/distances/_distance_pairwise.py
+++ b/sktime/distances/_distance_pairwise.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 __author__ = ["chrisholder", "TonyBagnall"]
-
 """Factory module that adds 3D vectorization to all exported distances.
 
-Applies pairwise_distance to all distances exported by module, so
-    exported distances function with 1D, 2D and 3D input.
+Applies pairwise_distance to all distances exported by module, so     exported distances
+function with 1D, 2D and 3D input.
 """
 
 import numpy as np

--- a/sktime/distances/_dtw.py
+++ b/sktime/distances/_dtw.py
@@ -60,7 +60,7 @@ class _DtwDistance(NumbaDistance):
         window: float = None,
         itakura_max_slope: float = None,
         bounding_matrix: np.ndarray = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> DistanceAlignmentPathCallable:
         """Create a no_python compiled dtw path distance callable.
 
@@ -142,7 +142,7 @@ class _DtwDistance(NumbaDistance):
         window: float = None,
         itakura_max_slope: float = None,
         bounding_matrix: np.ndarray = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> DistanceCallable:
         """Create a no_python compiled dtw distance callable.
 

--- a/sktime/distances/_edr.py
+++ b/sktime/distances/_edr.py
@@ -37,7 +37,7 @@ class _EdrDistance(NumbaDistance):
         itakura_max_slope: float = None,
         bounding_matrix: np.ndarray = None,
         epsilon: float = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> DistanceAlignmentPathCallable:
         """Create a no_python compiled edr alignment path distance callable.
 
@@ -136,7 +136,7 @@ class _EdrDistance(NumbaDistance):
         itakura_max_slope: float = None,
         bounding_matrix: np.ndarray = None,
         epsilon: float = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> DistanceCallable:
         """Create a no_python compiled edr distance callable.
 

--- a/sktime/distances/_erp.py
+++ b/sktime/distances/_erp.py
@@ -24,7 +24,7 @@ class _ErpDistance(NumbaDistance):
         itakura_max_slope: float = None,
         bounding_matrix: np.ndarray = None,
         g: float = 0.0,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> DistanceAlignmentPathCallable:
         """Create a no_python compiled erp distance alignment path callable.
 
@@ -111,7 +111,7 @@ class _ErpDistance(NumbaDistance):
         itakura_max_slope: float = None,
         bounding_matrix: np.ndarray = None,
         g: float = 0.0,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> DistanceCallable:
         """Create a no_python compiled erp distance callable.
 

--- a/sktime/distances/_resolve_metric.py
+++ b/sktime/distances/_resolve_metric.py
@@ -215,7 +215,6 @@ def _is_no_python_distance_callable(metric: Callable) -> bool:
     bool
         Boolean that is true if callable is a valid no_python compiled distance and
         false if the callable is an invalid no_python callable.
-
     """
     from sktime.distances._numba_utils import is_no_python_compiled_callable
 

--- a/sktime/distances/_twe.py
+++ b/sktime/distances/_twe.py
@@ -36,7 +36,7 @@ class _TweDistance(NumbaDistance):
         lmbda: float = 1.0,
         nu: float = 0.001,
         p: int = 2,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> DistanceCallable:
         """Create a no_python compiled twe distance callable.
 
@@ -128,7 +128,7 @@ class _TweDistance(NumbaDistance):
         lmbda: float = 1.0,
         nu: float = 0.001,
         p: int = 2,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> DistanceCallable:
         """Create a no_python compiled twe distance callable.
 

--- a/sktime/distances/lower_bounding.py
+++ b/sktime/distances/lower_bounding.py
@@ -69,7 +69,6 @@ class LowerBounding(Enum):
     .. [3]  Ratanamahatana, Chotirat & Keogh, Eamonn. (2004). Making Time-Series
             Classification More Accurate Using Learned Constraints.
             10.1137/1.9781611972740.2.
-
     """
 
     NO_BOUNDING = 1  # No bounding on the matrix

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Base class templates for distances or kernels between time series, and for tabular data.
+"""Base class templates for distances or kernels between time series, and for tabular
+data.
 
 templates in this module:
 
@@ -42,8 +42,8 @@ from sktime.datatypes._series_as_panel import convert_Series_to_Panel
 class BasePairwiseTransformer(BaseEstimator):
     """Base pairwise transformer for tabular or series data template class.
 
-    The base pairwise transformer specifies the methods and method
-    signatures that all pairwise transformers have to implement.
+    The base pairwise transformer specifies the methods and method signatures that all
+    pairwise transformers have to implement.
 
     Specific implementations of these methods is deferred to concrete classes.
     """
@@ -175,8 +175,8 @@ class BasePairwiseTransformer(BaseEstimator):
 class BasePairwiseTransformerPanel(BaseEstimator):
     """Base pairwise transformer for panel data template class.
 
-    The base pairwise transformer specifies the methods and method
-    signatures that all pairwise transformers have to implement.
+    The base pairwise transformer specifies the methods and method signatures that all
+    pairwise transformers have to implement.
 
     Specific implementations of these methods is deferred to concrete classes.
     """

--- a/sktime/dists_kernels/_base.py
+++ b/sktime/dists_kernels/_base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Base class templates for distances or kernels between time series, and for tabular
-data.
+"""Base class templates for distances or kernels between time series and tabular data.
 
 templates in this module:
 

--- a/sktime/dists_kernels/algebra.py
+++ b/sktime/dists_kernels/algebra.py
@@ -66,7 +66,6 @@ class CombinedDistance(_HeterogenousMetaEstimator, BasePairwiseTransformerPanel)
     _steps_attr = "_pw_trafos"
 
     def __init__(self, pw_trafos, operation=None):
-
         self.pw_trafos = pw_trafos
         self.pw_trafos_ = self._check_estimators(
             self.pw_trafos, cls_type=BasePairwiseTransformerPanel

--- a/sktime/dists_kernels/compose.py
+++ b/sktime/dists_kernels/compose.py
@@ -67,7 +67,6 @@ class PwTrafoPanelPipeline(_HeterogenousMetaEstimator, BasePairwiseTransformerPa
     }
 
     def __init__(self, pw_trafo, transformers):
-
         self.pw_trafo = pw_trafo
         self.transformers = transformers
         self.transformers_ = TransformerPipeline(transformers)

--- a/sktime/dists_kernels/compose_from_align.py
+++ b/sktime/dists_kernels/compose_from_align.py
@@ -25,7 +25,6 @@ class DistFromAligner(BasePairwiseTransformerPanel):
     }
 
     def __init__(self, aligner=None):
-
         self.aligner = aligner
 
         super(DistFromAligner, self).__init__()

--- a/sktime/dists_kernels/compose_tab_to_panel.py
+++ b/sktime/dists_kernels/compose_tab_to_panel.py
@@ -70,7 +70,6 @@ class AggrDist(BasePairwiseTransformerPanel):
         aggfunc=None,
         aggfunc_is_symm=False,  # False for safety, but set True later if aggfunc=None
     ):
-
         self.aggfunc = aggfunc
         self.aggfunc_is_symm = aggfunc_is_symm
         self.transformer = transformer
@@ -132,7 +131,6 @@ class AggrDist(BasePairwiseTransformerPanel):
 
         for i in range(n):
             for j in range(m):
-
                 if all_symm and j < i:
                     distmat[i, j] = distmat[j, i]
                 else:
@@ -200,7 +198,6 @@ class FlatDist(BasePairwiseTransformerPanel):
     }
 
     def __init__(self, transformer):
-
         self.transformer = transformer
 
         super(FlatDist, self).__init__()

--- a/sktime/dists_kernels/compose_tab_to_panel.py
+++ b/sktime/dists_kernels/compose_tab_to_panel.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Composers that create panel pairwise transformers from table pairwise transformers.
+"""Composers that create panel pairwise transformers from table pairwise transformers.
 
 Currently implemented composers in this module:
 

--- a/sktime/dists_kernels/dist_to_kern.py
+++ b/sktime/dists_kernels/dist_to_kern.py
@@ -52,7 +52,6 @@ class KernelFromDist(BasePairwiseTransformerPanel):
     }
 
     def __init__(self, dist, dist_diag=None):
-
         self.dist = dist
         self.dist_diag = dist_diag
 
@@ -183,7 +182,6 @@ class DistFromKernel(BasePairwiseTransformerPanel):
     }
 
     def __init__(self, kernel):
-
         self.kernel = kernel
 
         super(DistFromKernel, self).__init__()

--- a/sktime/dists_kernels/dtw.py
+++ b/sktime/dists_kernels/dtw.py
@@ -137,7 +137,6 @@ class DtwDist(BasePairwiseTransformerPanel):
         bounding_matrix: np.ndarray = None,
         g: float = 0.0,
     ):
-
         self.weighted = weighted
         self.derivative = derivative
         self.window = window

--- a/sktime/dists_kernels/dummy.py
+++ b/sktime/dists_kernels/dummy.py
@@ -27,7 +27,6 @@ class ConstantPwTrafoPanel(BasePairwiseTransformerPanel):
     }
 
     def __init__(self, constant=0):
-
         self.constant = constant
 
         super(ConstantPwTrafoPanel, self).__init__()

--- a/sktime/dists_kernels/indep.py
+++ b/sktime/dists_kernels/indep.py
@@ -67,7 +67,6 @@ class IndepDist(BasePairwiseTransformerPanel):
     }
 
     def __init__(self, dist, aggfun=None):
-
         self.dist = dist
         self.aggfun = aggfun
 

--- a/sktime/dists_kernels/scipy_dist.py
+++ b/sktime/dists_kernels/scipy_dist.py
@@ -64,7 +64,6 @@ class ScipyDist(BasePairwiseTransformer):
         var_weights=None,
         metric_kwargs=None,
     ):
-
         self.metric = metric
         self.p = p
         self.colalign = colalign

--- a/sktime/dists_kernels/scipy_dist.py
+++ b/sktime/dists_kernels/scipy_dist.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Interface module to scipy.
 
-Interface module to scipy.spatial's pairwise distance function cdist
-    exposes parameters as scikit-learn hyper-parameters
+Interface module to scipy.spatial's pairwise distance function cdist     exposes
+parameters as scikit-learn hyper-parameters
 """
 
 __author__ = ["fkiraly"]

--- a/sktime/dists_kernels/signature_kernel.py
+++ b/sktime/dists_kernels/signature_kernel.py
@@ -460,7 +460,6 @@ def sqize_kernel_low_rank_fast(
         R*R^t[i,j] is sequential kernel (low-rank) between i-th and j-th sequence in K
     """
     if normalize:
-
         Ksize = K.shape[0]
         B = np.ones([Ksize, 1, 1])
         R = np.ones([Ksize, 1])

--- a/sktime/forecasting/adapters/_hcrystalball.py
+++ b/sktime/forecasting/adapters/_hcrystalball.py
@@ -114,7 +114,6 @@ class HCrystalBallAdapter(BaseForecaster):
     }
 
     def __init__(self, model):
-
         self.model = model
         super(HCrystalBallAdapter, self).__init__()
 

--- a/sktime/forecasting/ardl.py
+++ b/sktime/forecasting/ardl.py
@@ -231,7 +231,6 @@ class ARDL(_StatsModelsAdapter):
         X_oos=None,
         dynamic=False,
     ):
-
         # Model Params
         self.lags = lags
         self.order = order

--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -32,10 +32,10 @@ class AutoARIMA(_PmdArimaAdapter):
     Canova-Hansen to determine the optimal order of seasonal differencing, D.
 
     In order to find the best model, auto-ARIMA optimizes for a given
-    information_criterion, one of (‘aic’, ‘aicc’, ‘bic’, ‘hqic’, ‘oob’)
+    information_criterion, one of ('aic', 'aicc', 'bic', 'hqic', 'oob')
     (Akaike Information Criterion, Corrected Akaike Information Criterion,
     Bayesian Information Criterion, Hannan-Quinn Information Criterion, or
-    “out of bag”–for validation scoring–respectively) and returns the ARIMA
+    "out of bag"–for validation scoring–respectively) and returns the ARIMA
     which minimizes the value.
 
     Note that due to stationarity issues, auto-ARIMA might not find a suitable
@@ -49,7 +49,7 @@ class AutoARIMA(_PmdArimaAdapter):
     ----------
     start_p : int, optional (default=2)
         The starting value of p, the order (or number of time lags)
-        of the auto-regressive (“AR”) model. Must be a positive integer.
+        of the auto-regressive ("AR") model. Must be a positive integer.
     d : int, optional (default=None)
         The order of first-differencing. If None (by default), the value will
         automatically be selected based on the results of the test (i.e.,
@@ -58,7 +58,7 @@ class AutoARIMA(_PmdArimaAdapter):
         value). Must be a positive integer or None. Note that if d is None,
         the runtime could be significantly longer.
     start_q : int, optional (default=2)
-        The starting value of q, the order of the moving-average (“MA”) model.
+        The starting value of q, the order of the moving-average ("MA") model.
         Must be a positive integer.
     max_p : int, optional (default=5)
         The maximum value of p, inclusive. Must be a positive integer greater
@@ -107,8 +107,8 @@ class AutoARIMA(_PmdArimaAdapter):
         Whether the time-series is stationary and d should be set to zero.
     information_criterion : str, optional (default='aic')
         The information criterion used to select the best ARIMA model. One of
-        pmdarima.arima.auto_arima.VALID_CRITERIA, (‘aic’, ‘bic’, ‘hqic’,
-        ‘oob’).
+        pmdarima.arima.auto_arima.VALID_CRITERIA, ('aic', 'bic', 'hqic',
+        'oob').
     alpha : float, optional (default=0.05)
         Level of the test for testing significance.
     test : str, optional (default='kpss')
@@ -125,8 +125,8 @@ class AutoARIMA(_PmdArimaAdapter):
         over-fit the model.
     n_jobs : int, optional (default=1)
         The number of models to fit in parallel in the case of a grid search
-        (stepwise=False). Default is 1, but -1 can be used to designate “as
-        many as possible”.
+        (stepwise=False). Default is 1, but -1 can be used to designate "as
+        many as possible".
     start_params : array-like, optional (default=None)
         Starting parameters for ARMA(p,q). If None, the default is given by
         ARMA._fit_start_params.
@@ -165,7 +165,7 @@ class AutoARIMA(_PmdArimaAdapter):
         be squelched.
     error_action : str, optional (default='warn')
         If unable to fit an ARIMA due to stationarity issues, whether to warn
-        (‘warn’), raise the ValueError (‘raise’) or ignore (‘ignore’). Note
+        ('warn'), raise the ValueError ('raise') or ignore ('ignore'). Note
         that the default behavior is to warn, and fits that fail will be
         returned as None. This is the recommended behavior, as statsmodels
         ARIMA and SARIMAX models hit bugs periodically that can cause an
@@ -178,14 +178,14 @@ class AutoARIMA(_PmdArimaAdapter):
         fit.
     random : bool, optional (default='False')
         Similar to grid searches, auto_arima provides the capability to
-        perform a “random search” over a hyper-parameter space. If random is
+        perform a "random search" over a hyper-parameter space. If random is
         True, rather than perform an exhaustive search or stepwise search,
         only n_fits ARIMA models will be fit (stepwise must be False for this
         option to do anything).
     random_state : int, long or numpy RandomState, optional (default=None)
         The PRNG for when random=True. Ensures replicable testing and results.
     n_fits : int, optional (default=10)
-        If random is True and a “random search” is going to be performed,
+        If random is True and a "random search" is going to be performed,
         n_iter is the number of ARIMA models to be fit.
     out_of_sample_size : int, optional (default=0)
         The number of examples from the tail of the time series to hold out
@@ -200,7 +200,7 @@ class AutoARIMA(_PmdArimaAdapter):
             > Append [5, 6] to end of self.arima_res_.data.endog values
     scoring : str, optional (default='mse')
         If performing validation (i.e., if out_of_sample_size > 0), the metric
-        to use for scoring the out-of-sample data. One of (‘mse’, ‘mae’)
+        to use for scoring the out-of-sample data. One of ('mse', 'mae')
     scoring_args : dict, optional (default=None)
         A dictionary of key-word arguments to be passed to the scoring metric.
     with_intercept : bool, optional (default=True)

--- a/sktime/forecasting/arima.py
+++ b/sktime/forecasting/arima.py
@@ -328,7 +328,6 @@ class AutoARIMA(_PmdArimaAdapter):
         hamilton_representation=False,
         concentrate_scale=False,
     ):
-
         self.start_p = start_p
         self.d = d
         self.start_q = start_q
@@ -698,7 +697,6 @@ class ARIMA(_PmdArimaAdapter):
         hamilton_representation=False,
         concentrate_scale=False,
     ):
-
         self.order = order
         self.seasonal_order = seasonal_order
         self.start_params = start_params

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Base class template for forecaster scitype.
+"""Base class template for forecaster scitype.
 
     class name: BaseForecaster
 
@@ -75,11 +74,10 @@ def _coerce_to_list(obj):
 class BaseForecaster(BaseEstimator):
     """Base forecaster template class.
 
-    The base forecaster specifies the methods and method
-    signatures that all forecasters have to implement.
+    The base forecaster specifies the methods and method signatures that all forecasters
+    have to implement.
 
-    Specific implementations of these methods is deferred to concrete
-    forecasters.
+    Specific implementations of these methods is deferred to concrete forecasters.
     """
 
     # default tag values - these typically make the "safest" assumption
@@ -1905,9 +1903,9 @@ class BaseForecaster(BaseEstimator):
     ):
         """Update forecaster and then make forecasts.
 
-        Implements default behaviour of calling update and predict
-        sequentially, but can be overwritten by subclasses
-        to implement more efficient updating algorithms when available.
+        Implements default behaviour of calling update and predict sequentially, but can
+        be overwritten by subclasses to implement more efficient updating algorithms
+        when available.
         """
         self.update(y=y, X=X, update_params=update_params)
         return self.predict(fh=fh, X=X)

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1746,7 +1746,6 @@ class BaseForecaster(BaseEstimator):
         # predict-like methods: return as list, then run through reconstruct
         # to obtain a pandas based container in one of the pandas mtype formats
         elif methodname in PREDICT_METHODS:
-
             if methodname == "update_predict_single":
                 self._yvec = y
 
@@ -2023,7 +2022,6 @@ class BaseForecaster(BaseEstimator):
             )
 
         if implements_interval:
-
             pred_int = pd.DataFrame()
             for a in alpha:
                 # compute quantiles corresponding to prediction interval coverage
@@ -2059,7 +2057,6 @@ class BaseForecaster(BaseEstimator):
             pred_int.columns = int_idx
 
         elif implements_proba:
-
             pred_proba = self.predict_proba(fh=fh, X=X)
             pred_int = pred_proba.quantile(alpha=alpha)
 

--- a/sktime/forecasting/base/_delegate.py
+++ b/sktime/forecasting/base/_delegate.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Delegator mixin that delegates all methods to wrapped forecaster.
 
-Useful for building estimators where all but one or a few methods are delegated.
-For that purpose, inherit from this estimator and then override only the methods
-    that are not delegated.
+Useful for building estimators where all but one or a few methods are delegated. For
+that purpose, inherit from this estimator and then override only the methods     that
+are not delegated.
 """
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
@@ -141,9 +141,9 @@ class _DelegatedForecaster(BaseForecaster):
     def _update_predict_single(self, y, fh, X=None, update_params=True):
         """Update forecaster and then make forecasts.
 
-        Implements default behaviour of calling update and predict
-        sequentially, but can be overwritten by subclasses
-        to implement more efficient updating algorithms when available.
+        Implements default behaviour of calling update and predict sequentially, but can
+        be overwritten by subclasses to implement more efficient updating algorithms
+        when available.
         """
         estimator = self._get_delegate()
         return estimator.update_predict_single(

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -62,8 +62,8 @@ DELEGATED_METHODS = (
 def _delegator(method):
     """Automatically decorate ForecastingHorizon class with pandas.Index methods.
 
-    Also delegates method calls to wrapped pandas.Index object.
-    methods from pandas.Index and delegate method calls to wrapped pandas.Index
+    Also delegates method calls to wrapped pandas.Index object. methods from
+    pandas.Index and delegate method calls to wrapped pandas.Index
     """
 
     def delegated(obj, *args, **kwargs):

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-
 """Implements meta forecaster for forecasters composed of other estimators."""
 
 __author__ = ["mloning"]

--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # !/usr/bin/env python3 -u
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""sktime window forecaster base class."""
+"""Sktime window forecaster base class."""
 
 __author__ = ["mloning", "big-o", "fkiraly"]
 __all__ = ["_BaseWindowForecaster"]

--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -108,7 +108,6 @@ class _ProphetAdapter(BaseForecaster):
 
         # Add floor and bottom when growth is logistic
         if self.growth == "logistic":
-
             if self.growth_cap is None:
                 raise ValueError(
                     "Since `growth` param is set to 'logistic', expecting `growth_cap`"

--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -58,8 +58,8 @@ class _TbatsAdapter(BaseForecaster):
     def _create_model_class(self):
         """Instantiate (T)BATS model.
 
-        This method should write a (T)BATS model to self._ModelClass,
-            and should be overridden by concrete classes.
+        This method should write a (T)BATS model to self._ModelClass,     and should be
+        overridden by concrete classes.
         """
         raise NotImplementedError
 

--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -292,7 +292,6 @@ class _TbatsAdapter(BaseForecaster):
         pred_int = pd.DataFrame(columns=int_idx, index=fh.to_absolute_index(cutoff))
 
         for c in coverage:
-
             # separate treatment for "0" coverage: upper/lower = point prediction
             if c == 0:
                 pred_int[("Coverage", 0, "lower")] = self._tbats_forecast(fh)

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -603,9 +603,9 @@ def test_regular_spaced_fh_of_different_periodicity():
     """Test for failure condition from bug #4462.
 
     Due to pandas frequency inference logic, a specific case of constructing
-    `ForecastingHorizon` could upset the constructor:
-    passing a regular `DatetimeIndex` with frequency different from the `freq` argument,
-    which would be triggered in some `to_absolute` conversions.
+    `ForecastingHorizon` could upset the constructor: passing a regular `DatetimeIndex`
+    with frequency different from the `freq` argument, which would be triggered in some
+    `to_absolute` conversions.
     """
     y = _make_series(n_columns=1)
 

--- a/sktime/forecasting/bats.py
+++ b/sktime/forecasting/bats.py
@@ -3,8 +3,8 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements BATS algorithm.
 
-BATS refers to Exponential smoothing state space model with Box-Cox
-transformation, ARMA errors, Trend and Seasonal components.
+BATS refers to Exponential smoothing state space model with Box-Cox transformation, ARMA
+errors, Trend and Seasonal components.
 
 Wrapping implementation in [1]_ of method proposed in [2]_.
 """

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -169,7 +169,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
         self.forecasters_ = []
         self.y_columns = list(y.columns)
 
-        for (name, forecaster, index) in forecasters:
+        for name, forecaster, index in forecasters:
             forecaster_ = forecaster.clone()
 
             pd_index = self._coerce_to_pd_index(index)

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -123,10 +123,9 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
     def _forecasters(self):
         """Make internal list of forecasters.
 
-        The list only contains the name and forecasters, dropping
-        the columns. This is for the implementation of get_params
-        via _HeterogenousMetaEstimator._get_params which expects
-        lists of tuples of len 2.
+        The list only contains the name and forecasters, dropping the columns. This is
+        for the implementation of get_params via _HeterogenousMetaEstimator._get_params
+        which expects lists of tuples of len 2.
         """
         forecasters = self.forecasters
         if isinstance(forecasters, BaseForecaster):

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -161,7 +161,6 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
         self._fit_forecasters(forecasters, y_train, X_train, fh_test)
 
         if self.method == "feature-importance":
-
             self.regressor_ = check_regressor(
                 regressor=self.regressor, random_state=self.random_state
             )

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -3,8 +3,8 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file).
 """Implements ensemble forecasters.
 
-Creates univariate (optionally weighted)
-combination of the predictions from underlying forecasts.
+Creates univariate (optionally weighted) combination of the predictions from underlying
+forecasts.
 """
 
 __author__ = ["mloning", "GuzalBulatova", "aiwalter", "RNKuhns", "AnH0ang"]

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -68,7 +68,6 @@ class ForecastByLevel(_DelegatedForecaster):
     _delegate_name = "forecaster_"
 
     def __init__(self, forecaster, groupby="local"):
-
         self.forecaster = forecaster
         self.groupby = groupby
 

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -197,7 +197,7 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
 
         if self.by == "level":
             hier_dict = self._get_hier_dict(z)
-            for (_, forecaster, level) in self.forecasters_:
+            for _, forecaster, level in self.forecasters_:
                 if level in hier_dict.keys():
                     frcstr = forecaster.clone()
                     df = z[z.index.droplevel(-1).isin(hier_dict[level])]
@@ -281,7 +281,7 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
         counter = 0
         zindex = z.index.droplevel(-1).unique()
 
-        for (_, forecaster, node) in self.forecasters_:
+        for _, forecaster, node in self.forecasters_:
             if z.index.nlevels == 2:
                 mi = pd.Index(node)
                 if counter == 0:

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -130,10 +130,9 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
     def _forecasters(self):
         """Make internal list of forecasters.
 
-        The list only contains the name and forecasters.
-        This is for the implementation of get_params
-        via _HeterogenousMetaEstimator._get_params which expects
-        lists of tuples of len 2.
+        The list only contains the name and forecasters. This is for the implementation
+        of get_params via _HeterogenousMetaEstimator._get_params which expects lists of
+        tuples of len 2.
         """
         forecasters = self.forecasters
         if isinstance(forecasters, BaseForecaster):
@@ -258,7 +257,8 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
         return hier_dict
 
     def _get_node_dict(self, z):
-        """Create a separate dictionary of nodes and forecasters linked with common key value.
+        """Create a separate dictionary of nodes and forecasters linked with common key
+        value.
 
         Parameters
         ----------
@@ -273,7 +273,6 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
         frcstr_dict : dict
                     Dictionary with key as int and value as
                     forecaster
-
         """
         node_dict = {}
         frcstr_dict = {}

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -257,8 +257,7 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
         return hier_dict
 
     def _get_node_dict(self, z):
-        """Create a separate dictionary of nodes and forecasters linked with common key
-        value.
+        """Create dictionaries of nodes and forecasters linked with common key value.
 
         Parameters
         ----------

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -410,7 +410,10 @@ class ForecastingPipeline(_Pipeline):
 
     @property
     def forecaster_(self):
-        """Return reference to the forecaster in the pipeline. Valid after _fit."""
+        """Return reference to the forecaster in the pipeline.
+
+        Valid after _fit.
+        """
         return self.steps_[-1][1]
 
     def __rpow__(self, other):

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -109,7 +109,6 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
         return estimator_tuples
 
     def _iter_transformers(self, reverse=False, fc_idx=-1):
-
         # exclude final forecaster
         steps = self.steps_[:fc_idx]
 
@@ -1237,7 +1236,6 @@ class ForecastX(BaseForecaster):
     def __init__(
         self, forecaster_y, forecaster_X, fh_X=None, behaviour="update", columns=None
     ):
-
         if behaviour not in ["update", "refit"]:
             raise ValueError('behaviour must be one of "update", "refit"')
 
@@ -1678,7 +1676,6 @@ class Permute(_DelegatedForecaster, BaseForecaster, _HeterogenousMetaEstimator):
         self.estimator_ = estimator.clone()
 
         if permutation is not None:
-
             inner_estimators = getattr(estimator, steps_arg)
             estimator_tuples = self._get_estimator_tuples(inner_estimators)
 

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-
 """Composition functionality for reduction approaches to forecasting."""
 
 __author__ = [
@@ -327,7 +326,6 @@ class _Reducer(_BaseWindowForecaster):
         -------
         y, X: A pandas dataframe or series
             contains the y and X data prepared for the respective windows, see above.
-
         """
         if hasattr(self._timepoints, "freq"):
             if self._timepoints.freq is None:

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1058,7 +1058,6 @@ class _DirRecReducer(_Reducer):
         y_pred = np.zeros(len(fh))
 
         for i in range(len(self.fh)):
-
             # Slice data using expanding window.
             X_pred = X_full[:, :, : window_length + i]
 
@@ -1928,7 +1927,6 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         self.estimators_ = []
 
         for lag in y_lags:
-
             t = Lag(lags=lag, index_out="original", keep_column_names=True)
             lagger_y_to_y[lag] = t
 
@@ -1994,7 +1992,6 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         y_pred_list = []
 
         for i, lag in enumerate(y_lags):
-
             predict_idx = y_abs[i]
 
             lag_plus = Lag(lag, index_out="extend", keep_column_names=True)
@@ -2279,7 +2276,6 @@ class RecursiveReductionForecaster(BaseForecaster, _ReducerMixin):
         y_pred_list = []
 
         for _ in y_lags_no_gaps:
-
             if hasattr(self.fh, "freq") and self.fh.freq is not None:
                 y_plus_preds = y_plus_preds.asfreq(self.fh.freq)
 
@@ -2457,7 +2453,6 @@ class YfromX(BaseForecaster, _ReducerMixin):
     }
 
     def __init__(self, estimator, pooling="local"):
-
         self.estimator = estimator
         self.pooling = pooling
         super(YfromX, self).__init__()

--- a/sktime/forecasting/compose/tests/test_multiplex.py
+++ b/sktime/forecasting/compose/tests/test_multiplex.py
@@ -109,9 +109,9 @@ def test_multiplex_with_grid_search():
 def test_multiplex_or_dunder():
     """Test that the MultiplexForecaster magic "|" dunder methodbahves as expected.
 
-    A MultiplexForecaster can be created by using the "|" dunder method on
-    either forecaster or MultiplexForecaster objects. Here we test that it performs
-    as expected on all the use cases, and raises the expected error in some others.
+    A MultiplexForecaster can be created by using the "|" dunder method on either
+    forecaster or MultiplexForecaster objects. Here we test that it performs as expected
+    on all the use cases, and raises the expected error in some others.
     """
     # test a simple | example with two forecasters:
     multiplex_two_forecaster = AutoETS() | NaiveForecaster()

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -155,8 +155,8 @@ def test_pipeline_with_detrender():
 def test_pipeline_with_dimension_changing_transformer():
     """Example of pipeline with dimension changing transformer.
 
-    The code below should run without generating any errors.  Issues
-    can arise from using Differencer in the pipeline.
+    The code below should run without generating any errors.  Issues can arise from
+    using Differencer in the pipeline.
     """
     y, X = load_longley()
 
@@ -225,8 +225,8 @@ def test_pipeline_with_dimension_changing_transformer():
 def test_nested_pipeline_with_index_creation_y_before_X():
     """Tests a nested pipeline where y indices are created before X indices.
 
-    The potential failure mode is the pipeline failing as y has more indices than X,
-    in an intermediate stage and erroneous checks from the pipeline raise an error.
+    The potential failure mode is the pipeline failing as y has more indices than X, in
+    an intermediate stage and erroneous checks from the pipeline raise an error.
     """
     X = get_examples("pd_multiindex_hier")[0]
     y = get_examples("pd_multiindex_hier")[1]
@@ -254,8 +254,8 @@ def test_nested_pipeline_with_index_creation_y_before_X():
 def test_nested_pipeline_with_index_creation_X_before_y():
     """Tests a nested pipeline where X indices are created before y indices.
 
-    The potential failure mode is the pipeline failing as X has more indices than y,
-    in an intermediate stage and erroneous checks from the pipeline raise an error.
+    The potential failure mode is the pipeline failing as X has more indices than y, in
+    an intermediate stage and erroneous checks from the pipeline raise an error.
     """
     X = get_examples("pd_multiindex_hier")[0]
     y = get_examples("pd_multiindex_hier")[1]
@@ -368,8 +368,8 @@ def test_forecasting_pipeline_dunder_exog():
 def test_tag_handles_missing_data():
     """Test missing data with Imputer in pipelines.
 
-    Make sure that no exception is raised when NaN and Imputer is given.
-    This test is based on bug issue #3547.
+    Make sure that no exception is raised when NaN and Imputer is given. This test is
+    based on bug issue #3547.
     """
     forecaster = MockForecaster()
     # make sure that test forecaster cant handle missing data

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-
 """Test reduce."""
 
 __author__ = ["Lovkush-A", "mloning", "LuisZugasti", "AyushmaanSeth"]
@@ -144,8 +143,8 @@ def test_sliding_window_transform_panel(n_timepoints, window_length, n_variables
 def test_sliding_window_transform_explicit():
     """Test sliding window transform explicit.
 
-    testing with explicitly written down expected outputs
-    intended to help future contributors understand the transformation
+    testing with explicitly written down expected outputs intended to help future
+    contributors understand the transformation
     """
     y = pd.Series(np.arange(9))
     X = pd.concat([y + 100, y + 200], axis=1)
@@ -240,9 +239,9 @@ def test_dummy_regressor_mean_prediction_endogenous_only(
 ):
     """Test dummy regressor mean prediction endogenous_only.
 
-    The DummyRegressor ignores the input feature data X, hence we can use it for
-    testing reduction from forecasting to both tabular and time series regression.
-    The DummyRegressor also supports the 'multioutput' strategy.
+    The DummyRegressor ignores the input feature data X, hence we can use it for testing
+    reduction from forecasting to both tabular and time series regression. The
+    DummyRegressor also supports the 'multioutput' strategy.
     """
     y = make_forecasting_problem()
     fh = check_fh(fh)
@@ -304,10 +303,16 @@ class _TestTimeSeriesRegressor(_Recorder, BaseRegressor):
     pass
 
     def _fit(self, X, y):
-        """Empty method to satisfy abstract parent. Needs refactoring."""
+        """Empty method to satisfy abstract parent.
+
+        Needs refactoring.
+        """
 
     def _predict(self, X):
-        """Empty method to satisfy abstract parent. Needs refactoring."""
+        """Empty method to satisfy abstract parent.
+
+        Needs refactoring.
+        """
 
 
 @pytest.mark.parametrize(
@@ -320,8 +325,8 @@ def test_consistent_data_passing_to_component_estimators_in_fit_and_predict(
 ):
     """Test consistent data passing to component estimators in fit and predict.
 
-    We generate data that represents time points in its values, i.e. an array of
-    values that increase in unit steps for each time point.
+    We generate data that represents time points in its values, i.e. an array of values
+    that increase in unit steps for each time point.
     """
     n_variables = 3
     n_timepoints = 10
@@ -390,8 +395,8 @@ def test_make_reduction_infer_scitype(estimator, scitype):
 def test_make_reduction_infer_scitype_for_sklearn_pipeline():
     """Test make_reduction.
 
-    The scitype of pipeline cannot be inferred here, as it may be used together
-    with a tabular or time series regressor.
+    The scitype of pipeline cannot be inferred here, as it may be used together with a
+    tabular or time series regressor.
     """
     estimator = make_pipeline(Tabularizer(), LinearRegression())
     forecaster = make_reduction(estimator, scitype="infer")
@@ -522,10 +527,9 @@ EXPECTED_AIRLINE_LINEAR_DIRECT = [
 def test_reductions_airline_data(forecaster, expected):
     """Test reduction forecasters.
 
-    Test reduction forecasters by making prediction
-    on airline dataset using linear estimators.
-    Predictions compared with values calculated by Lovkush
-    Agarwal on their local machine in Mar 2021
+    Test reduction forecasters by making prediction on airline dataset using linear
+    estimators. Predictions compared with values calculated by Lovkush Agarwal on their
+    local machine in Mar 2021
     """
     y = load_airline()
     y_train, y_test = temporal_train_test_split(y, test_size=24)
@@ -562,12 +566,11 @@ def test_dirrec_against_recursive_accumulated_error():
 def test_direct_vs_recursive():
     """Test reduction forecasters.
 
-    Test reduction forecasters by making prediction
-    on airline dataset using linear estimators.
-    Wenn windows_identical = False, all observations should be considered (see
-    documenation in make_reduction function), so results for direct and recursive
-    forecasting should match for the first forecasting horizon.
-    With the windows_identical
+    Test reduction forecasters by making prediction on airline dataset using linear
+    estimators. Wenn windows_identical = False, all observations should be considered
+    (see documenation in make_reduction function), so results for direct and recursive
+    forecasting should match for the first forecasting horizon. With the
+    windows_identical
     """
     y = load_airline()
     y_train, y_test = temporal_train_test_split(y, test_size=24)

--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -143,7 +143,6 @@ class ConformalIntervals(BaseForecaster):
         verbose=False,
         n_jobs=None,
     ):
-
         if not isinstance(method, str):
             raise TypeError(f"method must be a str, one of {self.ALLOWED_METHODS}")
 
@@ -327,7 +326,6 @@ class ConformalIntervals(BaseForecaster):
         return pred_int
 
     def _parse_initial_window(self, y, initial_window=None):
-
         n_samples = len(y)
 
         if initial_window is None:

--- a/sktime/forecasting/dummy.py
+++ b/sktime/forecasting/dummy.py
@@ -64,7 +64,6 @@ class ForecastKnownValues(BaseForecaster):
     }
 
     def __init__(self, y_known, method=None, fill_value=None, limit=None):
-
         self.y_known = y_known
         self.method = method
         self.fill_value = fill_value

--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -26,8 +26,8 @@ class DynamicFactor(_StatsModelsAdapter):
         The order of vector autoregression followed by factors.
     error_cov_type : {'scalar','diagonal','unstructured'} ,default = 'diagonal'
         The structure of the covariance matrix of the observation error term, where
-        “unstructured” puts no restrictions on the matrix, “diagonal” requires it
-        to be any diagonal matrix (uncorrelated errors), and “scalar” requires it
+        "unstructured" puts no restrictions on the matrix, "diagonal" requires it
+        to be any diagonal matrix (uncorrelated errors), and "scalar" requires it
         to be a scalar times the identity matrix.
     error_order : int , default = 0
         The order of the vector autoregression followed by the observation error
@@ -47,37 +47,37 @@ class DynamicFactor(_StatsModelsAdapter):
          describes whether or not start_params also includes the fixed parameters,
           in addition to the free parameters.
     cov_type : {'opg','oim','approx','robust','robust_approx','none'},default = 'opg'
-        ‘opg’ for the outer product of gradient estimator
-        ‘oim’ for the observed information matrix estimator, calculated
+        'opg' for the outer product of gradient estimator
+        'oim' for the observed information matrix estimator, calculated
         using the method of Harvey (1989)
-        ‘approx’ for the observed information matrix estimator, calculated using
+        'approx' for the observed information matrix estimator, calculated using
          a numerical approximation of the Hessian matrix.
-        ‘robust’ for an approximate (quasi-maximum likelihood) covariance matrix
+        'robust' for an approximate (quasi-maximum likelihood) covariance matrix
          that may be valid even in the presence of some misspecifications.
-          Intermediate calculations use the ‘oim’ method.
-        ‘robust_approx’ is the same as ‘robust’ except that the intermediate
-        calculations use the ‘approx’ method.
-        ‘none’ for no covariance matrix calculation
+          Intermediate calculations use the 'oim' method.
+        'robust_approx' is the same as 'robust' except that the intermediate
+        calculations use the 'approx' method.
+        'none' for no covariance matrix calculation
     cov_kwds :dict or None , default = None
-        ‘approx_complex_step’ : bool, optional - If True, numerical approximations are
+        'approx_complex_step' : bool, optional - If True, numerical approximations are
          computed using complex-step methods. If False, numerical approximations are
          computed using finite difference methods. Default is True.
-        ‘approx_centered’ : bool, optional - If True, numerical approximations computed
+        'approx_centered' : bool, optional - If True, numerical approximations computed
         using finite difference methods use a centered approximation. Default is False.
     method : str , 'lbfgs'
-        ‘newton’ for Newton-Raphson
-        ‘nm’ for Nelder-Mead
-        ‘bfgs’ for Broyden-Fletcher-Goldfarb-Shanno (BFGS)
-        ‘lbfgs’ for limited-memory BFGS with optional box constraints
-        ‘powell’ for modified Powell’s method
-        ‘cg’ for conjugate gradient
-        ‘ncg’ for Newton-conjugate gradient
-        ‘basinhopping’ for global basin-hopping solver
+        'newton' for Newton-Raphson
+        'nm' for Nelder-Mead
+        'bfgs' for Broyden-Fletcher-Goldfarb-Shanno (BFGS)
+        'lbfgs' for limited-memory BFGS with optional box constraints
+        'powell' for modified Powell's method
+        'cg' for conjugate gradient
+        'ncg' for Newton-conjugate gradient
+        'basinhopping' for global basin-hopping solver
     maxiter : int , optional ,default = 50
         The maximum number of iterations to perform.
     full_output : bool , default = 1
         Set to True to have all available output in the
-        Results object’s mle_retvals attribute.
+        Results object's mle_retvals attribute.
         The output is dependent on the solver.
     disp : bool ,   default = 5
         Set to True to print convergence messages.
@@ -87,16 +87,16 @@ class DynamicFactor(_StatsModelsAdapter):
     return_params : bool ,default = False
         Whether or not to return only the array of maximizing parameters.
     optim_score : {'harvey','approx'} , default = None
-        The method by which the score vector is calculated. ‘harvey’ uses the method
-        from Harvey (1989), ‘approx’ uses either finite difference or
+        The method by which the score vector is calculated. 'harvey' uses the method
+        from Harvey (1989), 'approx' uses either finite difference or
         complex step differentiation depending upon the value of optim_complex_step,
         and None uses the built-in gradient approximation of the optimizer.
     optim_complex_step : bool , default = True
         Whether or not to use complex step differentiation
         when approximating the score; if False, finite difference approximation is used.
     optim_hessian : {'opg','oim','approx'} , default = None
-        ‘opg’ uses outer product of gradients, ‘oim’ uses the information
-        matrix formula from Harvey (1989), and ‘approx’ uses numerical approximation.
+        'opg' uses outer product of gradients, 'oim' uses the information
+        matrix formula from Harvey (1989), and 'approx' uses numerical approximation.
     low_memory : bool , default = False
         If set to True, techniques are applied to substantially reduce memory usage.
         If used, some features of the results object will not be available
@@ -427,15 +427,15 @@ class DynamicFactor(_StatsModelsAdapter):
             If unspecified, but the model has been initialized,
             then that initialization is used.
             This must be specified if anchor is anything
-            other than “start” or 0.
+            other than "start" or 0.
         anchor : int,str,or datetime , optional
             Starting point from which to begin the simulations; type depends
             on the index of the given endog model.
-            Two special cases are the strings ‘start’ and ‘end’,
+            Two special cases are the strings 'start' and 'end',
             which refer to starting at the beginning and end of the sample,
             respectively. If a date/time index was provided to the model,
             then this argument can be a date string to parse or a datetime type.
-            Otherwise, an integer index should be given. Default is ‘start’.
+            Otherwise, an integer index should be given. Default is 'start'.
         repetitions : int , optional
             Number of simulated paths to generate. Default is 1 simulated path
 
@@ -510,7 +510,7 @@ class DynamicFactor(_StatsModelsAdapter):
             the last significant autocorrelation.
             In this case, a moving average model is assumed for the data
             and the standard errors for the confidence intervals should be generated
-             using Bartlett’s formula.
+             using Bartlett's formula.
         acf_kwargs : dict , optional
             Optional dictionary of keyword arguments that are directly
             passed on to the correlogram Matplotlib plot produced by plot_acf().

--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -277,7 +277,6 @@ class DynamicFactor(_StatsModelsAdapter):
         df_list = []
         # generate the forecasts for each alpha/coverage
         for coverage in coverage_list:
-
             alpha = 1 - coverage
 
             if "exog" in inspect.signature(model.__init__).parameters.keys():

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -118,7 +118,6 @@ def _evaluate_window(
     error_score,
     cutoff_dtype,
 ):
-
     # set default result values in case estimator fitting fails
     score = error_score
     fit_time = np.nan

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -3,8 +3,8 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Tests for model evaluation module.
 
-In particular, function `evaluate`, that performs time series
-cross-validation, is tested with various configurations for correct output.
+In particular, function `evaluate`, that performs time series cross-validation, is
+tested with various configurations for correct output.
 """
 
 __author__ = ["aiwalter", "mloning", "fkiraly"]

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -947,9 +947,7 @@ class BaseWindowSplitter(BaseSplitter):
         # If we start with a full window, the first split point depends on the window
         # length.
         if hasattr(self, "start_with_window") and self.start_with_window:
-
             if self._initial_window not in [None, 0]:
-
                 if is_timedelta_or_date_offset(x=self._initial_window):
                     start = y.get_loc(
                         y[start] + self._initial_window + self.step_length
@@ -1159,7 +1157,6 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
         initial_window: ACCEPTED_WINDOW_LENGTH_TYPES = DEFAULT_WINDOW_LENGTH,
         step_length: NON_FLOAT_WINDOW_LENGTH_TYPES = DEFAULT_STEP_LENGTH,
     ) -> None:
-
         start_with_window = initial_window != 0
 
         # Note that we pass the initial window as the window_length below. This

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -627,7 +627,6 @@ class BaseSplitter(BaseObject):
         Returns
         -------
         np.ndarray with integer indices of the train window
-
         """
         if split_point > max(0, train_start):
             return np.argwhere(
@@ -840,7 +839,6 @@ class BaseWindowSplitter(BaseSplitter):
         -------
         (np.ndarray, np.ndarray)
             Integer indices of the train/test windows
-
         """
         fh = _check_fh(self.fh)
         if not self.start_with_window:
@@ -1082,7 +1080,6 @@ class SlidingWindowSplitter(BaseWindowSplitter):
     >>> splitter = SlidingWindowSplitter(fh=[2, 4], window_length=3, step_length=2)
     >>> list(splitter.split(ts)) # doctest: +SKIP
     [(array([0, 1, 2]), array([4, 6])), (array([2, 3, 4]), array([6, 8]))]
-
     """
 
     def __init__(
@@ -1148,7 +1145,6 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
     >>> splitter = ExpandingWindowSplitter(fh=[2, 4], initial_window=5, step_length=2)
     >>> list(splitter.split(ts)) # doctest: +SKIP
     '[(array([0, 1, 2, 3, 4]), array([6, 8]))]'
-
     """
 
     def __init__(
@@ -1211,7 +1207,6 @@ class SingleWindowSplitter(BaseSplitter):
     >>> splitter = SingleWindowSplitter(fh=[2, 4], window_length=3)
     >>> list(splitter.split(ts)) # doctest: +SKIP
     [(array([3, 4, 5]), array([7, 9]))]
-
     """
 
     def __init__(

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -21,7 +21,6 @@ from sktime.utils.validation.forecasting import check_scoring
 
 
 class BaseGridSearch(_DelegatedForecaster):
-
     _tags = {
         "scitype:y": "both",
         "requires-fh-in-fit": False,
@@ -46,7 +45,6 @@ class BaseGridSearch(_DelegatedForecaster):
         update_behaviour="full_refit",
         error_score=np.nan,
     ):
-
         self.forecaster = forecaster
         self.cv = cv
         self.strategy = strategy

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -121,8 +121,8 @@ def test_gscv(forecaster, param_grid, cv, scoring, error_score):
 def test_rscv(forecaster, param_grid, cv, scoring, error_score, n_iter, random_state):
     """Test ForecastingRandomizedSearchCV.
 
-    Tests that ForecastingRandomizedSearchCV successfully searches the
-    parameter distributions to identify the best parameter set
+    Tests that ForecastingRandomizedSearchCV successfully searches the parameter
+    distributions to identify the best parameter set
     """
     y, X = load_longley()
     rscv = ForecastingRandomizedSearchCV(

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -325,7 +325,6 @@ class NaiveForecaster(_BaseWindowForecaster):
         return y_pred[fh_idx]
 
     def _predict_naive(self, fh=None, X=None):
-
         from sktime.transformations.series.lag import Lag
 
         strategy = self.strategy
@@ -353,7 +352,6 @@ class NaiveForecaster(_BaseWindowForecaster):
             y_pred = y_pred.iloc[:, 0]
 
         elif strategy == "last" and sp > 1:
-
             y_old = _pivot_sp(_y, sp, anchor_side="end")
             y_old = lagger.fit_transform(y_old)
 
@@ -655,7 +653,6 @@ class NaiveVariance(BaseForecaster):
     }
 
     def __init__(self, forecaster, initial_window=1, verbose=False):
-
         self.forecaster = forecaster
         self.initial_window = initial_window
         self.verbose = verbose
@@ -673,7 +670,6 @@ class NaiveVariance(BaseForecaster):
         self.clone_tags(self.forecaster, tags_to_clone)
 
     def _fit(self, y, X=None, fh=None):
-
         self.fh_early_ = fh is not None
         self.forecaster_ = self.forecaster.clone()
         self.forecaster_.fit(y=y, X=X, fh=fh)

--- a/sktime/forecasting/online_learning/_online_ensemble.py
+++ b/sktime/forecasting/online_learning/_online_ensemble.py
@@ -33,7 +33,6 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
     }
 
     def __init__(self, forecasters, ensemble_algorithm=None, n_jobs=None):
-
         self.n_jobs = n_jobs
         self.ensemble_algorithm = ensemble_algorithm
 

--- a/sktime/forecasting/reconcile.py
+++ b/sktime/forecasting/reconcile.py
@@ -109,7 +109,6 @@ class ReconcilerForecaster(BaseForecaster):
     METHOD_LIST = ["mint_cov", "mint_shrink", "wls_var"] + TRFORM_LIST
 
     def __init__(self, forecaster, method="mint_shrink"):
-
         self.forecaster = forecaster
         self.method = method
 

--- a/sktime/forecasting/sarimax.py
+++ b/sktime/forecasting/sarimax.py
@@ -143,7 +143,6 @@ class SARIMAX(_StatsModelsAdapter):
         validate_specification=True,
         random_state=None,
     ):
-
         self.order = order
         self.seasonal_order = seasonal_order
         self.trend = trend

--- a/sktime/forecasting/structural.py
+++ b/sktime/forecasting/structural.py
@@ -179,8 +179,8 @@ class UnobservedComponents(_StatsModelsAdapter):
 
     References
     ----------
-    .. [1] Seabold, Skipper, and Josef Perktold. “statsmodels: Econometric
-       and statistical modeling with python.” Proceedings of the 9th Python
+    .. [1] Seabold, Skipper, and Josef Perktold. "statsmodels: Econometric
+       and statistical modeling with python." Proceedings of the 9th Python
        in Science Conference. 2010.
 
     .. [2] Durbin, James, and Siem Jan Koopman. 2012.

--- a/sktime/forecasting/structural.py
+++ b/sktime/forecasting/structural.py
@@ -376,7 +376,7 @@ class UnobservedComponents(_StatsModelsAdapter):
         initial_state=None,
         anchor=None,
         repetitions=None,
-        **kwargs
+        **kwargs,
     ):
         r"""Simulate a new time series following the state space model.
 
@@ -450,7 +450,7 @@ class UnobservedComponents(_StatsModelsAdapter):
             anchor=anchor,
             repetitions=repetitions,
             exog=X,
-            **kwargs
+            **kwargs,
         )
 
     def plot_diagnostics(

--- a/sktime/forecasting/tbats.py
+++ b/sktime/forecasting/tbats.py
@@ -3,8 +3,8 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements TBATS algorithm.
 
-TBATS refers to Exponential smoothing state space model with Trigonometric
-Seasonality, Box-Cox transformation, ARMA errors, Trend and Seasonal components.
+TBATS refers to Exponential smoothing state space model with Trigonometric Seasonality,
+Box-Cox transformation, ARMA errors, Trend and Seasonal components.
 
 Wrapping implementation in [1]_ of method proposed in [2]_.
 """

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -396,7 +396,6 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         y_train = _make_series(n_columns=n_columns, index_type=index_type)
         estimator_instance.fit(y_train, fh=fh_int_oos)
         if estimator_instance.get_tag("capability:pred_int"):
-
             pred_ints = estimator_instance.predict_interval(
                 fh_int_oos, coverage=coverage
             )

--- a/sktime/forecasting/tests/test_ets.py
+++ b/sktime/forecasting/tests/test_ets.py
@@ -27,8 +27,7 @@ inf_ic_ts = pd.Series(
     reason="skip test if required soft dependency not available",
 )
 def test_airline_default():
-    """
-    Default condition.
+    """Default condition.
 
     fit <- ets(AirPassengers, model = "ZZZ")
     components: "M" "A" "M" "TRUE" (error, trend, season, damped)
@@ -54,8 +53,7 @@ def test_airline_default():
 )
 @pytest.mark.xfail(reason="flaky results on linux")
 def test_airline_allow_multiplicative_trend():
-    """
-    Allow multiplicative trend.
+    """Allow multiplicative trend.
 
     fit <- ets(AirPassengers, model = "ZZZ",
     allow.multiplicative.trend = TRUE)

--- a/sktime/forecasting/tests/test_interval_wrappers.py
+++ b/sktime/forecasting/tests/test_interval_wrappers.py
@@ -70,9 +70,8 @@ def test_wrapper_series_mtype(wrapper, override_y_mtype, mtype):
 def test_evaluate_with_window_splitters(wrapper, splitter, strategy, sample_frac):
     """Test interval wrappers with different strategies and cross validators.
 
-    The wrapper does some internal sliding window cross-validation to
-    calculate the `residuals_matrix`, which means the initial cross-validation
-    can cause issues.
+    The wrapper does some internal sliding window cross-validation to calculate the
+    `residuals_matrix`, which means the initial cross-validation can cause issues.
 
     This checks refit and update strategies as well as expanding and sliding window
     splitters.

--- a/sktime/forecasting/tests/test_naive.py
+++ b/sktime/forecasting/tests/test_naive.py
@@ -193,12 +193,11 @@ def test_strategy_mean_and_last_seasonal_additional_combinations(
 ):
     """Check that naive forecasters yield the right forecasts given simple data.
 
-    Test for perfectly cyclic data, and for robustness against a missing value.
-    More specifically,
-    check time series of n * window_length with a 1:n-1 train/test split,
-    for different combinations of the period and seasonal periodicity.
-    The time series contains perfectly cyclic data,
-    so switching between the "mean" and "last" strategies should not make a difference.
+    Test for perfectly cyclic data, and for robustness against a missing value. More
+    specifically, check time series of n * window_length with a 1:n-1 train/test split,
+    for different combinations of the period and seasonal periodicity. The time series
+    contains perfectly cyclic data, so switching between the "mean" and "last"
+    strategies should not make a difference.
     """
     # given <window_length> hours of data with a seasonal periodicity of <sp> hours
     freq = pd.Timedelta("1H")

--- a/sktime/forecasting/tests/test_pmdarima.py
+++ b/sktime/forecasting/tests/test_pmdarima.py
@@ -13,7 +13,10 @@ from sktime.utils.validation._dependencies import _check_estimator_deps
     reason="skip test if required soft dependency not available",
 )
 def test_ARIMA_pred_quantiles_insample():
-    """Test ARIMA predict_quantiles with in-sample fh. Failure condition of #4468."""
+    """Test ARIMA predict_quantiles with in-sample fh.
+
+    Failure condition of #4468.
+    """
     y = load_airline()
     forecaster = ARIMA(order=(1, 1, 0), seasonal_order=(0, 1, 0, 12))
     forecaster.fit(y)

--- a/sktime/forecasting/tests/test_structural.py
+++ b/sktime/forecasting/tests/test_structural.py
@@ -35,7 +35,6 @@ class ModelSpec:
 
         # Sample from model parameters.
         for t in range(1, n):
-
             zeta[t] = self.params["zeta"] * np.random.normal(loc=0.0, scale=sigma_zeta)
             beta[t] = self.params["beta_1"] * beta[t - 1] + zeta[t]
 

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -101,7 +101,6 @@ class ThetaForecaster(ExponentialSmoothing):
     }
 
     def __init__(self, initial_level=None, deseasonalize=True, sp=1):
-
         self.sp = sp
         self.deseasonalize = deseasonalize
         self.deseasonalizer_ = None

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """Theta forecasters."""
 
 __all__ = ["ThetaForecaster", "ThetaModularForecaster"]

--- a/sktime/forecasting/var.py
+++ b/sktime/forecasting/var.py
@@ -14,8 +14,7 @@ from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
 
 class VAR(_StatsModelsAdapter):
-    """
-    A VAR model is a generalisation of the univariate autoregressive.
+    """A VAR model is a generalisation of the univariate autoregressive.
 
     Direct interface for `statsmodels.tsa.vector_ar`
     A model for forecasting a vector of time series[1].
@@ -139,8 +138,7 @@ class VAR(_StatsModelsAdapter):
         return self
 
     def _predict(self, fh, X=None):
-        """
-        Wrap Statmodel's VAR forecast method.
+        """Wrap Statmodel's VAR forecast method.
 
         Parameters
         ----------

--- a/sktime/forecasting/var.py
+++ b/sktime/forecasting/var.py
@@ -240,7 +240,6 @@ class VAR(_StatsModelsAdapter):
         df_list = []
 
         for cov in coverage:
-
             alpha = 1 - cov
 
             fcast_interval = model.forecast_interval(

--- a/sktime/forecasting/varmax.py
+++ b/sktime/forecasting/varmax.py
@@ -338,8 +338,7 @@ class VARMAX(_StatsModelsAdapter):
     # 1. to pass in `dynamic`, `information_set` and `signal_only`
     # 2. to deal with statsmodel integer indexing issue
     def _predict(self, fh, X=None):
-        """
-        Wrap Statmodel's VARMAX forecast method.
+        """Wrap Statmodel's VARMAX forecast method.
 
         Parameters
         ----------

--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-
 """VECM Forecaster."""
 
 
@@ -14,8 +13,7 @@ from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
 
 class VECM(_StatsModelsAdapter):
-    r"""
-    A VECM model, or Vector Error Correction Model, is a restricted.
+    r"""A VECM model, or Vector Error Correction Model, is a restricted.
 
     VAR model used for nonstationary series that are cointegrated.r
 
@@ -117,8 +115,7 @@ class VECM(_StatsModelsAdapter):
         super(VECM, self).__init__()
 
     def _fit(self, y, fh=None, X=None):
-        """
-        Fit forecaster to training data.
+        """Fit forecaster to training data.
 
         Wrapper for statsmodel's VECM (_VECM) fit method
 
@@ -157,8 +154,7 @@ class VECM(_StatsModelsAdapter):
         return self
 
     def _predict(self, fh, X=None):
-        """
-        Forecast time series at future horizon.
+        """Forecast time series at future horizon.
 
         Wrapper for statsmodel's VECM (_VECM) predict method
 
@@ -214,8 +210,7 @@ class VECM(_StatsModelsAdapter):
         return y_pred
 
     def _predict_interval(self, fh, X=None, coverage=None):
-        """
-        Compute/return prediction quantiles for a forecast.
+        """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
             called from predict_interval and possibly predict_quantiles

--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -102,7 +102,6 @@ class VECM(_StatsModelsAdapter):
         exog_coint=None,
         exog_coint_fc=None,
     ):
-
         self.dates = dates
         self.freq = freq
         self.missing = missing
@@ -192,7 +191,6 @@ class VECM(_StatsModelsAdapter):
 
         # in-sample prediction by means of residuals
         if fh_int.min() <= 0:
-
             # .resid returns np.ndarray
             # both values need to be pd DataFrame for subtraction
             y_pred_insample = self._y - pd.DataFrame(self._fitted_forecaster.resid)

--- a/sktime/networks/lstmfcn.py
+++ b/sktime/networks/lstmfcn.py
@@ -7,8 +7,7 @@ from sktime.networks.base import BaseDeepNetwork
 
 
 class LSTMFCNNetwork(BaseDeepNetwork):
-    """
-    Implementation of LSTMFCNClassifier from Karim et al (2019) [1].
+    """Implementation of LSTMFCNClassifier from Karim et al (2019) [1].
 
     Overview
     --------
@@ -37,8 +36,7 @@ class LSTMFCNNetwork(BaseDeepNetwork):
         dropout=0.8,
         attention=False,
     ):
-        """
-        Initialize a new LSTMFCNNetwork object.
+        """Initialize a new LSTMFCNNetwork object.
 
         Parameters
         ----------
@@ -66,8 +64,7 @@ class LSTMFCNNetwork(BaseDeepNetwork):
         super(LSTMFCNNetwork, self).__init__()
 
     def build_network(self, input_shape, **kwargs):
-        """
-        Construct a network and return its input and output layers.
+        """Construct a network and return its input and output layers.
 
         Parameters
         ----------

--- a/sktime/networks/lstmfcn_layers.py
+++ b/sktime/networks/lstmfcn_layers.py
@@ -177,7 +177,7 @@ def make_attention_lstm():
             recurrent_dropout=0.0,
             return_attention=False,
             implementation=1,
-            **kwargs
+            **kwargs,
         ):
             super(AttentionLSTMCell, self).__init__(**kwargs)
             self.input_spec = [InputSpec(ndim=2)]
@@ -629,7 +629,7 @@ def make_attention_lstm():
             go_backwards=False,
             stateful=False,
             unroll=False,
-            **kwargs
+            **kwargs,
         ):
             import warnings
 
@@ -687,7 +687,7 @@ def make_attention_lstm():
                 go_backwards=go_backwards,
                 stateful=stateful,
                 unroll=unroll,
-                **kwargs
+                **kwargs,
             )
             self.return_attention = return_attention
 

--- a/sktime/networks/lstmfcn_layers.py
+++ b/sktime/networks/lstmfcn_layers.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-"""Attention Layers used in by the LSTM-FCN Network. Ported over from sktime-dl."""
+"""Attention Layers used in by the LSTM-FCN Network.
+
+Ported over from sktime-dl.
+"""
 
 
 def make_attention_lstm():

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -59,8 +59,7 @@ class MACNNNetwork(BaseDeepNetwork):
         self.random_state = random_state
 
     def _macnn_block(self, x, kernels, reduce):
-        """
-        Implement a single MACNN Block.
+        """Implement a single MACNN Block.
 
         Parameters
         ----------
@@ -103,8 +102,7 @@ class MACNNNetwork(BaseDeepNetwork):
         return x1 * x2
 
     def _stack(self, x, repeats, kernels, reduce):
-        """
-        Build MACNN Blocks and stack them.
+        """Build MACNN Blocks and stack them.
 
         Parameters
         ----------
@@ -128,8 +126,7 @@ class MACNNNetwork(BaseDeepNetwork):
         return x
 
     def build_network(self, input_shape, **kwargs):
-        """
-        Construct a network and return its input and output layers.
+        """Construct a network and return its input and output layers.
 
         Parameters
         ----------

--- a/sktime/networks/resnet.py
+++ b/sktime/networks/resnet.py
@@ -8,8 +8,7 @@ from sktime.utils.validation._dependencies import _check_dl_dependencies
 
 
 class ResNetNetwork(BaseDeepNetwork):
-    """
-    Establish the network structure for a ResNet.
+    """Establish the network structure for a ResNet.
 
     Adapted from the implementations used in [1]
 
@@ -34,7 +33,6 @@ class ResNetNetwork(BaseDeepNetwork):
     Zhiguang and Yan, Weizhong and Oates, Tim}, booktitle={2017
     International joint conference on neural networks (IJCNN)}, pages={
     1578--1585}, year={2017}, organization={IEEE} }
-
     """
 
     _tags = {"python_dependencies": ["tensorflow", "keras-self-attention"]}
@@ -45,8 +43,7 @@ class ResNetNetwork(BaseDeepNetwork):
         self.random_state = random_state
 
     def build_network(self, input_shape, **kwargs):
-        """
-        Construct a network and return its input and output layers.
+        """Construct a network and return its input and output layers.
 
         Arguments
         ---------

--- a/sktime/networks/tapnet.py
+++ b/sktime/networks/tapnet.py
@@ -175,7 +175,6 @@ class TapNetNetwork(BaseDeepNetwork):
         self.rp_group, self.rp_dim = self.rp_params
 
         if self.use_lstm:
-
             self.lstm_dim = 128
 
             x_lstm = keras.layers.LSTM(self.lstm_dim, return_sequences=True)(
@@ -195,7 +194,6 @@ class TapNetNetwork(BaseDeepNetwork):
                 self.conv_1_models = keras.Sequential()
 
                 for i in range(self.rp_group):
-
                     self.idx = np.random.permutation(input_shape[1])[0 : self.rp_dim]
                     channel = keras.layers.Lambda(
                         lambda x: tf.gather(x, indices=self.idx, axis=2)
@@ -250,7 +248,6 @@ class TapNetNetwork(BaseDeepNetwork):
                 x_conv = x_conv_sum
 
             else:
-
                 x_conv = keras.layers.Conv1D(
                     self.filter_sizes[0],
                     kernel_size=self.kernel_size[0],

--- a/sktime/param_est/base.py
+++ b/sktime/param_est/base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Base class template for parameter estimator scitype.
+"""Base class template for parameter estimator scitype.
 
     class name: BaseParamFitter
 
@@ -48,8 +47,8 @@ def _coerce_to_list(obj):
 class BaseParamFitter(BaseEstimator):
     """Base parameter fitting estimator class.
 
-    The base parameter fitter specifies the methods and method
-    signatures that all parameter fitter have to implement.
+    The base parameter fitter specifies the methods and method signatures that all
+    parameter fitter have to implement.
 
     Specific implementations of these methods is deferred to concrete instances.
     """

--- a/sktime/param_est/compose.py
+++ b/sktime/param_est/compose.py
@@ -97,7 +97,6 @@ class ParamFitterPipeline(_HeterogenousMetaEstimator, BaseParamFitter):
     # no default tag values - these are set dynamically below
 
     def __init__(self, param_est, transformers):
-
         self.param_est = param_est
         self.param_est_ = param_est.clone()
         self.transformers = transformers
@@ -296,7 +295,6 @@ class ParamFitterPipeline(_HeterogenousMetaEstimator, BaseParamFitter):
 
         # test case 2 depends on statsmodels, requires statsmodels
         if _check_estimator_deps(SeasonalityACF, severity="none"):
-
             p = SeasonalityACF()
 
             # construct without names

--- a/sktime/param_est/tests/test_plugin.py
+++ b/sktime/param_est/tests/test_plugin.py
@@ -20,7 +20,10 @@ from sktime.utils.validation._dependencies import _check_estimator_deps
     reason="skip test if required soft dependencies not available",
 )
 def test_seasonality_acf():
-    """Test PluginParamsForecaster on airline data. Same as docstring example."""
+    """Test PluginParamsForecaster on airline data.
+
+    Same as docstring example.
+    """
     y = load_airline()
 
     sp_est = Differencer() * SeasonalityACF()

--- a/sktime/performance_metrics/annotation/__init__.py
+++ b/sktime/performance_metrics/annotation/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """Metrics to assess performance of segmentation task."""
 
 from sktime.performance_metrics.annotation.metrics import (  # noqa

--- a/sktime/performance_metrics/annotation/metrics.py
+++ b/sktime/performance_metrics/annotation/metrics.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-"""
-Metrics for evaluating performance of segmentation estimators.
+"""Metrics for evaluating performance of segmentation estimators.
 
-Metrics are suitable for comparing predicted change point sets
-against true change points and quantify the error.
+Metrics are suitable for comparing predicted change point sets against true change
+points and quantify the error.
 """
 import numpy as np
 import numpy.typing as npt
@@ -16,8 +15,7 @@ __author__ = ["lmmentel"]
 def count_error(
     true_change_points: npt.ArrayLike, pred_change_points: npt.ArrayLike
 ) -> float:
-    """
-    Error counting the difference in the number of change points.
+    """Error counting the difference in the number of change points.
 
     Parameters
     ----------
@@ -41,8 +39,7 @@ def hausdorff_error(
     symmetric: bool = True,
     seed: int = 0,
 ) -> float:
-    """
-    Compute the Hausdorff distance between two sets of change points.
+    """Compute the Hausdorff distance between two sets of change points.
 
     .. seealso::
 
@@ -78,8 +75,7 @@ def hausdorff_error(
 def prediction_ratio(
     true_change_points: npt.ArrayLike, pred_change_points: npt.ArrayLike
 ) -> float:
-    """
-    Prediction ratio is the ratio of number of predicted to true change points.
+    """Prediction ratio is the ratio of number of predicted to true change points.
 
     Parameters
     ----------

--- a/sktime/performance_metrics/base/__init__.py
+++ b/sktime/performance_metrics/base/__init__.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-
 """Base class for defining performance metrics."""
 
 __author__ = ["RNKuhns"]

--- a/sktime/performance_metrics/base/_base.py
+++ b/sktime/performance_metrics/base/_base.py
@@ -15,7 +15,6 @@ class BaseMetric(BaseObject):
     """
 
     def __init__(self):
-
         super(BaseMetric, self).__init__()
 
     def __call__(self, y_true, y_pred, **kwargs):

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -431,7 +431,6 @@ class BaseForecastingErrorMetric(BaseMetric):
             RecursionError("Must implement one of _evaluate or _evaluate_by_index")
 
     def _check_consistent_input(self, y_true, y_pred, multioutput, multilevel):
-
         y_true_orig = y_true
         y_pred_orig = y_pred
 
@@ -513,7 +512,6 @@ class BaseForecastingErrorMetric(BaseMetric):
         return y_true_orig, y_pred_orig, multioutput, multilevel
 
     def _check_ys(self, y_true, y_pred, multioutput, multilevel, **kwargs):
-
         SCITYPES = ["Series", "Panel", "Hierarchical"]
         INNER_MTYPES = ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"]
 
@@ -637,7 +635,6 @@ class _DynamicForecastingErrorMetric(BaseForecastingErrorMetricFunc):
         params1 = {"func": custom_mape, "name": "custom_mape", "lower_is_better": False}
 
         def custom_mae(y_true, y_pred) -> float:
-
             result = np.mean(np.abs(y_true - y_pred))
 
             return float(result)

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -76,11 +76,10 @@ __all__ = [
 def _is_average(multilevel_or_multioutput):
     """Check if multilevel is one of the inputs that lead to averaging.
 
-    True if `multilevel_or_multioutput`
-    is one of the strings `"uniform_average"`, `"uniform_average_time"`
+    True if `multilevel_or_multioutput` is one of the strings `"uniform_average"`,
+    `"uniform_average_time"`
 
-    False if `multilevel_or_multioutput`
-    is the string `"raw_values"`
+    False if `multilevel_or_multioutput` is the string `"raw_values"`
 
     True otherwise
     """

--- a/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
@@ -40,20 +40,14 @@ y_train_multi, y_test_multi = temporal_train_test_split(y_multi)
 fh_multi = np.arange(len(y_test_multi)) + 1
 f_multi = NaiveVariance(NaiveForecaster())
 f_multi.fit(y_train_multi)
-"""
-Cases we need to test
-score average = TRUE/FALSE
-multivariable = TRUE/FALSE
-multiscores = TRUE/FALSE
+"""Cases we need to test score average = TRUE/FALSE multivariable = TRUE/FALSE
+multiscores = TRUE/FALSE.
 
-Data types
-Univariate and single score
-Univariate and multi score
-Multivariate and single score
-Multivariate and multiscor
+Data types Univariate and single score Univariate and multi score Multivariate and
+single score Multivariate and multiscor
 
-For each of the data types we need to test with score average = T/F \
-    and multioutput with "raw_values" and "uniform_average"
+For each of the data types we need to test with score average = T/F and multioutput with
+"raw_values" and "uniform_average"
 """
 quantile_pred_uni_s = f_uni.predict_quantiles(fh=fh_uni, alpha=[0.5])
 interval_pred_uni_s = f_uni.predict_interval(fh=fh_uni, coverage=0.9)

--- a/sktime/performance_metrics/tests/test_metrics_classes.py
+++ b/sktime/performance_metrics/tests/test_metrics_classes.py
@@ -111,7 +111,6 @@ def test_custom_metric(greater_is_better):
     y = load_airline()
 
     def custom_mape(y_true, y_pred) -> float:
-
         eps = np.finfo(np.float64).eps
 
         result = np.mean(np.abs(y_true - y_pred) / np.maximum(np.abs(y_true), eps))

--- a/sktime/proba/base.py
+++ b/sktime/proba/base.py
@@ -41,15 +41,15 @@ class BaseDistribution(BaseObject):
     def loc(self):
         """Location indexer.
 
-        Use `my_distribution.loc[index]` for `pandas`-like row/column subsetting
-        of `BaseDistribution` descendants.
+        Use `my_distribution.loc[index]` for `pandas`-like row/column subsetting of
+        `BaseDistribution` descendants.
 
         `index` can be any `pandas` `loc` compatible index subsetter.
 
         `my_distribution.loc[index]` or `my_distribution.loc[row_index, col_index]`
-        subset `my_distribution` to rows defined by `row_index`, cols by `col_index`,
-        to exactly the same/cols rows as `pandas` `loc` would subset
-        rows in `my_distribution.index` and columns in `my_distribution.columns`.
+        subset `my_distribution` to rows defined by `row_index`, cols by `col_index`, to
+        exactly the same/cols rows as `pandas` `loc` would subset rows in
+        `my_distribution.index` and columns in `my_distribution.columns`.
         """
         return _Indexer(ref=self, method="_loc")
 
@@ -57,15 +57,15 @@ class BaseDistribution(BaseObject):
     def iloc(self):
         """Integer location indexer.
 
-        Use `my_distribution.iloc[index]` for `pandas`-like row/column subsetting
-        of `BaseDistribution` descendants.
+        Use `my_distribution.iloc[index]` for `pandas`-like row/column subsetting of
+        `BaseDistribution` descendants.
 
         `index` can be any `pandas` `iloc` compatible index subsetter.
 
         `my_distribution.iloc[index]` or `my_distribution.iloc[row_index, col_index]`
-        subset `my_distribution` to rows defined by `row_index`, cols by `col_index`,
-        to exactly the same/cols rows as `pandas` `iloc` would subset
-        rows in `my_distribution.index` and columns in `my_distribution.columns`.
+        subset `my_distribution` to rows defined by `row_index`, cols by `col_index`, to
+        exactly the same/cols rows as `pandas` `iloc` would subset rows in
+        `my_distribution.index` and columns in `my_distribution.columns`.
         """
         return _Indexer(ref=self, method="_iloc")
 
@@ -342,7 +342,7 @@ class BaseDistribution(BaseObject):
         return spl.groupby(level=1).mean()
 
     def pdfnorm(self, a=2):
-        r"""a-norm of pdf, defaults to 2-norm.
+        r"""A-norm of pdf, defaults to 2-norm.
 
         computes a-norm of the entry marginal pdf, i.e.,
         :math:`\mathbb{E}[p_X(X)^{a-1}] = \int p(x)^a dx`,

--- a/sktime/proba/base.py
+++ b/sktime/proba/base.py
@@ -31,7 +31,6 @@ class BaseDistribution(BaseObject):
     }
 
     def __init__(self, index=None, columns=None):
-
         self.index = index
         self.columns = columns
 
@@ -87,7 +86,6 @@ class BaseDistribution(BaseObject):
         return self._iloc(rowidx=row_iloc, colidx=col_iloc)
 
     def _subset_params(self, rowidx, colidx):
-
         params = self._get_dist_params()
 
         subset_param_dict = {}
@@ -126,7 +124,6 @@ class BaseDistribution(BaseObject):
         )
 
     def _get_dist_params(self):
-
         params = self.get_params(deep=False)
         paramnames = params.keys()
         reserved_names = ["index", "columns"]
@@ -510,13 +507,11 @@ class _BaseTFDistribution(BaseDistribution):
     }
 
     def __init__(self, index=None, columns=None, distr=None):
-
         self.distr = distr
 
         super(_BaseTFDistribution, self).__init__(index=index, columns=columns)
 
     def __str__(self):
-
         return self.to_str()
 
     def pdf(self, x):

--- a/sktime/proba/normal.py
+++ b/sktime/proba/normal.py
@@ -37,7 +37,6 @@ class Normal(BaseDistribution):
     }
 
     def __init__(self, mu, sigma, index=None, columns=None):
-
         self.mu = mu
         self.sigma = sigma
         self.index = index

--- a/sktime/proba/tests/test_base_default_methods.py
+++ b/sktime/proba/tests/test_base_default_methods.py
@@ -30,7 +30,6 @@ class _DistrDefaultMethodTester(BaseDistribution):
     }
 
     def __init__(self, mu, sigma, index=None, columns=None):
-
         self.mu = mu
         self.sigma = sigma
         self.index = index

--- a/sktime/proba/tests/test_base_default_methods.py
+++ b/sktime/proba/tests/test_base_default_methods.py
@@ -2,12 +2,12 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Test class for default methods.
 
-This is not for direct use, but for testing whether the defaulting in various
-methods works.
+This is not for direct use, but for testing whether the defaulting in various methods
+works.
 
-Testing works via TestAllDistributions which discovers the classes in
-here, executes the public methods in interface conformance tests,
-which in turn triggers the fallback defaults.
+Testing works via TestAllDistributions which discovers the classes in here, executes the
+public methods in interface conformance tests, which in turn triggers the fallback
+defaults.
 """
 
 __author__ = ["fkiraly"]

--- a/sktime/proba/tfp.py
+++ b/sktime/proba/tfp.py
@@ -38,7 +38,6 @@ class TFNormal(_BaseTFDistribution):
     }
 
     def __init__(self, mu, sigma, index=None, columns=None):
-
         self.mu = mu
         self.sigma = sigma
         self.index = index

--- a/sktime/registry/_base_classes.py
+++ b/sktime/registry/_base_classes.py
@@ -50,8 +50,6 @@ TRANSFORMER_MIXIN_LIST - list of string
 
 TRANSFORMER_MIXIN_LOOKUP - dictionary
     keys/entries are 0/1-th entries of TRANSFORMER_MIXIN_REGISTER
-
-
 """
 
 __author__ = ["fkiraly"]

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -251,7 +251,7 @@ def _check_tag_cond(estimator, filter_tags=None, as_dataframe=True):
 
     cond_sat = True
 
-    for (key, value) in filter_tags.items():
+    for key, value in filter_tags.items():
         if not isinstance(value, list):
             value = [value]
         cond_sat = cond_sat and estimator.get_class_tag(key) in set(value)

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -37,7 +37,6 @@ ESTIMATOR_TAG_LIST - list of string
 ---
 
 check_tag_is_valid(tag_name, tag_value) - checks whether tag_value is valid for tag_name
-
 """
 
 __author__ = ["fkiraly", "victordremov"]

--- a/sktime/registry/tests/test_lookup.py
+++ b/sktime/registry/tests/test_lookup.py
@@ -59,7 +59,6 @@ def _get_type_tuple(estimator_scitype):
         corresponding to scitype strings in estimator_scitypes
     """
     if estimator_scitype is not None:
-
         estimator_classes = tuple(
             BASE_CLASS_LOOKUP[scitype] for scitype in _to_list(estimator_scitype)
         )

--- a/sktime/regression/_delegate.py
+++ b/sktime/regression/_delegate.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Delegator mixin that delegates all methods to wrapped regressors.
 
-Useful for building estimators where all but one or a few methods are delegated.
-For that purpose, inherit from this estimator and then override only the methods
-    that are not delegated.
+Useful for building estimators where all but one or a few methods are delegated. For
+that purpose, inherit from this estimator and then override only the methods     that
+are not delegated.
 """
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Abstract base class for time series regressors.
+"""Abstract base class for time series regressors.
 
     class name: BaseRegressor
 

--- a/sktime/regression/compose/_ensemble.py
+++ b/sktime/regression/compose/_ensemble.py
@@ -225,10 +225,10 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
     def fit(self, X, y, **kwargs):
         """Wrap fit to call BaseRegressor.fit.
 
-        This is a fix to get around the problem with multiple inheritance. The
-        problem is that if we just override _fit, this class inherits the fit from
-        the sklearn class BaseTimeSeriesForest. This is the simplest solution,
-        albeit a little hacky.
+        This is a fix to get around the problem with multiple inheritance. The problem
+        is that if we just override _fit, this class inherits the fit from the sklearn
+        class BaseTimeSeriesForest. This is the simplest solution, albeit a little
+        hacky.
         """
         return BaseRegressor.fit(self, X=X, y=y, **kwargs)
 

--- a/sktime/regression/compose/_ensemble.py
+++ b/sktime/regression/compose/_ensemble.py
@@ -48,7 +48,7 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
         The function to measure the quality of a split. Supported criteria are
         "squared_error" for the mean squared error, which is equal to variance reduction
         as feature selection criterion and minimizes the L2 loss using the mean of each
-        terminal node, "friedman_mse", which uses mean squared error with Friedman’s
+        terminal node, "friedman_mse", which uses mean squared error with Friedman's
         improvement score for potential splits, "absolute_error" for the mean absolute
         error, which minimizes the L1 loss using the median of each terminal node,
         and "poisson" which uses reduction in Poisson deviance to find splits.

--- a/sktime/regression/compose/_ensemble.py
+++ b/sktime/regression/compose/_ensemble.py
@@ -191,7 +191,6 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
         warm_start=False,
         max_samples=None,
     ):
-
         self.estimator = estimator
         # Assign values, even though passed on to base estimator below,
         # necessary here for cloning
@@ -245,7 +244,6 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
         BaseTimeSeriesForest._fit(self, X=X, y=y)
 
     def _validate_estimator(self):
-
         if not isinstance(self.n_estimators, numbers.Integral):
             raise ValueError(
                 "n_estimators must be an integer, "

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -102,7 +102,6 @@ class RegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
     # no default tag values - these are set dynamically below
 
     def __init__(self, regressor, transformers):
-
         self.regressor = regressor
         self.regressor_ = regressor.clone()
         self.transformers = transformers
@@ -392,7 +391,6 @@ class SklearnRegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
     # no default tag values - these are set dynamically below
 
     def __init__(self, regressor, transformers):
-
         from sklearn.base import clone
 
         self.regressor = regressor

--- a/sktime/regression/deep_learning/base.py
+++ b/sktime/regression/deep_learning/base.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Abstract base class for the Keras neural network regressors.
+"""Abstract base class for the Keras neural network regressors.
 
 The reason for this class between BaseClassifier and deep_learning classifiers is
 because we can generalise tags and _predict
@@ -48,8 +47,7 @@ class BaseDeepRegressor(BaseRegressor, ABC):
 
     @abstractmethod
     def build_model(self, input_shape, **kwargs):
-        """
-        Construct a compiled, un-trained, keras model that is ready for training.
+        """Construct a compiled, un-trained, keras model that is ready for training.
 
         Parameters
         ----------
@@ -63,8 +61,7 @@ class BaseDeepRegressor(BaseRegressor, ABC):
         ...
 
     def _predict(self, X, **kwargs):
-        """
-        Find regression estimate for all cases in X.
+        """Find regression estimate for all cases in X.
 
         Parameters
         ----------

--- a/sktime/regression/deep_learning/resnet.py
+++ b/sktime/regression/deep_learning/resnet.py
@@ -13,8 +13,7 @@ from sktime.utils.validation._dependencies import _check_dl_dependencies
 
 
 class ResNetRegressor(BaseDeepRegressor):
-    """
-    Residual Neural Network Regressor adopted from [1].
+    """Residual Neural Network Regressor adopted from [1].
 
     Parameters
     ----------

--- a/sktime/regression/deep_learning/rnn.py
+++ b/sktime/regression/deep_learning/rnn.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
-
 """Time Recurrent Neural Network (RNN) for regression."""
 
 __author__ = ["mloning"]
@@ -16,8 +15,7 @@ from sktime.utils.validation._dependencies import _check_dl_dependencies
 
 
 class SimpleRNNRegressor(BaseDeepRegressor):
-    """
-    Simple recurrent neural network.
+    """Simple recurrent neural network.
 
     Parameters
     ----------
@@ -85,8 +83,7 @@ class SimpleRNNRegressor(BaseDeepRegressor):
         self._network = RNNNetwork(random_state=random_state, units=units)
 
     def build_model(self, input_shape, **kwargs):
-        """
-        Construct a compiled, un-trained, keras model that is ready for training.
+        """Construct a compiled, un-trained, keras model that is ready for training.
 
         Parameters
         ----------
@@ -120,8 +117,7 @@ class SimpleRNNRegressor(BaseDeepRegressor):
         return model
 
     def _fit(self, X, y):
-        """
-        Fit the regressor on the training set (X, y).
+        """Fit the regressor on the training set (X, y).
 
         Parameters
         ----------

--- a/sktime/regression/deep_learning/tapnet.py
+++ b/sktime/regression/deep_learning/tapnet.py
@@ -195,8 +195,7 @@ class TapNetRegressor(BaseDeepRegressor):
         return model
 
     def _fit(self, X, y):
-        """
-        Fit the regressor on the training set (X, y).
+        """Fit the regressor on the training set (X, y).
 
         Parameters
         ----------

--- a/sktime/regression/distance_based/_time_series_neighbors.py
+++ b/sktime/regression/distance_based/_time_series_neighbors.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """KNN time series regression.
 
-This class is a KNN regressor which supports time series distance measures.
-The class has hardcoded string references to numba based distances in sktime.distances.
-It can also be used with callables, or sktime (pairwise transformer) estimators.
+This class is a KNN regressor which supports time series distance measures. The class
+has hardcoded string references to numba based distances in sktime.distances. It can
+also be used with callables, or sktime (pairwise transformer) estimators.
 
-This is a direct wrap or sklearn KNeighbors, with added functionality that allows
-time series distances to be passed, and the sktime time series regressor interface.
+This is a direct wrap or sklearn KNeighbors, with added functionality that allows time
+series distances to be passed, and the sktime time series regressor interface.
 """
 
 __author__ = ["fkiraly"]

--- a/sktime/regression/distance_based/_time_series_neighbors.py
+++ b/sktime/regression/distance_based/_time_series_neighbors.py
@@ -49,7 +49,7 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
         one of: 'uniform', 'distance', or a callable function
     algorithm : str, optional. default = 'brute'
         search method for neighbours
-        one of {'auto’, 'ball_tree', 'kd_tree', 'brute'}
+        one of {'auto', 'ball_tree', 'kd_tree', 'brute'}
     distance : str or callable, optional. default ='dtw'
         distance measure between time series
         if str, must be one of the following strings:

--- a/sktime/regression/tests/__init__.py
+++ b/sktime/regression/tests/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-"""tests for all time series regressors."""
+"""Tests for all time series regressors."""

--- a/sktime/series_as_features/base/estimators/interval_based/_tsf.py
+++ b/sktime/series_as_features/base/estimators/interval_based/_tsf.py
@@ -121,7 +121,6 @@ class BaseTimeSeriesForest:
         return self
 
     def _get_fitted_params(self):
-
         return {
             "classes": self.classes_,
             "intervals": self.intervals_,

--- a/sktime/series_as_features/base/estimators/tests/test_feature_importances_.py
+++ b/sktime/series_as_features/base/estimators/tests/test_feature_importances_.py
@@ -22,8 +22,8 @@ X_train, y_train = make_classification_problem()
 def test_feature_importances_single_feature_interval_and_estimator():
     """Test feature importances for single feature interval and estimator.
 
-    Check results of a simple case of single estimator, single feature and
-    single interval from different but equivalent implementations
+    Check results of a simple case of single estimator, single feature and single
+    interval from different but equivalent implementations
     """
     random_state = 1234
 
@@ -78,10 +78,9 @@ def test_feature_importances_single_feature_interval_and_estimator():
 def test_feature_importances_multi_intervals_estimators(n_intervals, n_estimators):
     """Test feature importances for multiple feature intervals and estimators.
 
-    Check for 4 more complex cases with 3 features, with both numbers of
-    intervals and estimators varied from 1 to 2.
-    Feature importances from each estimator on each interval, and
-    normalised feature values of the time series are checked using
+    Check for 4 more complex cases with 3 features, with both numbers of intervals and
+    estimators varied from 1 to 2. Feature importances from each estimator on each
+    interval, and normalised feature values of the time series are checked using
     different but equivalent implementations
     """
     random_state = 1234

--- a/sktime/series_as_features/model_selection/_split.py
+++ b/sktime/series_as_features/model_selection/_split.py
@@ -11,19 +11,17 @@ from sklearn.model_selection import train_test_split
 
 
 class PresplitFilesCV:
-    """
-    Cross-validation iterator over split predefined in files.
+    """Cross-validation iterator over split predefined in files.
 
-    This class is useful in orchestration where the train and test set
-    is provided in separate files.
+    This class is useful in orchestration where the train and test set is provided in
+    separate files.
     """
 
     def __init__(self, cv=None):
         self.cv = cv
 
     def split(self, data, y=None, groups=None):
-        """
-        Split the data according to the train/test index.
+        """Split the data according to the train/test index.
 
         Parameters
         ----------
@@ -67,8 +65,7 @@ class PresplitFilesCV:
                 yield train, test
 
     def get_n_splits(self):
-        """
-        Return the number of splits.
+        """Return the number of splits.
 
         Returns
         -------
@@ -79,8 +76,7 @@ class PresplitFilesCV:
 
 
 class SingleSplit:
-    """
-    Helper class for orchestration that uses a single split for training and testing.
+    """Helper class for orchestration that uses a single split for training and testing.
 
     Wrapper for sklearn.model_selection.train_test_split
 
@@ -130,8 +126,7 @@ class SingleSplit:
         self._stratify = stratify
 
     def split(self, data, y=None, groups=None):
-        """
-        Split the data into training and testing data.
+        """Split the data into training and testing data.
 
         Parameters
         ----------

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -553,7 +553,6 @@ class QuickTester:
         results = dict()
         # loop A: we loop over all the tests
         for test_name in test_names_subset:
-
             test_fun = getattr(self, test_name)
             fixture_sequence = self.fixture_sequence
 
@@ -593,7 +592,6 @@ class QuickTester:
 
             # loop B: for each test, we loop over all fixtures
             for params, fixt_name in zip(fixture_prod, fixture_names):
-
                 # this is needed because pytest unwraps 1-tuples automatically
                 # but subsequent code assumes params is k-tuple, no matter what k is
                 if len(fixture_vars) == 1:

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -74,8 +74,8 @@ CYTHON_ESTIMATORS = False
 def subsample_by_version_os(x):
     """Subsample objects by operating system and python version.
 
-    Ensures each estimator is tested at least once on every OS and python version,
-    if combined with a matrix of OS/versions.
+    Ensures each estimator is tested at least once on every OS and python version, if
+    combined with a matrix of OS/versions.
 
     Currently assumes that matrix includes py3.8-3.10, and win/ubuntu/mac.
     """
@@ -167,8 +167,8 @@ class BaseFixtureGenerator:
     def pytest_generate_tests(self, metafunc):
         """Test parameterization routine for pytest.
 
-        This uses create_conditional_fixtures_and_names and generator_dict
-        to create the fixtures for a mark.parametrize decoration of all tests.
+        This uses create_conditional_fixtures_and_names and generator_dict to create the
+        fixtures for a mark.parametrize decoration of all tests.
         """
         # get name of the test
         test_name = metafunc.function.__name__
@@ -795,9 +795,9 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
     def test_create_test_instances_and_names(self, estimator_class):
         """Check that create_test_instances_and_names works.
 
-        create_test_instance and create_test_instances_and_names are the
-        key methods used to create test instances in testing.
-        If this test does not pass, validity of the other tests cannot be guaranteed.
+        create_test_instance and create_test_instances_and_names are the key methods
+        used to create test instances in testing. If this test does not pass, validity
+        of the other tests cannot be guaranteed.
 
         Tests expected function signature of create_test_instances_and_names.
         """
@@ -945,9 +945,9 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
     def test_set_params_sklearn(self, estimator_class):
         """Check that set_params works correctly, mirrors sklearn check_set_params.
 
-        Instead of the "fuzz values" in sklearn's check_set_params,
-        we use the other test parameter settings (which are assumed valid).
-        This guarantees settings which play along with the __init__ content.
+        Instead of the "fuzz values" in sklearn's check_set_params, we use the other
+        test parameter settings (which are assumed valid). This guarantees settings
+        which play along with the __init__ content.
         """
         estimator = estimator_class.create_test_instance()
         test_params = estimator_class.get_test_params()
@@ -1424,8 +1424,8 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         """Test that single and multi-process run results are identical.
 
         Check that running an estimator on a single process is no different to running
-        it on multiple processes. We also check that we can set n_jobs=-1 to make use
-        of all CPUs. The test is not really necessary though, as we rely on joblib for
+        it on multiple processes. We also check that we can set n_jobs=-1 to make use of
+        all CPUs. The test is not really necessary though, as we rely on joblib for
         parallelization and can trust that it works as expected.
         """
         method_nsc = method_nsc_arraylike

--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -2,8 +2,8 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Tests that soft dependencies are handled correctly.
 
-sktime supports a number of soft dependencies which are necessary for using
-a certain module but otherwise not necessary.
+sktime supports a number of soft dependencies which are necessary for using a certain
+module but otherwise not necessary.
 
 Adapted from code of mloning for the legacy Azure CI/CD build tools.
 """

--- a/sktime/transformations/_delegate.py
+++ b/sktime/transformations/_delegate.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Delegator mixin that delegates all methods to wrapped transformer.
 
-Useful for building estimators where all but one or a few methods are delegated.
-For that purpose, inherit from this estimator and then override only the methods
-    that are not delegated.
+Useful for building estimators where all but one or a few methods are delegated. For
+that purpose, inherit from this estimator and then override only the methods     that
+are not delegated.
 """
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""
-Base class template for transformers.
+"""Base class template for transformers.
 
     class name: BaseTransformer
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -166,7 +166,6 @@ class BaseTransformer(BaseEstimator):
     ]
 
     def __init__(self):
-
         self._converter_store_X = dict()  # storage dictionary for in/output conversion
 
         super(BaseTransformer, self).__init__()
@@ -970,7 +969,6 @@ class BaseTransformer(BaseEstimator):
         # end checking X
 
         if y_inner_mtype != ["None"] and y is not None:
-
             if "Table" in y_inner_scitype:
                 y_possible_scitypes = "Table"
             elif X_scitype == "Series":

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -123,10 +123,9 @@ class ColumnEnsembleTransformer(_HeterogenousMetaEstimator, _ColumnEstimator):
     def _transformers(self):
         """Make internal list of transformers.
 
-        The list only contains the name and transformers, dropping
-        the columns. This is for the implementation of get_params
-        via _HeterogenousMetaEstimator._get_params which expects
-        lists of tuples of len 2.
+        The list only contains the name and transformers, dropping the columns. This is
+        for the implementation of get_params via _HeterogenousMetaEstimator._get_params
+        which expects lists of tuples of len 2.
         """
         transformers = self.transformers
         if isinstance(transformers, BaseTransformer):

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -170,7 +170,7 @@ class ColumnEnsembleTransformer(_HeterogenousMetaEstimator, _ColumnEstimator):
         self.transformers_ = []
         self._Xcolumns = list(X.columns)
 
-        for (name, transformer, index) in transformers:
+        for name, transformer, index in transformers:
             transformer_ = transformer.clone()
 
             pd_index = self._coerce_to_pd_index(index)

--- a/sktime/transformations/compose/_featureunion.py
+++ b/sktime/transformations/compose/_featureunion.py
@@ -78,7 +78,6 @@ class FeatureUnion(_HeterogenousMetaEstimator, BaseTransformer):
         transformer_weights=None,
         flatten_transform_index=True,
     ):
-
         self.transformer_list = transformer_list
         self.transformer_list_ = self._check_estimators(
             transformer_list, cls_type=BaseTransformer

--- a/sktime/transformations/compose/_grouped.py
+++ b/sktime/transformations/compose/_grouped.py
@@ -72,7 +72,6 @@ class TransformByLevel(_DelegatedTransformer):
     _delegate_name = "transformer_"
 
     def __init__(self, transformer, groupby="local", raise_warnings=True):
-
         self.transformer = transformer
         self.groupby = groupby
         self.raise_warnings = raise_warnings

--- a/sktime/transformations/compose/_id.py
+++ b/sktime/transformations/compose/_id.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Identity transformer.
 
-Note to developers: this is used as a component in many other transformers,
-therefore one should avoid importing other transformers from here.
+Note to developers: this is used as a component in many other transformers, therefore
+one should avoid importing other transformers from here.
 """
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 

--- a/sktime/transformations/compose/_ixtox.py
+++ b/sktime/transformations/compose/_ixtox.py
@@ -75,7 +75,6 @@ class IxToX(BaseTransformer):
     }
 
     def __init__(self, coerce_to_type="auto", level=None, ix_source="X"):
-
         self.coerce_to_type = coerce_to_type
         self.level = level
         self.ix_source = ix_source

--- a/sktime/transformations/compose/_pipeline.py
+++ b/sktime/transformations/compose/_pipeline.py
@@ -131,7 +131,6 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
     _steps_fitted_attr = "steps_"
 
     def __init__(self, steps):
-
         self.steps = steps
         self.steps_ = self._check_estimators(self.steps, cls_type=BaseTransformer)
 

--- a/sktime/transformations/compose/_ytox.py
+++ b/sktime/transformations/compose/_ytox.py
@@ -34,7 +34,6 @@ class YtoX(BaseTransformer):
     }
 
     def __init__(self, subset_index=False):
-
         self.subset_index = subset_index
 
         super(YtoX, self).__init__()

--- a/sktime/transformations/hierarchical/aggregate.py
+++ b/sktime/transformations/hierarchical/aggregate.py
@@ -73,7 +73,6 @@ class Aggregator(BaseTransformer):
     }
 
     def __init__(self, flatten_single_levels=True):
-
         self.flatten_single_levels = flatten_single_levels
 
         super(Aggregator, self).__init__()

--- a/sktime/transformations/hierarchical/reconcile.py
+++ b/sktime/transformations/hierarchical/reconcile.py
@@ -98,7 +98,6 @@ class Reconciler(BaseTransformer):
     METHOD_LIST = ["bu", "ols", "wls_str", "td_fcst"]
 
     def __init__(self, method="bu"):
-
         self.method = method
 
         super(Reconciler, self).__init__()
@@ -201,7 +200,6 @@ class Reconciler(BaseTransformer):
         recon_preds = []
         gmat = self.g_matrix
         for _name, group in X:
-
             if self.method == "td_fcst":
                 gmat = _update_td_fcst(
                     g_matrix=gmat, x_sf=group.droplevel(-1), conn_df=self.parent_child

--- a/sktime/transformations/hierarchical/tests/test_aggregate.py
+++ b/sktime/transformations/hierarchical/tests/test_aggregate.py
@@ -16,9 +16,9 @@ from sktime.utils._testing.hierarchical import _bottom_hier_datagen
 def test_aggregator_fit_transform_index(flatten_single_levels):
     """Tests fit_transform of aggregator function.
 
-    This test asserts that the output of Aggregator using fit_transfrom() with a
-    named multiindex is equal to an unnamed one. It also tests that
-    Aggregator does not change the names of the input index in both cases.
+    This test asserts that the output of Aggregator using fit_transfrom() with a named
+    multiindex is equal to an unnamed one. It also tests that Aggregator does not change
+    the names of the input index in both cases.
     """
     agg = Aggregator(flatten_single_levels=flatten_single_levels)
 
@@ -44,8 +44,8 @@ def test_aggregator_fit_transform_index(flatten_single_levels):
 def test_aggregator_flatten():
     """Tests Aggregator flattening single levels.
 
-    This tests that the flatten_single_levels argument works as expected for a
-    fixed example of a complicated hierarchy.
+    This tests that the flatten_single_levels argument works as expected for a fixed
+    example of a complicated hierarchy.
     """
     agg = Aggregator(flatten_single_levels=False)
     agg_flat = Aggregator(flatten_single_levels=True)

--- a/sktime/transformations/panel/channel_selection.py
+++ b/sktime/transformations/panel/channel_selection.py
@@ -62,7 +62,6 @@ class _distance_matrix:
         map_cls = centroid_frame.class_vals.to_dict()
         distance_frame = pd.DataFrame()
         for class_ in distance_pair:
-
             class_pair = []
             # calculate the distance of centroid here
             for _, (q, t) in enumerate(
@@ -194,7 +193,6 @@ class ElbowClassSum(BaseTransformer):
     }
 
     def __init__(self, distance=None):
-
         self.distance = distance
 
         super(ElbowClassSum, self).__init__()

--- a/sktime/transformations/panel/channel_selection.py
+++ b/sktime/transformations/panel/channel_selection.py
@@ -154,8 +154,8 @@ class ElbowClassSum(BaseTransformer):
 
     References
     ----------
-    ..[1]: Bhaskar Dhariyal et al. “Fast Channel Selection for Scalable Multivariate
-    Time Series Classification.” AALTD, ECML-PKDD, Springer, 2021
+    ..[1]: Bhaskar Dhariyal et al. "Fast Channel Selection for Scalable Multivariate
+    Time Series Classification." AALTD, ECML-PKDD, Springer, 2021
 
     Examples
     --------
@@ -327,8 +327,8 @@ class ElbowClassPairwise(BaseTransformer):
 
     References
     ----------
-    ..[1]: Bhaskar Dhariyal et al. “Fast Channel Selection for Scalable Multivariate
-    Time Series Classification.” AALTD, ECML-PKDD, Springer, 2021
+    ..[1]: Bhaskar Dhariyal et al. "Fast Channel Selection for Scalable Multivariate
+    Time Series Classification." AALTD, ECML-PKDD, Springer, 2021
 
     Examples
     --------

--- a/sktime/transformations/panel/channel_selection.py
+++ b/sktime/transformations/panel/channel_selection.py
@@ -253,8 +253,7 @@ class ElbowClassSum(BaseTransformer):
         return self
 
     def _transform(self, X, y=None):
-        """
-        Transform X and return a transformed version.
+        """Transform X and return a transformed version.
 
         Parameters
         ----------
@@ -375,7 +374,6 @@ class ElbowClassPairwise(BaseTransformer):
         Returns
         -------
         self : reference to self.
-
         """
         self.channels_selected_ = []
         start = int(round(time.time() * 1000))
@@ -395,8 +393,7 @@ class ElbowClassPairwise(BaseTransformer):
         return self
 
     def _transform(self, X, y=None):
-        """
-        Transform X and return a transformed version.
+        """Transform X and return a transformed version.
 
         Parameters
         ----------

--- a/sktime/transformations/panel/compose.py
+++ b/sktime/transformations/panel/compose.py
@@ -141,11 +141,9 @@ class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
         self._is_fitted = False
 
     def _hstack(self, Xs):
-        """
-        Stacks X horizontally.
+        """Stacks X horizontally.
 
-        Supports input types (X): list of numpy arrays, sparse arrays and
-        DataFrames
+        Supports input types (X): list of numpy arrays, sparse arrays and DataFrames
         """
         types = set(type(X) for X in Xs)
 
@@ -168,8 +166,8 @@ class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
     def _validate_output(self, result):
         """Validate output of every transformer.
 
-        Ensure that the output of each transformer is 2D. Otherwise
-        hstack can raise an error or produce incorrect results.
+        Ensure that the output of each transformer is 2D. Otherwise hstack can raise an
+        error or produce incorrect results.
 
         Output can also be a pd.Series which is actually a 1D
         """

--- a/sktime/transformations/panel/compose.py
+++ b/sktime/transformations/panel/compose.py
@@ -119,7 +119,6 @@ class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
         transformer_weights=None,
         preserve_dataframe=True,
     ):
-
         warn(
             "ColumnTransformer is not fully compliant with the sktime interface "
             "and will be replaced by sktime.transformations.ColumnEnsembleTransformer "

--- a/sktime/transformations/panel/dictionary_based/_sfa_fast.py
+++ b/sktime/transformations/panel/dictionary_based/_sfa_fast.py
@@ -2,7 +2,6 @@
 """Symbolic Fourier Approximation (SFA) Transformer.
 
 Configurable SFA transform for discretising time series into words.
-
 """
 
 __author__ = ["patrickzib"]

--- a/sktime/transformations/panel/dwt.py
+++ b/sktime/transformations/panel/dwt.py
@@ -89,9 +89,8 @@ class DWTTransformer(BaseTransformer):
     def _extract_wavelet_coefficients(self, data):
         """Extract wavelet coefficients of a 2d array of time series.
 
-        The coefficients correspond to the wavelet coefficients
-        from levels 1 to num_levels followed by the approximation
-        coefficients of the highest level.
+        The coefficients correspond to the wavelet coefficients from levels 1 to
+        num_levels followed by the approximation coefficients of the highest level.
         """
         num_levels = self.num_levels
         res = []

--- a/sktime/transformations/panel/pca.py
+++ b/sktime/transformations/panel/pca.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""sklearn PCA applied after flattening series."""
+"""Sklearn PCA applied after flattening series."""
 __author__ = ["prockenschaub", "fkiraly"]
 __all__ = ["PCATransformer"]
 

--- a/sktime/transformations/panel/reduce.py
+++ b/sktime/transformations/panel/reduce.py
@@ -111,7 +111,6 @@ class TimeBinner(BaseTransformer):
     }
 
     def __init__(self, idx, aggfunc=None):
-
         assert isinstance(
             idx, pd.IntervalIndex
         ), "idx should be of type pd.IntervalIndex"

--- a/sktime/transformations/panel/reduce.py
+++ b/sktime/transformations/panel/reduce.py
@@ -15,15 +15,13 @@ from sktime.transformations.base import BaseTransformer
 
 
 class Tabularizer(BaseTransformer):
-    """
-    A transformer that turns time series/panel data into tabular data.
+    """A transformer that turns time series/panel data into tabular data.
 
-    This estimator converts nested pandas dataframe containing
-    time-series/panel data with numpy arrays or pandas Series in
-    dataframe cells into a tabular pandas dataframe with only primitives in
-    cells. This is useful for transforming
-    time-series/panel data into a format that is accepted by standard
-    validation learning algorithms (as in sklearn).
+    This estimator converts nested pandas dataframe containing time-series/panel data
+    with numpy arrays or pandas Series in dataframe cells into a tabular pandas
+    dataframe with only primitives in cells. This is useful for transforming time-
+    series/panel data into a format that is accepted by standard validation learning
+    algorithms (as in sklearn).
     """
 
     _tags = {

--- a/sktime/transformations/panel/rocket/_minirocket_multi_numba.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multi_numba.py
@@ -34,7 +34,6 @@ def _fit_biases_multi(
     quantiles,
     seed,
 ):
-
     if seed is not None:
         np.random.seed(seed)
 
@@ -314,14 +313,12 @@ def _fit_biases_multi(
     num_channels_start = 0
 
     for dilation_index in range(num_dilations):
-
         dilation = dilations[dilation_index]
         padding = ((9 - 1) * dilation) // 2
 
         num_features_this_dilation = num_features_per_dilation[dilation_index]
 
         for kernel_index in range(num_kernels):
-
             feature_index_end = feature_index_start + num_features_this_dilation
 
             num_channels_this_combination = num_channels_per_combination[
@@ -353,14 +350,12 @@ def _fit_biases_multi(
             end = n_timepoints - padding
 
             for gamma_index in range(9 // 2):
-
                 C_alpha[:, -end:] = C_alpha[:, -end:] + A[:, :end]
                 C_gamma[gamma_index, :, -end:] = G[:, :end]
 
                 end += dilation
 
             for gamma_index in range(9 // 2 + 1, 9):
-
                 C_alpha[:, :-start] = C_alpha[:, :-start] + A[:, start:]
                 C_gamma[gamma_index, :, :-start] = G[:, start:]
 
@@ -384,7 +379,6 @@ def _fit_biases_multi(
 
 
 def _fit_dilations(n_timepoints, num_features, max_dilations_per_kernel):
-
     num_kernels = 84
 
     num_features_per_kernel = num_features // num_kernels
@@ -484,7 +478,6 @@ def _fit_multi(X, num_features=10_000, max_dilations_per_kernel=32, seed=None):
     cache=True,
 )
 def _transform_multi(X, parameters):
-
     n_instances, n_columns, n_timepoints = X.shape
 
     (
@@ -764,7 +757,6 @@ def _transform_multi(X, parameters):
     features = np.zeros((n_instances, num_features), dtype=np.float32)
 
     for example_index in prange(n_instances):
-
         _X = X[example_index]
 
         A = -_X  # A = alpha * X = -X
@@ -776,7 +768,6 @@ def _transform_multi(X, parameters):
         num_channels_start = 0
 
         for dilation_index in range(num_dilations):
-
             _padding0 = dilation_index % 2
 
             dilation = dilations[dilation_index]
@@ -794,21 +785,18 @@ def _transform_multi(X, parameters):
             end = n_timepoints - padding
 
             for gamma_index in range(9 // 2):
-
                 C_alpha[:, -end:] = C_alpha[:, -end:] + A[:, :end]
                 C_gamma[gamma_index, :, -end:] = G[:, :end]
 
                 end += dilation
 
             for gamma_index in range(9 // 2 + 1, 9):
-
                 C_alpha[:, :-start] = C_alpha[:, :-start] + A[:, start:]
                 C_gamma[gamma_index, :, :-start] = G[:, start:]
 
                 start += dilation
 
             for kernel_index in range(num_kernels):
-
                 feature_index_end = feature_index_start + num_features_this_dilation
 
                 num_channels_this_combination = num_channels_per_combination[

--- a/sktime/transformations/panel/rocket/_minirocket_multi_var_numba.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multi_var_numba.py
@@ -318,14 +318,12 @@ def _fit_biases_multi_var(
     num_channels_start = 0
 
     for dilation_index in range(num_dilations):
-
         dilation = dilations[dilation_index]
         padding = ((9 - 1) * dilation) // 2
 
         num_features_this_dilation = num_features_per_dilation[dilation_index]
 
         for kernel_index in range(num_kernels):
-
             feature_index_end = feature_index_start + num_features_this_dilation
 
             num_channels_this_combination = num_channels_per_combination[
@@ -364,19 +362,15 @@ def _fit_biases_multi_var(
             end = input_length - padding
 
             for gamma_index in range(9 // 2):
-
                 # thanks to Murtaza Jafferji @murtazajafferji for suggesting this fix
                 if end > 0:
-
                     C_alpha[:, -end:] = C_alpha[:, -end:] + A[:, :end]
                     C_gamma[gamma_index, :, -end:] = G[:, :end]
 
                 end += dilation
 
             for gamma_index in range(9 // 2 + 1, 9):
-
                 if start < input_length:
-
                     C_alpha[:, :-start] = C_alpha[:, :-start] + A[:, start:]
                     C_gamma[gamma_index, :, :-start] = G[:, start:]
 
@@ -400,7 +394,6 @@ def _fit_biases_multi_var(
 
 
 def _fit_dilations_multi_var(reference_length, num_features, max_dilations_per_kernel):
-
     num_kernels = 84
 
     num_features_per_kernel = num_features // num_kernels
@@ -518,7 +511,6 @@ def _fit_multi_var(
     cache=True,
 )
 def _transform_multi_var(X, L, parameters):
-
     n_instances = len(L)
 
     num_channels, _ = X.shape
@@ -802,7 +794,6 @@ def _transform_multi_var(X, L, parameters):
     features = np.zeros((n_instances, num_features), dtype=np.float32)
 
     for example_index in prange(n_instances):
-
         input_length = np.int64(L[example_index])
 
         b = np.sum(L[0 : example_index + 1])
@@ -819,7 +810,6 @@ def _transform_multi_var(X, L, parameters):
         num_channels_start = 0
 
         for dilation_index in range(num_dilations):
-
             dilation = dilations[dilation_index]
             padding = ((9 - 1) * dilation) // 2
 
@@ -835,7 +825,6 @@ def _transform_multi_var(X, L, parameters):
             end = input_length - padding
 
             for gamma_index in range(9 // 2):
-
                 # thanks to Murtaza Jafferji @murtazajafferji for suggesting this fix
                 if end > 0:
                     C_alpha[:, -end:] = C_alpha[:, -end:] + A[:, :end]
@@ -844,7 +833,6 @@ def _transform_multi_var(X, L, parameters):
                 end += dilation
 
             for gamma_index in range(9 // 2 + 1, 9):
-
                 if start < input_length:
                     C_alpha[:, :-start] = C_alpha[:, :-start] + A[:, start:]
                     C_gamma[gamma_index, :, :-start] = G[:, start:]
@@ -852,7 +840,6 @@ def _transform_multi_var(X, L, parameters):
                 start += dilation
 
             for kernel_index in range(num_kernels):
-
                 feature_index_end = feature_index_start + num_features_this_dilation
 
                 num_channels_this_combination = num_channels_per_combination[

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
@@ -78,7 +78,6 @@ class MiniRocketMultivariateVariable(BaseTransformer):
 
     .. [2] Angus Dempster, Daniel F Schmidt, Geoffrey I Webb
            https://github.com/angus924/minirocket
-
     """
 
     _tags = {

--- a/sktime/transformations/panel/rocket/_minirocket_numba.py
+++ b/sktime/transformations/panel/rocket/_minirocket_numba.py
@@ -26,7 +26,6 @@ if _check_soft_dependencies("numba", severity="none"):
     cache=True,
 )
 def _fit_biases(X, dilations, num_features_per_dilation, quantiles, seed):
-
     if seed is not None:
         np.random.seed(seed)
 
@@ -303,14 +302,12 @@ def _fit_biases(X, dilations, num_features_per_dilation, quantiles, seed):
     feature_index_start = 0
 
     for dilation_index in range(num_dilations):
-
         dilation = dilations[dilation_index]
         padding = ((9 - 1) * dilation) // 2
 
         num_features_this_dilation = num_features_per_dilation[dilation_index]
 
         for kernel_index in range(num_kernels):
-
             feature_index_end = feature_index_start + num_features_this_dilation
 
             _X = X[np.random.randint(n_instances)]
@@ -328,14 +325,12 @@ def _fit_biases(X, dilations, num_features_per_dilation, quantiles, seed):
             end = n_timepoints - padding
 
             for gamma_index in range(9 // 2):
-
                 C_alpha[-end:] = C_alpha[-end:] + A[:end]
                 C_gamma[gamma_index, -end:] = G[:end]
 
                 end += dilation
 
             for gamma_index in range(9 // 2 + 1, 9):
-
                 C_alpha[:-start] = C_alpha[:-start] + A[start:]
                 C_gamma[gamma_index, :-start] = G[start:]
 
@@ -355,7 +350,6 @@ def _fit_biases(X, dilations, num_features_per_dilation, quantiles, seed):
 
 
 def _fit_dilations(n_timepoints, num_features, max_dilations_per_kernel):
-
     num_kernels = 84
 
     num_features_per_kernel = num_features // num_kernels
@@ -392,7 +386,6 @@ def _quantiles(n):
 
 
 def _fit(X, num_features=10_000, max_dilations_per_kernel=32, seed=None):
-
     _, n_timepoints = X.shape
 
     num_kernels = 84
@@ -417,7 +410,6 @@ def _fit(X, num_features=10_000, max_dilations_per_kernel=32, seed=None):
     cache=True,
 )
 def _transform(X, parameters):
-
     n_instances, n_timepoints = X.shape
 
     dilations, num_features_per_dilation, biases = parameters
@@ -691,7 +683,6 @@ def _transform(X, parameters):
     features = np.zeros((n_instances, num_features), dtype=np.float32)
 
     for example_index in prange(n_instances):
-
         _X = X[example_index]
 
         A = -_X  # A = alpha * X = -X
@@ -700,7 +691,6 @@ def _transform(X, parameters):
         feature_index_start = 0
 
         for dilation_index in range(num_dilations):
-
             _padding0 = dilation_index % 2
 
             dilation = dilations[dilation_index]
@@ -718,21 +708,18 @@ def _transform(X, parameters):
             end = n_timepoints - padding
 
             for gamma_index in range(9 // 2):
-
                 C_alpha[-end:] = C_alpha[-end:] + A[:end]
                 C_gamma[gamma_index, -end:] = G[:end]
 
                 end += dilation
 
             for gamma_index in range(9 // 2 + 1, 9):
-
                 C_alpha[:-start] = C_alpha[:-start] + A[start:]
                 C_gamma[gamma_index, :-start] = G[start:]
 
                 start += dilation
 
             for kernel_index in range(num_kernels):
-
                 feature_index_end = feature_index_start + num_features_this_dilation
 
                 _padding1 = (_padding0 + kernel_index) % 2

--- a/sktime/transformations/panel/rocket/_multirocket_multi_numba.py
+++ b/sktime/transformations/panel/rocket/_multirocket_multi_numba.py
@@ -26,7 +26,6 @@ def _fit_biases(
     quantiles,
     seed,
 ):
-
     if seed is not None:
         np.random.seed(seed)
     num_examples, num_channels, input_length = X.shape
@@ -307,14 +306,12 @@ def _fit_biases(
     num_channels_start = 0
 
     for dilation_index in range(num_dilations):
-
         dilation = dilations[dilation_index]
         padding = ((9 - 1) * dilation) // 2
 
         num_features_this_dilation = num_features_per_dilation[dilation_index]
 
         for kernel_index in range(num_kernels):
-
             feature_index_end = feature_index_start + num_features_this_dilation
 
             num_channels_this_combination = num_channels_per_combination[
@@ -708,7 +705,6 @@ def _transform(X, X1, parameters, parameters1, n_features_per_kernel=4):
     n_features_per_transform = np.int64(features.shape[1] / 2)
 
     for example_index in prange(num_examples):
-
         _X = X[example_index]
 
         A = -_X  # A = alpha * X = -X
@@ -721,7 +717,6 @@ def _transform(X, X1, parameters, parameters1, n_features_per_kernel=4):
         num_channels_start = 0
 
         for dilation_index in range(num_dilations):
-
             _padding0 = dilation_index % 2
 
             dilation = dilations[dilation_index]
@@ -751,7 +746,6 @@ def _transform(X, X1, parameters, parameters1, n_features_per_kernel=4):
                 start += dilation
 
             for kernel_index in range(num_kernels):
-
                 feature_index_end = feature_index_start + num_features_this_dilation
 
                 num_channels_this_combination = num_channels_per_combination[
@@ -865,7 +859,6 @@ def _transform(X, X1, parameters, parameters1, n_features_per_kernel=4):
         num_channels_start = 0
 
         for dilation_index in range(num_dilations1):
-
             _padding0 = dilation_index % 2
 
             dilation = dilations1[dilation_index]
@@ -895,7 +888,6 @@ def _transform(X, X1, parameters, parameters1, n_features_per_kernel=4):
                 start += dilation
 
             for kernel_index in range(num_kernels):
-
                 feature_index_end = feature_index_start + num_features_this_dilation
 
                 num_channels_this_combination = num_channels_per_combination[

--- a/sktime/transformations/panel/rocket/_multirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_multirocket_multivariate.py
@@ -90,7 +90,6 @@ class MultiRocketMultivariate(BaseTransformer):
         n_jobs=1,
         random_state=None,
     ):
-
         self.max_dilations_per_kernel = max_dilations_per_kernel
         self.n_features_per_kernel = n_features_per_kernel
         self.num_kernels = num_kernels

--- a/sktime/transformations/panel/rocket/_multirocket_numba.py
+++ b/sktime/transformations/panel/rocket/_multirocket_numba.py
@@ -18,7 +18,6 @@ if _check_soft_dependencies("numba", severity="none"):
     cache=True,
 )
 def _transform(X, X1, parameters, parameters1, n_features_per_kernel):
-
     num_examples, input_length = X.shape
 
     dilations, num_features_per_dilation, biases = parameters
@@ -301,7 +300,6 @@ def _transform(X, X1, parameters, parameters1, n_features_per_kernel):
     n_features_per_transform = np.int64(features.shape[1] / 2)
 
     for example_index in prange(num_examples):
-
         _X = X[example_index]
 
         A = -_X  # A = alpha * X = -X
@@ -311,7 +309,6 @@ def _transform(X, X1, parameters, parameters1, n_features_per_kernel):
         feature_index_start = 0
 
         for dilation_index in range(num_dilations):
-
             _padding0 = dilation_index % 2
 
             dilation = dilations[dilation_index]
@@ -341,7 +338,6 @@ def _transform(X, X1, parameters, parameters1, n_features_per_kernel):
                 start += dilation
 
             for kernel_index in range(num_kernels):
-
                 feature_index_end = feature_index_start + num_features_this_dilation
 
                 _padding1 = (_padding0 + kernel_index) % 2
@@ -433,7 +429,6 @@ def _transform(X, X1, parameters, parameters1, n_features_per_kernel):
         feature_index_start = 0
 
         for dilation_index in range(num_dilations1):
-
             _padding0 = dilation_index % 2
 
             dilation = dilations1[dilation_index]
@@ -463,7 +458,6 @@ def _transform(X, X1, parameters, parameters1, n_features_per_kernel):
                 start += dilation
 
             for kernel_index in range(num_kernels):
-
                 feature_index_end = feature_index_start + num_features_this_dilation
 
                 _padding1 = (_padding0 + kernel_index) % 2
@@ -835,14 +829,12 @@ def _fit_biases(X, dilations, num_features_per_dilation, quantiles, seed):
     feature_index_start = 0
 
     for dilation_index in range(num_dilations):
-
         dilation = dilations[dilation_index]
         padding = ((9 - 1) * dilation) // 2
 
         num_features_this_dilation = num_features_per_dilation[dilation_index]
 
         for kernel_index in range(num_kernels):
-
             feature_index_end = feature_index_start + num_features_this_dilation
 
             _X = X[np.random.randint(num_examples)]

--- a/sktime/transformations/panel/rocket/_rocket_numba.py
+++ b/sktime/transformations/panel/rocket/_rocket_numba.py
@@ -45,7 +45,6 @@ def _generate_kernels(n_timepoints, num_kernels, n_columns, seed):
     a2 = 0  # for channel_indices
 
     for i in range(num_kernels):
-
         _length = lengths[i]
         _num_channel_indices = num_channel_indices[i]
 
@@ -105,13 +104,11 @@ def _apply_kernel_univariate(X, weights, length, bias, dilation, padding):
     end = (n_timepoints + padding) - ((length - 1) * dilation)
 
     for i in range(-padding, end):
-
         _sum = bias
 
         index = i
 
         for j in range(length):
-
             if index > -1 and index < n_timepoints:
                 _sum = _sum + weights[j] * X[index]
 
@@ -140,15 +137,12 @@ def _apply_kernel_multivariate(
     end = (n_timepoints + padding) - ((length - 1) * dilation)
 
     for i in range(-padding, end):
-
         _sum = bias
 
         index = i
 
         for j in range(length):
-
             if index > -1 and index < n_timepoints:
-
                 for k in range(num_channel_indices):
                     _sum = _sum + weights[k, j] * X[channel_indices[k], index]
 
@@ -189,19 +183,16 @@ def _apply_kernels(X, kernels):
     )  # 2 features per kernel
 
     for i in prange(n_instances):
-
         a1 = 0  # for weights
         a2 = 0  # for channel_indices
         a3 = 0  # for features
 
         for j in range(num_kernels):
-
             b1 = a1 + num_channel_indices[j] * lengths[j]
             b2 = a2 + num_channel_indices[j]
             b3 = a3 + 2
 
             if num_channel_indices[j] == 1:
-
                 _X[i, a3:b3] = _apply_kernel_univariate(
                     X[i, channel_indices[a2]],
                     weights[a1:b1],
@@ -212,7 +203,6 @@ def _apply_kernels(X, kernels):
                 )
 
             else:
-
                 _weights = weights[a1:b1].reshape((num_channel_indices[j], lengths[j]))
 
                 _X[i, a3:b3] = _apply_kernel_multivariate(

--- a/sktime/transformations/panel/segment.py
+++ b/sktime/transformations/panel/segment.py
@@ -56,8 +56,7 @@ class IntervalSegmenter(BaseTransformer):
         super(IntervalSegmenter, self).__init__()
 
     def _fit(self, X, y=None):
-        """
-        Fit transformer, generating random interval indices.
+        """Fit transformer, generating random interval indices.
 
         Parameters
         ----------
@@ -467,7 +466,6 @@ class SlidingWindowSegmenter(BaseTransformer):
         Adopted from -
         https://stackoverflow.com/questions/4923617/efficient-numpy-2d-array-
         construction-from-1d-array/4924433#4924433
-
         """
         shape = (n_timepoints, self.window_length)
         strides = (instance.itemsize, instance.itemsize)

--- a/sktime/transformations/panel/shapelet_transform.py
+++ b/sktime/transformations/panel/shapelet_transform.py
@@ -147,7 +147,6 @@ class ShapeletTransform(BaseTransformer):
         verbose=0,
         remove_self_similar=True,
     ):
-
         self.min_shapelet_length = min_shapelet_length
         self.max_shapelet_length = max_shapelet_length
         self.max_shapelets_to_store_per_class = max_shapelets_to_store_per_class
@@ -256,7 +255,6 @@ class ShapeletTransform(BaseTransformer):
         # for every series
         case_idx = 0
         while case_idx < len(cases_to_visit):
-
             series_id = cases_to_visit[case_idx][0]
             this_class_val = cases_to_visit[case_idx][1]
 
@@ -333,7 +331,6 @@ class ShapeletTransform(BaseTransformer):
                 candidates_to_visit = [candidate_starts_and_lens[x] for x in cand_idx]
 
             for candidate_idx in range(num_candidates_per_case):
-
                 # if shapelet heap for this class is not full yet, set entry
                 # criteria to be the predetermined IG threshold
                 ig_cutoff = self.predefined_ig_rejection_level
@@ -658,6 +655,7 @@ class ShapeletTransform(BaseTransformer):
         -------
         shapelet_list: list of Shapelet objects
         """
+
         # IMPORTANT: it is assumed that shapelets are already in descending
         # order of quality. This is preferable in the fit method as removing
         # self-similar

--- a/sktime/transformations/panel/shapelet_transform.py
+++ b/sktime/transformations/panel/shapelet_transform.py
@@ -656,12 +656,16 @@ class ShapeletTransform(BaseTransformer):
         shapelet_list: list of Shapelet objects
         """
 
-        # IMPORTANT: it is assumed that shapelets are already in descending
-        # order of quality. This is preferable in the fit method as removing
-        # self-similar
-        # shapelets may be False so the sort needs to happen there in those
-        # cases, and avoids a second redundant sort here if it is set to True
         def is_self_similar(shapelet_one, shapelet_two):
+            """Check if two shapelets are similar.
+
+            Notes
+            -----
+            IMPORTANT: it is assumed that shapelets are already in descending order
+            of quality. This is preferable in the fit method as removing self-similar
+            shapelets may be False so the sort needs to happen there in those cases,
+            and avoids a second redundant sort here if it is set to True
+            """
             # not self similar if from different series
             if shapelet_one.series_id != shapelet_two.series_id:
                 return False

--- a/sktime/transformations/panel/signature_based/_augmentations.py
+++ b/sktime/transformations/panel/signature_based/_augmentations.py
@@ -81,7 +81,6 @@ class _AddTime(BaseTransformer):
     }
 
     def _transform(self, X, y=None):
-
         data = np.swapaxes(X, 1, 2)
         # Batch and length dim
         B, L = data.shape[0], data.shape[1]

--- a/sktime/transformations/panel/signature_based/_augmentations.py
+++ b/sktime/transformations/panel/signature_based/_augmentations.py
@@ -64,9 +64,8 @@ def _make_augmentation_pipeline(augmentation_list):
 class _AddTime(BaseTransformer):
     """Add time component to each path.
 
-    For a path of shape [B, L, C] this adds a time channel to be placed at the
-    first index. The time channel will be of length L and scaled to exist in
-    [0, 1].
+    For a path of shape [B, L, C] this adds a time channel to be placed at the first
+    index. The time channel will be of length L and scaled to exist in [0, 1].
     """
 
     _tags = {
@@ -97,7 +96,9 @@ class _InvisibilityReset(BaseTransformer):
 
     This adds sensitivity to translation.
 
-    Introduced by Yang et al.: https://arxiv.org/pdf/1707.03993.pdf
+    Introduced by Yang et al.:
+    https://arxiv.org/pdf/1707.03993.pdf
+    : https: //arxiv.org/pdf/1707.03993.pdf
     """
 
     _tags = {

--- a/sktime/transformations/panel/signature_based/_checks.py
+++ b/sktime/transformations/panel/signature_based/_checks.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Input conversions for the SignatureClassifier.
 
-_checks.py
-====================
-Contains a reusable decorator function to handle the sklearn signature checks.
+_checks.py ==================== Contains a reusable decorator function to handle the
+sklearn signature checks.
 """
 import functools
 

--- a/sktime/transformations/panel/signature_based/_compute.py
+++ b/sktime/transformations/panel/signature_based/_compute.py
@@ -61,7 +61,6 @@ class _WindowSignatureTransform(BaseTransformer):
         )
 
     def _transform(self, X, y=None):
-
         import esig
 
         depth = self.sig_depth

--- a/sktime/transformations/panel/signature_based/_rescaling.py
+++ b/sktime/transformations/panel/signature_based/_rescaling.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 """Signature rescaling methods.
 
-rescaling.py
-=========================
-This implements the pre- and post- signature
-rescaling methods along with generic scaling methods along feature
-dimensions of 3D tensors.
-Code for `rescale_path` and `rescale_signature` written by Patrick Kidger.
+rescaling.py ========================= This implements the pre- and post- signature
+rescaling methods along with generic scaling methods along feature dimensions of 3D
+tensors. Code for `rescale_path` and `rescale_signature` written by Patrick Kidger.
 """
 import math
 

--- a/sktime/transformations/panel/signature_based/_window.py
+++ b/sktime/transformations/panel/signature_based/_window.py
@@ -21,7 +21,8 @@ _Pair = co.namedtuple("Pair", ("start", "end"))
 def _window_getter(
     window_name, window_depth=None, window_length=None, window_step=None
 ):
-    """Get the window method correspondent to the given string and initialises with specified parameters.
+    """Get the window method correspondent to the given string and initialises with
+    specified parameters.
 
     Parameters
     ----------
@@ -63,12 +64,12 @@ def _window_getter(
 class _Window:
     """Abstract base class for windows.
 
-    Each subclass must implement a __call__ method that returns a list of lists
-    of 2-tuples. Each 2-tuple specifies the start and end of each window.
+    Each subclass must implement a __call__ method that returns a list of lists of
+    2-tuples. Each 2-tuple specifies the start and end of each window.
 
-    These windows are grouped into a list that will (usually) cover the full
-    time series. These lists are grouped into another list for situations
-    where we consider windows of multiple scales.
+    These windows are grouped into a list that will (usually) cover the full time
+    series. These lists are grouped into another list for situations where we consider
+    windows of multiple scales.
     """
 
     def num_windows(self, length):
@@ -125,7 +126,8 @@ class _ExpandingSliding(_Window):
 
 
 class _Sliding(_ExpandingSliding):
-    """A window starting at zero and going to some point that increases between windows."""  # noqa: E501
+    """A window starting at zero and going to some point that increases between
+    windows."""  # noqa: E501
 
     def __init__(self, length, step):
         """Build a Sliding object.

--- a/sktime/transformations/panel/signature_based/_window.py
+++ b/sktime/transformations/panel/signature_based/_window.py
@@ -21,8 +21,7 @@ _Pair = co.namedtuple("Pair", ("start", "end"))
 def _window_getter(
     window_name, window_depth=None, window_length=None, window_step=None
 ):
-    """Get the window method correspondent to the given string and initialises with
-    specified parameters.
+    """Get window method correspondent to given string and initialises with parameters.
 
     Parameters
     ----------
@@ -126,17 +125,17 @@ class _ExpandingSliding(_Window):
 
 
 class _Sliding(_ExpandingSliding):
-    """A window starting at zero and going to some point that increases between
-    windows."""  # noqa: E501
+    """Build a Sliding object.
+
+    A window starting at zero and going to some point that increases between windows.
+
+    Parameters
+    ----------
+    length: int, The length of the window.
+    step: int, The sliding step size.
+    """
 
     def __init__(self, length, step):
-        """Build a Sliding object.
-
-        Parameters
-        ----------
-        length: int, The length of the window.
-        step: int, The sliding step size.
-        """
         super(_Sliding, self).__init__(
             initial_length=length, start_step=step, end_step=step
         )

--- a/sktime/transformations/panel/summarize/_extract.py
+++ b/sktime/transformations/panel/summarize/_extract.py
@@ -220,8 +220,7 @@ class RandomIntervalFeatureExtractor(BaseTransformer):
         super(RandomIntervalFeatureExtractor, self).__init__()
 
     def _fit(self, X, y=None):
-        """
-        Fit transformer, generating random interval indices.
+        """Fit transformer, generating random interval indices.
 
         Parameters
         ----------

--- a/sktime/transformations/panel/tsfresh.py
+++ b/sktime/transformations/panel/tsfresh.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""tsfresh interface class."""
+"""Tsfresh interface class."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 __author__ = ["AyushmaanSeth", "mloning", "alwinw", "MatthewMiddlehurst"]

--- a/sktime/transformations/series/acf.py
+++ b/sktime/transformations/series/acf.py
@@ -40,10 +40,10 @@ class AutoCorrelationTransformer(BaseTransformer):
         calculations.
 
         - "none" performs no checks or handling of missing values
-        - “raise” raises an exception if NaN values are found.
-        - “drop” removes the missing observations and then estimates the
+        - "raise" raises an exception if NaN values are found.
+        - "drop" removes the missing observations and then estimates the
           autocovariances treating the non-missing as contiguous.
-        - “conservative” computes the autocovariance using nan-ops so that nans
+        - "conservative" computes the autocovariance using nan-ops so that nans
           are removed when computing the mean and cross-products that are used to
           estimate the autocovariance. "n" in calculation is set to the number of
           non-missing observations.

--- a/sktime/transformations/series/acf.py
+++ b/sktime/transformations/series/acf.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-
 """Auto-correlation transformations.
 
-Module :mod:`sktime.transformations.series` implements auto-correlation
+Module
+:mod: `sktime.transformations.series` implements auto-correlation
 transformers.
 """
 

--- a/sktime/transformations/series/augmenter.py
+++ b/sktime/transformations/series/augmenter.py
@@ -62,7 +62,6 @@ class WhiteNoiseAugmenter(_AugmenterTags, BaseTransformer):
         augmentation for time series classification with neural networks. Plos
         one, 2021, 16. Jg., Nr. 7, S. e0254841.
         [3]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_continuous.random_state.html # noqa
-
     """
 
     _tags = {"python_dependencies": "scipy"}
@@ -114,7 +113,6 @@ class ReverseAugmenter(_AugmenterTags, BaseTransformer):
         [1]: IWANA, Brian Kenji; UCHIDA, Seiichi. An empirical survey of data
         augmentation for time series classification with neural networks. Plos
         one, 2021, 16. Jg., Nr. 7, S. e0254841.
-
     """
 
     def __init__(self):
@@ -180,7 +178,6 @@ class RandomSamplesAugmenter(_AugmenterTags, BaseTransformer):
     ----------
 
         [1]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_continuous.random_state.html # noqa
-
     """
 
     def __init__(

--- a/sktime/transformations/series/binning.py
+++ b/sktime/transformations/series/binning.py
@@ -73,7 +73,6 @@ class TimeBinAggregate(BaseTransformer):
     }
 
     def __init__(self, bins, aggfunc=None, return_index="bin_start"):
-
         self.bins = bins
         self.aggfunc = aggfunc
         self.return_index = return_index

--- a/sktime/transformations/series/bkfilter.py
+++ b/sktime/transformations/series/bkfilter.py
@@ -24,7 +24,7 @@ class BKFilter(BaseTransformer):
     data and deals with the periodicity of the business cycle. Applying their
     band-pass filter to a series will produce a new series that does not contain
     fluctuations at a higher or lower frequency than those of the business cycle.
-    Baxter-King follow Burns and Mitchell’s work on business cycles, which suggests
+    Baxter-King follow Burns and Mitchell's work on business cycles, which suggests
     that U.S. business cycles typically last from 1.5 to 8 years.
 
     Parameters

--- a/sktime/transformations/series/bkfilter.py
+++ b/sktime/transformations/series/bkfilter.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Interface to Baxter-King bandpass filter from `statsmodels`.
+"""Interface to Baxter-King bandpass filter from `statsmodels`.
 
 Interfaces `bk_filter` from `statsmodels.tsa.filters`.
 """

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -137,8 +137,7 @@ class BoxCoxTransformer(BaseTransformer):
         super(BoxCoxTransformer, self).__init__()
 
     def _fit(self, X, y=None):
-        """
-        Fit transformer to X and y.
+        """Fit transformer to X and y.
 
         private _fit containing the core logic, called from fit
 

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -315,7 +315,6 @@ class LogTransformer(BaseTransformer):
 
 
 def _make_boxcox_optimizer(bounds=None, brack=(-2.0, 2.0)):
-
     from scipy import optimize
 
     # bounds is None, use simple Brent optimisation

--- a/sktime/transformations/series/cffilter.py
+++ b/sktime/transformations/series/cffilter.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Interface to Christiano Fitzgerald asymmetric, random walk filter from `statsmodels`.
+"""Interface to Christiano Fitzgerald asymmetric, random walk filter from `statsmodels`.
 
 Interfaces `cf_filter` from `statsmodels.tsa.filters`.
 """

--- a/sktime/transformations/series/clasp.py
+++ b/sktime/transformations/series/clasp.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-
-"""
-ClaSP (Classification Score Profile) Transformer implementation.
+"""ClaSP (Classification Score Profile) Transformer implementation.
 
 Notes
 -----

--- a/sktime/transformations/series/clear_sky.py
+++ b/sktime/transformations/series/clear_sky.py
@@ -339,7 +339,6 @@ def _check_index(X):
     -------
     freq_ind : str or None
         Frequency of data in string format
-
     """
     if not (isinstance(X.index, pd.DatetimeIndex)) | (
         isinstance(X.index, pd.PeriodIndex)

--- a/sktime/transformations/series/clear_sky.py
+++ b/sktime/transformations/series/clear_sky.py
@@ -110,7 +110,6 @@ class ClearSky(BaseTransformer):
         n_jobs=None,
         backend="loky",
     ):
-
         self.quantile_prob = quantile_prob
         self.bw_diurnal = bw_diurnal
         self.bw_annual = bw_annual

--- a/sktime/transformations/series/date.py
+++ b/sktime/transformations/series/date.py
@@ -140,7 +140,6 @@ class DateTimeFeatures(BaseTransformer):
         manual_selection=None,
         keep_original_columns=False,
     ):
-
         self.ts_freq = ts_freq
         self.feature_scope = feature_scope
         self.manual_selection = manual_selection

--- a/sktime/transformations/series/date.py
+++ b/sktime/transformations/series/date.py
@@ -320,9 +320,8 @@ def _get_supported_calendar(ts_freq, DUMMIES):
 def _prep_dummies(DUMMIES):
     """Use to prepare dummy data.
 
-    Includes defining function call names and ranking
-    of date information based on frequency (e.g. year
-    has a lower frequency than week).
+    Includes defining function call names and ranking of date information based on
+    frequency (e.g. year has a lower frequency than week).
     """
     DUMMIES = pd.DataFrame(DUMMIES[1:], columns=DUMMIES[0])
 

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -543,7 +543,6 @@ class STLTransformer(BaseTransformer):
         return self
 
     def _transform(self, X, y=None):
-
         from statsmodels.tsa.seasonal import STL as _STL
 
         # fit again if indices not seen, but don't store anything
@@ -582,13 +581,11 @@ class STLTransformer(BaseTransformer):
         # return y + self.seasonal_ + self.trend_
 
     def _make_return_object(self, X, stl):
-
         # deseasonalize only
         transformed = pd.Series(X.values - stl.seasonal, index=X.index)
         # transformed = pd.Series(X.values - stl.seasonal - stl.trend, index=X.index)
 
         if self.return_components:
-
             seasonal = pd.Series(stl.seasonal, index=X.index)
             resid = pd.Series(stl.resid, index=X.index)
             trend = pd.Series(stl.trend, index=X.index)

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -261,8 +261,7 @@ class Differencer(BaseTransformer):
         return na_handling
 
     def _fit(self, X, y=None):
-        """
-        Fit transformer to X and y.
+        """Fit transformer to X and y.
 
         private _fit containing the core logic, called from fit
 

--- a/sktime/transformations/series/dobin.py
+++ b/sktime/transformations/series/dobin.py
@@ -239,17 +239,7 @@ def close_distance_matrix(X: npt.ArrayLike, k: int, frac: float):
 
     dist = pd.DataFrame(
         [
-            (
-                (
-                    X.iloc[
-                        i,
-                    ]
-                    - X.iloc[
-                        j,
-                    ]
-                )
-                ** 2
-            ).tolist()
+            ((X.iloc[i,] - X.iloc[j,]) ** 2).tolist()
             for (i, j) in zip(
                 np.repeat(indices[:, 0], repeats=k), indices[:, 1:].flatten()
             )
@@ -261,6 +251,4 @@ def close_distance_matrix(X: npt.ArrayLike, k: int, frac: float):
 
     mask = row_sums > q_frac
 
-    return dist.loc[
-        mask,
-    ]
+    return dist.loc[mask,]

--- a/sktime/transformations/series/func_transform.py
+++ b/sktime/transformations/series/func_transform.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
-
 """Implements FunctionTransformer, a class to create custom transformers."""
 
 __author__ = ["BoukePostma"]

--- a/sktime/transformations/series/hidalgo.py
+++ b/sktime/transformations/series/hidalgo.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """Hidalgo (Heterogeneous Intrinsic Dimensionality Algorithm) Segmentation."""
 
 __author__ = ["KatieBuc"]
@@ -134,8 +133,7 @@ class Hidalgo(BaseTransformer):
         super(Hidalgo, self).__init__()
 
     def _get_neighbourhood_params(self, X):
-        """
-        Neighbourhood information from input data X.
+        """Neighbourhood information from input data X.
 
         Parameters
         ----------
@@ -206,8 +204,7 @@ class Hidalgo(BaseTransformer):
         return N_in, f1
 
     def _initialise_params(self, N, mu, Iin, _rng):
-        """
-        Initialise parameters used in algorithm.
+        """Initialise parameters used in algorithm.
 
         Outputs
         ----------
@@ -276,8 +273,8 @@ class Hidalgo(BaseTransformer):
         N_in,
         _rng,
     ):
-        """
-        Gibbs sampling method to find joint posterior distribution of target variables.
+        """Gibbs sampling method to find joint posterior distribution of target
+        variables.
 
         Notes
         -----
@@ -308,7 +305,6 @@ class Hidalgo(BaseTransformer):
         -------
         sampling : 2D np.ndarray of shape (n_iter, Npar), where Npar = N + 2 * K + 2 + 1
             posterior samples of d, p, Z and likelihood samples, respectively.
-
         """
         zeta = self.zeta
         q = self.q

--- a/sktime/transformations/series/hidalgo.py
+++ b/sktime/transformations/series/hidalgo.py
@@ -114,7 +114,6 @@ class Hidalgo(BaseTransformer):
         f=None,
         seed=1,
     ):
-
         self.metric = metric
         self.K = K
         self.zeta = zeta
@@ -438,7 +437,6 @@ class Hidalgo(BaseTransformer):
                 for k1 in range(K):
                     g = 0
                     if use_Potts:
-
                         n_in = sum([Z[Iin[q * i + j]] == k1 for j in range(q)])
 
                         m_in = sum(
@@ -508,7 +506,6 @@ class Hidalgo(BaseTransformer):
             return lik0, lik1
 
         for it in range(n_iter):
-
             d = sample_d(K, a1, b1, _rng)
             sampling = np.append(sampling, d)
 
@@ -602,7 +599,6 @@ class Hidalgo(BaseTransformer):
         maxlik = -1e10
 
         for _ in range(n_replicas):
-
             sampling = self._gibbs_sampling(
                 N,
                 mu,
@@ -627,9 +623,7 @@ class Hidalgo(BaseTransformer):
                 for it in range(n_iter)
                 if it % sampling_rate == 0 and it >= n_iter * burn_in
             ]
-            sampling = sampling[
-                idx,
-            ]
+            sampling = sampling[idx,]
 
             lik = np.mean(sampling[:, -1], axis=0)
 

--- a/sktime/transformations/series/hidalgo.py
+++ b/sktime/transformations/series/hidalgo.py
@@ -273,8 +273,7 @@ class Hidalgo(BaseTransformer):
         N_in,
         _rng,
     ):
-        """Gibbs sampling method to find joint posterior distribution of target
-        variables.
+        """Gibbs sampling method for joint posterior distribution of target variables.
 
         Notes
         -----

--- a/sktime/transformations/series/hpfilter.py
+++ b/sktime/transformations/series/hpfilter.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Interface to Hodrick-Prescott filter from `statsmodels`.
+"""Interface to Hodrick-Prescott filter from `statsmodels`.
 
 Please see the original library
 (https://github.com/statsmodels/statsmodels/blob/main/statsmodels/tsa/filters/hp_filter.py)

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -294,7 +294,8 @@ class Imputer(BaseTransformer):
             pass
 
     def _create_random_distribution(self, z: pd.Series):
-        """Create a uniform random distribution function within boundaries of given series.
+        """Create a uniform random distribution function within boundaries of given
+        series.
 
         The distribution is discrete, if the series contains only int-like values.
 

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -294,8 +294,7 @@ class Imputer(BaseTransformer):
             pass
 
     def _create_random_distribution(self, z: pd.Series):
-        """Create a uniform random distribution function within boundaries of given
-        series.
+        """Create uniform distribution function within boundaries of given series.
 
         The distribution is discrete, if the series contains only int-like values.
 

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -106,7 +106,6 @@ class Imputer(BaseTransformer):
         forecaster=None,
         missing_values=None,
     ):
-
         self.method = method
         self.missing_values = missing_values
         self.value = value

--- a/sktime/transformations/series/kalman_filter.py
+++ b/sktime/transformations/series/kalman_filter.py
@@ -2,9 +2,8 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Kalman Filter Transformers.
 
-Series based transformers, based on Kalman Filter algorithm. Contains Base class
-and two transformers which are each Adapters for external packages
-pykalman and FilterPy.
+Series based transformers, based on Kalman Filter algorithm. Contains Base class and two
+transformers which are each Adapters for external packages pykalman and FilterPy.
 """
 
 __author__ = ["NoaBenAmi", "lielleravid"]
@@ -55,8 +54,8 @@ def _validate_param_shape(param_name, matrix_shape, actual_shape, time_steps=Non
     """Validate shape of matrix parameter.
 
     Assert `actual_shape` equals to:
-        -   'shape' of a single matrix or
-        -   'shape' of time_steps matrices.
+        -  'shape' of a single matrix or
+        -  'shape' of time_steps matrices.
     If neither, raise an informative `ValueError` that includes the parameter's name.
 
     Parameters
@@ -92,7 +91,8 @@ def _validate_param_shape(param_name, matrix_shape, actual_shape, time_steps=Non
 
 
 def _init_matrix(matrices, transform_func, default_val):
-    """Initialize default value if matrix is None, or transform input matrix to np.ndarray.
+    """Initialize default value if matrix is None, or transform input matrix to
+    np.ndarray.
 
     Parameters
     ----------
@@ -210,17 +210,17 @@ class BaseKalmanFilter:
 
     Two prediction equations:
 
-    -   State Extrapolation Equation - prediction or estimation of the future state,
+    -  State Extrapolation Equation - prediction or estimation of the future state,
         based on the known present estimation.
-    -	Covariance Extrapolation Equation - the measure of uncertainty in our prediction.
+    -  Covariance Extrapolation Equation - the measure of uncertainty in our prediction.
 
     Two update equations:
 
-    -   State Update Equation - estimation of the current state,
+    -  State Update Equation - estimation of the current state,
         based on the known past estimation and present measurement.
-    -	Covariance Update Equation - the measure of uncertainty in our estimation.
+    -  Covariance Update Equation - the measure of uncertainty in our estimation.
 
-    Kalman Gain Equation – this is a required argument for the update equations.
+    Kalman Gain Equation - this is a required argument for the update equations.
     It acts as a weighting parameter for the past estimations and the given measurement.
     It defines the weight of the past estimation and
     the weight of the measurement in estimating the current state.
@@ -798,7 +798,8 @@ class KalmanFilterTransformerPK(BaseKalmanFilter, BaseTransformer):
         return F, H, Q, R, transition_offsets, measurement_offsets, X0, P0
 
     def _get_estimate_matrices(self):
-        """Map parameters names to `pykalman` parameters names for use of `pykalman` `em`.
+        """Map parameters names to `pykalman` parameters names for use of `pykalman`
+        `em`.
 
         Returns
         -------
@@ -843,7 +844,8 @@ class KalmanFilterTransformerPK(BaseKalmanFilter, BaseTransformer):
 
 
 class KalmanFilterTransformerFP(BaseKalmanFilter, BaseTransformer):
-    """Kalman Filter is used for denoising data or inferring the hidden state of data given.
+    """Kalman Filter is used for denoising data or inferring the hidden state of data
+    given.
 
     The Kalman Filter is an unsupervised algorithm, consisting of
     several mathematical equations which are used to create

--- a/sktime/transformations/series/kalman_filter.py
+++ b/sktime/transformations/series/kalman_filter.py
@@ -91,8 +91,7 @@ def _validate_param_shape(param_name, matrix_shape, actual_shape, time_steps=Non
 
 
 def _init_matrix(matrices, transform_func, default_val):
-    """Initialize default value if matrix is None, or transform input matrix to
-    np.ndarray.
+    """Initialize default value if matrix is None, or transform to np.ndarray.
 
     Parameters
     ----------
@@ -798,8 +797,7 @@ class KalmanFilterTransformerPK(BaseKalmanFilter, BaseTransformer):
         return F, H, Q, R, transition_offsets, measurement_offsets, X0, P0
 
     def _get_estimate_matrices(self):
-        """Map parameters names to `pykalman` parameters names for use of `pykalman`
-        `em`.
+        """Map parameter names to `pykalman` names for use of `pykalman` `em`.
 
         Returns
         -------
@@ -844,8 +842,7 @@ class KalmanFilterTransformerPK(BaseKalmanFilter, BaseTransformer):
 
 
 class KalmanFilterTransformerFP(BaseKalmanFilter, BaseTransformer):
-    """Kalman Filter is used for denoising data or inferring the hidden state of data
-    given.
+    """Kalman Filter is used for denoising or inferring the hidden state of given data.
 
     The Kalman Filter is an unsupervised algorithm, consisting of
     several mathematical equations which are used to create

--- a/sktime/transformations/series/kinematic.py
+++ b/sktime/transformations/series/kinematic.py
@@ -82,7 +82,6 @@ class KinematicFeatures(BaseTransformer):
 
     # todo: add any hyper-parameters and components to constructor
     def __init__(self, features=None):
-
         self.features = features
         if features is None:
             self._features = ["v_abs", "a_abs", "curv"]

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -140,7 +140,6 @@ class Lag(BaseTransformer):
         flatten_transform_index=True,
         keep_column_names=False,
     ):
-
         self.lags = lags
         self.freq = freq
         self.index_out = index_out
@@ -442,7 +441,6 @@ class ReducerTransform(BaseTransformer):
         transformers=None,
         impute_method="bfill",
     ):
-
         self.lags = lags
         self.freq = freq
         self.shifted_vars = shifted_vars

--- a/sktime/transformations/series/outlier_detection.py
+++ b/sktime/transformations/series/outlier_detection.py
@@ -69,7 +69,6 @@ class HampelFilter(BaseTransformer):
     }
 
     def __init__(self, window_length=10, n_sigma=3, k=1.4826, return_bool=False):
-
         self.window_length = window_length
         self.n_sigma = n_sigma
         self.k = k

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -208,7 +208,6 @@ class WindowSummarizer(BaseTransformer):
         target_cols=None,
         truncate=None,
     ):
-
         self.lag_feature = lag_feature
         self.n_jobs = n_jobs
         self.target_cols = target_cols

--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -200,8 +200,8 @@ all_args = [
 def test_eval(test_input, expected):
     """Tests which columns are returned for different arguments.
 
-    For a detailed description what these arguments do,
-    and how they interact see docstring of DateTimeFeatures.
+    For a detailed description what these arguments do, and how they interact see
+    docstring of DateTimeFeatures.
     """
     assert len(test_input) == len(expected)
     assert all([a == b for a, b in zip(test_input, expected)])

--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -15,7 +15,6 @@ from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils.validation._dependencies import _check_estimator_deps
 
 if _check_estimator_deps(DateTimeFeatures, severity="none"):
-
     # Load multivariate dataset longley and apply calendar extraction
 
     y, X = load_longley()

--- a/sktime/transformations/series/tests/test_featureizer.py
+++ b/sktime/transformations/series/tests/test_featureizer.py
@@ -17,8 +17,8 @@ y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
 def test_featurized_values():
     """Test against plain transformation.
 
-    Test to check that the featurized values are same as if transformation
-    is done without YtoX.
+    Test to check that the featurized values are same as if transformation is done
+    without YtoX.
     """
     lags = len(y_test)
     featurizer = YtoX() * ExponentTransformer() * Lag(lags)

--- a/sktime/transformations/series/tests/test_hidalgo.py
+++ b/sktime/transformations/series/tests/test_hidalgo.py
@@ -281,8 +281,6 @@ def test_gibbs():
         _rng,
     )
     sampling = np.reshape(sampling, (10, 17))
-    actual = sampling[
-        [6, 8],
-    ]
+    actual = sampling[[6, 8],]
 
     assert np.allclose(actual, expected)

--- a/sktime/transformations/series/tests/test_kalman_filter.py
+++ b/sktime/transformations/series/tests/test_kalman_filter.py
@@ -21,8 +21,8 @@ ts = 10
 def create_data(shape, missing_values=False, p=0.15, mult=10):
     """Create random ndarray of shape `shape`.
 
-    The result array will contain missing values (represented by np.nan)
-    if parameter `missing_values` is set to true.
+    The result array will contain missing values (represented by np.nan) if parameter
+    `missing_values` is set to true.
     """
     if isinstance(shape, int):
         shape = (shape,)
@@ -117,8 +117,8 @@ params_3_1_lists = {
 def get_params_mapping(params):
     """Transform parameters names.
 
-    From KalmanFilterTransformerPK, KalmanFilterTransformerFP naming
-    forms to `pykalman`'s naming form.
+    From KalmanFilterTransformerPK, KalmanFilterTransformerFP naming forms to
+    `pykalman`'s naming form.
     """
     params_mapping = {
         "state_transition": "transition_matrices",
@@ -174,8 +174,8 @@ def init_kf_pykalman(
 def init_kf_filterpy(measurements, adapter, n=10, y=None):
     """Adjust params and measurements.
 
-    Given measurements and adapter, adjust params and measurements to
-    `FilterPy` usable form.
+    Given measurements and adapter, adjust params and measurements to `FilterPy` usable
+    form.
     """
     y_dim = 1 if y is None else y.shape[-1]
 
@@ -315,9 +315,9 @@ def init_kf_filterpy(measurements, adapter, n=10, y=None):
 def test_transform_and_smooth_pk(params, measurements):
     """Test KalmanFilterTransformerPK `fit` and `transform`.
 
-    Creating two instances of KalmanFilterTransformerPK, one instance
-    with parameter `denoising` set to False, and the other's set to True.
-    Compare result with `pykalman`'s `filter` and `smooth`.
+    Creating two instances of KalmanFilterTransformerPK, one instance with parameter
+    `denoising` set to False, and the other's set to True. Compare result with
+    `pykalman`'s `filter` and `smooth`.
     """
     mask_measurements = np.ma.masked_invalid(np.copy(measurements))
 
@@ -549,10 +549,9 @@ def test_transform_and_smooth_pk(params, measurements):
 def test_em(classes, params, measurements):
     """Test adapters matrix estimation.
 
-    Call `fit` of input adapter/s, and compare all matrix parameters
-    with `pykalman`'s matrix parameters returned from `em`.
-    This test is useful for both KalmanFilterTransformerPK and
-    KalmanFilterTransformerFP.
+    Call `fit` of input adapter/s, and compare all matrix parameters with `pykalman`'s
+    matrix parameters returned from `em`. This test is useful for both
+    KalmanFilterTransformerPK and KalmanFilterTransformerFP.
     """
     mask_measurements = np.ma.masked_invalid(np.copy(measurements))
 
@@ -720,10 +719,8 @@ def test_em(classes, params, measurements):
 def test_bad_inputs(classes, params, measurements):
     """Test adapters bad inputs error handling.
 
-    Call `fit` of input adapter/s, and pass if ValueError
-    was thrown.
-    This test is useful for both KalmanFilterTransformerPK
-    and KalmanFilterTransformerFP.
+    Call `fit` of input adapter/s, and pass if ValueError was thrown. This test is
+    useful for both KalmanFilterTransformerPK and KalmanFilterTransformerFP.
     """
     with pytest.raises(ValueError):
         for _class in classes:
@@ -850,9 +847,9 @@ def test_bad_inputs(classes, params, measurements):
 def test_transform_and_smooth_fp(params, measurements, y):
     """Test KalmanFilterTransformerFP `fit` and `transform`.
 
-    Creating two instances of KalmanFilterTransformerFP, one instance
-    with parameter `denoising` set to False, and the other's set to True.
-    Compare result with `FilterPy`'s `batch_filter` and `rts_smoother`.
+    Creating two instances of KalmanFilterTransformerFP, one instance with parameter
+    `denoising` set to False, and the other's set to True. Compare result with
+    `FilterPy`'s `batch_filter` and `rts_smoother`.
     """
     from filterpy.kalman.kalman_filter import batch_filter, rts_smoother
 

--- a/sktime/transformations/series/tests/test_summarize.py
+++ b/sktime/transformations/series/tests/test_summarize.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-
 """Test functionality of summary transformer."""
 __author__ = ["RNKuhns"]
 import re

--- a/sktime/transformations/series/tests/test_window_summarizer.py
+++ b/sktime/transformations/series/tests/test_window_summarizer.py
@@ -15,8 +15,8 @@ from sktime.transformations.series.summarize import WindowSummarizer
 def check_eval(test_input, expected):
     """Test which columns are returned for different arguments.
 
-    For a detailed description what these arguments do,
-    and how theyinteract see docstring of DateTimeFeatures.
+    For a detailed description what these arguments do, and how theyinteract see
+    docstring of DateTimeFeatures.
     """
     if test_input is not None:
         assert len(test_input) == len(expected)

--- a/sktime/transformations/series/time_since.py
+++ b/sktime/transformations/series/time_since.py
@@ -17,8 +17,7 @@ from sktime.transformations.base import BaseTransformer
 
 
 class TimeSince(BaseTransformer):
-    """Computes element-wise time elapsed between the time index and a reference start
-    time.
+    """Compute element-wise time elapsed between time index and a reference start time.
 
     Creates a column(s) which represents: `t` - `start`, where `start` is
     a reference time and `t` is the time index. The type of `start` must be

--- a/sktime/transformations/series/time_since.py
+++ b/sktime/transformations/series/time_since.py
@@ -17,7 +17,8 @@ from sktime.transformations.base import BaseTransformer
 
 
 class TimeSince(BaseTransformer):
-    """Computes element-wise time elapsed between the time index and a reference start time.
+    """Computes element-wise time elapsed between the time index and a reference start
+    time.
 
     Creates a column(s) which represents: `t` - `start`, where `start` is
     a reference time and `t` is the time index. The type of `start` must be

--- a/sktime/transformations/tests/test_base.py
+++ b/sktime/transformations/tests/test_base.py
@@ -2,12 +2,11 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Unit tests for base class conversion and vectorization functionality.
 
-Each test covers a "decision path" in the base class boilerplate,
-    with a focus on frequently breaking paths in base class refactor and bugfixing.
-The path taken depends on tags of a given transformer, and input data type.
-Concrete transformer classes from sktime are imported to cover
-    different combinations of transformer tags.
-Transformer scenarios cover different combinations of input data types.
+Each test covers a "decision path" in the base class boilerplate,     with a focus on
+frequently breaking paths in base class refactor and bugfixing. The path taken depends
+on tags of a given transformer, and input data type. Concrete transformer classes from
+sktime are imported to cover     different combinations of transformer tags. Transformer
+scenarios cover different combinations of input data types.
 """
 
 __author__ = ["fkiraly"]

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -184,7 +184,10 @@ def test_pipeline_column_vectorization():
 
 
 def test_pipeline_inverse():
-    """Tests that inverse composition works, with inverse skips. Also see #3084."""
+    """Tests that inverse composition works, with inverse skips.
+
+    Also see #3084.
+    """
     X = load_airline()
     t = LogTransformer() * Imputer()
 

--- a/sktime/transformations/tests/test_multiplexer.py
+++ b/sktime/transformations/tests/test_multiplexer.py
@@ -74,8 +74,8 @@ def test_multiplex_transformer_in_grid():
     """Test behavior of MultiplexTransformer.
 
     It often makes sense to use MultiplexTransformer in conjunction with
-    ForecastingGridSearchCV within a pipeline.  Here we check that when you do that
-    you get the expected result.
+    ForecastingGridSearchCV within a pipeline.  Here we check that when you do that you
+    get the expected result.
     """
     y = load_shampoo_sales()
     # randomly make some of the values nans:
@@ -113,9 +113,9 @@ def test_multiplex_transformer_in_grid():
 def test_multiplex_or_dunder():
     """Test that the MultiplexTransforemer magic "|" dunder works.
 
-    A MultiplexTransformer can be created by using the "|" dunder method on
-    either transformer or MultiplexTransformer objects. Here we test that it performs
-    as expected on all the use cases, and raises the expected error in some others.
+    A MultiplexTransformer can be created by using the "|" dunder method on either
+    transformer or MultiplexTransformer objects. Here we test that it performs as
+    expected on all the use cases, and raises the expected error in some others.
     """
     # test a simple | example with two transformers:
     multiplex_two_transformers = ExponentTransformer(2) | ExponentTransformer(3)

--- a/sktime/utils/_maint/_show_versions.py
+++ b/sktime/utils/_maint/_show_versions.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
 # License: BSD 3 clause
-
 """Utility methods to print system info for debugging.
 
-adapted from :func:`sklearn.show_versions`
+adapted from
+:func: `sklearn.show_versions`
 """
 
 __author__ = ["mloning", "fkiraly"]
@@ -16,8 +16,7 @@ import sys
 
 
 def _get_sys_info():
-    """
-    System information.
+    """System information.
 
     Return
     ------
@@ -55,8 +54,7 @@ DEFAULT_DEPS_TO_SHOW = [
 
 
 def _get_deps_info(deps=None):
-    """
-    Overview of the installed version of main dependencies.
+    """Overview of the installed version of main dependencies.
 
     Parameters
     ----------

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -138,7 +138,6 @@ def deep_equals(x, y, return_msg=False):
 
 
 def _is_np_nan(x):
-
     return isinstance(x, float) and np.isnan(x)
 
 

--- a/sktime/utils/_testing/hierarchical.py
+++ b/sktime/utils/_testing/hierarchical.py
@@ -149,7 +149,6 @@ def _bottom_hier_datagen(
         df.index.rename("timepoints", inplace=True)
         return df
     else:
-
         df.columns = ["l1_node01"]
 
         intercept = np.arange(0, intercept_max, 0.01)
@@ -164,7 +163,6 @@ def _bottom_hier_datagen(
         node_lookup.columns = ["l1_agg"]
 
         if no_levels >= 2:
-
             # create index from bottom up, sampling node names
             for i in range(2, no_levels + 1):
                 node_lookup["l" + str(i) + "_agg"] = node_lookup.groupby(

--- a/sktime/utils/_testing/scenarios_getter.py
+++ b/sktime/utils/_testing/scenarios_getter.py
@@ -137,7 +137,7 @@ def _check_tag_cond(obj, filter_tags=None):
 
     cond_sat = True
 
-    for (key, value) in filter_tags.items():
+    for key, value in filter_tags.items():
         if not isinstance(value, list):
             value = [value]
         cond_sat = cond_sat and obj.get_class_tag(key) in set(value)

--- a/sktime/utils/estimators/_base.py
+++ b/sktime/utils/estimators/_base.py
@@ -87,7 +87,6 @@ def make_mock_estimator(
     >>> mock_estimator_instance = mock_estimator_class({"strategy": "last", "sp": 1})
     >>> mock_estimator_instance.fit(y)
     _MockEstimator(...)
-
     """
     dunder_methods_regex = r"^__\w+__$"
 

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -522,7 +522,6 @@ def load_model(model_uri, dst_path=None):
 
 
 def _save_model(model, path, serialization_format):
-
     _check_soft_dependencies("mlflow", severity="error")
     from mlflow.exceptions import MlflowException
     from mlflow.protos.databricks_pb2 import INTERNAL_ERROR
@@ -546,7 +545,6 @@ def _save_model(model, path, serialization_format):
 
 
 def _load_model(path, serialization_format):
-
     _check_soft_dependencies("mlflow", severity="error")
     from mlflow.exceptions import MlflowException
     from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -630,7 +628,6 @@ class _SktimeModelWrapper:
         self.sktime_model = sktime_model
 
     def predict(self, X):
-
         from mlflow.exceptions import MlflowException
         from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
@@ -641,7 +638,6 @@ class _SktimeModelWrapper:
             raw_predictions[SKTIME_PREDICT] = self.sktime_model.predict(X=X)
 
         else:
-
             if not isinstance(self.sktime_model.pyfunc_predict_conf, dict):
                 raise MlflowException(
                     f"Attribute {PYFUNC_PREDICT_CONF} must be of type dict.",

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -323,8 +323,7 @@ def log_model(
     serialization_format=SERIALIZATION_FORMAT_PICKLE,
     **kwargs,
 ):  # TODO: can we specify a type for fitted instance of sktime model below?
-    """
-    Log a sktime model as an MLflow artifact for the current run.
+    """Log a sktime model as an MLflow artifact for the current run.
 
     Parameters
     ----------
@@ -448,8 +447,7 @@ def log_model(
 
 
 def load_model(model_uri, dst_path=None):
-    """
-    Load a sktime model from a local file or a run.
+    """Load a sktime model from a local file or a run.
 
     Parameters
     ----------

--- a/sktime/utils/plotting.py
+++ b/sktime/utils/plotting.py
@@ -118,7 +118,6 @@ def plot_series(
 
     # plot series
     for x, y, color, label, marker in zip(xs, series, colors, labels, markers):
-
         # scatter if little data is available or index is not complete
         if len(x) <= 3 or not np.array_equal(np.arange(x[0], x[-1] + 1), x):
             plot_func = sns.scatterplot

--- a/sktime/utils/seasonality.py
+++ b/sktime/utils/seasonality.py
@@ -62,7 +62,7 @@ def autocorrelation_seasonality_test(y, sp):
             / np.sqrt(n_timepoints)
             * np.sqrt(np.cumsum(np.append(1, 2 * coefs[1:] ** 2)))
         )
-        limit = limits[sp - 1]  #  zero-based indexing
+        limit = limits[sp - 1]  # zero-based indexing
         return np.abs(coef) > limit
 
 

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -109,7 +109,6 @@ def _check_soft_dependencies(
         )
 
     for package in packages:
-
         try:
             req = Requirement(package)
         except InvalidRequirement:

--- a/sktime/utils/validation/forecasting.py
+++ b/sktime/utils/validation/forecasting.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """Validations for use with forecasting module."""
 
 __all__ = [
@@ -157,8 +156,7 @@ def check_y(y, allow_empty=False, allow_constant=True, enforce_index_type=None):
 
 
 def check_cv(cv, enforce_start_with_window=False):
-    """
-    Check CV generators.
+    """Check CV generators.
 
     Parameters
     ----------
@@ -372,7 +370,6 @@ def check_cutoffs(cutoffs: VALID_CUTOFF_TYPES) -> np.ndarray:
     ValueError
         If cutoffs is not a instance of np.array or pd.Index
         If cutoffs array is empty.
-
     """
     if not isinstance(cutoffs, ACCEPTED_CUTOFF_TYPES):
         raise ValueError(
@@ -464,7 +461,8 @@ def check_scoring(scoring, allow_y_pred_benchmark=False, obj=None):
 
 
 def check_regressor(regressor=None, random_state=None):
-    """Check if a regressor is given and if it is valid, otherwise set default regressor.
+    """Check if a regressor is given and if it is valid, otherwise set default
+    regressor.
 
     Parameters
     ----------
@@ -494,8 +492,7 @@ def check_regressor(regressor=None, random_state=None):
 
 
 def check_interval_df(interval_df, index_to_match):
-    """
-    Verify that a predicted interval DataFrame is formatted correctly.
+    """Verify that a predicted interval DataFrame is formatted correctly.
 
     Parameters
     ----------

--- a/sktime/utils/validation/forecasting.py
+++ b/sktime/utils/validation/forecasting.py
@@ -461,8 +461,7 @@ def check_scoring(scoring, allow_y_pred_benchmark=False, obj=None):
 
 
 def check_regressor(regressor=None, random_state=None):
-    """Check if a regressor is given and if it is valid, otherwise set default
-    regressor.
+    """Check if a valid regressor is given, otherwise set default regressor.
 
     Parameters
     ----------

--- a/sktime/utils/validation/series.py
+++ b/sktime/utils/validation/series.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3 -u
 # -*- coding: utf-8 -*-
-
 """Functions for checking input data."""
 
 __author__ = ["mloning", "Dbhasin1", "khrapovs"]


### PR DESCRIPTION
Closes #4676.

What this PR does:

1. Update hook versions.
2. Apply code formatting changes identified by `black`. (affected ~140 files)
3. Apply docstring length/style changes identified by `flake8`+`pydocstyle`. (affected ~180 files)

Notes for reviewers:

* For the 3rd point above, used `docformatter` locally to automate few docstring changes, and these are part of d736b6624d5e6254da4a7888d491eb157dcb0ccf.
* In few places where it was unable to solve the issues (mostly `D205` and `D400`), used my own judgement to modify docstrings slightly to avoid lint failures. These possibly biased changes are part of ae526adfb2eef63970803bb51d5babe0245438ec, and should be reviewed carefully.