### PR TITLE
[ENH] add tag for inexact `inverse_transform`-s

### DIFF
--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -194,7 +194,7 @@ class MyTransformer(BaseTransformer):
         # if False, exception is raised if inverse_transform is called,
         #   unless the skip-inverse-transform tag is set to True
         #
-        # capability:inverse_transform:range = domain of intvertibility of transform
+        # capability:inverse_transform:range = domain of invertibility of transform
         "capability:inverse_transform:range": None,
         # valid values: None (no range), list of two floats [min, max]
         # if None, inverse_transform is assumed to be defined for all values

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -194,6 +194,20 @@ class MyTransformer(BaseTransformer):
         # if False, exception is raised if inverse_transform is called,
         #   unless the skip-inverse-transform tag is set to True
         #
+        # capability:inverse_transform:range = domain of intvertibility of transform
+        "capability:inverse_transform:range": None,
+        # valid values: None (no range), list of two floats [min, max]
+        # if None, inverse_transform is assumed to be defined for all values
+        # if list of floats, invertibility is assumed
+        # only in the closed interval [min, max] of transform
+        # note: the range applies to the *input* of transform, not the output
+        #
+        # capability:inverse_transform:exact = is inverse transform exact?
+        "capability:inverse_transform:exact": True,
+        # valid values: boolean True (yes), False (no)
+        # if True, inverse_transform is assumed to be exact inverse of transform
+        # if False, inverse_transform is assumed to be an approximation
+        #
         # skip-inverse-transform = is inverse-transform skipped when called?
         "skip-inverse-transform": False,
         # if False, capability:inverse_transform tag behaviour is as per devault

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -204,6 +204,12 @@ ESTIMATOR_TAG_REGISTER = [
         "domain of invertibility of transform, must be list [lower, upper] of float",
     ),
     (
+        "capability:inverse_transform:exact",
+        "transformer",
+        "bool",
+        "whether inverse_transform is expected to be an exact inverse to transform",
+    ),
+    (
         "capability:pred_int",
         "forecaster",
         "bool",

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -110,6 +110,7 @@ class BaseTransformer(BaseEstimator):
         "scitype:instancewise": True,  # is this an instance-wise transform?
         "capability:inverse_transform": False,  # can the transformer inverse transform?
         "capability:inverse_transform:range": None,
+        "capability:inverse_transform:exact": True,
         # inverting range of inverse transform = domain of invertibility of transform
         "univariate-only": False,  # can the transformer handle multivariate X?
         "X_inner_mtype": "pd.DataFrame",  # which mtypes do _fit/_predict support for X?

--- a/sktime/transformations/tests/test_all_transformers.py
+++ b/sktime/transformations/tests/test_all_transformers.py
@@ -167,6 +167,10 @@ class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
         if estimator_instance.get_tag("skip-inverse-transform", False):
             return None
 
+        # skip this test if inverse_transform is not assumed an exact inverse
+        if not estimator_instance.get_tag("capability:inverse_transform:exact", True):
+            return None
+
         X = scenario.args["transform"]["X"]
         Xt = scenario.run(estimator_instance, method_sequence=["fit", "transform"])
         Xit = estimator_instance.inverse_transform(Xt)


### PR DESCRIPTION
This PR adds a tag for inexact `inverse_transform`-s, i.e., transformers where `inverse_transform` is not assumed to be an exact inverse to `transform`.

This tag is then used to turn off the test for exact inversion, conditional on the tag being `False`.

An example of an inexact inverse would be recomposition in VMD (e.g., https://github.com/sktime/sktime/pull/5129), or more generally recomposition after decomposition that removes an error term.