### PR TITLE
[MNT] use `pypi` API token for release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -141,6 +141,5 @@ jobs:
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
+          password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: wheelhouse/


### PR DESCRIPTION
To strengthen our security posture, we've enabled 2FA on the pypi account.

It appears that this implies that uploads are only possible with API tokens, so we need to replace the login/password secret with an API token secret.

This PR points the release workflow to the API token secret, and we need to enter the secret via the GitHub settings.