### PR TITLE
[MNT] speed up `test_gscv_proba` test

### DIFF
--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -194,7 +194,7 @@ def test_gscv_hierarchical(forecaster, param_grid, cv, scoring, error_score):
 @pytest.mark.parametrize("error_score", ERROR_SCORES)
 def test_gscv_proba(cv, scoring, error_score):
     """Test ForecastingGridSearchCV with probabilistic metrics."""
-    y = load_airline()
+    y = load_airline()[:36]
 
     forecaster = ARIMA()
     param_grid = {"order": [(1, 0, 0), (1, 1, 0)]}


### PR DESCRIPTION
This PR speeds up the `test_gscv_proba` test by cutting down on the data size and therefore the number of folds in the tuning.

Each run of the test takes ca 1min, at a total of 18 fixture combinations.