### PR TITLE
[ENH] replace `"Coverage"` and `"Quantiles"` default variable name in univariate case with variable name

### DIFF
--- a/sktime/datatypes/_proba/_convert.py
+++ b/sktime/datatypes/_proba/_convert.py
@@ -85,8 +85,8 @@ def convert_pred_interval_to_quantiles(y_pred, inplace=False):
     idx = y_pred.columns
     var_names = idx.get_level_values(0)
 
+    # todo 0.22.0 - predict_interval new interface - remove this
     # treat univariate default name
-    # todo: maybe not a good idea, remove this...
     # here because it's in the current specification
     var_names = ["Quantiles" if x == "Coverage" else x for x in var_names]
 
@@ -152,8 +152,8 @@ def convert_pred_quantiles_to_interval(y_pred, inplace=False):
     idx = y_pred.columns
     var_names = idx.get_level_values(0)
 
+    # todo 0.22.0 - predict_interval new interface - remove this
     # treat univariate default name
-    # todo: maybe not a good idea, remove this...
     # here because it's in the current specification
     var_names = ["Coverage" if x == "Quantiles" else x for x in var_names]
 

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -37,6 +37,7 @@ __author__ = ["mloning", "big-o", "fkiraly", "sveameyer13", "miraep8"]
 __all__ = ["BaseForecaster"]
 
 from copy import deepcopy
+from inspect import getfullargspec
 from itertools import product
 from warnings import warn
 
@@ -492,7 +493,9 @@ class BaseForecaster(BaseEstimator):
         #  input conversions are skipped since we are using X_inner
         return self.predict(fh=fh, X=X_inner)
 
-    def predict_quantiles(self, fh=None, X=None, alpha=None):
+    # todo 0.22.0 - update default of legacy_interface arg in docstring
+    # todo 0.23.0 - remove legacy_interface arg and logic using it, update docstring
+    def predict_quantiles(self, fh=None, X=None, alpha=None, legacy_interface=None):
         """Compute/return quantile forecasts.
 
         If alpha is iterable, multiple quantiles will be calculated.
@@ -518,6 +521,12 @@ class BaseForecaster(BaseEstimator):
             if self.get_tag("X-y-must-have-same-index"), must contain fh.index
         alpha : float or list of float of unique values, optional (default=[0.05, 0.95])
             A probability or list of, at which quantile forecasts are computed.
+        legacy_interface : bool, default=True
+            controls legacy behaviour for level 0 naming of quantiles reuturn
+            If "True", in univariate case level 0 will be named "Quantiles" and not
+            according to the variable name.
+            If "False", return is as described.
+            Default will change to False in 0.22.0, argument will be removed in 0.23.0.
 
         Returns
         -------
@@ -538,6 +547,29 @@ class BaseForecaster(BaseEstimator):
             )
         self.check_is_fitted()
 
+        # todo 0.22.0 - switch legacy_interface default to False
+        if legacy_interface is None:
+            _legacy_interface = True
+        else:
+            _legacy_interface = legacy_interface
+
+        if _legacy_interface:
+            warn(
+                "In 0.22.0, predict_quantiles return default column level 0 name will "
+                "change for univariate probabilistic quantile forecasts "
+                "from 'Quantiles' to variable name. The old behaviour can be "
+                "retained by setting the legacy_interface argument to True, "
+                "until 0.23.0 when the legacy_interface argument will be removed."
+            )
+        elif legacy_interface is not None:
+            warn(
+                "Until 0.23.0, the predict_quantiles legacy_interface argument "
+                "can be used for facilitating deprecation and change to the new "
+                "predict_quantiles interface. It will be removed in 0.23.0, "
+                "from when passing the legacy_interface argument will raise an "
+                "exception."
+            )
+
         # input checks and conversions
 
         # check fh and coerce to ForecastingHorizon
@@ -552,22 +584,38 @@ class BaseForecaster(BaseEstimator):
         # input check and conversion for X
         X_inner = self._check_X(X=X)
 
+        # todo 0.23.0: remove logic for adapting legacy_interface
+        # this is needed since user implemented estimators might not have the
+        # legacy_interface argument
+        has_li_arg = "legacy_interface" in getfullargspec(self._predict_quantiles).args
+        if has_li_arg:
+            kwargs = {"legacy_interface": _legacy_interface}
+        else:
+            kwargs = {}
+
         # we call the ordinary _predict_quantiles if no looping/vectorization needed
         if not self._is_vectorized:
-            quantiles = self._predict_quantiles(fh=fh, X=X_inner, alpha=alpha)
+            quantiles = self._predict_quantiles(fh=fh, X=X_inner, alpha=alpha, **kwargs)
         else:
             # otherwise we call the vectorized version of predict_quantiles
             quantiles = self._vectorize(
-                "predict_quantiles", fh=fh, X=X_inner, alpha=alpha
+                "predict_quantiles",
+                fh=fh,
+                X=X_inner,
+                alpha=alpha,
+                **kwargs,
             )
 
         return quantiles
 
+    # todo 0.22.0 - update default of legacy_interface arg in docstring
+    # todo 0.23.0 - remove legacy_interface arg and logic using it
     def predict_interval(
         self,
         fh=None,
         X=None,
         coverage=0.90,
+        legacy_interface=None,
     ):
         """Compute/return prediction interval forecasts.
 
