### PR TITLE
[ENH] support passing horizons as `range` object in `ForecastingHorizon` and in `fit` and `predict` methods

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2145,6 +2145,10 @@
       "contributions": [
         "bug",
         "code",
+        "doc",
+        "ideas",
+        "maintenance",
+        "review",
         "test"
       ]
     },

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2148,6 +2148,8 @@
         "doc",
         "ideas",
         "maintenance",
+        "mentoring",
+        "question",
         "review",
         "test"
       ]

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -80,7 +80,7 @@ def _check_values(values: Union[VALID_FORECASTING_HORIZON_TYPES]) -> pd.Index:
 
     Parameters
     ----------
-    values : int, list of int, array of int, certain pd.Index types
+    values : int, range, list of int, array of int, certain pd.Index types
         Forecasting horizon with steps ahead to predict.
 
     Raises
@@ -107,6 +107,11 @@ def _check_values(values: Union[VALID_FORECASTING_HORIZON_TYPES]) -> pd.Index:
     elif is_int(values):
         values = pd.Index([values], dtype=int)
 
+    # convert range object to pandas.RangeIndex
+    # range has to be for integers, no need to separate check
+    elif isinstance(values, range):
+        values = pd.Index(values)
+
     elif is_timedelta_or_date_offset(values):
         values = pd.Index([values])
 
