### PR TITLE
[MNT] add back `pycatch22` as a soft dependency post python 3.7 EOL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ all_extras = [
     "numba>=0.53; python_version < '3.11'",
     "pmdarima>=1.8.0,!=1.8.1,<3.0.0",
     "prophet>=1.1",
+    "pycatch22",
     "pykalman>=0.9.5; python_version < '3.11'",
     "pyod>=0.8.0; python_version < '3.11'",
     "scikit_posthocs>=0.6.5",


### PR DESCRIPTION
Reverts the temporary fix https://github.com/sktime/sktime/pull/3917/files which removed `pycatch22` as a soft dependency (and prevented dependent estimator tests to run).

Potentially fixes https://github.com/sktime/sktime/issues/3895 if the install is without problems now, post-3.7 EOL.