### PR TITLE
[BUG] fix `DataConversionWarning` in `FeatureSelection`

### DIFF
--- a/sktime/transformations/series/feature_selection.py
+++ b/sktime/transformations/series/feature_selection.py
@@ -77,7 +77,7 @@ class FeatureSelection(BaseTransformer):
         "scitype:instancewise": True,  # is this an instance-wise transform?
         "X_inner_mtype": ["pd.DataFrame", "pd.Series"],
         # which mtypes do _fit/_predict support for X?
-        "y_inner_mtype": "pd.DataFrame",  # which mtypes do _fit/_predict support for y?
+        "y_inner_mtype": "pd.Series",  # which mtypes do _fit/_predict support for y?
         "fit_is_empty": False,
         "transform-returns-same-time-index": True,
         "skip-inverse-transform": True,


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4881

The reason was that internally, the `y` passed to the `sklearn` estimator was 2D (a `pd.DataFrame`), not 1D as expected by `sklearn`.

This is fixed by changing the internal `y`-type coercion to `pd.Series` (which is 1D and `sklearn` compatible)