### PR TITLE
[MNT] except some DL and `numba` based estimators from tests to prevent memory overload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,7 +196,7 @@ jobs:
           mkdir -p testdir/
           cp .coveragerc testdir/
           cp setup.cfg testdir/
-          python -m pytest -v -n 1
+          python -m pytest -v
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,7 +196,7 @@ jobs:
           mkdir -p testdir/
           cp .coveragerc testdir/
           cp setup.cfg testdir/
-          python -m pytest
+          python -m pytest -v
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,7 +196,7 @@ jobs:
           mkdir -p testdir/
           cp .coveragerc testdir/
           cp setup.cfg testdir/
-          python -m pytest -v
+          python -m pytest -v -n 1
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v3

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: ## Run unit tests
 	mkdir -p ${TEST_DIR}
 	cp .coveragerc ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
-	python -m pytest
+	python -m pytest -v
 
 test_check_suite: ## run only estimator contract tests in TestAll classes
 	-rm -rf ${TEST_DIR}

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -38,7 +38,6 @@ EXCLUDE_ESTIMATORS = [
     "MACNNClassifier",
     "SimpleRNNClassifier",
     "SimpleRNNRegressor",
-    "AlignerDtwNumba",
 ]
 
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -35,6 +35,7 @@ EXCLUDE_ESTIMATORS = [
     "TimeSeriesLloyds",  # an abstract class, but does not follow naming convention
     # DL classifier suspected to cause hangs and memouts, see #4610
     "FCNClassifier",
+    "MACNNClassifier",
 ]
 
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -36,6 +36,8 @@ EXCLUDE_ESTIMATORS = [
     # DL classifier suspected to cause hangs and memouts, see #4610
     "FCNClassifier",
     "MACNNClassifier",
+    "SimpleRNNClassifier",
+    "SimpleRNNRegressor",
 ]
 
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -38,6 +38,7 @@ EXCLUDE_ESTIMATORS = [
     "MACNNClassifier",
     "SimpleRNNClassifier",
     "SimpleRNNRegressor",
+    "EditDist",
 ]
 
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -38,6 +38,7 @@ EXCLUDE_ESTIMATORS = [
     "MACNNClassifier",
     "SimpleRNNClassifier",
     "SimpleRNNRegressor",
+    "AlignerDtwNumba",
 ]
 
 


### PR DESCRIPTION
Update: removes some recent esetimators from the tests.

Reference to the memory issue is added to the comments in the config files, so we can get back to this, e.g., when we change the testing framework.

---

Suspecting `MACNNClassifier` to be beind the memory related crashes on windows, python 3.9 (https://github.com/sktime/sktime/issues/4610), seeing what happens if we except it from the tests.

Suspicion is due to it being a recent addition. FYI @achieveordie.
