### PR TITLE
[ENH] refactor and add conditional execution to `numba` based distance tests

### DIFF
--- a/sktime/distances/tests/test_distance_correctness.py
+++ b/sktime/distances/tests/test_distance_correctness.py
@@ -99,7 +99,7 @@ def test_correctness(dist, uni_multi):
         param_list = [{}]
 
     # assert distance between fixtures d, d2 are same as expected
-    for j, param in param_list:
+    for j, param in enumerate(param_list):
         d = dist(trainX[0], trainX[ind2], param)
         d2 = dist(trainX[0], trainX[ind2], param)
         assert_almost_equal(d, expected[dist_str][j], 4)

--- a/sktime/distances/tests/test_distance_correctness.py
+++ b/sktime/distances/tests/test_distance_correctness.py
@@ -106,6 +106,11 @@ def test_correctness(dist, uni_multi):
 
     # assert distance between fixtures d, d2 are same as expected
     for j, param in enumerate(param_list):
+        # deal with custom setting of epsilon in multi
+        # this was in the original test before refactoring
+        if "epsilon" in param and "uni_multi" == "multi":
+            param = {"epsilon": param["epsilon"] / 50}
+        # check that distance is same as expected
         d = dist(trainX[0], trainX[ind2], **param)
         d2 = dist(trainX[0], trainX[ind2], **param)
         assert_almost_equal(d, expected[dist_str][j], 4)

