### PR TITLE
[MNT] restrict `sphinx < 7.2.0` to address build failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ docs = [
     "sphinx-gallery<0.14.0",
     "sphinx-design<0.6.0",
     "sphinx-version-warning",
-    "Sphinx<8.0.0",
+    "Sphinx<7.2.0",
     "tabulate",
 ]
 


### PR DESCRIPTION
Temporary fix for #5117, which is likely caused by the 7.2.0 release 12 hours ago.