### PR TITLE
[ENH] rework data loader module, ability to specify download mirrors

### DIFF
--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -231,7 +231,7 @@ def _mkdir_if_not_exist(*path):
     return full_path
 
 
-CLASSIF_URLS = ["https://timeseriesclassification.com"]
+CLASSIF_URLS = ["https://timeseriesclassification.com/ClassificationDownloads"]
 
 
 def _load_dataset(name, split, return_X_y, return_type=None, extract_path=None):

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -190,7 +190,7 @@ def _cache_dataset(url, name, extract_path=None, repeats=1, verbose=False):
                 print(
                     f"Downloading dataset {name} from {u} to {extract_path}"
                     f"(attempt {repeat} of {repeats} total). "
-                )
+                )  # noqa: T201
 
             try:
                 _download_and_extract(name_url, extract_path=extract_path)
@@ -199,12 +199,14 @@ def _cache_dataset(url, name, extract_path=None, repeats=1, verbose=False):
             except zipfile.BadZipFile:
                 if verbose:
                     if repeat < len(repeats) - 1:
-                        print("Download failed, continuing with next attempt. ")
+                        print(
+                            "Download failed, continuing with next attempt. "
+                        )  # noqa: T201
                     else:
                         print(
                             "All attempts for mirror failed, "
                             "continuing with next mirror."
-                        )
+                        )  # noqa: T201
 
     raise RuntimeError(
         f"Dataset with name ={name} could not be downloaded from any of the mirrors."

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -286,7 +286,7 @@ def _load_dataset(name, split, return_X_y, return_type=None, extract_path=None):
     # so we need to check whether it is already in the download/cache path
     # download path is extract_path/local_data, defaults to sktime/datasets/local_data
     if extract_path is None:
-        extract_path = os.path.join(extract_path, "local_data")
+        extract_path = os.path.join(MODULE, "local_data")
 
     if name in _list_available_datasets(extract_path):
         return _get_data_from(extract_path)

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -187,10 +187,10 @@ def _cache_dataset(url, name, extract_path=None, repeats=1, verbose=False):
         name_url = f"{u}/{name}.zip"
         for repeat in range(repeats):
             if verbose:
-                print(
+                print(  # noqa: T201
                     f"Downloading dataset {name} from {u} to {extract_path}"
                     f"(attempt {repeat} of {repeats} total). "
-                )  # noqa: T201
+                )
 
             try:
                 _download_and_extract(name_url, extract_path=extract_path)
@@ -199,14 +199,14 @@ def _cache_dataset(url, name, extract_path=None, repeats=1, verbose=False):
             except zipfile.BadZipFile:
                 if verbose:
                     if repeat < len(repeats) - 1:
-                        print(
+                        print(  # noqa: T201
                             "Download failed, continuing with next attempt. "
-                        )  # noqa: T201
+                        )
                     else:
-                        print(
+                        print(  # noqa: T201
                             "All attempts for mirror failed, "
                             "continuing with next mirror."
-                        )  # noqa: T201
+                        )
 
     raise RuntimeError(
         f"Dataset with name ={name} could not be downloaded from any of the mirrors."

--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -198,7 +198,7 @@ def _cache_dataset(url, name, extract_path=None, repeats=1, verbose=False):
 
             except zipfile.BadZipFile:
                 if verbose:
-                    if repeat < len(repeats) - 1:
+                    if repeat < repeats - 1:
                         print(  # noqa: T201
                             "Download failed, continuing with next attempt. "
                         )


### PR DESCRIPTION
This PR reworks the somewhat messy data loader module, and adds an ability to specify download mirrors for remote datasets.

This is towards https://github.com/sktime/sktime/issues/4754 but does create a framework for arbitrary data loader mirrors - I focused mainly on enabling the mirroring/fallback feature for existing loaders, rather than a framework level refactor.

A refactor would also include the forecasting data loader and factor out more of the repetitive code in functions.

FYI @achieveordie, @hazrulakmal, as you have both recently worked on this module.

In terms of addressing #4754, it should now be easy to add an arbitrary number of mirrors to prevent a blowout failure to users if the UEA data repository decides to abruptly change folder structure again without deprecation or warning.