### PR TITLE
[ENH] speed up parameter fitter base class boilerplate

### DIFF
--- a/sktime/datatypes/_convert.py
+++ b/sktime/datatypes/_convert.py
@@ -101,8 +101,9 @@ def convert(
     obj : object to convert - any type, should comply with mtype spec for as_scitype
     from_type : str - the type to convert "obj" to, a valid mtype string
         valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
-    to_type : str - the type to convert "obj" to, a valid mtype string
-        valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
+    to_type : str - the mtype to convert "obj" to, a valid mtype string
+        or list of str, this specifies admissible types for conversion to;
+        if list, will convert to first mtype of the same scitype as from_mtype
     as_scitype : str, optional - name of scitype the object "obj" is considered as
         default = inferred from from_type
         valid scitype strings, with explanation, are in datatypes.SCITYPE_REGISTER
@@ -127,9 +128,14 @@ def convert(
     if obj is None:
         return None
 
+    # if to_type is a list, we do the following:
+    # if on the list, then don't do a conversion (convert to from_type)
+    # if not on the list, we find and convert to first mtype that has same scitype
+    to_type = _get_first_mtype_of_same_scitype(
+        from_mtype=from_type, to_mtypes=to_type, varname="to_type"
+    )
+
     # input type checks
-    if not isinstance(to_type, str):
-        raise TypeError("to_type must be a str")
     if not isinstance(from_type, str):
         raise TypeError("from_type must be a str")
     if as_scitype is None:
@@ -186,8 +192,9 @@ def convert_to(
     Parameters
     ----------
     obj : object to convert - any type, should comply with mtype spec for as_scitype
-    to_type : str - the type to convert "obj" to, a valid mtype string
-            or list of str, this specifies admissible types for conversion to
+    to_type : str - the mtype to convert "obj" to, a valid mtype string
+        or list of str, this specifies admissible types for conversion to;
+        if list, will convert to first mtype of the same scitype as obj
         valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
     as_scitype : str, optional - name of scitype the object "obj" is considered as
         pre-specifying the scitype reduces the number of checks done in type inference
@@ -240,25 +247,6 @@ def convert_to(
     from_type = infer_mtype(obj=obj, as_scitype=as_scitype)
     as_scitype = mtype_to_scitype(from_type)
 
-    # if to_type is a list, we do the following:
-    # if on the list, then don't do a conversion (convert to from_type)
-    # if not on the list, we find and convert to first mtype that has same scitype
-    if isinstance(to_type, list):
-        # no conversion of from_type is in the list
-        if from_type in to_type:
-            to_type = from_type
-        # otherwise convert to first element of same scitype
-        else:
-            same_scitype_mtypes = [
-                mtype for mtype in to_type if mtype_to_scitype(mtype) == as_scitype
-            ]
-            if len(same_scitype_mtypes) == 0:
-                raise TypeError(
-                    "to_type contains no mtype compatible with the scitype of obj,"
-                    f"which is {as_scitype}"
-                )
-            to_type = same_scitype_mtypes[0]
-
     converted_obj = convert(
         obj=obj,
         from_type=from_type,
@@ -269,6 +257,42 @@ def convert_to(
     )
 
     return converted_obj
+
+
+def _get_first_mtype_of_same_scitype(from_mtype, to_mtypes, varname="to_mtypes"):
+    """Return first mtype in list mtypes that has same scitype as from_mtype.
+
+    Parameters
+    ----------
+    from_mtype : str - mtype of object to convert from
+    to_mtypes : list of str - mtypes to convert to
+    varname : str - name of variable to_mtypes, for error message
+
+    Returns
+    -------
+    to_type : str - first mtype in to_mtypes that has same scitype as from_mtype
+    """
+    if isinstance(to_mtypes, str):
+        return to_mtypes
+
+    if not isinstance(to_mtypes, list):
+        raise TypeError(f"{varname} must be a str or a list of str")
+
+    # no conversion of from_type is in the list
+    if from_mtype in to_mtypes:
+        return from_mtype
+    # otherwise convert to first element of same scitype
+    scitype = mtype_to_scitype(from_mtype)
+    same_scitype_mtypes = [
+        mtype for mtype in to_mtypes if mtype_to_scitype(mtype) == scitype
+    ]
+    if len(same_scitype_mtypes) == 0:
+        raise TypeError(
+            f"{varname} contains no mtype compatible with the scitype of obj,"
+            f"which is {scitype}"
+        )
+    to_type = same_scitype_mtypes[0]
+    return to_type
 
 
 def _conversions_defined(scitype: str):

--- a/sktime/param_est/base.py
+++ b/sktime/param_est/base.py
@@ -27,7 +27,7 @@ from sktime.base import BaseEstimator
 from sktime.datatypes import (
     VectorizedDF,
     check_is_scitype,
-    convert_to,
+    convert,
     scitype_to_mtype,
     update_data,
 )
@@ -271,11 +271,13 @@ class BaseParamFitter(BaseEstimator):
         if not X_valid:
             raise TypeError(msg + mtypes_msg)
         X_scitype = X_metadata["scitype"]
+        X_mtype = X_metadata["mtype"]
         # end checking X
 
         # converts X, converts None to None if X is None
-        X_inner = convert_to(
+        X_inner = convert(
             X,
+            from_type=X_mtype,
             to_type=X_inner_mtype,
             as_scitype=X_scitype,
         )

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -58,6 +58,7 @@ from sktime.datatypes import (
     VectorizedDF,
     check_is_mtype,
     check_is_scitype,
+    convert,
     convert_to,
     mtype_to_scitype,
     update_data,
@@ -927,6 +928,7 @@ class BaseTransformer(BaseEstimator):
 
         # checking X
         X_metadata_required = ["is_univariate"]
+
         X_valid, msg, X_metadata = check_is_scitype(
             X,
             scitype=ALLOWED_SCITYPES,
@@ -998,6 +1000,7 @@ class BaseTransformer(BaseEstimator):
                 raise TypeError("y " + msg_invalid_input)
 
             y_scitype = y_metadata["scitype"]
+            y_mtype = y_metadata["mtype"]
 
         else:
             # y_scitype is used below - set to None if y is None
@@ -1023,7 +1026,9 @@ class BaseTransformer(BaseEstimator):
                 as_scitype = "Panel"
             else:
                 as_scitype = "Hierarchical"
-            X = convert_to_scitype(X, to_scitype=as_scitype, from_scitype=X_scitype)
+            X, X_mtype = convert_to_scitype(
+                X, to_scitype=as_scitype, from_scitype=X_scitype, return_to_mtype=True
+            )
             X_scitype = as_scitype
             # then pass to case 1, which we've reduced to, X now has inner scitype
 
@@ -1032,8 +1037,9 @@ class BaseTransformer(BaseEstimator):
         #   and does not require vectorization because of cols (multivariate)
         if not requires_vectorization:
             # converts X
-            X_inner = convert_to(
+            X_inner = convert(
                 X,
+                from_type=X_mtype,
                 to_type=X_inner_mtype,
                 store=metadata["_converter_store_X"],
                 store_behaviour="reset",
@@ -1041,8 +1047,9 @@ class BaseTransformer(BaseEstimator):
 
             # converts y, returns None if y is None
             if y_inner_mtype != ["None"] and y is not None:
-                y_inner = convert_to(
+                y_inner = convert(
                     y,
+                    from_type=y_mtype,
                     to_type=y_inner_mtype,
                     as_scitype=y_scitype,
                 )
@@ -1145,11 +1152,17 @@ class BaseTransformer(BaseEstimator):
             #   we cannot convert back to pd.Series, do pd.DataFrame instead then
             #   this happens only for Series, not Panel
             if X_input_scitype == "Series":
+                if X_input_mtype == "pd.Series":
+                    Xt_metadata_required = ["is_univariate"]
+                else:
+                    Xt_metadata_required = []
+
                 valid, msg, metadata = check_is_mtype(
                     Xt,
                     ["pd.DataFrame", "pd.Series", "np.ndarray"],
-                    return_metadata=True,
+                    return_metadata=Xt_metadata_required,
                 )
+
                 if not valid:
                     raise TypeError(
                         f"_transform output of {type(self)} does not comply "
@@ -1157,9 +1170,20 @@ class BaseTransformer(BaseEstimator):
                         " for mtype specifications. Returned error message:"
                         f" {msg}. Returned object: {Xt}"
                     )
-                if not metadata["is_univariate"] and X_input_mtype == "pd.Series":
+                if X_input_mtype == "pd.Series" and not metadata["is_univariate"]:
                     X_output_mtype = "pd.DataFrame"
+                # Xt_mtype = metadata["mtype"]
+            # else:
+            #     Xt_mtype = X_input_mtype
 
+            # Xt = convert(
+            #     Xt,
+            #     from_type=Xt_mtype,
+            #     to_type=X_output_mtype,
+            #     as_scitype=X_input_scitype,
+            #     store=_converter_store_X,
+            #     store_behaviour="freeze",
+            # )
             Xt = convert_to(
                 Xt,
                 to_type=X_output_mtype,


### PR DESCRIPTION
This PR speeds up the parameter fitter base class boilerplate by avoiding to carry out mtype checks twice.

This is achieved by replacing one instance of `convert_to` (which checks the mtype, redundant to `check_is_mtype`), by an equivalent instance of `convert`, using the mtype output of `check_is_mtype`.

Related:
https://github.com/sktime/sktime/discussions/5056
https://github.com/sktime/sktime/pull/5036

Depends on https://github.com/sktime/sktime/pull/5036 due to the changes to `convert` being common to both speed-ups.