--- a/sktime/distances/tests/test_distance_correctness.py
+++ b/sktime/distances/tests/test_distance_correctness.py
@@ -46,6 +46,7 @@ unit_test_distances = {
     "ddtw": [80806.0, 76289.0625, 76289.0625],
     "wddtw": [38144.53125, 19121.4927, 1.34957],
     "twe": [242.001, 628.0029999999999, 3387.044],
+    "squared": [384147.0],
 }
 basic_motions_distances = {
     "euclidean": [27.51835240],
@@ -58,6 +59,7 @@ basic_motions_distances = {
     "ddtw": [297.18771, 160.48649, 160.29823],
     "wddtw": [80.149117, 1.458858, 0.0],
     "twe": [1.325876246546281, 14.759114523578294, 218.21301289250758],
+    "squared": [757.259719],
 }
 
 
@@ -75,6 +77,10 @@ def test_correctness(dist, uni_multi):
     """
     # skip test if distance function/class have not changed
     if not run_test_for_class([dist.dist_func, dist.dist_instance.__class__]):
+        return None
+
+    # msm distance is not implemented for multivariate
+    if uni_multi == "multi" and dist.canonical_name in ["msm"]:
         return None
 
     dist_str = dist.canonical_name

--- a/sktime/distances/tests/test_distance_correctness.py
+++ b/sktime/distances/tests/test_distance_correctness.py
@@ -3,38 +3,15 @@
 Compare the distance calculations on the 1D and 2D (d,m) format input against the
 results generated with tsml, in distances.tests.TestDistances.
 """
-__author__ = ["chrisholder", "TonyBagnall"]
+__author__ = ["chrisholder", "TonyBagnall", "fkiraly"]
 
 import pytest
 from numpy.testing import assert_almost_equal
 
 from sktime.datasets import load_basic_motions, load_unit_test
-from sktime.distances import (
-    ddtw_distance,
-    dtw_distance,
-    edr_distance,
-    erp_distance,
-    euclidean_distance,
-    lcss_distance,
-    msm_distance,
-    twe_distance,
-    wddtw_distance,
-    wdtw_distance,
-)
+from sktime.distances._distance import _METRIC_INFOS
+from sktime.tests.test_switch import run_test_for_class
 from sktime.utils.validation._dependencies import _check_soft_dependencies
-
-distances = [
-    "dtw",
-    "wdtw",
-    "lcss",
-    "msm",
-    "ddtw",
-    "euclidean",
-    "erp",
-    "ddtw",
-    "wddtw",
-    "twe",
-]
 
 distance_parameters = {
     "dtw": [0.0, 0.1, 1.0],  # window
@@ -47,8 +24,19 @@ distance_parameters = {
     "ddtw": [0.0, 0.1, 1.0],  # window
     "twe": [0.0, 0.1, 1.0],  # window
 }
+distance_param_name = {
+    "dtw": "window",
+    "wdtw": "g",
+    "wddtw": "g",
+    "msm": "c",
+    "erp": "window",
+    "lcss": "epsilon",
+    "edr": "epsilon",
+    "ddtw": "window",
+    "twe": "window",
+}
 unit_test_distances = {
-    "euclidean": 619.7959,
+    "euclidean": [619.7959],
     "dtw": [384147.0, 315012.0, 275854.0],
     "wdtw": [137927.0, 68406.15849, 2.2296],
     "msm": [1515.0, 1516.4, 1529.0],
@@ -60,7 +48,7 @@ unit_test_distances = {
     "twe": [242.001, 628.0029999999999, 3387.044],
 }
 basic_motions_distances = {
-    "euclidean": 27.51835240,
+    "euclidean": [27.51835240],
     "dtw": [757.259719, 330.834497, 330.834497],
     "wdtw": [165.41724, 3.308425, 0],
     "msm": [70.014828, 89.814828, 268.014828],
@@ -77,86 +65,42 @@ basic_motions_distances = {
     not _check_soft_dependencies("numba", severity="none"),
     reason="skip test if required soft dependency not available",
 )
-def test_multivariate_correctness():
-    """Test distance correctness on BasicMotions: multivariate, equal length."""
-    trainX, trainy = load_basic_motions(return_type="numpy3D")
-    case1 = trainX[0]
-    case2 = trainX[1]
-    d = euclidean_distance(case1, case2)
-    assert_almost_equal(d, basic_motions_distances["euclidean"], 4)
-    twe_mult = []
-    for j in range(0, 3):
-        d = dtw_distance(case1, case2, window=distance_parameters["dtw"][j])
-        assert_almost_equal(d, basic_motions_distances["dtw"][j], 4)
-        d = wdtw_distance(case1, case2, g=distance_parameters["wdtw"][j])
-        assert_almost_equal(d, basic_motions_distances["wdtw"][j], 4)
-        d = lcss_distance(case1, case2, epsilon=distance_parameters["lcss"][j] / 50.0)
-        assert_almost_equal(d, basic_motions_distances["lcss"][j], 4)
-        d = erp_distance(case1, case2, window=distance_parameters["erp"][j])
-        assert_almost_equal(d, basic_motions_distances["erp"][j], 4)
-        d = edr_distance(case1, case2, epsilon=distance_parameters["edr"][j] / 50.0)
-        assert_almost_equal(d, basic_motions_distances["edr"][j], 4)
-        d = ddtw_distance(case1, case2, window=distance_parameters["ddtw"][j])
-        assert_almost_equal(d, basic_motions_distances["ddtw"][j], 4)
-        d = wddtw_distance(case1, case2, g=distance_parameters["wddtw"][j])
-        assert_almost_equal(d, basic_motions_distances["wddtw"][j], 4)
-        d = twe_distance(case1, case2, window=distance_parameters["twe"][j])
-        twe_mult.append(d)
-        assert_almost_equal(d, basic_motions_distances["twe"][j], 4)
+@pytest.mark.parametrize("uni_multi", ["uni", "multi"])
+@pytest.mark.parametrize("dist", _METRIC_INFOS)
+def test_correctness(dist, uni_multi):
+    """Test dtw correctness on:
 
+    uni_multi = "uni" -> UnitTest: univariate, equal length.
+    uni_multi = "multi" -> BasicMotions: multivariate, equal length.
+    """
+    # skip test if distance function/class have not changed
+    if not run_test_for_class([dist.dist_func, dist.dist_instance.__class__]):
+        return None
 
-@pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
-    reason="skip test if required soft dependency not available",
-)
-def test_univariate_correctness():
-    """Test dtw correctness on UnitTest: univariate, equal length."""
-    trainX, trainy = load_unit_test(return_type="numpy3D")
-    trainX2, trainy2 = load_unit_test(return_type="numpy2D")
-    # Test 2D and 3D instances from UnitTest
-    cases1 = [trainX[0], trainX2[0]]
-    cases2 = [trainX[2], trainX2[2]]
-    # Add test cases1 and 2 are the same
-    d = euclidean_distance(cases1[0], cases2[0])
-    d2 = euclidean_distance(cases1[1], cases2[1])
-    assert_almost_equal(d, unit_test_distances["euclidean"], 4)
-    assert d == d2
-    twe_uni = []
-    for j in range(0, 3):
-        d = dtw_distance(cases1[0], cases2[0], window=distance_parameters["dtw"][j])
-        d2 = dtw_distance(cases1[1], cases2[1], window=distance_parameters["dtw"][j])
-        assert_almost_equal(d, unit_test_distances["dtw"][j], 4)
-        assert d == d2
-        d = wdtw_distance(cases1[0], cases2[0], g=distance_parameters["wdtw"][j])
-        d2 = wdtw_distance(cases1[1], cases2[1], g=distance_parameters["wdtw"][j])
-        assert_almost_equal(d, unit_test_distances["wdtw"][j], 4)
-        assert d == d2
-        d = lcss_distance(cases1[0], cases2[0], epsilon=distance_parameters["lcss"][j])
-        d2 = lcss_distance(cases1[1], cases2[1], epsilon=distance_parameters["lcss"][j])
-        assert_almost_equal(d, unit_test_distances["lcss"][j], 4)
-        assert d == d2
-        d = msm_distance(cases1[0], cases2[0], c=distance_parameters["msm"][j])
-        d2 = msm_distance(cases1[1], cases2[1], c=distance_parameters["msm"][j])
-        assert_almost_equal(d, unit_test_distances["msm"][j], 4)
-        assert d == d2
-        d = erp_distance(cases1[0], cases2[0], window=distance_parameters["erp"][j])
-        d2 = erp_distance(cases1[1], cases2[1], window=distance_parameters["erp"][j])
-        assert_almost_equal(d, unit_test_distances["erp"][j], 4)
-        assert d == d2
-        d = edr_distance(cases1[0], cases2[0], epsilon=distance_parameters["edr"][j])
-        d2 = edr_distance(cases1[1], cases2[1], epsilon=distance_parameters["edr"][j])
-        assert_almost_equal(d, unit_test_distances["edr"][j], 4)
-        assert d == d2
-        d = ddtw_distance(cases1[0], cases2[0], window=distance_parameters["ddtw"][j])
-        d2 = ddtw_distance(cases1[1], cases2[1], window=distance_parameters["ddtw"][j])
-        assert_almost_equal(d, unit_test_distances["ddtw"][j], 4)
-        assert d == d2
-        d = wddtw_distance(cases1[0], cases2[0], g=distance_parameters["wddtw"][j])
-        d2 = wddtw_distance(cases1[1], cases2[1], g=distance_parameters["wddtw"][j])
-        assert_almost_equal(d, unit_test_distances["wddtw"][j], 4)
-        assert d == d2
-        d = twe_distance(cases1[0], cases2[1], window=distance_parameters["twe"][j])
-        d2 = twe_distance(cases1[1], cases2[1], window=distance_parameters["twe"][j])
-        twe_uni.append(d)
-        assert_almost_equal(d, unit_test_distances["twe"][j], 4)
+    dist_str = dist.canonical_name
+    dist = dist.dist_func
+
+    if uni_multi == "uni":
+        loader = load_unit_test
+        ind2 = 2
+        expected = unit_test_distances
+    else:
+        loader = load_basic_motions
+        ind2 = 1
+        expected = basic_motions_distances
+
+    trainX, _ = loader(return_type="numpy3D")
+
+    # test parameters
+    if dist_str in distance_param_name:
+        params_multi = distance_parameters[dist_str]
+        param_list = [{distance_param_name[dist_str]: x} for x in params_multi]
+    else:
+        param_list = [{}]
+
+    # assert distance between fixtures d, d2 are same as expected
+    for j, param in param_list:
+        d = dist(trainX[0], trainX[ind2], param)
+        d2 = dist(trainX[0], trainX[ind2], param)
+        assert_almost_equal(d, expected[dist_str][j], 4)
         assert d == d2

--- a/sktime/distances/tests/test_distance_correctness.py
+++ b/sktime/distances/tests/test_distance_correctness.py
@@ -108,7 +108,7 @@ def test_correctness(dist, uni_multi):
     for j, param in enumerate(param_list):
         # deal with custom setting of epsilon in multi
         # this was in the original test before refactoring
-        if "epsilon" in param and "uni_multi" == "multi":
+        if "epsilon" in param and uni_multi == "multi":
             param = {"epsilon": param["epsilon"] / 50}
         # check that distance is same as expected
         d = dist(trainX[0], trainX[ind2], **param)

--- a/sktime/distances/tests/test_distance_correctness.py
+++ b/sktime/distances/tests/test_distance_correctness.py
@@ -100,7 +100,7 @@ def test_correctness(dist, uni_multi):
 
     # assert distance between fixtures d, d2 are same as expected
     for j, param in enumerate(param_list):
-        d = dist(trainX[0], trainX[ind2], param)
-        d2 = dist(trainX[0], trainX[ind2], param)
+        d = dist(trainX[0], trainX[ind2], **param)
+        d2 = dist(trainX[0], trainX[ind2], **param)
         assert_almost_equal(d, expected[dist_str][j], 4)
         assert d == d2

--- a/sktime/distances/tests/test_numba_distance_parameters.py
+++ b/sktime/distances/tests/test_numba_distance_parameters.py
@@ -86,7 +86,8 @@ DIST_PARAMS = {
 @pytest.mark.parametrize("dist", _METRIC_INFOS)
 def test_distance_params(dist: MetricInfo):
     """Test parametisation of distance callables."""
-    if not run_test_for_class(dist.dist_func):
+    # skip test if distance function/class have not changed
+    if not run_test_for_class([dist.dist_func, dist.dist_instance.__class__]):
         return None
 
     if dist.canonical_name in DIST_PARAMS:


### PR DESCRIPTION
This PR refactors some of the `numba` based distance tests to use `pytest` parametrization, and ensures that they are only executed conditional on change of the logic.

Also corrects the condition where this had previously been done, as the test distances are split across functions and classes.

To ensure the refactored tests run, see PR https://github.com/sktime/sktime/pull/5142 which removes the conditional execution, and executes always for this diagnostic purpose.