### PR TITLE
[ENH] faster `X`-split in default case of `evaluate`

### DIFF
--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -446,14 +446,11 @@ def evaluate(
                 yield y_train, y_test, None, None
         else:
             if cv_X is None:
-                from sktime.forecasting.model_selection import (
-                    SameLocSplitter,
-                    TestPlusTrainSplitter,
-                )
-
-                cv_X = SameLocSplitter(TestPlusTrainSplitter(cv), y)
-
-            genx = cv_X.split_series(X)
+                def genx():
+                    for train_loc, test_loc in cv.split_loc(y):
+                        yield X.loc[train_loc], X.loc[test_loc]
+            else:
+                genx = cv_X.split_series(X)
 
             for (y_train, y_test), (X_train, X_test) in zip(geny, genx):
                 yield y_train, y_test, X_train, X_test


### PR DESCRIPTION
This PR tries to speed up the default logic for splitting `X` in `evaluate` if no `cv_X` is passed.

Currently, we look up the `iloc` from a `loc` split, even though we wouldn't need to do that

More generally, the same should be done in the `SameLocSplitter` when `split_series` is called - it should default to `split_loc`, not `split_iloc`, that would equally avoid the lookup.

For testing and discussion.