### PR TITLE
[ENH] fix `Differencer` for integer index

### DIFF
--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -143,7 +143,7 @@ def _inverse_diff(X, lags, X_diff_seq=None):
     # invert last lag index
     if X_diff_seq is not None:
         X_diff_orig = X_diff_seq[len(lags)]
-        X_ix_shift = X.index.shift(-lag_last)
+        X_ix_shift = _shift(X.index, -lag_last)
         X_update = X_diff_orig.loc[X_ix_shift.intersection(X_diff_orig.index)]
 
         X = X.combine_first(X_update)

--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -42,8 +42,11 @@ def test_differencer_produces_expected_results(na_handling):
 
 @pytest.mark.parametrize("y", test_cases)
 @pytest.mark.parametrize("lags", lags_to_test)
-def test_differencer_same_series(y, lags):
+@pytest.mark.parametrize("index_type", ["int", "datetime"])
+def test_differencer_same_series(y, lags, index_type):
     """Test transform against inverse_transform."""
+    if index_type == "int":
+        y = y.reset_index(drop=True)
     transformer = Differencer(lags=lags, na_handling="drop_na")
     y_transform = transformer.fit_transform(y)
     y_reconstructed = transformer.inverse_transform(y_transform)
@@ -56,8 +59,12 @@ def test_differencer_same_series(y, lags):
 @pytest.mark.parametrize("na_handling", ["keep_na", "fill_zero"])
 @pytest.mark.parametrize("y", test_cases)
 @pytest.mark.parametrize("lags", lags_to_test)
-def test_differencer_remove_missing_false(y, lags, na_handling):
+@pytest.mark.parametrize("index_type", ["int", "datetime"])
+def test_differencer_remove_missing_false(y, lags, na_handling, index_type):
     """Test transform against inverse_transform."""
+    if index_type == "int":
+        y = y.reset_index(drop=True)
+
     transformer = Differencer(lags=lags, na_handling=na_handling)
     y_transform = transformer.fit_transform(y)
 
@@ -73,8 +80,12 @@ def test_differencer_remove_missing_false(y, lags, na_handling):
 
 @pytest.mark.parametrize("y", test_cases)
 @pytest.mark.parametrize("lags", lags_to_test)
-def test_differencer_prediction(y, lags):
+@pytest.mark.parametrize("index_type", ["int", "datetime"])
+def test_differencer_prediction(y, lags, index_type):
     """Test transform against inverse_transform."""
+    if index_type == "int":
+        y = y.reset_index(drop=True)
+
     y_train = y.iloc[:-12].copy()
     y_true = y.iloc[-12:].copy()
 


### PR DESCRIPTION
This fixes an unreported bug in `Differencer._inverse_transform` for integer index.

In `_inverse_transform`, `Differencer` would call the `shift` method of the index which is not defined for integer based index - this should have used the internal `_shift` method.

The tests did not catch this as all tests were datetime-index based.
This has now been rectified.