@@ -594,6 +642,12 @@ class BaseForecaster(BaseEstimator):
             if self.get_tag("X-y-must-have-same-index"), must contain fh.index
         coverage : float or list of float of unique values, optional (default=0.90)
            nominal coverage(s) of predictive interval(s)
+        legacy_interface : bool, default=True
+            controls legacy behaviour for level 0 naming of pred_int return
+            If "True", in univariate case level 0 will be named "Coverage" and not
+            according to the variable name.
+            If "False", return is as described.
+            Default will change to False in 0.22.0, argument will be removed in 0.23.0.
 
         Returns
         -------
@@ -619,6 +673,29 @@ class BaseForecaster(BaseEstimator):
             )
         self.check_is_fitted()
 
+        # todo 0.22.0 - switch legacy_interface default to False
+        if legacy_interface is None:
+            _legacy_interface = True
+        else:
+            _legacy_interface = legacy_interface
+
+        if _legacy_interface:
+            warn(
+                "In 0.22.0, predict_interval return default column level 0 name will "
+                "change for univariate probabilistic interval forecasts "
+                "from 'Coverage' to variable name. The old behaviour can be "
+                "retained by setting the legacy_interface argument to True, "
+                "until 0.23.0 when the legacy_interface argument will be removed."
+            )
+        elif legacy_interface is not None:
+            warn(
+                "Until 0.23.0, the predict_interval legacy_interface argument "
+                "can be used for facilitating deprecation and change to the new "
+                "predict_interval interface. It will be removed in 0.23.0, "
+                "from when passing the legacy_interface argument will raise an "
+                "exception."
+            )
+
         # input checks and conversions
 
         # check fh and coerce to ForecastingHorizon
@@ -629,13 +706,28 @@ class BaseForecaster(BaseEstimator):
         # check and convert X
         X_inner = self._check_X(X=X)
 
+        # todo 0.23.0: remove logic for adapting legacy_interface
+        # this is needed since user implemented estimators might not have the
+        # legacy_interface argument
+        has_li_arg = "legacy_interface" in getfullargspec(self._predict_interval).args
+        if has_li_arg:
+            kwargs = {"legacy_interface": _legacy_interface}
+        else:
+            kwargs = {}
+
         # we call the ordinary _predict_interval if no looping/vectorization needed
         if not self._is_vectorized:
-            pred_int = self._predict_interval(fh=fh, X=X_inner, coverage=coverage)
+            pred_int = self._predict_interval(
+                fh=fh, X=X_inner, coverage=coverage, **kwargs
+            )
         else:
             # otherwise we call the vectorized version of predict_interval
             pred_int = self._vectorize(
-                "predict_interval", fh=fh, X=X_inner, coverage=coverage
+                "predict_interval",
+                fh=fh,
+                X=X_inner,
+                coverage=coverage,
+                **kwargs,
             )
 
         return pred_int
@@ -1912,7 +2004,9 @@ class BaseForecaster(BaseEstimator):
         self.update(y=y, X=X, update_params=update_params)
         return self.predict(fh=fh, X=X)
 
