### PR TITLE
[ENH] Added temporal importance curve generation and plotting to BaseTimeSeriesForest

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2197,7 +2197,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/19725980?v=4",
       "profile": "https://github.com/CTFallon",
       "contributions": [
-        "doc"
+        "doc",
+        "code"
       ]
     },
     {
@@ -2206,7 +2207,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/mgazian000",
       "profile": "https://github.com/mgazian000",
       "contributions": [
-        "doc"
+        "doc",
+        "code"
       ]
     }
   ]

--- a/sktime/classification/plotting/temporal_importance_diagram.py
+++ b/sktime/classification/plotting/temporal_importance_diagram.py
@@ -5,6 +5,9 @@ __author__ = ["MatthewMiddlehurst"]
 import numpy as np
 
 from sktime.classification.interval_based import CanonicalIntervalForest
+from sktime.series_as_features.base.estimators.interval_based import (
+    BaseTimeSeriesForest,
+)
 from sktime.transformations.panel import catch22
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
@@ -75,3 +78,25 @@ def plot_cif(cif, normalise_time_points=False, top_curves_shown=None, plot_mean=
         top_curves_shown=top_curves_shown,
         plot_mean=plot_mean,
     )
+
+
+def plot_TSF_temporal_importance_curve(tsf, file_name):
+    """Temporal Importance curve diagram generator for TSF."""
+    import matplotlib.pyplot as plt
+
+    if not isinstance(tsf, BaseTimeSeriesForest) or not tsf._is_fitted:
+        raise ValueError("Input must be a fitted object that inherits from BaseTSF")
+
+    curves = {
+        "Mean": tsf.mean_curve_,
+        "StDev": tsf.stdev_curve_,
+        "Slope": tsf.slope_curve_,
+    }
+
+    for curve_name, curve in curves.items():
+        plt.plot(curve, label=curve_name)
+
+    plt.legend()
+
+    plt.savefig(file_name)
+    plt.clf()

--- a/sktime/classification/plotting/temporal_importance_diagram.py
+++ b/sktime/classification/plotting/temporal_importance_diagram.py
@@ -1,7 +1,8 @@
 """Temporal importance curve diagram generators for interval forests."""
 
-__author__ = ["MatthewMiddlehurst"]
+__author__ = ["MatthewMiddlehurst", "mgazian000", "CTFallon"]
 
+__all__ = ["plot_curves", "plot_cif", "plot_TSF_temporal_importance_curve"]
 import numpy as np
 
 from sktime.classification.interval_based import CanonicalIntervalForest

--- a/sktime/series_as_features/base/estimators/interval_based/_tsf.py
+++ b/sktime/series_as_features/base/estimators/interval_based/_tsf.py
@@ -7,6 +7,8 @@ __author__ = [
     "kanand77",
     "mloning",
     "Oleksii Kachaiev",
+    "CTFallon",
+    "mgazian000",
 ]
 __all__ = [
     "BaseTimeSeriesForest",


### PR DESCRIPTION
#### Reference Issues/PRs
Resolves issues discussed in #4701.


#### What does this implement/fix? Explain your changes.
Added two bits of functionality.
- in `BaseTimeSeriesForest` class (`series_as_features/base/estimators/interval_based/_tsf.py`), added `_temporal_curves` function which correctly calculates the importance of each feature for every timestamp. This new function is automatically called during `_fit` and creates four numpy.ndarray attributes to `BaseTimeSeriesForest`.
- adds function `plot_TSF_temporal_importance_curve` to `classification/plotting/temporal_importance_diagram.py` which takes a fitted estimator that inherits from `BaseTimeSeriesForest` and creates a plot of the three features' importance curves.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

We are fairly new to sktime, so overall program paradigm. To enumerate a few questions:
- The plotting function currently saves the plot, should it instead return the plot?
- For large forests, the `_temporal_curves` function might take a while: should it be removed from `_fit`, and perhaps changed into a public function that the user can call explicitly, and be called in the plotting function?
- Calculating the actual curves can probably be optimized, but that is not my strong suit.

#### Did you add any tests for the change?

No.

#### Any other comments?

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).