### PR TITLE
[BUG] fix conversion from `pd-multiindex` to `df-list` if not all index levels are present

### DIFF
--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -1005,7 +1005,7 @@ def from_multiindex_to_dflist(obj, store=None):
 
     obj = _coerce_df_dtypes(obj)
 
-    instance_index = obj.index.levels[0]
+    instance_index = set(obj.index.get_level_values(0))
 
     Xlist = [obj.loc[i].rename_axis(None) for i in instance_index]
 

--- a/sktime/datatypes/tests/test_convert_bugfixes.py
+++ b/sktime/datatypes/tests/test_convert_bugfixes.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""Tests for specific bugfixes to conversion logic."""
+
+__author__ = ["fkiraly"]
+
+
+def test_multiindex_to_df_list_large_level_values():
+    """Tests for failure condition in bug #4668.
+
+    Conversion from pd-multiindex to df-list would fail if the
+    first MultiIndex level (level index 0) had strictly more levels
+    than unique values in it, this can occur post subsetting.
+    """
+    from sktime.datasets import load_osuleaf
+    from sktime.datatypes import convert_to
+
+    X, _ = load_osuleaf(return_type="pd-multiindex")
+    X1 = X.loc[:3]
+
+    convert_to(X1, "df-list")


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4668.

See there for a bug description - the fix replaces the level values by the set of unique indices in the first (index 0) `MultiIndex` level, to avoid indexing at a non-existing index level value.