-    def _predict_interval(self, fh, X, coverage):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
         """Compute/return prediction interval forecasts.
 
         private _predict_interval containing the core logic,
@@ -1964,7 +2058,9 @@ class BaseForecaster(BaseEstimator):
             alphas.extend([0.5 - 0.5 * float(c), 0.5 + 0.5 * float(c)])
 
         # compute quantile forecasts corresponding to upper/lower
-        pred_int = self._predict_quantiles(fh=fh, X=X, alpha=alphas)
+        pred_int = self._predict_quantiles(
+            fh=fh, X=X, alpha=alphas, legacy_interface=legacy_interface
+        )
 
         # change the column labels (multiindex) to the format for intervals
         # idx returned by _predict_quantiles is
@@ -1972,9 +2068,12 @@ class BaseForecaster(BaseEstimator):
         idx = pred_int.columns
         # variable names (unique, in same order)
         var_names = idx.get_level_values(0).unique()
-        # if was univariate & unnamed variable, replace default
-        if len(var_names) == 1 and var_names == ["Quantiles"]:
-            var_names = ["Coverage"]
+
+        # todo 0.23.0 - predict_interval new interface - remove this
+        if legacy_interface:
+            # if was univariate & unnamed variable, replace default
+            if len(var_names) == 1 and var_names == ["Quantiles"]:
+                var_names = ["Coverage"]
         # idx returned by _predict_interval should be
         #   3-level MultiIndex with variable names, coverage, lower/upper
         int_idx = pd.MultiIndex.from_product([var_names, coverage, ["lower", "upper"]])
@@ -1983,7 +2082,9 @@ class BaseForecaster(BaseEstimator):
 
         return pred_int
 
-    def _predict_quantiles(self, fh, X, alpha):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -2029,7 +2130,9 @@ class BaseForecaster(BaseEstimator):
                 coverage = abs(1 - 2 * a)
 
                 # compute quantile forecasts corresponding to upper/lower
-                pred_a = self._predict_interval(fh=fh, X=X, coverage=[coverage])
+                pred_a = self._predict_interval(
+                    fh=fh, X=X, coverage=[coverage], legacy_interface=legacy_interface
+                )
                 pred_int = pd.concat([pred_int, pred_a], axis=1)
 
             # now we need to subset to lower/upper depending
@@ -2047,9 +2150,12 @@ class BaseForecaster(BaseEstimator):
             idx = pred_int.columns
             # variable names (unique, in same order)
             var_names = idx.get_level_values(0).unique()
-            # if was univariate & unnamed variable, replace default
-            if len(var_names) == 1 and var_names == ["Coverage"]:
-                var_names = ["Quantiles"]
+
+            # todo 0.23.0 - predict_interval new interface - remove this
+            if legacy_interface:
+                # if was univariate & unnamed variable, replace default
+                if len(var_names) == 1 and var_names == ["Coverage"]:
+                    var_names = ["Quantiles"]
             # idx returned by _predict_quantiles should be
             #   is 2-level MultiIndex with variable names, alpha
             int_idx = pd.MultiIndex.from_product([var_names, alpha])
@@ -2149,9 +2255,9 @@ class BaseForecaster(BaseEstimator):
             #   the indices and column names are already correct
             pred_var = pd.DataFrame(vars_dict)
 
-            # check whether column format was "nameless", set it to RangeIndex then
+            # check whether column format was "nameless", set it to expected vars
             if len(pred_var.columns) == 1 and pred_var.columns == ["Coverage"]:
-                pred_var.columns = pd.RangeIndex(1)
+                pred_var.columns = self._get_varnames(default=0, legacy_interface=False)
 
         return pred_var
 
@@ -2301,6 +2407,27 @@ class BaseForecaster(BaseEstimator):
                     store_behaviour="freeze",
                 )
         return _format_moving_cutoff_predictions(y_preds, cutoffs)
+
+    def _get_varnames(self, default=None, legacy_interface=True):
+        """Return variable column for DataFrame-like returns.
+
+        Developer note: currently a helper for predict_interval, predict_quantiles,
+        valid only in the univariate case. Can be extended later.
+        """
+        if legacy_interface:
+            var_name = default
+        else:
+            y = self._y
+            if isinstance(y, pd.Series):
+                var_name = self._y.name
+            elif isinstance(y, pd.DataFrame):
+                return y.columns
+            else:
+                var_name = 0
+            if var_name is None:
+                var_name = 0
+
+        return [var_name]
 
 
 def _format_moving_cutoff_predictions(y_preds, cutoffs):

--- a/sktime/forecasting/base/_delegate.py
+++ b/sktime/forecasting/base/_delegate.py
@@ -149,7 +149,9 @@ class _DelegatedForecaster(BaseForecaster):
             y=y, fh=fh, X=X, update_params=update_params
         )
 
-    def _predict_quantiles(self, fh, X, alpha):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -182,9 +184,13 @@ class _DelegatedForecaster(BaseForecaster):
                 at quantile probability in second-level col index, for each row index.
         """
         estimator = self._get_delegate()
-        return estimator.predict_quantiles(fh=fh, X=X, alpha=alpha)
+        return estimator.predict_quantiles(
+            fh=fh, X=X, alpha=alpha, legacy_interface=legacy_interface
+        )
 
-    def _predict_interval(self, fh, X, coverage):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -221,7 +227,9 @@ class _DelegatedForecaster(BaseForecaster):
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
         estimator = self._get_delegate()
