### PR TITLE
[BUG] fix wrong logic for `index_out="shift"` in `Lag` transformer

### DIFF
--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -248,7 +248,7 @@ class Lag(BaseTransformer):
                 Xt = Xt.loc[X_orig_idx]
             # sub-set to shifted index, if "shifted"
             # this is necessary, because we added indices from _X above
-            if index_out == "shifted":
+            if index_out == "shift":
                 Xt = Xt.loc[X_orig_idx_shifted]
 
             Xt_list.append(Xt)

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -246,7 +246,7 @@ class Lag(BaseTransformer):
             # sub-set to original, if "original"
             if index_out == "original":
                 Xt = Xt.loc[X_orig_idx]
-            # sub-set to shifted index, if "shifted"
+            # sub-set to shifted index, if "shift"
             # this is necessary, because we added indices from _X above
             if index_out == "shift":
                 Xt = Xt.loc[X_orig_idx_shifted]

--- a/sktime/transformations/series/tests/test_lag.py
+++ b/sktime/transformations/series/tests/test_lag.py
@@ -47,6 +47,23 @@ def test_lag_fit_transform_out_index(X, index_out):
 
 @pytest.mark.parametrize("X", X_fixtures)
 @pytest.mark.parametrize("index_out", index_outs)
+def test_lag_fit_transform_out_values(X, index_out):
+    """Test that index sets of fit_transform output behave as expected."""
+    t = Lag(2, index_out=index_out)
+    X_fit = X[:2]
+    X_trafo = X[2:]
+    Xt = t.fit(X_fit).transform(X_trafo)
+
+    if index_out in ["original", "extend"]:
+        assert all(Xt.iloc[0].values == X_fit.iloc[0].values)
+        assert all(Xt.iloc[2].values == X_trafo.iloc[0].values)
+
+    elif index_out == "shift":
+        assert all(Xt.values == X_trafo.values)
+
+
+@pytest.mark.parametrize("X", X_fixtures)
+@pytest.mark.parametrize("index_out", index_outs)
 @pytest.mark.parametrize("lag", [2, [2, 4], [-1, 0, 5]])
 def test_lag_fit_transform_columns(X, index_out, lag):
     """Test that columns of fit_transform output behave as expected."""

--- a/sktime/transformations/series/tests/test_lag.py
+++ b/sktime/transformations/series/tests/test_lag.py
@@ -42,6 +42,7 @@ def test_lag_fit_transform_out_index(X, index_out):
     elif index_out == "shift":
         assert len(Xt) == len(X)
         assert X.index[2:].isin(Xt.index).all()
+        assert not X.index[:2].isin(Xt.index).any()
 
 
 @pytest.mark.parametrize("X", X_fixtures)

--- a/sktime/transformations/series/tests/test_lag.py
+++ b/sktime/transformations/series/tests/test_lag.py
@@ -15,7 +15,7 @@ from sktime.utils._testing.series import _make_series
 # some examples with range vs time index, univariate vs multivariate (mv)
 X_range_idx = get_examples("pd.DataFrame")[0]
 X_range_idx_mv = get_examples("pd.DataFrame")[1]
-X_time_idx = pd.DataFrame(_make_series())
+X_time_idx = _make_series()
 X_time_idx_mv = _make_series(n_columns=2)
 
 # all fixtures
@@ -50,6 +50,8 @@ def test_lag_fit_transform_out_index(X, index_out):
 def test_lag_fit_transform_out_values(X, index_out):
     """Test that index sets of fit_transform output behave as expected."""
     t = Lag(2, index_out=index_out)
+    if isinstance(X, pd.Series):
+        X = pd.DataFrame(X)
     X_fit = X[:2]
     X_trafo = X[2:]
     Xt = t.fit(X_fit).transform(X_trafo)

--- a/sktime/transformations/series/tests/test_lag.py
+++ b/sktime/transformations/series/tests/test_lag.py
@@ -5,6 +5,7 @@ __author__ = ["fkiraly"]
 
 import itertools
 
+import numpy as np
 import pandas as pd
 import pytest
 

--- a/sktime/transformations/series/tests/test_lag.py
+++ b/sktime/transformations/series/tests/test_lag.py
@@ -57,12 +57,12 @@ def test_lag_fit_transform_out_values(X, index_out):
     Xt = t.fit(X_fit).transform(X_trafo)
 
     if index_out in ["original", "extend"]:
-        assert all(Xt.iloc[0].values == X_fit.iloc[0].values)
+        np.testing.assert_equal(Xt.iloc[2].values, X_fit.iloc[0].values)
         if len(Xt) > 2:
-            assert all(Xt.iloc[2].values == X_trafo.iloc[0].values)
+            np.testing.assert_equal(Xt.iloc[2].values, X_trafo.iloc[0].values)
 
     elif index_out == "shift":
-        assert (Xt.values == X_trafo.values).all()
+        np.testing.assert_equal(Xt.values, X_trafo.values).all()
 
 
 @pytest.mark.parametrize("X", X_fixtures)

--- a/sktime/transformations/series/tests/test_lag.py
+++ b/sktime/transformations/series/tests/test_lag.py
@@ -58,12 +58,12 @@ def test_lag_fit_transform_out_values(X, index_out):
     Xt = t.fit(X_fit).transform(X_trafo)
 
     if index_out in ["original", "extend"]:
-        np.testing.assert_equal(Xt.iloc[2].values, X_fit.iloc[0].values)
+        np.testing.assert_equal(Xt.iloc[0].values, X_fit.iloc[0].values)
         if len(Xt) > 2:
             np.testing.assert_equal(Xt.iloc[2].values, X_trafo.iloc[0].values)
 
     elif index_out == "shift":
-        np.testing.assert_equal(Xt.values, X_trafo.values).all()
+        np.testing.assert_equal(Xt.values, X_trafo.values)
 
 
 @pytest.mark.parametrize("X", X_fixtures)

--- a/sktime/transformations/series/tests/test_lag.py
+++ b/sktime/transformations/series/tests/test_lag.py
@@ -15,7 +15,7 @@ from sktime.utils._testing.series import _make_series
 # some examples with range vs time index, univariate vs multivariate (mv)
 X_range_idx = get_examples("pd.DataFrame")[0]
 X_range_idx_mv = get_examples("pd.DataFrame")[1]
-X_time_idx = _make_series()
+X_time_idx = pd.DataFrame(_make_series())
 X_time_idx_mv = _make_series(n_columns=2)
 
 # all fixtures
@@ -56,10 +56,11 @@ def test_lag_fit_transform_out_values(X, index_out):
 
     if index_out in ["original", "extend"]:
         assert all(Xt.iloc[0].values == X_fit.iloc[0].values)
-        assert all(Xt.iloc[2].values == X_trafo.iloc[0].values)
+        if len(Xt) > 2:
+            assert all(Xt.iloc[2].values == X_trafo.iloc[0].values)
 
     elif index_out == "shift":
-        assert all(Xt.values == X_trafo.values)
+        assert (Xt.values == X_trafo.values).all()
 
 
 @pytest.mark.parametrize("X", X_fixtures)


### PR DESCRIPTION
Fixes an unreported bug: due to a confusion between strings `"shift"` and `"shifted"`, the `Lag` transformer would run incorrect logic for `index_out="shift"`.

This has been rectified, and the test has been sharpened to check for this.