### PR TITLE
&hazrulakmal [MNT] fix remaining `sklearn 1.3.0` compatibility issues

### DIFF
--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -42,7 +42,7 @@ Estimators with a soft dependency need to ensure the following:
    or a ``list`` of ``str``, of import dependencies. Exceptions will automatically raised when constructing the estimator
    in an environment without the required packages.
 *  In a case where the package import differs from the package name, i.e., ``import package_string`` is different from
-   ``pip install different-package-string`` (usually the case for packages containing a dash in the name), the ``python_dependecies_alias`` tag
+   ``pip install different-package-string`` (usually the case for packages containing a dash in the name), the ``python_dependencies_alias`` tag
    should be populated to pass the information on package and import strings as ``dict`` such as ``{"scikit-learn":"sklearn"}``.
 *  If the soft dependencies require specific python versions, the ``python_version``
    tag should also be populated, with a PEP 440 compliant version specification ``str`` such as ``"<3.10"`` or ``">3.6,~=3.8"``.

--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -20,25 +20,20 @@ There are three types of dependencies in ``sktime``: **core**, **soft**, or **de
 
 We try to keep the number of core dependencies to a minimum and rely on other packages as soft dependencies when feasible.
 
+Handling soft dependencies
+--------------------------
 
-Adding a soft dependency
-------------------------
+This section explains how to handle existing soft depencies.
+For adding a new soft dependency, see the section "adding a new soft dependency".
 
-Soft dependencies in ``sktime`` should usually be restricted to estimators.
-
-When adding a new soft dependency or changing the version of an existing one, the following files need to be updated:
-
-*  `pyproject.toml <https://github.com/sktime/sktime/blob/main/pyproject.toml>`__,
-   adding the dependency or version bounds in the ``all_extras`` dependency set.
-   Following the `PEP 621 <https://www.python.org/dev/peps/pep-0621/>`_ convention, all dependencies
-   including build time dependencies and optional dependencies are specified in this file.
+Soft dependencies in ``sktime`` should usually be isolated to estimators.
 
 Informative warnings or error messages for missing soft dependencies should be raised, in a situation where a user would need them.
 This is handled through our ``_check_soft_dependencies`` utility
 `here <https://github.com/sktime/sktime/blob/main/sktime/utils/validation/_dependencies.py>`__.
-
 There are specific conventions to add such warnings in estimators, as below.
-To add an estimator with a soft dependency, ensure the following:
+
+Estimators with a soft dependency need to ensure the following:
 
 *  imports of the soft dependency only happen inside the estimator,
    e.g., in ``_fit`` or ``__init__`` methods of the estimator.
@@ -60,6 +55,25 @@ To add an estimator with a soft dependency, ensure the following:
    rather than for the whole module!  This decorator will then skip your test unless the system has the required packages installed.  Doing this is
    helpful for any users running ``check_estimator`` on all estimators, or a full local `pytest` run without the required soft dependency.
    Again, see the tests for pydarima (in forecasting) for a concrete example.
+
+Adding a new soft dependency
+----------------------------
+
+When adding a new soft dependency or changing the version of an existing one,
+the following need to be updated:
+
+*  in `pyproject.toml <https://github.com/sktime/sktime/blob/main/pyproject.toml>`__,
+   add the dependency or update version bounds in the ``all_extras`` dependency set.
+   Following the `PEP 621 <https://www.python.org/dev/peps/pep-0621/>`_ convention, all dependencies
+   including build time dependencies and optional dependencies are specified in ``pyproject.toml``.
+*  Soft dependencies compatible with ``pandas 2`` should also be added/updated in the
+   ``all_extras_pandas2`` dependency set in ``pyproject.toml``. This dependency set
+   is used only in testing.
+
+It should be checked that new soft dependencies do not imply
+upper bounds on ``sktime`` core dependencies, or severe limitations to the user
+installation workflow.
+In such a case, it is strongly suggested not to add the soft dependency.
 
 Adding a core or developer dependency
 -------------------------------------

--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -51,7 +51,7 @@ class AlignerDTW(BaseAligner):
         "capability:distance": True,  # does compute/return overall distance?
         "capability:distance-matrix": True,  # does compute/return distance matrix?
         "python_dependencies": "dtw-python",
