### PR TITLE
[MNT] update readthedocs env to python 3.11 and ubuntu 22.04

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,9 +10,9 @@ python:
       extra_requirements:
         - docs
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
This PR updates the readthedocs env to the current [official recommendations](https://docs.readthedocs.io/en/stable/config-file/v2.html), namely python 3.11 and ubuntu 22.04. That should also, hopefully, speed up the docs build.