### PR TITLE
[MNT] fix duplication of `pytest` `durations` parameter in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,23 +42,23 @@ test_softdeps: ## Run unit tests to check soft dependency handling in estimators
 	mkdir -p ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
 	cd ${TEST_DIR}
-	python -m pytest -v -n auto --showlocals --durations=100 -k 'test_all_estimators' $(PYTESTOPTIONS) --pyargs sktime.registry
-	python -m pytest -v -n auto --showlocals --durations=100 -k 'test_check_estimator_does_not_raise' $(PYTESTOPTIONS) --pyargs sktime.utils.tests
-	python -m pytest -v -n auto --showlocals --durations=100 $(PYTESTOPTIONS) --pyargs sktime.tests.test_softdeps
+	python -m pytest -v -n auto --showlocals -k 'test_all_estimators' $(PYTESTOPTIONS) --pyargs sktime.registry
+	python -m pytest -v -n auto --showlocals -k 'test_check_estimator_does_not_raise' $(PYTESTOPTIONS) --pyargs sktime.utils.tests
+	python -m pytest -v -n auto --showlocals $(PYTESTOPTIONS) --pyargs sktime.tests.test_softdeps
 
 test_softdeps_full: ## Run all non-suite unit tests without soft dependencies
 	-rm -rf ${TEST_DIR}
 	mkdir -p ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
 	cd ${TEST_DIR}
-	python -m pytest -v --showlocals --durations=100 -k 'not TestAll' $(PYTESTOPTIONS)
+	python -m pytest -v --showlocals -k 'not TestAll' $(PYTESTOPTIONS)
 
 test_mlflow: ## Run mlflow integration tests
 	-rm -rf ${TEST_DIR}
 	mkdir -p ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
 	cd ${TEST_DIR}
-	python -m pytest -v --showlocals --durations=100 $(PYTESTOPTIONS) --pyargs sktime.utils.tests.test_mlflow_sktime_model_export
+	python -m pytest -v --showlocals $(PYTESTOPTIONS) --pyargs sktime.utils.tests.test_mlflow_sktime_model_export
 
 tests: test
 

--- a/Makefile
+++ b/Makefile
@@ -42,23 +42,23 @@ test_softdeps: ## Run unit tests to check soft dependency handling in estimators
 	mkdir -p ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
 	cd ${TEST_DIR}
-	python -m pytest -v -n auto --showlocals --durations=20 -k 'test_all_estimators' $(PYTESTOPTIONS) --pyargs sktime.registry
-	python -m pytest -v -n auto --showlocals --durations=20 -k 'test_check_estimator_does_not_raise' $(PYTESTOPTIONS) --pyargs sktime.utils.tests
-	python -m pytest -v -n auto --showlocals --durations=20 $(PYTESTOPTIONS) --pyargs sktime.tests.test_softdeps
+	python -m pytest -v -n auto --showlocals --durations=100 -k 'test_all_estimators' $(PYTESTOPTIONS) --pyargs sktime.registry
+	python -m pytest -v -n auto --showlocals --durations=100 -k 'test_check_estimator_does_not_raise' $(PYTESTOPTIONS) --pyargs sktime.utils.tests
+	python -m pytest -v -n auto --showlocals --durations=100 $(PYTESTOPTIONS) --pyargs sktime.tests.test_softdeps
 
 test_softdeps_full: ## Run all non-suite unit tests without soft dependencies
 	-rm -rf ${TEST_DIR}
 	mkdir -p ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
 	cd ${TEST_DIR}
-	python -m pytest -v --showlocals --durations=20 -k 'not TestAll' $(PYTESTOPTIONS)
+	python -m pytest -v --showlocals --durations=100 -k 'not TestAll' $(PYTESTOPTIONS)
 
 test_mlflow: ## Run mlflow integration tests
 	-rm -rf ${TEST_DIR}
 	mkdir -p ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
 	cd ${TEST_DIR}
-	python -m pytest -v --showlocals --durations=20 $(PYTESTOPTIONS) --pyargs sktime.utils.tests.test_mlflow_sktime_model_export
+	python -m pytest -v --showlocals --durations=100 $(PYTESTOPTIONS) --pyargs sktime.utils.tests.test_mlflow_sktime_model_export
 
 tests: test
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ addopts =
     --ignore examples
     --ignore docs
     --doctest-modules
-    --durations 10
+    --durations 20
     --timeout 600
     --cov sktime
     --cov-report xml


### PR DESCRIPTION
Fixes the duplication of the `pytest` `durations` parameter where `setup.cfg` would override the `durations` passed later on.