### PR TITLE
[ENH] speed up `NaiveForecaster`'s `"drift"` strategy

### DIFF
--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -367,7 +367,7 @@ class NaiveForecaster(_BaseWindowForecaster):
             return y_pred
 
         def diff_to_last(template):
-            """Fill a pd.Series at expected_index with diff to last ix in template
+            """Fill a pd.Series at expected_index with diff to last ix in template.
 
             Parameters
             ----------
@@ -454,7 +454,7 @@ class NaiveForecaster(_BaseWindowForecaster):
             Exogenous time series
         """
         strategy = self.strategy
-        NEW_PREDICT = ["last"]
+        NEW_PREDICT = ["last", "drift"]
 
         if strategy in NEW_PREDICT:
             return self._predict_naive(fh=fh, X=X)

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -457,6 +457,8 @@ class NaiveForecaster(_BaseWindowForecaster):
             # y_diff_w_new[i] = y_diff_w[last(i)]
             y_diff_w_new = naive_last(y_diff_w)
 
+            # we consistendly coerce dates to floats
+            # this cancels out in the fraction below
             y_ix = ix_to_float_series(_y.index)
             # y_ix_diff_w[j] = _y.index[j] - _y.index[j-offset]
             y_ix_diff_w = y_ix.diff(offset).fillna(method="bfill")
@@ -469,6 +471,8 @@ class NaiveForecaster(_BaseWindowForecaster):
             # y_ix_diff[i] = i - last(i)
             y_ix_diff = diff_to_last(y_ix)
 
+            # both y_ix_diff and y_ix_diff_w_new are float coerced
+            # this is consistently done so the conversion factor cancels out
             y_pred = y_last + y_ix_diff * y_diff_w_new / y_ix_diff_w_new
 
         y_pred.name = _y.name

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -381,9 +381,9 @@ class NaiveForecaster(_BaseWindowForecaster):
                 where ``j`` is the largest element of ``template.index``
                 with the property ``j<i``.
             """
-            ix_old = pd.DataFrame(template.index, index=template.index, columns=[0])
+            ix_old = ix_to_float_series(template, out="DataFrame")
             ix_old = lagger.fit_transform(ix_old)
-            ix_new = pd.DataFrame(expected_index, index=expected_index, columns=[0])
+            ix_new = ix_to_float_series(expected_index, out="DataFrame")
             full_ix = pd.concat([ix_old, ix_new], keys=["a", "b"]).sort_index(level=-1)
             ix_diff_full = full_ix.diff().fillna(method="ffill")
             # subset to index of expected_index
@@ -393,17 +393,19 @@ class NaiveForecaster(_BaseWindowForecaster):
 
             return ix_diff
 
-        def ix_to_float_series(ix):
-            """Coerce index to a pd.Series with integer index and float values.
+        def ix_to_float_series(ix, out="Series"):
+            """Coerce index to a pandas object with integer index and float values.
 
             Parameters
             ----------
             ix : pd.Series, or pd.Index
                 if pd.Series, is replaced by ix.index
+            out : str, one of "Series" or "DataFrame"
+                typ
 
             Returns
             -------
-            s : pd.Series
+            s : pd.Series or pd.DataFrame
                 s.index[i] is i
                 s[i] is ix[i], coerced to float
             """
@@ -415,6 +417,10 @@ class NaiveForecaster(_BaseWindowForecaster):
             if s.values.dtype == "object":
                 s = s.astype("int64")
                 s = s.astype("float64")
+
+            if out == "DataFrame":
+                s = pd.DataFrame(s)
+                s.columns = [0]
 
             return s
 

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -416,7 +416,7 @@ class NaiveForecaster(_BaseWindowForecaster):
 
         elif strategy == "drift":
 
-            offset = self.window_length_
+            offset = self.window_length_ - 1
 
             # below, denote by last(i) the largest j in _y.index
             # such that j < i


### PR DESCRIPTION
This PR aims at speeding up `NaiveForecaster`'s `"drift"` strategy, especially in-sample.

Towards https://github.com/sktime/sktime/issues/4460.

The strategy is similar to the one used in `"last"`.

Possibly todo: restrict the `_y` to the time stamp range of the `expected_index` (possibly minus `offset`), or we compute `diff` of an unnecessarily long series.

FYI @kgeis, @MCRE-BE