### PR TITLE
[MNT] bound `tslearn<0.6.0` due to bad dependency handling and massive imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ all_extras = [
     "tbats>=1.1.0",
     "tensorflow; python_version < '3.11'",
     "tsfresh>=0.17.0",
-    "tslearn>=0.5.2; python_version < '3.11'",
+    "tslearn>=0.5.2,<0.6.0; python_version < '3.11'",
     "xarray",
     "seasonal",
 ]


### PR DESCRIPTION
`tslearn` has released 0.6.0, which now imports `geomstats`, which imports `pytorch`.

The dependency tree is vastly increasing, and `tslearn` does not seem to isolate their (soft?) dependencies properly, as the backend seems to be required by the code but is not actually installed (resulting in failing import exceptions).

This is now causing CI failures in the soft dependency set on `main`, and will likely cause failures to users who install it (or `tslearn`). Therefore we need to restrict the `tslearn` version.