### PR TITLE
[MNT] unpin `sphinx` and plugins, with defensive upper bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,11 +157,11 @@ docs = [
     "nbsphinx>=0.8.6",
     "numpydoc",
     "pydata-sphinx-theme",
-    "sphinx_issues<4.0.0",
+    "sphinx-issues<4.0.0",
     "sphinx-gallery<0.14.0",
     "sphinx-design<0.5.0",
     "sphinx-version-warning",
-    "sphinx<8.0.0",
+    "Sphinx<8.0.0",
     "tabulate",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,11 +157,11 @@ docs = [
     "nbsphinx>=0.8.6",
     "numpydoc",
     "pydata-sphinx-theme",
-    "sphinx_issues==1.2.0",
-    "sphinx-gallery==0.6.0",
-    "sphinx-design==0.3.0",
+    "sphinx_issues",
+    "sphinx-gallery",
+    "sphinx-design",
     "sphinx-version-warning",
-    "sphinx==4.1.1",
+    "sphinx",
     "tabulate",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,11 +157,11 @@ docs = [
     "nbsphinx>=0.8.6",
     "numpydoc",
     "pydata-sphinx-theme",
-    "sphinx_issues",
-    "sphinx-gallery",
-    "sphinx-design",
+    "sphinx_issues<4.0.0",
+    "sphinx-gallery<0.14.0",
+    "sphinx-design<0.5.0",
     "sphinx-version-warning",
-    "sphinx",
+    "sphinx<8.0.0",
     "tabulate",
 ]
 


### PR DESCRIPTION
This PR replaces all the pins from `sphinx` and plugins with defensive upper bounds - next MAJOR release if the package is post-0, next MINOR release if the package is on zero-point.


---

original post: Diagnostic PR to see what happens if we remove all the pins from sphinx and plugins.