### PR TITLE
[MNT] address deprecation of `sklearn` `if_delegate_has_method` in 1.3

### DIFF
--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -2,10 +2,9 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 __author__ = ["fkiraly", "mloning"]
-__all__ = ["ColumnwiseTransformer"]
+__all__ = ["ColumnEnsembleTransformer", "ColumnwiseTransformer"]
 
 import pandas as pd
-from sklearn.utils.metaestimators import if_delegate_has_method
 
 from sktime.base._meta import _ColumnEstimator, _HeterogenousMetaEstimator
 from sktime.transformations.base import BaseTransformer
@@ -397,7 +396,6 @@ class ColumnwiseTransformer(BaseTransformer):
 
         return X
 
-    @if_delegate_has_method(delegate="transformer")
     def update(self, X, y=None, update_params=True):
         """Update parameters.
 


### PR DESCRIPTION
`sklearn`'s `if_delegate_has_method` is deprecated and will be removed in 1.3.

This PR removes one instance of the method being imported - it is not relevant for the transformer contract, therefore it can be safely removed.

Also see https://github.com/sktime/sktime/issues/4585#issuecomment-1604960337 for this being reported by @celestinoxp.