### PR TITLE
[DOC] add missing metrics to API reference

### DIFF
--- a/docs/source/api_reference/performance_metrics.rst
+++ b/docs/source/api_reference/performance_metrics.rst
@@ -13,10 +13,10 @@ The :mod:`sktime.performance_metrics` module contains metrics for evaluating and
 Forecasting
 -----------
 
-.. currentmodule:: sktime.performance_metrics.forecasting
+Point forecasts - classes
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Classes
-~~~~~~~
+.. currentmodule:: sktime.performance_metrics.forecasting
 
 .. autosummary::
     :toctree: auto_generated/
@@ -44,8 +44,10 @@ Classes
     MeanLinexError
     RelativeLoss
 
-Functions
-~~~~~~~~~
+Point forecasts - functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: sktime.performance_metrics.forecasting
 
 .. autosummary::
     :toctree: auto_generated/
@@ -74,9 +76,37 @@ Functions
     mean_linex_error
     relative_loss
 
+Quantile and interval forecasts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Segmentation
-~~~~~~~~~~~~
+.. currentmodule:: sktime.performance_metrics.forecasting
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class_with_call.rst
+
+    PinballLoss
+    EmpiricalCoverage
+    ConstraintViolation
+
+Distribution forecasts
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: sktime.performance_metrics.forecasting
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class_with_call.rst
+
+    CRPS
+    LogLoss
+    SquaredDistrLoss
+
+
+Time series segmentation
+------------------------
+
+.. currentmodule:: sktime.performance_metrics.annotation
 
 .. autosummary::
     :toctree: auto_generated/

--- a/docs/source/api_reference/performance_metrics.rst
+++ b/docs/source/api_reference/performance_metrics.rst
@@ -79,7 +79,7 @@ Point forecasts - functions
 Quantile and interval forecasts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. currentmodule:: sktime.performance_metrics.forecasting
+.. currentmodule:: sktime.performance_metrics.forecasting.probabilistic
 
 .. autosummary::
     :toctree: auto_generated/
@@ -92,7 +92,7 @@ Quantile and interval forecasts
 Distribution forecasts
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. currentmodule:: sktime.performance_metrics.forecasting
+.. currentmodule:: sktime.performance_metrics.forecasting.probabilistic
 
 .. autosummary::
     :toctree: auto_generated/

--- a/sktime/performance_metrics/forecasting/probabilistic/__init__.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "ConstraintViolation",
     "CRPS",
     "LogLoss",
+    "SquaredDistrLoss",
 ]
 
 from sktime.performance_metrics.forecasting.probabilistic._classes import (
@@ -26,5 +27,6 @@ from sktime.performance_metrics.forecasting.probabilistic._classes import (
     EmpiricalCoverage,
     LogLoss,
     PinballLoss,
+    SquaredDistrLoss,
     _BaseProbaForecastingErrorMetric,
 )

--- a/sktime/performance_metrics/forecasting/probabilistic/_classes.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/_classes.py
@@ -376,7 +376,7 @@ class _BaseProbaForecastingErrorMetric(BaseForecastingErrorMetric):
 
 
 class PinballLoss(_BaseProbaForecastingErrorMetric):
-    """Evaluate the pinball loss at all quantiles given in data.
+    """Pinball loss aka quantile loss for quantile/interval predictions.
 
     Parameters
     ----------
@@ -462,7 +462,7 @@ class PinballLoss(_BaseProbaForecastingErrorMetric):
 
 
 class EmpiricalCoverage(_BaseProbaForecastingErrorMetric):
-    """Evaluate the pinball loss at all quantiles given in data.
+    """Empirical coverage percentage for interval predictions.
 
     Parameters
     ----------
@@ -529,7 +529,7 @@ class EmpiricalCoverage(_BaseProbaForecastingErrorMetric):
 
 
 class ConstraintViolation(_BaseProbaForecastingErrorMetric):
-    """Evaluate the pinball loss at all quantiles given in data.
+    """Percentage of interval constraint violations for interval predictions.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR adds some missing metrics to the API reference:

* quantile prediction metrics
* distribution forecast metrics
* time series segmentation metrics