### PR TITLE
[BUG] Add temporary fix to _BaseWindowForecaster to handle simultaneous in and out-of-sample forecasts

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2208,6 +2208,17 @@
       "contributions": [
         "doc"
       ]
+    },
+
+    {
+      "login": "felipeangelimvieira",
+      "name": "Felipe Angelim",
+      "avatar_url": "https://avatars.githubusercontent.com/felipeangelimvieira",
+      "profile": "https://github.com/felipeangelimvieira",
+      "contributions": [
+        "code",
+        "bug"
+      ]
     }
   ]
 }

--- a/sktime/forecasting/base/_sktime.py
+++ b/sktime/forecasting/base/_sktime.py
@@ -41,6 +41,10 @@ class _BaseWindowForecaster(BaseForecaster):
             y_oos = self._predict_fixed_cutoff(
                 fh.to_out_of_sample(self.cutoff), **kwargs
             )
+
+            if isinstance(y_ins, pd.DataFrame) and isinstance(y_oos, pd.Series):
+                y_oos = y_oos.to_frame(y_ins.columns[0])
+
             y_pred = pd.concat([y_ins, y_oos])
 
         # ensure pd.Series name attribute is preserved

--- a/sktime/forecasting/tests/test_window_forecasters.py
+++ b/sktime/forecasting/tests/test_window_forecasters.py
@@ -5,10 +5,12 @@
 __author__ = ["mloning"]
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from sktime.forecasting.base._sktime import _BaseWindowForecaster
 from sktime.forecasting.model_selection import temporal_train_test_split
+from sktime.forecasting.naive import NaiveForecaster
 from sktime.registry import all_estimators
 from sktime.utils._testing.forecasting import make_forecasting_problem
 from sktime.utils._testing.series import _make_series
@@ -42,3 +44,18 @@ def test_last_window(Forecaster):
 
     np.testing.assert_array_equal(actual, expected)
     assert len(actual) == f.window_length_
+
+
+def test_insample_and_outofsample_forecasting():
+    n = 20
+    df = pd.DataFrame(
+        index=pd.period_range("2020-01-01", periods=n, freq="D"),
+        data={"value": np.arange(n)},
+    )
+
+    model = NaiveForecaster(strategy="mean", window_length=7)
+    model.fit(df)
+
+    assert (model.predict(fh=[1, 2, 3]).values.flatten() == [16, 16, 16]).all()
+    assert (model.predict(fh=[0]).values.flatten() == [15]).all()
+    assert (model.predict(fh=[0, 1, 2, 3]).values.flatten() == [15, 16, 16, 16]).all()


### PR DESCRIPTION
Added temporary fix to _BaseWindowForecaster to handle simultaneous in and out-of-sample forecasts (see #4773). Also added a test to check if NaiveForecaster and BaseWindowForecaster work as expected.


#### Reference Issues/PRs
Fixes #4773

#### What does this implement/fix? Explain your changes.

Added an if clause to [_BaseWindowForecaster _predict method](https://github.com/sktime/sktime/blob/32493231800d94f8a5b6df6d1bc42ae0fb398c69/sktime/forecasting/base/_sktime.py#L44) to correctly concatenate the outputs of in and out of sample forecasts.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### Did you add any tests for the change?

Added `test_insample_and_outofsample_forecasting` to `sktime/forecasting/tests/test_window_forecasters.py`

#### Any other comments?
As this is my first contribution to this package, I'm not sure if I'm skipping some name or other convention. Please feel free to highlight if something should be altered in this PR.



