### PR TITLE
[BUG] fix `ConformalIntervals` failure if wrapped estimator supports hierarchical mtypes - restriction to Series

### DIFF
--- a/sktime/datatypes/_alignment/_registry.py
+++ b/sktime/datatypes/_alignment/_registry.py
@@ -1,4 +1,7 @@
-import pandas as pd
+"""Registry of mtypes for Alignment scitype.
+
+See datatypes._registry for API.
+"""
 
 __all__ = [
     "MTYPE_REGISTER_ALIGNMENT",
@@ -19,4 +22,4 @@ MTYPE_REGISTER_ALIGNMENT = [
     ),
 ]
 
-MTYPE_LIST_ALIGNMENT = pd.DataFrame(MTYPE_REGISTER_ALIGNMENT)[0].values
+MTYPE_LIST_ALIGNMENT = [x[0] for x in MTYPE_REGISTER_ALIGNMENT]

--- a/sktime/datatypes/_hierarchical/_registry.py
+++ b/sktime/datatypes/_hierarchical/_registry.py
@@ -3,8 +3,6 @@
 See datatypes._registry for API.
 """
 
-import pandas as pd
-
 __all__ = [
     "MTYPE_REGISTER_HIERARCHICAL",
     "MTYPE_LIST_HIERARCHICAL",
@@ -27,4 +25,4 @@ MTYPE_REGISTER_HIERARCHICAL = [
 
 MTYPE_SOFT_DEPS_HIERARCHICAL = {"dask_hierarchical": "dask"}
 
-MTYPE_LIST_HIERARCHICAL = pd.DataFrame(MTYPE_REGISTER_HIERARCHICAL)[0].values
+MTYPE_LIST_HIERARCHICAL = [x[0] for x in MTYPE_REGISTER_HIERARCHICAL]

--- a/sktime/datatypes/_panel/_registry.py
+++ b/sktime/datatypes/_panel/_registry.py
@@ -3,8 +3,6 @@
 See datatypes._registry for API.
 """
 