-        return estimator.predict_interval(fh=fh, X=X, coverage=coverage)
+        return estimator.predict_interval(
+            fh=fh, X=X, coverage=coverage, legacy_interface=legacy_interface
+        )
 
     def _predict_var(self, fh, X=None, cov=False):
         """Forecast variance at future horizon.

--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -75,7 +75,9 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
 
         return self
 
-    def _predict_in_or_out_of_sample(self, fh, fh_type, X=None, levels=None):
+    def _predict_in_or_out_of_sample(
+        self, fh, fh_type, X=None, levels=None, legacy_interface=True
+    ):
         maximum_forecast_horizon = fh.to_relative(self.cutoff)[-1]
 
         absolute_horizons = fh.to_absolute_index(self.cutoff)
@@ -102,8 +104,13 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
         if levels is None:
             return final_point_predictions
 
+        var_names = self._get_varnames(
+            default="Coverage", legacy_interface=legacy_interface
+        )
+        var_name = var_names[0]
+
         interval_predictions_indices = pandas.MultiIndex.from_product(
-            [["Coverage"], levels, ["lower", "upper"]]
+            [var_names, levels, ["lower", "upper"]]
         )
         interval_predictions = pandas.DataFrame(
             index=absolute_horizons, columns=interval_predictions_indices
@@ -128,10 +135,10 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
                 upper_interval_predictions = upper_interval_predictions.to_numpy()
 
             interval_predictions[
-                ("Coverage", level, "lower")
+                (var_name, level, "lower")
             ] = lower_interval_predictions[horizon_positions]
             interval_predictions[
-                ("Coverage", level, "upper")
+                (var_name, level, "upper")
             ] = upper_interval_predictions[horizon_positions]
 
         return interval_predictions
@@ -192,7 +199,9 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
 
         return final_point_predictions
 
-    def _predict_interval(self, fh, X, coverage):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg and logic using it
+    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -238,7 +247,10 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
 
         if in_sample_horizon:
             in_sample_interval_predictions = self._predict_in_or_out_of_sample(
-                in_sample_horizon, "in-sample", levels=coverage
+                in_sample_horizon,
+                "in-sample",
+                levels=coverage,
+                legacy_interface=legacy_interface,
             )
             interval_predictions.append(in_sample_interval_predictions)
 
@@ -248,6 +260,7 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
                 "out-of-sample",
                 X=X_predict_input,
                 levels=coverage,
+                legacy_interface=legacy_interface,
             )
             interval_predictions.append(out_of_sample_interval_predictions)
 

--- a/sktime/forecasting/base/adapters/_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_statsforecast.py
@@ -198,7 +198,9 @@ class _StatsForecastAdapter(BaseForecaster):
         else:
             return pd.Series(mean, index=fh_abs.to_pandas())
 
-    def _predict_interval(self, fh, X, coverage):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg and logic using it
+    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -239,7 +241,11 @@ class _StatsForecastAdapter(BaseForecaster):
         fh_is_oosample = fh.is_all_out_of_sample(cutoff)
 
         # prepare the return DataFrame - empty with correct cols
-        var_names = ["Coverage"]
+        var_names = self._get_varnames(
+            default="Coverage", legacy_interface=legacy_interface
+        )
+        var_name = var_names[0]
+
         int_idx = pd.MultiIndex.from_product([var_names, coverage, ["lower", "upper"]])
         pred_int = pd.DataFrame(columns=int_idx)
 
@@ -256,8 +262,8 @@ class _StatsForecastAdapter(BaseForecaster):
         if fh_is_in_sample or fh_is_oosample:
             # needs to be replaced, also seems duplicative, identical to part A
             for intervals, a in zip(y_pred_int, coverage):
-                pred_int[("Coverage", a, "lower")] = intervals["lower"]
-                pred_int[("Coverage", a, "upper")] = intervals["upper"]
+                pred_int[(var_name, a, "lower")] = intervals["lower"]
+                pred_int[(var_name, a, "upper")] = intervals["upper"]
             return pred_int
 
         # both in-sample and out-of-sample values (we reach this line only then)
@@ -265,7 +271,7 @@ class _StatsForecastAdapter(BaseForecaster):
         _, y_ins_pred_int = self._predict_in_sample(fh_ins, **kwargs)
         _, y_oos_pred_int = self._predict_fixed_cutoff(fh_oos, **kwargs)
         for ins_int, oos_int, a in zip(y_ins_pred_int, y_oos_pred_int, coverage):
-            pred_int[("Coverage", a, "lower")] = pd.concat([ins_int, oos_int])["lower"]
-            pred_int[("Coverage", a, "upper")] = pd.concat([ins_int, oos_int])["upper"]
+            pred_int[(var_name, a, "lower")] = pd.concat([ins_int, oos_int])["lower"]
+            pred_int[(var_name, a, "upper")] = pd.concat([ins_int, oos_int])["upper"]
 
         return pred_int

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -147,7 +147,9 @@ class _StatsModelsAdapter(BaseForecaster):
 
         raise NotImplementedError("abstract method")
 
-    def _predict_interval(self, fh, X, coverage):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg and logic using it
+    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
         """Compute/return prediction interval forecasts.
 
         private _predict_interval containing the core logic,
@@ -201,18 +203,20 @@ class _StatsModelsAdapter(BaseForecaster):
             **get_prediction_arguments
         )
 
