### PR TITLE
[BUG] fix `BoxCoxTransformer` failure after `scipy` 1.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "packaging",
     "scikit-base<0.6.0",
     "scikit-learn>=0.24.0,<1.3.0",
-    "scipy<1.11.0,>=1.2.0",
+    "scipy<2.0.0,>=1.2.0",
 ]
 
 [project.optional-dependencies]

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -263,9 +263,9 @@ class BoxCoxTransformer(BaseTransformer):
         params1 = {"method": "pearsonr"}
         params2 = {"method": "mle"}
         params3 = {"method": "guerrero", "sp": 2}
-        params4 = {"method": "fixed", "lambda_fixed" : 1}
-        params5 = {"method": "fixed", "lambda_fixed" : 0}
-        params6 = {"method": "fixed", "lambda_fixed" : -1}
+        params4 = {"method": "fixed", "lambda_fixed": 1}
+        params5 = {"method": "fixed", "lambda_fixed": 0}
+        params6 = {"method": "fixed", "lambda_fixed": -1}
 
         return [params1, params2, params3, params4, params5, params6]
 

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -135,7 +135,6 @@ class BoxCoxTransformer(BaseTransformer):
     def __init__(self, bounds=None, method="mle", sp=None, lambda_fixed=0.0):
         self.bounds = bounds
         self.method = method
-        self.lambda_ = None
         self.sp = sp
         self.lambda_fixed = lambda_fixed
         super().__init__()
@@ -147,6 +146,12 @@ class BoxCoxTransformer(BaseTransformer):
                 f"BoxCoxTransformer method must be one of the strings {VALID_METHODS},"
                 f" but found {method}"
             )
+
+        if method == "fixed":
+            self.set_tags(**{"fit_is_empty": True})
+            self.lambda_ = lambda_fixed
+        else:
+            self.lambda_ = None
 
     def _fit(self, X, y=None):
         """Fit transformer to X and y.

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -58,10 +58,10 @@ class BoxCoxTransformer(BaseTransformer):
 
     * ``"personr"`` - maximization of Pearson correlation between transformed
       and normalized untransformed. Direct interface to ``scipy.stats.boxcox_normmax``
-      with ``method="pearsonr"`` and otherwise defaults.
+      with ``method="pearsonr"``, with ``bracket=bounds``,  and otherwise defaults.
     * ``"mle"`` - maximization of the Box-Cox log-likelihood.
       Direct interface to ``scipy.stats.boxcox_normmax`` with ``method="mle"``
-      and otherwise defaults.
+      with ``bracket=bounds``, and otherwise defaults.
     * ``"guerrero"`` - Guerrero's method with seasonal periodicity, see [2]_.
       this requires the seasonality parameter to be passed as ``sp``.
     * ``"fixed"`` - fixed, pre-specified :math:`\lambda`,

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -85,7 +85,7 @@ class BoxCoxTransformer(BaseTransformer):
     The :math:`\lambda` parameter is fitted per time series and instance and variable,
     by a method depending on the ``method`` parameter:
 
-    * ``"personr"`` - maximization of Pearson correlation between transformed
+    * ``"pearsonr"`` - maximization of Pearson correlation between transformed
       and normalized untransformed. Direct interface to ``scipy.stats.boxcox_normmax``
       with ``method="pearsonr"``, with ``bracket=bounds``,  and otherwise defaults.
     * ``"mle"`` - maximization of the Box-Cox log-likelihood.

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -65,7 +65,7 @@ class BoxCoxTransformer(BaseTransformer):
     * ``"guerrero"`` - Guerrero's method with seasonal periodicity, see [2]_.
       this requires the seasonality parameter to be passed as ``sp``.
     * ``"fixed"`` - fixed, pre-specified :math:`\lambda`,
-      which is passed as ``lambda``.
+      which is passed as ``lambda_fixed``.
 
     Parameters
     ----------

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -48,10 +48,9 @@ def _box_norm(X, bounds, method):
         from scipy import optimize
         from scipy.stats import boxcox_normmax
 
-        options = {'xatol': 1e-12}  # absolute tolerance on `x`
+        options = {"xatol": 1e-12}
 
         def optimizer(fun):
-
             return optimize.minimize_scalar(
                 fun, bounds=bounds, method="bounded", options=options
             )

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -50,6 +50,9 @@ def _box_norm(X, bounds, method):
 
         options = {"xatol": 1e-12}
 
+        if bounds is None:
+            bounds = (-1e12, 1e12)
+
         def optimizer(fun):
             return optimize.minimize_scalar(
                 fun, bounds=bounds, method="bounded", options=options

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -95,10 +95,12 @@ class BoxCoxTransformer(BaseTransformer):
 
     Parameters
     ----------
-    bounds : 2-tuple of float
+    bounds : 2-tuple of finite float
         Initial bracket (lower, upper) for the optimization range
         when fitting the value of lambda. Default = unbounded.
         Ignored if ``method == "fixed"``.
+        For half-open bounds pass a large bound value, e.g., (0, 1e12) for positive
+        lambda. Infinity and nan as bound values are not supported.
     method : {"pearsonr", "mle", "guerrero", "fixed"}, default="mle"
         The optimization approach used to determine the lambda value used
         in the Box-Cox transformation.
@@ -282,8 +284,8 @@ class BoxCoxTransformer(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        params1 = {"method": "pearsonr"}
-        params2 = {"method": "mle"}
+        params1 = {"method": "mle"}
+        params2 = {"method": "pearsonr"}
         params3 = {"method": "guerrero", "sp": 2}
         params4 = {"method": "fixed", "lambda_fixed": 1}
         params5 = {"method": "fixed", "lambda_fixed": 0}


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4769 by using `scipy`'s on-board box-cox-fitter for methods `"mle"` and `"pearsonr"` and enforcing positive values.

The reason for the failure was use of negative values in some interface test cases, which previously would produce garbage results but `scipy` would not complain. As of 1.11.0, it complains (albeit with a confusing error message that makes it hard to track down that it is in fact from negative values in some test cases). See further discussion here: https://github.com/scipy/scipy/issues/18761

This is now solved by introducing an `enforce_positive` argument to `BoxCoxTransformer`, which ensures positive values before fitting. This can be turned off to obtain the previous behaviour, but for positive values it will be the same (although with an additional `np.sign` and `np.abs` calculation that should be fast).

Also makes the following changes, while we're cleaning this up:

* The `sktime` box-cox-fitter in `BoxCoxTransformer` was not using `scipy`'s since the latter did not have settable bounds when the former was originally implemented. I have hence replaced it with `scipy`'s own box-cox-fitter and using a bounded optimizer if bounds are passed, from `scipy` 1.7.0 on where it exists in the form we need. Pre-1.7.0, I've left the old behaviour.
* improved docstring - general improvements, removed some wrong math statements, made clear what the choice of method means and when it interfaces `scipy`
* added a `"fixed"` method, which allows to use the transformer with a fixed parameter - or tune it via grid search.
* input checks on `method`

Note: the fix is behaviour changing, but imo does not require deprecation because it changes some behaviour from buggy/misleading (only in the sub-case where negative values were passed) to sensible.