### PR TITLE
[ENH] Allow unrestriced ID string for BaseBenchmarking

### DIFF
--- a/sktime/benchmarking/_base_kotsu.py
+++ b/sktime/benchmarking/_base_kotsu.py
@@ -12,10 +12,10 @@ from kotsu.registration import _Registry, _Spec  # noqa: E402
 
 def _check_entity_id_format(entity_id_format: str, id: str) -> None:
     """Check if given input id followed regex specified in entity_id_format."""
-    if not isinstance(entity_id_format, str):
-        raise TypeError(
-            f"entity_id_format must be a str but receive {type(entity_id_format)}"
-        )
+    # if not isinstance(entity_id_format, (str, None)):
+    #     raise TypeError(
+    #         f"entity_id_format must be a str but receive {type(entity_id_format)}"
+    #     )
 
     if entity_id_format is not None:
         entity_id_re = re.compile(entity_id_format)
@@ -27,7 +27,7 @@ def _check_entity_id_format(entity_id_format: str, id: str) -> None:
             )
 
 
-class _SpecSktime(_Spec):
+class _SktimeSpec(_Spec):
     """A specification for a particular instance of an entity.
 
     Used to register entity and parameters full specification for evaluations.
@@ -75,14 +75,15 @@ class _SpecSktime(_Spec):
         self._kwargs = {} if kwargs is None else kwargs
 
 
-class ModelRegistrySktime(_Registry):
+class SktimeModelRegistry(_Registry):
     """Register an entity by ID.
 
     IDs should remain stable over time and should be guaranteed to resolve to
     the same entity dynamics (or be desupported).
     """
 
-    def __init__(self):
+    def __init__(self, entity_id_fomat: str):
+        self.entity_id_fomat = entity_id_fomat
         super().__init__()
 
     def register(
@@ -123,10 +124,11 @@ class ModelRegistrySktime(_Registry):
                 category=UserWarning,
                 stacklevel=2,
             )
-        self.entity_specs[id] = _SpecSktime(
+        self.entity_specs[id] = _SktimeSpec(
             id,
             entry_point,
             deprecated=deprecated,
             nondeterministic=nondeterministic,
+            entity_id_fomat=self.entity_id_fomat,
             kwargs=kwargs,
         )

--- a/sktime/benchmarking/_kotsu.py
+++ b/sktime/benchmarking/_kotsu.py
@@ -1,0 +1,132 @@
+"""Interface to overide kotsu code for sktime use."""
+
+import re
+import warnings
+from typing import Callable, Optional, Union
+
+from sktime.utils.validation._dependencies import _check_soft_dependencies
+
+_check_soft_dependencies("kotsu", severity="error")
+from kotsu.registration import _Registry, _Spec  # noqa: E402
+
+
+def _check_entity_id_format(entity_id_format: str, id: str) -> None:
+    """Check if given input id followed regex specified in entity_id_format."""
+    if not isinstance(entity_id_format, str):
+        raise TypeError(
+            f"entity_id_format must be a str but receive {type(entity_id_format)}"
+        )
+
+    if entity_id_format is not None:
+        entity_id_re = re.compile(entity_id_format)
+        match = entity_id_re.search(id)
+        if not match:
+            raise ValueError(
+                f"Attempted to register malformed entity ID: [id={id}]. "
+                f"(Currently all IDs must be of the form {entity_id_re.pattern}.)"
+            )
+
+
+class _SpecSktime(_Spec):
+    """A specification for a particular instance of an entity.
+
+    Used to register entity and parameters full specification for evaluations.
+
+    Parameters
+    ----------
+    id: str
+        A unique entity ID. Required format; [username/](entity-name)-v(version)
+        [username/] is optional.
+    entry_point: Callable or str
+        The python entrypoint of the entity class. Should be one of:
+        - the string path to the python object (e.g.module.name:factory_func, or
+            module.name:Class)
+        - the python object (class or factory) itself
+    deprecated: Bool, optional (default=False)
+        Flag to denote whether this entity should be skipped in validation runs and
+        considered deprecated and replaced by a more recent/better validation/model
+    nondeterministic: Bool, optional (default=False)
+        Whether this entity is non-deterministic even after seeding
+    entity_id_fomat: str, optional (default=None)
+        Specifying regex to make sure ID follow certain desired format.
+    kwargs: Dict, optional (default=None)
+        The kwargs to pass to the entity entry point when instantiating the entity
+
+    Notes
+    -----
+    Taken and adapted from:
+    https://github.com/datavaluepeople/kotsu/blob/main/kotsu/registration.py
+    """
+
+    def __init__(
+        self,
+        id: str,
+        entry_point: Union[Callable, str],
+        deprecated: bool = False,
+        nondeterministic: bool = False,
+        entity_id_fomat: str = None,
+        kwargs: Optional[dict] = None,
+    ):
+        _check_entity_id_format(entity_id_fomat, id)
+        self.id = id
+        self.entry_point = entry_point
+        self.deprecated = deprecated
+        self.nondeterministic = nondeterministic
+        self._kwargs = {} if kwargs is None else kwargs
+
+
+class ModelRegistrySktime(_Registry):
+    """Register an entity by ID.
+
+    IDs should remain stable over time and should be guaranteed to resolve to
+    the same entity dynamics (or be desupported).
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def register(
+        self,
+        id: str,
+        entry_point: Union[Callable, str],
+        deprecated: bool = False,
+        nondeterministic: bool = False,
+        kwargs: Optional[dict] = None,
+    ):
+        """Register an entity.
+
+        Parameters
+        ----------
+        id: str
+            A unique entity ID. Required format; [username/](entity-name)-v(version)
+            [username/] is optional.
+        entry_point: Callable or str
+            The python entrypoint of the entity class. Should be one of:
+            - the string path to the python object (e.g.module.name:factory_func, or
+                module.name:Class)
+            - the python object (class or factory) itself
+        deprecated: Bool, optional (default=False)
+            Flag to denote whether this entity should be skipped in validation runs and
+            considered deprecated and replaced by a more recent/better validation/model
+        nondeterministic: Bool, optional (default=False)
+            Whether this entity is non-deterministic even after seeding
+        entity_id_fomat: str, optional (default=None)
+            Specifying regex to make sure ID follow certain desired format.
+        kwargs: Dict, optional (default=None)
+            The kwargs to pass to the entity entry point when instantiating the entity
+        """
+        if id in self.entity_specs:
+            warnings.warn(
+                message=f"Entity with ID [id={id}] already registered, but the ID is "
+                "now being used to register another entity, OVERWRITING previous "
+                "registered entity.",
+                category=UserWarning,
+                stacklevel=2,
+            )
+        self.entity_specs[id] = _SpecSktime(
+            id,
+            entry_point,
+            deprecated=deprecated,
+            nondeterministic=nondeterministic,
+            kwargs=kwargs,
+        )

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -80,7 +80,8 @@ class BaseBenchmark:
         _check_soft_dependencies("kotsu")
         import kotsu
 
