### PR TITLE
[BUG] Fix forecaster based imputation strategy `Imputer` if forecaster requires `fh` in `fit`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2283,7 +2283,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/99316631",
       "profile": "https://github.com/MCRE-BE",
       "contributions": [
-        "bug"
+        "bug",
+        "code"
       ]
     }
   ]

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2276,6 +2276,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "MCRE-BE",
+      "name": "Mathias Creemers",
+      "avatar_url": "https://avatars.githubusercontent.com/u/99316631",
+      "profile": "https://github.com/MCRE-BE",
+      "contributions": [
+        "bug"
+      ]
     }
   ]
 }

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -371,7 +371,6 @@ class Imputer(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-
         from sklearn.linear_model import LinearRegression
 
         from sktime.forecasting.compose import make_reduction

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -371,7 +371,13 @@ class Imputer(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+
+        from sklearn.linear_model import LinearRegression
+
+        from sktime.forecasting.compose import make_reduction
         from sktime.forecasting.trend import TrendForecaster
+
+        linear_forecaster = make_reduction(LinearRegression(), strategy="multioutput")
 
         return [
             {"method": "drift"},
@@ -384,6 +390,7 @@ class Imputer(BaseTransformer):
             {"method": "pad"},
             {"method": "random"},
             {"method": "forecaster", "forecaster": TrendForecaster()},
+            {"method": "forecaster", "forecaster": linear_forecaster},
         ]
 
 

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -345,6 +345,7 @@ class Imputer(BaseTransformer):
                     X=self._y[col].fillna(method="ffill").fillna(method="backfill")
                     if self._y is not None
                     else None,
+                    fh=fh,
                 )
 
                 # replace missing values with predicted values


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #4997

#### What does this implement/fix? Explain your changes.
Passes the missing ForecastingHorizon to the fit method
Adds a test to check with a forecaster requiring fh in fit and not only in predict.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### Did you add any tests for the change?
Yes

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).