### PR TITLE
[MNT] speed up clustering dunder test

### DIFF
--- a/sktime/clustering/compose/tests/test_pipeline.py
+++ b/sktime/clustering/compose/tests/test_pipeline.py
@@ -54,8 +54,8 @@ def test_dunder_mul():
 def test_mul_sklearn_autoadapt():
     """Test auto-adapter for sklearn in mul."""
     RAND_SEED = 42
-    X = _make_panel_X(n_instances=10, n_timepoints=20, random_state=RAND_SEED)
-    X_test = _make_panel_X(n_instances=10, n_timepoints=20, random_state=RAND_SEED)
+    X = _make_panel_X(n_instances=3, n_timepoints=12, random_state=RAND_SEED)
+    X_test = _make_panel_X(n_instances=3, n_timepoints=12, random_state=RAND_SEED)
 
     t1 = ExponentTransformer(power=2)
     t2 = StandardScaler()


### PR DESCRIPTION
This PR speeds up a costly test for the clustering estimator dunders, by using a much smaller dataset.
The test time was >1 min and should now be in the range of seconds at most.