### PR TITLE
[ENH] loading of `sktime` datasets from GitHub LFS buffer mirror instead of direct upstream at UEA

### DIFF
--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -193,9 +193,8 @@ def _load_dataset(name, split, return_X_y, return_type=None, extract_path=None):
         ):
             # Dataset is not already present in the datasets directory provided.
             # If it is not there, download and install it.
-            url = (
-                f"https://github.com/sktime/sktime-datasets/raw/main/TSC/{name}.zip"
-            )
+            url = f"https://github.com/sktime/sktime-datasets/raw/main/TSC/{name}.zip"
+
             # This also tests the validitiy of the URL, can't rely on the html
             # status code as it always returns 200
             try:

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -194,8 +194,8 @@ def _load_dataset(name, split, return_X_y, return_type=None, extract_path=None):
             # Dataset is not already present in the datasets directory provided.
             # If it is not there, download and install it.
             url = (
-                "https://timeseriesclassification.com/"
-                f"ClassificationDownloads/{name}.zip"
+                "https://github.com/sktime/sktime-datasets/raw/main/TSC/"
+                f"{name}.zip"
             )
             # This also tests the validitiy of the URL, can't rely on the html
             # status code as it always returns 200
@@ -206,9 +206,9 @@ def _load_dataset(name, split, return_X_y, return_type=None, extract_path=None):
                 )
             except zipfile.BadZipFile as e:
                 raise ValueError(
-                    f"Invalid dataset name ={name} is not available on extract path ="
-                    f"{extract_path}. Nor is it available on "
-                    f"https://timeseriesclassification.com/.",
+                    f"Error, dataset of name ={name} not available on extract path ="
+                    f"{extract_path}. Please raise an issue on the sktime GitHub "
+                    "if you think this should work."
                 ) from e
 
     return _load_provided_dataset(

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -194,8 +194,7 @@ def _load_dataset(name, split, return_X_y, return_type=None, extract_path=None):
             # Dataset is not already present in the datasets directory provided.
             # If it is not there, download and install it.
             url = (
-                "https://github.com/sktime/sktime-datasets/raw/main/TSC/"
-                f"{name}.zip"
+                f"https://github.com/sktime/sktime-datasets/raw/main/TSC/{name}.zip"
             )
             # This also tests the validitiy of the URL, can't rely on the html
             # status code as it always returns 200


### PR DESCRIPTION
This PR changes the primary download location of datasets distributed with `sktime` from the (recently unreliable) UEA datasets repository to a mirror of it, the `sktime-datasets` repository, which is using GitHub LFS.

The `sktime-datasets` repository acts as a downstream buffer from the UEA datasets repository, and prevents that abrupt changes to file paths, file contents, etc reach the user instantly (and surprisingly).

Mid-term, we can set up cron CI around `sktime-datasets` to check integrity and consistency with the upstream.