### PR TITLE
[BUG] Fix `vectorize_est` returning jumbled rows for row vectorization, `pd.DataFrame` return, if row names were not lexicographically ordered

### DIFF
--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -19,10 +19,7 @@ from sktime.forecasting.var import VAR
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_panel
 from sktime.utils._testing.series import _make_series
-from sktime.utils.validation._dependencies import (
-    _check_estimator_deps,
-    _check_soft_dependencies,
-)
+from sktime.utils.validation._dependencies import _check_estimator_deps
 
 PANEL_MTYPES = ["pd-multiindex", "nested_univ", "numpy3D"]
 HIER_MTYPES = ["pd_multiindex_hier"]
@@ -279,10 +276,6 @@ def test_vectorization_multivariate(mtype, exogeneous):
     assert y_pred_equal_length, msg
 
 
-@pytest.mark.skipif(
-    not _check_soft_dependencies("statsmodels", severity="none"),
-    reason="skip test if required soft dependency not available",
-)
 def test_col_vectorization_correct_col_order():
     """Test that forecaster vectorization preserves column index ordering.
 
@@ -304,6 +297,38 @@ def test_col_vectorization_correct_col_order():
     # if they were jumbled, as in #4683 by lexicographic column name order,
     # this assertion would fail since the values are all different
     assert (y_pred == y.iloc[4]).all().all()
+
+
+def test_row_vectorization_correct_row_order():
+    """Test that forecaster vectorization preserves row index ordering.
+
+    Failure case is as in issue #5108 where the row index is correct,
+    but the values are in fact coming from forecasters in jumbled order.
+    """
+    n_instances = 3
+    n_points = 5
+
+    t_ix = pd.date_range(start='2022-07-01', periods=n_points * n_instances, freq='D')
+    y = pd.DataFrame(
+        {
+            'y': [i for i in range(n_points * n_instances)],
+            'id': ["T1"] * n_points + ["T2"] * n_points + ["T11"] * n_points,
+            'timestamp': t_ix,
+        }
+    ).set_index(['id', 'timestamp'])
+
+    fh = [1]
+
+    forecaster = NaiveForecaster(strategy="last")
+
+    forecaster.fit(y)
+    y_pred = forecaster.predict(fh)
+
+    last_ix = range(n_points - 1, n_points * n_instances, n_points)
+    y_last = y.iloc[last_ix]
+
+    assert all(y_last.index.get_level_values(0) == y_pred.index.get_level_values(0))
+    assert all(y_last.values == y_pred.values)
 
 
 @pytest.mark.skipif(

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -308,14 +308,14 @@ def test_row_vectorization_correct_row_order():
     n_instances = 3
     n_points = 5
 
-    t_ix = pd.date_range(start='2022-07-01', periods=n_points * n_instances, freq='D')
+    t_ix = pd.date_range(start="2022-07-01", periods=n_points * n_instances, freq="D")
     y = pd.DataFrame(
         {
-            'y': [i for i in range(n_points * n_instances)],
-            'id': ["T1"] * n_points + ["T2"] * n_points + ["T11"] * n_points,
-            'timestamp': t_ix,
+            "y": [i for i in range(n_points * n_instances)],
+            "id": ["T1"] * n_points + ["T2"] * n_points + ["T11"] * n_points,
+            "timestamp": t_ix,
         }
-    ).set_index(['id', 'timestamp'])
+    ).set_index(["id", "timestamp"])
 
     fh = [1]
 

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -6,6 +6,7 @@ __author__ = ["fkiraly"]
 from functools import reduce
 from operator import mul
 
+import numpy as np
 import pandas as pd
 import pytest
 from pandas.testing import assert_series_equal
@@ -282,9 +283,9 @@ def test_col_vectorization_correct_col_order():
     Failure case is as in issue #4683 where the column index is correct,
     but the values are in fact coming from forecasters in jumbled order.
     """
-    from sktime.datasets import load_macroeconomic
-
-    y = load_macroeconomic().iloc[:5]
+    cols = ["realgdp", "realcons", "realinv", "realgovt", "realdpi", "cpi", "m1"]
+    vals = np.random.rand(5, 7)
+    y = pd.DataFrame(vals, columns=cols)
 
     f = NaiveForecaster()
     # force univariate tag to trigger vectorization over columns for sure


### PR DESCRIPTION
Fixes #5108.

Similar to the fix in #4684, although `pandas` needs to be prevented from sorting columns in two places:

* in the `groupby` call in `items`
* in/after the `pivot` call in `vectorize_est`, same problem as #4684.

Adds a compact version of the failure case reported in https://github.com/sktime/sktime/issues/5108 as a test.

Further, removed the `statsmodels` dependency in the related column test by replacing a `statsmodels` dataset with an equivalent, randomly generated one (also with string, non-ordered columns).