### PR TITLE
[BUG] use correct arguments in `geometric_mean_absolute_error`

### DIFF
--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -1302,9 +1302,7 @@ def geometric_mean_absolute_error(
     else:
         check_consistent_length(y_true, horizon_weight)
         output_errors = _weighted_geometric_mean(
-            np.abs(errors),
-            sample_weight=horizon_weight,
-            axis=0,
+            np.abs(errors), weights=horizon_weight, axis=0
         )
 
     if isinstance(multioutput, str):
@@ -1427,9 +1425,7 @@ def geometric_mean_squared_error(
     else:
         check_consistent_length(y_true, horizon_weight)
         output_errors = _weighted_geometric_mean(
-            np.square(errors),
-            sample_weight=horizon_weight,
-            axis=0,
+            np.square(errors), weights=horizon_weight, axis=0
         )
 
     if square_root:

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -62,6 +62,13 @@ def test_gmse_function():
         0.7000014418652152,
     )
 
+    assert np.allclose(
+        gmse(
+            np.array([1, 2, 3]), np.array([6, 5, 4]), horizon_weight=np.array([7, 8, 9])
+        ),
+        6.185891035775025,
+    )
+
 
 def test_linex_class():
     """Doctest from MeanLinexError."""


### PR DESCRIPTION
Fixes #4986