### PR TITLE
Set the matplotlib backend to agg to avoid that a GUI is triggered.

### DIFF
--- a/sktime/utils/tests/test_plotting.py
+++ b/sktime/utils/tests/test_plotting.py
@@ -48,14 +48,14 @@ def valid_data_types():
     return valid_data_types
 
 
-# todo: remove skip when issue #2066 has been fixed
-@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", series_to_test)
 def test_plot_series_runs_without_error(series_to_plot):
     """Test whether plot_series runs without error."""
     _check_soft_dependencies("matplotlib")
+    import matplotlib
     import matplotlib.pyplot as plt
 
+    matplotlib.use("agg")
     _plot_series(series_to_plot)
     plt.gcf().canvas.draw_idle()
 
@@ -69,8 +69,6 @@ def test_plot_series_runs_without_error(series_to_plot):
     plt.close()
 
 
-# todo: remove skip when issue #2066 has been fixed
-@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", invalid_input_types)
 def test_plot_series_invalid_input_type_raises_error(series_to_plot, valid_data_types):
     """Tests whether plot_series raises error for invalid input types."""
@@ -88,8 +86,6 @@ def test_plot_series_invalid_input_type_raises_error(series_to_plot, valid_data_
             _plot_series(series_to_plot)
 
 
-# todo: remove skip when issue #2066 has been fixed
-@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize(
     "series_to_plot", [(y_airline_true, y_airline_test.reset_index(drop=True))]
 )
@@ -102,8 +98,6 @@ def test_plot_series_with_unequal_index_type_raises_error(
         _plot_series(series_to_plot)
 
 
-# todo: remove skip when issue #2066 has been fixed
-@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", series_to_test)
 def test_plot_series_invalid_marker_kwarg_len_raises_error(series_to_plot):
     """Tests whether plot_series raises error for inconsistent series/markers."""
@@ -121,8 +115,6 @@ def test_plot_series_invalid_marker_kwarg_len_raises_error(series_to_plot):
         _plot_series(series_to_plot, markers=markers)
 
 
-# todo: remove skip when issue #2066 has been fixed
-@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", series_to_test)
 def test_plot_series_invalid_label_kwarg_len_raises_error(series_to_plot):
     """Tests whether plot_series raises error for inconsistent series/labels."""
@@ -140,14 +132,14 @@ def test_plot_series_invalid_label_kwarg_len_raises_error(series_to_plot):
         _plot_series(series_to_plot, labels=labels)
 
 
-# todo: remove skip when issue #2066 has been fixed
-@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", series_to_test)
 def test_plot_series_output_type(series_to_plot):
     """Tests whether plot_series returns plt.fig and plt.ax."""
     _check_soft_dependencies("matplotlib")
+    import matplotlib
     import matplotlib.pyplot as plt
 
+    matplotlib.use("agg")
     # Test output case where kwarg ax=None
     fig, ax = _plot_series(series_to_plot)
 
@@ -175,14 +167,15 @@ def test_plot_series_output_type(series_to_plot):
     )
 
 
-# todo: remove skip when issue #2066 has been fixed
-@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 def test_plot_series_uniform_treatment_of_int64_range_index_types():
     """Verify that plot_series treats Int64 and Range indices equally."""
     # We test that int64 and range indices are treated uniformly and do not raise an
     # error of inconsistent index types
     _check_soft_dependencies("matplotlib")
+    import matplotlib
     import matplotlib.pyplot as plt
+
+    matplotlib.use("agg")
 
     y1 = pd.Series(np.arange(10))
     y2 = pd.Series(np.random.normal(size=10))
@@ -193,23 +186,21 @@ def test_plot_series_uniform_treatment_of_int64_range_index_types():
     plt.close()
 
 
-# todo: remove skip when issue #2066 has been fixed
-@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 # Generically test whether plots only accepting univariate input run
 @pytest.mark.parametrize("series_to_plot", [y_airline])
 @pytest.mark.parametrize("plot_func", univariate_plots)
 def test_univariate_plots_run_without_error(series_to_plot, plot_func):
     """Tests whether plots that accept univariate series run without error."""
     _check_soft_dependencies("matplotlib")
+    import matplotlib
     import matplotlib.pyplot as plt
 
+    matplotlib.use("agg")
     plot_func(series_to_plot)
     plt.gcf().canvas.draw_idle()
     plt.close()
 
 
-# todo: remove skip when issue #2066 has been fixed
-@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 # Generically test whether plots only accepting univariate input
 # raise an error when invalid input type is found
 @pytest.mark.parametrize("series_to_plot", invalid_input_types)
@@ -231,16 +222,16 @@ def test_univariate_plots_invalid_input_type_raises_error(
             plot_func(series_to_plot)
 
 
-# todo: remove skip when issue #2066 has been fixed
-@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 # Generically test output of plots only accepting univariate input
 @pytest.mark.parametrize("series_to_plot", [y_airline])
 @pytest.mark.parametrize("plot_func", univariate_plots)
 def test_univariate_plots_output_type(series_to_plot, plot_func):
     """Tests whether plots accepting univariate series have correct output types."""
     _check_soft_dependencies("matplotlib")
+    import matplotlib
     import matplotlib.pyplot as plt
 
+    matplotlib.use("agg")
     fig, ax = plot_func(series_to_plot)
 
     is_fig_figure = isinstance(fig, plt.Figure)
@@ -255,8 +246,6 @@ def test_univariate_plots_output_type(series_to_plot, plot_func):
     )
 
 
-# todo: remove skip when issue #2066 has been fixed
-@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 # For plots that only accept univariate input, from here onwards are
 # tests specific to a given plot. E.g. to test specific arguments or functionality.
 @pytest.mark.parametrize("series_to_plot", [y_airline])
@@ -265,15 +254,17 @@ def test_univariate_plots_output_type(series_to_plot, plot_func):
 def test_plot_lags_arguments(series_to_plot, lags, suptitle):
     """Tests whether plot_lags run with different input arguments."""
     _check_soft_dependencies("matplotlib")
+
+    import matplotlib
     import matplotlib.pyplot as plt
+
+    matplotlib.use("agg")
 
     plot_lags(series_to_plot, lags=lags, suptitle=suptitle)
     plt.gcf().canvas.draw_idle()
     plt.close()
 
 
-# todo: remove skip when issue #2066 has been fixed
-@pytest.mark.skip(reason="sporadic failure on win CI/CD, see issue 2066")
 @pytest.mark.parametrize("series_to_plot", [y_airline])
 @pytest.mark.parametrize("lags", [6, 12, 24, 36])
 @pytest.mark.parametrize("suptitle", ["Correlation Plot", None])
@@ -281,8 +272,11 @@ def test_plot_lags_arguments(series_to_plot, lags, suptitle):
 def test_plot_correlations_arguments(series_to_plot, lags, suptitle, series_title):
     """Tests whether plot_lags run with different input arguments."""
     _check_soft_dependencies("matplotlib")
+
+    import matplotlib
     import matplotlib.pyplot as plt
 
+    matplotlib.use("agg")
     plot_correlations(
         series_to_plot, lags=lags, suptitle=suptitle, series_title=series_title
     )


### PR DESCRIPTION
Set the backend of matplotlib to 'agg' to hopefully deactivate the tkinter/gui...
#### Reference Issues/PRs
fixes #2066
<!--
# f
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
