### PR TITLE
[ENH] Add DropNA transformer

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2286,6 +2286,16 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "hliebert",
+      "name": "Helge Liebert",
+      "avatar_url": "https://avatars.githubusercontent.com/u/20834265",
+      "profile": "https://github.com/hliebert",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ]
 }

--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -418,7 +418,7 @@ Binning and segmentation
     IntervalSegmenter
     RandomIntervalSegmenter
 
-Missing value imputation
+Missing value treatment
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: sktime.transformations.series.impute
@@ -427,6 +427,7 @@ Missing value imputation
     :toctree: auto_generated/
     :template: class.rst
 
+    DropNA
     Imputer
 
 Seasonality and Date-Time Features

--- a/sktime/transformations/series/dropna.py
+++ b/sktime/transformations/series/dropna.py
@@ -108,13 +108,18 @@ class DropNA(BaseTransformer):
 
     def _check_thresh(self, thresh, how):
         """Check thresh parameter, should be a valid value as per docstring."""
-        if not isinstance(thresh, self.VALID_THRESH_TYPES):
+        if not isinstance(thresh, self.VALID_THRESH_TYPES) or isinstance(thresh, bool):
             raise TypeError(
                 f'invalid thresh parameter value encountered: "{thresh}", '
-                f"thresh must be of type: {self.VALID_HOW_VALUES}"
+                f"thresh must be of type: {self.VALID_THRESH_TYPES}"
             )
-        if isinstance(thresh, float) and not (0 < thresh < 1):
-            raise ValueError("thresh must be a fraction between zero and one")
+        if (isinstance(thresh, int) and not (thresh > 0)) or (
+            isinstance(thresh, float) and not (0 < thresh < 1)
+        ):
+            raise ValueError(
+                "thresh must be positive integer or a fraction between zero and one"
+            )
+
         if (how is not None) and (thresh is not None):
             raise TypeError("thresh cannot be set together with how")
 

--- a/sktime/transformations/series/dropna.py
+++ b/sktime/transformations/series/dropna.py
@@ -32,7 +32,9 @@ class DropNA(BaseTransformer):
     thresh : int or float, optional
          If int, require at least that many non-NA values (as in pandas.dropna).
          If float, minimum share of non-NA values for rows/columns to be
-         retained. Cannot be combined with how.
+         retained. Fraction must be contained within (0,1]. Setting fraction
+         to 1.0 is equivalent to setting how='any'. thresh cannot be combined
+         with how.
 
     remember : bool, default False if axis==0, True if axis==1
         If True, drops the same rows/columns in transform as in fit. If false,
@@ -114,7 +116,7 @@ class DropNA(BaseTransformer):
                 f"thresh must be of type: {self.VALID_THRESH_TYPES}"
             )
         if (isinstance(thresh, int) and not (thresh > 0)) or (
-            isinstance(thresh, float) and not (0 < thresh < 1)
+            isinstance(thresh, float) and not (0 < thresh <= 1)
         ):
             raise ValueError(
                 "thresh must be positive integer or a fraction between zero and one"

--- a/sktime/transformations/series/dropna.py
+++ b/sktime/transformations/series/dropna.py
@@ -239,7 +239,6 @@ class DropNA(BaseTransformer):
             {"axis": 1, "how": "all", "thresh": None},
             {"axis": 0, "how": None, "thresh": 0.9},
             {"axis": 1, "how": None, "thresh": 0.9},
-            {"axis": 0, "how": None, "thresh": 3},
             {"axis": 1, "how": None, "thresh": 3},
         ]
 

--- a/sktime/transformations/series/dropna.py
+++ b/sktime/transformations/series/dropna.py
@@ -109,7 +109,7 @@ class DropNA(BaseTransformer):
     def _check_thresh(self, thresh, how):
         """Check thresh parameter, should be a valid value as per docstring."""
         if not isinstance(thresh, self.VALID_THRESH_TYPES):
