### PR TITLE
[ENH] add speed test for negative `check_is_mtype` outcomes

### DIFF
--- a/sktime/datatypes/tests/test_check.py
+++ b/sktime/datatypes/tests/test_check.py
@@ -2,6 +2,8 @@
 
 __author__ = ["fkiraly"]
 
+from time import time
+
 import numpy as np
 
 from sktime.datatypes._check import (
@@ -317,19 +319,23 @@ def test_check_negative(scitype, mtype):
 
             # check fixtures that exist against checks that exist
             if fixture_wrong_type is not None and check_is_defined:
-                assert not check_is_mtype(fixture_wrong_type, mtype, scitype), (
+
+                start_time = time()
+                result = check_is_mtype(
+                    fixture_wrong_type, mtype, scitype, return_metadata=[]
+                )[0]
+                end_time = time()
+                duration = end_time - start_time
+
+                assert not result, (
                     f"check_is_mtype {mtype} returns True "
                     f"on {wrong_mtype} fixture {i}"
                 )
 
-            # check fixtures that exist against checks that exist
-            if fixture_wrong_type is not None and check_is_defined:
-                result = check_is_mtype(
-                    fixture_wrong_type, mtype, scitype, return_metadata=[]
-                )[0]
-                assert not result, (
-                    f"check_is_mtype {mtype} returns True "
-                    f"on {wrong_mtype} fixture {i}"
+                assert duration < 1e-5, (
+                    f"negative check by check_is_mtype {mtype} on "
+                    f"{wrong_mtype} fixture {i} took too long - negative check "
+                    f"duration should be < 1e-5 secs, but took {duration} secs"
                 )
 
 


### PR DESCRIPTION
This adds a max duration check on `test_check_negative`, which tests uses of `check_is_mtype` with an expected negative outcome, on other `mtype`-s.

The max duration is set to `1e-5` seconds, as on examples of other mtypes the negative result should be identifiable from one or few type checks which should take orders of magnitude less.

Also removes what looks like an accidental merge-duplication in `test_check_negative` that led to carrying out the test twice.