### PR TITLE
[ENH] generalized `tslearn` adapter and clusterer refactor

### DIFF
--- a/sktime/base/adapters/__init__.py
+++ b/sktime/base/adapters/__init__.py
@@ -1,6 +1,6 @@
 """Module containing adapters other framework packages covering multiple tasks."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-__all__ = ["TslearnAdapter"]
+__all__ = ["_TslearnAdapter"]
 
-from sktime.base.adapters._tslearn import TslearnAdapter
+from sktime.base.adapters._tslearn import _TslearnAdapter

--- a/sktime/base/adapters/__init__.py
+++ b/sktime/base/adapters/__init__.py
@@ -1,0 +1,6 @@
+"""Module containing adapters other framework packages covering multiple tasks."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+__all__ = ["TslearnAdapter"]
+
+from sktime.base.adapters._tslearn import TslearnAdapter

--- a/sktime/base/adapters/_tslearn.py
+++ b/sktime/base/adapters/_tslearn.py
@@ -1,0 +1,107 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Implements adapter for tslearn models."""
+
+__all__ = ["_TslearnAdapter"]
+__author__ = ["fkiraly"]
+
+from inspect import signature
+
+
+class _TslearnAdapter:
+    """Mixin adapter class for tslearn models."""
+
+    _tags = {
+        "X_inner_mtype": "numpy3D",
+        "python_dependencies": ["tslearn"],
+    }
+
+    # defines the name of the attribute to be set on the estimator
+    _estimator_attr = "_estimator"
+
+    def _get_tslearn_class(self):
+        """Abstract method to get tslearn class.
+
+        should import and return tslearn class
+        """
+        # from tslearn import TslearnClass
+        #
+        # return TslearnClass
+        raise NotImplementedError("abstract method")
+
+    def _get_tslearn_object(self):
+        """Abstract method to initialize tslearn object.
+
+        The default initializes result of _get_tslearn_class
+        with self.get_params.
+        """
+        cls = self._get_tslearn_class()
+        return cls(**self.get_params())
+
+    def _init_tslearn_object(self):
+        """Abstract method to initialize tslearn object and set to _estimator_attr.
+
+        The default writes the return of _get_tslearn_object to
+        the attribute of self with name _estimator_attr
+        """
+        cls = self._get_tslearn_object()
+        setattr(self, self._estimator_attr, cls)
+        return getattr(self, self._estimator_attr)
+
+    def _fit(self, X, y=None):
+        """Fit estimator training data.
+
+        Parameters
+        ----------
+        X : 3D np.ndarray of shape (n_instances, n_dimensions, series_length)
+            Training time series instances to cluster
+        y: None or 1D np.ndarray of shape (n_instances,)
+            Training labels, passed only for classifiers or regressors
+
+        Returns
+        -------
+        self: sktime estimator
+            Fitted estimator.
+        """
+        tslearn_est = self._init_tslearn_object()
+
+        # check if tslearn_est fit has y parameter
+        # if yes, call with y, otherwise without
+        tslearn_has_y = "y" in signature(tslearn_est.fit).parameters
+
+        if tslearn_has_y:
+            tslearn_est.fit(X, y)
+        else:
+            tslearn_est.fit(X)
+
+        # write fitted params to self
+        tslearn_fitted_params = self._get_fitted_params_default(tslearn_est)
+        for k, v in tslearn_fitted_params.items():
+            setattr(self, f"{k}_", v)
+
+        return self
+
+    def _predict(self, X, y=None):
+        """Predict the closest cluster each sample in X belongs to.
+
+        Parameters
+        ----------
+        X : np.ndarray (2d or 3d array of shape (n_instances, series_length) or shape
+            (n_instances, n_dimensions, series_length))
+            Time series instances to predict their cluster indexes.
+        y: ignored, exists for API consistency reasons.
+
+        Returns
+        -------
+        np.ndarray (1d array of shape (n_instances,))
+            Index of the cluster each time series in X belongs to.
+        """
+        tslearn_est = getattr(self, self._estimator_attr)
+
+        # check if tslearn_est fit has y parameter
+        # if yes, call with y, otherwise without
+        tslearn_has_y = "y" in signature(tslearn_est.predict).parameters
+
+        if tslearn_has_y:
+            return tslearn_est.predict(X, y)
+        else:
+            return tslearn_est.predict(X)

--- a/sktime/base/adapters/_tslearn.py
+++ b/sktime/base/adapters/_tslearn.py
@@ -15,7 +15,7 @@ class _TslearnAdapter:
         "python_dependencies": ["tslearn"],
     }
 
-    # defines the name of the attribute to be set on the estimator
+    # defines the name of the attribute containing the tslearn estimator
     _estimator_attr = "_estimator"
 
     def _get_tslearn_class(self):

--- a/sktime/clustering/base.py
+++ b/sktime/clustering/base.py
@@ -241,8 +241,9 @@ class BaseClusterer(BaseEstimator):
         """
         preds = self._predict(X)
         n_instances = len(preds)
