### PR TITLE
&yarnabrina [ENH] Add an explicit context manager during estimator dump

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -132,8 +132,10 @@ class BaseObject(_BaseObject):
         path = Path(path) if isinstance(path, str) else path
         path.mkdir()
 
-        pickle.dump(type(self), open(path / "_metadata", "wb"))
-        pickle.dump(self, open(path / "_obj", "wb"))
+        with open(path / "_metadata", "wb") as file:
+            pickle.dump(type(self), file)
+        with open(path / "_obj", "wb") as file:
+            pickle.dump(self, file)
 
         shutil.make_archive(base_name=path, format="zip", root_dir=path)
         shutil.rmtree(path)

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -32,18 +32,18 @@ EXCLUDE_ESTIMATORS = [
     "LSTMFCNClassifier",  # unknown cause, see bug report #4033
     "TimeSeriesLloyds",  # an abstract class, but does not follow naming convention
     # DL classifier suspected to cause hangs and memouts, see #4610
-    "FCNClassifier",
-    "MACNNClassifier",
-    "SimpleRNNClassifier",
-    "SimpleRNNRegressor",
-    "EditDist",
-    "CNNClassifier",
-    "FCNClassifier",
-    "InceptionTimeClassifer",
-    "LSTMFCNClassifier",
-    "MLPClassifier",
-    "CNNRegressor",
-    "ResNetRegressor",
+    # "FCNClassifier",
+    # "MACNNClassifier",
+    # "SimpleRNNClassifier",
+    # "SimpleRNNRegressor",
+    # "EditDist",
+    # "CNNClassifier",
+    # "FCNClassifier",
+    # "InceptionTimeClassifer",
+    # "LSTMFCNClassifier",
+    # "MLPClassifier",
+    # "CNNRegressor",
+    # "ResNetRegressor",
 ]
 
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -32,18 +32,18 @@ EXCLUDE_ESTIMATORS = [
     "LSTMFCNClassifier",  # unknown cause, see bug report #4033
     "TimeSeriesLloyds",  # an abstract class, but does not follow naming convention
     # DL classifier suspected to cause hangs and memouts, see #4610
-    # "FCNClassifier",
-    # "MACNNClassifier",
-    # "SimpleRNNClassifier",
-    # "SimpleRNNRegressor",
-    # "EditDist",
-    # "CNNClassifier",
-    # "FCNClassifier",
-    # "InceptionTimeClassifer",
-    # "LSTMFCNClassifier",
-    # "MLPClassifier",
-    # "CNNRegressor",
-    # "ResNetRegressor",
+    "FCNClassifier",
+    "MACNNClassifier",
+    "SimpleRNNClassifier",
+    "SimpleRNNRegressor",
+    "EditDist",
+    "CNNClassifier",
+    "FCNClassifier",
+    "InceptionTimeClassifer",
+    "LSTMFCNClassifier",
+    "MLPClassifier",
+    "CNNRegressor",
+    "ResNetRegressor",
 ]
 
 


### PR DESCRIPTION
@yarnabrina and @fkiraly  caught a possible memory leak in the saving method of our base object. I'm adding a context manager to explicitly close files that may or may not be closed by the garbage collector.

@fkiraly also suspects that this could be the culprit behind the memouts that DL estimators were suffering from. To test this, I'm temporarily skipping all excepted DL estimators.