### PR TITLE
[ENH] widen scope of change-conditional test execution

### DIFF
--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -15,13 +15,13 @@ from sktime.forecasting.compose import TransformedTargetForecaster
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.model_evaluation import evaluate
 from sktime.forecasting.model_selection import (
-    BaseGridSearch,
     ForecastingGridSearchCV,
     ForecastingRandomizedSearchCV,
     ForecastingSkoptSearchCV,
     SingleWindowSplitter,
     SlidingWindowSplitter,
 )
+from sktime.forecasting.model_selection._tune import BaseGridSearch
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.forecasting.tests._config import (
     TEST_N_ITERS,

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -15,6 +15,7 @@ from sktime.forecasting.compose import TransformedTargetForecaster
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.model_evaluation import evaluate
 from sktime.forecasting.model_selection import (
+    BaseGridSearch,
     ForecastingGridSearchCV,
     ForecastingRandomizedSearchCV,
     ForecastingSkoptSearchCV,
@@ -34,13 +35,20 @@ from sktime.performance_metrics.forecasting import (
     MeanSquaredError,
 )
 from sktime.performance_metrics.forecasting.probabilistic import CRPS, PinballLoss
+from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.series.detrend import Detrender
 from sktime.transformations.series.impute import Imputer
 from sktime.utils._testing.hierarchical import _make_hierarchical
-from sktime.utils.validation._dependencies import _check_estimator_deps
 
 TEST_METRICS = [MeanAbsolutePercentageError(symmetric=True), MeanSquaredError()]
 TEST_METRICS_PROBA = [CRPS(), PinballLoss()]
+
+TUNER_CLASSES = [
+    BaseGridSearch,
+    ForecastingGridSearchCV,
+    ForecastingRandomizedSearchCV,
+    ForecastingSkoptSearchCV,
+]
 
 
 def _get_expected_scores(forecaster, cv, param_grid, y, X, scoring):
@@ -108,6 +116,10 @@ CVs = [
 ERROR_SCORES = [np.nan, "raise", 1000]
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ForecastingGridSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize(
     "forecaster, param_grid", [(NAIVE, NAIVE_GRID), (PIPE, PIPE_GRID)]
 )
@@ -131,6 +143,10 @@ def test_gscv(forecaster, param_grid, cv, scoring, error_score):
     _check_fitted_params_keys(gscv.get_fitted_params())
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ForecastingRandomizedSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize(
     "forecaster, param_grid", [(NAIVE, NAIVE_GRID), (PIPE, PIPE_GRID)]
 )
@@ -163,6 +179,10 @@ def test_rscv(forecaster, param_grid, cv, scoring, error_score, n_iter, random_s
     _check_cv(forecaster, rscv, cv, param_distributions, y, X, scoring)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ForecastingGridSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize(
     "forecaster, param_grid", [(NAIVE, NAIVE_GRID), (PIPE, PIPE_GRID)]
 )
@@ -186,8 +206,8 @@ def test_gscv_hierarchical(forecaster, param_grid, cv, scoring, error_score):
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(ARIMA, severity="none"),
-    reason="skip test if required soft dependency for hmmlearn not available",
+    not run_test_for_class([ForecastingGridSearchCV, ARIMA, CRPS, PinballLoss]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
 )
 @pytest.mark.parametrize("scoring", TEST_METRICS_PROBA)
 @pytest.mark.parametrize("cv", CVs)
@@ -214,8 +234,8 @@ def test_gscv_proba(cv, scoring, error_score):
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(ForecastingSkoptSearchCV, severity="none"),
-    reason="skip test if required soft dependency not compatible",
+    not run_test_for_class(ForecastingSkoptSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
 )
 @pytest.mark.parametrize(
     "forecaster, param_grid", [(NAIVE, NAIVE_GRID), (PIPE, PIPE_GRID)]
@@ -254,8 +274,8 @@ def test_skoptcv(forecaster, param_grid, cv, scoring, error_score, n_iter):
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(ForecastingSkoptSearchCV, severity="none"),
-    reason="skip test if required soft dependency not compatible",
+    not run_test_for_class(ForecastingSkoptSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_skoptcv_multiple_forecaster():
     """Test ForecastingSkoptSearchCV with multiple forecasters and custom n_iter.

--- a/sktime/forecasting/tests/test_interval_wrappers.py
+++ b/sktime/forecasting/tests/test_interval_wrappers.py
@@ -17,6 +17,7 @@ from sktime.forecasting.model_selection import (
 )
 from sktime.forecasting.naive import NaiveForecaster, NaiveVariance
 from sktime.performance_metrics.forecasting.probabilistic import PinballLoss
+from sktime.tests.test_switch import run_test_for_class
 
 INTERVAL_WRAPPERS = [ConformalIntervals, NaiveVariance]
 CV_SPLITTERS = [SlidingWindowSplitter, ExpandingWindowSplitter]
@@ -25,6 +26,10 @@ SAMPLE_FRACS = [None, 0.5]
 MTYPES_SERIES = scitype_to_mtype("Series", softdeps="present")
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(INTERVAL_WRAPPERS),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("mtype", MTYPES_SERIES)
 @pytest.mark.parametrize("override_y_mtype", [True, False])
 @pytest.mark.parametrize("wrapper", INTERVAL_WRAPPERS)
@@ -62,6 +67,10 @@ def test_wrapper_series_mtype(wrapper, override_y_mtype, mtype):
     assert len(pred_var) == 3
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(INTERVAL_WRAPPERS),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("wrapper", INTERVAL_WRAPPERS)
 @pytest.mark.parametrize("splitter", CV_SPLITTERS)
 @pytest.mark.parametrize("strategy", EVALUATE_STRATEGY)

--- a/sktime/forecasting/tests/test_reconcile.py
+++ b/sktime/forecasting/tests/test_reconcile.py
@@ -11,6 +11,7 @@ from pandas.testing import assert_frame_equal
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.reconcile import ReconcilerForecaster
+from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.hierarchical.aggregate import Aggregator
 from sktime.utils._testing.hierarchical import _bottom_hier_datagen, _make_hierarchical
 from sktime.utils.validation._dependencies import _check_soft_dependencies
@@ -24,6 +25,10 @@ flatten_list = [True, False]
 # test the reconciled predictions are actually hierarchical
 # test the index/columns on the g and s matrices match
 # test it works for named and unnamed indexes
+@pytest.mark.skipif(
+    not run_test_for_class(ReconcilerForecaster),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
     reason="skip test if required soft dependency not available",
@@ -75,6 +80,10 @@ def test_reconciler_fit_predict(method, flatten, no_levels):
     assert prds_recon.equals(reconciler_unnamed.fit_predict(y=y, fh=fh)), msg
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ReconcilerForecaster),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
     reason="skip test if required soft dependency not available",

--- a/sktime/transformations/tests/test_optionalpassthrough.py
+++ b/sktime/transformations/tests/test_optionalpassthrough.py
@@ -2,9 +2,15 @@
 
 import pytest
 
+from sktime.tests.test_switch import run_test_for_class
+from sktime.transformations.compose import OptionalPassthrough
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(OptionalPassthrough),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
     reason="skip test if required soft dependency is not available",
@@ -23,7 +29,6 @@ def test_optionalpassthrough():
         SlidingWindowSplitter,
     )
     from sktime.forecasting.naive import NaiveForecaster
-    from sktime.transformations.compose import OptionalPassthrough
     from sktime.transformations.series.adapt import TabularToSeriesAdaptor
     from sktime.transformations.series.detrend import Deseasonalizer
 
@@ -52,6 +57,10 @@ def test_optionalpassthrough():
 
 
 @pytest.mark.skipif(
+    not run_test_for_class(OptionalPassthrough),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
     reason="skip test if required soft dependency is not available",
 )
@@ -67,6 +76,10 @@ def test_passthrough_does_not_broadcast_variables():
     t.fit(X)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(OptionalPassthrough),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
     reason="skip test if required soft dependency is not available",


### PR DESCRIPTION
This PR speeds up the non-suite test CI elements by making more costly tests conditional on change of the tested estimator:

* tests for forecaster tuning estimators
* probabilistic forecast interval wrappers
* `OptionalPassthrough`
* `ReconcilerForecaster`