-            raise ValueError(
+            raise TypeError(
                 f'invalid thresh parameter value encountered: "{thresh}", '
                 f"thresh must be of type: {self.VALID_HOW_VALUES}"
             )
@@ -123,7 +123,7 @@ class DropNA(BaseTransformer):
     def _check_remember(self, remember):
         """Check remember parameter, should be a valid type as per docstring."""
         if not isinstance(remember, self.VALID_REMEMBER_TYPES):
-            raise ValueError(
+            raise TypeError(
                 f'invalid remember parameter value encountered: "{remember}", '
                 f"remember must be of type: {self.VALID_REMEMBER_TYPES}"
             )
@@ -159,7 +159,7 @@ class DropNA(BaseTransformer):
             mask = X.count(axis=self._agg_axis) < self._thresh
         elif isinstance(self._thresh, float):
             mask = (
-                X.count(axis=self._agg_axis).div(X.shape[self._agg_axis]) < self._thresh
+                X.notna().mean(axis=self._agg_axis) < self._thresh
             )
 
         if mask is not None:
@@ -200,7 +200,7 @@ class DropNA(BaseTransformer):
                 return X
         else:
             if isinstance(thresh, float):
-                mask = X.count(axis=agg_axis).div(X.shape[agg_axis]) < thresh
+                mask = X.notna().mean(axis=agg_axis) < thresh
                 index_to_drop = mask.index[mask]
                 return X.drop(labels=index_to_drop, axis=axis)
             elif isinstance(thresh, int):

--- a/sktime/transformations/series/dropna.py
+++ b/sktime/transformations/series/dropna.py
@@ -231,6 +231,8 @@ class DropNA(BaseTransformer):
             {"axis": 0, "how": "all", "thresh": None},
             {"axis": 1, "how": "all", "thresh": None},
             {"axis": 0, "how": None, "thresh": 0.9},
+            {"axis": 1, "how": None, "thresh": 0.9},
+            {"axis": 0, "how": None, "thresh": 3},
             {"axis": 1, "how": None, "thresh": 3},
         ]
 

--- a/sktime/transformations/series/dropna.py
+++ b/sktime/transformations/series/dropna.py
@@ -46,7 +46,7 @@ class DropNA(BaseTransformer):
         "scitype:transform-output": "Series",
         "scitype:instancewise": True,
         "scitype:transform-labels": "None",
-        "X_inner_mtype": "pd.DataFrame",
+        "X_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         "fit_is_empty": False,
         "capability:inverse_transform": False,
         "capability:unequal_length": True,

--- a/sktime/transformations/series/dropna.py
+++ b/sktime/transformations/series/dropna.py
@@ -1,0 +1,210 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Transformer to drop rows or columns containing missing values."""
+
+__author__ = ["hliebert"]
+
+from sktime.transformations.base import BaseTransformer
+
+
+class DropNA(BaseTransformer):
+    """Drop missing values transformation.
+
+    Drops rows or columns with missing values from X. Mostly wraps
+    pandas.DataFrame.dropna, but allows specifying thresh as a fraction of
+    non-missing observations.
+
+    Parameters
+    ----------
+    axis : {0 or 'index', 1 or 'columns'}, default 0
+        Determine if rows or columns which contain missing values are removed.
+        Must be 0 or 'index' for univariate input.
+
+        * 0, or 'index' : Drop rows which contain missing values.
+        * 1, or 'columns' : Drop columns which contain missing value.
+
+    how : {'any', 'all'}, default 'any'
+        Determine if row or column is removed from DataFrame, when we have
+        at least one NA or all NA.
+
+        * 'any' : If any NA values are present, drop that row or column.
+        * 'all' : If all values are NA, drop that row or column.
+
+    thresh : int or float, optional
+         If int, require that many non-NA values (as in pandas.dropna). If
+         float, share of non-NA values for rows or columns to be retained.
+         Cannot be combined with how.
+    """
+
+    _tags = {
+        "univariate-only": False,
+        "scitype:transform-input": "Series",
+        "scitype:transform-output": "Series",
+        "scitype:instancewise": True,
+        "scitype:transform-labels": "None",
+        "X_inner_mtype": "pd.DataFrame",
+        "fit_is_empty": False,
+        "capability:inverse_transform": False,
+        "capability:unequal_length": True,
+        "handles-missing-data": False,
+    }
+
+    VALID_AXIS_VALUES = [0, "index", 1, "columns"]
+    VALID_HOW_VALUES = [None, "any", "all"]
+    VALID_THRESH_TYPES = (type(None), int, float)
+
+    def __init__(self, axis=0, how=None, thresh=None):
+        self.axis = self._check_axis(axis)
+        self.how = self._check_how(how)
+        self.thresh = self._check_thresh(thresh, how)
+        super().__init__()
+
+        # use numeric axis internally
+        if self.axis == "index":
+            self._axis = 0
+        elif self.axis == "columns":
+            self._axis = 1
+        else:
+            self._axis = self.axis
+
+        # set default for criterion, default to "any" if neither how nor thresh passed
+        if (self.how is None) and (self.thresh is None):
+            self._how = "any"
+        else:
+            self._how = how
+
+        self._thresh = self.thresh
+
+    def _check_axis(self, axis):
+        """Check axis parameter, should be a valid string as per docstring."""
+        if axis not in self.VALID_AXIS_VALUES:
+            raise ValueError(
+                f'invalid axis parameter value encountered: "{axis}", '
+                f"axis must be one of: {self.VALID_AXIS_VALUES}"
+            )
+
+        return axis
+
+    def _check_how(self, how):
+        """Check how parameter, should be a valid string as per docstring."""
+        if how not in self.VALID_HOW_VALUES:
+            raise ValueError(
+                f'invalid how parameter value encountered: "{how}", '
+                f"how must be one of: {self.VALID_HOW_VALUES}"
+            )
+
+        return how
+
+    def _check_thresh(self, thresh, how):
+        """Check thresh parameter, should be a valid value as per docstring."""
+        if not isinstance(thresh, self.VALID_THRESH_TYPES):
+            raise ValueError(
+                f'invalid thresh parameter value encountered: "{thresh}", '
+                f"thresh must be of type: {self.VALID_HOW_VALUES}"
+            )
+        if isinstance(thresh, float) and not (0 < thresh < 1):
+            raise ValueError("thresh must be a fraction between zero and one")
+        if (how is not None) and (thresh is not None):
+            raise TypeError("thresh cannot be set together with how")
+
+        return thresh
+
+    def _fit(self, X, y=None):
+        """Fit transformer to X and y.
+
+        private _fit containing the core logic, called from fit
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            if self.get_tag("univariate-only")==True:
+                guaranteed to have a single column
+            if self.get_tag("univariate-only")==False: no restrictions apply
+        y : None, present only for interface compatibility
+
+        Returns
+        -------
+        self: reference to self
+        """
+        self.dropped_index_values_ = None
+
+        agg_axis = 1 - self._axis
+
+        mask = None
+        if self._how == "any":
+            mask = X.isna().any(axis=agg_axis)
+        elif self._how == "all":
+            mask = X.isna().all(axis=agg_axis)
+        elif isinstance(self._thresh, int):
+            mask = X.count(axis=agg_axis) < self._thresh
+        elif isinstance(self._thresh, float):
+            mask = X.count(axis=agg_axis).div(X.shape[agg_axis]) < self._thresh
+
+        if mask is not None:
+            self.dropped_index_values_ = mask.index[mask].to_list()
+        else:
+            self.dropped_index_values_ = None
+
+        return self
+
+    def _transform(self, X, y=None):
+        """Transform X and return a transformed version.
+
+        private _transform containing core logic, called from transform
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            if self.get_tag("univariate-only")==True:
+                guaranteed to have a single column
+            if self.get_tag("univariate-only")==False: no restrictions apply
+        y : None, present only for interface compatibility
+
+        Returns
+        -------
+        transformed version of X
+        """
+        dropped_index_values = self.dropped_index_values_
+        axis = self._axis
+
+        if dropped_index_values is not None:
+            return X.drop(labels=dropped_index_values, axis=axis)
+        else:
+            return X
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for transformers.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params = [
+            {"axis": 0, "how": "any", "thresh": None},
+            {"axis": 1, "how": "any", "thresh": None},
+            {"axis": "index", "how": "any", "thresh": None},
+            {"axis": "columns", "how": "any", "thresh": None},
+            {"axis": 0, "how": "all", "thresh": None},
+            {"axis": 1, "how": "all", "thresh": None},
+            {"axis": 0, "how": None, "thresh": 0.9},
+            {"axis": 1, "how": None, "thresh": 0.9},
+            {"axis": 0, "how": None, "thresh": 4},
+            {"axis": 1, "how": None, "thresh": 4},
+            {"axis": 0, "how": None, "thresh": 1.9},
+            {"axis": 1, "how": None, "thresh": 1.9},
+            {"axis": 0, "how": "any", "thresh": 0.9},
+            {"axis": 1, "how": "any", "thresh": 0.9},
+        ]
+
+        return params

--- a/sktime/transformations/series/dropna.py
+++ b/sktime/transformations/series/dropna.py
@@ -30,9 +30,9 @@ class DropNA(BaseTransformer):
         * 'all' : If all values are NA, drop that row or column.
 
     thresh : int or float, optional
-         If int, require that many non-NA values (as in pandas.dropna). If
-         float, share of non-NA values for rows or columns to be retained.
-         Cannot be combined with how.
+         If int, require at least that many non-NA values (as in pandas.dropna).
+         If float, minimum share of non-NA values for rows/columns to be
+         retained. Cannot be combined with how.
 
     remember : bool, default False if axis==0, True if axis==1
         If True, drops the same rows/columns in transform as in fit. If false,
@@ -158,9 +158,7 @@ class DropNA(BaseTransformer):
         elif isinstance(self._thresh, int):
             mask = X.count(axis=self._agg_axis) < self._thresh
         elif isinstance(self._thresh, float):
-            mask = (
-                X.notna().mean(axis=self._agg_axis) < self._thresh
-            )
+            mask = X.notna().mean(axis=self._agg_axis) < self._thresh
 
         if mask is not None:
             self.dropped_index_values_ = mask.index[mask].to_list()

--- a/sktime/transformations/series/dropna.py
+++ b/sktime/transformations/series/dropna.py
@@ -193,18 +193,10 @@ class DropNA(BaseTransformer):
         params = [
             {"axis": 0, "how": "any", "thresh": None},
             {"axis": 1, "how": "any", "thresh": None},
-            {"axis": "index", "how": "any", "thresh": None},
-            {"axis": "columns", "how": "any", "thresh": None},
             {"axis": 0, "how": "all", "thresh": None},
             {"axis": 1, "how": "all", "thresh": None},
             {"axis": 0, "how": None, "thresh": 0.9},
-            {"axis": 1, "how": None, "thresh": 0.9},
-            {"axis": 0, "how": None, "thresh": 4},
-            {"axis": 1, "how": None, "thresh": 4},
-            {"axis": 0, "how": None, "thresh": 1.9},
-            {"axis": 1, "how": None, "thresh": 1.9},
-            {"axis": 0, "how": "any", "thresh": 0.9},
-            {"axis": 1, "how": "any", "thresh": 0.9},
+            {"axis": 1, "how": None, "thresh": 3},
         ]
 
         return params

--- a/sktime/transformations/series/tests/test_dropna.py
+++ b/sktime/transformations/series/tests/test_dropna.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3 -u
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Unit tests of DropNA functionality."""
+
+__author__ = ["hliebert"]
+__all__ = []
+
+import numpy as np
+import pytest
+
+from sktime.datasets import load_longley
+from sktime.transformations.series.dropna import DropNA
+from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
+
+# todo: univariate case (implement check that axis=0 first).
+
+y_few_na, X_few_na = load_longley()
+X_few_na.loc["1947", "GNPDEFL"] = np.nan
+X_few_na.loc["1950", "GNPDEFL"] = np.nan
+X_few_na.loc["1950", "GNP"] = np.nan
+
+X_few_na_expected = {
+    "0": {
+        "None": X_few_na.drop(
+            labels=[
+                "1947",
+                "1950",
+            ],
+            axis=0,
+        ),
+        "any": X_few_na.drop(
+            labels=[
+                "1947",
+                "1950",
+            ],
+            axis=0,
+        ),
+        "all": X_few_na,
+    },
+    "index": {
+        "None": X_few_na.drop(
+            labels=[
+                "1947",
+                "1950",
+            ],
+            axis=0,
+        ),
+        "any": X_few_na.drop(
+            labels=[
+                "1947",
+                "1950",
+            ],
+            axis=0,
+        ),
+        "all": X_few_na,
+    },
+    "1": {
+        "None": X_few_na.drop(
+            labels=[
+                "GNPDEFL",
+                "GNP",
+            ],
+            axis=1,
+        ),
+        "any": X_few_na.drop(
+            labels=[
+                "GNPDEFL",
+                "GNP",
+            ],
+            axis=1,
+        ),
+        "all": X_few_na,
+    },
+    "columns": {
+        "None": X_few_na.drop(
+            labels=[
+                "GNPDEFL",
+                "GNP",
+            ],
+            axis=1,
+        ),
+        "any": X_few_na.drop(
+            labels=[
+                "GNPDEFL",
+                "GNP",
+            ],
+            axis=1,
+        ),
+        "all": X_few_na,
+    },
+}
+
+y_many_na, X_many_na = load_longley()
+X_many_na.loc["1947", "GNPDEFL"] = np.nan
+X_many_na.loc["1950", "GNPDEFL"] = np.nan
+X_many_na.loc["1950", "GNP"] = np.nan
+X_many_na.loc[:, "ARMED"] = np.nan
+X_many_na.loc[:, "POP"] = np.nan
+X_many_na.loc["1960", :] = np.nan
+X_many_na.loc["1962", :] = np.nan
+X_many_na.dropna(axis=1)
+
+X_many_na_expected = {
+    "0": {
+        "None": X_many_na.drop(labels=X_many_na.index, axis=0),
+        "any": X_many_na.drop(labels=X_many_na.index, axis=0),
+        "all": X_many_na.drop(labels=["1960", "1962"]),
+    },
+    "index": {
+        "None": X_many_na.drop(labels=X_many_na.index, axis=0),
+        "any": X_many_na.drop(labels=X_many_na.index, axis=0),
+        "all": X_many_na.drop(labels=["1960", "1962"]),
+    },
+    "1": {
+        "None": X_many_na.drop(labels=X_many_na.columns, axis=1),
+        "any": X_many_na.drop(labels=X_many_na.columns, axis=1),
+        "all": X_many_na.drop(
+            labels=[
+                "ARMED",
+                "POP",
+            ],
+            axis=1,
+        ),
+    },
+    "columns": {
+        "None": X_many_na.drop(labels=X_many_na.columns, axis=1),
+        "any": X_many_na.drop(labels=X_many_na.columns, axis=1),
+        "all": X_many_na.drop(
+            labels=[
+                "ARMED",
+                "POP",
+            ],
+            axis=1,
+        ),
+    },
+}
+
+
+@pytest.mark.parametrize("axis", DropNA.VALID_AXIS_VALUES)
+@pytest.mark.parametrize("how", DropNA.VALID_HOW_VALUES)
+def test_dropna_few_na(axis, how):
+    """Test expected results on a DataFrame with occasional missings."""
+    transformer = DropNA(axis=axis, how=how, thresh=None)
+    X_transformed = transformer.fit_transform(X_few_na)
+    X_expected = X_few_na_expected[str(axis)][str(how)]
+
+    _assert_array_almost_equal(X_transformed, X_expected)
+
+
+@pytest.mark.parametrize("axis", DropNA.VALID_AXIS_VALUES)
+@pytest.mark.parametrize("how", DropNA.VALID_HOW_VALUES)
+def test_dropna_many_na(axis, how):
+    """Test expected results on a DataFrame with complete columns/rows missing."""
+    transformer = DropNA(axis=axis, how=how, thresh=None)
+    X_transformed = transformer.fit_transform(X_many_na)
+    X_expected = X_many_na_expected[str(axis)][str(how)]
+
+    _assert_array_almost_equal(X_transformed, X_expected)
+
+
+@pytest.mark.parametrize("how", ["any", "all"])
+@pytest.mark.parametrize("thresh", [10, 0.5])
+def test_dropna_incompatible_arguments(how, thresh):
+    """Test that how and thresh arguments cannot be both set."""
+    with pytest.raises(TypeError):
+        DropNA(axis=0, how=str(how), thresh=thresh)
+
+
+@pytest.mark.parametrize("how", ["any", "all", "invalid_value"])
+@pytest.mark.parametrize("thresh", [3, 0.9, True, False, "invalid_value", [1, 2, 3]])
+def test_dropna_invalid_arguments(how, thresh):
+    """Test that invalid arguments or combinations thereof are not accepted."""
+    with pytest.raises((TypeError, ValueError)):
+        DropNA(axis=0, how=str(how), thresh=thresh)

--- a/sktime/transformations/series/tests/test_dropna.py
+++ b/sktime/transformations/series/tests/test_dropna.py
@@ -19,71 +19,23 @@ X_few_na.loc["1950", "GNP"] = np.nan
 
 X_few_na_expected = {
     "0": {
-        "None": X_few_na.drop(
-            labels=[
-                "1947",
-                "1950",
-            ],
-            axis=0,
-        ),
-        "any": X_few_na.drop(
-            labels=[
-                "1947",
-                "1950",
-            ],
-            axis=0,
-        ),
+        "None": X_few_na.drop(labels=["1947", "1950"], axis=0),
+        "any": X_few_na.drop(labels=["1947", "1950"], axis=0),
         "all": X_few_na,
     },
     "index": {
-        "None": X_few_na.drop(
-            labels=[
-                "1947",
-                "1950",
-            ],
-            axis=0,
-        ),
-        "any": X_few_na.drop(
-            labels=[
-                "1947",
-                "1950",
-            ],
-            axis=0,
-        ),
+        "None": X_few_na.drop(labels=["1947", "1950"], axis=0),
+        "any": X_few_na.drop(labels=["1947", "1950"], axis=0),
         "all": X_few_na,
     },
     "1": {
-        "None": X_few_na.drop(
-            labels=[
-                "GNPDEFL",
-                "GNP",
-            ],
-            axis=1,
-        ),
-        "any": X_few_na.drop(
-            labels=[
-                "GNPDEFL",
-                "GNP",
-            ],
-            axis=1,
-        ),
+        "None": X_few_na.drop(labels=["GNPDEFL", "GNP"], axis=1),
+        "any": X_few_na.drop(labels=["GNPDEFL", "GNP"], axis=1),
         "all": X_few_na,
     },
     "columns": {
-        "None": X_few_na.drop(
-            labels=[
-                "GNPDEFL",
-                "GNP",
-            ],
-            axis=1,
-        ),
-        "any": X_few_na.drop(
-            labels=[
-                "GNPDEFL",
-                "GNP",
-            ],
-            axis=1,
-        ),
+        "None": X_few_na.drop(labels=["GNPDEFL", "GNP"], axis=1),
+        "any": X_few_na.drop(labels=["GNPDEFL", "GNP"], axis=1),
         "all": X_few_na,
     },
 }
@@ -112,24 +64,12 @@ X_many_na_expected = {
     "1": {
         "None": X_many_na.drop(labels=X_many_na.columns, axis=1),
         "any": X_many_na.drop(labels=X_many_na.columns, axis=1),
-        "all": X_many_na.drop(
-            labels=[
-                "ARMED",
-                "POP",
-            ],
-            axis=1,
-        ),
+        "all": X_many_na.drop(labels=["ARMED", "POP"], axis=1),
     },
     "columns": {
         "None": X_many_na.drop(labels=X_many_na.columns, axis=1),
         "any": X_many_na.drop(labels=X_many_na.columns, axis=1),
-        "all": X_many_na.drop(
-            labels=[
-                "ARMED",
-                "POP",
-            ],
-            axis=1,
-        ),
+        "all": X_many_na.drop(labels=["ARMED", "POP"], axis=1),
     },
 }
 

--- a/sktime/transformations/series/tests/test_dropna.py
+++ b/sktime/transformations/series/tests/test_dropna.py
@@ -12,8 +12,6 @@ from sktime.datasets import load_longley
 from sktime.transformations.series.dropna import DropNA
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 
-# todo: univariate case (implement check that axis=0 first).
-
 y_few_na, X_few_na = load_longley()
 X_few_na.loc["1947", "GNPDEFL"] = np.nan
 X_few_na.loc["1950", "GNPDEFL"] = np.nan

--- a/sktime/transformations/series/tests/test_dropna.py
+++ b/sktime/transformations/series/tests/test_dropna.py
@@ -156,17 +156,38 @@ def test_dropna_many_na(axis, how):
     _assert_array_almost_equal(X_transformed, X_expected)
 
 
+@pytest.mark.parametrize("axis", DropNA.VALID_AXIS_VALUES)
 @pytest.mark.parametrize("how", ["any", "all"])
 @pytest.mark.parametrize("thresh", [10, 0.5])
-def test_dropna_incompatible_arguments(how, thresh):
+@pytest.mark.parametrize("remember", [None, True, False])
+def test_dropna_conflicting_arguments(axis, how, thresh, remember):
     """Test that how and thresh arguments cannot be both set."""
+    with pytest.raises(TypeError, match=r"thresh cannot be set together with how"):
+        DropNA(axis=axis, how=str(how), thresh=thresh)
+
+
+@pytest.mark.parametrize("axis", DropNA.VALID_AXIS_VALUES)
+@pytest.mark.parametrize("how", [True, False, "invalid_value", [1, 2, 3]])
+@pytest.mark.parametrize("remember", [None, True, False])
+def test_dropna_invalid_arguments_how(axis, how, remember):
+    """Test that invalid arguments for how are not accepted."""
+    with pytest.raises(ValueError):
+        DropNA(axis=axis, how=how, thresh=None, remember=remember)
+
+
+@pytest.mark.parametrize("axis", DropNA.VALID_AXIS_VALUES)
+@pytest.mark.parametrize("thresh", [True, False, "invalid_value", [1, 2, 3]])
+@pytest.mark.parametrize("remember", [None, True, False])
+def test_dropna_invalid_arguments_thresh_type(axis, thresh, remember):
+    """Test that invalid arguments for thresh are not accepted."""
     with pytest.raises(TypeError):
-        DropNA(axis=0, how=str(how), thresh=thresh)
+        DropNA(axis=axis, how=None, thresh=thresh, remember=remember)
 
 
-@pytest.mark.parametrize("how", ["any", "all", "invalid_value"])
-@pytest.mark.parametrize("thresh", [3, 0.9, True, False, "invalid_value", [1, 2, 3]])
-def test_dropna_invalid_arguments(how, thresh):
-    """Test that invalid arguments or combinations thereof are not accepted."""
-    with pytest.raises((TypeError, ValueError)):
-        DropNA(axis=0, how=str(how), thresh=thresh)
+@pytest.mark.parametrize("axis", DropNA.VALID_AXIS_VALUES)
+@pytest.mark.parametrize("thresh", [-5, -3.5, 1.5])
+@pytest.mark.parametrize("remember", [None, True, False])
+def test_dropna_invalid_arguments_thresh_value(axis, thresh, remember):
+    """Test that arguments outside sensible range for thresh are not accepted."""
+    with pytest.raises(ValueError):
+        DropNA(axis=axis, how=None, thresh=thresh)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #4977.

#### What does this implement/fix? Explain your changes.
Implements a `DropNA` transformer that saves the dropped index/column names from `fit`.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
Any feedback is appreciated. This is mostly a thin wrapper around `pd.DataFrame.dropna`, accepting the arguments `axis`, `how`, and `thresh`, defaulting to `axis=0` and `how=any`. With univariate series, only `axis=0` will work. 

I am validating the inputs to some degree and I've extended the `thresh` argument to also accept a fraction of non-NA values (pandas only accepts counts). I've always found the pandas default of specifying the threshold in terms of non-NA values strange (as opposed to specifying NA values) , but I've left it as is to be consistent. Thoughts on this?

#### Did you add any tests for the change?
I've added a couple of tests for the functionality and to make sure the parameter validation works. I haven't added any tests with a univariate series so far.

#### Any other comments?
Any feedback is appreciated.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

