### PR TITLE
Revert "[ENH] replace `"Coverage"` and `"Quantiles"` default variable name in univariate case with variable name"

### DIFF
--- a/sktime/datatypes/_proba/_convert.py
+++ b/sktime/datatypes/_proba/_convert.py
@@ -85,8 +85,8 @@ def convert_pred_interval_to_quantiles(y_pred, inplace=False):
     idx = y_pred.columns
     var_names = idx.get_level_values(0)
 
-    # todo 0.22.0 - predict_interval new interface - remove this
     # treat univariate default name
+    # todo: maybe not a good idea, remove this...
     # here because it's in the current specification
     var_names = ["Quantiles" if x == "Coverage" else x for x in var_names]
 
@@ -152,8 +152,8 @@ def convert_pred_quantiles_to_interval(y_pred, inplace=False):
     idx = y_pred.columns
     var_names = idx.get_level_values(0)
 
-    # todo 0.22.0 - predict_interval new interface - remove this
     # treat univariate default name
+    # todo: maybe not a good idea, remove this...
     # here because it's in the current specification
     var_names = ["Coverage" if x == "Quantiles" else x for x in var_names]
 

--- a/sktime/forecasting/base/_delegate.py
+++ b/sktime/forecasting/base/_delegate.py
@@ -149,9 +149,7 @@ class _DelegatedForecaster(BaseForecaster):
             y=y, fh=fh, X=X, update_params=update_params
         )
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
+    def _predict_quantiles(self, fh, X, alpha):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -184,13 +182,9 @@ class _DelegatedForecaster(BaseForecaster):
                 at quantile probability in second-level col index, for each row index.
         """
         estimator = self._get_delegate()
-        return estimator.predict_quantiles(
-            fh=fh, X=X, alpha=alpha, legacy_interface=legacy_interface
-        )
+        return estimator.predict_quantiles(fh=fh, X=X, alpha=alpha)
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -227,9 +221,7 @@ class _DelegatedForecaster(BaseForecaster):
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
         estimator = self._get_delegate()
-        return estimator.predict_interval(
-            fh=fh, X=X, coverage=coverage, legacy_interface=legacy_interface
-        )
+        return estimator.predict_interval(fh=fh, X=X, coverage=coverage)
 
     def _predict_var(self, fh, X=None, cov=False):
         """Forecast variance at future horizon.

--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -205,9 +205,7 @@ class _ProphetAdapter(BaseForecaster):
 
         return y_pred
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg and logic using it
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -247,11 +245,7 @@ class _ProphetAdapter(BaseForecaster):
         X = self._convert_X_for_exog(X, fh)
 
         # prepare the return DataFrame - empty with correct cols
-        var_names = self._get_varnames(
-            default="Coverage", legacy_interface=legacy_interface
-        )
-        var_name = var_names[0]
-
+        var_names = ["Coverage"]
         int_idx = pd.MultiIndex.from_product([var_names, coverage, ["lower", "upper"]])
         pred_int = pd.DataFrame(columns=int_idx)
 
@@ -275,10 +269,10 @@ class _ProphetAdapter(BaseForecaster):
             # retrieve lower/upper and write in pred_int return frame
             # instead of writing lower to lower, upper to upper
             #  we take the min/max for lower and upper
-            #  because prophet (erroneously?) uses MC independent for upper/lower
+            #  because prophet (erroneously?) uses MC indenendent for upper/lower
             #  so if coverage is small, it can happen that upper < lower in prophet
-            pred_int[(var_name, c, "lower")] = out_prophet.min(axis=1)
-            pred_int[(var_name, c, "upper")] = out_prophet.max(axis=1)
+            pred_int[("Coverage", c, "lower")] = out_prophet.min(axis=1)
+            pred_int[("Coverage", c, "upper")] = out_prophet.max(axis=1)
 
         if self.y_index_was_int_ or self.y_index_was_period_:
             pred_int.index = self.fh.to_absolute_index(cutoff=self.cutoff)

--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -75,9 +75,7 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
 
         return self
 
-    def _predict_in_or_out_of_sample(
-        self, fh, fh_type, X=None, levels=None, legacy_interface=True
-    ):
+    def _predict_in_or_out_of_sample(self, fh, fh_type, X=None, levels=None):
         maximum_forecast_horizon = fh.to_relative(self.cutoff)[-1]
 
         absolute_horizons = fh.to_absolute_index(self.cutoff)
@@ -104,13 +102,8 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
         if levels is None:
             return final_point_predictions
 
