### PR TITLE
[ENH] contiguous `fh` option for `FhPlexForecaster`

### DIFF
--- a/sktime/forecasting/compose/_fhplex.py
+++ b/sktime/forecasting/compose/_fhplex.py
@@ -158,7 +158,7 @@ class FhPlexForecaster(BaseForecaster):
         fh_params = self.fh_params
         fh_contiguous = self.fh_contiguous
 
-        if not fh_contiguous:
+        if fh_contiguous:
             fh_rel = fh.to_relative(self.cutoff)
 
         fh_keys = self._get_fh_keys(fh)
@@ -187,7 +187,7 @@ class FhPlexForecaster(BaseForecaster):
         """Get prediction DataFrame for method."""
         fh_contiguous = self.fh_contiguous
 
-        if not fh_contiguous:
+        if fh_contiguous:
             fh_abs = fh_keys.to_absolute(self.cutoff)
 
         fh_keys = self._get_fh_keys(fh_keys)

--- a/sktime/forecasting/compose/_fhplex.py
+++ b/sktime/forecasting/compose/_fhplex.py
@@ -75,8 +75,8 @@ class FhPlexForecaster(BaseForecaster):
     }
 
     def __init__(
-            self, forecaster, fh_params=None, fh_lookup="relative", fh_contiguous=False
-        ):
+        self, forecaster, fh_params=None, fh_lookup="relative", fh_contiguous=False
+    ):
         self.forecaster = forecaster
         self.fh_params = fh_params
         self.fh_lookup = fh_lookup

--- a/sktime/forecasting/compose/_fhplex.py
+++ b/sktime/forecasting/compose/_fhplex.py
@@ -40,11 +40,11 @@ class FhPlexForecaster(BaseForecaster):
         if "as-is", fh will be coerced to ForecastingHorizon (but not relative/absolute)
     fh_contiguous : bool, default=False
         whether fh in inner loops are enforced to be contiguous
-        True: forecaster with fh_params[fN] is asked to forecast fN and only fN
-        False: forecaster with fh_params[fN] is asked to forecast 1, 2, ..., fN
+        False: forecaster with fh_params[fN] is asked to forecast fN and only fN
+        True: forecaster with fh_params[fN] is asked to forecast 1, 2, ..., fN
             and the output is then subset to the forecast of fN
             this is required if the forecaster can only forecast contiguous horizons
-        CAUTION: if using grid search inside, then ``False`` will cause the
+        CAUTION: if using grid search inside, then ``True`` will cause the
         tuning metric to be evaluated on horizons 1, 2, ..., fN, not just fN
 
     Attributes

--- a/sktime/forecasting/compose/_fhplex.py
+++ b/sktime/forecasting/compose/_fhplex.py
@@ -41,9 +41,11 @@ class FhPlexForecaster(BaseForecaster):
     fh_contiguous : bool, default=False
         whether fh in inner loops are enforced to be contiguous
         True: forecaster with fh_params[fN] is asked to forecast fN and only fN
-        False: forecaster with fh_params[fN] is asked to forecast 1,2, ... fN
+        False: forecaster with fh_params[fN] is asked to forecast 1, 2, ..., fN
             and the output is then subset to the forecast of fN
             this is required if the forecaster can only forecast contiguous horizons
+        CAUTION: if using grid search inside, then ``False`` will cause the
+        tuning metric to be evaluated on horizons 1, 2, ..., fN, not just fN
 
     Attributes
     ----------


### PR DESCRIPTION
Fixes #4918, by adding parameter for "option 3", as discussed here: https://github.com/sktime/sktime/issues/4918#issuecomment-1645205543