### PR TITLE
[DOC] developer guide on remote setup of test suite

### DIFF
--- a/docs/source/developer_guide/testing_framework.rst
+++ b/docs/source/developer_guide/testing_framework.rst
@@ -155,6 +155,33 @@ Further, scenarios inherit from ``BaseObject``, which allows to use the ``sktime
 
 For further details on scenarios, inspect the docstring of ``BaseScenario``.
 
+Remote CI set-up
+~~~~~~~~~~~~~~~~
+
+The remote CI runs all package level tests, module level tests, and low-level tests
+for all combinations of supported operating systems (OS) and python versions.
+
+The estimators package and module level are distributed across OS and
+python version combinations so that:
+
+* only about a third of estimators are run per combination
+* a given estimator runs at least once for a given OS
+* a given estimator runs at least once for a python version
+
+This is for reducing runtime and memory requirements for each CI element.
+
+The precise logic maps estimators, OS and python versions on integers,
+and matches estimators with the sum of OS and python version modulo 3.
+
+This logic located in ``subsample_by_version_os`` in ``tests.test_all_estimators``,
+which is called in ``pytest_generate_tests`` of ``BaseFixtureGenerator``, which
+is inherited by all the ``TestAll[estimator_type]`` classes.
+
+By default, the subsetting by OS and python version is switched off,
+but can be turned on by setting the ``pytest`` flag ``matrixdesign`` to ``True``
+(see ``conftest.py``)
+
+
 Extending the testing module
 ----------------------------
 


### PR DESCRIPTION
This doc adds a section to the developer guide on the `sktime` testing framework that describes the remote setup of the test suite, including the subsampling.

It is a bit compact, so a case could be made to extend it into its own section that also explains the GHA setup (not sure if that's duplicative).

FYI @yarnabrina who requested/suggested this - review appreciated.