-        var_names = self._get_varnames(
-            default="Coverage", legacy_interface=legacy_interface
-        )
-        var_name = var_names[0]
-
         interval_predictions_indices = pandas.MultiIndex.from_product(
-            [var_names, levels, ["lower", "upper"]]
+            [["Coverage"], levels, ["lower", "upper"]]
         )
         interval_predictions = pandas.DataFrame(
             index=absolute_horizons, columns=interval_predictions_indices
@@ -135,10 +128,10 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
                 upper_interval_predictions = upper_interval_predictions.to_numpy()
 
             interval_predictions[
-                (var_name, level, "lower")
+                ("Coverage", level, "lower")
             ] = lower_interval_predictions[horizon_positions]
             interval_predictions[
-                (var_name, level, "upper")
+                ("Coverage", level, "upper")
             ] = upper_interval_predictions[horizon_positions]
 
         return interval_predictions
@@ -199,9 +192,7 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
 
         return final_point_predictions
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg and logic using it
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -247,10 +238,7 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
 
         if in_sample_horizon:
             in_sample_interval_predictions = self._predict_in_or_out_of_sample(
-                in_sample_horizon,
-                "in-sample",
-                levels=coverage,
-                legacy_interface=legacy_interface,
+                in_sample_horizon, "in-sample", levels=coverage
             )
             interval_predictions.append(in_sample_interval_predictions)
 
@@ -260,7 +248,6 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
                 "out-of-sample",
                 X=X_predict_input,
                 levels=coverage,
-                legacy_interface=legacy_interface,
             )
             interval_predictions.append(out_of_sample_interval_predictions)
 

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -244,9 +244,7 @@ class _PmdArimaAdapter(BaseForecaster):
             result.index = fh_abs.to_pandas()
             return result
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg and logic using it
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -289,11 +287,7 @@ class _PmdArimaAdapter(BaseForecaster):
         fh_is_oosample = fh.is_all_out_of_sample(cutoff)
 
         # prepare the return DataFrame - empty with correct cols
-        var_names = self._get_varnames(
-            default="Coverage", legacy_interface=legacy_interface
-        )
-        var_name = var_names[0]
-
+        var_names = ["Coverage"]
         int_idx = pd.MultiIndex.from_product([var_names, coverage, ["lower", "upper"]])
         pred_int = pd.DataFrame(columns=int_idx)
 
@@ -311,8 +305,8 @@ class _PmdArimaAdapter(BaseForecaster):
         if fh_is_in_sample or fh_is_oosample:
             # needs to be replaced, also seems duplicative, identical to part A
             for intervals, a in zip(y_pred_int, coverage):
-                pred_int[(var_name, a, "lower")] = intervals["lower"]
-                pred_int[(var_name, a, "upper")] = intervals["upper"]
+                pred_int[("Coverage", a, "lower")] = intervals["lower"]
+                pred_int[("Coverage", a, "upper")] = intervals["upper"]
             return pred_int
 
         # both in-sample and out-of-sample values (we reach this line only then)
@@ -320,8 +314,8 @@ class _PmdArimaAdapter(BaseForecaster):
         _, y_ins_pred_int = self._predict_in_sample(fh_ins, **kwargs)
         _, y_oos_pred_int = self._predict_fixed_cutoff(fh_oos, **kwargs)
         for ins_int, oos_int, a in zip(y_ins_pred_int, y_oos_pred_int, coverage):
-            pred_int[(var_name, a, "lower")] = pd.concat([ins_int, oos_int])["lower"]
-            pred_int[(var_name, a, "upper")] = pd.concat([ins_int, oos_int])["upper"]
+            pred_int[("Coverage", a, "lower")] = pd.concat([ins_int, oos_int])["lower"]
+            pred_int[("Coverage", a, "upper")] = pd.concat([ins_int, oos_int])["upper"]
 
         return pred_int
 

--- a/sktime/forecasting/base/adapters/_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_statsforecast.py
@@ -198,9 +198,7 @@ class _StatsForecastAdapter(BaseForecaster):
         else:
             return pd.Series(mean, index=fh_abs.to_pandas())
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg and logic using it
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -241,11 +239,7 @@ class _StatsForecastAdapter(BaseForecaster):
         fh_is_oosample = fh.is_all_out_of_sample(cutoff)
 
         # prepare the return DataFrame - empty with correct cols
-        var_names = self._get_varnames(
-            default="Coverage", legacy_interface=legacy_interface
-        )
-        var_name = var_names[0]
-
+        var_names = ["Coverage"]
         int_idx = pd.MultiIndex.from_product([var_names, coverage, ["lower", "upper"]])
         pred_int = pd.DataFrame(columns=int_idx)
 
@@ -262,8 +256,8 @@ class _StatsForecastAdapter(BaseForecaster):
         if fh_is_in_sample or fh_is_oosample:
             # needs to be replaced, also seems duplicative, identical to part A
             for intervals, a in zip(y_pred_int, coverage):
