### PR TITLE
[BUG] in `craft`, fix false positive detection of `True`, `False` as class names

### DIFF
--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -35,9 +35,18 @@ def _extract_class_names(spec):
     -------
     cls_name_list : list of str
         list of all maximal alphanumeric substrings starting with a capital in ``spec``
+        excluding reserved expressions True, False (if they occur)
     """
+    # class names are all UpperCamelCase alphanumeric strings
+    # which is the same as maximal substrings starting with a capital
     pattern = r"\b([A-Z][A-Za-z0-9_]*)\b"
     cls_name_list = re.findall(pattern, spec)
+
+    # we need to exclude expressions that look like classes per the regex
+    # but aren't
+    EXCLUDE_LIST = ["True", "False"]
+    cls_name_list = [x for x in cls_name_list if x not in EXCLUDE_LIST]
+
     return cls_name_list
 
 


### PR DESCRIPTION
This PR fixes an unreported bug in the `craft` utility, which incorrectly identified reserved expressions `True`, `False`, as class names as they were `UpperCamelCase`.

The fix simply hard codes an exclusion of reserved expressions `True`, `False`.

Afaik there are also no further reserved expressions which look like class names.

Tested indirectly in https://github.com/sktime/sktime/pull/5058 which initially failed due to an example that included `True`.