### PR TITLE
[ENH] enable use of `TabularToSeriesAdaptor` with feature selectors, and passing of `y`

### DIFF
--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -73,16 +73,16 @@ class TabularToSeriesAdaptor(BaseTransformer):
         whether transformer_ should be fitted in transform (True), or in fit (False)
             recommended setting in forecasting (single series or hierarchical): False
             recommended setting in ts classification, regression, clustering: True
-    pass_y : str, optional, one of "auto" (default), "fit", "fit_transform", "no"
+    pass_y : str, optional, one of "auto" (default), "fit", "always", "never"
         Whether to pass y to transformer methods of the ``transformer`` clone.
         "auto": passes y to methods fit, transform, fit_transform, inverse_transform,
             if and only if y is a named arg of either method.
             Note: passes y even if it is None
         "fit": passes y to method fit, but not to transform.
             Note: passes y even if it is None, or if not a named arg
-        "fit_transform": passes y to all methods, fit, transform, inverse_transform.
+        "always": passes y to all methods, fit, transform, inverse_transform.
             Note: passes y even if it is None, or if not a named arg
-        "no": never passes y to any method.
+        "never": never passes y to any method.
 
     Attributes
     ----------
@@ -149,13 +149,14 @@ class TabularToSeriesAdaptor(BaseTransformer):
             return_y = method in ["fit", "fit_transform"]
         elif pass_y == "fit":
             return_y = method in ["fit", "fit_transform"]
-        elif pass_y == "fit_transform":
+        elif pass_y == "always":
             return_y = True
-        elif pass_y == "no":
+        elif pass_y == "never":
             return_y = False
         else:
             raise ValueError(
-                f"error in {self.__class__.__name__}, pass_y={pass_y} not supported"
+                f"error in {self.__class__.__name__}, pass_y={pass_y} not supported, "
+                "must be one of 'auto', 'fit', 'always', 'never'"
             )
 
         if return_y:

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -134,7 +134,7 @@ class TabularToSeriesAdaptor(BaseTransformer):
         if self._skip_fit:
             self.set_tags(**{"fit_is_empty": True})
 
-        trafo_has_y, trafo_has_y_default = self._trafo_fit_has_y_and_default("fit")
+        trafo_has_y, trafo_has_y_default = self._trafo_has_y_and_default("fit")
         need_y = trafo_has_y and not trafo_has_y_default
         if need_y or pass_y not in ["auto", "no"]:
             self.set_tags(**{"y_inner_mtype": "numpy1D"})
@@ -160,7 +160,7 @@ class TabularToSeriesAdaptor(BaseTransformer):
         pass_y = self.pass_y
 
         if pass_y == "auto":
-            has_y, has_y_default = self._trafo_fit_has_y_and_default(method)
+            has_y, has_y_default = self._trafo_has_y_and_default(method)
             need_y = has_y and not has_y_default
             return_y = need_y
         elif pass_y == "fit":

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -146,7 +146,9 @@ class TabularToSeriesAdaptor(BaseTransformer):
         pass_y = self.pass_y
 
         if pass_y == "auto":
-            return_y = method in ["fit", "fit_transform"]
+            trafo_fit_params = list(signature(self.transformer.fit).parameters.keys())
+            fit_takes_y = "y" in trafo_fit_params
+            return_y = fit_takes_y and method in ["fit", "fit_transform"]
         elif pass_y == "fit":
             return_y = method in ["fit", "fit_transform"]
         elif pass_y == "always":

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -116,6 +116,7 @@ class TabularToSeriesAdaptor(BaseTransformer):
         self.transformer = transformer
         self.transformer_ = clone(self.transformer)
         self.fit_in_transform = fit_in_transform