-                pred_int[(var_name, a, "lower")] = intervals["lower"]
-                pred_int[(var_name, a, "upper")] = intervals["upper"]
+                pred_int[("Coverage", a, "lower")] = intervals["lower"]
+                pred_int[("Coverage", a, "upper")] = intervals["upper"]
             return pred_int
 
         # both in-sample and out-of-sample values (we reach this line only then)
@@ -271,7 +265,7 @@ class _StatsForecastAdapter(BaseForecaster):
         _, y_ins_pred_int = self._predict_in_sample(fh_ins, **kwargs)
         _, y_oos_pred_int = self._predict_fixed_cutoff(fh_oos, **kwargs)
         for ins_int, oos_int, a in zip(y_ins_pred_int, y_oos_pred_int, coverage):
-            pred_int[(var_name, a, "lower")] = pd.concat([ins_int, oos_int])["lower"]
-            pred_int[(var_name, a, "upper")] = pd.concat([ins_int, oos_int])["upper"]
+            pred_int[("Coverage", a, "lower")] = pd.concat([ins_int, oos_int])["lower"]
+            pred_int[("Coverage", a, "upper")] = pd.concat([ins_int, oos_int])["upper"]
 
         return pred_int

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -147,9 +147,7 @@ class _StatsModelsAdapter(BaseForecaster):
 
         raise NotImplementedError("abstract method")
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg and logic using it
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction interval forecasts.
 
         private _predict_interval containing the core logic,
@@ -203,20 +201,18 @@ class _StatsModelsAdapter(BaseForecaster):
             **get_prediction_arguments
         )
 