-        columns = pd.MultiIndex.from_product(
-            [["Coverage"], coverage, ["lower", "upper"]]
+        var_names = self._get_varnames(
+            default="Coverage", legacy_interface=legacy_interface
         )
+        var_name = var_names[0]
+        columns = pd.MultiIndex.from_product([var_names, coverage, ["lower", "upper"]])
         pred_int = pd.DataFrame(index=valid_indices, columns=columns)
 
         for c in coverage:
             pred_statsmodels = self._extract_conf_int(prediction_results, (1 - c))
 
-            pred_int[("Coverage", c, "lower")] = pred_statsmodels.loc[
+            pred_int[(var_name, c, "lower")] = pred_statsmodels.loc[
                 valid_indices, "lower"
             ]
-            pred_int[("Coverage", c, "upper")] = pred_statsmodels.loc[
+            pred_int[(var_name, c, "upper")] = pred_statsmodels.loc[
                 valid_indices, "upper"
             ]
 

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -230,7 +230,9 @@ class BaggingForecaster(BaseForecaster):
         y_pred.name = self._y.name
         return y_pred
 
-    def _predict_quantiles(self, fh, X, alpha):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -263,7 +265,9 @@ class BaggingForecaster(BaseForecaster):
         """
         # X is ignored
         y_pred = self.forecaster_.predict(fh=fh, X=None)
-        return _calculate_data_quantiles(y_pred, alpha)
+        return self._calculate_data_quantiles(
+            y_pred, alpha, legacy_interface=legacy_interface
+        )
 
     def _update(self, y, X=None, update_params=True):
         """Update cutoff value and, optionally, fitted parameters.
@@ -319,26 +323,34 @@ class BaggingForecaster(BaseForecaster):
 
         return params
 
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _calculate_data_quantiles(
+        self, df: pd.DataFrame, alpha: List[float], legacy_interface=True
+    ) -> pd.DataFrame:
+        """Generate quantiles for each time point.
 
-def _calculate_data_quantiles(df: pd.DataFrame, alpha: List[float]) -> pd.DataFrame:
-    """Generate quantiles for each time point.
+        Parameters
+        ----------
+        df : pd.DataFrame
+            A dataframe of mtype pd-multiindex or hierarchical
+        alpha : List[float]
+            list of the desired quantiles
 
-    Parameters
-    ----------
-    df : pd.DataFrame
-        A dataframe of mtype pd-multiindex or hierarchical
-    alpha : List[float]
-        list of the desired quantiles
+        Returns
+        -------
+        pd.DataFrame
+            The specified quantiles
+        """
+        var_names = self._get_varnames(
+            default="Quantiles", legacy_interface=legacy_interface
+        )
+        var_name = var_names[0]
 
-    Returns
-    -------
-    pd.DataFrame
-        The specified quantiles
-    """
-    index = pd.MultiIndex.from_product([["Quantiles"], alpha])
-    pred_quantiles = pd.DataFrame(columns=index)
-    for a in alpha:
-        quant_a = df.groupby(level=-1, as_index=True).quantile(a)
-        pred_quantiles[[("Quantiles", a)]] = quant_a
+        index = pd.MultiIndex.from_product([var_names, alpha])
+        pred_quantiles = pd.DataFrame(columns=index)
+        for a in alpha:
+            quant_a = df.groupby(level=-1, as_index=True).quantile(a)
+            pred_quantiles[[(var_name, a)]] = quant_a
 
-    return pred_quantiles
+        return pred_quantiles

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -222,7 +222,9 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
         """
         return self._by_column("predict", fh=fh, X=X)
 
-    def _predict_quantiles(self, fh=None, X=None, alpha=None):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_quantiles(self, fh=None, X=None, alpha=None, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -255,7 +257,12 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
                 at quantile probability in second-level col index, for each row index.
         """
         out = self._by_column(
-            "predict_quantiles", fh=fh, X=X, alpha=alpha, col_multiindex=True
+            "predict_quantiles",
+            fh=fh,
+            X=X,
+            alpha=alpha,
+            col_multiindex=True,
+            legacy_interface=legacy_interface,
         )
         if len(out.columns.get_level_values(0).unique()) == 1:
             out.columns = out.columns.droplevel(level=0)
@@ -263,7 +270,9 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
             out.columns = out.columns.droplevel(level=1)
         return out
 
-    def _predict_interval(self, fh=None, X=None, coverage=None):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_interval(self, fh=None, X=None, coverage=None, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -300,7 +309,12 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
         out = self._by_column(
-            "predict_interval", fh=fh, X=X, coverage=coverage, col_multiindex=True
+            "predict_interval",
+            fh=fh,
+            X=X,
+            coverage=coverage,
+            col_multiindex=True,
+            legacy_interface=legacy_interface,
         )
         if len(out.columns.get_level_values(0).unique()) == 1:
             out.columns = out.columns.droplevel(level=0)

--- a/sktime/forecasting/compose/_fhplex.py
+++ b/sktime/forecasting/compose/_fhplex.py
@@ -255,7 +255,9 @@ class FhPlexForecaster(BaseForecaster):
         )
         return y_pred
 
-    def _predict_quantiles(self, fh, X, alpha):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg and logic using it
+    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -287,10 +289,14 @@ class FhPlexForecaster(BaseForecaster):
             Row index is fh. Entries are quantile forecasts, for var in col index,
                 at quantile probability in second-level col index, for each row index.
         """
-        y_pred = self._get_preds(fh, "predict_quantiles", X=X, alpha=alpha)
+        y_pred = self._get_preds(
+            fh, "predict_quantiles", X=X, alpha=alpha, legacy_interface=legacy_interface
+        )
         return y_pred
 
-    def _predict_interval(self, fh, X, coverage):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg and logic using it
+    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -326,7 +332,13 @@ class FhPlexForecaster(BaseForecaster):
                 Upper/lower interval end forecasts are equivalent to
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
-        y_pred = self._get_preds(fh, "predict_interval", X=X, coverage=coverage)
+        y_pred = self._get_preds(
+            fh,
+            "predict_interval",
+            X=X,
+            coverage=coverage,
+            legacy_interface=legacy_interface,
+        )
         return y_pred
 
     def _predict_var(self, fh, X=None, cov=False):

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -161,6 +161,7 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                         if len(levels) == 1:
                             levels = levels[0]
                         yt[ix] = y.xs(ix, level=levels, axis=1)
+                        # todo 0.23.0 - get rid of the "Coverage" case treatment
                         # deal with the "Coverage" case, we need to get rid of this
                         #   i.d., special 1st level name of prediction objet
                         #   in the case where there is only one variable
@@ -508,7 +509,9 @@ class ForecastingPipeline(_Pipeline):
         X = self._transform(X=X)
         return self.forecaster_.predict(fh, X)
 
-    def _predict_quantiles(self, fh, X, alpha):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -541,9 +544,13 @@ class ForecastingPipeline(_Pipeline):
                 at quantile probability in second-level col index, for each row index.
         """
         X = self._transform(X=X)
-        return self.forecaster_.predict_quantiles(fh=fh, X=X, alpha=alpha)
+        return self.forecaster_.predict_quantiles(
+            fh=fh, X=X, alpha=alpha, legacy_interface=legacy_interface
+        )
 
-    def _predict_interval(self, fh, X, coverage):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -580,7 +587,9 @@ class ForecastingPipeline(_Pipeline):
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
         X = self._transform(X=X)
-        return self.forecaster_.predict_interval(fh=fh, X=X, coverage=coverage)
+        return self.forecaster_.predict_interval(
+            fh=fh, X=X, coverage=coverage, legacy_interface=legacy_interface
+        )
 
     def _predict_var(self, fh, X=None, cov=False):
         """Forecast variance at future horizon.
@@ -1068,7 +1077,9 @@ class TransformedTargetForecaster(_Pipeline):
         Z = check_series(Z)
         return self._get_inverse_transform(self.transformers_pre_, Z, X)
 
-    def _predict_quantiles(self, fh, X, alpha):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -1100,13 +1111,17 @@ class TransformedTargetForecaster(_Pipeline):
             Row index is fh. Entries are quantile forecasts, for var in col index,
                 at quantile probability in second-level col index, for each row index.
         """
-        pred_int = self.forecaster_.predict_quantiles(fh=fh, X=X, alpha=alpha)
+        pred_int = self.forecaster_.predict_quantiles(
+            fh=fh, X=X, alpha=alpha, legacy_interface=legacy_interface
+        )
         pred_int_transformed = self._get_inverse_transform(
             self.transformers_pre_, pred_int, mode="proba"
         )
         return pred_int_transformed
 
-    def _predict_interval(self, fh, X, coverage):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,
@@ -1142,7 +1157,9 @@ class TransformedTargetForecaster(_Pipeline):
                 Upper/lower interval end forecasts are equivalent to
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
-        pred_int = self.forecaster_.predict_interval(fh=fh, X=X, coverage=coverage)
+        pred_int = self.forecaster_.predict_interval(
+            fh=fh, X=X, coverage=coverage, legacy_interface=legacy_interface
+        )
         pred_int_transformed = self._get_inverse_transform(
             self.transformers_pre_, pred_int, mode="proba"
         )
@@ -1391,7 +1408,9 @@ class ForecastX(BaseForecaster):
 
         return self
 
-    def _predict_interval(self, fh, X, coverage):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
         """Compute/return prediction interval forecasts.
 
         private _predict_interval containing the core logic,
@@ -1423,10 +1442,14 @@ class ForecastX(BaseForecaster):
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
         X = self._get_forecaster_X_prediction(fh=fh, X=X)
-        y_pred = self.forecaster_y_.predict_interval(fh=fh, X=X, coverage=coverage)
+        y_pred = self.forecaster_y_.predict_interval(
+            fh=fh, X=X, coverage=coverage, legacy_interface=legacy_interface
+        )
         return y_pred
 
-    def _predict_quantiles(self, fh, X, alpha):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_quantiles(self, fh, X=None, alpha=None, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -1453,7 +1476,9 @@ class ForecastX(BaseForecaster):
                 at quantile probability in second col index, for the row index.
         """
         X = self._get_forecaster_X_prediction(fh=fh, X=X)
-        y_pred = self.forecaster_y_.predict_quantiles(fh=fh, X=X, alpha=alpha)
+        y_pred = self.forecaster_y_.predict_quantiles(
+            fh=fh, X=X, alpha=alpha, legacy_interface=legacy_interface
+        )
         return y_pred
 
     def _predict_var(self, fh=None, X=None, cov=False):

--- a/sktime/forecasting/compose/tests/test_bagging.py
+++ b/sktime/forecasting/compose/tests/test_bagging.py
@@ -7,7 +7,6 @@ import pytest
 
 from sktime.datasets import load_airline
 from sktime.forecasting.compose import BaggingForecaster
-from sktime.forecasting.compose._bagging import _calculate_data_quantiles
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.transformations.bootstrap import STLBootstrapTransformer
 from sktime.transformations.series.boxcox import LogTransformer
@@ -18,7 +17,7 @@ y = load_airline()
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
-    reason="skip test if required soft dependency for hmmlearn not available",
+    reason="skip test if required soft dependency is not available",
 )
 @pytest.mark.parametrize("transformer", [LogTransformer, NaiveForecaster])
 def test_bagging_forecaster_transformer_type_error(transformer):
@@ -37,7 +36,7 @@ def test_bagging_forecaster_transformer_type_error(transformer):
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
-    reason="skip test if required soft dependency for hmmlearn not available",
+    reason="skip test if required soft dependency is not available",
 )
 @pytest.mark.parametrize("forecaster", [LogTransformer])
 def test_bagging_forecaster_forecaster_type_error(forecaster):
@@ -70,4 +69,8 @@ def test_calculate_data_quantiles():
         index=pd.Index(data=fh, name="time"),
     )
 
