### PR TITLE
[ENH] improvements to `_HeterogenousMetaEstimator` and `_ColumnEstimator`

### DIFF
--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -786,11 +786,30 @@ class _ColumnEstimator:
     """Mixin class with utilities for by-column applicates."""
 
     def _coerce_to_pd_index(self, obj, ref=None):
-        """Coerce obj to pandas Index."""
-        if ref is None:
-            ref = self._y
-        # replace ints by column names
-        obj = self._get_indices(ref, obj)
+        """Coerce obj to pandas Index, replacing ints by index elements.
+
+        Parameters
+        ----------
+        obj : iterable of pandas compatible index elements or int
+        ref : reference index, coercible to pd.Index, optional, default=None
+
+        Returns
+        -------
+        obj coerced to pd.Index
+            if ref was passed, and
+            if obj had int or np.integer elements which do not occur in ref,
+            then each int-like element is replaced by the i-th element of ref
+        """
+        if ref is not None:
+            # coerce ref to pd.Index
+            if not isinstance(ref, pd.Index):
+                if hasattr(ref, "index") and isinstance(ref.index, pd.Index):
+                    ref = ref.index
+            else:
+                ref = pd.Index(ref)
+
+            # replace ints by column names
+            obj = self._get_indices(ref, obj)
 
         # deal with numpy int by coercing to python int
         if np.issubdtype(type(obj), np.integer):

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -131,8 +131,8 @@ class _HeterogenousMetaEstimator:
         # 2. Step replacement
         items = getattr(self, attr)
         names = []
-        if items:
-            names, _ = zip(*items)
+        if items and isinstance(items, (list, tuple)):
+            names = list(zip(*items))[0]
         for name in list(params.keys()):
             if "__" not in name and name in names:
                 self._replace_estimator(attr, name, params.pop(name))
@@ -143,9 +143,12 @@ class _HeterogenousMetaEstimator:
     def _replace_estimator(self, attr, name, new_val):
         # assumes `name` is a valid estimator name
         new_estimators = list(getattr(self, attr))
-        for i, (estimator_name, _) in enumerate(new_estimators):
+        for i, est_tpl in enumerate(new_estimators):
+            estimator_name = est_tpl[0]
             if estimator_name == name:
-                new_estimators[i] = (name, new_val)
+                new_tpl = list(est_tpl)
+                new_tpl[1] = new_val
+                new_estimators[i] = tuple(new_tpl)
                 break
         setattr(self, attr, new_estimators)
 
@@ -782,10 +785,12 @@ def is_flat(obj):
 class _ColumnEstimator:
     """Mixin class with utilities for by-column applicates."""
 
-    def _coerce_to_pd_index(self, obj):
+    def _coerce_to_pd_index(self, obj, ref=None):
         """Coerce obj to pandas Index."""
+        if ref is None:
+            ref = self._y
         # replace ints by column names
-        obj = self._get_indices(self._y, obj)
+        obj = self._get_indices(ref, obj)
 
         # deal with numpy int by coercing to python int
         if np.issubdtype(type(obj), np.integer):

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -170,7 +170,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
         for name, forecaster, index in forecasters:
             forecaster_ = forecaster.clone()
 
-            pd_index = self._coerce_to_pd_index(index)
+            pd_index = self._coerce_to_pd_index(index, self._y.index)
 
             forecaster_.fit(y.loc[:, pd_index], X, fh)
             self.forecasters_.append((name, forecaster_, index))
@@ -191,7 +191,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
         self : an instance of self.
         """
         for _, forecaster, index in self.forecasters_:
-            pd_index = self._coerce_to_pd_index(index)
+            pd_index = self._coerce_to_pd_index(index, self._y.index)
             forecaster.update(y.loc[:, pd_index], X, update_params=update_params)
         return self
 


### PR DESCRIPTION
This improves the `_HeterogenousMetaEstimator` and `_ColumnEstimator`:

* `_HeterogenousMetaEstimator` now allows tuples of any length in the `_steps_attr`, as long as the zeroth elements are str names, and the first elements are estimators
* `_ColumnEstimator._coerce_to_pd_index` has been refactored so that a `ref` reference index is passed instead of assuming `self._y` is present (which is the case only in forecasters)

The change to `_HeterogenousMetaEstimator` is indirectly tested in https://github.com/sktime/sktime/pull/4789 and will be tested in `scikit-base`.

The change to `_ColumnEstimator._coerce_to_pd_index` is covered by existing tests as it is a re-factor that makes it more flexible (allowing #4789).