-        var_names = self._get_varnames(
-            default="Coverage", legacy_interface=legacy_interface
+        columns = pd.MultiIndex.from_product(
+            [["Coverage"], coverage, ["lower", "upper"]]
         )
-        var_name = var_names[0]
-        columns = pd.MultiIndex.from_product([var_names, coverage, ["lower", "upper"]])
         pred_int = pd.DataFrame(index=valid_indices, columns=columns)
 
         for c in coverage:
             pred_statsmodels = self._extract_conf_int(prediction_results, (1 - c))
 
-            pred_int[(var_name, c, "lower")] = pred_statsmodels.loc[
+            pred_int[("Coverage", c, "lower")] = pred_statsmodels.loc[
                 valid_indices, "lower"
             ]
-            pred_int[(var_name, c, "upper")] = pred_statsmodels.loc[
+            pred_int[("Coverage", c, "upper")] = pred_statsmodels.loc[
                 valid_indices, "upper"
             ]
 

--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -246,9 +246,7 @@ class _TbatsAdapter(BaseForecaster):
 
         return pred_int
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg and logic using it
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -288,26 +286,22 @@ class _TbatsAdapter(BaseForecaster):
         cutoff = self.cutoff
 
         # accumulator of results
-        var_names = self._get_varnames(
-            default="Coverage", legacy_interface=legacy_interface
-        )
-        var_name = var_names[0]
-
+        var_names = ["Coverage"]
         int_idx = pd.MultiIndex.from_product([var_names, coverage, ["lower", "upper"]])
         pred_int = pd.DataFrame(columns=int_idx, index=fh.to_absolute_index(cutoff))
 
         for c in coverage:
             # separate treatment for "0" coverage: upper/lower = point prediction
             if c == 0:
-                pred_int[(var_name, 0, "lower")] = self._tbats_forecast(fh)
-                pred_int[(var_name, 0, "upper")] = pred_int[(var_name, 0, "lower")]
+                pred_int[("Coverage", 0, "lower")] = self._tbats_forecast(fh)
+                pred_int[("Coverage", 0, "upper")] = pred_int[("Coverage", 0, "lower")]
                 continue
 
             # tbats prediction intervals
             tbats_pred_int = self._tbats_forecast_interval(fh, c)
 
-            pred_int[(var_name, c, "lower")] = tbats_pred_int["lower"]
-            pred_int[(var_name, c, "upper")] = tbats_pred_int["upper"]
+            pred_int[("Coverage", c, "lower")] = tbats_pred_int["lower"]
+            pred_int[("Coverage", c, "upper")] = tbats_pred_int["upper"]
 
         return pred_int
 

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -222,9 +222,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
         """
         return self._by_column("predict", fh=fh, X=X)
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_quantiles(self, fh=None, X=None, alpha=None, legacy_interface=True):
+    def _predict_quantiles(self, fh=None, X=None, alpha=None):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -257,12 +255,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
                 at quantile probability in second-level col index, for each row index.
         """
         out = self._by_column(
-            "predict_quantiles",
-            fh=fh,
-            X=X,
-            alpha=alpha,
-            col_multiindex=True,
-            legacy_interface=legacy_interface,
+            "predict_quantiles", fh=fh, X=X, alpha=alpha, col_multiindex=True
         )
         if len(out.columns.get_level_values(0).unique()) == 1:
             out.columns = out.columns.droplevel(level=0)
@@ -270,9 +263,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
             out.columns = out.columns.droplevel(level=1)
         return out
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_interval(self, fh=None, X=None, coverage=None, legacy_interface=True):
+    def _predict_interval(self, fh=None, X=None, coverage=None):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -309,12 +300,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
         out = self._by_column(
-            "predict_interval",
-            fh=fh,
-            X=X,
-            coverage=coverage,
-            col_multiindex=True,
-            legacy_interface=legacy_interface,
+            "predict_interval", fh=fh, X=X, coverage=coverage, col_multiindex=True
         )
         if len(out.columns.get_level_values(0).unique()) == 1:
             out.columns = out.columns.droplevel(level=0)

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -161,7 +161,6 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                         if len(levels) == 1:
                             levels = levels[0]
                         yt[ix] = y.xs(ix, level=levels, axis=1)
-                        # todo 0.23.0 - get rid of the "Coverage" case treatment
                         # deal with the "Coverage" case, we need to get rid of this
                         #   i.d., special 1st level name of prediction objet
                         #   in the case where there is only one variable
@@ -509,9 +508,7 @@ class ForecastingPipeline(_Pipeline):
         X = self._transform(X=X)
         return self.forecaster_.predict(fh, X)
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
+    def _predict_quantiles(self, fh, X, alpha):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -544,13 +541,9 @@ class ForecastingPipeline(_Pipeline):
                 at quantile probability in second-level col index, for each row index.
         """
         X = self._transform(X=X)
-        return self.forecaster_.predict_quantiles(
-            fh=fh, X=X, alpha=alpha, legacy_interface=legacy_interface
-        )
+        return self.forecaster_.predict_quantiles(fh=fh, X=X, alpha=alpha)
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -587,9 +580,7 @@ class ForecastingPipeline(_Pipeline):
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
         X = self._transform(X=X)
-        return self.forecaster_.predict_interval(
-            fh=fh, X=X, coverage=coverage, legacy_interface=legacy_interface
-        )
+        return self.forecaster_.predict_interval(fh=fh, X=X, coverage=coverage)
 
     def _predict_var(self, fh, X=None, cov=False):
         """Forecast variance at future horizon.
@@ -1077,9 +1068,7 @@ class TransformedTargetForecaster(_Pipeline):
         Z = check_series(Z)
         return self._get_inverse_transform(self.transformers_pre_, Z, X)
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
+    def _predict_quantiles(self, fh, X, alpha):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -1111,17 +1100,13 @@ class TransformedTargetForecaster(_Pipeline):
             Row index is fh. Entries are quantile forecasts, for var in col index,
                 at quantile probability in second-level col index, for each row index.
         """
-        pred_int = self.forecaster_.predict_quantiles(
-            fh=fh, X=X, alpha=alpha, legacy_interface=legacy_interface
-        )
+        pred_int = self.forecaster_.predict_quantiles(fh=fh, X=X, alpha=alpha)
         pred_int_transformed = self._get_inverse_transform(
             self.transformers_pre_, pred_int, mode="proba"
         )
         return pred_int_transformed
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -1157,9 +1142,7 @@ class TransformedTargetForecaster(_Pipeline):
                 Upper/lower interval end forecasts are equivalent to
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
-        pred_int = self.forecaster_.predict_interval(
-            fh=fh, X=X, coverage=coverage, legacy_interface=legacy_interface
-        )
+        pred_int = self.forecaster_.predict_interval(fh=fh, X=X, coverage=coverage)
         pred_int_transformed = self._get_inverse_transform(
             self.transformers_pre_, pred_int, mode="proba"
         )
@@ -1408,9 +1391,7 @@ class ForecastX(BaseForecaster):
 
         return self
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction interval forecasts.
 
         private _predict_interval containing the core logic,
@@ -1442,14 +1423,10 @@ class ForecastX(BaseForecaster):
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
         X = self._get_forecaster_X_prediction(fh=fh, X=X)
-        y_pred = self.forecaster_y_.predict_interval(
-            fh=fh, X=X, coverage=coverage, legacy_interface=legacy_interface
-        )
+        y_pred = self.forecaster_y_.predict_interval(fh=fh, X=X, coverage=coverage)
         return y_pred
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_quantiles(self, fh, X=None, alpha=None, legacy_interface=True):
+    def _predict_quantiles(self, fh, X, alpha):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -1476,9 +1453,7 @@ class ForecastX(BaseForecaster):
                 at quantile probability in second col index, for the row index.
         """
         X = self._get_forecaster_X_prediction(fh=fh, X=X)
-        y_pred = self.forecaster_y_.predict_quantiles(
-            fh=fh, X=X, alpha=alpha, legacy_interface=legacy_interface
-        )
+        y_pred = self.forecaster_y_.predict_quantiles(fh=fh, X=X, alpha=alpha)
         return y_pred
 
     def _predict_var(self, fh=None, X=None, cov=False):

--- a/sktime/forecasting/compose/tests/test_bagging.py
+++ b/sktime/forecasting/compose/tests/test_bagging.py
@@ -7,6 +7,7 @@ import pytest
 
 from sktime.datasets import load_airline
 from sktime.forecasting.compose import BaggingForecaster
+from sktime.forecasting.compose._bagging import _calculate_data_quantiles
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.transformations.bootstrap import STLBootstrapTransformer
 from sktime.transformations.series.boxcox import LogTransformer
@@ -17,7 +18,7 @@ y = load_airline()
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
-    reason="skip test if required soft dependency is not available",
+    reason="skip test if required soft dependency for hmmlearn not available",
 )
 @pytest.mark.parametrize("transformer", [LogTransformer, NaiveForecaster])
 def test_bagging_forecaster_transformer_type_error(transformer):
@@ -36,7 +37,7 @@ def test_bagging_forecaster_transformer_type_error(transformer):
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
-    reason="skip test if required soft dependency is not available",
+    reason="skip test if required soft dependency for hmmlearn not available",
 )
 @pytest.mark.parametrize("forecaster", [LogTransformer])
 def test_bagging_forecaster_forecaster_type_error(forecaster):
@@ -69,8 +70,4 @@ def test_calculate_data_quantiles():
         index=pd.Index(data=fh, name="time"),
     )
 
