### PR TITLE
[ENH] private `split_loc` and tag to control dispatch of `split_series` to `split` vs `split_loc`

### DIFF
--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -456,7 +456,7 @@ class BaseSplitter(BaseObject):
         """
         y_index = self._coerce_to_index(y)
 
-        yield from self._split_loc(y_index):
+        yield from self._split_loc(y_index)
 
     def _split_loc(self, y: ACCEPTED_Y_TYPES) -> Iterator[Tuple[pd.Index, pd.Index]]:
         """Get loc references to train/test splits of `y`.

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1538,7 +1538,7 @@ class TestPlusTrainSplitter(BaseSplitter):
 
         for y_train_inner, y_test_inner in cv.split_loc(y):
             y_train_self = y_train_inner
-            y_test_self = y_train_inner.union(y_test_inner, sort=True)
+            y_test_self = y_train_inner.union(y_test_inner)
             yield y_train_self, y_test_self
 
     def get_n_splits(self, y: Optional[ACCEPTED_Y_TYPES] = None) -> int:

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1436,8 +1436,7 @@ class SameLocSplitter(BaseSplitter):
         else:
             y_template = self.y_template
 
-        for y_train_loc, y_test_loc in cv.split_loc(y_template):
-            yield y.loc[y_train_loc], y.loc[y_test_loc]
+        yield from cv.split_loc(y_template)
 
     def get_n_splits(self, y: Optional[ACCEPTED_Y_TYPES] = None) -> int:
         """Return the number of splits.

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -456,8 +456,7 @@ class BaseSplitter(BaseObject):
         """
         y_index = self._coerce_to_index(y)
 
-        for y_train_loc, y_test_loc in self._split_loc(y_index):
-            yield y_train_loc, y_test_loc
+        yield from self._split_loc(y_index):
 
     def _split_loc(self, y: ACCEPTED_Y_TYPES) -> Iterator[Tuple[pd.Index, pd.Index]]:
         """Get loc references to train/test splits of `y`.

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1409,6 +1409,32 @@ class SameLocSplitter(BaseSplitter):
             y_test_iloc = y.get_indexer(y_test_loc)
             yield y_train_iloc, y_test_iloc
 
+    def _split_loc(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+        """Get loc references to train/test splits of `y`.
+
+        private _split containing the core logic, called from split_loc
+
+        Parameters
+        ----------
+        y : pd.Index
+            index of time series to split
+
+        Yields
+        ------
+        train : pd.Index
+            Training window indices, loc references to training indices in y
+        test : pd.Index
+            Test window indices, loc references to test indices in y
+        """
+        cv = self.cv
+        if self.y_template is None:
+            y_template = y
+        else:
+            y_template = self.y_template
+
+        for y_train_loc, y_test_loc in cv.split_loc(y_template):
+            yield y.loc[y_train_loc], y.loc[y_test_loc]
+
     def get_n_splits(self, y: Optional[ACCEPTED_Y_TYPES] = None) -> int:
         """Return the number of splits.
 

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -503,19 +503,23 @@ class BaseSplitter(BaseObject):
 
         use_iloc_or_loc = self.get_tag("split_series_uses", "iloc", raise_error=False)
 
-        for train, test in self.split(y.index):
-            if use_iloc_or_loc == "iloc":
-                y_train = y.iloc[train]
-                y_test = y.iloc[test]
-            elif use_iloc_or_loc == "loc":
-                y_train = y.loc[train]
-                y_test = y.loc[test]
-            else:
-                raise RuntimeError(
-                    f"error in {self.__class__.__name__}.split_series: "
-                    f"split_series_uses tag must be 'iloc' or 'loc', "
-                    f"but found {use_iloc_or_loc}"
-                )
+        if use_iloc_or_loc == "iloc":
+            splitter_name = "split"
+        elif use_iloc_or_loc == "loc":
+            splitter_name = "split_loc"
+        else:
+            raise RuntimeError(
+                f"error in {self.__class__.__name__}.split_series: "
+                f"split_series_uses tag must be 'iloc' or 'loc', "
+                f"but found {use_iloc_or_loc}"
+            )
+
+        _split = getattr(self, splitter_name)
+        _slicer = getattr(y, use_iloc_or_loc)
+
+        for train, test in _split(y.index):
+            y_train = _slicer[train]
+            y_test = _slicer[test]
 
             y_train = convert_to(y_train, y_orig_mtype)
             y_test = convert_to(y_test, y_orig_mtype)

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -409,6 +409,12 @@ ESTIMATOR_TAG_REGISTER = [
         "whether _split is natively implemented for hierarchical y types",
     ),
     (
+        "split_series_uses",
+        "splitter",
+        ("str", ["iloc", "loc"]),
+        "whether split_series uses split (iloc) or split_loc (loc) to split series",
+    ),
+    (
         "capabilities:exact",
         "distribution",
         ("list", "str"),

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -411,7 +411,7 @@ ESTIMATOR_TAG_REGISTER = [
     (
         "split_series_uses",
         "splitter",
-        ("str", ["iloc", "loc"]),
+        ("str", ["iloc", "loc", "custom"]),
         "whether split_series uses split (iloc) or split_loc (loc) to split series",
     ),
     (


### PR DESCRIPTION
This PR introduces, for splitters (`BaseSplitter` descendants):

* an optional private `_split_loc` to implement, which can differ from the default of looking up `loc` from `iloc` indices
* a tag `split_series_uses`, which determines whether `split_series` dispatches to `split_loc` or `split` (iloc). This may be later extended to have splitters where only `split_series` exists, e.g., which are not just determined by rows

This PR also changes implementation of two splitters which in sum make the forecasting benchmark `evaluate` more performant:
* for the `SameLocSplitter`, `split_series` should dispatch to `split_loc` for performance gain.
* the `TestPlusTrainSplitter` should dispatch to the same as the wrapped, for performance gain.

An alternative approach to https://github.com/sktime/sktime/pull/4902 to speed up `evaluate`, but both could be merged.