### PR TITLE
[BUG] fix `numba` based aligners

### DIFF
--- a/sktime/alignment/base.py
+++ b/sktime/alignment/base.py
@@ -88,7 +88,14 @@ class BaseAligner(BaseEstimator):
 
         self._fit(X=X_inner, Z=Z)
 
-        self._X = X_inner
+        # convert X to df-list for use in get_aligned, get_alignment_loc
+        if X_inner_mtype != "df-list":
+            self._X = convert(
+                X, from_type=X_mtype, to_type="df-list", as_scitype="Panel"
+            )
+        else:
+            self._X = X_inner
+
         self._Z = Z
 
         self._is_fitted = True

--- a/sktime/alignment/dtw_numba.py
+++ b/sktime/alignment/dtw_numba.py
@@ -120,6 +120,7 @@ class AlignerDtwNumba(BaseAligner):
         "capability:multiple-alignment": False,  # can align more than two sequences?
         "capability:distance": True,  # does compute/return overall distance?
         "capability:distance-matrix": True,  # does compute/return distance matrix?
+        "X_inner_mtype": "numpy3D",
         "python_dependencies": "numba",
     }
 
@@ -179,8 +180,8 @@ class AlignerDtwNumba(BaseAligner):
         """
         from sktime.distances import distance_alignment_path
 
-        X1 = X[0].values.T
-        X2 = X[1].values.T
+        X1 = X[0]
+        X2 = X[1]
 
         metric_key = self.metric_key
         kwargs = self.kwargs

--- a/sktime/alignment/edit_numba.py
+++ b/sktime/alignment/edit_numba.py
@@ -116,6 +116,7 @@ class AlignerEditNumba(BaseAligner):
         "capability:multiple-alignment": False,  # can align more than two sequences?
         "capability:distance": True,  # does compute/return overall distance?
         "capability:distance-matrix": True,  # does compute/return distance matrix?
+        "alignment_type": "partial",
         "X_inner_mtype": "numpy3D",
         "python_dependencies": "numba",
     }

--- a/sktime/alignment/edit_numba.py
+++ b/sktime/alignment/edit_numba.py
@@ -187,8 +187,8 @@ class AlignerEditNumba(BaseAligner):
         """
         from sktime.distances import distance_alignment_path
 
-        X1 = X[0].values.T
-        X2 = X[1].values.T
+        X1 = X[0]
+        X2 = X[1]
 
         metric_key = self.distance
         kwargs = self.kwargs

--- a/sktime/alignment/edit_numba.py
+++ b/sktime/alignment/edit_numba.py
@@ -113,6 +113,9 @@ class AlignerEditNumba(BaseAligner):
 
     _tags = {
         "symmetric": True,  # all the distances are symmetric
+        "capability:multiple-alignment": False,  # can align more than two sequences?
+        "capability:distance": True,  # does compute/return overall distance?
+        "capability:distance-matrix": True,  # does compute/return distance matrix?
         "X_inner_mtype": "numpy3D",
         "python_dependencies": "numba",
     }


### PR DESCRIPTION
This PR fixes a bug in the `numba` based aligners which were detected by the release action.

The bug was unreported, and causes `transform` to break at call, due to the `X_inner_mtype` tag and the handling of `X` in `transform` being inconsistent. This has now been rectified, assuming `numpy3D` in both tag and `_transform` logic.

Odd that we did not catch this earlier.

FYI @yarnabrina, any idea why the differential testing did not catch this?