### PR TITLE
[MNT] 0.20.0 deprecation actions

### DIFF
--- a/sktime/benchmarking/tests/test_TSCStrategy.py
+++ b/sktime/benchmarking/tests/test_TSCStrategy.py
@@ -4,7 +4,7 @@ import pytest
 
 from sktime.benchmarking.strategies import TSCStrategy
 from sktime.benchmarking.tasks import TSCTask
-from sktime.classification.compose import ComposableTimeSeriesForestClassifier
+from sktime.classification.ensemble import ComposableTimeSeriesForestClassifier
 from sktime.datasets import load_gunpoint, load_italy_power_demand
 
 classifier = ComposableTimeSeriesForestClassifier(n_estimators=2)

--- a/sktime/benchmarking/tests/test_orchestration.py
+++ b/sktime/benchmarking/tests/test_orchestration.py
@@ -21,8 +21,8 @@ from sktime.benchmarking.orchestration import Orchestrator
 from sktime.benchmarking.results import HDDResults, RAMResults
 from sktime.benchmarking.strategies import TSCStrategy
 from sktime.benchmarking.tasks import TSCTask
-from sktime.classification.ensemble import ComposableTimeSeriesForestClassifier
 from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
+from sktime.classification.ensemble import ComposableTimeSeriesForestClassifier
 from sktime.datasets import load_arrow_head, load_gunpoint
 from sktime.series_as_features.model_selection import SingleSplit
 from sktime.transformations.panel.reduce import Tabularizer

--- a/sktime/benchmarking/tests/test_orchestration.py
+++ b/sktime/benchmarking/tests/test_orchestration.py
@@ -21,7 +21,7 @@ from sktime.benchmarking.orchestration import Orchestrator
 from sktime.benchmarking.results import HDDResults, RAMResults
 from sktime.benchmarking.strategies import TSCStrategy
 from sktime.benchmarking.tasks import TSCTask
-from sktime.classification.compose import ComposableTimeSeriesForestClassifier
+from sktime.classification.ensemble import ComposableTimeSeriesForestClassifier
 from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
 from sktime.datasets import load_arrow_head, load_gunpoint
 from sktime.series_as_features.model_selection import SingleSplit

--- a/sktime/classification/compose/__init__.py
+++ b/sktime/classification/compose/__init__.py
@@ -16,9 +16,3 @@ from sktime.classification.compose._pipeline import (
     ClassifierPipeline,
     SklearnClassifierPipeline,
 )
-
-# 0.20.0 - remove this import
-from sktime.classification.ensemble import (
-    ComposableTimeSeriesForestClassifier,
-    WeightedEnsembleClassifier,
-)

--- a/sktime/classification/ensemble/_ctsf.py
+++ b/sktime/classification/ensemble/_ctsf.py
@@ -227,14 +227,6 @@ class ComposableTimeSeriesForestClassifier(BaseTimeSeriesForest, BaseClassifier)
         )
         BaseClassifier.__init__(self)
 
-        # todo: remove in 0.20.0
-        warn(
-            "ComposableTimeSeriesClassifier has moved to classification.ensemble, "
-            "and will no longer be importable from classification.compose "
-            "from 0.20.0 on. To safely deprecate the old location, "
-            "replace the import with an import from classification.ensemble."
-        )
-
         # We need to add is-fitted state when inheriting from scikit-learn
         self._is_fitted = False
 

--- a/sktime/classification/ensemble/_weighted.py
+++ b/sktime/classification/ensemble/_weighted.py
@@ -4,8 +4,6 @@
 __author__ = ["fkiraly"]
 __all__ = ["WeightedEnsembleClassifier"]
 
-from warnings import warn
-
 import numpy as np
 from sklearn.metrics import accuracy_score
 
@@ -152,14 +150,6 @@ class WeightedEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
             self._metric = metric
 
         super(WeightedEnsembleClassifier, self).__init__()
-
-        # todo: remove in 0.20.0
-        warn(
-            "WeightedEnsembleClassifier has moved to classification.ensemble, "
-            "and will no longer be importable from classification.compose "
-            "from 0.20.0 on. To safely deprecate the old location, "
-            "replace the import with an import from classification.ensemble."
-        )
 
         # set property tags based on tags of components
         ests = self.classifiers_

--- a/sktime/classification/ensemble/tests/__init__.py
+++ b/sktime/classification/ensemble/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for ensemble classifiers."""

--- a/sktime/classification/ensemble/tests/test_ensemble.py
+++ b/sktime/classification/ensemble/tests/test_ensemble.py
@@ -9,7 +9,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.tree import DecisionTreeClassifier
 
-from sktime.classification.compose import ComposableTimeSeriesForestClassifier
+from sktime.classification.ensemble import ComposableTimeSeriesForestClassifier
 from sktime.datasets import load_unit_test
 from sktime.transformations.compose import FeatureUnion
 from sktime.transformations.panel.segment import RandomIntervalSegmenter

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -717,7 +717,7 @@ def _to_relative(fh: ForecastingHorizon, cutoff=None) -> ForecastingHorizon:
             absolute = _coerce_to_period(absolute, freq=fh.freq)
             cutoff = _coerce_to_period(cutoff, freq=fh.freq)
 
-        # TODO: 0.20.0:
+        # TODO: 0.21.0:
         # Check at every minor release whether lower pandas bound >=0.15.0
         # if yes, can remove the workaround in the "else" condition and the check
         #


### PR DESCRIPTION
Deprecation actions for the 0.20.0 release:

* remove deprecation period imports and warnings after moving `ComposableTimeSeriesClassifier` and `WeightedEnsembleClassifier` to `classification.ensemble`
* bump next checkpoint for `pandas` `freq` related compatibility fix for 0.21.0