### PR TITLE
[MNT] speed up various tests in the forecasting module

### DIFF
--- a/sktime/forecasting/compose/tests/test_reduce_global.py
+++ b/sktime/forecasting/compose/tests/test_reduce_global.py
@@ -246,7 +246,7 @@ def test_equality_transfo_nontranso(regressor):
 
     random_int = random.randint(1, 1000)
     regressor.random_state = random_int
-    forecaster = make_reduction(regressor, window_length=int(12), strategy="recursive")
+    forecaster = make_reduction(regressor, window_length=int(6), strategy="recursive")
     forecaster.fit(y_train)
     y_pred = forecaster.predict(fh)
     recursive_without = mean_absolute_percentage_error(y_test, y_pred, symmetric=False)

--- a/sktime/forecasting/compose/tests/test_reduce_global.py
+++ b/sktime/forecasting/compose/tests/test_reduce_global.py
@@ -246,14 +246,10 @@ def test_equality_transfo_nontranso(regressor):
 
     random_int = random.randint(1, 1000)
     regressor.random_state = random_int
-    forecaster = make_reduction(
-        regressor, window_length=int(12), strategy="recursive"
-    )
+    forecaster = make_reduction(regressor, window_length=int(12), strategy="recursive")
     forecaster.fit(y_train)
     y_pred = forecaster.predict(fh)
-    recursive_without = mean_absolute_percentage_error(
-        y_test, y_pred, symmetric=False
-    )
+    recursive_without = mean_absolute_percentage_error(y_test, y_pred, symmetric=False)
     forecaster = make_reduction(
         regressor,
         window_length=None,
@@ -264,9 +260,7 @@ def test_equality_transfo_nontranso(regressor):
 
     forecaster.fit(y_train)
     y_pred = forecaster.predict(fh)
-    recursive_global = mean_absolute_percentage_error(
-        y_test, y_pred, symmetric=False
-    )
+    recursive_global = mean_absolute_percentage_error(y_test, y_pred, symmetric=False)
     np.testing.assert_almost_equal(recursive_without, recursive_global)
 
 

--- a/sktime/forecasting/compose/tests/test_reduce_global.py
+++ b/sktime/forecasting/compose/tests/test_reduce_global.py
@@ -233,42 +233,41 @@ def test_list_reduction(y, index_names):
 )
 def test_equality_transfo_nontranso(regressor):
     """Test that recursive reducers return same results for global / local forecasts."""
-    y = load_airline()
-    y_train, y_test = temporal_train_test_split(y, test_size=30)
+    y = load_airline()[:36]
+    y_train, y_test = temporal_train_test_split(y, test_size=12)
     fh = ForecastingHorizon(y_test.index, is_relative=False)
 
-    lag_vec = [i for i in range(12, 0, -1)]
+    lag_vec = [i for i in range(6, 0, -1)]
     kwargs = {
         "lag_feature": {
             "lag": lag_vec,
         }
     }
 
-    for _i in range(1, 5):
-        random_int = random.randint(1, 1000)
-        regressor.random_state = random_int
-        forecaster = make_reduction(
-            regressor, window_length=int(12), strategy="recursive"
-        )
-        forecaster.fit(y_train)
-        y_pred = forecaster.predict(fh)
-        recursive_without = mean_absolute_percentage_error(
-            y_test, y_pred, symmetric=False
-        )
-        forecaster = make_reduction(
-            regressor,
-            window_length=None,
-            strategy="recursive",
-            transformers=[WindowSummarizer(**kwargs, n_jobs=1)],
-            pooling="global",
-        )
+    random_int = random.randint(1, 1000)
+    regressor.random_state = random_int
+    forecaster = make_reduction(
+        regressor, window_length=int(12), strategy="recursive"
+    )
+    forecaster.fit(y_train)
+    y_pred = forecaster.predict(fh)
+    recursive_without = mean_absolute_percentage_error(
+        y_test, y_pred, symmetric=False
+    )
+    forecaster = make_reduction(
+        regressor,
+        window_length=None,
+        strategy="recursive",
+        transformers=[WindowSummarizer(**kwargs, n_jobs=1)],
+        pooling="global",
+    )
 
