### PR TITLE
[BUG] fix `PluginParamsForecaster` in `params: dict` case

### DIFF
--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -109,7 +109,7 @@ class ConformalIntervals(BaseForecaster):
     >>> gscv_with_conformal = PluginParamsForecaster(
     ...     gscv,
     ...     conformal_with_fallback,
-    ...     params={"best_forecaster": "forecaster"},
+    ...     params={"forecaster": "best_forecaster"},
     ... )
     >>> y = load_airline()
     >>> gscv_with_conformal.fit(y, fh=[1, 2, 3])

--- a/sktime/param_est/plugin.py
+++ b/sktime/param_est/plugin.py
@@ -55,6 +55,9 @@ class PluginParamsForecaster(_DelegatedForecaster):
         this clone is fitted in the pipeline when `fit` is called
     forecaster_ : sktime forecaster, clone of forecaster in `forecaster`
         this clone is fitted in the pipeline when `fit` is called
+    param_map_ : dict
+        mapping of parameters from `param_est_` to `forecaster_` used in `fit`,
+        after filtering for parameters present in both
 
     Examples
     --------

--- a/sktime/param_est/plugin.py
+++ b/sktime/param_est/plugin.py
@@ -44,7 +44,7 @@ class PluginParamsForecaster(_DelegatedForecaster):
         list of str: parameters in the list are plugged into parameters of the same name
             only parameters present in both `forecaster` and `param_est` are plugged in
         str: considered as a one-element list of str with the string as single element
-        dict: parameter with name of key is plugged into parameter with name of value
+        dict: parameter with name of value is plugged into parameter with name of key
             only keys present in `param_est` and values in `forecaster` are plugged in
     update_params : bool, optional, default=False
         whether fitted parameters by param_est_ are to be updated in self.update
@@ -180,8 +180,10 @@ class PluginParamsForecaster(_DelegatedForecaster):
         }
         self.param_map_ = param_map
 
+        print(param_map)
         # obtain the values of fitted params, and set forecaster to those
-        new_params = {x: fitted_params[x] for x in param_map}
+        new_params = {k: fitted_params[v] for k, v in param_map.items()}
+        print(new_params)
         forecaster.set_params(**new_params)
 
         # fit the forecaster, with the fitted parameter values

--- a/sktime/param_est/plugin.py
+++ b/sktime/param_est/plugin.py
@@ -180,10 +180,8 @@ class PluginParamsForecaster(_DelegatedForecaster):
         }
         self.param_map_ = param_map
 
-        print(param_map)
         # obtain the values of fitted params, and set forecaster to those
         new_params = {k: fitted_params[v] for k, v in param_map.items()}
-        print(new_params)
         forecaster.set_params(**new_params)
 
         # fit the forecaster, with the fitted parameter values

--- a/sktime/param_est/tests/test_plugin.py
+++ b/sktime/param_est/tests/test_plugin.py
@@ -45,7 +45,7 @@ def test_paramplugin_dict():
     from sklearn.ensemble import RandomForestRegressor
 
     from sktime.forecasting.base import ForecastingHorizon
-    from sktime.forecasting.compose import make_reduction, EnsembleForecaster
+    from sktime.forecasting.compose import EnsembleForecaster, make_reduction
     from sktime.forecasting.model_selection import (
         ExpandingWindowSplitter,
         ForecastingGridSearchCV,
@@ -73,7 +73,7 @@ def test_paramplugin_dict():
     plugin_fcst = PluginParamsForecaster(
         param_est=cv_random_forest,
         forecaster=ensembler,
-        params={"forecasters": "n_best_forecasters"}
+        params={"forecasters": "n_best_forecasters"},
     )
 
     plugin_fcst.fit(y, X, fh=horizon)

--- a/sktime/param_est/tests/test_plugin.py
+++ b/sktime/param_est/tests/test_plugin.py
@@ -3,9 +3,10 @@
 
 __author__ = ["fkiraly"]
 
+import numpy as np
 import pytest
 
-from sktime.datasets import load_airline
+from sktime.datasets import load_airline, load_longley
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.param_est.fixed import FixedParams
 from sktime.param_est.plugin import PluginParamsForecaster
@@ -34,3 +35,46 @@ def test_seasonality_acf():
     PluginParamsForecaster(
         FixedParams({"foo": 12}), NaiveForecaster(), params={"foo": "sp"}
     )
+
+
+def test_paramplugin_dict():
+    """Test PluginParamsForecaster with param: dict.
+
+    Failure case from bug report #4921.
+    """
+    from sklearn.ensemble import RandomForestRegressor
+
+    from sktime.forecasting.base import ForecastingHorizon
+    from sktime.forecasting.compose import make_reduction, EnsembleForecaster
+    from sktime.forecasting.model_selection import (
+        ExpandingWindowSplitter,
+        ForecastingGridSearchCV,
+    )
+    from sktime.param_est.plugin import PluginParamsForecaster
+
+    y, X = load_longley()
+    horizon = ForecastingHorizon(np.arange(1, 4), is_relative=True)
+
+    random_forest = make_reduction(
+        RandomForestRegressor(),
+        window_length=2,
+        strategy="direct",
+        windows_identical=False,
+    )
+    expanding_window_cv = ExpandingWindowSplitter(fh=horizon, step_length=1)
+    cv_random_forest = ForecastingGridSearchCV(
+        forecaster=random_forest,
+        cv=expanding_window_cv,
+        param_grid={"estimator__max_features": np.linspace(0.1, 0.9, num=5)},
+        return_n_best_forecasters=3,
+    )
+
+    ensembler = EnsembleForecaster(forecasters=[], aggfunc="median")
+    plugin_fcst = PluginParamsForecaster(
+        param_est=cv_random_forest,
+        forecaster=ensembler,
+        params={"forecasters": "n_best_forecasters"}
+    )
+
+    plugin_fcst.fit(y, X, fh=horizon)
+    plugin_fcst.predict(fh=horizon, X=X)


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/4921

The internal logic for parsing the `dict` for plugin specification was jumbled - the subsetting would subset the opposite way round, compared to the plugin direction.

This has now been fixed by changing the plugin direction, making it also consistent with user expectation in the `dict` case.

The failure case from https://github.com/sktime/sktime/discussions/4884#discussioncomment-6506787 has been added as a test.

Deprecation is not needed imo, as this replaces a bug failure with actual behaviour, even if it changes the specification claimed by the docstring.