### PR TITLE
[ENH] speed up `BaseTransformer` checks and conversion boilerplate

### DIFF
--- a/sktime/datatypes/_convert.py
+++ b/sktime/datatypes/_convert.py
@@ -101,8 +101,9 @@ def convert(
     obj : object to convert - any type, should comply with mtype spec for as_scitype
     from_type : str - the type to convert "obj" to, a valid mtype string
         valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
-    to_type : str - the type to convert "obj" to, a valid mtype string
-        valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
+    to_type : str - the mtype to convert "obj" to, a valid mtype string
+        or list of str, this specifies admissible types for conversion to;
+        if list, will convert to first mtype of the same scitype as from_mtype
     as_scitype : str, optional - name of scitype the object "obj" is considered as
         default = inferred from from_type
         valid scitype strings, with explanation, are in datatypes.SCITYPE_REGISTER
@@ -127,9 +128,14 @@ def convert(
     if obj is None:
         return None
 
+    # if to_type is a list, we do the following:
+    # if on the list, then don't do a conversion (convert to from_type)
+    # if not on the list, we find and convert to first mtype that has same scitype
+    to_type = _get_first_mtype_of_same_scitype(
+        from_mtype=from_type, to_mtypes=to_type, varname="to_type"
+    )
+
     # input type checks
-    if not isinstance(to_type, str):
-        raise TypeError("to_type must be a str")
     if not isinstance(from_type, str):
         raise TypeError("from_type must be a str")
     if as_scitype is None:
@@ -186,8 +192,9 @@ def convert_to(
     Parameters
     ----------
     obj : object to convert - any type, should comply with mtype spec for as_scitype
-    to_type : str - the type to convert "obj" to, a valid mtype string
-            or list of str, this specifies admissible types for conversion to
+    to_type : str - the mtype to convert "obj" to, a valid mtype string
+        or list of str, this specifies admissible types for conversion to;
+        if list, will convert to first mtype of the same scitype as obj
         valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
     as_scitype : str, optional - name of scitype the object "obj" is considered as
         pre-specifying the scitype reduces the number of checks done in type inference
@@ -240,25 +247,6 @@ def convert_to(
     from_type = infer_mtype(obj=obj, as_scitype=as_scitype)
     as_scitype = mtype_to_scitype(from_type)
 
-    # if to_type is a list, we do the following:
-    # if on the list, then don't do a conversion (convert to from_type)
-    # if not on the list, we find and convert to first mtype that has same scitype
-    if isinstance(to_type, list):
-        # no conversion of from_type is in the list
-        if from_type in to_type:
-            to_type = from_type
-        # otherwise convert to first element of same scitype
-        else:
-            same_scitype_mtypes = [
-                mtype for mtype in to_type if mtype_to_scitype(mtype) == as_scitype
-            ]
-            if len(same_scitype_mtypes) == 0:
-                raise TypeError(
-                    "to_type contains no mtype compatible with the scitype of obj,"
-                    f"which is {as_scitype}"
-                )
-            to_type = same_scitype_mtypes[0]
-
     converted_obj = convert(
         obj=obj,
         from_type=from_type,
@@ -269,6 +257,42 @@ def convert_to(
     )
 
     return converted_obj
+
+
+def _get_first_mtype_of_same_scitype(from_mtype, to_mtypes, varname="to_mtypes"):
+    """Return first mtype in list mtypes that has same scitype as from_mtype.
+
+    Parameters
+    ----------
+    from_mtype : str - mtype of object to convert from
+    to_mtypes : list of str - mtypes to convert to
+    varname : str - name of variable to_mtypes, for error message
+
+    Returns
+    -------
+    to_type : str - first mtype in to_mtypes that has same scitype as from_mtype
+    """
+    if isinstance(to_mtypes, str):
+        return to_mtypes
+
+    if not isinstance(to_mtypes, list):
+        raise TypeError(f"{varname} must be a str or a list of str")
+
+    # no conversion of from_type is in the list
+    if from_mtype in to_mtypes:
+        return from_mtype
+    # otherwise convert to first element of same scitype
+    scitype = mtype_to_scitype(from_mtype)
+    same_scitype_mtypes = [
+        mtype for mtype in to_mtypes if mtype_to_scitype(mtype) == scitype
+    ]
+    if len(same_scitype_mtypes) == 0:
+        raise TypeError(
+            f"{varname} contains no mtype compatible with the scitype of obj,"
+            f"which is {scitype}"
+        )
+    to_type = same_scitype_mtypes[0]
+    return to_type
 
 
 def _conversions_defined(scitype: str):

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1026,7 +1026,9 @@ class BaseTransformer(BaseEstimator):
                 as_scitype = "Panel"
             else:
                 as_scitype = "Hierarchical"
-            X = convert_to_scitype(X, to_scitype=as_scitype, from_scitype=X_scitype)
+            X, X_mtype = convert_to_scitype(
+                X, to_scitype=as_scitype, from_scitype=X_scitype, return_to_mtype=True
+            )
             X_scitype = as_scitype
             # then pass to case 1, which we've reduced to, X now has inner scitype
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1172,25 +1172,25 @@ class BaseTransformer(BaseEstimator):
                     )
                 if X_input_mtype == "pd.Series" and not metadata["is_univariate"]:
                     X_output_mtype = "pd.DataFrame"
-                # Xt_mtype = metadata["mtype"]
-            # else:
-            #     Xt_mtype = X_input_mtype
+                Xt_mtype = metadata["mtype"]
+            else:
+                Xt_mtype = X_input_mtype
 
-            # Xt = convert(
-            #     Xt,
-            #     from_type=Xt_mtype,
-            #     to_type=X_output_mtype,
-            #     as_scitype=X_input_scitype,
-            #     store=_converter_store_X,
-            #     store_behaviour="freeze",
-            # )
-            Xt = convert_to(
+            Xt = convert(
                 Xt,
+                from_type=Xt_mtype,
                 to_type=X_output_mtype,
                 as_scitype=X_input_scitype,
                 store=_converter_store_X,
                 store_behaviour="freeze",
             )
+            # Xt = convert_to(
+            #     Xt,
+            #     to_type=X_output_mtype,
+            #     as_scitype=X_input_scitype,
+            #     store=_converter_store_X,
+            #     store_behaviour="freeze",
+            # )
         elif output_scitype == "Primitives":
             # we ensure the output is pd_DataFrame_Table
             # & ensure the returned index is sensible

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1172,7 +1172,7 @@ class BaseTransformer(BaseEstimator):
                     X_output_mtype = "pd.DataFrame"
                 # Xt_mtype = metadata["mtype"]
             # else:
-                # Xt_mtype = X_input_mtype
+            #     Xt_mtype = X_input_mtype
 
             # Xt = convert(
             #     Xt,

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1172,25 +1172,25 @@ class BaseTransformer(BaseEstimator):
                     )
                 if X_input_mtype == "pd.Series" and not metadata["is_univariate"]:
                     X_output_mtype = "pd.DataFrame"
-                Xt_mtype = metadata["mtype"]
-            else:
-                Xt_mtype = X_input_mtype
+                # Xt_mtype = metadata["mtype"]
+            # else:
+            #     Xt_mtype = X_input_mtype
 
-            Xt = convert(
-                Xt,
-                from_type=Xt_mtype,
-                to_type=X_output_mtype,
-                as_scitype=X_input_scitype,
-                store=_converter_store_X,
-                store_behaviour="freeze",
-            )
-            # Xt = convert_to(
+            # Xt = convert(
             #     Xt,
+            #     from_type=Xt_mtype,
             #     to_type=X_output_mtype,
             #     as_scitype=X_input_scitype,
             #     store=_converter_store_X,
             #     store_behaviour="freeze",
             # )
+            Xt = convert_to(
+                Xt,
+                to_type=X_output_mtype,
+                as_scitype=X_input_scitype,
+                store=_converter_store_X,
+                store_behaviour="freeze",
+            )
         elif output_scitype == "Primitives":
             # we ensure the output is pd_DataFrame_Table
             # & ensure the returned index is sensible

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1171,7 +1171,7 @@ class BaseTransformer(BaseEstimator):
                 if X_input_mtype == "pd.Series" and not metadata["is_univariate"]:
                     X_output_mtype = "pd.DataFrame"
                 # Xt_mtype = metadata["mtype"]
-            else:
+            # else:
                 # Xt_mtype = X_input_mtype
 
             # Xt = convert(

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1170,13 +1170,20 @@ class BaseTransformer(BaseEstimator):
                     )
                 if X_input_mtype == "pd.Series" and not metadata["is_univariate"]:
                     X_output_mtype = "pd.DataFrame"
-                Xt_mtype = metadata["mtype"]
+                # Xt_mtype = metadata["mtype"]
             else:
-                Xt_mtype = X_input_mtype
+                # Xt_mtype = X_input_mtype
 
-            Xt = convert(
+            # Xt = convert(
+            #     Xt,
+            #     from_type=Xt_mtype,
+            #     to_type=X_output_mtype,
+            #     as_scitype=X_input_scitype,
+            #     store=_converter_store_X,
+            #     store_behaviour="freeze",
+            # )
+            Xt = convert_to(
                 Xt,
-                from_type=Xt_mtype,
                 to_type=X_output_mtype,
                 as_scitype=X_input_scitype,
                 store=_converter_store_X,

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1178,7 +1178,7 @@ class BaseTransformer(BaseEstimator):
                 Xt,
                 from_type=Xt_mtype,
                 to_type=X_output_mtype,
-                as_scitype=output_scitype,
+                as_scitype=X_input_scitype,
                 store=_converter_store_X,
                 store_behaviour="freeze",
             )


### PR DESCRIPTION
This PR speeds up `BaseTransformer` checks and conversion boilerplate:

* replacing some `convert_to` calls by more specific `convert` calls that ensure we do not repeat mtype checks
* specifying explicitly the needed metadata in an instance where all metadata was returned, to avoid costly metadata queries that are discarded
* refactoring `convert` and `convert_to`, moving logic that determines the target mtype into a separate function, and allowing `convert` to have `list` as `to_type`
* adding an option to `convert_to_scitype` to return the mtype of the converted-to output. This is passed as an input to `convert` in the `BaseTransformer` boilerplate to avoid checks to obtain this information.