### PR TITLE
[BUG] fixes logic but if `ConformalIntervals` wraps a hierarchical estimator

### DIFF
--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -15,7 +15,7 @@ import pandas as pd
 from joblib import Parallel, delayed
 from sklearn.base import clone
 
-from sktime.datatypes import MTYPE_LIST_SERIES, convert, convert_to
+from sktime.datatypes import ALL_TIME_SERIES_MTYPES, convert, convert_to
 from sktime.datatypes._utilities import get_slice
 from sktime.forecasting.base import BaseForecaster
 
@@ -125,8 +125,8 @@ class ConformalIntervals(BaseForecaster):
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,
         "capability:pred_int:insample": False,
-        "X_inner_mtype": MTYPE_LIST_SERIES,
-        "y_inner_mtype": MTYPE_LIST_SERIES,
+        "X_inner_mtype": ALL_TIME_SERIES_MTYPES,
+        "y_inner_mtype": ALL_TIME_SERIES_MTYPES,
     }
 
     ALLOWED_METHODS = [


### PR DESCRIPTION
This fixes a remaining logic bug with PR https://github.com/sktime/sktime/pull/5093 in case that `ConformalIntervals` wraps a genuinely hierarchical estimator.

In this case, `ConformalIntervals` should compute residuals based on hierarchical forecasts, but instead it accidentally vectorizes.

This is due to the `y_inner_mtype` not containing panel or hierarchical mtypes - this is rectified.