### PR TITLE
&yarnabrina [MNT] testing only estimators from modules that have changed compared to `main`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,8 +168,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+
+      - name: Fetch 'main' branch
+        run: git fetch origin main
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -216,8 +217,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+
+      - name: Fetch 'main' branch
+        run: git fetch origin main
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -252,8 +254,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+
+      - name: Fetch 'main' branch
+        run: git fetch origin main
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,6 +168,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -214,10 +216,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
@@ -246,10 +252,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,6 +191,9 @@ jobs:
       - name: Show dependencies
         run: python -m pip list
 
+      - name: Show available branches
+        run: git branch -a
+
       - name: Run tests
         run: |
           mkdir -p testdir/
@@ -225,6 +228,9 @@ jobs:
       - name: Show dependencies
         run: python -m pip list
 
+      - name: Show available branches
+        run: git branch -a
+
       - name: Run tests
         run: make test
 
@@ -253,6 +259,9 @@ jobs:
 
       - name: Show dependencies
         run: python -m pip list
+
+      - name: Show available branches
+        run: git branch -a
 
       - name: Run tests
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,9 +168,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: Fetch 'main' branch
-        run: git fetch origin main
+        with:
+          fetch-depth: 0
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -217,9 +216,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-
-      - name: Fetch 'main' branch
-        run: git fetch origin main
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -254,9 +252,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-
-      - name: Fetch 'main' branch
-        run: git fetch origin main
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,8 +168,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+
+      - run: git remote set-branches origin 'main'
+
+      - run: git fetch --depth 1
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -216,8 +218,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+
+      - run: git remote set-branches origin 'main'
+
+      - run: git fetch --depth 1
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -252,8 +256,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+
+      - run: git remote set-branches origin 'main'
+
+      - run: git fetch --depth 1
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/conftest.py
+++ b/conftest.py
@@ -25,6 +25,11 @@ def pytest_addoption(parser):
         default=False,
         help="test only cython estimators, with tag requires_cython=True",
     )
+    parser.addoption(
+        "--only_changed_modules",
+        default=False,
+        help="test only cython estimators, with tag requires_cython=True",
+    )
 
 
 def pytest_configure(config):
@@ -35,3 +40,5 @@ def pytest_configure(config):
         test_all_estimators.MATRIXDESIGN = True
     if config.getoption("--only_cython_estimators") in [True, "True"]:
         test_all_estimators.CYTHON_ESTIMATORS = True
+    if config.getoption("--only_changed_modules") in [True, "True"]:
+        test_all_estimators.ONLY_CHANGED_MODULES = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ addopts =
     --cov-report html
     --showlocals
     --matrixdesign True
+    --only_changed_modules True
     -n auto
 filterwarnings =
     ignore::UserWarning

--- a/sktime/forecasting/statsforecast.py
+++ b/sktime/forecasting/statsforecast.py
@@ -306,7 +306,10 @@ class StatsForecastAutoARIMA(_GeneralisedStatsForecastAdapter):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        params = {"approximation": True, "max_p": 4, "max_Q": 1}
+        del parameter_set  # to avoid being detected as unused by ``vulture`` etc.
+
+        params = [{}, {"approximation": True, "max_p": 4, "max_Q": 1}]
+
         return params
 
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -53,6 +53,7 @@ from sktime.utils._testing.estimator_checks import (
     _list_required_methods,
 )
 from sktime.utils._testing.scenarios_getter import retrieve_scenarios
