### PR TITLE
[MNT] speed up `test_probabilistic_metrics` by explicit fixture generation instead of using forecaster fit/predict

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2302,7 +2302,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/45173421",
       "profile": "https://github.com/Ram0nB",
       "contributions": [
-        "doc"
+        "doc",
+		"code"
       ]
     },
     {

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2303,7 +2303,7 @@
       "profile": "https://github.com/Ram0nB",
       "contributions": [
         "doc",
-		"code"
+        "code"
       ]
     },
     {

--- a/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
@@ -43,9 +43,9 @@ def sample_data(request):
         interval_pred = {}
         for col in range(n_columns):
             if n_columns == 1:
-                y_vals = y_train
+                y_vals = y_test
             else:
-                y_vals = y_train.iloc[:, col]
+                y_vals = y_test.iloc[:, col]
             for coverage in np.array([coverage_or_alpha]).flatten():
                 interval_pred[(col, coverage, "lower")] = (
                     y_vals * np.random.uniform(0.9, 1.1, len(y_vals)) * (1 - coverage)
@@ -60,9 +60,9 @@ def sample_data(request):
         quantile_pred = {}
         for col in range(n_columns):
             if n_columns == 1:
-                y_vals = y_train
+                y_vals = y_test
             else:
-                y_vals = y_train.iloc[:, col]
+                y_vals = y_test.iloc[:, col]
             for alpha in coverage_or_alpha:
                 quantile_pred[(col, alpha)] = (
                     y_vals * np.random.uniform(0.9, 1.1, len(y_vals)) * (0.5 + alpha)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#2890


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Explicit prediction generation rather than via the NaiveForecaster/NaiveVariance to speed up testing

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No


#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.


<!--
Thanks for contributing!
-->