-        from sktime.benchmarking._base_kotsu import SktimeModelRegistry
+        # from sktime.benchmarking._base_kotsu import SktimeModelRegistry
+        from _base_kotsu import SktimeModelRegistry
 
         self.estimators = SktimeModelRegistry(entity_id_fomat)
         self.validations = kotsu.registration.ValidationRegistry()

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -76,11 +76,13 @@ class BaseBenchmark:
     A benchmark consists of a set of tasks and a set of estimators.
     """
 
-    def __init__(self):
+    def __init__(self, entity_id_fomat: Optional[str] = None):
         _check_soft_dependencies("kotsu")
         import kotsu
 
-        self.estimators = kotsu.registration.ModelRegistry()
+        from sktime.benchmarking._base_kotsu import SktimeModelRegistry
+
+        self.estimators = SktimeModelRegistry(entity_id_fomat)
         self.validations = kotsu.registration.ValidationRegistry()
         self.kotsu_run = kotsu.run.run
 

--- a/sktime/benchmarking/forecasting.py
+++ b/sktime/benchmarking/forecasting.py
@@ -2,7 +2,9 @@
 import functools
 from typing import Callable, Dict, List, Optional, Union
 
-from sktime.benchmarking.benchmarks import BaseBenchmark
+# from sktime.benchmarking.benchmarks import BaseBenchmark
+from benchmarks import BaseBenchmark
+
 from sktime.forecasting.base import BaseForecaster
 from sktime.forecasting.model_evaluation import evaluate
 from sktime.forecasting.model_selection._split import BaseSplitter


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Towards #4873 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

This is a design for which to override, make patches and get more control to kotsu framework within sktime. I started with a small change first to get a green light before proceeding with others. 

I have a question I need a help with:

so I added a new module/file named *_base_kotsu.py* to override a few classes from kotsu. However, when I try to check the implementation using an absolute import, I encounter a problem. To ensure that Python imports the module from my developer setup instead of my miniconda environment, I have to use relative import. Using absolute import leads to problems like Module Not Found when doing `from sktime.benchmarking._base_kotsu import something`. I am unsure if I set up my environment incorrectly. I believe I installed my environment correctly using `pip install --editable .[dev]` -  is there a way to double check if the env in editable mode?


#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
WIP

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->
- [ ] make the same override for validation id

@fkiraly @benHeid 
