### PR TITLE
[ENH] Interface statsmodels MSTL

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -150,6 +150,14 @@ Trend forecasters
     PolynomialTrendForecaster
     STLForecaster
 
+.. currentmodule:: sktime.forecasting.mstl
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    MSTL
+
 Exponential smoothing based forecasters
 ---------------------------------------
 

--- a/sktime/forecasting/mstl.py
+++ b/sktime/forecasting/mstl.py
@@ -54,6 +54,10 @@ class MSTL(_StatsModelsAdapter):
     >>> plt.show()
     """
 
+    _tags = {
+        "python_dependencies": "statsmodels",
+    }
+
     def __init__(
         self,
         periods=None,

--- a/sktime/forecasting/mstl.py
+++ b/sktime/forecasting/mstl.py
@@ -1,0 +1,110 @@
+# !/usr/bin/env python3 -u
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Implements MSTL."""
+
+__all__ = ["MSTL"]
+__authors__ = ["luca-miniati"]
+
+from typing import Optional
+
+from sktime.forecasting.base.adapters import _StatsModelsAdapter
+
+
+class MSTL(_StatsModelsAdapter):
+    """Season-Trend decomposition using LOESS for multiple seasonalities.
+
+    Direct interface for `statsmodels.tsa.seasonal.MSTL`.
+
+    Parameters
+    ----------
+    endog : array_like
+        Data to be decomposed. Must be squeezable to 1-d.
+    periods : {int, array_like, None}, optional
+        Periodicity of the seasonal components. If None and endog is a pandas Series or
+        DataFrame, attempts to determine from endog. If endog is a ndarray, periods
+        must be provided.
+    windows : {int, array_like, None}, optional
+        Length of the seasonal smoothers for each corresponding period. Must be an odd
+        integer, and should normally be >= 7 (default). If None then default values
+        determined using 7 + 4 * np.arange(1, n + 1, 1) where n is number of seasonal
+        components.
+    lmbda : {float, str, None}, optional
+        The lambda parameter for the Box-Cox transform to be applied to endog prior to
+        decomposition. If None, no transform is applied. If “auto”, a value will be
+        estimated that maximizes the log-likelihood function.
+    iterate : int, optional
+        Number of iterations to use to refine the seasonal component.
+    stl_kwargs : dict, optional
+        Arguments to pass to STL.
+
+    References
+    ----------
+    [1] https://www.statsmodels.org/dev/generated/statsmodels.tsa.seasonal.MSTL.html
+
+    Examples
+    --------
+    >>> from sktime.forecasting.mstl import MSTL
+    >>> from sktime.datasets import load_airline
+    >>> import matplotlib.pyplot as plt
+    >>> y = load_airline()
+    >>> mstl = MSTL()  # doctest: +SKIP
+    >>> res = mstl.fit(y)  # doctest: +SKIP
+    >>> res.plot()  # doctest: +SKIP
+    >>> plt.tight_layout()
+    >>> plt.show()
+    """
+
+    def __init__(
+        self,
+        periods=None,
+        windows=None,
+        lmbda=None,
+        iterate=Optional[int],
+        stl_kwargs=Optional[dict],
+    ):
+        super().__init__()
+
+        self.periods = periods
+        self.windows = windows
+        self.lmbda = lmbda
+        self.iterate = iterate
+        self.stl_kwargs = stl_kwargs
+
+    def _fit_forecaster(self, y, X=None):
+        from statsmodels.tsa.seasonal import MSTL as _MSTL
+
+        self._forecaster = _MSTL(
+            y, self.periods, self.windows, self.lmbda, self.iterate, self.stl_kwargs
+        )
+
+        self._fitted_forecaster = self._forecaster.fit()
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str , default = "default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for forecasters.
+
+        Returns
+        -------
+        params : dict or list of dict , default = {}
+            arameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params
+        """
+        params1 = {}
+        params2 = {
+            "periods": [1, 12],
+            "windows": 9,
+            "lmbda": "auto",
+            "iterate": 10,
+            "stl_kwargs": {"trend_deg": 0},
+        }
+
+        return [params1, params2]


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Interfaces statsmodels MSTL

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [x] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).
