### PR TITLE
[ENH] add more test parameters to some estimators

### DIFF
--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -305,5 +305,5 @@ class ProbabilityThresholdEarlyClassifier(BaseClassifier):
             est = DummyClassifier()
 
         params1 = {"classification_points": [3], "estimator": est}
-        params2 = {"probability_threshold": 0.9}
+        params2 = {"probability_threshold": 0.9, "estimator": est}
         return [params1, params2]

--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -304,5 +304,6 @@ class ProbabilityThresholdEarlyClassifier(BaseClassifier):
         else:
             est = DummyClassifier()
 
-        params = {"classification_points": [3], "estimator": est}
-        return params
+        params1 = {"classification_points": [3], "estimator": est}
+        params2 = {"probability_threshold": 0.9}
+        return [params1, params2]

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -881,6 +881,7 @@ class NaiveVariance(BaseForecaster):
         from sktime.forecasting.naive import NaiveForecaster
 
         FORECASTER = NaiveForecaster()
-        params_list = {"forecaster": FORECASTER}
+        params1 = {"forecaster": FORECASTER}
+        params2 = {"forecaster": FORECASTER, "initial_window": 2}
 
-        return params_list
+        return [params1, params2]

--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -24,15 +24,17 @@ class VECM(_StatsModelsAdapter):
     freq : str, optional
         See :class:`statsmodels.tsa.base.tsa_model.TimeSeriesModel` for more
         information.
-    missing : str, optional
+    missing : str, optional, default="none"
         See :class:`statsmodels.base.model.Model` for more information.
-    k_ar_diff : int
+    k_ar_diff : int, optional, default=1
         Number of lagged differences in the model. Equals :math:`k_{ar} - 1` in
         the formula above.
-    coint_rank : int
+    coint_rank : int, optional, default=1
         Cointegration rank, equals the rank of the matrix :math:`\\Pi` and the
         number of columns of :math:`\\alpha` and :math:`\\beta`.
-    deterministic : str {``"n"``, ``"co"``, ``"ci"``, ``"lo"``, ``"li"``}
+    deterministic : str, optional, default="n"
+        must be one of {``"n"``, ``"co"``, ``"ci"``, ``"lo"``, ``"li"``}
+
         * ``"n"`` - no deterministic terms
         * ``"co"`` - constant outside the cointegration relation
         * ``"ci"`` - constant within the cointegration relation
@@ -45,16 +47,16 @@ class VECM(_StatsModelsAdapter):
         (i.e. ``"ci"``) or leave it unrestricted (i.e. ``"co"``). Do not use
         both ``"ci"`` and ``"co"``. The same applies for ``"li"`` and ``"lo"``
         when using a linear term. See the Notes-section for more information.
-    seasons : int, default: 0
+    seasons : int, optional, default: 0
         Number of periods in a seasonal cycle. 0 means no seasons.
-    first_season : int, default: 0
+    first_season : int, optional, default: 0
         Season of the first observation.
     method : str {"ml"}, default: "ml"
         Estimation method to use. "ml" stands for Maximum Likelihood.
-    exog_coint : a scalar (float), 1D ndarray of size nobs,
+    exog_coint : optional, a scalar (float), 1D ndarray of size nobs,
         2D ndarray/pd.DataFrame of size (any, neqs)
         Deterministic terms inside the cointegration relation.
-    exog_coint_fc : a scalar (float), 1D ndarray of size nobs,
+    exog_coint_fc : optional, a scalar (float), 1D ndarray of size nobs,
         2D ndarray/pd.DataFrame of size (any, neqs)
         Forcasted value of exog_coint
 
@@ -276,3 +278,27 @@ class VECM(_StatsModelsAdapter):
         )
 
         return pred_int
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for forecasters.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params1 = {}
+        params2 = {"k_ar_diff": 2}
+
+        return [params1, params2]

--- a/sktime/transformations/series/date.py
+++ b/sktime/transformations/series/date.py
@@ -254,7 +254,7 @@ class DateTimeFeatures(BaseTransformer):
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
         params1 = {"feature_scope": "minimal"}
-        params2 = {"feature_scope": "efficient", "keep_original_columns": True"}
+        params2 = {"feature_scope": "efficient", "keep_original_columns": True}
         params3 = {"manual_selection": ["day_of_year", "day_of_month"]}
         return [params1, params2, params3]
 

--- a/sktime/transformations/series/date.py
+++ b/sktime/transformations/series/date.py
@@ -241,6 +241,23 @@ class DateTimeFeatures(BaseTransformer):
 
         return Xt
 
+    @classmethod
+    def get_test_params(cls):
+        """Return testing parameter settings for the estimator.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params1 = {"feature_scope": "minimal"}
+        params2 = {"feature_scope": "efficient", "keep_original_columns": True"}
+        params3 = {"manual_selection": ["day_of_year", "day_of_month"]}
+        return [params1, params2, params3]
+
 
 def _check_manual_selection(manual_selection, DUMMIES):
     if (manual_selection is not None) and (


### PR DESCRIPTION
This PR adds test parameters to some estimators, specifically to those in files touched by the 0.22.0 deprecation action, in order to make the incremental tests happy.