### PR TITLE
[ENH] `ColumnEnsembleTransformer` dunders

### DIFF
--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -782,10 +782,12 @@ def is_flat(obj):
 class _ColumnEstimator:
     """Mixin class with utilities for by-column applicates."""
 
-    def _coerce_to_pd_index(self, obj):
+    def _coerce_to_pd_index(self, obj, ref=None):
         """Coerce obj to pandas Index."""
+        if ref is None:
+            ref = self._y
         # replace ints by column names
-        obj = self._get_indices(self._y, obj)
+        obj = self._get_indices(ref, obj)
 
         # deal with numpy int by coercing to python int
         if np.issubdtype(type(obj), np.integer):

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -131,8 +131,8 @@ class _HeterogenousMetaEstimator:
         # 2. Step replacement
         items = getattr(self, attr)
         names = []
-        if items:
-            names, _ = zip(*items)
+        if items and isinstance(items, (list, tuple)):
+            names = list(zip(*items))[0]
         for name in list(params.keys()):
             if "__" not in name and name in names:
                 self._replace_estimator(attr, name, params.pop(name))
@@ -143,9 +143,12 @@ class _HeterogenousMetaEstimator:
     def _replace_estimator(self, attr, name, new_val):
         # assumes `name` is a valid estimator name
         new_estimators = list(getattr(self, attr))
-        for i, (estimator_name, _) in enumerate(new_estimators):
+        for i, est_tpl in enumerate(new_estimators):
+            estimator_name = est_tpl[0]
             if estimator_name == name:
-                new_estimators[i] = (name, new_val)
+                new_tpl = list(est_tpl)
+                new_tpl[1] = new_val
+                new_estimators[i] = tuple(new_tpl)
                 break
         setattr(self, attr, new_estimators)
 

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -90,7 +90,7 @@ class ColumnEnsembleTransformer(
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
     # this must be an iterable of (name: str, estimator, ...) tuples for the default
-    _steps_attr = "_transformers"
+    _steps_attr = "transformers"
     # if the estimator is fittable, _HeterogenousMetaEstimator also
     # provides an override for get_fitted_params for params from the fitted estimators
     # the fitted estimators should be in a different attribute, _steps_fitted_attr

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -95,7 +95,7 @@ class ColumnEnsembleTransformer(_HeterogenousMetaEstimator, _ColumnEstimator):
         if remainder not in ["drop", "passthrough", None]:
             if not isinstance(remainder, BaseTransformer):
                 raise ValueError(
-                    "the remainder parameter of ColumnEnsembletransformer "
+                    "the remainder parameter of ColumnEnsembleTransformer "
                     ' must be one of the strings "drop", "passthrough", None,'
                     "or an sktime transformer inheriting from BaseTransformer"
                 )

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -152,6 +152,30 @@ class ColumnEnsembleTransformer(
             tags_to_clone = ["scitype:transform-output", "scitype:transform-labels"]
             self.clone_tags(transformers[0][1], tags_to_clone)
 
+    def __add__(self, other):
+        """Magic + method, return (right) concatenated ColumnEnsembleTransformer.
+
+        Implemented for `other` being a transformer, otherwise returns `NotImplemented`.
+
+        Parameters
+        ----------
+        other: `sktime` transformer, must inherit from BaseTransformer
+            otherwise, `NotImplemented` is returned
+
+        Returns
+        -------
+        ColumnEnsembleTransformer object,
+            concatenation of `self` (first) with `other` (last).
+            not nested, contains only non-ColumnEnsembleTransformer transformers
+        """
+        return self._dunder_concat(
+            other=other,
+            base_class=BaseTransformer,
+            composite_class=ColumnEnsembleTransformer,
+            attr_name="transformers",
+            concat_order="left",
+        )
+
     @property
     def _transformers(self):
         """Make internal list of transformers.

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -32,6 +32,9 @@ class ColumnEnsembleTransformer(
     This is useful for heterogeneous or columnar data, to combine several
     feature extraction mechanisms or transformations into a single transformer.
 
+    Note: this estimator has the same effect as combining
+    ``FeatureUnion`` with ``ColumnSelect``, but can be more convenient or compact.
+
     Parameters
     ----------
     transformers : sktime trafo, or list of tuples (str, estimator, int or pd.index)

--- a/sktime/transformations/panel/compose.py
+++ b/sktime/transformations/panel/compose.py
@@ -83,7 +83,6 @@ class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
         If True, pandas dataframe is returned.
         If False, numpy array is returned.
 
-
     Attributes
     ----------
     transformers_ : list

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -168,6 +168,32 @@ class ColumnSelect(BaseTransformer):
         self.index_treatment = index_treatment
         super().__init__()
 
+    def __mul__(self, other):
+        """Magic * method, return ColumnEnsembleTransformer.
+
+        Implemented for `other` being a transformer, otherwise returns `NotImplemented`.
+
+        Parameters
+        ----------
+        other: `sktime` transformer, must inherit from BaseTransformer
+            otherwise, `NotImplemented` is returned
+
+        Returns
+        -------
+        ColumnEnsembleTransformer, other[self.columns], if self has default params
+            otherwise, returns NotImplemented
+        """
+        if self.integer_treatment != "col" or self.index_treatment != "remove":
+            return NotImplemented
+
+        if not isinstance(other, BaseTransformer):
+            return NotImplemented
+
+        from sktime.transformations.compose import ColumnEnsembleTransformer
+
+        name = f"{other.__class__.__name}[{self.columns}]"
+        return ColumnEnsembleTransformer([name, other, self.columns])
+
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.
 

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -10,6 +10,7 @@ from sklearn.preprocessing import StandardScaler
 from sktime.datasets import load_airline
 from sktime.datatypes import get_examples
 from sktime.transformations.compose import (
+    ColumnEnsembleTransformer,
     FeatureUnion,
     InvertTransform,
     OptionalPassthrough,
@@ -214,8 +215,8 @@ def test_subset_getitem():
     t_both = t[["a", "b"], ["b__0", "b__2", "c__0", "c__2"]]
     t_none = t[:, :]
 
-    assert isinstance(t_before, TransformerPipeline)
-    assert isinstance(t_after_with_colon, TransformerPipeline)
+    assert isinstance(t_before, ColumnEnsembleTransformer)
+    assert isinstance(t_after_with_colon, ColumnEnsembleTransformer)
     assert isinstance(t_before_with_colon, TransformerPipeline)
     assert isinstance(t_both, TransformerPipeline)
     assert isinstance(t_none, ThetaLinesTransformer)


### PR DESCRIPTION
This PR changes how the `+` and `[ ]` dunders combine.

Previously, `est1["a"] + est2["b"]` would create a `Featureunion` of `TransformerPipeline`-s, each pipeline being a pipeline of a `ColumnSelect` and `est1`/`est2`.

Post PR, this resolves to `ColumnEnsembleTransformer([(x, est1, "a"), (y, est2, "b")])`, where `x` and `y` are auto-generated names.

Depends on https://github.com/sktime/sktime/pull/4789

Todo: requires deprecation, as the changing resultant estimator will change how tuning parameters are named, and may break existing code.