### PR TITLE
[ENH] input checks for `BaseBenchmark`, allow `add_estimator` to accept multiple estimators

### DIFF
--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -10,7 +10,7 @@ from sktime.base import BaseEstimator
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 
-def coer_estimator_and_id(estimators, estimator_id=None):
+def coerce_estimator_and_id(estimators, estimator_id=None):
     """Coerce estimators to a dict with estimator_id as key and estimator as value.
 
     Parameters
@@ -75,7 +75,7 @@ class BaseBenchmark:
         estimator_id : str, optional (default=None)
             Identifier for estimator. If none given then uses estimator's class name.
         """
-        estimators = coer_estimator_and_id(estimator, estimator_id)
+        estimators = coerce_estimator_and_id(estimator, estimator_id)
         for estimator_id, estimator in estimators.items():
             estimator = estimator.clone()  # extra cautious
             self.estimators.register(id=estimator_id, entry_point=estimator.clone)

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -10,19 +10,8 @@ from sktime.base import BaseEstimator
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 
-def is_initalised_estimator(estimator):
-    """Check if the estimator is an initialised BaseEstimator object.
-
-    Parameters
-    ----------
-    estimator : object
-        The estimator to check.
-
-    Returns
-    -------
-    is_estimator : bool
-        Whether the estimator is an initialised BaseEstimator object or not.
-    """
+def is_initalised_estimator(estimator: BaseEstimator) -> bool:
+    """Check if estimator is initialised BaseEstimator object."""
     if isinstance(estimator, BaseEstimator):
         return True
     return False

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -68,8 +68,8 @@ class BaseBenchmark:
         ----------
         estimator : Dict, List or BaseEstimator object
             Estimator to add to the benchmark.
-            If Dict, keys are estimator_ids and values are estimators, use to customise
-            the identifier ID.
+            If Dict, keys are estimator_ids and values are estimators,
+            use to customise the identifier ID.
             If List, each element is an estimator. estimator_ids are generated
             automatically using the estimator's class name.
         estimator_id : str, optional (default=None)

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -37,9 +37,9 @@ def coer_estimator_and_id(estimators, estimator_id=None):
         estimator_id = estimator_id or f"{estimators.__class__.__name__+ VERSION_ID}"
         return {estimator_id: estimators}
     else:
