### PR TITLE
[DOC] remove outdated references from transformers API

### DIFF
--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -85,15 +85,6 @@ Pipeline building
 
     FunctionTransformer
 
-.. currentmodule:: sktime.transformations.series.subset
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    ColumnSelect
-    IndexSubset
-
 
 Sklearn and pandas adapters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -85,20 +85,15 @@ Pipeline building
 
     FunctionTransformer
 
-.. currentmodule:: sktime.transformations.panel.compose
+.. currentmodule:: sktime.transformations.series.subset
 
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
-    SeriesToSeriesRowTransformer
-    SeriesToPrimitivesRowTransformer
+    ColumnSelect
+    IndexSubset
 
-.. autosummary::
-    :toctree: auto_generated/
-    :template: function.rst
-
-    make_row_transformer
 
 Sklearn and pandas adapters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The row transformers (compositors that add broadcasting that is now standard for all transformers) have been removed a while ago from `sktime` - this PR removes the dead references to them from the transformers API.