### PR TITLE
[ENH] ensure robustness of `StatsForecastBackAdapter` w.r.t. change of `predict_interval` return format

### DIFF
--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -384,14 +384,16 @@ class StatsForecastBackAdapter:
     def format_pred_int(self, y_pred_name, y_pred, pred_int, coverage, level):
         pred_int_prefix = "fitted-" if y_pred_name == "fitted" else ""
 
+        pred_int_no_lev = pred_int.droplevel(0, axis=1)
+
         return {
             y_pred_name: y_pred,
             **{
-                f"{pred_int_prefix}lo-{_l}": pred_int[("Coverage", c, "lower")].values
+                f"{pred_int_prefix}lo-{_l}": pred_int_no_lev[(c, "lower")].values
                 for c, _l in zip(reversed(coverage), reversed(level))
             },
             **{
-                f"{pred_int_prefix}hi-{_l}": pred_int[("Coverage", c, "upper")].values
+                f"{pred_int_prefix}hi-{_l}": pred_int_no_lev[(c, "upper")].values
                 for c, _l in zip(coverage, level)
             },
         }


### PR DESCRIPTION
This PR changes the `StatsForecastBackAdapter` to ensure it is not affected by the change of `predict_interval` return format.

This is done by simply dropping the first column index level, which should therefore avoid any impact of the default change.

Note to @yarnabrina, @luca-miniati - it sems the adapter assumes a univariate forecaster. Is this intentional, and is this sufficient?