-    pd.testing.assert_frame_equal(_calculate_data_quantiles(df, alpha), output_df)
+    f = BaggingForecaster.create_test_instance()
+    f.fit(y)
+
+    calc_output = f._calculate_data_quantiles(df, alpha)
+    pd.testing.assert_frame_equal(calc_output, output_df)

--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -219,7 +219,9 @@ class DynamicFactor(_StatsModelsAdapter):
             )
         return y_pred.loc[fh.to_absolute_index(self.cutoff)]
 
-    def _predict_interval(self, fh, X, coverage):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -406,7 +406,9 @@ class NaiveForecaster(_BaseWindowForecaster):
 
         return y_pred
 
-    def _predict_quantiles(self, fh, X, alpha):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg and logic using it
+    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         Uses normal distribution as predictive distribution to compute the
@@ -440,9 +442,13 @@ class NaiveForecaster(_BaseWindowForecaster):
             np.sqrt(pred_var.to_numpy().reshape(len(pred_var), 1)) * z_scores
         ).reshape(len(y_pred), len(alpha))
 
+        var_names = self._get_varnames(
+            default="Quantiles", legacy_interface=legacy_interface
+        )
+
         pred_quantiles = pd.DataFrame(
             errors + y_pred.values.reshape(len(y_pred), 1),
-            columns=pd.MultiIndex.from_product([["Quantiles"], alpha]),
+            columns=pd.MultiIndex.from_product([var_names, alpha]),
             index=fh.to_absolute_index(self.cutoff),
         )
 