-import pandas as pd
-
 __all__ = [
     "MTYPE_REGISTER_PANEL",
     "MTYPE_LIST_PANEL",
@@ -46,4 +44,4 @@ MTYPE_REGISTER_PANEL = [
 
 MTYPE_SOFT_DEPS_PANEL = {"xr.DataArray": "xarray", "dask_panel": "dask"}
 
-MTYPE_LIST_PANEL = pd.DataFrame(MTYPE_REGISTER_PANEL)[0].values
+MTYPE_LIST_PANEL = [x[0] for x in MTYPE_REGISTER_PANEL]

--- a/sktime/datatypes/_proba/_registry.py
+++ b/sktime/datatypes/_proba/_registry.py
@@ -1,4 +1,7 @@
-import pandas as pd
+"""Registry of mtypes for Proba scitype.
+
+See datatypes._registry for API.
+"""
 
 __all__ = [
     "MTYPE_REGISTER_PROBA",
@@ -13,4 +16,4 @@ MTYPE_REGISTER_PROBA = [
     # ("pred_dost", "Proba", "full distribution predictions, tensorflow-probability"),
 ]
 
-MTYPE_LIST_PROBA = pd.DataFrame(MTYPE_REGISTER_PROBA)[0].values
+MTYPE_LIST_PROBA = [x[0] for x in MTYPE_REGISTER_PROBA]

--- a/sktime/datatypes/_series/_registry.py
+++ b/sktime/datatypes/_series/_registry.py
@@ -3,8 +3,6 @@
 See datatypes._registry for API.
 """
 
-import pandas as pd
-
 __all__ = [
     "MTYPE_REGISTER_SERIES",
     "MTYPE_LIST_SERIES",
@@ -38,4 +36,4 @@ MTYPE_REGISTER_SERIES = [
 
 MTYPE_SOFT_DEPS_SERIES = {"xr.DataArray": "xarray", "dask_series": "dask"}
 
-MTYPE_LIST_SERIES = pd.DataFrame(MTYPE_REGISTER_SERIES)[0].values
+MTYPE_LIST_SERIES = [x[0] for x in MTYPE_REGISTER_SERIES]

--- a/sktime/datatypes/_table/_registry.py
+++ b/sktime/datatypes/_table/_registry.py
@@ -1,4 +1,7 @@
-import pandas as pd
+"""Registry of mtypes for Table scitype.
+
+See datatypes._registry for API.
+"""
 
 __all__ = [
     "MTYPE_REGISTER_TABLE",
@@ -14,4 +17,4 @@ MTYPE_REGISTER_TABLE = [
     ("list_of_dict", "Table", "list of dictionaries with primitive entries"),
 ]
 
-MTYPE_LIST_TABLE = pd.DataFrame(MTYPE_REGISTER_TABLE)[0].values
+MTYPE_LIST_TABLE = [x[0] for x in MTYPE_REGISTER_TABLE]

--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -15,7 +15,7 @@ import pandas as pd
 from joblib import Parallel, delayed
 from sklearn.base import clone
 
-from sktime.datatypes import convert, convert_to
+from sktime.datatypes import MTYPE_LIST_SERIES, convert, convert_to
 from sktime.datatypes._utilities import get_slice
 from sktime.forecasting.base import BaseForecaster
 
@@ -125,6 +125,8 @@ class ConformalIntervals(BaseForecaster):
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,
         "capability:pred_int:insample": False,
+        "X_inner_mtype": MTYPE_LIST_SERIES,
+        "y_inner_mtype": MTYPE_LIST_SERIES,
     }
 
     ALLOWED_METHODS = [
@@ -165,8 +167,6 @@ class ConformalIntervals(BaseForecaster):
             "requires-fh-in-fit",
             "ignores-exogeneous-X",
             "handles-missing-data",
-            "y_inner_mtype",
-            "X_inner_mtype",
             "X-y-must-have-same-index",
             "enforce_index_type",
         ]
@@ -371,6 +371,7 @@ class ConformalIntervals(BaseForecaster):
             if sample_frac is passed this will have NaN values for 1 - sample_frac
             fraction of the matrix
         """
+        print(y)
         y = convert_to(y, "pd.Series")
 
         n_initial_window = self._parse_initial_window(y, initial_window=initial_window)

--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -371,7 +371,6 @@ class ConformalIntervals(BaseForecaster):
             if sample_frac is passed this will have NaN values for 1 - sample_frac
             fraction of the matrix
         """
-        print(y)
         y = convert_to(y, "pd.Series")
 
         n_initial_window = self._parse_initial_window(y, initial_window=initial_window)

--- a/sktime/forecasting/tests/test_conformal.py
+++ b/sktime/forecasting/tests/test_conformal.py
@@ -31,7 +31,7 @@ def test_conformal_standard():
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_conformal_with_gscv():
-    """With ForecastingGridSearchCV and parameter plugin"""
+    """With ForecastingGridSearchCV and parameter plugin."""
     from sktime.forecasting.model_selection import (
         ExpandingWindowSplitter,
         ForecastingGridSearchCV,
@@ -63,3 +63,47 @@ def test_conformal_with_gscv():
     y_pred_quantiles = gscv_with_conformal.predict_quantiles()
 
     assert check_is_mtype(y_pred_quantiles, "pred_quantiles", "Proba")
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ConformalIntervals),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_conformal_with_hierarchical():
+    """Test ConformalIntervals with a wrapped estimator of hierarchical mtype.
+
+    Failure case of bug #5092.
+    """
+    from sklearn.linear_model import LinearRegression
+
+    from sktime.forecasting.compose import ForecastX, make_reduction
+    from sktime.forecasting.model_selection import temporal_train_test_split
+    from sktime.utils._testing.hierarchical import _make_hierarchical
+
+    df = _make_hierarchical(
+        hierarchy_levels=(2, 3),
+        max_timepoints=25,
+        min_timepoints=25,
+        n_columns=4,
+        all_positive=True,
+        random_state=0,
+    )
+
+    y = df[["c0", "c1"]]
+    X = df[["c2", "c3"]]
+
+    y_train, y_test, X_train, X_test = temporal_train_test_split(y, X=X, test_size=5)
+
+    regressor = LinearRegression()
+    endogenous_model = make_reduction(regressor, pooling="global")
+
+    exogenous_model = NaiveForecaster()
+
+    forecaster = ConformalIntervals(
+        ForecastX(endogenous_model.clone(), exogenous_model.clone()), initial_window=15
+    )
+
+    forecaster.fit(y_train, X=X_train, fh=range(1, 3))
+
+    forecaster.predict(X=X_test)
+    forecaster.predict_interval(X=X_test)


### PR DESCRIPTION
This PR fixes #5092, i.e., the `ConformalIntervals` failure where the wrapped estimator supports hierarchical or panel mtypes.

As discussed in the issue, the failure condition was if the wrapped estimator supported a hierarchical mtype. As the tags were cloned and `ConformalIntervals` did not support hierarchical or panel mtypes, this led to failure.

This is fixed by no longer cloning the mtype tags, but letting all mtypes through.

This PR also cleans up the mtype lists exported from the `registry`, which - despite the name, weren't lists but `numpy.ndarray`-s. This would also cause problems if they were directly used in tags. This has been rectified, the objects are now lists (as the name claims and as the user would expect).