### PR TITLE
[BUG] remove `IOError` dataset from TSC data registry

### DIFF
--- a/sktime/datasets/tsc_dataset_names.py
+++ b/sktime/datasets/tsc_dataset_names.py
@@ -159,7 +159,6 @@ univariate = [
     "WordSynonyms",
     "Worms",
     "WormsTwoClass",
-    "IOError",
 ]
 
 """ 33 UEA multivariate time series classification problems [2]"""


### PR DESCRIPTION
The `IOError` dataset from the TSC data registry no longer seems to exist - this PR simply removes it from the string registry.