-    f = BaggingForecaster.create_test_instance()
-    f.fit(y)
-
-    calc_output = f._calculate_data_quantiles(df, alpha)
-    pd.testing.assert_frame_equal(calc_output, output_df)
+    pd.testing.assert_frame_equal(_calculate_data_quantiles(df, alpha), output_df)

--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -203,9 +203,7 @@ class ConformalIntervals(BaseForecaster):
                 update=True,
             )
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -260,11 +258,7 @@ class ConformalIntervals(BaseForecaster):
 
         ABS_RESIDUAL_BASED = ["conformal", "conformal_bonferroni", "empirical_residual"]
 
-        var_names = self._get_varnames(
-            default="Coverage", legacy_interface=legacy_interface
-        )
-
-        cols = pd.MultiIndex.from_product([var_names, coverage, ["lower", "upper"]])
+        cols = pd.MultiIndex.from_product([["Coverage"], coverage, ["lower", "upper"]])
         pred_int = pd.DataFrame(index=fh_absolute_idx, columns=cols)
         for fh_ind, offset in zip(fh_absolute, fh_relative):
             resids = np.diagonal(residuals_matrix, offset=offset)
@@ -299,6 +293,36 @@ class ConformalIntervals(BaseForecaster):
             pred_int[col] = y_pred + sign * pred_int[col]
 
         return pred_int.convert_dtypes()
+
+    def _predict_quantiles(self, fh, X, alpha):
+        """Compute/return prediction quantiles for a forecast.
+
+        private _predict_quantiles containing the core logic,
+            called from predict_quantiles and default _predict_interval
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon
+            The forecasting horizon with the steps ahead to to predict.
+        X : optional (default=None)
+            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            Exogeneous time series to predict from.
+        alpha : list of float, optional (default=[0.5])
+            A list of probabilities at which quantile forecasts are computed.
+
+        Returns
+        -------
+        quantiles : pd.DataFrame
+            Column has multi-index: first level is variable name from y in fit,
+                second level being the values of alpha passed to the function.
+            Row index is fh, with additional (upper) levels equal to instance levels,
+                    from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
+            Entries are quantile forecasts, for var in col index,
+                at quantile probability in second col index, for the row index.
+        """
+        pred_int = BaseForecaster._predict_quantiles(self, fh, X, alpha)
+
+        return pred_int
 
     def _parse_initial_window(self, y, initial_window=None):
         n_samples = len(y)