+from sktime.utils.git_diff import is_class_changed
 from sktime.utils.random_state import set_random_state
 from sktime.utils.sampling import random_partition
 from sktime.utils.validation._dependencies import (
@@ -68,6 +69,10 @@ MATRIXDESIGN = False
 # whether to test only estimators that require cython, C compiler such as gcc
 # default is False, can be set to True by pytest --only_cython_estimators True flag
 CYTHON_ESTIMATORS = False
+
+# whether to test only estimators from modules that are changed w.r.t. main
+# default is False, can be set to True by pytest --only_changed_modules True flag
+ONLY_CHANGED_MODULES = False
 
 
 def subsample_by_version_os(x):
@@ -217,6 +222,12 @@ class BaseFixtureGenerator:
         # but all are tested on every OS at least once, and on every python version once
         if MATRIXDESIGN:
             est_list = subsample_by_version_os(est_list)
+
+        # this setting ensures that only estimators are tested that have changed
+        # in the sense that any line in the module is different from main
+        if ONLY_CHANGED_MODULES:
+            est_list = [est for est in est_list if is_class_changed(est)]
+
         return est_list
 
     def generator_dict(self):

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -3,9 +3,9 @@
 __author__ = ["fkiraly"]
 __all__ = []
 
-import subprocess
 import importlib.util
 import inspect
+import subprocess
 
 
 def get_module_from_class(cls):

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -1,0 +1,80 @@
+"""Git related utilities to identify changed modules."""
+
+__author__ = ["fkiraly"]
+__all__ = []
+
+import subprocess
+import importlib.util
+import inspect
+
+
+def get_module_from_class(cls):
+    """Get full parent module string from class.
+
+    Parameters
+    ----------
+    cls : class
+        class to get module string from, e.g., NaiveForecaster
+
+    Returns
+    -------
+    str : module string, e.g., sktime.forecasting.naive
+    """
+    module = inspect.getmodule(cls)
+    return module.__name__ if module else None
+
+
+def get_path_from_module(module_str):
+    """Get local path string from module string.
+
+    Parameters
+    ----------
+    module_str : str
+        module string, e.g., sktime.forecasting.naive
+
+    Returns
+    -------
+    str : local path string, e.g., sktime\forecasting\naive.py
+    """
+    try:
+        module_spec = importlib.util.find_spec(module_str)
+        if module_spec is None:
+            raise ImportError(
+                f"Errpr in get_path_from_module, module '{module_str}' not found."
+            )
+        return module_spec.origin
+    except Exception as e:
+        raise ImportError(f"Error finding module '{module_str}': {e}")
+
+
+def is_module_changed(module_str):
+    """Check if a module has changed compared to the main branch.
+
+    Parameters
+    ----------
+    module_str : str
+        module string, e.g., sktime.forecasting.naive
+    """
+    module_file_path = get_path_from_module(module_str)
+    cmd = f"git diff main -- {module_file_path}"
+    try:
+        output = subprocess.check_output(cmd, shell=True, text=True)
+        return bool(output)
+    except subprocess.CalledProcessError:
+        return True
+
+
+def is_class_changed(cls):
+    """Check if a class' parent module has changed compared to the main branch.
+
+    Parameters
+    ----------
+    cls : class
+        class to get module string from, e.g., NaiveForecaster
+
+    Returns
+    -------
+    bool : True if changed, False otherwise
+    """
+    module_str = get_module_from_class(cls)
+    return is_module_changed(module_str)

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -56,7 +56,7 @@ def is_module_changed(module_str):
         module string, e.g., sktime.forecasting.naive
     """
     module_file_path = get_path_from_module(module_str)
-    cmd = f"git diff main -- {module_file_path}"
+    cmd = f"git diff remotes/origin/main -- {module_file_path}"
     try:
         output = subprocess.check_output(cmd, shell=True, text=True)
         return bool(output)

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -40,7 +40,7 @@ def get_path_from_module(module_str):
         module_spec = importlib.util.find_spec(module_str)
         if module_spec is None:
             raise ImportError(
-                f"Errpr in get_path_from_module, module '{module_str}' not found."
+                f"Error in get_path_from_module, module '{module_str}' not found."
             )
         return module_spec.origin
     except Exception as e:

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -25,7 +25,7 @@ def get_module_from_class(cls):
 
 
 def get_path_from_module(module_str):
-    """Get local path string from module string.
+    r"""Get local path string from module string.
 
     Parameters
     ----------

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -44,7 +44,7 @@ def get_path_from_module(module_str):
             )
         return module_spec.origin
     except Exception as e:
-        raise ImportError(f"Error finding module '{module_str}': {e}")
+        raise ImportError(f"Error finding module '{module_str}'") from e
 
 
 def is_module_changed(module_str):


### PR DESCRIPTION
Experimental PR that ensures only estimators are tested that have changed compared to `main`.

The design relies on a new utility that checks changes to `main` using `subprocess` calling `git`.

How we know it works:
* The CI in this PR runs none of the suite tests for any of the estimators in `sktime`, since this PR does not change any of the relevant files.
* whereas, in this PR https://github.com/sktime/sktime/pull/5023 where two estimator modules have changed, it runs exactly the suite tests for the two estimators.

Also, this most likely gets us a good way towards https://github.com/sktime/sktime/issues/2890, at least when it comes to tests arising from the `TestAll` portion of the test framework.