+        self.pass_y = pass_y
 
         super().__init__()
 

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -271,7 +271,9 @@ class TabularToSeriesAdaptor(BaseTransformer):
 
         params1 = {"transformer": StandardScaler(), "fit_in_transform": False}
         params2 = {
-            "transformer": StandardScaler(), "fit_in_transform": True, "pass_y": "auto"
+            "transformer": StandardScaler(),
+            "fit_in_transform": True,
+            "pass_y": "auto",
         }
         params3 = {"transformer": VarianceThreshold(), "pass_y": "fit"}
         params4 = {"transformer": VarianceThreshold()}

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -62,7 +62,8 @@ class TabularToSeriesAdaptor(BaseTransformer):
 
     Whether ``y`` is passed to transformer methods is controlled by ``pass_y``.
     If the inner transformer has non-defaulting ``y`` args, the default behaviour is
-    to pass ``y`` to ``fit`` and, ``fit_transform``, but not to ``transform``.
+    to pass ``y`` to ``fit``, ``fit_transform``, or ``transform``.
+    If no ``y`` arg is present, or if it has a default value, ``y`` is not passed.
 
     Parameters
     ----------

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -5,6 +5,8 @@
 __author__ = ["mloning", "fkiraly"]
 __all__ = ["TabularToSeriesAdaptor"]
 
+from inspect import signature
+
 import numpy as np
 from sklearn.base import clone
 
@@ -58,20 +60,34 @@ class TabularToSeriesAdaptor(BaseTransformer):
             (but not in a time series classification/regression/clustering setting,
             because in these settings the independent samples are the individual series)
 
+    Whether ``y`` is passed to transformer methods is controlled by ``pass_y``.
+    If the inner transformer has ``y`` args, the default behaviour is to pass
+    a potential ``y`` to ``fit`` and, ``fit_transform``, but not to ``transform``.
+
     Parameters
     ----------
     transformer : Estimator
         scikit-learn-like transformer to fit and apply to series.
         This is used as a "blueprint" and not fitted or otherwise mutated.
+    fit_in_transform: bool, optional, default=False
+        whether transformer_ should be fitted in transform (True), or in fit (False)
+            recommended setting in forecasting (single series or hierarchical): False
+            recommended setting in ts classification, regression, clustering: True
+    pass_y : str, optional, one of "auto" (default), "fit", "fit_transform", "no"
+        Whether to pass y to transformer methods of the ``transformer`` clone.
+        "auto": passes y to methods fit, transform, fit_transform, inverse_transform,
+            if and only if y is a named arg of either method.
+            Note: passes y even if it is None
+        "fit": passes y to method fit, but not to transform.
+            Note: passes y even if it is None, or if not a named arg
+        "fit_transform": passes y to all methods, fit, transform, inverse_transform.
+            Note: passes y even if it is None, or if not a named arg
+        "no": never passes y to any method.
 
     Attributes
     ----------
     transformer_ : Estimator
         Transformer that is fitted to data, clone of transformer.
-    fit_in_transform: bool, optional, default=False
-        whether transformer_ should be fitted in transform (True), or in fit (False)
-            recommended setting in forecasting (single series or hierarchical): False
-            recommended setting in ts classification, regression, clustering: True
 
     Examples
     --------
@@ -96,7 +112,7 @@ class TabularToSeriesAdaptor(BaseTransformer):
         "fit_is_empty": False,
     }
 
-    def __init__(self, transformer, fit_in_transform=False):
+    def __init__(self, transformer, fit_in_transform=False, pass_y="auto"):
         self.transformer = transformer
         self.transformer_ = clone(self.transformer)
         self.fit_in_transform = fit_in_transform
@@ -117,6 +133,36 @@ class TabularToSeriesAdaptor(BaseTransformer):
         if self._skip_fit:
             self.set_tags(**{"fit_is_empty": True})
 
