### PR TITLE
[ENH] distance/kernel tag, uniformize base module

### DIFF
--- a/sktime/clustering/dbscan.py
+++ b/sktime/clustering/dbscan.py
@@ -9,7 +9,7 @@ from sklearn.cluster import DBSCAN
 
 from sktime.clustering.base import BaseClusterer
 from sktime.datatypes import update_data
-from sktime.dists_kernels._base import BasePairwiseTransformerPanel
+from sktime.dists_kernels.base import BasePairwiseTransformerPanel
 
 
 class TimeSeriesDBSCAN(BaseClusterer):

--- a/sktime/dists_kernels/__init__.py
+++ b/sktime/dists_kernels/__init__.py
@@ -1,6 +1,6 @@
 """Module exports for dist_kernels module."""
 
-from sktime.dists_kernels._base import (
+from sktime.dists_kernels.base import (
     BasePairwiseTransformer,
     BasePairwiseTransformerPanel,
 )

--- a/sktime/dists_kernels/algebra.py
+++ b/sktime/dists_kernels/algebra.py
@@ -5,7 +5,7 @@ __author__ = ["fkiraly"]
 import numpy as np
 
 from sktime.base import _HeterogenousMetaEstimator
-from sktime.dists_kernels._base import BasePairwiseTransformerPanel
+from sktime.dists_kernels.base import BasePairwiseTransformerPanel
 
 SUPPORTED_MTYPES = ["pd-multiindex", "nested_univ", "df-list", "numpy3D"]
 

--- a/sktime/dists_kernels/base/__init__.py
+++ b/sktime/dists_kernels/base/__init__.py
@@ -1,0 +1,8 @@
+"""Module exports for dist_kernels.base module."""
+
+from sktime.dists_kernels.base._base import (
+    BasePairwiseTransformer,
+    BasePairwiseTransformerPanel,
+)
+
+__all__ = ["BasePairwiseTransformer", "BasePairwiseTransformerPanel"]

--- a/sktime/dists_kernels/base/_base.py
+++ b/sktime/dists_kernels/base/_base.py
@@ -53,6 +53,7 @@ class BasePairwiseTransformer(BaseEstimator):
         "fit_is_empty": True,  # is "fit" empty? Yes, for all pairwise transforms
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:multivariate": True,  # can estimator handle multivariate data?
+        "pwtrafo_type": "distance",  # type of pw. transformer, "kernel" or "distance"
     }
 
     def __init__(self):
@@ -187,6 +188,7 @@ class BasePairwiseTransformerPanel(BaseEstimator):
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "capability:unequal_length": True,  # can dist handle unequal length panels?
+        "pwtrafo_type": "distance",  # type of pw. transformer, "kernel" or "distance"
     }
 
     def __init__(self):

--- a/sktime/dists_kernels/compose.py
+++ b/sktime/dists_kernels/compose.py
@@ -3,7 +3,7 @@
 __author__ = ["fkiraly"]
 
 from sktime.base import _HeterogenousMetaEstimator
-from sktime.dists_kernels._base import BasePairwiseTransformerPanel
+from sktime.dists_kernels.base import BasePairwiseTransformerPanel
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.compose import TransformerPipeline
 
@@ -85,10 +85,14 @@ class PwTrafoPanelPipeline(_HeterogenousMetaEstimator, BasePairwiseTransformerPa
             "capability:missing_values:removes", False
         )
 
+        # type of trafo is the same
+        trafo_type = pw_trafo.get_tag("pwtrafo_type", "distance")
+
         # set the pipeline tags to the above
         tags_to_set = {
             "capability:multivariate": multivariate,
             "capability:missing_values": missing,
+            "pwtrafo_type": trafo_type,
         }
         self.set_tags(**tags_to_set)
 

--- a/sktime/dists_kernels/compose_from_align.py
+++ b/sktime/dists_kernels/compose_from_align.py
@@ -4,7 +4,7 @@ __author__ = ["fkiraly"]
 
 import numpy as np
 
-from sktime.dists_kernels._base import BasePairwiseTransformerPanel
+from sktime.dists_kernels.base import BasePairwiseTransformerPanel
 
 
 class DistFromAligner(BasePairwiseTransformerPanel):

--- a/sktime/dists_kernels/compose_tab_to_panel.py
+++ b/sktime/dists_kernels/compose_tab_to_panel.py
@@ -10,7 +10,7 @@ __author__ = ["fkiraly"]
 
 import numpy as np
 
-from sktime.dists_kernels._base import (
+from sktime.dists_kernels.base import (
     BasePairwiseTransformer,
     BasePairwiseTransformerPanel,
 )

--- a/sktime/dists_kernels/dist_to_kern.py
+++ b/sktime/dists_kernels/dist_to_kern.py
@@ -48,6 +48,7 @@ class KernelFromDist(BasePairwiseTransformerPanel):
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "capability:unequal_length": True,  # can dist handle unequal length panels?
+        "pwtrafo_type": "kernel",
     }
 
     def __init__(self, dist, dist_diag=None):
@@ -178,6 +179,7 @@ class DistFromKernel(BasePairwiseTransformerPanel):
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "capability:unequal_length": True,  # can dist handle unequal length panels?
+        "pwtrafo_type": "distance",
     }
 
     def __init__(self, kernel):

--- a/sktime/dists_kernels/dist_to_kern.py
+++ b/sktime/dists_kernels/dist_to_kern.py
@@ -4,7 +4,7 @@ __author__ = ["fkiraly"]
 
 import numpy as np
 
