### PR TITLE
Installation documentation: Pip install without soft dependencies for conda environments

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -180,7 +180,8 @@ In the ``anaconda prompt`` terminal:
 
 3. Activate the environment: :code:`conda activate sktime-dev`
 
-4. Build an editable version of sktime :code:`pip install -e .[all_extras,dev]`
+4. Build an editable version of sktime :code:`pip install -e .[dev]`
+If you also want to install the soft dependencies, install them one-by-one or use: :code:`pip install -e .[all_extras,dev]`
 
 5. If everything has worked you should see message "successfully installed sktime"
 
@@ -194,7 +195,7 @@ Some users have experienced issues when installing NumPy, particularly version 1
 
         .. code-block:: bash
 
-            pip install -e ."[all_extras,dev]"
+            pip install -e ."[dev]"
 
 .. note::
 


### PR DESCRIPTION
Fixes #4934 . See also #4933 

This PR provides more clarity and consistency to the installation documentaton. https://www.sktime.net/en/stable/installation.html

In the steps describing the installation process for development setup using conda the pip install statement was changed. The attribute "all_extras" is deleted - not proposing the installation of the soft dependencies.
 
