### PR TITLE
[BUG] 0.21.0 release bugfix - fix interaction of `sklearn 1.3.0` with dynamic error metic based on `partial` in `test_make_scorer`

### DIFF
--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -6,7 +6,6 @@ Classes named as ``*Score`` return a value to maximize: the higher the better.
 Classes named as ``*Error`` or ``*Loss`` return a value to minimize:
 the lower the better.
 """
-from functools import partial
 from inspect import getfullargspec, isfunction, signature
 from warnings import warn
 
@@ -571,6 +570,10 @@ class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
             func = type(self).func
         else:
             func = self.func
+
+        # import here for now to avoid interaction with getmembers in tests
+        # todo: clean up ancient getmembers in test_metrics_classes
+        from functools import partial
 
         # if func does not catch kwargs, subset to args of func
         if getfullargspec(func).varkw is None or isinstance(func, partial):

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -561,6 +561,9 @@ class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
         # this dict should contain all parameters
         params = self.get_params()
 
+        # drop func from params
+        params.pop("func")
+
         # adding kwargs to the metric, should not overwrite params (but does if clashes)
         params.update(kwargs)
 

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -6,6 +6,7 @@ Classes named as ``*Score`` return a value to maximize: the higher the better.
 Classes named as ``*Error`` or ``*Loss`` return a value to minimize:
 the lower the better.
 """
+from functools import partial
 from inspect import getfullargspec, isfunction, signature
 from warnings import warn
 
@@ -561,9 +562,6 @@ class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
         # this dict should contain all parameters
         params = self.get_params()
 
-        # drop func from params
-        params.pop("func", None)
-
         # adding kwargs to the metric, should not overwrite params (but does if clashes)
         params.update(kwargs)
 
@@ -575,7 +573,7 @@ class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
             func = self.func
 
         # if func does not catch kwargs, subset to args of func
-        if getfullargspec(func).varkw is None:
+        if getfullargspec(func).varkw is None or isinstance(func, partial):
             func_params = signature(func).parameters.keys()
             func_params = set(func_params).difference(["y_true", "y_pred"])
             func_params = func_params.intersection(params.keys())

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -562,7 +562,7 @@ class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
         params = self.get_params()
 
         # drop func from params
-        params.pop("func")
+        params.pop("func", None)
 
         # adding kwargs to the metric, should not overwrite params (but does if clashes)
         params.update(kwargs)


### PR DESCRIPTION
This fixes an interaction of new input checking logic in `sklearn 1.3.0` with dynamic forecasting error metics based on `partial` that was uncovered `test_make_scorer`, regression test for #4827.