### PR TITLE
[BUG] Fix `predict_residuals` internal data type conversion

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1129,10 +1129,7 @@ class BaseForecaster(BaseEstimator):
         y_pred = self.predict(fh=fh, X=X)
 
         if not type(y_pred) == type(y):
-            raise TypeError(
-                "y must have same type, dims, index as expected predict return. "
-                f"expected type {type(y_pred)}, but found {type(y)}"
-            )
+            y = convert_to(y, self._y_mtype_last_seen)
 
         y_res = y - y_pred
 

--- a/sktime/forecasting/base/tests/test_base_bugs.py
+++ b/sktime/forecasting/base/tests/test_base_bugs.py
@@ -9,8 +9,8 @@ from sktime.forecasting.model_selection import (
     ExpandingWindowSplitter,
     ForecastingGridSearchCV,
 )
+from sktime.forecasting.naive import NaiveForecaster
 from sktime.forecasting.reconcile import ReconcilerForecaster
-from sktime.forecasting.sarimax import SARIMAX
 from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.transformations.hierarchical.aggregate import Aggregator
 from sktime.transformations.series.difference import Differencer
@@ -62,10 +62,6 @@ def test_heterogeneous_get_fitted_params():
     reconciler.get_fitted_params()  # triggers an error pre-fix
 
 
-@pytest.mark.skipif(
-    not _check_estimator_deps(SARIMAX, severity="none"),
-    reason="skip test if required soft dependency not available",
-)
 def test_predict_residuals_conversion():
     """Regression test for bugfix #4766, related to predict_residuals internal type."""
     from sktime.datasets import load_longley
@@ -73,7 +69,7 @@ def test_predict_residuals_conversion():
 
     y, X = load_longley()
     y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
-    pipe = Differencer() * SARIMAX()
+    pipe = Differencer() * NaiveForecaster()
     pipe.fit(y=y_train, X=X_train, fh=[1, 2, 3, 4])
     result = pipe.predict_residuals()
 


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4766

The `predict_residuals` internal calculation of residuals could break due to different data types for the observed and the predicted, as in some cases the observed would be obtained from `self._y` which can be data type coerced.

The "optimal" solution would be to not do any coercion or conversion, but for now this should be fixed by converting to the predicted which has the data type consistent with the `fit` input.