### PR TITLE
[DOC] improves formatting of docstring examples

### DIFF
--- a/sktime/base/_serialize.py
+++ b/sktime/base/_serialize.py
@@ -35,6 +35,7 @@ def load(serial):
     Examples
     --------
     Example 1: saving an estimator as pickle and loading
+
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>>
@@ -55,6 +56,7 @@ def load(serial):
     >>> y_pred = forecaster_loaded.predict()
 
     Example 2: saving a deep learning estimator on the hard drive and loading
+
     >>> import numpy as np
     >>> from sktime.classification.deep_learning import CNNClassifier
     >>>

--- a/sktime/classification/compose/_pipeline.py
+++ b/sktime/classification/compose/_pipeline.py
@@ -87,6 +87,7 @@ class ClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
     >>> y_pred = pipeline.predict(X_test)
 
     Alternative construction via dunder method:
+
     >>> pipeline = PCATransformer() * TimeSeriesForestClassifier(n_estimators=5)
     """
 
@@ -400,6 +401,7 @@ class SklearnClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
     >>> y_pred = pipeline.predict(X_test)
 
     Alternative construction via dunder method:
+
     >>> pipeline = t1 * t2 * KNeighborsClassifier()
     """
 

--- a/sktime/clustering/compose/_pipeline.py
+++ b/sktime/clustering/compose/_pipeline.py
@@ -87,6 +87,7 @@ class ClustererPipeline(_HeterogenousMetaEstimator, BaseClusterer):
     >>> y_pred = pipeline.predict(X_test) # doctest: +SKIP
 
     Alternative construction via dunder method:
+
     >>> pipeline = PCATransformer() * TimeSeriesKMeans() # doctest: +SKIP
     """
 
@@ -409,6 +410,7 @@ class SklearnClustererPipeline(ClustererPipeline):
     >>> y_pred = pipeline.predict(X_test)
 
     Alternative construction via dunder method:
+
     >>> pipeline = t1 * t2 * KMeans()
     """
 

--- a/sktime/dists_kernels/algebra.py
+++ b/sktime/dists_kernels/algebra.py
@@ -47,6 +47,7 @@ class CombinedDistance(_HeterogenousMetaEstimator, BasePairwiseTransformerPanel)
     >>> dist_mat = sum_dist.transform(X)
 
     the same can also be done more compactly using dunders:
+
     >>> sum_dist = DtwDist() + DtwDist(weighted=True)
     >>> dist_mat = sum_dist(X)
     """

--- a/sktime/dists_kernels/compose_tab_to_panel.py
+++ b/sktime/dists_kernels/compose_tab_to_panel.py
@@ -54,10 +54,12 @@ class AggrDist(BasePairwiseTransformerPanel):
     Examples
     --------
     Mean pairwise euclidean distance between between time series
+
     >>> from sktime.dists_kernels import AggrDist, ScipyDist
     >>> mean_euc_tsdist = AggrDist(ScipyDist())
 
     Mean pairwise Gaussian kernel between time series
+
     >>> from sklearn.gaussian_process.kernels import RBF
     >>> mean_gaussian_tskernel = AggrDist(RBF())
     """
@@ -182,10 +184,12 @@ class FlatDist(BasePairwiseTransformerPanel):
     Examples
     --------
     Euclidean distance between time series of equal length, considered as vectors
+
     >>> from sktime.dists_kernels import FlatDist, ScipyDist
     >>> euc_tsdist = FlatDist(ScipyDist())
 
     Gaussian kernel between time series of equal length, considered as vectors
+
     >>> from sklearn.gaussian_process.kernels import RBF
     >>> flat_gaussian_tskernel = FlatDist(RBF())
     """

--- a/sktime/dists_kernels/dtw.py
+++ b/sktime/dists_kernels/dtw.py
@@ -118,6 +118,7 @@ class DtwDist(BasePairwiseTransformerPanel):
     >>> distmat = d.transform(X)  # doctest: +SKIP
 
     distances are also callable, this does the same:
+
     >>> distmat = d(X)  # doctest: +SKIP
     """
 

