### PR TITLE
[MNT] remove verbose flag on windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,7 +196,7 @@ jobs:
           mkdir -p testdir/
           cp .coveragerc testdir/
           cp setup.cfg testdir/
-          python -m pytest -v
+          python -m pytest
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
This removes a forgotten "verbose" flag from the windows CI that was added for diagnostic of the sporadic failures.