### PR TITLE
[ENH] improved `BaseForecaster` exception messages, with reference to `self` class name

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -261,7 +261,9 @@ class BaseForecaster(BaseEstimator):
             if not len(key) == 2:
                 raise ValueError(
                     "there should be one or two keys when calling [] or getitem, "
-                    "e.g., mytrafo[key], or mytrafo[key1, key2]"
+                    "of a forecaster, "
+                    "e.g., mytrafo[key], or mytrafo[key1, key2]. "
+                    f"But {self.__class__.__name__} instance got tuple with {len(key)} keys."
                 )
             columns1 = key[0]
             columns2 = key[1]
@@ -1599,7 +1601,8 @@ class BaseForecaster(BaseEstimator):
         # raise error if some method tries to accessed it before it has been set
         if self._fh is None:
             raise ValueError(
-                "No `fh` has been set yet, please specify `fh` " "in `fit` or `predict`"
+                f"No `fh` has been set yet, in this instance of {self.__class__.__name__} "
+                "please specify `fh` " "in `fit` or `predict`"
             )
 
         return self._fh
@@ -1635,8 +1638,8 @@ class BaseForecaster(BaseEstimator):
         requires_fh = self.get_tag("requires-fh-in-fit")
 
         msg = (
-            f"This is because fitting of the `"
-            f"{self.__class__.__name__}` "
+            f"This is because fitting of the "
+            f"forecaster {self.__class__.__name__} "
             f"depends on `fh`. "
         )
 
@@ -1654,8 +1657,8 @@ class BaseForecaster(BaseEstimator):
                 if not requires_fh and self._fh is None:
                     raise ValueError(
                         "The forecasting horizon `fh` must be passed "
-                        "either to `fit` or `predict`, "
-                        "but was found in neither."
+                        "either to `fit` or `predict`, but was found in neither "
+                        f"call of this {self.__class__.__name__} instance's methods."
                     )
                 # in case C. fh is not optional in fit: this is fine
                 # any error would have already been caught in fit
@@ -1666,7 +1669,7 @@ class BaseForecaster(BaseEstimator):
                 # fh must be passed in fit
                 raise ValueError(
                     "The forecasting horizon `fh` must be passed to "
-                    "`fit`, but none was found. " + msg
+                    f"`fit` of {self.__class__.__name__}, but none was found. " + msg
                 )
                 # in case C. fh is optional in fit:
                 # this is fine, nothing to check/raise
@@ -1693,8 +1696,8 @@ class BaseForecaster(BaseEstimator):
                 raise ValueError(
                     "A different forecasting horizon `fh` has been "
                     "provided from "
-                    "the one seen in `fit`. If you want to change the "
-                    "forecasting "
+                    f"the one seen in `fit` in this instance of {self.__class__.__name__}. "
+                    "If you want to change the forecasting "
                     "horizon, please re-fit the forecaster. " + msg
                 )
             # if existing one and new match, ignore new one

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1602,7 +1602,7 @@ class BaseForecaster(BaseEstimator):
         if self._fh is None:
             raise ValueError(
                 f"No `fh` has been set yet, in this instance of {self.__class__.__name__} "
-                "please specify `fh` " "in `fit` or `predict`"
+                "please specify `fh` in `fit` or `predict`"
             )
 
         return self._fh

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -263,7 +263,8 @@ class BaseForecaster(BaseEstimator):
                     "there should be one or two keys when calling [] or getitem, "
                     "of a forecaster, "
                     "e.g., mytrafo[key], or mytrafo[key1, key2]. "
-                    f"But {self.__class__.__name__} instance got tuple with {len(key)} keys."
+                    f"But {self.__class__.__name__} instance got tuple"
+                    f" with {len(key)} keys."
                 )
             columns1 = key[0]
             columns2 = key[1]
@@ -1601,7 +1602,8 @@ class BaseForecaster(BaseEstimator):
         # raise error if some method tries to accessed it before it has been set
         if self._fh is None:
             raise ValueError(
-                f"No `fh` has been set yet, in this instance of {self.__class__.__name__} "
+                f"No `fh` has been set yet, in this instance of "
+                f"{self.__class__.__name__}, "
                 "please specify `fh` in `fit` or `predict`"
             )
 
@@ -1696,7 +1698,8 @@ class BaseForecaster(BaseEstimator):
                 raise ValueError(
                     "A different forecasting horizon `fh` has been "
                     "provided from "
-                    f"the one seen in `fit` in this instance of {self.__class__.__name__}. "
+                    "the one seen already in `fit`, in this instance of "
+                    f"{self.__class__.__name__}. "
                     "If you want to change the forecasting "
                     "horizon, please re-fit the forecaster. " + msg
                 )


### PR DESCRIPTION
This PR improves some exception messageas in `BaseForecaster`, to point to the class name that raised the error - this is useful in diagnosing errors raised by composites such as in #4698.