### PR TITLE
DIAGNOSTIC [MNT] longer runtime ranking table

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ addopts =
     --ignore examples
     --ignore docs
     --doctest-modules
-    --durations 20
+    --durations 100
     --timeout 600
     --cov sktime
     --cov-report xml


### PR DESCRIPTION
DO NOT MERGE - diagnostic

This diagnostic PR produces a longer (100 instead of 20 tests) runtime ranking table at the end of the test reports.