### PR TITLE
[MNT] 0.20.0 release action - remove python 3.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,7 +164,7 @@ jobs:
     strategy:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3
@@ -206,7 +206,7 @@ jobs:
     strategy:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-20.04, macOS-11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -236,7 +236,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macOS-11]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3
@@ -64,11 +64,6 @@ jobs:
       matrix:
         include:
           # Window 64 bit
-          - os: windows-2019
-            python: 37
-            python-version: '3.7'
-            bitness: 64
-            platform_id: win_amd64
           - os: windows-2019
             python: 38
             python-version: '3.8'

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For **deep learning**, see our companion package: [sktime-dl](https://github.com
 For trouble shooting and detailed installation instructions, see the [documentation](https://www.sktime.net/en/latest/installation.html).
 
 - **Operating system**: macOS X · Linux · Windows 8.1 or higher
-- **Python version**: Python 3.7, 3.8, 3.9, 3.10, and 3.11 (only 64 bit)
+- **Python version**: Python 3.8, 3.9, 3.10, and 3.11 (only 64 bit)
 - **Package managers**: [pip] · [conda] (via `conda-forge`)
 
 [pip]: https://pip.pypa.io/en/stable/

--- a/build_tools/check_install_from_test_pypi.sh
+++ b/build_tools/check_install_from_test_pypi.sh
@@ -18,7 +18,7 @@ echo "Creating test environment ..."
 
 # shellcheck disable=SC1091
 source "$(conda info --base)"/etc/profile.d/conda.sh  # set up conda
-conda create -n sktime_testenv python=3.7
+conda create -n sktime_testenv python=3.8
 conda activate sktime_testenv
 
 # Install from test PyPI

--- a/docs/source/get_started.rst
+++ b/docs/source/get_started.rst
@@ -11,7 +11,7 @@ Installation
 
 ``sktime`` currently supports:
 
-* environments with python version 3.7, 3.8, or 3.9.
+* environments with python version 3.8, 3.9, 3.10, or 3.11.
 * operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 * installation via ``PyPi`` or ``conda``
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,7 +5,7 @@ Installation
 
 ``sktime`` currently supports:
 
-* Python versions 3.7, 3.8, 3.9, 3.10, and 3.11.
+* Python versions 3.8, 3.9, 3.10, and 3.11.
 * Operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 
 See here for a `full list of precompiled wheels available on PyPI <https://pypi.org/simple/sktime/>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,13 +37,12 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: Unix",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
-requires-python = ">=3.7,<3.12"
+requires-python = ">=3.8,<3.12"
 dependencies = [
     "deprecated>=1.2.13",
     "numpy>=1.21.0,<1.25",

--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -20,7 +20,7 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
         # "X-y-must-have-same-index": True,  # TODO: need to check (how?)
         # "enforce_index_type": None,  # TODO: need to check (how?)
         "handles-missing-data": False,
-        "python_version": ">=3.7",  # TODO: change to 3.8 (when?)
+        "python_version": ">=3.8",
         "python_dependencies": ["statsforecast"],
     }
 

--- a/sktime/forecasting/compose/tests/test_ensemble.py
+++ b/sktime/forecasting/compose/tests/test_ensemble.py
@@ -4,7 +4,6 @@
 """Unit tests of EnsembleForecaster functionality."""
 
 __author__ = ["GuzalBulatova", "RNKuhns"]
-import sys
 
 import numpy as np
 import pandas as pd

--- a/sktime/forecasting/compose/tests/test_ensemble.py
+++ b/sktime/forecasting/compose/tests/test_ensemble.py
@@ -94,7 +94,6 @@ def test_aggregation_unweighted(forecasters, y, aggfunc):
         ),
     ],
 )
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
 def test_aggregation_weighted(forecasters, y, aggfunc, weights):
     """Assert weighted aggfunc returns the correct values."""
     forecaster = EnsembleForecaster(


### PR DESCRIPTION
Scheduled release action for 0.20.0 - removing python 3.7 due to end of life. See https://github.com/sktime/sktime/issues/4569

Removed from:

* package metadata, support
* estimator metadata
* CI and tests
* documentation