### PR TITLE
[ENH] Deprecate pseudo-private DL deserializing methods in favour of public interface

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -152,6 +152,30 @@ class BaseObject(_BaseObject):
         deserialized self resulting in output `serial`, of `cls.save(None)`
         """
         import pickle
+        from warnings import warn
+
+        warn(
+            "`load_from_serial()` will be deprecated in 0.20.2 in the favor of load() "
+            "which is the standard way of deserializing estimators.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return pickle.loads(serial)
+
+    @classmethod
+    def _load_from_serial(cls, serial):
+        """Private helper method to load object from serialized memory container.
+
+        Parameters
+        ----------
+        serial : 1st element of output of `cls.save(None)`
+
+        Returns
+        -------
+        deserialized self resulting in output `serial`, of `cls.save(None)`
+        """
+        import pickle
 
         return pickle.loads(serial)
 
@@ -161,7 +185,33 @@ class BaseObject(_BaseObject):
 
         Parameters
         ----------
-        serial : result of ZipFile(path).open("object)
+        serial : result of ZipFile(path).open("object")
+
+        Returns
+        -------
+        deserialized self resulting in output at `path`, of `cls.save(path)`
+        """
+        import pickle
+        from warnings import warn
+        from zipfile import ZipFile
+
+        warn(
+            "`load_from_path()` will be deprecated in 0.20.2 in the favor of load() "
+            "which is the standard way of deserializing estimators.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+
+        with ZipFile(serial, "r") as file:
+            return pickle.loads(file.open("_obj").read())
+
+    @classmethod
+    def _load_from_path(cls, serial):
+        """Private helper method to load object from file location.
+
+        Parameters
+        ----------
+        serial : result of ZipFile(path).open("object")
 
         Returns
         -------

--- a/sktime/classification/deep_learning/base.py
+++ b/sktime/classification/deep_learning/base.py
@@ -300,6 +300,63 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         _check_soft_dependencies("h5py")
         import pickle
         from tempfile import TemporaryFile
+        from warnings import warn
+
+        warn(
+            "`load_from_serial()` will be deprecated in 0.20.2 in the favor of load() "
+            "which is the standard way of deserializing estimators.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+
+        import h5py
+        from tensorflow.keras.models import load_model
+
+        if not isinstance(serial, tuple):
+            raise TypeError(
+                "`serial` is expected to be a tuple, "
+                f"instead found of type: {type(serial)}"
+            )
+        if len(serial) != 3:
+            raise ValueError(
+                "`serial` should have 3 elements. "
+                "All 3 elements represent in-memory serialization "
+                "of the estimator. "
+                f"Found a tuple of length: {len(serial)} instead."
+            )
+
+        serial, in_memory_model, in_memory_history = serial
+        if in_memory_model is None:
+            cls.model_ = None
+        else:
+            with TemporaryFile() as store_:
+                store_.write(in_memory_model)
+                h5file = h5py.File(store_, "r")
+                cls.model_ = load_model(h5file)
+                h5file.close()
+
+        cls.history = pickle.loads(in_memory_history)
+        return pickle.loads(serial)
+
+    @classmethod
+    def _load_from_serial(cls, serial):
+        """Private helper method load object from serialized memory container.
+
+        Parameters
+        ----------
+        serial: 1st element of output of `cls.save(None)`
+                This is a tuple of size 3.
+                The first element represents pickle-serialized instance.
+                The second element represents h5py-serialized `keras` model.
+                The third element represent pickle-serialized history of `.fit()`.
+
+        Returns
+        -------
+        Deserialized self resulting in output `serial`, of `cls.save(None)`
+        """
+        _check_soft_dependencies("h5py")
+        import pickle
+        from tempfile import TemporaryFile
 
         import h5py
         from tensorflow.keras.models import load_model
@@ -336,7 +393,56 @@ class BaseDeepClassifier(BaseClassifier, ABC):
 
         Parameters
         ----------
-        serial : Name of the zip file.
+        serial : pathlib.Path
+            Name of the zip file
+
+        Returns
+        -------
+        deserialized self resulting in output at `path`, of `cls.save(path)`
+        """
+        import pickle
+        from shutil import rmtree
+        from warnings import warn
+        from zipfile import ZipFile
+
+        from tensorflow import keras
+
+        warn(
+            "`load_from_path()` will be deprecated in 0.20.2 in the favor of load() "
+            "which is the standard way of deserializing estimators.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+
+        temp_unzip_loc = serial.parent / "temp_unzip/"
+        temp_unzip_loc.mkdir()
+
+        with ZipFile(serial, mode="r") as zip_file:
+            for file in zip_file.namelist():
+                if not file.startswith("keras/"):
+                    continue
+                zip_file.extract(file, temp_unzip_loc)
+
+        keras_location = temp_unzip_loc / "keras"
+        if keras_location.exists():
+            cls.model_ = keras.models.load_model(keras_location)
+        else:
+            cls.model_ = None
+
+        rmtree(temp_unzip_loc)
+        cls.history = keras.callbacks.History()
+        with ZipFile(serial, mode="r") as file:
+            cls.history.set_params(pickle.loads(file.open("history").read()))
+            return pickle.loads(file.open("_obj").read())
+
+    @classmethod
+    def _load_from_path(cls, serial):
+        """Private helper method to load object from file location.
+
+        Parameters
+        ----------
+        serial : pathlib.Path object.
+            Name of the zip file.
 
         Returns
         -------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #4740

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
The two class methods will be deprecated in 0.20.2. I think this should provide the users time to upgrade their code accordingly.
 
#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
None

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
