### PR TITLE
[MNT] move fixtures in `test_dropna` to `pytest` fixtures

### DIFF
--- a/sktime/transformations/series/tests/test_dropna.py
+++ b/sktime/transformations/series/tests/test_dropna.py
@@ -12,71 +12,88 @@ from sktime.datasets import load_longley
 from sktime.transformations.series.dropna import DropNA
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 
-y_few_na, X_few_na = load_longley()
-X_few_na.loc["1947", "GNPDEFL"] = np.nan
-X_few_na.loc["1950", "GNPDEFL"] = np.nan
-X_few_na.loc["1950", "GNP"] = np.nan
 
-X_few_na_expected = {
-    "0": {
-        "None": X_few_na.drop(labels=["1947", "1950"], axis=0),
-        "any": X_few_na.drop(labels=["1947", "1950"], axis=0),
-        "all": X_few_na,
-    },
-    "index": {
-        "None": X_few_na.drop(labels=["1947", "1950"], axis=0),
-        "any": X_few_na.drop(labels=["1947", "1950"], axis=0),
-        "all": X_few_na,
-    },
-    "1": {
-        "None": X_few_na.drop(labels=["GNPDEFL", "GNP"], axis=1),
-        "any": X_few_na.drop(labels=["GNPDEFL", "GNP"], axis=1),
-        "all": X_few_na,
-    },
-    "columns": {
-        "None": X_few_na.drop(labels=["GNPDEFL", "GNP"], axis=1),
-        "any": X_few_na.drop(labels=["GNPDEFL", "GNP"], axis=1),
-        "all": X_few_na,
-    },
-}
+@pytest.fixture
+def X_few_na():
+    """DataFrame with occasional missings."""
+    _, X_few_na = load_longley()
+    X_few_na.loc["1947", "GNPDEFL"] = np.nan
+    X_few_na.loc["1950", "GNPDEFL"] = np.nan
+    X_few_na.loc["1950", "GNP"] = np.nan
+    return X_few_na
 
-y_many_na, X_many_na = load_longley()
-X_many_na.loc["1947", "GNPDEFL"] = np.nan
-X_many_na.loc["1950", "GNPDEFL"] = np.nan
-X_many_na.loc["1950", "GNP"] = np.nan
-X_many_na.loc[:, "ARMED"] = np.nan
-X_many_na.loc[:, "POP"] = np.nan
-X_many_na.loc["1960", :] = np.nan
-X_many_na.loc["1962", :] = np.nan
-X_many_na.dropna(axis=1)
 
