### PR TITLE
[ENH] set `ForecastX` missing data handling tag to `True` to properly cope with future unknown variables

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -1234,6 +1234,7 @@ class ForecastX(BaseForecaster):
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
+        "handles-missing-data": True,
     }
 
     def __init__(


### PR DESCRIPTION
This PR sets the `ForecastX` missing data handling tag to `True` to properly cope with future unknown variables.

An edge case - or, arguably, a general case if none of the future variables are known - is showcased in this issue discussion:
https://github.com/sktime/sktime/issues/4848

More precisely, `ForecastX` should always allow for `nans` in future `X`, as these may be in places where there is genuinely no knowledge about the future. Alternatively, dummy values have to be provided which sounds odd.

FYI @davidgilbertson