### PR TITLE
[MNT] mark and skip slow non-suite tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,7 +196,7 @@ jobs:
           mkdir -p testdir/
           cp .coveragerc testdir/
           cp setup.cfg testdir/
-          python -m pytest
+          python -m pytest -m "not slow"
 
       - name: Publish code coverage
         uses: codecov/codecov-action@v3

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: ## Run unit tests
 	mkdir -p ${TEST_DIR}
 	cp .coveragerc ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
-	python -m pytest
+	python -m pytest -m "not slow"
 
 test_check_suite: ## run only estimator contract tests in TestAll classes
 	-rm -rf ${TEST_DIR}
@@ -51,7 +51,7 @@ test_softdeps_full: ## Run all non-suite unit tests without soft dependencies
 	mkdir -p ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
 	cd ${TEST_DIR}
-	python -m pytest -v --showlocals --durations=20 -k 'not TestAll' $(PYTESTOPTIONS)
+	python -m pytest -v --showlocals --durations=20 -k 'not TestAll' -m "not slow" $(PYTESTOPTIONS)
 
 test_mlflow: ## Run mlflow integration tests
 	-rm -rf ${TEST_DIR}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    datadownload: test that downloads data from external sources
+    slow: mark test as slow

--- a/sktime/classification/early_classification/tests/test_teaser.py
+++ b/sktime/classification/early_classification/tests/test_teaser.py
@@ -119,6 +119,7 @@ def test_teaser_near_classification_points():
     not _check_soft_dependencies("numba", severity="none"),
     reason="skip test if required soft dependency not available",
 )
+@pytest.mark.slow
 def test_teaser_full_length():
     """Test of TEASER on the full data with the default estimator."""
     X_train, y_train, X_test, y_test, indices = load_unit_data()

--- a/sktime/classification/hybrid/tests/test_hivecote_v2.py
+++ b/sktime/classification/hybrid/tests/test_hivecote_v2.py
@@ -11,6 +11,7 @@ from sktime.utils.validation._dependencies import _check_soft_dependencies
     not _check_soft_dependencies("numba", severity="none"),
     reason="skip test if required soft dependency not available",
 )
+@pytest.mark.slow
 def test_contracted_hivecote_v2():
     """Test of contracted HIVECOTEV2 on unit test data."""
     # load unit test data


### PR DESCRIPTION
This PR marks and skips individual, slow non-suite tests.

A non-suite test may be marked as slow if it has a runtime of 20sec or larger, and it is unclear how to speed it up.

The proposal inherent is to skip these tests, and track them via the "slow" mark, potentially speeding them up as a good first issue.

We could run the expensive tests in a CRON or at release.