### PR TITLE
[DOC] adds a banner for non-latest branches in read-the-docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,6 +49,7 @@ extensions = [
     "myst_parser",
     "sphinx_design",
     "sphinx_issues",
+    "versionwarning.extension",
 ]
 
 # Recommended by sphinx_design when using the MyST Parser
@@ -435,3 +436,15 @@ intersphinx_mapping = {
 
 # -- Options for _todo extension ----------------------------------------------
 todo_include_todos = False
+
+# sphinx-version-warning config
+versionwarning_messages = {
+    "latest": (
+        "This document is for the development version. "
+        'For the stable version documentation, see <a href="/en/stable/">here</a>.'
+    )
+}
+
+# Show warning at top of page
+versionwarning_body_selector = "div.document"
+versionwarning_banner_title = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ docs = [
     "sphinx_issues==1.2.0",
     "sphinx-gallery==0.6.0",
     "sphinx-design==0.3.0",
+    "sphinx-version-warning",
     "sphinx==4.1.1",
     "tabulate",
 ]


### PR DESCRIPTION
Closes #4677 

Adds a new dependency `sphinx-version-warning` as part of `docs` optional dependency. The changes in this PR follows `elyra` example almost unchanged, though `ray`, `marshmallow`, etc. also seem to have same format.