### PR TITLE
[MNT] xfail UEA data loaders until fixed by mirroring/buffering

### DIFF
--- a/sktime/datasets/tests/test_single_problem_loaders.py
+++ b/sktime/datasets/tests/test_single_problem_loaders.py
@@ -77,6 +77,9 @@ def test_load_numpy2d_multivariate_raises(loader):
         X, y = loader(return_type="numpy2d")
 
 
+@pytest.mark.xfail(
+    reason="repeatedly failed due to random changes, see 4754. xfail until fixed."
+)
 def test_load_UEA():
     """Test loading of a random subset of the UEA data, to check API."""
     from sktime.datasets.tsc_dataset_names import multivariate, univariate

--- a/sktime/datasets/tests/test_single_problem_loaders.py
+++ b/sktime/datasets/tests/test_single_problem_loaders.py
@@ -78,7 +78,7 @@ def test_load_numpy2d_multivariate_raises(loader):
 
 
 @pytest.mark.xfail(
-    reason="repeatedly failed due to random changes, see 4754. xfail until fixed."
+    reason="repeated upstream location failures, see 4754. xfail until fixed."
 )
 def test_load_UEA():
     """Test loading of a random subset of the UEA data, to check API."""


### PR DESCRIPTION
The UEA benchmark data repository has grown increasingly unreliable, see https://github.com/sktime/sktime/issues/4754 - there is also a current failure on `main`.

This PR `xfail`-s the loader tests until this is fixed by a buffer or mirror, see #4754.