### PR TITLE
[MNT] also restrict `tslearn` on the `pandas 2` testing dependency set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ all_extras_pandas2 = [
     "tbats>=1.1.0",
     "tensorflow; python_version < '3.11'",
     "tsfresh>=0.17.0",
-    "tslearn>=0.5.2; python_version < '3.11'",
+    "tslearn>=0.5.2,<0.6.0; python_version < '3.11'",
     "xarray",
     "seasonal",
 ]


### PR DESCRIPTION
Ensures that the addition in https://github.com/sktime/sktime/pull/4795 also has the bound from https://github.com/sktime/sktime/pull/4819