### PR TITLE
[ENH] test-plus-train splitter compositor

### DIFF
--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "SlidingWindowSplitter",
     "temporal_train_test_split",
     "ExpandingWindowSplitter",
+    "TestPlusTrainSplitter",
     "ForecastingGridSearchCV",
     "ForecastingRandomizedSearchCV",
 ]
@@ -18,6 +19,7 @@ from sktime.forecasting.model_selection._split import (
     ExpandingWindowSplitter,
     SingleWindowSplitter,
     SlidingWindowSplitter,
+    TestPlusTrainSplitter,
     temporal_train_test_split,
 )
 from sktime.forecasting.model_selection._tune import (

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1358,8 +1358,8 @@ class TestPlusTrainSplitter(BaseSplitter):
     def get_n_splits(self, y: Optional[ACCEPTED_Y_TYPES] = None) -> int:
         """Return the number of splits.
 
-        Since this splitter returns a single train/test split,
-        this number is trivially 1.
+        This will always be equal to the number of splits
+        of ``self.cv`` on ``y``.
 
         Parameters
         ----------

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1391,10 +1391,8 @@ class TestPlusTrainSplitter(BaseSplitter):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        from sktime.datasets import load_airline
         from sktime.forecasting.model_selection import ExpandingWindowSplitter
 
-        y = load_airline()
         cv_tpl = ExpandingWindowSplitter(fh=[2, 4], initial_window=24, step_length=12)
 
         params = {"cv": cv_tpl}

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -8,6 +8,7 @@ __all__ = [
     "CutoffSplitter",
     "SingleWindowSplitter",
     "temporal_train_test_split",
+    "TestPlusTrainSplitter",
 ]
 __author__ = ["mloning", "kkoralturk", "khrapovs", "chillerobscuro"]
 
@@ -1298,6 +1299,107 @@ class SingleWindowSplitter(BaseSplitter):
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
         params = {"fh": 3}
+        return params
+
+
+class TestPlusTrainSplitter(BaseSplitter):
+    r"""Splitter that adds the train sets to the test sets.
+
+    Takes a splitter ``cv`` and modifies it in the following way:
+    The i-th train sets is identical to the i-th train set of ``cv``.
+    The i-th test set is the union of the i-th train set and i-th test set of ``cv``.
+
+    Parameters
+    ----------
+    cv : BaseSplitter
+        splitter to modify as above
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.model_selection import ExpandingWindowSplitter
+
+    >>> y = load_airline()
+    >>> y_template = y[:60]
+    >>> cv_tpl = ExpandingWindowSplitter(fh=[2, 4], initial_window=24, step_length=12)
+
+    >>> splitter = TestPlusTrainSplitter(cv_tpl)
+    """
+
+    def __init__(self, cv):
+        self.cv = cv
+        super().__init__()
+
+    def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+        """Get iloc references to train/test splits of `y`.
+
+        private _split containing the core logic, called from split
+
+        Parameters
+        ----------
+        y : pd.Index or time series in sktime compatible time series format
+            Time series to split, or index of time series to split
+
+        Yields
+        ------
+        train : 1D np.ndarray of dtype int
+            Training window indices, iloc references to training indices in y
+        test : 1D np.ndarray of dtype int
+            Test window indices, iloc references to test indices in y
+        """
+        cv = self.cv
+
+        for y_train_inner, y_test_inner in cv.split(y):
+            y_train_self = y_train_inner
+            y_test_self = set(y_train_inner).union(y_test_inner)
+            y_test_self = np.array(list(y_test_self))
+            yield y_train_self, y_test_self
+
+    def get_n_splits(self, y: Optional[ACCEPTED_Y_TYPES] = None) -> int:
+        """Return the number of splits.
+
+        Since this splitter returns a single train/test split,
+        this number is trivially 1.
+
+        Parameters
+        ----------
+        y : pd.Series or pd.Index, optional (default=None)
+            Time series to split
+
+        Returns
+        -------
+        n_splits : int
+            The number of splits.
+        """
+        return self.cv.get_n_splits(y)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the splitter.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        from sktime.datasets import load_airline
+        from sktime.forecasting.model_selection import ExpandingWindowSplitter
+
+        y = load_airline()
+        y_template = y[:60]
+        cv_tpl = ExpandingWindowSplitter(fh=[2, 4], initial_window=24, step_length=12)
+
+        params = {"cv": cv_tpl}
+
         return params
 
 

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1351,8 +1351,7 @@ class TestPlusTrainSplitter(BaseSplitter):
 
         for y_train_inner, y_test_inner in cv.split(y):
             y_train_self = y_train_inner
-            y_test_self = set(y_train_inner).union(y_test_inner)
-            y_test_self = np.array(list(y_test_self))
+            y_test_self = np.union1d(y_train_inner, y_test_inner)
             yield y_train_self, y_test_self
 
     def get_n_splits(self, y: Optional[ACCEPTED_Y_TYPES] = None) -> int:

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1395,7 +1395,6 @@ class TestPlusTrainSplitter(BaseSplitter):
         from sktime.forecasting.model_selection import ExpandingWindowSplitter
 
         y = load_airline()
-        y_template = y[:60]
         cv_tpl = ExpandingWindowSplitter(fh=[2, 4], initial_window=24, step_length=12)
 
         params = {"cv": cv_tpl}


### PR DESCRIPTION
This PR adds a composite splitter which takes any splitter and changes its test splits to be the union of respective test plus train split.

Related issues and PR:
https://github.com/sktime/sktime/issues/4842
https://github.com/sktime/sktime/pull/4851
https://github.com/sktime/sktime/pull/4861