### PR TITLE
&SmirnGregHM [BUG] ensure forecasting tuners do not vectorize over columns (variables)

### DIFF
--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -85,6 +85,21 @@ class BaseGridSearch(_DelegatedForecaster):
     #     see further details in _DelegatedForecaster docstring
     _delegate_name = "best_forecaster_"
 
+    # ensure informative exception is raised for forecasters_ attribute
+    @property
+    def forecasters_(self):
+        raise AttributeError(
+            f"{self.__class__.__name__}.forecasters_ property should not be called "
+            "as tuning wrappers do not broadcast over instances or variables, "
+            "this is left to the underlying forecaster. "
+            "A previous, erroneous instance of column broadcasting was removed "
+            "in 0.22.1, see issue #5143 for a discussion. "
+            "To tune per column/variable, wrap the tuner in ColumnEnsembleForecaster. "
+            "To tune per instance or hierarchy level, wrap the tuner in "
+            "ForecastByLevel. In both cases, individual tuned forecasters will be "
+            "present in the forecasters_ attribute."
+        )
+
     def _extend_to_all_scitypes(self, tagname):
         """Ensure mtypes for all scitypes are in the tag with tagname.
 

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -69,7 +69,6 @@ class BaseGridSearch(_DelegatedForecaster):
             "capability:pred_int",
             "capability:pred_int:insample",
             "capability:insample",
-            "scitype:y",
             "ignores-exogeneous-X",
             "handles-missing-data",
             "y_inner_mtype",

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -90,6 +90,8 @@ class BaseGridSearch(_DelegatedForecaster):
 
         Mutates self tag with name `tagname`.
         If no mtypes are present of a time series scitype, adds a pandas based one.
+        If only univariate pandas scitype is present for Series ("pd.Series"),
+        also adds the multivariate one ("pd.DataFrame").
 
         Parameters
         ----------

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -103,10 +103,16 @@ class BaseGridSearch(_DelegatedForecaster):
         if not isinstance(tagval, list):
             tagval = [tagval]
         scitypes = mtype_to_scitype(tagval, return_unique=True)
+        # if no Series mtypes are present, add pd.DataFrame
         if "Series" not in scitypes:
             tagval = tagval + ["pd.DataFrame"]
+        # ensure we have a Series mtype capable of multivariate
+        elif "pd.Series" in tagval and "pd.DataFrame" not in tagval:
+            tagval = ["pd.DataFrame"] + tagval
+        # if no Panel mtypes are present, add pd.DataFrame based one
         if "Panel" not in scitypes:
             tagval = tagval + ["pd-multiindex"]
+        # if no Hierarchical mtypes are present, add pd.DataFrame based one
         if "Hierarchical" not in scitypes:
             tagval = tagval + ["pd_multiindex_hier"]
         self.set_tags(**{tagname: tagval})

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -82,7 +82,8 @@ class BaseGridSearch(_DelegatedForecaster):
                 "currently it tunes one parameter per variable. "
                 "In order to maintain the current behaviour, ensure to set "
                 "the parameter tune_by_variable to True explicitly before upgrading "
-                "to version 0.24.0."
+                "to version 0.24.0.",
+                DeprecationWarning,
             )
             tune_by_variable = True
 

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -102,6 +102,11 @@ class BaseGridSearch(_DelegatedForecaster):
         self._extend_to_all_scitypes("y_inner_mtype")
         self._extend_to_all_scitypes("X_inner_mtype")
 
+        # this ensures univariate broadcasting over variables
+        # if tune_by_variable is True
+        if tune_by_variable:
+            self.set_tags(**{"scitype:y": "univariate"})
+
     # attribute for _DelegatedForecaster, which then delegates
     #     all non-overridden methods are same as of getattr(self, _delegate_name)
     #     see further details in _DelegatedForecaster docstring
@@ -114,6 +119,9 @@ class BaseGridSearch(_DelegatedForecaster):
         If no mtypes are present of a time series scitype, adds a pandas based one.
         If only univariate pandas scitype is present for Series ("pd.Series"),
         also adds the multivariate one ("pd.DataFrame").
+
+        If tune_by_instance is True, only Series mtypes are added,
+        and potentially present Panel or Hierarchical mtypes are removed.
 
         Parameters
         ----------
@@ -139,6 +147,10 @@ class BaseGridSearch(_DelegatedForecaster):
         # if no Hierarchical mtypes are present, add pd.DataFrame based one
         if "Hierarchical" not in scitypes:
             tagval = tagval + ["pd_multiindex_hier"]
+
+        if self.tune_by_instance:
+            tagval = [x for x in tagval if mtype_to_scitype(x) == "Series"]
+
         self.set_tags(**{tagname: tagval})
 
     def _get_fitted_params(self):

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -145,9 +145,9 @@ def test_gscv(forecaster, param_grid, cv, scoring, error_score, multivariate):
         scoring=scoring,
         error_score=error_score,
         # todo 0.24.0: remove this
-        # and/or add a test for tune_by_column=True
+        # and/or add a test for tune_by_variable=True
         # in this case, the forecaster is expeceted to vectorize over columns
-        tune_by_column=False,
+        tune_by_variable=False,
     )
     gscv.fit(y, X)
 
@@ -214,9 +214,9 @@ def test_gscv_hierarchical(forecaster, param_grid, cv, scoring, error_score, n_c
         scoring=scoring,
         error_score=error_score,
         # todo 0.24.0: remove this
-        # and/or add a test for tune_by_column=True
+        # and/or add a test for tune_by_variable=True
         # in this case, the forecaster is expeceted to vectorize over columns
-        tune_by_column=False,
+        tune_by_variable=False,
     )
     gscv.fit(y, X)
 

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -98,7 +98,10 @@ def _create_hierarchical_data(n_columns=1):
     return y, X
 
 
-NAIVE = NaiveForecaster(strategy="mean")
+# estimator fixtures used for tuning
+# set_tags in NaiveForecaster ensures that it is univariate and broadcasts
+# this is currently the case, but a future improved NaiveForecaster may reduce coverage
+NAIVE = NaiveForecaster(strategy="mean").set_tags(**{"scitype:y": "univariate"})
 NAIVE_GRID = {"window_length": TEST_WINDOW_LENGTHS_INT}
 PIPE = TransformedTargetForecaster(
     [

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -132,7 +132,6 @@ ERROR_SCORES = [np.nan, "raise", 1000]
 @pytest.mark.parametrize("multivariate", [True, False])
 def test_gscv(forecaster, param_grid, cv, scoring, error_score, multivariate):
     """Test ForecastingGridSearchCV."""
-    y, X = load_longley()
     if multivariate:
         X, y = load_longley()
     else:

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3 -u
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Test grid search CV."""
+"""Test forecasting tuners."""
 
 __author__ = ["mloning", "fkiraly"]
