### PR TITLE
[BUG] Refit forecaster if fh is different

### DIFF
--- a/sktime/forecasting/reconcile.py
+++ b/sktime/forecasting/reconcile.py
@@ -176,7 +176,12 @@ class ReconcilerForecaster(BaseForecaster):
         fh_resid = ForecastingHorizon(
             y.index.get_level_values(-1).unique(), is_relative=False
         )
-        self.residuals_ = y - self.forecaster_.predict(fh=fh_resid, X=X)
+
+        if np.array_equal(self._fh, fh_resid):
+            self.residuals_ = y - self.forecaster_.predict(fh=fh_resid, X=X)
+        else:
+            forecaster_resid = self.forecaster_.clone().fit(y=y, X=X, fh=fh_resid)
+            self.residuals_ = y - forecaster_resid.predict(fh=fh_resid, X=X)
 
         # now define recon matrix
         if self.method == "mint_cov":
@@ -271,7 +276,13 @@ class ReconcilerForecaster(BaseForecaster):
         fh_resid = ForecastingHorizon(
             y.index.get_level_values(-1).unique(), is_relative=False
         )
-        update_residuals = y - self.forecaster_.predict(fh=fh_resid, X=X)
+
+        if np.array_equal(self._fh, fh_resid):
+            update_residuals = y - self.forecaster_.predict(fh=fh_resid, X=X)
+        else:
+            forecaster_resid = self.forecaster_.clone().fit(y=y, X=X, fh=fh_resid)
+            update_residuals = y - forecaster_resid.predict(fh=fh_resid, X=X)
+
         self.residuals_ = pd.concat([self.residuals_, update_residuals], axis=0)
         self.residuals_ = self.residuals_.sort_index()
 


### PR DESCRIPTION
#### Reference Issues/PRs
As discussed here: https://github.com/sktime/sktime/issues/3479#issuecomment-1667230141

#### What does this implement/fix? Explain your changes.
Before this change, attempting to use `ReconcilerForecaster` with a forecaster that took `fh` in `fit` resulted in an error as `ReconcilerForecaster` would attempt to call `.predict` with a different `fh` to get residuals.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
@fkiraly you mentioned I could check the forecaster tag `requires-fh-in-fit`, and if `False` there's no need to refit the forecaster. But what about the case where `fh` isn't _required_ in `fit`, but was passed by the user anyway. Would that still create an error?

#### Did you add any tests for the change?
Not yet, can I get some guidance on how to test that it handles something that "requires fh in fit"? What's the simplest built-in forecaster that requires this?

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
