### PR TITLE
[MNT] clean-up of `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,7 @@
 # The file lists sktime's algorithm maintainers as specified in GOVERNANCE.md.
 # Each line is a file pattern followed by one or more owners.
 
-* @fkiraly @aiwalter @guzalbulatova
-
-
-sktime/regression/dummy/ @badrmarani
+* @achieveordie @benheid @fkiraly @yarnabrina
 
 sktime/classification/dictionary_based/_boss.py @patrickzib @MatthewMiddlehurst @TonyBagnall
 sktime/classification/dictionary_based/_cboss.py @patrickzib @MatthewMiddlehurst @TonyBagnall
@@ -35,64 +32,51 @@ sktime/classification/shapelet_based/_stc.py @ABostrom @MatthewMiddlehurst @Tony
 sktime/classification/sklearn/_continuous_interval_tree.py @MatthewMiddlehurst
 sktime/classification/sklearn/_rotation_forest.py @MatthewMiddlehurst
 
+sktime/forecasting/adapters/_hcrystalball.py @MichalChromcak
+sktime/forecasting/arima.py @HYang1996
+sktime/forecasting/base/adapters/_statsforecast.py @FedericoGarza
+sktime/forecasting/bats.py @aiwalter
+sktime/forecasting/compose/_ensemble.py @aiwalter
+sktime/forecasting/ets.py @HYang1996
+sktime/forecasting/fbprophet.py @aiwalter
+sktime/forecasting/model_selection/_split @koralturkk
+sktime/forecasting/online_learning/ @magittan
+sktime/forecasting/sarimax.py @TNTran92
+sktime/forecasting/statsforecast.py @FedericoGarza
+sktime/forecasting/structural.py @juanitorduz
+sktime/forecasting/tests/test_ets.py @HYang1996
+sktime/forecasting/tbats.py @aiwalter
+
+sktime/regression/dummy/ @badrmarani
+
+sktime/transformations/panel/augmenter.py @MrPr3ntice @iljamaurer
+sktime/transformations/panel/catch22.py @MatthewMiddlehurst
+sktime/transformations/panel/catch22wrapper.py @MatthewMiddlehurst
+sktime/transformations/panel/channel_selection.py @haskarb @a-pasos-ruiz
 sktime/transformations/panel/dictionary_based/_paa.py @patrickzib @MatthewMiddlehurst
 sktime/transformations/panel/dictionary_based/_sax.py @patrickzib @MatthewMiddlehurst
 sktime/transformations/panel/dictionary_based/_sfa.py @patrickzib @MatthewMiddlehurst
 sktime/transformations/panel/dictionary_based/_sfa_fast.py @patrickzib @MatthewMiddlehurst
-sktime/transformations/panel/catch22.py @MatthewMiddlehurst
-sktime/transformations/panel/catch22wrapper.py @MatthewMiddlehurst
 sktime/transformations/panel/random_intervals.py @MatthewMiddlehurst
-sktime/transformations/panel/shapelet_transform.py @ABostrom @MatthewMiddlehurst @TonyBagnall
-sktime/transformations/panel/supervised_intervals.py @MatthewMiddlehurst
 sktime/transformations/panel/rocket/ @angus924
 sktime/transformations/panel/rocket/_multirocket.py @ChangWeiTan @fstinner @angus924
 sktime/transformations/panel/rocket/_multirocket_multivariate.py @ChangWeiTan @fstinner @angus924
-sktime/transformations/series/impute.py @aiwalter
-sktime/transformations/series/outlier_detection.py @aiwalter
-sktime/transformations/series/compose.py @aiwalter
-sktime/transformations/series/feature_selection.py @aiwalter
 sktime/transformations/panel/signature_based/ @jambo6
-sktime/transformations/series/theta.py @GuzalBulatova
+sktime/transformations/panel/shapelet_transform.py @ABostrom @MatthewMiddlehurst @TonyBagnall
+sktime/transformations/panel/supervised_intervals.py @MatthewMiddlehurst
+
+sktime/transformations/series/clasp.py @patrickzib @ermshaua
+sktime/transformations/series/date.py @danbartl @KishManani
 sktime/transformations/series/difference.py @rnkuhns
 sktime/transformations/series/exponent.py @rnkuhns
-sktime/transformations/series/scaledlogit.py @ltsaprounis
+sktime/transformations/series/feature_selection.py @aiwalter
+sktime/transformations/series/impute.py @aiwalter
 sktime/transformations/series/kalman_filter.py @NoaBenAmi
-sktime/transformations/panel/augmenter.py @MrPr3ntice @iljamaurer
-sktime/transformations/multiplex.py @miraep8
-sktime/transformations/tests/test_multiplexer.py @miraep8
-sktime/transformations/panel/channel_selection.py @haskarb @a-pasos-ruiz @TonyBagnall
+sktime/transformations/series/outlier_detection.py @aiwalter
+sktime/transformations/series/scaledlogit.py @ltsaprounis
 sktime/transformations/series/time_since.py @KishManani
-
-sktime/forecasting/base/ @fkiraly @mloning @aiwalter
-sktime/forecasting/base/adapters/_statsforecast.py @FedericoGarza
-sktime/forecasting/naive.py @Flix6x
-sktime/forecasting/ets.py @HYang1996
-sktime/forecasting/tests/test_ets.py @HYang1996
-sktime/forecasting/fbprophet.py @aiwalter
-sktime/forecasting/bats.py @aiwalter
-sktime/forecasting/tbats.py @aiwalter
-sktime/forecasting/arima.py @HYang1996
-sktime/forecasting/adapters/_hcrystalball.py @MichalChromcak
-sktime/forecasting/statsforecast.py @FedericoGarza
-sktime/forecasting/structural.py @juanitorduz
-sktime/forecasting/model_selection/_split @koralturkk
-sktime/forecasting/compose/_column_ensemble.py @GuzalBulatova
-sktime/forecasting/compose/_multiplexer.py @koralturkk @aiwalter
-sktime/forecasting/compose/_pipeline.py @aiwalter
-sktime/forecasting/compose/_ensemble.py @aiwalter
-sktime/forecasting/online_learning/ @magittan
-sktime/forecasting/sarimax.py @TNTran92
-
-sktime/performance_metrics/forecasting/_functions.py @aiwalter @rnkuhns
-sktime/performance_metrics/forecasting/_classes.py @rnkuhns
-sktime/performance_metrics/annotation
+sktime/transformations/series/theta.py @GuzalBulatova
 
 sktime/annotation/clasp.py @patrickzib @ermshaua
-sktime/annotation/igts.py
-sktime/annotation/ggs.py
-sktime/annotation/datagen.py
-sktime/transformations/series/clasp.py @patrickzib @ermshaua
-
-.github/workflows/* @freddyaboulton
 
 sktime/utils/mlflow_sktime.py @benjaminbluhm

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,11 @@
 
 * @achieveordie @benheid @fkiraly @yarnabrina
 
+sktime/annotation/hmm_learn/ @miraep8
+sktime/annotation/clasp.py @patrickzib @ermshaua
+sktime/annotation/eagglo.py @KatieBuc
+sktime/annotation/stray.py @KatieBuc
+
 sktime/classification/dictionary_based/_boss.py @patrickzib @MatthewMiddlehurst @TonyBagnall
 sktime/classification/dictionary_based/_cboss.py @patrickzib @MatthewMiddlehurst @TonyBagnall
 sktime/classification/dictionary_based/_muse.py @patrickzib @MatthewMiddlehurst @TonyBagnall
@@ -37,6 +42,7 @@ sktime/forecasting/arima.py @HYang1996
 sktime/forecasting/base/adapters/_statsforecast.py @FedericoGarza
 sktime/forecasting/bats.py @aiwalter
 sktime/forecasting/compose/_ensemble.py @aiwalter
+sktime/forecasting/compose/_hierarchy_ensemble.py @VyomkeshVyas
 sktime/forecasting/ets.py @HYang1996
 sktime/forecasting/fbprophet.py @aiwalter
 sktime/forecasting/model_selection/_split @koralturkk
@@ -65,6 +71,7 @@ sktime/transformations/panel/signature_based/ @jambo6
 sktime/transformations/panel/shapelet_transform.py @ABostrom @MatthewMiddlehurst @TonyBagnall
 sktime/transformations/panel/supervised_intervals.py @MatthewMiddlehurst
 
+sktime/transformations/series/clear_sky.py @ciaran-g
 sktime/transformations/series/clasp.py @patrickzib @ermshaua
 sktime/transformations/series/date.py @danbartl @KishManani
 sktime/transformations/series/difference.py @rnkuhns
@@ -76,7 +83,5 @@ sktime/transformations/series/outlier_detection.py @aiwalter
 sktime/transformations/series/scaledlogit.py @ltsaprounis
 sktime/transformations/series/time_since.py @KishManani
 sktime/transformations/series/theta.py @GuzalBulatova
-
-sktime/annotation/clasp.py @patrickzib @ermshaua
 
 sktime/utils/mlflow_sktime.py @benjaminbluhm


### PR DESCRIPTION
This cleans up the `CODEOWNERS` file as follows:

* orders `CODEOWNERS` by alphabet
* sets the general owners to the currently four core developers with daily/weekly contribution frequency - @achieveordie, @benHeid , @fkiraly, @yarnabrina - this does not have a formal meaning of ownership, it only means we receive review requests
* removes codeowners of base and some general framework building modules - these are "commonly owned" and not an individual's
* rectifies ownership where it was missing or incorrect
    * adds missing `DateTimeTransformer` (@danbartl, @KishManani)
    * adds missing `ClearSkyTransformer` (@ciaran-g)
    * adds missing `HierarchyEnsembleForecaster` (@VyomkeshVyas)
    * added missing owners in the annotation module - @miraep8, @katiebuc

There are probably others, I wonder whether it's worth updating it here - notifications will in general not be sent to individuals without write access. So, should owners (if applicable) not rather be attached via a tag instead?