@@ -694,7 +700,9 @@ class NaiveVariance(BaseForecaster):
             )
         return self
 
-    def _predict_quantiles(self, fh, X, alpha):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         Uses normal distribution as predictive distribution to compute the
@@ -727,10 +735,15 @@ class NaiveVariance(BaseForecaster):
         z_scores = norm.ppf(alpha)
         errors = [pred_var**0.5 * z for z in z_scores]
 
-        index = pd.MultiIndex.from_product([["Quantiles"], alpha])
+        var_names = self._get_varnames(
+            default="Quantiles", legacy_interface=legacy_interface
+        )
+        var_name = var_names[0]
+
+        index = pd.MultiIndex.from_product([var_names, alpha])
         pred_quantiles = pd.DataFrame(columns=index)
         for a, error in zip(alpha, errors):
-            pred_quantiles[("Quantiles", a)] = y_pred + error
+            pred_quantiles[(var_name, a)] = y_pred + error
 
         fh_absolute = fh.to_absolute(self.cutoff)
         pred_quantiles.index = fh_absolute.to_pandas()

--- a/sktime/forecasting/squaring_residuals.py
+++ b/sktime/forecasting/squaring_residuals.py
@@ -269,7 +269,9 @@ class SquaringResiduals(BaseForecaster):
             forecaster.update(X=X, y=y, update_params=update_params)
         return self
 
-    def _predict_quantiles(self, fh, X, alpha):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -313,10 +315,15 @@ class SquaringResiduals(BaseForecaster):
 
         errors = [pred_var * z for z in z_scores]
 
-        index = pd.MultiIndex.from_product([["Quantiles"], alpha])
+        var_names = self._get_varnames(
+            default="Quantiles", legacy_interface=legacy_interface
+        )
+        var_name = var_names[0]
+
+        index = pd.MultiIndex.from_product([var_names, alpha])
         pred_quantiles = pd.DataFrame(columns=index)
         for a, error in zip(alpha, errors):
-            pred_quantiles[("Quantiles", a)] = y_pred + error
+            pred_quantiles[(var_name, a)] = y_pred + error
 
         pred_quantiles.index = fh_abs.to_pandas()
 

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -5,6 +5,8 @@
 
 __author__ = ["mloning", "kejsitake", "fkiraly"]
 
+from inspect import getfullargspec
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -426,7 +428,14 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         if estimator_instance.get_tag("capability:pred_int"):
             # todo 0.23.0: remove legacy_interface arg and logic
             # simply remove the arg
-            for legacy_interface in [True, False]:
+            pi_args = getfullargspec(estimator_instance._predict_interval).args
+            has_li_arg = "legacy_interface" in pi_args
+            if has_li_arg:
+                test_for = [True, False]
+            else:
+                test_for = [True]
+
+            for legacy_interface in test_for:
                 pred_ints = estimator_instance.predict_interval(
                     fh=fh_int_oos, coverage=coverage, legacy_interface=legacy_interface
                 )
@@ -527,7 +536,14 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         if estimator_instance.get_tag("capability:pred_int"):
             # todo 0.23.0: remove legacy_interface arg and logic
             # simply remove the arg
-            for legacy_interface in [True, False]:
+            pi_args = getfullargspec(estimator_instance._predict_quantiles).args
+            has_li_arg = "legacy_interface" in pi_args
+            if has_li_arg:
+                test_for = [True, False]
+            else:
+                test_for = [True]
+
+            for legacy_interface in test_for:
                 quantiles = estimator_instance.predict_quantiles(
                     fh=fh_int_oos, alpha=alpha, legacy_interface=legacy_interface
                 )

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -396,6 +396,24 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         )
         assert all(expected == found), msg
 