--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -219,9 +219,7 @@ class DynamicFactor(_StatsModelsAdapter):
             )
         return y_pred.loc[fh.to_absolute_index(self.cutoff)]
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -406,9 +406,7 @@ class NaiveForecaster(_BaseWindowForecaster):
 
         return y_pred
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg and logic using it
-    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
+    def _predict_quantiles(self, fh, X, alpha):
         """Compute/return prediction quantiles for a forecast.
 
         Uses normal distribution as predictive distribution to compute the
@@ -442,13 +440,9 @@ class NaiveForecaster(_BaseWindowForecaster):
             np.sqrt(pred_var.to_numpy().reshape(len(pred_var), 1)) * z_scores
         ).reshape(len(y_pred), len(alpha))
 
-        var_names = self._get_varnames(
-            default="Quantiles", legacy_interface=legacy_interface
-        )
-
         pred_quantiles = pd.DataFrame(
             errors + y_pred.values.reshape(len(y_pred), 1),
-            columns=pd.MultiIndex.from_product([var_names, alpha]),
+            columns=pd.MultiIndex.from_product([["Quantiles"], alpha]),
             index=fh.to_absolute_index(self.cutoff),
         )
 
@@ -700,9 +694,7 @@ class NaiveVariance(BaseForecaster):
             )
         return self
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
+    def _predict_quantiles(self, fh, X, alpha):
         """Compute/return prediction quantiles for a forecast.
 
         Uses normal distribution as predictive distribution to compute the
@@ -735,15 +727,10 @@ class NaiveVariance(BaseForecaster):
         z_scores = norm.ppf(alpha)
         errors = [pred_var**0.5 * z for z in z_scores]
 
-        var_names = self._get_varnames(
-            default="Quantiles", legacy_interface=legacy_interface
-        )
-        var_name = var_names[0]
-
-        index = pd.MultiIndex.from_product([var_names, alpha])
+        index = pd.MultiIndex.from_product([["Quantiles"], alpha])
         pred_quantiles = pd.DataFrame(columns=index)
         for a, error in zip(alpha, errors):
-            pred_quantiles[(var_name, a)] = y_pred + error
+            pred_quantiles[("Quantiles", a)] = y_pred + error
 
         fh_absolute = fh.to_absolute(self.cutoff)
         pred_quantiles.index = fh_absolute.to_pandas()

--- a/sktime/forecasting/squaring_residuals.py
+++ b/sktime/forecasting/squaring_residuals.py
@@ -269,9 +269,7 @@ class SquaringResiduals(BaseForecaster):
             forecaster.update(X=X, y=y, update_params=update_params)
         return self
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
+    def _predict_quantiles(self, fh, X, alpha):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -315,15 +313,10 @@ class SquaringResiduals(BaseForecaster):
 
         errors = [pred_var * z for z in z_scores]
 
-        var_names = self._get_varnames(
-            default="Quantiles", legacy_interface=legacy_interface
-        )
-        var_name = var_names[0]
-
-        index = pd.MultiIndex.from_product([var_names, alpha])
+        index = pd.MultiIndex.from_product([["Quantiles"], alpha])
         pred_quantiles = pd.DataFrame(columns=index)
         for a, error in zip(alpha, errors):
-            pred_quantiles[(var_name, a)] = y_pred + error
+            pred_quantiles[("Quantiles", a)] = y_pred + error
 
         pred_quantiles.index = fh_abs.to_pandas()
 

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -346,11 +346,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
 
         _assert_correct_columns(y_pred, y_train)
 