-__all__ = ["test_gscv", "test_rscv"]
 
 import numpy as np
 import pytest
@@ -145,6 +144,10 @@ def test_gscv(forecaster, param_grid, cv, scoring, error_score, multivariate):
         cv=cv,
         scoring=scoring,
         error_score=error_score,
+        # todo 0.24.0: remove this
+        # and/or add a test for tune_by_column=True
+        # in this case, the forecaster is expeceted to vectorize over columns
+        tune_by_column=False,
     )
     gscv.fit(y, X)
 
@@ -210,6 +213,10 @@ def test_gscv_hierarchical(forecaster, param_grid, cv, scoring, error_score, n_c
         cv=cv,
         scoring=scoring,
         error_score=error_score,
+        # todo 0.24.0: remove this
+        # and/or add a test for tune_by_column=True
+        # in this case, the forecaster is expeceted to vectorize over columns
+        tune_by_column=False,
     )
     gscv.fit(y, X)
 


### PR DESCRIPTION
This PR introduces parameters to forecasting tuners such as `ForecastingGridSearchCV` to control whether parameters are tuned overall, or for instances or variables.

The current behaviour is retained for the default, which is tuning per variable and for all instances.

As this is somewhat inconsistent, this PR also starts a deprecation period with an end state where the default is a single parameter tuned for all instances and variables.

Fixes #5143, see there for a discussion why this is a (logic) bug - the solution is now to move to the most intuitive setting as a default, but leave the option to tune by instance or variable to an user, and expose this cleaerly in the docstrings.

Also extends the tests as follows:

* adds test cases where the multivariate case is tested
* adds checks for presence of `best_params` in all relevant tests