### PR TITLE
[BUG] add test case for failure of `set_params` with nested `sklearn` object

### DIFF
--- a/sktime/base/tests/test_base_sktime.py
+++ b/sktime/base/tests/test_base_sktime.py
@@ -64,4 +64,4 @@ def test_clone_nested_sklearn():
     copy_model.set_params(estimator__random_state=42, estimator__learning_rate=0.01)
 
     # failure condition, see issue #4704: the setting of the copy also sets the orig
-    assert original_model.get_params()["estimator__random_state"] == 5
+    assert original_model.get_params()["estimator__random_state"] == 42

--- a/sktime/base/tests/test_base_sktime.py
+++ b/sktime/base/tests/test_base_sktime.py
@@ -64,4 +64,4 @@ def test_clone_nested_sklearn():
     copy_model.set_params(estimator__random_state=42, estimator__learning_rate=0.01)
 
     # failure condition, see issue #4704: the setting of the copy also sets the orig
-    assert original_model.get_params()["random_state"] == 5
+    assert original_model.get_params()["estimator__random_state"] == 5

--- a/sktime/base/tests/test_base_sktime.py
+++ b/sktime/base/tests/test_base_sktime.py
@@ -64,4 +64,4 @@ def test_clone_nested_sklearn():
     copy_model.set_params(estimator__random_state=42, estimator__learning_rate=0.01)
 
     # failure condition, see issue #4704: the setting of the copy also sets the orig
-    assert original_model.get_params()["estimator__random_state"] == 42
+    assert original_model.get_params()["estimator__random_state"] == 5

--- a/sktime/base/tests/test_base_sktime.py
+++ b/sktime/base/tests/test_base_sktime.py
@@ -50,3 +50,18 @@ def test_get_fitted_params_sklearn_nested():
 
     assert "regressor" in params.keys()
     assert "regressor__n_features_in" in params.keys()
+
+
+def test_clone_nested_sklearn():
+    """Tests nested set_params of with sklearn components has no side effects."""
+    from sklearn.ensemble import GradientBoostingRegressor
+
+    from sktime.forecasting.compose import make_reduction
+
+    sklearn_model = GradientBoostingRegressor(random_state=5, learning_rate=0.02)
+    original_model = make_reduction(sklearn_model)
+    copy_model = original_model.clone()
+    copy_model.set_params(estimator__random_state=42, estimator__learning_rate=0.01)
+
+    # failure condition, see issue #4704: the setting of the copy also sets the orig
+    assert original_model.get_params()["random_state"] == 5


### PR DESCRIPTION
This adds a test case for the failure of `set_params` with nested `sklearn` objects, see https://github.com/sktime/sktime/issues/4704

The fix is in `skbase` and is also tested there: https://github.com/sktime/skbase/pull/195

This PR adds a test in `sktime` with the `sktime` objects for which the failure was reported in #4704.