### PR TITLE
[BUG] fix check causing exception in `ConformalIntervals` in `_predict`

### DIFF
--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -185,6 +185,8 @@ class ConformalIntervals(BaseForecaster):
                 initial_window=self.initial_window,
                 sample_frac=self.sample_frac,
             )
+        else:
+            self.residuals_matrix_ = None
 
         return self
 


### PR DESCRIPTION
This fixes a potential exception caused by late passing of `fh` in `ConformalIntervals` in `predict`.