-from sktime.dists_kernels._base import BasePairwiseTransformerPanel
+from sktime.dists_kernels.base import BasePairwiseTransformerPanel
 
 SUPPORTED_MTYPES = ["pd-multiindex", "nested_univ", "df-list", "numpy3D"]
 

--- a/sktime/dists_kernels/dtw.py
+++ b/sktime/dists_kernels/dtw.py
@@ -7,7 +7,7 @@ from typing import Union
 import numpy as np
 
 from sktime.distances import pairwise_distance
-from sktime.dists_kernels._base import BasePairwiseTransformerPanel
+from sktime.dists_kernels.base import BasePairwiseTransformerPanel
 
 
 class DtwDist(BasePairwiseTransformerPanel):

--- a/sktime/dists_kernels/dummy.py
+++ b/sktime/dists_kernels/dummy.py
@@ -4,7 +4,7 @@ __author__ = ["fkiraly"]
 
 import numpy as np
 
-from sktime.dists_kernels._base import BasePairwiseTransformerPanel
+from sktime.dists_kernels.base import BasePairwiseTransformerPanel
 
 SUPPORTED_MTYPES = ["df-list", "nested_univ", "numpy3D"]
 

--- a/sktime/dists_kernels/edit_dist.py
+++ b/sktime/dists_kernels/edit_dist.py
@@ -7,7 +7,7 @@ from typing import Union
 import numpy as np
 
 from sktime.distances import pairwise_distance
-from sktime.dists_kernels._base import BasePairwiseTransformerPanel
+from sktime.dists_kernels.base import BasePairwiseTransformerPanel
 
 
 class EditDist(BasePairwiseTransformerPanel):

--- a/sktime/dists_kernels/indep.py
+++ b/sktime/dists_kernels/indep.py
@@ -4,7 +4,7 @@ __author__ = ["fkiraly"]
 
 import numpy as np
 
-from sktime.dists_kernels._base import BasePairwiseTransformerPanel
+from sktime.dists_kernels.base import BasePairwiseTransformerPanel
 
 SUPPORTED_MTYPES = ["pd-multiindex", "nested_univ"]
 
@@ -77,10 +77,12 @@ class IndepDist(BasePairwiseTransformerPanel):
         if isinstance(dist, BasePairwiseTransformerPanel):
             missing = missing and dist.get_tag("capability:missing_values")
             unequal = unequal and dist.get_tag("capability:unequal_length")
+            pw_type = unequal = unequal and dist.get_tag("pwtrafo_type")
 
         tag_dict = {
             "capability:missing_values": missing,
             "capability:unequal_length": unequal,
+            "pwtrafo_type": pw_type,
         }
 
         self.set_tags(**tag_dict)

--- a/sktime/dists_kernels/scipy_dist.py
+++ b/sktime/dists_kernels/scipy_dist.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from scipy.spatial.distance import cdist
 
-from sktime.dists_kernels._base import BasePairwiseTransformer
+from sktime.dists_kernels.base import BasePairwiseTransformer
 
 
 class ScipyDist(BasePairwiseTransformer):

--- a/sktime/dists_kernels/signature_kernel.py
+++ b/sktime/dists_kernels/signature_kernel.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy.sparse.linalg import svds
 from sklearn.base import BaseEstimator, TransformerMixin
 
-from sktime.dists_kernels._base import BasePairwiseTransformerPanel
+from sktime.dists_kernels.base import BasePairwiseTransformerPanel
 
 # cumsum varia
 # ------------
@@ -903,7 +903,7 @@ class SignatureKernel(BasePairwiseTransformerPanel):
         Journal of Machine Learning Research.
     """
 
-    _tags = {"X_inner_mtype": "numpy3D"}
+    _tags = {"X_inner_mtype": "numpy3D", "pwtrafo_type": "kernel"}
 
     def __init__(
         self,

--- a/sktime/registry/_base_classes.py
+++ b/sktime/registry/_base_classes.py
@@ -61,7 +61,7 @@ from sktime.base import BaseEstimator, BaseObject
 from sktime.classification.base import BaseClassifier
 from sktime.classification.early_classification import BaseEarlyClassifier
 from sktime.clustering.base import BaseClusterer
-from sktime.dists_kernels._base import (
+from sktime.dists_kernels.base import (
     BasePairwiseTransformer,
     BasePairwiseTransformerPanel,
 )

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -104,6 +104,12 @@ ESTIMATOR_TAG_REGISTER = [
         "is the transformer symmetric, i.e., t(x,y)=t(y,x) always?",
     ),
     (
+        "pwtrafo_type",
+        ["transformer-pairwise", "transformer-pairwise-panel"],
+        ("str", ["distance", "kernel", "other"]),
+        "mathematical type of pairwise transformer - distance, kernel, or other",
+    ),
+    (
         "scitype:X",
         "param_est",
         "str",

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -23,7 +23,7 @@ from sklearn.utils.estimator_checks import (
 
 from sktime.base import BaseEstimator, BaseObject, load
 from sktime.classification.deep_learning.base import BaseDeepClassifier
-from sktime.dists_kernels._base import (
+from sktime.dists_kernels.base import (
     BasePairwiseTransformer,
     BasePairwiseTransformerPanel,
 )


### PR DESCRIPTION
This PR makes improvements to the distances/kernels module:

* addition of a tag `"pwtrafo_type"` to distances/kernels, which tells the user whether it is (mathematically) a distance or a kernel, in the ML sense
* moves the `_base` module into a `base` folder and updates references, to bring the module in line with all others