### PR TITLE
[MNT] add `statsforecast` to the `pandas2` compatible dependency set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ all_extras_pandas2 = [
     "pyod>=0.8.0; python_version < '3.11'",
     "scikit_posthocs>=0.6.5",
     "seaborn>=0.11.0",
+    "statsforecast>=0.5.2; python_version < '3.11'",
     "statsmodels>=0.12.1",
     "stumpy>=1.5.1; python_version < '3.11'",
     "tbats>=1.1.0",


### PR DESCRIPTION
According to @yarnabrina, `statsforecast` is now compatible with `pandas 2`, so should be added to the respective dependency set in `pyproject.toml`.