### PR TITLE
[BUG] fix breaking absolute/relative conversions of `ForecastingHorizon` when inferred frequency of a `DatetimeIndex` is `"MS"`

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -804,7 +804,10 @@ def _to_absolute(fh: ForecastingHorizon, cutoff) -> ForecastingHorizon:
 
         if is_timestamp:
             # coerce back to DatetimeIndex after operation
-            absolute = absolute.to_timestamp(fh.freq)
+            if hasattr(absolute, "freq") and absolute.freq is not None:
+                absolute = absolute.to_timestamp()
+            else:
+                absolute = absolute.to_timestamp(fh.freq)
 
         return fh._new(absolute, is_relative=False, freq=fh.freq)
 
@@ -859,7 +862,10 @@ def _coerce_to_period(x, freq=None):
             "_coerce_to_period requires freq argument to be passed if x is pd.Timestamp"
         )
     try:
-        return x.to_period(freq)
+        if hasattr(x, "freq") and x.freq is not None:
+            return x.to_period()
+        else:
+            return x.to_period(freq)
     except (ValueError, AttributeError) as e:
         msg = str(e)
         if "Invalid frequency" in msg or "_period_dtype_code" in msg:


### PR DESCRIPTION
Fixes #5131.

The reason are breaking absolute/relative conversions of `ForecastingHorizon` when inferred frequency of a `DatetimeIndex` is `"MS"`, more precisely an assumption that inferred frequencies of `DatetimeIndex` and `PeriodIndex` always have the same frequecy string in all cases, which is not true in this case (`MS` vs `M`).

The fix is giving the default calls to `to_period` and `to_timestamp` priority if a `freq` attribute is available, to avoid passing a discrepant `freq` string and have the `pandas.Index` machinery infer the counterpart correctly.

No tests have been added - it would be great, @yarnabrina, if you could add tests, or think about what tests we would need to add where to cover this, to ensure we have all conversions checked and not just an integration case. We can of course add #5131, but I want to avoid patchwork.