-X_many_na_expected = {
-    "0": {
-        "None": X_many_na.drop(labels=X_many_na.index, axis=0),
-        "any": X_many_na.drop(labels=X_many_na.index, axis=0),
-        "all": X_many_na.drop(labels=["1960", "1962"]),
-    },
-    "index": {
-        "None": X_many_na.drop(labels=X_many_na.index, axis=0),
-        "any": X_many_na.drop(labels=X_many_na.index, axis=0),
-        "all": X_many_na.drop(labels=["1960", "1962"]),
-    },
-    "1": {
-        "None": X_many_na.drop(labels=X_many_na.columns, axis=1),
-        "any": X_many_na.drop(labels=X_many_na.columns, axis=1),
-        "all": X_many_na.drop(labels=["ARMED", "POP"], axis=1),
-    },
-    "columns": {
-        "None": X_many_na.drop(labels=X_many_na.columns, axis=1),
-        "any": X_many_na.drop(labels=X_many_na.columns, axis=1),
-        "all": X_many_na.drop(labels=["ARMED", "POP"], axis=1),
-    },
-}
+@pytest.fixture
+def X_few_na_expected(X_few_na):
+    """Expected results for a DataFrame with occasional missings."""
+    return {
+        "0": {
+            "None": X_few_na.drop(labels=["1947", "1950"], axis=0),
+            "any": X_few_na.drop(labels=["1947", "1950"], axis=0),
+            "all": X_few_na,
+        },
+        "index": {
+            "None": X_few_na.drop(labels=["1947", "1950"], axis=0),
+            "any": X_few_na.drop(labels=["1947", "1950"], axis=0),
+            "all": X_few_na,
+        },
+        "1": {
+            "None": X_few_na.drop(labels=["GNPDEFL", "GNP"], axis=1),
+            "any": X_few_na.drop(labels=["GNPDEFL", "GNP"], axis=1),
+            "all": X_few_na,
+        },
+        "columns": {
+            "None": X_few_na.drop(labels=["GNPDEFL", "GNP"], axis=1),
+            "any": X_few_na.drop(labels=["GNPDEFL", "GNP"], axis=1),
+            "all": X_few_na,
+        },
+    }
+
+
+@pytest.fixture
+def X_many_na():
+    """DataFrame with complete columns/rows missing."""
+    _, X_many_na = load_longley()
+    X_many_na.loc["1947", "GNPDEFL"] = np.nan
+    X_many_na.loc["1950", "GNPDEFL"] = np.nan
+    X_many_na.loc["1950", "GNP"] = np.nan
+    X_many_na.loc[:, "ARMED"] = np.nan
+    X_many_na.loc[:, "POP"] = np.nan
+    X_many_na.loc["1960", :] = np.nan
+    X_many_na.loc["1962", :] = np.nan
+    X_many_na.dropna(axis=1)
+
+
+@pytest.fixture
+def X_many_na_expected(X_many_na):
+    """Expected results for a DataFrame with complete columns/rows missing."""
+    return {
+        "0": {
+            "None": X_many_na.drop(labels=X_many_na.index, axis=0),
+            "any": X_many_na.drop(labels=X_many_na.index, axis=0),
+            "all": X_many_na.drop(labels=["1960", "1962"]),
+        },
+        "index": {
+            "None": X_many_na.drop(labels=X_many_na.index, axis=0),
+            "any": X_many_na.drop(labels=X_many_na.index, axis=0),
+            "all": X_many_na.drop(labels=["1960", "1962"]),
+        },
+        "1": {
+            "None": X_many_na.drop(labels=X_many_na.columns, axis=1),
+            "any": X_many_na.drop(labels=X_many_na.columns, axis=1),
+            "all": X_many_na.drop(labels=["ARMED", "POP"], axis=1),
+        },
+        "columns": {
+            "None": X_many_na.drop(labels=X_many_na.columns, axis=1),
+            "any": X_many_na.drop(labels=X_many_na.columns, axis=1),
+            "all": X_many_na.drop(labels=["ARMED", "POP"], axis=1),
+        },
+    }
 
 
 @pytest.mark.parametrize("axis", DropNA.VALID_AXIS_VALUES)
 @pytest.mark.parametrize("how", DropNA.VALID_HOW_VALUES)
-def test_dropna_few_na(axis, how):
+def test_dropna_few_na(axis, how, X_few_na, X_few_na_expected):
     """Test expected results on a DataFrame with occasional missings."""
     transformer = DropNA(axis=axis, how=how, thresh=None)
     X_transformed = transformer.fit_transform(X_few_na)
@@ -87,7 +104,7 @@ def test_dropna_few_na(axis, how):
 
 @pytest.mark.parametrize("axis", DropNA.VALID_AXIS_VALUES)
 @pytest.mark.parametrize("how", DropNA.VALID_HOW_VALUES)
-def test_dropna_many_na(axis, how):
+def test_dropna_many_na(axis, how, X_many_na, X_many_na_expected):
     """Test expected results on a DataFrame with complete columns/rows missing."""
     transformer = DropNA(axis=axis, how=how, thresh=None)
     X_transformed = transformer.fit_transform(X_many_na)
@@ -103,7 +120,7 @@ def test_dropna_many_na(axis, how):
 def test_dropna_conflicting_arguments(axis, how, thresh, remember):
     """Test that how and thresh arguments cannot be both set."""
     with pytest.raises(TypeError, match=r"thresh cannot be set together with how"):
-        DropNA(axis=axis, how=str(how), thresh=thresh)
+        DropNA(axis=axis, how=str(how), thresh=thresh, remember=remember)
 
 
 @pytest.mark.parametrize("axis", DropNA.VALID_AXIS_VALUES)

--- a/sktime/transformations/series/tests/test_dropna.py
+++ b/sktime/transformations/series/tests/test_dropna.py
@@ -62,6 +62,7 @@ def X_many_na():
     X_many_na.loc["1960", :] = np.nan
     X_many_na.loc["1962", :] = np.nan
     X_many_na.dropna(axis=1)
+    return X_many_na
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR moves fixtures in `test_dropna` to `pytest` fixtures.

Thanks again, @hliebert, for the great transformer!

I noticed a few things that could be bugs in the tests, would appreciate your quick eye on this:

* in current line 64, there is a `dropna` that does nothing, as the default is not mutating (`inplace=False`). Did you want an assignment?
* in `test_dropna_conflicting_arguments`, the `remember` arg was not used. Should the transformer be constructed with it?