-        "python_dependecies_alias": {"dtw-python": "dtw"},
+        "python_dependencies_alias": {"dtw-python": "dtw"},
     }
 
     def __init__(

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -73,6 +73,9 @@ class BaseObject(_BaseObject):
     Extends skbase BaseObject with additional features.
     """
 
+    # global dependency alias tag for sklearn dependency management
+    _tags = {"python_dependecies_alias": {"scikit-learn": "sklearn"}}
+
     def __eq__(self, other):
         """Equality dunder. Checks equal class and parameters.
 

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -74,7 +74,7 @@ class BaseObject(_BaseObject):
     """
 
     # global dependency alias tag for sklearn dependency management
-    _tags = {"python_dependecies_alias": {"scikit-learn": "sklearn"}}
+    _tags = {"python_dependencies_alias": {"scikit-learn": "sklearn"}}
 
     def __eq__(self, other):
         """Equality dunder. Checks equal class and parameters.

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -73,9 +73,6 @@ class BaseObject(_BaseObject):
     Extends skbase BaseObject with additional features.
     """
 
-    # global dependency alias tag for sklearn dependency management
-    _tags = {"python_dependencies_alias": {"scikit-learn": "sklearn"}}
-
     def __eq__(self, other):
         """Equality dunder. Checks equal class and parameters.
 
@@ -359,6 +356,9 @@ class BaseEstimator(BaseObject):
 
     Extends sktime's BaseObject to include basic functionality for fittable estimators.
     """
+
+    # global dependency alias tag for sklearn dependency management
+    _tags = {"python_dependencies_alias": {"scikit-learn": "sklearn"}}
 
     def __init__(self):
         self._is_fitted = False

--- a/sktime/classification/distance_based/_elastic_ensemble.py
+++ b/sktime/classification/distance_based/_elastic_ensemble.py
@@ -290,7 +290,7 @@ class ElasticEnsemble(BaseClassifier):
                     param_distributions=ElasticEnsemble._get_100_param_options(
                         self.distance_measures[dm], X
                     ),
-                    n_iter=100 * self.proportion_of_param_options,
+                    n_iter=int(100 * self.proportion_of_param_options),
                     cv=LeaveOneOut(),
                     scoring="accuracy",
                     n_jobs=self._threads_to_use,

--- a/sktime/classification/feature_based/_matrix_profile_classifier.py
+++ b/sktime/classification/feature_based/_matrix_profile_classifier.py
@@ -68,6 +68,9 @@ class MatrixProfileClassifier(BaseClassifier):
         "capability:multithreading": True,
         "capability:predict_proba": True,
         "classifier_type": "distance",
+        # sklearn 1.3.0 has a bug which causes predict_proba to fail
+        # see scikit-learn#26768 and sktime#4778
+        "python_dependencies": "scikit-learn!=1.3.0",
     }
 
     def __init__(

--- a/sktime/classification/feature_based/_matrix_profile_classifier.py
+++ b/sktime/classification/feature_based/_matrix_profile_classifier.py
@@ -57,11 +57,11 @@ class MatrixProfileClassifier(BaseClassifier):
     >>> from sktime.classification.feature_based import MatrixProfileClassifier
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
-    >>> clf = MatrixProfileClassifier()
-    >>> clf.fit(X_train, y_train)
-    MatrixProfileClassifier(...)
-    >>> y_pred = clf.predict(X_test)
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)  # doctest: +SKIP
+    >>> clf = MatrixProfileClassifier()  # doctest: +SKIP
+    >>> clf.fit(X_train, y_train)  # doctest: +SKIP
+    MatrixProfileClassifier(...)  # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)  # doctest: +SKIP
     """
 
     _tags = {


### PR DESCRIPTION
There are some remaining compatibility issues from the `sklearn 1.3.0` release which the pre-release testing did not catch. See https://github.com/sktime/sktime/pull/4778. This PR fixes those.

* `ElasticEnsemble` instantiated `sklearn` `RandomizedSearchCV` with `float` `n_iter`, which sets off the parameter validation since 1.3.0. Fixed by coercing to `int` (rounding down)
* `MatrixProfileClassifier` fails due to `sklearn` bug https://github.com/scikit-learn/scikit-learn/issues/26768. This is 1.3.0 specific and appears fixed for (not yet released) 1.3.1, so added an `sklearn!=1.3.0` version requirement for `MatrixProfileClassifier`

Depends on the bugfix https://github.com/sktime/sktime/pull/4867 to ensure the specifier `sklearn!=1.3.0` is handled correctly.