### PR TITLE
[MNT] reduce CI test log verbosity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,7 +196,7 @@ jobs:
           mkdir -p testdir/
           cp .coveragerc testdir/
           cp setup.cfg testdir/
-          python -m pytest -v
+          python -m pytest
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v3

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: ## Run unit tests
 	mkdir -p ${TEST_DIR}
 	cp .coveragerc ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
-	python -m pytest -v
+	python -m pytest
 
 test_check_suite: ## run only estimator contract tests in TestAll classes
 	-rm -rf ${TEST_DIR}


### PR DESCRIPTION
This PR makes small changes to the CI to reduce verbosity of test logs.

Recently increased to diagnose issue https://github.com/sktime/sktime/issues/4610, but we probably should revert the setting before the 0.19.2 release.