### PR TITLE
[MNT] skip failing `test_transform_and_smooth_fp` on `main`

### DIFF
--- a/sktime/transformations/series/tests/test_kalman_filter.py
+++ b/sktime/transformations/series/tests/test_kalman_filter.py
@@ -731,6 +731,7 @@ def test_bad_inputs(classes, params, measurements):
     not _check_soft_dependencies("filterpy", severity="none"),
     reason="skip test if required soft dependency filterpy not available",
 )
+@pytest.mark.xfail
 @pytest.mark.parametrize(
     "params, measurements, y",
     [  # test case 1 -

--- a/sktime/transformations/series/tests/test_kalman_filter.py
+++ b/sktime/transformations/series/tests/test_kalman_filter.py
@@ -731,7 +731,7 @@ def test_bad_inputs(classes, params, measurements):
     not _check_soft_dependencies("filterpy", severity="none"),
     reason="skip test if required soft dependency filterpy not available",
 )
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="failure of unknown cause, see #4835")
 @pytest.mark.parametrize(
     "params, measurements, y",
     [  # test case 1 -


### PR DESCRIPTION
Temporary fix for https://github.com/sktime/sktime/issues/4835, skips test with an `xfail`