### PR TITLE
[MNT] remove forgotten `deprecated` import from 0.13.0

### DIFF
--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -10,7 +10,6 @@ __all__ = ["ProbabilityThresholdEarlyClassifier"]
 import copy
 
 import numpy as np
-from deprecated.sphinx import deprecated
 from joblib import Parallel, delayed
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.utils import check_random_state
@@ -21,12 +20,8 @@ from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.utils.validation.panel import check_X
 
 
-# TODO: remove message in v0.16.0 and change base class
-@deprecated(
-    version="0.13.0",
-    reason="The base class of ProbabilityThresholdEarlyClassifier will be changed to BaseEarlyClassifier in v0.16.0. This will change how classification safety decisions are made and returned, see BaseEarlyClassifier or TEASER for the new interface.",  # noqa: E501
-    category=FutureWarning,
-)
+# TODO: fix this in 0.21.0
+# base class should have been changed to BaseEarlyClassifier
 class ProbabilityThresholdEarlyClassifier(BaseClassifier):
     """Probability Threshold Early Classifier.
 


### PR DESCRIPTION
This removes a forgotten, old import of `deprecated` dating back to 0.13.0.

There was a deprecation action attached which never got carried out, we should revisit this later (so I added a todo with the next MINOR release instead)