--- a/sktime/dists_kernels/edit_dist.py
+++ b/sktime/dists_kernels/edit_dist.py
@@ -110,6 +110,7 @@ class EditDist(BasePairwiseTransformerPanel):
     >>> distmat = d.transform(X)  # doctest: +SKIP
 
     distances are also callable, this does the same:
+
     >>> distmat = d(X)  # doctest: +SKIP
     """
 

--- a/sktime/forecasting/auto_reg.py
+++ b/sktime/forecasting/auto_reg.py
@@ -64,6 +64,7 @@ class AutoREG(_StatsModelsAdapter):
     Examples
     --------
     Use AutoREG to forecast univariate data.
+
     >>> from sktime.forecasting.auto_reg import AutoREG  # doctest: +SKIP
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.base import ForecastingHorizon
@@ -76,6 +77,7 @@ class AutoREG(_StatsModelsAdapter):
 
 
     Use AutoREG to forecast with exogenous data.
+
     >>> from sktime.forecasting.auto_reg import AutoREG  # doctest: +SKIP
     >>> from sktime.datasets import load_longley
     >>> from sktime.forecasting.base import ForecastingHorizon

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -221,18 +221,22 @@ class ForecastingHorizon:
     >>> y_train, y_test = temporal_train_test_split(y, test_size=6)
 
         List as ForecastingHorizon
+
     >>> ForecastingHorizon([1, 2, 3])  # doctest: +SKIP
     >>> # ForecastingHorizon([1, 2, 3], is_relative=True)
 
         Numpy as ForecastingHorizon
+
     >>> ForecastingHorizon(np.arange(1, 7))  # doctest: +SKIP
     >>> # ForecastingHorizon([1, 2, 3, 4, 5, 6], is_relative=True)
 
         Absolute ForecastingHorizon with a pandas Index
+
     >>> ForecastingHorizon(y_test.index, is_relative=False) # doctest: +SKIP
     >>> # ForecastingHorizon(['1960-07', ..., '1960-12'], is_relative=False)
 
         Converting
+
     >>> # set cutoff (last time point of training data)
     >>> cutoff = y_train.index[-1]
     >>> cutoff
@@ -248,6 +252,7 @@ class ForecastingHorizon:
     >>> # ForecastingHorizon(['1960-07', ..., '1960-12'], is_relative=False)
 
         Automatically casted ForecastingHorizon from list when calling predict()
+
     >>> forecaster = NaiveForecaster(strategy="drift")
     >>> forecaster.fit(y_train)
     NaiveForecaster(...)
@@ -256,6 +261,7 @@ class ForecastingHorizon:
     >>> # ForecastingHorizon([1, 2, 3], dtype='int64', is_relative=True)
 
         This is identical to give an object of ForecastingHorizon
+
     >>> y_pred = forecaster.predict(fh=ForecastingHorizon([1,2,3]))
     >>> forecaster.fh  # doctest: +SKIP
     >>> # ForecastingHorizon([1, 2, 3], dtype='int64', is_relative=True)

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -47,6 +47,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
     >>> from sktime.datasets import load_longley
 
     Using integers (column iloc references) for indexing:
+
     >>> y = load_longley()[1][["GNP", "UNEMP"]]
     >>> forecasters = [
     ...     ("trend", PolynomialTrendForecaster(), 0),
@@ -58,6 +59,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
     >>> y_pred = forecaster.predict()
 
     Using strings for indexing:
+
     >>> df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     >>> fc = ColumnEnsembleForecaster(
     ...     [("foo", NaiveForecaster(), "a"), ("bar", NaiveForecaster(), "b")]
@@ -67,6 +69,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
     >>> y_pred = fc.predict()
 
     Applying one forecaster to multiple columns, multivariate:
+
     >>> df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
     >>> fc = ColumnEnsembleForecaster(
     ...    [("ab", NaiveForecaster(), ["a", 1]), ("c", NaiveForecaster(), 2)]

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -372,6 +372,7 @@ class ForecastingPipeline(_Pipeline):
 
         Example 3: using the dunder method
         Note: * (= apply to `y`) has precedence over ** (= apply to `X`)
+
     >>> forecaster = NaiveForecaster(strategy="drift")
     >>> imputer = Imputer(method="mean")
     >>> pipe = (imputer * MinMaxScaler()) ** forecaster
@@ -777,6 +778,7 @@ class TransformedTargetForecaster(_Pipeline):
     >>> y = load_airline()
 
         Example 1: string/estimator pairs
+
     >>> pipe = TransformedTargetForecaster(steps=[
     ...     ("imputer", Imputer(method="mean")),
     ...     ("detrender", Detrender()),
@@ -787,6 +789,7 @@ class TransformedTargetForecaster(_Pipeline):
     >>> y_pred = pipe.predict(fh=[1,2,3])
 
         Example 2: without strings
+
     >>> pipe = TransformedTargetForecaster([
     ...     Imputer(method="mean"),
     ...     Detrender(),
@@ -795,6 +798,7 @@ class TransformedTargetForecaster(_Pipeline):
     ... ])
 
         Example 3: using the dunder method
+
     >>> forecaster = NaiveForecaster(strategy="drift")
     >>> imputer = Imputer(method="mean")
     >>> pipe = imputer * Detrender() * forecaster * ExponentTransformer()
@@ -1231,6 +1235,7 @@ class ForecastX(BaseForecaster):
 
     to forecast only some columns, use the `columns` arg,
     and pass known columns to `predict`:
+
     >>> columns = ["ARMED", "POP"]
     >>> pipe = ForecastX(  # doctest: +SKIP
     ...     forecaster_X=VAR(),
@@ -1629,6 +1634,7 @@ class Permute(_DelegatedForecaster, BaseForecaster, _HeterogenousMetaEstimator):
     >>> from sktime.transformations.series.exponent import ExponentTransformer
 
     Simple example: permute sequence of estimator in forecasting pipeline
+
     >>> y = load_airline()
     >>> fh = ForecastingHorizon([1, 2, 3])
     >>> pipe = ForecastingPipeline(
@@ -1644,6 +1650,7 @@ class Permute(_DelegatedForecaster, BaseForecaster, _HeterogenousMetaEstimator):
     >>> y_pred = permuted.predict()
 
     The permuter is useful in combination with grid search (toy example):
+
     >>> from sktime.datasets import load_shampoo_sales
     >>> from sktime.forecasting.model_selection import (
     ...     ExpandingWindowSplitter,

--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -89,6 +89,7 @@ class ConformalIntervals(BaseForecaster):
     recommended use of ConformalIntervals together with ForecastingGridSearch
     is by 1. first running grid search, 2. then ConformalIntervals on the tuned params
     otherwise, nested sliding windows will cause high compute requirement
+
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.conformal import ConformalIntervals
     >>> from sktime.forecasting.naive import NaiveForecaster

--- a/sktime/forecasting/dummy.py
+++ b/sktime/forecasting/dummy.py
@@ -51,6 +51,7 @@ class ForecastKnownValues(BaseForecaster):
     ForecastKnownValues(...)
 
     The forecast "plays back" the known/prescribed values from y_known
+
     >>> y_pred = fcst.predict()
     """
 

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -337,6 +337,7 @@ def evaluate(
     --------
         The type of evaluation that is done by `evaluate` depends on metrics in
         param `scoring`. Default is `MeanAbsolutePercentageError`.
+
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.model_evaluation import evaluate
     >>> from sktime.forecasting.model_selection import ExpandingWindowSplitter
@@ -351,11 +352,13 @@ def evaluate(
         i.e., point forecast metrics, interval metrics, quantile forecast metrics.
         https://www.sktime.net/en/stable/api_reference/performance_metrics.html?highlight=metrics
         To evaluate estimators using a specific metric, provide them to the scoring arg.
+
     >>> from sktime.performance_metrics.forecasting import MeanAbsoluteError
     >>> loss = MeanAbsoluteError()
     >>> results = evaluate(forecaster=forecaster, y=y, cv=cv, scoring=loss)
 
         Optionally, users can provide a list of metrics to `scoring` argument.
+
     >>> from sktime.performance_metrics.forecasting import MeanSquaredError
     >>> results = evaluate(
     ...     forecaster=forecaster,
@@ -366,6 +369,7 @@ def evaluate(
 
         An example of an interval metric is the `PinballLoss`.
         It can be used with all probabilistic forecasters.
+
     >>> from sktime.forecasting.naive import NaiveVariance
     >>> from sktime.performance_metrics.forecasting.probabilistic import PinballLoss
     >>> loss = PinballLoss()

--- a/sktime/forecasting/model_selection/_split.py
+++ b/sktime/forecasting/model_selection/_split.py
@@ -1480,6 +1480,7 @@ class SameLocSplitter(BaseSplitter):
     >>> splitter = SameLocSplitter(cv_tpl, y_template)
 
     these two are the same:
+
     >>> list(cv_tpl.split(y_template)) # doctest: +SKIP
     >>> list(splitter.split(y)) # doctest: +SKIP
     """

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -454,6 +454,7 @@ class ForecastingGridSearchCV(BaseGridSearch):
 
         Advanced model meta-tuning (model selection) with multiple forecasters
         together with hyper-parametertuning at same time using sklearn notation:
+
     >>> from sktime.datasets import load_shampoo_sales
     >>> from sktime.forecasting.exp_smoothing import ExponentialSmoothing
     >>> from sktime.forecasting.naive import NaiveForecaster

--- a/sktime/param_est/compose.py
+++ b/sktime/param_est/compose.py
@@ -81,6 +81,7 @@ class ParamFitterPipeline(_HeterogenousMetaEstimator, BaseParamFitter):
     12
 
     Alternative construction via dunder method:
+
     >>> pipe = Differencer() * SeasonalityACF()  # doctest: +SKIP
     """
 

--- a/sktime/param_est/plugin.py
+++ b/sktime/param_est/plugin.py
@@ -78,6 +78,7 @@ class PluginParamsForecaster(_DelegatedForecaster):
     12
 
     using dictionary to plug "foo" parameter into "sp"
+
     >>> from sktime.param_est.fixed import FixedParams
     >>> sp_plugin = PluginParamsForecaster(
     ...     FixedParams({"foo": 12}), NaiveForecaster(), params={"foo": "sp"}

--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -71,6 +71,7 @@ class SeasonalityACF(BaseParamFitter):
 
     Series should be stationary before applying ACF.
     To pipeline SeasonalityACF with the Differencer, use the ParamFitterPipeline:
+
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.seasonality import SeasonalityACF
     >>> from sktime.transformations.series.difference import Differencer

--- a/sktime/pipeline/_make_pipeline.py
+++ b/sktime/pipeline/_make_pipeline.py
@@ -24,6 +24,7 @@ def make_pipeline(*steps):
     >>> y = load_airline()
 
     Example 1: forecaster pipeline
+
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.trend import PolynomialTrendForecaster
     >>> from sktime.pipeline import make_pipeline
@@ -34,6 +35,7 @@ def make_pipeline(*steps):
     'TransformedTargetForecaster'
 
     Example 2: classifier pipeline
+
     >>> from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
     >>> from sktime.pipeline import make_pipeline
     >>> from sktime.transformations.series.exponent import ExponentTransformer
@@ -42,6 +44,7 @@ def make_pipeline(*steps):
     'ClassifierPipeline'
 
     Example 3: transformer pipeline
+
     >>> from sktime.pipeline import make_pipeline
     >>> from sktime.transformations.series.exponent import ExponentTransformer
     >>> pipe = make_pipeline(ExponentTransformer(), ExponentTransformer())

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -83,6 +83,7 @@ class RegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
     >>> y_pred = pipeline.predict(X_test)
 
     Alternative construction via dunder method:
+
     >>> pipeline = PCATransformer() * KNeighborsTimeSeriesRegressor(n_neighbors=2)
     """
 
@@ -372,6 +373,7 @@ class SklearnRegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
     >>> y_pred = pipeline.predict(X_test)
 
     Alternative construction via dunder method:
+
     >>> pipeline = t1 * t2 * KNeighborsRegressor()
     """
 

--- a/sktime/transformations/compose/_pipeline.py
+++ b/sktime/transformations/compose/_pipeline.py
@@ -81,9 +81,11 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
 
         Example 1, option A: construct without strings (unique names are generated for
         the two components t1 and t2)
+
     >>> pipe = TransformerPipeline(steps = [t1, t2])
 
         Example 1, option B: construct with strings to give custom names to steps
+
     >>> pipe = TransformerPipeline(
     ...         steps = [
     ...             ("trafo1", t1),
@@ -92,21 +94,26 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
     ...     )
 
         Example 1, option C: for quick construction, the * dunder method can be used
+
     >>> pipe = t1 * t2
 
         Example 2: sklearn transformers can be used in the pipeline.
         If applied to Series, sklearn transformers are applied by series instance.
         If applied to Table, sklearn transformers are applied to the table as a whole.
+
     >>> from sklearn.preprocessing import StandardScaler
     >>> from sktime.transformations.series.summarize import SummaryTransformer
 
         This applies the scaler per series, then summarizes:
+
     >>> pipe = StandardScaler() * SummaryTransformer()
 
         This applies the sumamrization, then scales the full summary table:
+
     >>> pipe = SummaryTransformer() * StandardScaler()
 
         This scales the series, then summarizes, then scales the full summary table:
+
     >>> pipe = StandardScaler() * SummaryTransformer() * StandardScaler()
     """
 

--- a/sktime/transformations/panel/channel_selection.py
+++ b/sktime/transformations/panel/channel_selection.py
@@ -167,6 +167,7 @@ class ElbowClassSum(BaseTransformer):
     >>> Xt = cs.transform(X)
 
     Any sktime compatible distance can be used, e.g., DTW distance:
+
     >>> from sktime.dists_kernels import DtwDist
     >>>
     >>> cs = ElbowClassSum(distance=DtwDist())

--- a/sktime/transformations/series/date.py
+++ b/sktime/transformations/series/date.py
@@ -91,22 +91,27 @@ class DateTimeFeatures(BaseTransformer):
     >>> y = load_airline()
 
     Returns columns `y`, `year`, `month_of_year`
+
     >>> transformer = DateTimeFeatures(ts_freq="M")
     >>> y_hat = transformer.fit_transform(y)
 
     Returns columns `y`, `month_of_year`
+
     >>> transformer = DateTimeFeatures(ts_freq="M", manual_selection=["month_of_year"])
     >>> y_hat = transformer.fit_transform(y)
 
     Returns columns 'y', 'year', 'quarter_of_year', 'month_of_year', 'month_of_quarter'
+
     >>> transformer = DateTimeFeatures(ts_freq="M", feature_scope="comprehensive")
     >>> y_hat = transformer.fit_transform(y)
 
     Returns columns 'y', 'year', 'quarter_of_year', 'month_of_year'
+
     >>> transformer = DateTimeFeatures(ts_freq="M", feature_scope="efficient")
     >>> y_hat = transformer.fit_transform(y)
 
     Returns columns 'y',  'year', 'month_of_year'
+
     >>> transformer = DateTimeFeatures(ts_freq="M", feature_scope="minimal")
     >>> y_hat = transformer.fit_transform(y)
     """

--- a/sktime/transformations/series/holiday/_holidayfeats.py
+++ b/sktime/transformations/series/holiday/_holidayfeats.py
@@ -58,6 +58,7 @@ class HolidayFeatures(BaseTransformer):
     >>> X = pd.DataFrame(values, index=index)  # doctest: +SKIP
 
     Returns country holiday features with custom holiday windows
+
     >>> transformer = HolidayFeatures(
     ...    calendar=country_holidays(country="FR"),
     ...    return_categorical=True,
@@ -65,6 +66,7 @@ class HolidayFeatures(BaseTransformer):
     >>> yt = transformer.fit_transform(X)  # doctest: +SKIP
 
     Returns financial holiday features
+
     >>> transformer = HolidayFeatures(
     ...    calendar=financial_holidays(market="NYSE"),
     ...    return_categorical=True,
@@ -72,6 +74,7 @@ class HolidayFeatures(BaseTransformer):
     >>> yt = transformer.fit_transform(X)  # doctest: +SKIP
 
     Returns custom made holiday features
+
     >>> transformer = HolidayFeatures(
     ...    calendar={date(2000,1,14): "Regional Holiday",
     ...              date(2000, 1, 26): "Regional Holiday"},

--- a/sktime/transformations/series/kalman_filter.py
+++ b/sktime/transformations/series/kalman_filter.py
@@ -472,6 +472,7 @@ class KalmanFilterTransformerPK(BaseKalmanFilter, BaseTransformer):
     Examples
     --------
         Basic example:
+
     >>> import numpy as np  # doctest: +SKIP
     >>> import sktime.transformations.series.kalman_filter as kf
     >>> time_steps, state_dim, measurement_dim = 10, 2, 3
@@ -481,6 +482,7 @@ class KalmanFilterTransformerPK(BaseKalmanFilter, BaseTransformer):
     >>> X_transformed = transformer.fit_transform(X=X)  # doctest: +SKIP
 
         Example of - denoising, matrix estimation and missing values:
+
     >>> import numpy as np  # doctest: +SKIP
     >>> import sktime.transformations.series.kalman_filter as kf
     >>> time_steps, state_dim, measurement_dim = 10, 2, 2
@@ -501,6 +503,7 @@ class KalmanFilterTransformerPK(BaseKalmanFilter, BaseTransformer):
     >>> X_transformed = transformer.fit_transform(X=X)  # doctest: +SKIP
 
         Example of - dynamic inputs (matrix per time-step) and missing values:
+
     >>> import numpy as np  # doctest: +SKIP
     >>> import sktime.transformations.series.kalman_filter as kf
     >>> time_steps, state_dim, measurement_dim = 10, 4, 4
@@ -926,6 +929,7 @@ class KalmanFilterTransformerFP(BaseKalmanFilter, BaseTransformer):
     Examples
     --------
         Basic example:
+
     >>> import numpy as np  # doctest: +SKIP
     >>> import sktime.transformations.series.kalman_filter as kf
     >>> time_steps, state_dim, measurement_dim = 10, 2, 3
@@ -958,6 +962,7 @@ class KalmanFilterTransformerFP(BaseKalmanFilter, BaseTransformer):
     >>> Xt = transformer.fit_transform(X=X, y=control_variable)  # doctest: +SKIP
 
         Example of - dynamic inputs (matrix per time-step), missing values:
+
     >>> import numpy as np  # doctest: +SKIP
     >>> import sktime.transformations.series.kalman_filter as kf
     >>> time_steps, state_dim, measurement_dim = 10, 4, 4

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -86,12 +86,14 @@ class Lag(BaseTransformer):
     >>> Xt = t.fit_transform(X)
 
         Multiple lags can be provided, this will result in multiple columns:
+
     >>> t = Lag([2, 4, -1])
     >>> Xt = t.fit_transform(X)
 
         The default setting of index_out will extend indices either side.
         To ensure that the index remains the same after transform,
         use index_out="original"
+
     >>> t = Lag([2, 4, -1], index_out="original")
     >>> Xt = t.fit_transform(X)
 
@@ -100,6 +102,7 @@ class Lag(BaseTransformer):
         trivial cases). This may need to be handled, e.g., if a subsequent
         pipeline step does not accept NA. To deal with the NAs,
         pipeline with the Imputer:
+
     >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.impute import Imputer
     >>> from sktime.transformations.series.lag import Lag
@@ -384,15 +387,18 @@ class ReducerTransform(BaseTransformer):
     >>> X = load_airline()
 
     Single lag will yield a time series with the same variables:
+
     >>> t = Lag(2)
     >>> Xt = t.fit_transform(X)
 
     Multiple lags can be provided, this will result in multiple columns:
+
     >>> t = Lag([2, 4, -1])
     >>> Xt = t.fit_transform(X)
 
     The default setting of index_out will extend indices either side.
     To ensure that the index remains the same after transform, use index_out="original"
+
     >>> t = Lag([2, 4, -1], index_out="original")
     >>> Xt = t.fit_transform(X)
 
@@ -400,6 +406,7 @@ class ReducerTransform(BaseTransformer):
     (except when index_out="shift" and there is only a single lag, or in trivial cases)
     This may need to be handled, e.g., if a subsequent pipeline step does not accept NA.
     To deal with the NAs, pipeline with the Imputer:
+
     >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.impute import Imputer
     >>> from sktime.transformations.series.lag import Lag

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -153,6 +153,7 @@ class WindowSummarizer(BaseTransformer):
     >>> y_transformed = transformer.fit_transform(y)
 
         Example with transforming multiple columns of exogeneous features
+
     >>> y, X = load_longley()
     >>> y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
     >>> fh = ForecastingHorizon(X_test.index, is_relative=False)
@@ -169,6 +170,7 @@ class WindowSummarizer(BaseTransformer):
 
         Example with transforming multiple columns of exogeneous features
         as well as the y column
+
     >>> Z_train = pd.concat([X_train, y_train], axis=1)
     >>> Z_test = pd.concat([X_test, y_test], axis=1)
     >>> pipe = ForecastingPipeline(

--- a/sktime/transformations/series/time_since.py
+++ b/sktime/transformations/series/time_since.py
@@ -61,11 +61,13 @@ class TimeSince(BaseTransformer):
 
         Create a single column with time elapsed since start date of time series.
         The output is in units of integer number of months, same as the index `freq`.
+
     >>> transformer = TimeSince()
     >>> Xt = transformer.fit_transform(X)
 
         Create multiple columns with different start times. The output is in units
         of integer number of months, same as the index `freq`.
+
     >>> transformer = TimeSince(["2000-01", "2000-02"])
     >>> Xt = transformer.fit_transform(X)
     """

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -70,15 +70,18 @@ def check_estimator(
 
     Running all tests for ExponentTransformer class,
     this uses all instances from get_test_params and compatible scenarios
+
     >>> results = check_estimator(ExponentTransformer)
     All tests PASSED!
 
     Running all tests for a specific ExponentTransformer
     this uses the instance that is passed and compatible scenarios
+
     >>> results = check_estimator(ExponentTransformer(42))
     All tests PASSED!
 
     Running specific test (all fixtures) for ExponentTransformer
+
     >>> results = check_estimator(ExponentTransformer, tests_to_run="test_clone")
     All tests PASSED!
 
@@ -86,6 +89,7 @@ def check_estimator(
     'test_clone[ExponentTransformer-1]': 'PASSED'}
 
     Running one specific test-fixture-combination for ExponentTransformer
+
     >>> check_estimator(
     ...    ExponentTransformer, fixtures_to_run="test_clone[ExponentTransformer-1]"
     ... )


### PR DESCRIPTION
Fixes #5013.

Adds empty lines to docstrings examples missing new lines before or after comments in examples sections.