+        trafo_fit_params = list(signature(transformer.fit).parameters.keys())
+        if "y" in trafo_fit_params or pass_y not in ["auto", "no"]:
+            self.set_tags(**{"y_inner_mtype": "numpy1D"})
+
+    def _get_y_args(self, y, method="fit"):
+        """Get empty dict or dict with y, depending on pass_y and method.
+
+        The return is a dict which is passed to the method of name method,
+        according to the pass_y setting.
+        """
+        pass_y = self.pass_y
+
+        if pass_y == "auto":
+            return_y = method in ["fit", "fit_transform"]
+        elif pass_y == "fit":
+            return_y = method in ["fit", "fit_transform"]
+        elif pass_y == "fit_transform":
+            return_y = True
+        elif pass_y == "no":
+            return_y = False
+        else:
+            raise ValueError(
+                f"error in {self.__class__.__name__}, pass_y={pass_y} not supported"
+            )
+
+        if return_y:
+            return {"y": y}
+        else:
+            return {}
+
     def _fit(self, X, y=None):
         """Fit transformer to X and y.
 
@@ -133,8 +179,11 @@ class TabularToSeriesAdaptor(BaseTransformer):
         -------
         self: a fitted instance of the estimator
         """
+        y_args = self._get_y_args(y, method="fit")
+
         if not self._skip_fit:
-            self.transformer_.fit(X)
+            self.transformer_.fit(X, **y_args)
+
         return self
 
     def _transform(self, X, y=None):
@@ -154,8 +203,11 @@ class TabularToSeriesAdaptor(BaseTransformer):
         Xt : 2D np.ndarray
             transformed version of X
         """
+        y_fit_args = self._get_y_args(y, method="fit")
+        y_trafo_args = self._get_y_args(y, method="transform")
+
         if self._skip_fit:
-            Xt = self.transformer_.fit(X).transform(X)
+            Xt = self.transformer_.fit(X, **y_fit_args).transform(X, **y_trafo_args)
         else:
             Xt = self.transformer_.transform(X)
 
@@ -186,10 +238,13 @@ class TabularToSeriesAdaptor(BaseTransformer):
         Xt : 2D np.ndarray
             inverse transformed version of X
         """
+        y_fit_args = self._get_y_args(y, method="fit")
+        y_i_args = self._get_y_args(y, method="inverse_transform")
+
         if self.fit_in_transform:
-            Xt = self.transformer_.fit(X).inverse_transform(X)
+            Xt = self.transformer_.fit(X, **y_fit_args).inverse_transform(X, **y_i_args)
         else:
-            Xt = self.transformer_.inverse_transform(X)
+            Xt = self.transformer_.inverse_transform(X, **y_i_args)
         return Xt
 
     @classmethod
@@ -210,12 +265,17 @@ class TabularToSeriesAdaptor(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+        from sklearn.feature_selection import VarianceThreshold
         from sklearn.preprocessing import StandardScaler
 
         params1 = {"transformer": StandardScaler(), "fit_in_transform": False}
-        params2 = {"transformer": StandardScaler(), "fit_in_transform": True}
+        params2 = {
+            "transformer": StandardScaler(), "fit_in_transform": True, "pass_y": "auto"
+        }
+        params3 = {"transformer": VarianceThreshold(), "pass_y": "fit"}
+        params4 = {"transformer": VarianceThreshold()}
 
-        return [params1, params2]
+        return [params1, params2, params3, params4]
 
 
 class PandasTransformAdaptor(BaseTransformer):


### PR DESCRIPTION
This PR extends `TabularToSeriesAdaptor` so it is compatible with feature selectors such as `SelectKBest` or `VarianceThreshold`, and allows passing of `y`.

Addresses feature request in https://github.com/sktime/sktime/discussions/4967.

* the default behaviour for an inner estimator that requiesa `y` in `fit` (i.e., having a defaultless named argument `y`) is to pass on any `y` seen in `fit`, and only pass `X` otherwise (i.e., if the inner estimator does not have an arg `y`, or one with a default); and, never passing `y` to `transform`.
* the behaviour can be modified by the new `pass_y` argument to pass never, always (including to `transform`), or to `fit` (covering the case where `y` can be passed but is not a named argument)

No deprecation is needed as far as I see, because the estimator would crash in cases where `y` was required, previously.

Also fixes a minor docstring hiccup where the `fit_in_transform` arg was erroneously in the "attributes" section, and not the "parameters" section where it should have been.