### PR TITLE
[MNT] speed up basic `check_estimator` tests

### DIFF
--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -5,11 +5,11 @@ __author__ = ["fkiraly"]
 import pytest
 
 from sktime.classification.dummy import DummyClassifier
+from sktime.forecasting.dummy import ForecastKnownValues
 from sktime.transformations.series.exponent import ExponentTransformer
 from sktime.utils.estimator_checks import check_estimator
-from sktime.utils.estimators import MockForecaster
 
-EXAMPLE_CLASSES = [DummyClassifier, MockForecaster, ExponentTransformer]
+EXAMPLE_CLASSES = [DummyClassifier, ForecastKnownValues, ExponentTransformer]
 
 
 @pytest.mark.parametrize("estimator_class", EXAMPLE_CLASSES)


### PR DESCRIPTION
This speeds up the `check_estimator` tests by replacing the computationally expensive `MockForecaster` (probably due to printing and logging?) with the very quick `ForecastKnownValues` dummy, the oracle forecaster.

Related to: https://github.com/sktime/sktime/issues/2890

This should not change test coverage, as it is `check_estimator` which is tested, so any forecaster with maximal capabilities (such as `ForecastKnownValues`) should be fine.