### PR TITLE
[MNT] remove bound `dask<2023.7.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ all_extras_pandas2 = [
     "attrs",
     "cloudpickle",
     "dash!=2.9.0",
-    "dask<2023.7.1",
+    "dask",
     "dtw-python",
     "esig==0.9.7; python_version < '3.10'",
     "filterpy>=1.4.5; python_version < '3.11'",


### PR DESCRIPTION
Reverts sktime/sktime#4928, removes the temporary bound `dask<2023.7.1`.

`dask` `2023.7.2` was released, to diagnose if bug #4925 is still present.