-        n_clusters = self.n_clusters
-        if n_clusters is None:
+        if hasattr(self, "n_clusters") and self.n_clusters is not None:
+            n_clusters = self.n_clusters
+        else:
             n_clusters = max(preds) + 1
         dists = np.zeros((X.shape[0], n_clusters))
         for i in range(n_instances):

--- a/sktime/clustering/kernel_k_means.py
+++ b/sktime/clustering/kernel_k_means.py
@@ -4,10 +4,11 @@ from typing import Dict, Union
 import numpy as np
 from numpy.random import RandomState
 
+from sktime.base.adapters._tslearn import _TslearnAdapter
 from sktime.clustering.base import BaseClusterer, TimeSeriesInstances
 
 
-class TimeSeriesKernelKMeans(BaseClusterer):
+class TimeSeriesKernelKMeans(_TslearnAdapter, BaseClusterer):
     """Kernel algorithm wrapper tslearns implementation.
 
     Parameters
@@ -68,6 +69,18 @@ class TimeSeriesKernelKMeans(BaseClusterer):
         "python_dependencies": "tslearn",
     }
 
+    # defines the name of the attribute containing the tslearn estimator
+    _estimator_attr = "_tslearn_kernel_k_means"
+
+    def _get_tslearn_class(self):
+        """Get tslearn class.
+
+        should import and return tslearn class
+        """
+        from tslearn.clustering import KernelKMeans as TsLearnKernelKMeans
+
+        return TsLearnKernelKMeans
+
     def __init__(
         self,
         n_clusters: int = 8,
@@ -94,64 +107,7 @@ class TimeSeriesKernelKMeans(BaseClusterer):
         self.inertia_ = None
         self.n_iter_ = 0
 
-        self._tslearn_kernel_k_means = None
-
         super().__init__(n_clusters=n_clusters)
-
-    def _fit(self, X: TimeSeriesInstances, y=None) -> np.ndarray:
-        """Fit time series clusterer to training data.
-
-        Parameters
-        ----------
-        X : np.ndarray (2d or 3d array of shape (n_instances, series_length) or shape
-            (n_instances, n_dimensions, series_length))
-            Training time series instances to cluster.
-        y: ignored, exists for API consistency reasons.
-
-        Returns
-        -------
-        self:
-            Fitted estimator.
-        """
-        from tslearn.clustering import KernelKMeans as TsLearnKernelKMeans
-
-        verbose = 0
-        if self.verbose is True:
-            verbose = 1
-
-        if self._tslearn_kernel_k_means is None:
-            self._tslearn_kernel_k_means = TsLearnKernelKMeans(
-                n_clusters=self.n_clusters,
-                kernel=self.kernel,
-                max_iter=self.max_iter,
-                tol=self.tol,
-                n_init=self.n_init,
-                kernel_params=self.kernel_params,
-                n_jobs=self.n_jobs,
-                verbose=verbose,
-                random_state=self.random_state,
-            )
-        self._tslearn_kernel_k_means.fit(X)
-        self.labels_ = self._tslearn_kernel_k_means.labels_
-        self.inertia_ = self._tslearn_kernel_k_means.inertia_
-        self.n_iter_ = self._tslearn_kernel_k_means.n_iter_
-
-    def _predict(self, X: TimeSeriesInstances, y=None) -> np.ndarray:
-        """Predict the closest cluster each sample in X belongs to.
-
-        Parameters
-        ----------
-        X : np.ndarray (2d or 3d array of shape (n_instances, series_length) or shape
-            (n_instances, n_dimensions, series_length))
-            Time series instances to predict their cluster indexes.
-        y: ignored, exists for API consistency reasons.
-
-        Returns
-        -------
-        np.ndarray (1d array of shape (n_instances,))
-            Index of the cluster each time series in X belongs to.
-        """
-        return self._tslearn_kernel_k_means.predict(X)
 
     @classmethod
     def get_test_params(cls, parameter_set="default") -> Dict:

--- a/sktime/clustering/kernel_k_means.py
+++ b/sktime/clustering/kernel_k_means.py
@@ -5,7 +5,6 @@ import numpy as np
 from numpy.random import RandomState
 
 from sktime.base.adapters._tslearn import _TslearnAdapter
-from sktime.clustering.base import BaseClusterer, TimeSeriesInstances
 
 
 class TimeSeriesKernelKMeans(_TslearnAdapter, BaseClusterer):

--- a/sktime/clustering/kernel_k_means.py
+++ b/sktime/clustering/kernel_k_means.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.random import RandomState
 
 from sktime.base.adapters._tslearn import _TslearnAdapter
+from sktime.clustering.base import BaseClusterer
 
 
 class TimeSeriesKernelKMeans(_TslearnAdapter, BaseClusterer):


### PR DESCRIPTION
This PR adds a generalized adapter for `tslearn` classifiers, clusterers, and regressors.

As a proof-of-concept and refactor test, the estimator with `tslearn` depndency is refactored to use the adapter.

On short-term, if this works as intended, this should allow to interface all of `tslearn` easily.