### PR TITLE
[ENH] add `skbase` to default package version display of `show_versions`

### DIFF
--- a/sktime/utils/_maint/_show_versions.py
+++ b/sktime/utils/_maint/_show_versions.py
@@ -40,6 +40,7 @@ DEFAULT_DEPS_TO_SHOW = [
     "pip",
     "sktime",
     "sklearn",
+    "skbase",
     "numpy",
     "scipy",
     "pandas",


### PR DESCRIPTION
This PR adds `skbase` to the default package version display of `show_versions` - it's a core dependency so should be there.