### PR TITLE
[BUG] fix dead source link for UEA datasets

### DIFF
--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -195,7 +195,10 @@ def _load_dataset(name, split, return_X_y, return_type=None, extract_path=None):
         ):
             # Dataset is not already present in the datasets directory provided.
             # If it is not there, download and install it.
-            url = "https://timeseriesclassification.com/Downloads/%s.zip" % name
+            url = (
+                "https://timeseriesclassification.com/"
+                f"ClassificationDownloads/{name}.zip"
+            )
             # This also tests the validitiy of the URL, can't rely on the html
             # status code as it always returns 200
             try:


### PR DESCRIPTION
UEA have changed the location of their classification datasets, which breaks the loaders that directly access the URL.

This PR fixes the issue temporarily, for the mid term we want to think about mirrors that make the data loaders less dependent on individual data sources that can deprecate without warning.

Fixes #4703