### PR TITLE
[DOC] sort slightly disordered forecasting API reference

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -168,6 +168,15 @@ Exponential smoothing based forecasters
 
     AutoETS
 
+.. currentmodule:: sktime.forecasting.statsforecast
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    StatsForecastAutoETS
+    StatsForecastAutoCES
+
 .. currentmodule:: sktime.forecasting.theta
 
 .. autosummary::
@@ -176,19 +185,23 @@ Exponential smoothing based forecasters
 
     ThetaForecaster
 
-.. currentmodule:: sktime.forecasting.croston
+.. currentmodule:: sktime.forecasting.statsforecast
 
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
-    Croston
+    StatsForecastAutoTheta
 
 AR/MA type forecasters
 ----------------------
 
 Forecasters with AR or MA component.
-All "ARIMA" models below include SARIMAX capability.
+
+All "ARIMA" and "Auto-ARIMA" models below include SARIMAX capability.
+
+(V)AR(I)MAX models
+~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: sktime.forecasting.arima
 
@@ -196,19 +209,7 @@ All "ARIMA" models below include SARIMAX capability.
     :toctree: auto_generated/
     :template: class.rst
 
-    AutoARIMA
     ARIMA
-
-.. currentmodule:: sktime.forecasting.statsforecast
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    StatsForecastAutoARIMA
-    StatsForecastAutoCES
-    StatsForecastAutoETS
-    StatsForecastAutoTheta
 
 .. currentmodule:: sktime.forecasting.sarimax
 
@@ -233,6 +234,23 @@ All "ARIMA" models below include SARIMAX capability.
     :template: class.rst
 
     VARMAX
+
+Auto-ARIMA models
+~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    AutoARIMA
+
+.. currentmodule:: sktime.forecasting.statsforecast
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    StatsForecastAutoARIMA
 
 Structural time series models
 -----------------------------
@@ -276,6 +294,17 @@ Structural time series models
     :template: class.rst
 
     DynamicFactor
+
+Intermittent time series forecasters
+------------------------------------
+
+.. currentmodule:: sktime.forecasting.croston
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    Croston
 
 Ensembles and stacking
 ----------------------


### PR DESCRIPTION
The estimators in the forecasting API reference were slightly disordered, some estimators were sorted in the wrong category.
The mismatches were mostly `statsforecast` based estimators which were mistakenly added below the first such model - in the ARIMA category, even though they didn't belong there.

I made the following changes:

* sorted the `statsforecast` models in the right categories, Auto-Theta, Auto-ETS and -CES need to go in the exponential smoothing category
* split the AR/MA category into plain (V)AR(I)MAX and Auto-ARIMA models
* added an intermittent time series category