-    # todo 0.23.0: remove legacy_interface arg and logic
-    # behaviour should be legacy_interface=False
-    def _check_predict_intervals(
-        self, pred_ints, y_train, fh, coverage, legacy_interface
-    ):
+    def _check_predict_intervals(self, pred_ints, y_train, fh, coverage):
         """Check expected interval prediction output."""
         # check expected type
         valid, msg, _ = check_is_mtype(
@@ -363,24 +359,11 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         _assert_correct_pred_time_index(pred_ints.index, cutoff, fh)
 
         # check columns
-
-        def get_expected_columns():
-            if isinstance(y_train, pd.Series):
-                if legacy_interface:
-                    return ["Coverage"]
-                elif hasattr(y_train, "name") and y_train.name is not None:
-                    return [y_train.name]
-                else:
-                    return [0]
-            else:
-                if legacy_interface and len(y_train.columns) == 1:
-                    return ["Coverage"]
-                else:
-                    return y_train.columns
-
         # Forecasters where name of variables do not exist
         # In this cases y_train is series - the upper level in dataframe == 'Coverage'
-        expected_columns = get_expected_columns()
+        expected_columns = (
+            ["Coverage"] if isinstance(y_train, pd.Series) else y_train.columns
+        )
         expected_coverages = [coverage] if isinstance(coverage, float) else coverage
         expected = pd.MultiIndex.from_product(
             [expected_columns, expected_coverages, ["lower", "upper"]]
@@ -424,28 +407,16 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         y_train = _make_series(n_columns=n_columns, index_type=index_type)
         estimator_instance.fit(y_train, fh=fh_int_oos)
         if estimator_instance.get_tag("capability:pred_int"):
-            # todo 0.23.0: remove legacy_interface arg and logic
-            # simply remove the arg
-            for legacy_interface in [True, False]:
-                pred_ints = estimator_instance.predict_interval(
-                    fh=fh_int_oos, coverage=coverage, legacy_interface=legacy_interface
-                )
-                self._check_predict_intervals(
-                    pred_ints,
-                    y_train,
-                    fh_int_oos,
-                    coverage,
-                    legacy_interface=legacy_interface,
-                )
+            pred_ints = estimator_instance.predict_interval(
+                fh_int_oos, coverage=coverage
+            )
+            self._check_predict_intervals(pred_ints, y_train, fh_int_oos, coverage)
+
         else:
             with pytest.raises(NotImplementedError, match="prediction intervals"):
                 estimator_instance.predict_interval(fh_int_oos, coverage=coverage)
 
-    # todo 0.23.0: remove legacy_interface arg and logic
-    # behaviour should be legacy_interface=False
-    def _check_predict_quantiles(
-        self, pred_quantiles, y_train, fh, alpha, legacy_interface
-    ):
+    def _check_predict_quantiles(self, pred_quantiles, y_train, fh, alpha):
         """Check expected quantile prediction output."""
         # check expected type
         valid, msg, _ = check_is_mtype(
@@ -461,22 +432,11 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         _assert_correct_pred_time_index(pred_quantiles.index, cutoff, fh)
 
         # check columns
-
-        def get_expected_columns():
-            if isinstance(y_train, pd.Series):
-                if legacy_interface:
-                    return ["Quantiles"]
-                elif hasattr(y_train, "name") and y_train.name is not None:
-                    return [y_train.name]
-                else:
-                    return [0]
-            else:
-                if legacy_interface and len(y_train.columns) == 1:
-                    return ["Quantiles"]
-                else:
-                    return y_train.columns
-
-        expected_columns = get_expected_columns()
+        # Forecasters where name of variables do not exist
+        # In this cases y_train is series - the upper level in dataframe == 'Quantiles'
+        expected_columns = (
+            ["Quantiles"] if isinstance(y_train, pd.Series) else y_train.columns
+        )
         expected_quantiles = [alpha] if isinstance(alpha, float) else alpha
         expected = pd.MultiIndex.from_product([expected_columns, expected_quantiles])
 
@@ -525,19 +485,8 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         y_train = _make_series(n_columns=n_columns)
         estimator_instance.fit(y_train, fh=fh_int_oos)
         if estimator_instance.get_tag("capability:pred_int"):
-            # todo 0.23.0: remove legacy_interface arg and logic
-            # simply remove the arg
-            for legacy_interface in [True, False]:
-                quantiles = estimator_instance.predict_quantiles(
-                    fh=fh_int_oos, alpha=alpha, legacy_interface=legacy_interface
-                )
-                self._check_predict_quantiles(
-                    quantiles,
-                    y_train,
-                    fh_int_oos,
-                    alpha,
-                    legacy_interface=legacy_interface,
-                )
+            quantiles = estimator_instance.predict_quantiles(fh=fh_int_oos, alpha=alpha)
+            self._check_predict_quantiles(quantiles, y_train, fh_int_oos, alpha)
         else:
             with pytest.raises(NotImplementedError, match="quantile predictions"):
                 estimator_instance.predict_quantiles(fh=fh_int_oos, alpha=alpha)

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -195,55 +195,7 @@ class ThetaForecaster(ExponentialSmoothing):
 
         return drift
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg and logic using it
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
-        """Compute/return prediction quantiles for a forecast.
-
-        private _predict_interval containing the core logic,
-            called from predict_interval and possibly predict_quantiles
-
-        State required:
-            Requires state to be "fitted".
-
-        Accesses in self:
-            Fitted model attributes ending in "_"
-            self.cutoff
-
-        Parameters
-        ----------
-        fh : guaranteed to be ForecastingHorizon
-            The forecasting horizon with the steps ahead to to predict.
-        X :  sktime time series object, optional (default=None)
-            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
-            Exogeneous time series for the forecast
-        coverage : list of float (guaranteed not None and floats in [0,1] interval)
-           nominal coverage(s) of predictive interval(s)
-
-        Returns
-        -------
-        pred_int : pd.DataFrame
-            Column has multi-index: first level is variable name from y in fit,
-                second level coverage fractions for which intervals were computed.
-                    in the same order as in input `coverage`.
-                Third level is string "lower" or "upper", for lower/upper interval end.
-            Row index is fh, with additional (upper) levels equal to instance levels,
-                from y seen in fit, if y_inner_mtype is Panel or Hierarchical.
-            Entries are forecasts of lower/upper interval end,
-                for var in col index, at nominal coverage in second col index,
-                lower/upper depending on third col index, for the row index.
-                Upper/lower interval end forecasts are equivalent to
-                quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
-        """
-        pred_int = BaseForecaster._predict_interval(
-            self, fh, X, coverage, legacy_interface
-        )
-
-        return pred_int
-
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg and logic using it
-    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
+    def _predict_quantiles(self, fh, X, alpha):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -267,11 +219,7 @@ class ThetaForecaster(ExponentialSmoothing):
                 at quantile probability in second col index, for the row index.
         """
         # prepare return data frame
-        var_names = self._get_varnames(
-            default="Quantiles", legacy_interface=legacy_interface
-        )
-        var_name = var_names[0]
-        index = pd.MultiIndex.from_product([var_names, alpha])
+        index = pd.MultiIndex.from_product([["Quantiles"], alpha])
         pred_quantiles = pd.DataFrame(columns=index)
 
         sem = self.sigma_ * np.sqrt(
@@ -282,7 +230,7 @@ class ThetaForecaster(ExponentialSmoothing):
 
         # we assume normal additive noise with sem variance
         for a in alpha:
-            pred_quantiles[(var_name, a)] = y_pred + norm.ppf(a) * sem
+            pred_quantiles[("Quantiles", a)] = y_pred + norm.ppf(a) * sem
         # todo: should this not increase with the horizon?
         # i.e., sth like norm.ppf(a) * sem * fh.to_absolute(cutoff) ?
         # I've just refactored this so will leave it for now

--- a/sktime/forecasting/var.py
+++ b/sktime/forecasting/var.py
@@ -189,9 +189,7 @@ class VAR(_StatsModelsAdapter):
         )
         return y_pred
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,

--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -208,9 +208,7 @@ class VECM(_StatsModelsAdapter):
 
         return y_pred
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
+    def _predict_interval(self, fh, X, coverage):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,

--- a/sktime/utils/estimators/_forecasters.py
+++ b/sktime/utils/estimators/_forecasters.py
@@ -141,10 +141,8 @@ class MockUnivariateForecasterLogger(BaseForecaster, _MockEstimatorMixin):
         """
         return self
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
     @_method_logger
-    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
+    def _predict_quantiles(self, fh, X, alpha):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -175,17 +173,12 @@ class MockUnivariateForecasterLogger(BaseForecaster, _MockEstimatorMixin):
             Row index is fh. Entries are quantile forecasts, for var in col index,
                 at quantile probability in second-level col index, for each row index.
         """
-        var_names = self._get_varnames(
-            default="Quantiles", legacy_interface=legacy_interface
-        )
-        var_name = var_names[0]
-
         fh_index = fh.to_absolute_index(self.cutoff)
-        col_index = pd.MultiIndex.from_product([var_names, alpha])
+        col_index = pd.MultiIndex.from_product([["Quantiles"], alpha])
         pred_quantiles = pd.DataFrame(columns=col_index, index=fh_index)
 
         for a in alpha:
-            pred_quantiles[(var_name, a)] = pd.Series(
+            pred_quantiles[("Quantiles", a)] = pd.Series(
                 self.prediction_constant * 2 * a, index=fh_index
             )
 
@@ -326,9 +319,7 @@ class MockForecaster(BaseForecaster):
         """
         return self
 
-    # todo 0.22.0 - switch legacy_interface default to False
-    # todo 0.23.0 - remove legacy_interface arg
-    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
+    def _predict_quantiles(self, fh, X, alpha):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -361,7 +352,7 @@ class MockForecaster(BaseForecaster):
         """
         cols = self._y.columns
 
-        if legacy_interface and len(cols) == 1:
+        if len(cols) == 1:
             cols = ["Quantiles"]
 
         col_index = pd.MultiIndex.from_product([cols, alpha])

--- a/sktime/utils/estimators/tests/test_forecasters.py
+++ b/sktime/utils/estimators/tests/test_forecasters.py
@@ -54,11 +54,8 @@ def test_mock_univariate_forecaster_log(y, X_train, X_pred, fh):
         ("_update", {"y": y_series, "X": _X_train, "update_params": fh}),
         (
             "_predict_quantiles",
-            # todo 0.22.0: change the value of "legacy_interface" to False
-            # todo 0.23.0: remove the key "legacy_interface"
-            {"fh": fh, "X": _X_pred, "alpha": [0.1, 0.9], "legacy_interface": True},
+            {"fh": fh, "X": _X_pred, "alpha": [0.1, 0.9]},
         ),
     ]
 
-    equals, msg = deep_equals(forecaster.log, expected_log, return_msg=True)
-    assert equals, msg
+    assert deep_equals(forecaster.log, expected_log)


### PR DESCRIPTION
Reverts sktime/sktime#4780 as it needs to go into 0.21.0, not 0.20.1