### PR TITLE
[DOC] minor improvements to forecasting and transformer extension templates

### DIFF
--- a/extension_templates/forecasting_supersimple.py
+++ b/extension_templates/forecasting_supersimple.py
@@ -88,8 +88,8 @@ class MyForecaster(BaseForecaster):
         self.paramb = paramb
         self.paramc = paramc
 
-        # todo: change "MyForecaster" to the name of the class
-        super(MyForecaster, self).__init__()
+        # leave this as is
+        super().__init__()
 
         # todo: optional, parameter checking logic (if applicable) should happen here
         # if writes derived values to self, should *not* overwrite self.parama etc

--- a/extension_templates/forecasting_supersimple.py
+++ b/extension_templates/forecasting_supersimple.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Extension template for forecasters, SIMPLE version.
 

--- a/extension_templates/forecasting_supersimple.py
+++ b/extension_templates/forecasting_supersimple.py
@@ -6,7 +6,7 @@ Contains only bare minimum of implementation requirements for a functional forec
 Also assumes *no composition*, i.e., no forecaster or other estimator components.
 Assumes pd.DataFrame used internally, and no hierarchical functionality.
 For advanced cases (probabilistic, composition, hierarchical, etc),
-    see full extension template in forecasting.py
+    see extension templates in forecasting.py or forecasting_simple.py
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -4,7 +4,7 @@
 Contains only bare minimum of implementation requirements for a functional transformer.
 Also assumes *no composition*, i.e., no transformer or other estimator components.
 For advanced cases (inverse transform, composition, etc),
-    see full extension template in forecasting.py
+    see full extension template in transformer.py
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -4,7 +4,7 @@
 Contains only bare minimum of implementation requirements for a functional transformer.
 Also assumes *no composition*, i.e., no transformer or other estimator components.
 For advanced cases (inverse transform, composition, etc),
-    see extension templates in forecasting.py or forecasting_simple.py
+    see full extension template in forecasting.py
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -4,7 +4,7 @@
 Contains only bare minimum of implementation requirements for a functional transformer.
 Also assumes *no composition*, i.e., no transformer or other estimator components.
 For advanced cases (inverse transform, composition, etc),
-    see full extension template in forecasting.py
+    see extension templates in forecasting.py or forecasting_simple.py
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template

--- a/extension_templates/transformer_supersimple.py
+++ b/extension_templates/transformer_supersimple.py
@@ -7,7 +7,7 @@ Covers only the case of series-to-series transformation.
 Assumes pd.DataFrame used internally, and no hierarchical functionality.
 Also assumes *no composition*, i.e., no transformer or other estimator components.
 For advanced cases (inverse transform, composition, etc),
-    see full extension template in forecasting.py
+    see extension templates in forecasting.py or forecasting_simple.py
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template

--- a/extension_templates/transformer_supersimple.py
+++ b/extension_templates/transformer_supersimple.py
@@ -7,7 +7,7 @@ Covers only the case of series-to-series transformation.
 Assumes pd.DataFrame used internally, and no hierarchical functionality.
 Also assumes *no composition*, i.e., no transformer or other estimator components.
 For advanced cases (inverse transform, composition, etc),
-    see extension templates in forecasting.py or forecasting_simple.py
+    see extension templates in transformer.py or transformer_simple.py
 
 Purpose of this implementation template:
     quick implementation of new estimators following the template

--- a/extension_templates/transformer_supersimple.py
+++ b/extension_templates/transformer_supersimple.py
@@ -96,8 +96,8 @@ class MyTransformer(BaseTransformer):
         self.paramb = paramb
         self.paramc = paramc
 
-        # todo: change "MyTransformer" to the name of the class
-        super(MyTransformer, self).__init__()
+        # leave this as is
+        super().__init__()
 
         # todo: optional, parameter checking logic (if applicable) should happen here
         # if writes derived values to self, should *not* overwrite self.parama etc

--- a/extension_templates/transformer_supersimple.py
+++ b/extension_templates/transformer_supersimple.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Extension template for transformers, SIMPLE version.
 


### PR DESCRIPTION
Makes minor improvements to the forecasting and transformer extension templates:

* adds reference to the "simple" extension template in the preamble
* updates the files to comply with the new (post-3.7) linting conventions