### PR TITLE
[BUG] clarify tuning estimators' docstrings and error messages in case of `refit=False`

### DIFF
--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -239,11 +239,14 @@ class BaseGridSearch(_DelegatedForecaster):
             )
         self.best_score_ = results.loc[self.best_index_, f"mean_{scoring_name}"]
         self.best_params_ = results.loc[self.best_index_, "params"]
-        self.best_forecaster_ = self.forecaster.clone().set_params(**self.best_params_)
-
-        # Refit model with best parameters.
         if self.refit:
+            # Refit model with best parameters.
+            self.best_forecaster_ = self.forecaster.clone()
+            self.best_forecaster_.set_params(**self.best_params_)
             self.best_forecaster_.fit(y, X, fh)
+        else:
+            self.best_forecaster_ = # we need to set this to the fitted best forecaster
+            # but it is not clear where to get it from
 
         # Sort values according to rank
         results = results.sort_values(
@@ -1256,6 +1259,7 @@ class ForecastingSkoptSearchCV(BaseGridSearch):
             "scoring": MeanAbsolutePercentageError(symmetric=True),
             "update_behaviour": "inner_only",
             "n_iter": 1,
+            "refit": False,
         }
 
         return [params, params2]

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -239,14 +239,11 @@ class BaseGridSearch(_DelegatedForecaster):
             )
         self.best_score_ = results.loc[self.best_index_, f"mean_{scoring_name}"]
         self.best_params_ = results.loc[self.best_index_, "params"]
+        self.best_forecaster_ = self.forecaster.clone().set_params(**self.best_params_)
+
+        # Refit model with best parameters.
         if self.refit:
-            # Refit model with best parameters.
-            self.best_forecaster_ = self.forecaster.clone()
-            self.best_forecaster_.set_params(**self.best_params_)
             self.best_forecaster_.fit(y, X, fh)
-        else:
-            self.best_forecaster_ = # we need to set this to the fitted best forecaster
-            # but it is not clear where to get it from
 
         # Sort values according to rank
         results = results.sort_values(
@@ -1259,7 +1256,6 @@ class ForecastingSkoptSearchCV(BaseGridSearch):
             "scoring": MeanAbsolutePercentageError(symmetric=True),
             "update_behaviour": "inner_only",
             "n_iter": 1,
-            "refit": False,
         }
 
         return [params, params2]

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -299,7 +299,7 @@ class BaseGridSearch(_DelegatedForecaster):
                 f" but found refit=False. If refit=False, {self.__class__.__name__} can"
                 " be used only to tune hyper-parameters, as a parameter estimator."
             )
-        return super()._predict(self, fh, X)
+        return super()._predict(fh, X)
 
     def _update(self, y, X=None, update_params=True):
         """Update time series to incremental training data.

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -299,7 +299,7 @@ class BaseGridSearch(_DelegatedForecaster):
                 f" but found refit=False. If refit=False, {self.__class__.__name__} can"
                 " be used only to tune hyper-parameters, as a parameter estimator."
             )
-        return super()._predict(fh, X)
+        return super()._predict(fh=fh, X=X)
 
     def _update(self, y, X=None, update_params=True):
         """Update time series to incremental training data.


### PR DESCRIPTION
This PR fixes https://github.com/sktime/sktime/issues/4929

As discussed there, the `refit=False` parameter was incorrectly described in docstrings, and error messages that were raised were not informative.

This PR updates the docstring with a clear description of how `refit=False` is intended to be used, and adds an informative error message.