### PR TITLE
[ENH] make `statsforecast` adapter compatible with optional `predict` `level` arguments, and different init param sets

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -470,6 +470,15 @@
       ]
     },
     {
+      "login": "Arnau",
+      "name": "Arnau",
+      "avatar_url": "https://avatars.githubusercontent.com/u/38285979?s=400&u=8bdd0021cb5bae47ba5bd69c355c694dc3090f5e&v=4",
+      "profile": "https://www.linkedin.com/in/arnau-jim%C3%A9nez-castany-b2ba2597/",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
       "login": "ABostrom",
       "name": "Aaron Bostrom",
       "avatar_url": "https://avatars0.githubusercontent.com/u/9571933?v=4",

--- a/sktime/forecasting/arch.py
+++ b/sktime/forecasting/arch.py
@@ -48,14 +48,13 @@ class StatsForecastGARCH(_GeneralisedStatsForecastAdapter):
 
         super().__init__()
 
-    def _instantiate_model(self):
-        # import inside method to avoid hard dependency
+    def _get_statsforecast_class(self):
         from statsforecast.models import GARCH as _GARCH
 
-        return _GARCH(
-            p=self.p,
-            q=self.q,
-        )
+        return _GARCH
+
+    def _get_statsforecast_params(self):
+        return {"p": self.p, "q": self.q}
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -110,13 +109,13 @@ class StatsForecastARCH(_GeneralisedStatsForecastAdapter):
 
         super().__init__()
 
-    def _instantiate_model(self):
-        # import inside method to avoid hard dependency
+    def _get_statsforecast_class(self):
         from statsforecast.models import ARCH as _ARCH
 
-        return _ARCH(
-            p=self.p,
-        )
+        return _ARCH
+
+    def _get_statsforecast_params(self):
+        return {"p": self.p}
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -28,6 +28,14 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
     def __init__(self):
         super().__init__()
 
+        forecaster = self._instantiate_model()
+
+        if "level" not in signature(forecaster.predict_in_sample).parameters.keys():
+            self.set_tags(**{"capability:pred_int": False})
+
+        if "level" not in signature(forecaster.predict).parameters.keys():
+            self.set_tags(**{"capability:pred_int:insample": False})
+
         self._forecaster = None
 
     def _instantiate_model(self):

--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -42,6 +42,9 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
     def _get_statsforecast_class(self):
         raise NotImplementedError("abstract method")
 
+    def _get_statsforecast_params(self):
+        raise NotImplementedError("abstract method")
+
     def _get_init_statsforecast_params(self):
         statsforecast_class = self._get_statsforecast_class()
         return list(signature(statsforecast_class.__init__).parameters.keys())
@@ -63,7 +66,9 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
         return sktime_params
 
     def _instantiate_model(self):
-        raise NotImplementedError("abstract method")
+        cls = self._get_statsforecast_class()
+        params = self._validate_init_params(**self._get_statsforecast_params())
+        return cls(**params)
 
     def _fit(self, y, X, fh):
         """Fit forecaster to training data.

--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -31,10 +31,10 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
         forecaster = self._instantiate_model()
 
         if "level" not in signature(forecaster.predict_in_sample).parameters.keys():
-            self.set_tags(**{"capability:pred_int": False})
+            self.set_tags(**{"capability:pred_int:insample": False})
 
         if "level" not in signature(forecaster.predict).parameters.keys():
-            self.set_tags(**{"capability:pred_int:insample": False})
+            self.set_tags(**{"capability:pred_int": False})
 
         self._forecaster = None
 

--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -1,6 +1,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements adapter for StatsForecast models."""
 from inspect import signature
+from typing import Dict
 from warnings import warn
 
 import pandas
@@ -31,8 +32,8 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
 
         self._forecaster = None
         pred_supported = self._check_supports_pred_int()
-        self._support_pred_int_in_sample = pred_supported[0]
-        self._support_pred_int = pred_supported[1]
+        self._support_pred_int_in_sample = pred_supported["int_in_sample"]
+        self._support_pred_int = pred_supported["int"]
 
         self.set_tags(
             **{"capability:pred_int:insample": self._support_pred_int_in_sample}
@@ -315,7 +316,7 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
 
         return final_interval_predictions
 
-    def _check_supports_pred_int(self):
+    def _check_supports_pred_int(self) -> Dict[str, bool]:
         """
         Check if prediction intervals will work with forecaster.
 
@@ -326,13 +327,13 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
         support interval predictions.
 
          Furthermore, will throw a warning to let the user know that he should consider
-         upgrading statsforecast versio as both or one of the two methods might
+         upgrading statsforecast version as both or one of the two methods might
          not be able to produce confidence intervals.
 
         Returns
         -------
-        Tuple of bool
-            A tuple containing two boolean values:
+        Dict of bool
+            A dict containing two boolean values:
             - `support_pred_int_in_sample`: True if prediction intervals are supported
               in `predict_in_sample`, False otherwise.
             - `support_pred_int`: True if prediction intervals are supported
@@ -368,7 +369,7 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
         else:
             support_pred_int = True
 
-        return support_pred_int_in_sample, support_pred_int
+        return {"int_in_sample": support_pred_int_in_sample, "int": support_pred_int}
 
 
 class StatsForecastBackAdapter:

--- a/sktime/forecasting/statsforecast.py
+++ b/sktime/forecasting/statsforecast.py
@@ -253,45 +253,42 @@ class StatsForecastAutoARIMA(_GeneralisedStatsForecastAdapter):
 
         return AutoARIMA
 
-    def _instantiate_model(self):
-        # import inside method to avoid hard dependency
-        from statsforecast.models import AutoARIMA as _AutoARIMA
-
-        return _AutoARIMA(
-            d=self.d,
-            D=self.D,
-            max_p=self.max_p,
-            max_q=self.max_q,
-            max_P=self.max_P,
-            max_Q=self.max_Q,
-            max_order=self.max_order,
-            max_d=self.max_d,
-            max_D=self.max_D,
-            start_p=self.start_p,
-            start_q=self.start_q,
-            start_P=self.start_P,
-            start_Q=self.start_Q,
-            stationary=self.stationary,
-            seasonal=self.seasonal,
-            ic=self.information_criterion,
-            stepwise=self.stepwise,
-            nmodels=self.n_fits,
-            trace=self.trace,
-            approximation=self.approximation,
-            method=self.method,
-            truncate=self.truncate,
-            test=self.test,
-            test_kwargs=self.offset_test_args,
-            seasonal_test=self.seasonal_test,
-            seasonal_test_kwargs=self.seasonal_test_args,
-            allowdrift=self.trend,
-            allowmean=self.with_intercept,
-            blambda=self.blambda,
-            biasadj=self.biasadj,
-            parallel=self.parallel,
-            num_cores=self.n_jobs,
-            season_length=self.sp,
-        )
+    def _get_statsforecast_params(self):
+        return {
+            "d": self.d,
+            "D": self.D,
+            "max_p": self.max_p,
+            "max_q": self.max_q,
+            "max_P": self.max_P,
+            "max_Q": self.max_Q,
+            "max_order": self.max_order,
+            "max_d": self.max_d,
+            "max_D": self.max_D,
+            "start_p": self.start_p,
+            "start_q": self.start_q,
+            "start_P": self.start_P,
+            "start_Q": self.start_Q,
+            "stationary": self.stationary,
+            "seasonal": self.seasonal,
+            "ic": self.information_criterion,
+            "stepwise": self.stepwise,
+            "nmodels": self.n_fits,
+            "trace": self.trace,
+            "approximation": self.approximation,
+            "method": self.method,
+            "truncate": self.truncate,
+            "test": self.test,
+            "test_kwargs": self.offset_test_args,
+            "seasonal_test": self.seasonal_test,
+            "seasonal_test_kwargs": self.seasonal_test_args,
+            "allowdrift": self.trend,
+            "allowmean": self.with_intercept,
+            "blambda": self.blambda,
+            "biasadj": self.biasadj,
+            "parallel": self.parallel,
+            "num_cores": self.n_jobs,
+            "season_length": self.sp,
+        }
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -372,17 +369,12 @@ class StatsForecastAutoTheta(_GeneralisedStatsForecastAdapter):
 
         return AutoTheta
 
-    def _instantiate_model(self):
-        """Create underlying forecaster instance."""
-        from statsforecast.models import AutoTheta
-
-        params = self._validate_init_params(
-            season_length=self.season_length,
-            decomposition_type=self.decomposition_type,
-            model=self.model,
-        )
-
-        return AutoTheta(**params)
+    def _get_statsforecast_params(self):
+        return {
+            "season_length": self.season_length,
+            "decomposition_type": self.decomposition_type,
+            "model": self.model,
+        }
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -472,13 +464,12 @@ class StatsForecastAutoETS(_GeneralisedStatsForecastAdapter):
 
         return AutoETS
 
-    def _instantiate_model(self):
-        """Create underlying forecaster instance."""
-        from statsforecast.models import AutoETS
-
-        return AutoETS(
-            season_length=self.season_length, model=self.model, damped=self.damped
-        )
+    def _get_statsforecast_params(self):
+        return {
+            "season_length": self.season_length,
+            "model": self.model,
+            "damped": self.damped,
+        }
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -553,11 +544,11 @@ class StatsForecastAutoCES(_GeneralisedStatsForecastAdapter):
 
         return AutoCES
 
-    def _instantiate_model(self):
-        """Create underlying forecaster instance."""
-        from statsforecast.models import AutoCES
-
-        return AutoCES(season_length=self.season_length, model=self.model)
+    def _get_statsforecast_params(self):
+        return {
+            "season_length": self.season_length,
+            "model": self.model,
+        }
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -664,14 +655,11 @@ class StatsForecastMSTL(_GeneralisedStatsForecastAdapter):
 
         return MSTL
 
-    def _instantiate_model(self):
-        """Create underlying forecaster instance."""
-        from statsforecast.models import MSTL
-
-        return MSTL(
-            season_length=self.season_length,
-            trend_forecaster=self._trend_forecaster,
-        )
+    def _get_statsforecast_params(self):
+        return {
+            "season_length": self.season_length,
+            "trend_forecaster": self._trend_forecaster,
+        }
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/forecasting/statsforecast.py
+++ b/sktime/forecasting/statsforecast.py
@@ -247,6 +247,12 @@ class StatsForecastAutoARIMA(_GeneralisedStatsForecastAdapter):
 
         super().__init__()
 
+    def _get_statsforecast_class(self):
+        """Get the class of the statsforecast forecaster."""
+        from statsforecast.models import AutoARIMA
+
+        return AutoARIMA
+
     def _instantiate_model(self):
         # import inside method to avoid hard dependency
         from statsforecast.models import AutoARIMA as _AutoARIMA
@@ -360,15 +366,23 @@ class StatsForecastAutoTheta(_GeneralisedStatsForecastAdapter):
 
         super().__init__()
 
+    def _get_statsforecast_class(self):
+        """Get the class of the statsforecast forecaster."""
+        from statsforecast.models import AutoTheta
+
+        return AutoTheta
+
     def _instantiate_model(self):
         """Create underlying forecaster instance."""
         from statsforecast.models import AutoTheta
 
-        return AutoTheta(
+        params = self._validate_init_params(
             season_length=self.season_length,
             decomposition_type=self.decomposition_type,
             model=self.model,
         )
+
+        return AutoTheta(**params)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -452,6 +466,12 @@ class StatsForecastAutoETS(_GeneralisedStatsForecastAdapter):
 
         super().__init__()
 
+    def _get_statsforecast_class(self):
+        """Create underlying forecaster instance."""
+        from statsforecast.models import AutoETS
+
+        return AutoETS
+
     def _instantiate_model(self):
         """Create underlying forecaster instance."""
         from statsforecast.models import AutoETS
@@ -526,6 +546,12 @@ class StatsForecastAutoCES(_GeneralisedStatsForecastAdapter):
         self.model = model
 
         super().__init__()
+
+    def _get_statsforecast_class(self):
+        """Get the class of the statsforecast forecaster."""
+        from statsforecast.models import AutoCES
+
+        return AutoCES
 
     def _instantiate_model(self):
         """Create underlying forecaster instance."""
@@ -632,6 +658,11 @@ class StatsForecastMSTL(_GeneralisedStatsForecastAdapter):
                     " that the forecaster you pass into the model is a sktime "
                     "forecaster."
                 )
+
+    def _get_statsforecast_class(self):
+        from statsforecast.models import MSTL
+
+        return MSTL
 
     def _instantiate_model(self):
         """Create underlying forecaster instance."""


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #5024 and #5207:

* Versions previous to v1.5.0 of `statsforecast` do not have the `level`
argument in the `predict` or `predict_in_sample` methods of the
forecasters.
* `statsforecast` removed the `parallel` argument in some estimator since v1.6.0

Details:

#### What does this implement/fix? Explain your changes.
Now before calling `predict` or `predict_in_sample`  we make sure the methods contain the `level` argument otherwise we do not pass it.

To handle the `level` argument we will set tags dynamically at instantiation time to see if they are there in the methods `predict_in_sample` and `predict`. 

Also newer versions of `statsforecast` removed parameters that were available in previous versions. We will take care of it by throwing a warning if the user passes a keyword argument that is not supported by the current version of `statsforecast` that they might be using. We will throw a warning if the user passes the keyword argument which is non-existent in its current version of `statsforecast`.

If a parameter is set by default and NOT passed by the user, the parameter will also be ignored but NO warning will be thrown as the user did not intend to use that parameter in the first place, so he should not care.


#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

Make sure it will work for any version of `stasforecast`

#### Did you add any tests for the change?

No




#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.


