### PR TITLE
[MNT] xfail `mlflow` failure #4904 until debugged, gitignore for `py-spy`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ sktime/_contrib/temp/
 
 # example mlflow runs
 examples/local/
+
+# py-spy profiler output
+profile.svg

--- a/sktime/forecasting/tests/test_ets.py
+++ b/sktime/forecasting/tests/test_ets.py
@@ -46,7 +46,6 @@ def test_airline_default():
     assert_array_equal(fit_result_R, fit_result)
 
 
-@pytest.mark.xfail(reason="known failure to be debugged, see #4904")
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
     reason="skip test if required soft dependency not available",

--- a/sktime/forecasting/tests/test_ets.py
+++ b/sktime/forecasting/tests/test_ets.py
@@ -46,6 +46,7 @@ def test_airline_default():
     assert_array_equal(fit_result_R, fit_result)
 
 
+@pytest.mark.xfail(reason="known failure to be debugged, see #4904")
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
     reason="skip test if required soft dependency not available",

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -529,6 +529,7 @@ def test_log_model(auto_arima_model, tmp_path, should_start_run, serialization_f
         mlflow.end_run()
 
 
+@pytest.mark.xfail(reason="known failure to be debugged, see #4904")
 @pytest.mark.skipif(
     not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",


### PR DESCRIPTION
Small maintenance actions:

* `xfail`-s the `mlflow` failure in #4904 until debugged
* add `py-spy` outputs to `.gitignore`, see #4900