+    # todo 0.23.0: remove this helper function and related logic
+    def _get_pred_int_test_config(self, estimator_instance):
+        """Get value of pred_int:legacy_interface:testcfg config from estimator.
+
+        If "auto", returns [False] if sktime version is 0.22.X,
+        [True] if sktime version is 0.21.X,
+        otherwise [value of the config] - should be True or False.
+        """
+        import sktime
+
+        cfg = estimator_instance.get_config().get(
+            "pred_int:legacy_interface:testcfg", "auto"
+        )
+        if cfg == "auto":
+            return [int(sktime.__version__.split(".")[1]) >= 22]
+        else:
+            return [cfg]
+
     @pytest.mark.parametrize("index_type", [None, "range"])
     @pytest.mark.parametrize(
         "coverage", TEST_ALPHAS, ids=[f"alpha={a}" for a in TEST_ALPHAS]
@@ -433,7 +451,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
             if has_li_arg:
                 test_for = [True, False]
             else:
-                test_for = [True]
+                test_for = self._get_pred_int_test_config(estimator_instance)
 
             for legacy_interface in test_for:
                 pred_ints = estimator_instance.predict_interval(
@@ -541,7 +559,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
             if has_li_arg:
                 test_for = [True, False]
             else:
-                test_for = [True]
+                test_for = self._get_pred_int_test_config(estimator_instance)
 
             for legacy_interface in test_for:
                 quantiles = estimator_instance.predict_quantiles(

--- a/sktime/forecasting/var.py
+++ b/sktime/forecasting/var.py
@@ -189,7 +189,9 @@ class VAR(_StatsModelsAdapter):
         )
         return y_pred
 
-    def _predict_interval(self, fh, X, coverage):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,

--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -208,7 +208,9 @@ class VECM(_StatsModelsAdapter):
 
         return y_pred
 
-    def _predict_interval(self, fh, X, coverage):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_interval(self, fh, X, coverage, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_interval containing the core logic,

--- a/sktime/utils/estimators/_forecasters.py
+++ b/sktime/utils/estimators/_forecasters.py
@@ -141,8 +141,10 @@ class MockUnivariateForecasterLogger(BaseForecaster, _MockEstimatorMixin):
         """
         return self
 
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
     @_method_logger
-    def _predict_quantiles(self, fh, X, alpha):
+    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -173,12 +175,17 @@ class MockUnivariateForecasterLogger(BaseForecaster, _MockEstimatorMixin):
             Row index is fh. Entries are quantile forecasts, for var in col index,
                 at quantile probability in second-level col index, for each row index.
         """
+        var_names = self._get_varnames(
+            default="Quantiles", legacy_interface=legacy_interface
+        )
+        var_name = var_names[0]
+
         fh_index = fh.to_absolute_index(self.cutoff)
-        col_index = pd.MultiIndex.from_product([["Quantiles"], alpha])
+        col_index = pd.MultiIndex.from_product([var_names, alpha])
         pred_quantiles = pd.DataFrame(columns=col_index, index=fh_index)
 
         for a in alpha:
-            pred_quantiles[("Quantiles", a)] = pd.Series(
+            pred_quantiles[(var_name, a)] = pd.Series(
                 self.prediction_constant * 2 * a, index=fh_index
             )
 
@@ -319,7 +326,9 @@ class MockForecaster(BaseForecaster):
         """
         return self
 
-    def _predict_quantiles(self, fh, X, alpha):
+    # todo 0.22.0 - switch legacy_interface default to False
+    # todo 0.23.0 - remove legacy_interface arg
+    def _predict_quantiles(self, fh, X, alpha, legacy_interface=True):
         """Compute/return prediction quantiles for a forecast.
 
         private _predict_quantiles containing the core logic,
@@ -352,7 +361,7 @@ class MockForecaster(BaseForecaster):
         """
         cols = self._y.columns
 
-        if len(cols) == 1:
+        if legacy_interface and len(cols) == 1:
             cols = ["Quantiles"]
 
         col_index = pd.MultiIndex.from_product([cols, alpha])

--- a/sktime/utils/estimators/tests/test_forecasters.py
+++ b/sktime/utils/estimators/tests/test_forecasters.py
@@ -54,8 +54,11 @@ def test_mock_univariate_forecaster_log(y, X_train, X_pred, fh):
         ("_update", {"y": y_series, "X": _X_train, "update_params": fh}),
         (
             "_predict_quantiles",
-            {"fh": fh, "X": _X_pred, "alpha": [0.1, 0.9]},
+            # todo 0.22.0: change the value of "legacy_interface" to False
+            # todo 0.23.0: remove the key "legacy_interface"
+            {"fh": fh, "X": _X_pred, "alpha": [0.1, 0.9], "legacy_interface": True},
         ),
     ]
 
-    assert deep_equals(forecaster.log, expected_log)
+    equals, msg = deep_equals(forecaster.log, expected_log, return_msg=True)
+    assert equals, msg


### PR DESCRIPTION
Copy of https://github.com/sktime/sktime/pull/4780 which was reverted to ensure it ships with 0.21.0, not 0.20.1.

Fixes #4709 - in `predict_interval` and `predict_quantiles` return, replaces `"Coverage"` and `"Quantiles"` default variable name in the univariate case with the variable name, to make this consistent with the multivariate case. If no variable name is available, the variable name used is the integer 0.

This is done with a deprecation horizon or two MINOR cyles, by introducing a `legacy_interface` argument to public and private `predict_interval`, `predict_quantiles`. A value `True` (default) gives current behaviour, `False` gives future behaviour. In 0.22.0, we switch the default to `False`, and remove the argument in 0.23.0.

This includes tests for `legacy_interface` both `True` and `False`, with deprecation notes on removing this later.