### PR TITLE
[MNT] 0.20.0 release action - increase `scikit-base` bound to `<0.6.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "numpy>=1.21.0,<1.25",
     "pandas>=1.1.0,<2.1.0",
     "packaging",
-    "scikit-base<0.5.0",
+    "scikit-base<0.6.0",
     "scikit-learn>=0.24.0,<1.3.0",
     "scipy<2.0.0,>=1.2.0",
 ]


### PR DESCRIPTION
For 0.20.0 release: increase `scikit-base` bound to `<0.6.0`.

The 0.5.X releases of `scikit-base` will also drop python 3.7 support.