-        raise ValueError(
-            f"estimator must be of a type a dict, list or\
-            BaseEstimator object but received {type(estimators)}"
+        raise TypeError(
+            "estimator must be of a type a dict, list or "
+            f"BaseEstimator object but received {type(estimators)}"
         )
 
 

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -30,7 +30,10 @@ def _check_estimators_type(objs: Union[dict, list, BaseEstimator]) -> None:
     items = objs.values() if isinstance(objs, dict) else objs
     compatible = all(is_initalised_estimator(estimator) for estimator in items)
     if not compatible:
-        raise TypeError("Estimator must be an initialised BaseEstimator object.")
+        raise TypeError(
+            "One or many estimator(s) is not an initialised BaseEstimator "
+            "object(s). Please instantiate the estimator(s) first."
+        )
 
 
 def coerce_estimator_and_id(estimators, estimator_id=None):

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -38,7 +38,7 @@ def coer_estimator_and_id(estimators, estimator_id=None):
         return {estimator_id: estimators}
     else:
         raise ValueError(
-            f"estimator must be of a type a dict, list or  \
+            f"estimator must be of a type a dict, list or\
             BaseEstimator object but received {type(estimators)}"
         )
 
@@ -66,8 +66,12 @@ class BaseBenchmark:
 
         Parameters
         ----------
-        estimator : BaseEstimator object
+        estimator : Dict, List or BaseEstimator object
             Estimator to add to the benchmark.
+            If Dict, keys are estimator_ids and values are estimators, use to customise
+            the identifier ID.
+            If List, each element is an estimator. estimator_ids are generated
+            automatically using the estimator's class name.
         estimator_id : str, optional (default=None)
             Identifier for estimator. If none given then uses estimator's class name.
         """

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -28,7 +28,7 @@ def _check_estimators_type(objs: Union[dict, list, BaseEstimator]) -> None:
     if isinstance(objs, BaseEstimator):
         objs = [objs]
     items = objs.values() if isinstance(objs, dict) else objs
-    compatible = all([is_initalised_estimator(estimator) for estimator in items])
+    compatible = all(is_initalised_estimator(estimator) for estimator in items)
     if not compatible:
         raise TypeError("Estimator must be an initialised BaseEstimator object.")
 

--- a/sktime/benchmarking/tests/test_forecasting.py
+++ b/sktime/benchmarking/tests/test_forecasting.py
@@ -127,6 +127,7 @@ def test_coer_estimator_and_id(estimator, estimator_id, expected_output):
 )
 def test_multiple_estimators(estimators):
     """Test add_estimator with multiple estimators."""
+    # single estimator test is checked in test_forecastingbenchmark
     benchmark = ForecastingBenchmark()
     benchmark.add_estimator(estimators)
     registered_estimators = benchmark.estimators.entity_specs.keys()

--- a/sktime/benchmarking/tests/test_forecasting.py
+++ b/sktime/benchmarking/tests/test_forecasting.py
@@ -112,3 +112,24 @@ def test_coer_estimator_and_id(estimator, estimator_id, expected_output):
     assert (
         coer_estimator_and_id(estimator, estimator_id) == expected_output
     ), "coer_estimator_and_id does not return the expected output."
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("kotsu", severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+@pytest.mark.parametrize(
+    "estimators",
+    [
+        ({"N-v1": NaiveForecaster(), "T-v1": TrendForecaster()}),
+        ([NaiveForecaster(), TrendForecaster()]),
+    ],
+)
+def test_multiple_estimators(estimators):
+    """Test add_estimator with multiple estimators."""
+    benchmark = ForecastingBenchmark()
+    benchmark.add_estimator(estimators)
+    registered_estimators = benchmark.estimators.entity_specs.keys()
+    assert len(registered_estimators) == len(
+        estimators
+    ), "add_estimator does not register all estimators."

--- a/sktime/benchmarking/tests/test_forecasting.py
+++ b/sktime/benchmarking/tests/test_forecasting.py
@@ -3,7 +3,7 @@
 import pandas as pd
 import pytest
 
-from sktime.benchmarking.benchmarks import coer_estimator_and_id
+from sktime.benchmarking.benchmarks import coerce_estimator_and_id
 from sktime.benchmarking.forecasting import ForecastingBenchmark
 from sktime.forecasting.model_selection import ExpandingWindowSplitter
 from sktime.forecasting.naive import NaiveForecaster
@@ -107,11 +107,11 @@ def test_forecastingbenchmark(tmp_path, expected_results_df, scorers):
 
 
 @pytest.mark.parametrize("estimator, estimator_id, expected_output", COER_CASES)
-def test_coer_estimator_and_id(estimator, estimator_id, expected_output):
-    """Test coer_estimator_and_id return expected output."""
+def test_coerce_estimator_and_id(estimator, estimator_id, expected_output):
+    """Test coerce_estimator_and_id return expected output."""
     assert (
-        coer_estimator_and_id(estimator, estimator_id) == expected_output
-    ), "coer_estimator_and_id does not return the expected output."
+        coerce_estimator_and_id(estimator, estimator_id) == expected_output
+    ), "coerce_estimator_and_id does not return the expected output."
 
 
 @pytest.mark.skipif(

--- a/sktime/benchmarking/tests/test_forecasting.py
+++ b/sktime/benchmarking/tests/test_forecasting.py
@@ -3,7 +3,7 @@
 import pandas as pd
 import pytest
 
-from sktime.benchmarking import forecasting
+from sktime.benchmarking.forecasting import ForecastingBenchmark
 from sktime.forecasting.model_selection import ExpandingWindowSplitter
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.performance_metrics.forecasting import (
@@ -62,7 +62,7 @@ def data_loader_simple() -> pd.DataFrame:
 )
 def test_forecastingbenchmark(tmp_path, expected_results_df, scorers):
     """Test benchmarking a forecaster estimator."""
-    benchmark = forecasting.ForecastingBenchmark()
+    benchmark = ForecastingBenchmark()
 
     benchmark.add_estimator(NaiveForecaster(strategy="last"))
 


### PR DESCRIPTION
See #4873 

The current ForecastingBenchmark interface requires manually looping over multiple estimators to benchmark multiple models, as the add_estimator interface only accepts one estimator per call. This PR provides an option for users to add multiple models with a single add_estimator call while maintaining the existing interface. The interface for multiple models looks as follows:

```python
from sktime.benchmarking.forecasting import ForecastingBenchmark
from sktime.forecasting.naive import NaiveForecaster
from sktime.forecasting.arima import AutoARIMA

benchmark = ForecastingBenchmark()

# for auto naming
models = [NaiveForecaster(), AutoARIMA()]
benchmark.add_estimator(models)

# for custom naming
models ={"Arima-v1":AutoARIMA(),
        "Naive-v1":NaiveForecaster()}
benchmark.add_estimator(models)

# existing interface still works
benchmark.add_estimator(NaiveForecaster())
benchmark.add_estimator(AutoARIMA())
```

### Questions
1. are there any other preferences in terms of the interface?
2. In sktime, are there any best practices regarding where to place util functions within the module? Should I create another folder called *_utils.py* to place any benchmarking util functions, or is the existing solution sufficient?

FYI @fkiraly @marrov 