### PR TITLE
[DOC] API reference for time series aligners

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -24,7 +24,7 @@ For a scientific manual, see the :ref:`user_guide`.
     api_reference/dists_kernels
     api_reference/param_est
     api_reference/performance_metrics
-    api_reference/series_as_features
+    api_reference/alignment
     api_reference/annotation
     api_reference/datasets
     api_reference/data_format

--- a/docs/source/api_reference/alignment.rst
+++ b/docs/source/api_reference/alignment.rst
@@ -9,14 +9,14 @@ dynamic time warrping aligners.
 Dynamic time warping
 --------------------
 
+.. currentmodule:: sktime.alignment.dtw_python
+
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst
 
     AlignerDTW
     AlignerDTWfromDist
-
-.. currentmodule:: sktime.dists_kernels.indep
 
 .. currentmodule:: sktime.alignment.dtw_numba
 

--- a/docs/source/api_reference/alignment.rst
+++ b/docs/source/api_reference/alignment.rst
@@ -4,7 +4,7 @@ Time series alignment
 =====================
 
 The :mod:`sktime.alignment` module contains time series aligners, such as
-dynamic time warrping aligners.
+dynamic time warping aligners.
 
 Dynamic time warping
 --------------------

--- a/docs/source/api_reference/alignment.rst
+++ b/docs/source/api_reference/alignment.rst
@@ -1,0 +1,27 @@
+.. _alignment_ref:
+
+Time series alignment
+=====================
+
+The :mod:`sktime.alignment` module contains time series aligners, such as
+dynamic time warrping aligners.
+
+Dynamic time warping
+--------------------
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    AlignerDTW
+    AlignerDTWfromDist
+
+.. currentmodule:: sktime.dists_kernels.indep
+
+.. currentmodule:: sktime.alignment.dtw_numba
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    AlignerDtwNumba


### PR DESCRIPTION
Adds API reference for the time series alignment module.
Looks like this was missing (even though linked from README).

Towards https://github.com/sktime/sktime/issues/1634