### PR TITLE
&hoesler [BUG] Fix `vectorize_est` returning jumbled columns for column vectorization, `pd.DataFrame` return, if column names were not lexicographically ordered

### DIFF
--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -593,18 +593,8 @@ class VectorizedDF:
             ret.append((group_name, col_name, est_i_result))
 
         if return_type == "pd.DataFrame":
-            df_long = pd.DataFrame(ret)
-            cols_right_order = df_long.loc[:, 1].unique()
-
-            df = df_long.pivot(index=0, columns=1, values=2)
-            # DataFrame.pivot sorts the columns (is this a bug? see #4683)
-            # either way, we need to fix this:
-            df = df.loc[:, cols_right_order]
-
-            # remove "0" and "1" from index/columns name
-            df.index.names = [None] * len(df.index.names)
-            df.columns.name = None
-
+            df = pd.DataFrame(ret)
+            df = df.pivot(index=0, columns=1, values=2).reindex(df[1], axis=1)
             # TODO: add test case for tuple index
             try:
                 df.index = pd.MultiIndex.from_tuples(df.index)

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -593,7 +593,18 @@ class VectorizedDF:
             ret.append((group_name, col_name, est_i_result))
 
         if return_type == "pd.DataFrame":
-            df = pd.DataFrame(ret).pivot(index=0, columns=1, values=2)
+            df_long = pd.DataFrame(ret)
+            cols_right_order = df_long.loc[:, 1].unique()
+
+            df = df_long.pivot(index=0, columns=1, values=2)
+            # DataFrame.pivot sorts the columns (is this a bug? see #4683)
+            # either way, we need to fix this:
+            df = df.loc[:, cols_right_order]
+
+            # remove "0" and "1" from index/columns name
+            df.index.names = [None] * len(df.index.names)
+            df.columns.name = None
+
             # TODO: add test case for tuple index
             try:
                 df.index = pd.MultiIndex.from_tuples(df.index)

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -593,8 +593,18 @@ class VectorizedDF:
             ret.append((group_name, col_name, est_i_result))
 
         if return_type == "pd.DataFrame":
-            df = pd.DataFrame(ret)
-            df = df.pivot(index=0, columns=1, values=2).reindex(df[1], axis=1)
+            df_long = pd.DataFrame(ret)
+            cols_right_order = df_long.loc[:, 1].unique()
+
+            df = df_long.pivot(index=0, columns=1, values=2)
+            # DataFrame.pivot sorts the columns (is this a bug? see #4683)
+            # either way, we need to fix this:
+            df = df.reindex(cols_right_order, axis=1)
+
+            # remove "0" and "1" from index/columns name
+            df.index.names = [None] * len(df.index.names)
+            df.columns.name = None
+
             # TODO: add test case for tuple index
             try:
                 df.index = pd.MultiIndex.from_tuples(df.index)

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -20,7 +20,10 @@ from sktime.forecasting.var import VAR
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_panel
 from sktime.utils._testing.series import _make_series
-from sktime.utils.validation._dependencies import _check_estimator_deps
+from sktime.utils.validation._dependencies import (
+    _check_estimator_deps,
+    _check_soft_dependencies,
+)
 
 PANEL_MTYPES = ["pd-multiindex", "nested_univ", "numpy3D"]
 HIER_MTYPES = ["pd_multiindex_hier"]
@@ -277,6 +280,10 @@ def test_vectorization_multivariate(mtype, exogeneous):
     assert y_pred_equal_length, msg
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_col_vectorization_correct_col_order():
     """Test that forecaster vectorization preserves column index ordering.
 

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -295,6 +295,9 @@ def test_col_vectorization_correct_col_order():
     y = load_macroeconomic().iloc[:5]
 
     f = NaiveForecaster()
+    # force univariate tag to trigger vectorization over columns for sure
+    f.set_tags(**{"scitype:y": "univariate"})
+
     f.fit(y=y, fh=[1])
     y_pred = f.predict()
 

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -132,7 +132,7 @@ class BaseForecastingErrorMetric(BaseMetric):
         self.multioutput = multioutput
         self.multilevel = multilevel
 
-        if not hasattr(self, "name"):
+        if not hasattr(self, "name") or self.name is None:
             self.name = type(self).__name__
 
         super(BaseForecastingErrorMetric, self).__init__()


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4683.

The fix is adding some lines of code that correct the behaviour of `Dataframe.pivot` used in the code (see #4633) by adding some more lines that prevent the columns from being lexicographically sorted, by manually reverting the sorting that `pivot` does.

Further:

* adds a test, indirectly through the minimal forecaster case that failed in #4683.
* fixes an unreported bug in forecasting metrics that could end up with the `name` attr being `None`. This was masked by how `pivot` was previously applied and would result in a vectorization result with all `None` columns.