### PR TITLE
&MCRE-BE [BUG] Fix `Differencer.inverse_transform` on train data if `na_handling=fill_zero`

### DIFF
--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -147,7 +147,7 @@ def _inverse_diff(X, lags, X_diff_seq=None):
         X_update = X_diff_orig.loc[X_ix_shift.intersection(X_diff_orig.index)]
         X.loc[
             X_diff_orig.index.difference(
-                _shift(X_diff_orig.index, lag_last)
+                _shift(X_diff_orig.index, sum(lags) + lag_last)
             ).intersection(X.index)
         ] = np.nan
         X = X.combine_first(X_update)

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -142,9 +142,19 @@ def _inverse_diff(X, lags, X_diff_seq=None):
 
     # invert last lag index
     if X_diff_seq is not None:
+        # Get the train time series before the last difference
         X_diff_orig = X_diff_seq[len(lags)]
+        # Shift the differenced time series index by the last lag
+        # to match the original time series index
         X_ix_shift = _shift(X.index, -lag_last)
+        # Get the original time series values for the intersecting
+        # indices between the shifted index and the original index
         X_update = X_diff_orig.loc[X_ix_shift.intersection(X_diff_orig.index)]
+        # Set the values of the differenced time series to nan for all indices
+        # that are in the indices of the original and the by the sum of all lags
+        # shifted original time series that are available in the differenced time
+        # series (intersection). These are the indices for which no valid differenced
+        # values exist.
         X.loc[
             X_diff_orig.index.difference(
                 _shift(X_diff_orig.index, sum(lags) + lag_last)

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -145,7 +145,11 @@ def _inverse_diff(X, lags, X_diff_seq=None):
         X_diff_orig = X_diff_seq[len(lags)]
         X_ix_shift = _shift(X.index, -lag_last)
         X_update = X_diff_orig.loc[X_ix_shift.intersection(X_diff_orig.index)]
-        X.loc[X.index.intersection(X_diff_orig.index[:lag_last])] = np.nan
+        X.loc[
+            X_diff_orig.index.difference(
+                _shift(X_diff_orig.index, lag_last)
+            ).intersection(X.index)
+        ] = np.nan
         X = X.combine_first(X_update)
 
     X_diff_last = X.copy()

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -145,7 +145,7 @@ def _inverse_diff(X, lags, X_diff_seq=None):
         X_diff_orig = X_diff_seq[len(lags)]
         X_ix_shift = _shift(X.index, -lag_last)
         X_update = X_diff_orig.loc[X_ix_shift.intersection(X_diff_orig.index)]
-
+        X.loc[X.index.intersection(X_diff_orig.index[:lag_last])] = np.nan
         X = X.combine_first(X_update)
 
     X_diff_last = X.copy()

--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -8,9 +8,8 @@ __all__ = []
 import numpy as np
 import pandas as pd
 import pytest
-from datasets import load_longley
 
-from sktime.datasets import load_airline
+from sktime.datasets import load_airline, load_longley
 from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.transformations.series.difference import Differencer
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal

--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -174,7 +174,7 @@ def test_inverse_train_data_fill_zero(lags, index_type):
     y = y_airline
     if index_type == "int":
         y = y.reset_index(drop=True)
-    diff = Differencer().fit(y)
+    diff = Differencer(lags).fit(y)
     result = diff.inverse_transform(diff.transform(y))
     _assert_array_almost_equal(result, y)
 

--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -8,10 +8,10 @@ __all__ = []
 import numpy as np
 import pandas as pd
 import pytest
-
 from datasets import load_longley
-from forecasting.model_selection import temporal_train_test_split
+
 from sktime.datasets import load_airline
+from sktime.forecasting.model_selection import temporal_train_test_split
 from sktime.transformations.series.difference import Differencer
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 from sktime.utils.validation._dependencies import _check_soft_dependencies

--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -9,6 +9,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from datasets import load_longley
+from forecasting.model_selection import temporal_train_test_split
 from sktime.datasets import load_airline
 from sktime.transformations.series.difference import Differencer
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
@@ -166,6 +168,15 @@ def test_differencer_cutoff():
 
     # fit
     gscv.fit(train_model, X=X_train)
+
+
+def test_inverse_train_data_fill_zero():
+    y, X = load_longley()
+    y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
+
+    diff = Differencer().fit(y_train)
+    result = diff.inverse_transform(diff.transform(y_train))
+    _assert_array_almost_equal(result, y_train)
 
 
 def test_differencer_inverse_does_not_memorize():

--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -9,8 +9,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from sktime.datasets import load_airline, load_longley
-from sktime.forecasting.model_selection import temporal_train_test_split
+from sktime.datasets import load_airline
 from sktime.transformations.series.difference import Differencer
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 from sktime.utils.validation._dependencies import _check_soft_dependencies
@@ -169,13 +168,15 @@ def test_differencer_cutoff():
     gscv.fit(train_model, X=X_train)
 
 
-def test_inverse_train_data_fill_zero():
-    y, X = load_longley()
-    y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
-
-    diff = Differencer().fit(y_train)
-    result = diff.inverse_transform(diff.transform(y_train))
-    _assert_array_almost_equal(result, y_train)
+@pytest.mark.parametrize("lags", lags_to_test)
+@pytest.mark.parametrize("index_type", ["int", "datetime"])
+def test_inverse_train_data_fill_zero(lags, index_type):
+    y = y_airline
+    if index_type == "int":
+        y = y.reset_index(drop=True)
+    diff = Differencer().fit(y)
+    result = diff.inverse_transform(diff.transform(y))
+    _assert_array_almost_equal(result, y)
 
 
 def test_differencer_inverse_does_not_memorize():


### PR DESCRIPTION
Set first lag values to nan if it has the same index as the train time series. This should fix the strange results in inverse_transform of the Differencer if fill_zero is set.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #4993 and fixes #4965.

Regarding both issues, I am not sure if there are additional problems... 

<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

The fix sets the first lag values of the input time series to nan if the index aligns with the index of the train time series. Thus, the  combine_first operation will set it to the values of the original time series and cumsum reproduces the original time series.

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?
* Is the solution understandable and maintainable or looks it like black magic.
* Regarding both linked issues, are they solved with this single bugfix or are additional problems there.. Currently, I am not sure about it. 

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?
I added a test for reproducing the original bug.

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