-        forecaster.fit(y_train)
-        y_pred = forecaster.predict(fh)
-        recursive_global = mean_absolute_percentage_error(
-            y_test, y_pred, symmetric=False
-        )
-        np.testing.assert_almost_equal(recursive_without, recursive_global)
+    forecaster.fit(y_train)
+    y_pred = forecaster.predict(fh)
+    recursive_global = mean_absolute_percentage_error(
+        y_test, y_pred, symmetric=False
+    )
+    np.testing.assert_almost_equal(recursive_without, recursive_global)
 
 
 def test_nofreq_pass():

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -265,10 +265,10 @@ def test_evaluate_hierarchical(backend):
         return None
 
     y = _make_hierarchical(
-        random_state=0, hierarchy_levels=(2, 2), min_timepoints=20, max_timepoints=20
+        random_state=0, hierarchy_levels=(2, 2), min_timepoints=12, max_timepoints=12
     )
     X = _make_hierarchical(
-        random_state=42, hierarchy_levels=(2, 2), min_timepoints=20, max_timepoints=20
+        random_state=42, hierarchy_levels=(2, 2), min_timepoints=12, max_timepoints=12
     )
     y = y.sort_index()
     X = X.sort_index()

--- a/sktime/forecasting/tests/test_interval_wrappers.py
+++ b/sktime/forecasting/tests/test_interval_wrappers.py
@@ -75,27 +75,27 @@ def test_evaluate_with_window_splitters(wrapper, splitter, strategy, sample_frac
     This checks refit and update strategies as well as expanding and sliding window
     splitters.
     """
-    y = load_airline()
+    y = load_airline()[:36]
 
     if splitter == SlidingWindowSplitter:
         cv = splitter(
-            fh=np.arange(1, 13),
-            window_length=48,
-            step_length=12,
+            fh=np.arange(1, 7),
+            window_length=18,
+            step_length=6,
         )
     elif splitter == ExpandingWindowSplitter:
         cv = splitter(
-            fh=np.arange(1, 13),
-            initial_window=48,
-            step_length=12,
+            fh=np.arange(1, 7),
+            initial_window=18,
+            step_length=6,
         )
 
     f = NaiveForecaster()
 
     if wrapper == ConformalIntervals:
-        interval_forecaster = wrapper(f, initial_window=24, sample_frac=sample_frac)
+        interval_forecaster = wrapper(f, initial_window=12, sample_frac=sample_frac)
     else:
-        interval_forecaster = wrapper(f, initial_window=24)
+        interval_forecaster = wrapper(f, initial_window=12)
 
     results = evaluate(
         forecaster=interval_forecaster,

--- a/sktime/forecasting/tests/test_interval_wrappers.py
+++ b/sktime/forecasting/tests/test_interval_wrappers.py
@@ -75,18 +75,18 @@ def test_evaluate_with_window_splitters(wrapper, splitter, strategy, sample_frac
     This checks refit and update strategies as well as expanding and sliding window
     splitters.
     """
-    y = load_airline()[:48]
+    y = load_airline()[:60]
 
     if splitter == SlidingWindowSplitter:
         cv = splitter(
             fh=np.arange(1, 7),
-            window_length=18,
+            window_length=24,
             step_length=6,
         )
     elif splitter == ExpandingWindowSplitter:
         cv = splitter(
             fh=np.arange(1, 7),
-            initial_window=18,
+            initial_window=24,
             step_length=6,
         )
 
@@ -109,5 +109,5 @@ def test_evaluate_with_window_splitters(wrapper, splitter, strategy, sample_frac
         backend=None,
     )
 
-    assert len(results) == 5
+    assert len(results) == 8
     assert not results.test_PinballLoss.isna().any()

--- a/sktime/forecasting/tests/test_interval_wrappers.py
+++ b/sktime/forecasting/tests/test_interval_wrappers.py
@@ -109,5 +109,5 @@ def test_evaluate_with_window_splitters(wrapper, splitter, strategy, sample_frac
         backend=None,
     )
 
-    assert len(results) == 8
+    assert len(results) == 5
     assert not results.test_PinballLoss.isna().any()

--- a/sktime/forecasting/tests/test_interval_wrappers.py
+++ b/sktime/forecasting/tests/test_interval_wrappers.py
@@ -109,5 +109,5 @@ def test_evaluate_with_window_splitters(wrapper, splitter, strategy, sample_frac
         backend=None,
     )
 
-    assert len(results) == 8
+    assert len(results) == 6
     assert not results.test_PinballLoss.isna().any()

--- a/sktime/forecasting/tests/test_interval_wrappers.py
+++ b/sktime/forecasting/tests/test_interval_wrappers.py
@@ -75,7 +75,7 @@ def test_evaluate_with_window_splitters(wrapper, splitter, strategy, sample_frac
     This checks refit and update strategies as well as expanding and sliding window
     splitters.
     """
-    y = load_airline()[:36]
+    y = load_airline()[:48]
 
     if splitter == SlidingWindowSplitter:
         cv = splitter(


### PR DESCRIPTION
This speeds up various tests by reducing the number of data points or folds:

* `test_reduce_global`
* `test_evaluate_hierarchical`
* `test_evaluate_with_window_splitters`

Related to: https://github.com/sktime/sktime/issues/2890