### PR TITLE
[MNT] bound `scipy<1.11.0` after bracket failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "packaging",
     "scikit-base<0.6.0",
     "scikit-learn>=0.24.0,<1.3.0",
-    "scipy<2.0.0,>=1.2.0",
+    "scipy<1.11.0,>=1.2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This bounds `scipy` away from the new release, given `BracketError` failures #4769, which may or may not be due to a bug in `scipy` - in any case they seem unclear and hard to fix.

We may also want to consider making the defensive bounds in `scipy` more granular in the future.