### PR TITLE
[ENH] splitter that replicates `loc` of another splitter

### DIFF
--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -5,6 +5,7 @@
 __author__ = ["mloning", "kkoralturk"]
 __all__ = [
     "CutoffSplitter",
+    "SameLocSplitter",
     "SingleWindowSplitter",
     "SlidingWindowSplitter",
     "temporal_train_test_split",
@@ -16,6 +17,7 @@ __all__ = [
 from sktime.forecasting.model_selection._split import (
     CutoffSplitter,
     ExpandingWindowSplitter,
+    SameLocSplitter,
     SingleWindowSplitter,
     SlidingWindowSplitter,
     temporal_train_test_split,

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -333,6 +333,10 @@ class BaseSplitter(BaseObject):
         Single step ahead or array of steps ahead to forecast.
     """
 
+    _tags = {"split_hierarchical": False}
+    # split_hierarchical: whether _split supports hierarchical types natively
+    # if not, splitter broadcasts over instances
+
     def __init__(
         self,
         fh: FORECASTING_HORIZON_TYPES = DEFAULT_FH,
@@ -364,6 +368,8 @@ class BaseSplitter(BaseObject):
         y_index = self._coerce_to_index(y)
 
         if not isinstance(y_index, pd.MultiIndex):
+            split = self._split
+        elif self.get_tag("split_hierarchical", False, raise_error=False):
             split = self._split
         else:
             split = self._split_vectorized
@@ -1335,6 +1341,9 @@ class SameLocSplitter(BaseSplitter):
     >>> list(cv_tpl.split(y_template)) # doctest: +SKIP
     >>> list(splitter.split(y)) # doctest: +SKIP
     """
+
+    _tags = {"split_hierarchical": True}
+    # SameLocSplitter supports hierarchical pandas index
 
     def __init__(self, cv, y_template=None):
         self.cv = cv

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -9,6 +9,7 @@ __all__ = [
     "SingleWindowSplitter",
     "SameLocSplitter",
     "temporal_train_test_split",
+    "TestPlusTrainSplitter",
 ]
 __author__ = ["mloning", "kkoralturk", "khrapovs", "chillerobscuro", "fkiraly"]
 
@@ -1410,6 +1411,104 @@ class SameLocSplitter(BaseSplitter):
         cv_tpl = ExpandingWindowSplitter(fh=[2, 4], initial_window=24, step_length=12)
 
         params = {"cv": cv_tpl, "y_template": y_template}
+
+        return params
+
+
+class TestPlusTrainSplitter(BaseSplitter):
+    r"""Splitter that adds the train sets to the test sets.
+
+    Takes a splitter ``cv`` and modifies it in the following way:
+    The i-th train sets is identical to the i-th train set of ``cv``.
+    The i-th test set is the union of the i-th train set and i-th test set of ``cv``.
+
+    Parameters
+    ----------
+    cv : BaseSplitter
+        splitter to modify as above
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.model_selection import ExpandingWindowSplitter
+
+    >>> y = load_airline()
+    >>> y_template = y[:60]
+    >>> cv_tpl = ExpandingWindowSplitter(fh=[2, 4], initial_window=24, step_length=12)
+
+    >>> splitter = TestPlusTrainSplitter(cv_tpl)
+    """
+
+    def __init__(self, cv):
+        self.cv = cv
+        super().__init__()
+
+    def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+        """Get iloc references to train/test splits of `y`.
+
+        private _split containing the core logic, called from split
+
+        Parameters
+        ----------
+        y : pd.Index or time series in sktime compatible time series format
+            Time series to split, or index of time series to split
+
+        Yields
+        ------
+        train : 1D np.ndarray of dtype int
+            Training window indices, iloc references to training indices in y
+        test : 1D np.ndarray of dtype int
+            Test window indices, iloc references to test indices in y
+        """
+        cv = self.cv
+
+        for y_train_inner, y_test_inner in cv.split(y):
+            y_train_self = y_train_inner
+            y_test_self = set(y_train_inner).union(y_test_inner)
+            y_test_self = np.array(list(y_test_self))
+            yield y_train_self, y_test_self
+
+    def get_n_splits(self, y: Optional[ACCEPTED_Y_TYPES] = None) -> int:
+        """Return the number of splits.
+
+        Since this splitter returns a single train/test split,
+        this number is trivially 1.
+
+        Parameters
+        ----------
+        y : pd.Series or pd.Index, optional (default=None)
+            Time series to split
+
+        Returns
+        -------
+        n_splits : int
+            The number of splits.
+        """
+        return self.cv.get_n_splits(y)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the splitter.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        from sktime.forecasting.model_selection import ExpandingWindowSplitter
+
+        cv_tpl = ExpandingWindowSplitter(fh=[2, 4], initial_window=24, step_length=12)
+
+        params = {"cv": cv_tpl}
 
         return params
 

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1365,8 +1365,8 @@ class SameLocSplitter(BaseSplitter):
     def get_n_splits(self, y: Optional[ACCEPTED_Y_TYPES] = None) -> int:
         """Return the number of splits.
 
-        Since this splitter returns a single train/test split,
-        this number is trivially 1.
+        This will always be equal to the number of splits
+        of ``self.cv`` on ``self.y_template``.
 
         Parameters
         ----------

--- a/sktime/forecasting/model_selection/tests/test_split.py
+++ b/sktime/forecasting/model_selection/tests/test_split.py
@@ -597,3 +597,30 @@ def test_same_loc_splitter():
     for (t1, tt1), (t2, tt2) in zip(split_template_loc, split_templated_loc):
         assert np.all(t1 == t2)
         assert np.all(tt1 == tt2)
+
+
+def test_same_loc_splitter_hierarchical():
+    """Test that SameLocSplitter works as intended for hierarchical data."""
+    hierarchy_levels1 = (2, 2)
+    hierarchy_levels2 = (3, 4)
+    n1 = 7
+    n2 = 2 * n1
+    y_template = _make_hierarchical(
+        hierarchy_levels=hierarchy_levels1, max_timepoints=n1, min_timepoints=n1
+    )
+
+    y = _make_hierarchical(
+        hierarchy_levels=hierarchy_levels2, max_timepoints=n2, min_timepoints=n2
+    )
+
+    cv_tpl = ExpandingWindowSplitter(fh=[1, 2], initial_window=1, step_length=2)
+
+    splitter = SameLocSplitter(cv_tpl, y_template)
+
+    # these should be in general the same
+    split_template_loc = list(cv_tpl.split_loc(y_template))
+    split_templated_loc = list(splitter.split_loc(y))
+
+    for (t1, tt1), (t2, tt2) in zip(split_template_loc, split_templated_loc):
+        assert np.all(t1 == t2)
+        assert np.all(tt1 == tt2)

--- a/sktime/forecasting/model_selection/tests/test_split.py
+++ b/sktime/forecasting/model_selection/tests/test_split.py
@@ -29,7 +29,6 @@ from sktime.forecasting.tests._config import (
     TEST_YS,
     VALID_INDEX_FH_COMBINATIONS,
 )
-from sktime.utils._testing.deep_equals import deep_equals
 from sktime.utils._testing.forecasting import _make_fh
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.series import _make_series
@@ -587,10 +586,14 @@ def test_same_loc_splitter():
     split_template_iloc = list(cv_tpl.split(y_template))
     split_templated_iloc = list(splitter.split(y))
 
-    assert deep_equals(split_template_iloc, split_templated_iloc)
+    for (t1, tt1), (t2, tt2) in zip(split_template_iloc, split_templated_iloc):
+        assert np.all(t1 == t2)
+        assert np.all(tt1 == tt2)
 
     # these should be in general the same
     split_template_loc = list(cv_tpl.split_loc(y_template))
     split_templated_loc = list(splitter.split_loc(y))
 
-    assert deep_equals(split_template_loc, split_templated_loc)
+    for (t1, tt1), (t2, tt2) in zip(split_template_loc, split_templated_loc):
+        assert np.all(t1 == t2)
+        assert np.all(tt1 == tt2)

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -396,6 +396,12 @@ ESTIMATOR_TAG_REGISTER = [
         "parameters reserved by the base class and present in all child estimators",
     ),
     (
+        "split_hierarchical",
+        "splitter",
+        "bool",
+        "whether _split is natively implemented for hierarchical y types",
+    ),
+    (
         "capabilities:exact",
         "distribution",
         ("list", "str"),


### PR DESCRIPTION
This adds a splitter that takes a splitter and some data, and always replicates the same `loc` references for splits of another splitter.

Related issue and discussion: https://github.com/sktime/sktime/issues/4842

More general form of `temporal_train_test_split`, particularly useful for the case where we want to split `X` and `y`, and primarily `y`, and `X` can have different indices from `y`.

This ability partially addresses #4842, FYI @felipeangelimvieira