### PR TITLE
[ENH] remove `sklearn` dependency in `test_get_params`

### DIFF
--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -17,9 +17,6 @@ import joblib
 import numpy as np
 import pandas as pd
 import pytest
-from sklearn.utils.estimator_checks import (
-    check_get_params_invariance as _check_get_params_invariance,
-)
 
 from sktime.base import BaseEstimator, BaseObject, load
 from sktime.classification.deep_learning.base import BaseDeepClassifier

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -922,7 +922,13 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         estimator = estimator_instance
         params = estimator.get_params()
         assert isinstance(params, dict)
-        _check_get_params_invariance(estimator.__class__.__name__, estimator)
+
+        e = estimator.clone()
+
+        shallow_params = e.get_params(deep=False)
+        deep_params = e.get_params(deep=True)
+
+        assert all(item in deep_params.items() for item in shallow_params.items())
 
     def test_set_params(self, estimator_instance):
         """Check that set_params works correctly."""


### PR DESCRIPTION
Mirror of `skbase` https://github.com/sktime/skbase/pull/212

This PR removes the `sklearn` dependency in `get_test_params`, by replacing `_check_get_params_invariance` with an `skbase`-native implementation.

The call to `clone` is replaced with the object's one `clone`method.

Related: https://github.com/sktime/sktime/pull/2903 which needs a custom `clone` to function (due to a serialized estimator being a parameter).