### PR TITLE
[MNT] ensure CI for python 3.8-3.10 runs on `pandas 2`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,7 +186,7 @@ jobs:
         run: conda install -c anaconda libpython
 
       - name: Install sktime and dependencies
-        run: python -m pip install .[all_extras,dev]
+        run: python -m pip install .[all_extras_pandas2,dev]
 
       - name: Show dependencies
         run: python -m pip list
@@ -220,7 +220,7 @@ jobs:
 
       - name: Install sktime and dependencies
         run: |
-          python -m pip install .[all_extras,dev] --no-cache-dir
+          python -m pip install .[all_extras_pandas2,dev] --no-cache-dir
 
       - name: Show dependencies
         run: python -m pip list

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -51,7 +51,7 @@ jobs:
         run: echo "WHEELNAME=$(ls ./wheelhouse/sktime-*none-any.whl)" >> $GITHUB_ENV
 
       - name: Install wheel and extras
-        run: python -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"
+        run: python -m pip install "${{ env.WHEELNAME }}[all_extras_pandas2,dev]"
 
       - name: Run tests
         run: make test
@@ -115,7 +115,7 @@ jobs:
         run: conda activate test
 
       - name: Install wheel and extras
-        run: python -m pip install "${env:WHEELNAME}[all_extras,dev]"
+        run: python -m pip install "${env:WHEELNAME}[all_extras_pandas2,dev]"
 
       - name: Show conda packages
         run: conda list -n test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,38 @@ all_extras = [
     "seasonal",
 ]
 
+all_extras_pandas2 = [
+    "attrs",
+    "cloudpickle",
+    "dash!=2.9.0",
+    "dask",
+    "dtw-python",
+    "esig==0.9.7; python_version < '3.10'",
+    "filterpy>=1.4.5; python_version < '3.11'",
+    "h5py",
+    "hmmlearn>=0.2.7; python_version < '3.11'",
+    "gluonts>=0.9.0",
+    "keras-self-attention; python_version < '3.11'",
+    "kotsu>=0.3.1",
+    "matplotlib>=3.3.2",
+    "mne",
+    "numba>=0.53; python_version < '3.11'",
+    "pmdarima>=1.8.0,!=1.8.1,<3.0.0",
+    "prophet>=1.1",
+    "pykalman>=0.9.5; python_version < '3.11'",
+    "pyod>=0.8.0; python_version < '3.11'",
+    "scikit_posthocs>=0.6.5",
+    "seaborn>=0.11.0",
+    "statsmodels>=0.12.1",
+    "stumpy>=1.5.1; python_version < '3.11'",
+    "tbats>=1.1.0",
+    "tensorflow; python_version < '3.11'",
+    "tsfresh>=0.17.0",
+    "tslearn>=0.5.2; python_version < '3.11'",
+    "xarray",
+    "seasonal",
+]
+
 cython_extras = [
     "mrsqm; python_version < '3.11'",
 ]


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4794

This is done by removal of packages conflicting with `pandas 2` from the dependency set that is tested.

The `all_extras` set does not change, instead a smaller `all_extras_pandas2` is tested.