@@ -121,6 +126,7 @@ def _check_values(values: Union[VALID_FORECASTING_HORIZON_TYPES]) -> pd.Index:
     else:
         valid_types = (
             "int",
+            "range",
             "1D np.ndarray of type int",
             "1D np.ndarray of type timedelta or dateoffset",
             "list of type int",

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -80,7 +80,7 @@ def _check_values(values: Union[VALID_FORECASTING_HORIZON_TYPES]) -> pd.Index:
 
     Parameters
     ----------
-    values : int, list, array, certain pd.Index types
+    values : int, list of int, array of int, certain pd.Index types
         Forecasting horizon with steps ahead to predict.
 
     Raises
@@ -123,7 +123,7 @@ def _check_values(values: Union[VALID_FORECASTING_HORIZON_TYPES]) -> pd.Index:
             "int",
             "1D np.ndarray of type int",
             "1D np.ndarray of type timedelta or dateoffset",
-            "list",
+            "list of type int",
             *[f"pd.{index_type.__name__}" for index_type in VALID_INDEX_TYPES],
         )
         raise TypeError(

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -374,6 +374,10 @@ def test_nullable_dtypes(nullable_type):
     assert y_pred.dtype == "float64"
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(VAR, severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_range_fh_in_fit():
     """Test using ``range`` in ``fit``."""
     test_dataset = _make_panel(n_instances=10, n_columns=5)
@@ -385,6 +389,10 @@ def test_range_fh_in_fit():
     assert var_predictions.shape == (10 * 2, 5)
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(VAR, severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_range_fh_in_predict():
     """Test using ``range`` in ``predict``."""
     test_dataset = _make_panel(n_instances=10, n_columns=5)

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -372,3 +372,35 @@ def test_nullable_dtypes(nullable_type):
     assert isinstance(y_pred, pd.Series)
     assert len(y_pred) == 40
     assert y_pred.dtype == "float64"
+
+
+def test_range_fh_in_fit():
+    """Test using ``range`` in ``fit``."""
+    test_dataset = _make_panel(n_instances=10, n_columns=5)
+
+    var_model = VAR().fit(test_dataset, fh=range(1, 2 + 1))
+    var_predictions = var_model.predict()
+
+    assert isinstance(var_predictions, pd.DataFrame)
+    assert var_predictions.shape == (10 * 2, 5)
+
+
+def test_range_fh_in_predict():
+    """Test using ``range`` in ``predict``."""
+    test_dataset = _make_panel(n_instances=10, n_columns=5)
+
+    var_model = VAR().fit(test_dataset)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "The forecasting horizon `fh` must be passed either to `fit` or `predict`,"
+            " but was found in neither."
+        ),
+    ):
+        _ = var_model.predict()
+
+    var_predictions = var_model.predict(fh=range(1, 2 + 1))
+
+    assert isinstance(var_predictions, pd.DataFrame)
+    assert var_predictions.shape == (10 * 2, 5)

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -615,26 +615,30 @@ def test_regular_spaced_fh_of_different_periodicity():
 
 
 def test_standard_range_in_fh():
-    """Test creation of ``ForecastingHorizon`` using ``range``."""
+    """Test using most common ``range`` without start/step."""
     standard_range = ForecastingHorizon(values=range(5))
     assert (standard_range == ForecastingHorizon(values=[0, 1, 2, 3, 4])).all()
 
 
 def test_range_with_positive_step_in_fh():
+    """Test using ``range`` with positive step."""
     range_with_positive_step = ForecastingHorizon(values=range(0, 5, 2))
     assert (range_with_positive_step == ForecastingHorizon(values=[0, 2, 4])).all()
 
 
 def test_range_with_negative_step_in_fh():
+    """Test using ``range`` with negative step."""
     range_with_negative_step = ForecastingHorizon(values=range(3, -5, -2))
     assert (range_with_negative_step == ForecastingHorizon(values=[3, 1, -1, -3])).all()
 
 
 def test_range_sorting_in_fh():
+    """Test that ``range`` is independent of order."""
     standard_range = ForecastingHorizon(values=range(5))
     assert (standard_range == ForecastingHorizon(values=[0, 3, 4, 1, 2])).all()
 
 
 def test_empty_range_in_fh():
+    """Test when ``range`` has zero length."""
     empty_range = ForecastingHorizon(values=range(-5))
     assert (empty_range == ForecastingHorizon(values=[])).all()

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -616,8 +616,8 @@ def test_regular_spaced_fh_of_different_periodicity():
 
 def test_standard_range_in_fh():
     """Test using most common ``range`` without start/step."""
-    standard_range = ForecastingHorizon(values=range(5))
-    assert (standard_range == ForecastingHorizon(values=[0, 1, 2, 3, 4])).all()
+    standard_range = ForecastingHorizon(values=range(1, 5 + 1))
+    assert (standard_range == ForecastingHorizon(values=[1, 2, 3, 4, 5])).all()
 
 
 def test_range_with_positive_step_in_fh():

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -612,3 +612,29 @@ def test_regular_spaced_fh_of_different_periodicity():
     naive = NaiveForecaster()
     naive.fit(y)
     naive.predict([1, 3, 5])
+
+
+def test_standard_range_in_fh():
+    """Test creation of ``ForecastingHorizon`` using ``range``."""
+    standard_range = ForecastingHorizon(values=range(5))
+    assert (standard_range == ForecastingHorizon(values=[0, 1, 2, 3, 4])).all()
+
+
+def test_range_with_positive_step_in_fh():
+    range_with_positive_step = ForecastingHorizon(values=range(0, 5, 2))
+    assert (range_with_positive_step == ForecastingHorizon(values=[0, 2, 4])).all()
+
+
+def test_range_with_negative_step_in_fh():
+    range_with_negative_step = ForecastingHorizon(values=range(3, -5, -2))
+    assert (range_with_negative_step == ForecastingHorizon(values=[3, 1, -1, -3])).all()
+
+
+def test_range_sorting_in_fh():
+    standard_range = ForecastingHorizon(values=range(5))
+    assert (standard_range == ForecastingHorizon(values=[0, 3, 4, 1, 2])).all()
+
+
+def test_empty_range_in_fh():
+    empty_range = ForecastingHorizon(values=range(-5))
+    assert (empty_range == ForecastingHorizon(values=[])).all()


### PR DESCRIPTION
Related #4698.

Before this PR, `ForecastingHorizon` did not support passing `range` objects. Since asking for all horizons till a specific one is quite common, one had to do `ForecastingHorizon(values=list(range(12)))` to get next `12` predictions, or use `numpy.arange`.

This PR adds support for `range` (and tests for the same), so that one can do `ForecastingHorizon(values=range(12))` to do the above. This also updates the documentations slightly to explicitly note that list/array passed to create horizon must be of integers.

(note: also added few contribution types to my name as part of this PR. can be removed by reverting commit https://github.com/sktime/sktime/pull/4716/commits/f8d9429c2ff3b32b3a176b7b124c788efaf871af if inappropriate.)