### PR TITLE
[ENH] fixture names in probability distribution tests

### DIFF
--- a/sktime/proba/tests/test_all_distrs.py
+++ b/sktime/proba/tests/test_all_distrs.py
@@ -72,7 +72,7 @@ class TestAllDistributions(DistributionFixtureGenerator, QuickTester):
         assert (res_panel.index == dummy_panel.index).all()
         assert (res_panel.columns == dummy_panel.columns).all()
 
-    @pytest.mark.parametrize("method", METHODS_SCALAR)
+    @pytest.mark.parametrize("method", METHODS_SCALAR, ids=METHODS_SCALAR)
     def test_methods_scalar(self, estimator_instance, method):
         """Test expected return of scalar methods."""
         if not _has_capability(estimator_instance, method):
@@ -83,7 +83,7 @@ class TestAllDistributions(DistributionFixtureGenerator, QuickTester):
 
         _check_output_format(res, d, method)
 
-    @pytest.mark.parametrize("method", METHODS_X)
+    @pytest.mark.parametrize("method", METHODS_X, ids=METHODS_X)
     def test_methods_x(self, estimator_instance, method):
         """Test expected return of methods that take sample-like argument."""
         if not _has_capability(estimator_instance, method):
@@ -95,7 +95,7 @@ class TestAllDistributions(DistributionFixtureGenerator, QuickTester):
 
         _check_output_format(res, d, method)
 
-    @pytest.mark.parametrize("method", METHODS_P)
+    @pytest.mark.parametrize("method", METHODS_P, ids=METHODS_P)
     def test_methods_p(self, estimator_instance, method):
         """Test expected return of methods that take percentage-like argument."""
         if not _has_capability(estimator_instance, method):


### PR DESCRIPTION
Minor improvement for the probability distribution suite tests - changes fixture names of method tests to include method name. Als see https://github.com/sktime/skpro/pull/24