### PR TITLE
[ENH] Refactor of `BaseDistribution` and descendants - generalised distribution param broadcasting in base class

### DIFF
--- a/sktime/proba/base.py
+++ b/sktime/proba/base.py
@@ -158,17 +158,17 @@ class BaseDistribution(BaseObject):
         else:
             return msg
 
-    def _get_bc_params(self, to_broadcast, dtype=None):
-        """Fully broadcast parameters of self, given param shapes and index, columns."""
-        length = len(to_broadcast)
+    def _get_bc_params(self, *args, dtype=None):
+        """Fully broadcast tuple of parameters given param shapes and index, columns."""
+        number_of_params = len(args)
         if hasattr(self, "index") and self.index is not None:
-            to_broadcast += [self.index.to_numpy().reshape(-1, 1)]
+            args += tuple(self.index.to_numpy().reshape(-1, 1))
         if hasattr(self, "columns") and self.columns is not None:
-            to_broadcast += [self.columns.to_numpy()]
-        bc = np.broadcast_arrays(*to_broadcast)
+            args += tuple(self.columns.to_numpy())
+        bc = np.broadcast_arrays(*args)
         if dtype is not None:
             bc = [array.astype(dtype) for array in bc]
-        return bc[:length]
+        return bc[:number_of_params]
 
     def pdf(self, x):
         r"""Probability density function.

--- a/sktime/proba/base.py
+++ b/sktime/proba/base.py
@@ -159,8 +159,33 @@ class BaseDistribution(BaseObject):
             return msg
 
     def _get_bc_params(self, *args, dtype=None):
-        """Fully broadcast tuple of parameters given param shapes and index, columns."""
+        """Fully broadcast tuple of parameters given param shapes and index, columns.
+
+        Parameters
+        ----------
+        args : float, int, array of floats, or array of ints (1D or 2D)
+            Distribution parameters that are to be made broadcastable. If no positional
+            arguments are provided, all parameters of `self` are used except for `index`
+            and `columns`.
+        dtype : str, optional
+            broadcasted arrays are cast to all have datatype `dtype`. If None, then no
+            datatype casting is done.
+
+        Returns
+        -------
+        Tuple of float or integer arrays
+            Each element of the tuple represents a different broadcastable distribution
+            parameter.
+        """
         number_of_params = len(args)
+        if number_of_params == 0:
+            # Handle case where no positional arguments are provided
+            params = self.get_params()
+            params.pop("index")
+            params.pop("columns")
+            args = tuple(params.values())
+            number_of_params = len(args)
+
         if hasattr(self, "index") and self.index is not None:
             args += (self.index.to_numpy().reshape(-1, 1),)
         if hasattr(self, "columns") and self.columns is not None:

--- a/sktime/proba/base.py
+++ b/sktime/proba/base.py
@@ -162,9 +162,9 @@ class BaseDistribution(BaseObject):
         """Fully broadcast tuple of parameters given param shapes and index, columns."""
         number_of_params = len(args)
         if hasattr(self, "index") and self.index is not None:
-            args += tuple(self.index.to_numpy().reshape(-1, 1))
+            args += (self.index.to_numpy().reshape(-1, 1),)
         if hasattr(self, "columns") and self.columns is not None:
-            args += tuple(self.columns.to_numpy())
+            args += (self.columns.to_numpy(),)
         bc = np.broadcast_arrays(*args)
         if dtype is not None:
             bc = [array.astype(dtype) for array in bc]

--- a/sktime/proba/base.py
+++ b/sktime/proba/base.py
@@ -158,6 +158,18 @@ class BaseDistribution(BaseObject):
         else:
             return msg
 
+    def _get_bc_params(self, to_broadcast, dtype=None):
+        """Fully broadcast parameters of self, given param shapes and index, columns."""
+        length = len(to_broadcast)
+        if hasattr(self, "index") and self.index is not None:
+            to_broadcast += [self.index.to_numpy().reshape(-1, 1)]
+        if hasattr(self, "columns") and self.columns is not None:
+            to_broadcast += [self.columns.to_numpy()]
+        bc = np.broadcast_arrays(*to_broadcast)
+        if dtype is not None:
+            bc = [array.astype(dtype) for array in bc]
+        return bc[:length]
+
     def pdf(self, x):
         r"""Probability density function.
 

--- a/sktime/proba/normal.py
+++ b/sktime/proba/normal.py
@@ -45,7 +45,7 @@ class Normal(BaseDistribution):
         # and broadcast of parameters.
         # move this functionality to the base class
         # 0.19.0?
-        self._mu, self._sigma = self._get_bc_params()
+        self._mu, self._sigma = self._get_bc_params([self.mu, self.sigma])
         shape = self._mu.shape
 
         if index is None:
@@ -55,16 +55,6 @@ class Normal(BaseDistribution):
             columns = pd.RangeIndex(shape[1])
 
         super().__init__(index=index, columns=columns)
-
-    def _get_bc_params(self):
-        """Fully broadcast parameters of self, given param shapes and index, columns."""
-        to_broadcast = [self.mu, self.sigma]
-        if hasattr(self, "index") and self.index is not None:
-            to_broadcast += [self.index.to_numpy().reshape(-1, 1)]
-        if hasattr(self, "columns") and self.columns is not None:
-            to_broadcast += [self.columns.to_numpy()]
-        bc = np.broadcast_arrays(*to_broadcast)
-        return bc[0], bc[1]
 
     def energy(self, x=None):
         r"""Energy of self, w.r.t. self or a constant frame x.

--- a/sktime/proba/normal.py
+++ b/sktime/proba/normal.py
@@ -45,7 +45,7 @@ class Normal(BaseDistribution):
         # and broadcast of parameters.
         # move this functionality to the base class
         # 0.19.0?
-        self._mu, self._sigma = self._get_bc_params([self.mu, self.sigma])
+        self._mu, self._sigma = self._get_bc_params(*(self.mu, self.sigma))
         shape = self._mu.shape
 
         if index is None:

--- a/sktime/proba/normal.py
+++ b/sktime/proba/normal.py
@@ -45,7 +45,7 @@ class Normal(BaseDistribution):
         # and broadcast of parameters.
         # move this functionality to the base class
         # 0.19.0?
-        self._mu, self._sigma = self._get_bc_params(*(self.mu, self.sigma))
+        self._mu, self._sigma = self._get_bc_params(self.mu, self.sigma)
         shape = self._mu.shape
 
         if index is None:

--- a/sktime/proba/normal.py
+++ b/sktime/proba/normal.py
@@ -45,7 +45,7 @@ class Normal(BaseDistribution):
         # and broadcast of parameters.
         # move this functionality to the base class
         # 0.19.0?
-        self._mu, self._sigma = self._get_bc_params(self.mu, self.sigma)
+        self._mu, self._sigma = self._get_bc_params(*(self.mu, self.sigma))
         shape = self._mu.shape
 
         if index is None:

--- a/sktime/proba/t.py
+++ b/sktime/proba/t.py
@@ -44,7 +44,9 @@ class TDistribution(BaseDistribution):
         self.index = index
         self.columns = columns
 
-        self._mu, self._sigma, self._df = self._get_bc_params()
+        self._mu, self._sigma, self._df = self._get_bc_params(
+            [self.mu, self.sigma, self.df]
+        )
         shape = self._mu.shape
 
         if index is None:
@@ -54,16 +56,6 @@ class TDistribution(BaseDistribution):
             columns = pd.RangeIndex(shape[1])
 
         super().__init__(index=index, columns=columns)
-
-    def _get_bc_params(self):
-        """Fully broadcast parameters of self, given param shapes and index, columns."""
-        to_broadcast = [self.mu, self.sigma, self.df]
-        if hasattr(self, "index") and self.index is not None:
-            to_broadcast += [self.index.to_numpy().reshape(-1, 1)]
-        if hasattr(self, "columns") and self.columns is not None:
-            to_broadcast += [self.columns.to_numpy()]
-        bc = np.broadcast_arrays(*to_broadcast)
-        return bc[0], bc[1], bc[2]
 
     def mean(self):
         r"""Return expected value of the distribution.

--- a/sktime/proba/t.py
+++ b/sktime/proba/t.py
@@ -45,7 +45,7 @@ class TDistribution(BaseDistribution):
         self.columns = columns
 
         self._mu, self._sigma, self._df = self._get_bc_params(
-            self.mu, self.sigma, self.df
+            *(self.mu, self.sigma, self.df)
         )
         shape = self._mu.shape
 

--- a/sktime/proba/t.py
+++ b/sktime/proba/t.py
@@ -45,7 +45,7 @@ class TDistribution(BaseDistribution):
         self.columns = columns
 
         self._mu, self._sigma, self._df = self._get_bc_params(
-            *(self.mu, self.sigma, self.df)
+            self.mu, self.sigma, self.df
         )
         shape = self._mu.shape
 

--- a/sktime/proba/t.py
+++ b/sktime/proba/t.py
@@ -45,7 +45,7 @@ class TDistribution(BaseDistribution):
         self.columns = columns
 
         self._mu, self._sigma, self._df = self._get_bc_params(
-            [self.mu, self.sigma, self.df]
+            *(self.mu, self.sigma, self.df)
         )
         shape = self._mu.shape
 

--- a/sktime/proba/tests/test_base_default_methods.py
+++ b/sktime/proba/tests/test_base_default_methods.py
@@ -34,7 +34,7 @@ class _DistrDefaultMethodTester(BaseDistribution):
         self.index = index
         self.columns = columns
 
-        self._mu, self._sigma = self._get_bc_params(*(self.mu, self.sigma))
+        self._mu, self._sigma = self._get_bc_params(self.mu, self.sigma)
         shape = self._mu.shape
 
         if index is None:

--- a/sktime/proba/tests/test_base_default_methods.py
+++ b/sktime/proba/tests/test_base_default_methods.py
@@ -34,7 +34,7 @@ class _DistrDefaultMethodTester(BaseDistribution):
         self.index = index
         self.columns = columns
 
-        self._mu, self._sigma = self._get_bc_params(self.mu, self.sigma)
+        self._mu, self._sigma = self._get_bc_params(*(self.mu, self.sigma))
         shape = self._mu.shape
 
         if index is None:

--- a/sktime/proba/tests/test_base_default_methods.py
+++ b/sktime/proba/tests/test_base_default_methods.py
@@ -34,7 +34,7 @@ class _DistrDefaultMethodTester(BaseDistribution):
         self.index = index
         self.columns = columns
 
-        self._mu, self._sigma = self._get_bc_params()
+        self._mu, self._sigma = self._get_bc_params([self.mu, self.sigma])
         shape = self._mu.shape
 
         if index is None:

--- a/sktime/proba/tests/test_base_default_methods.py
+++ b/sktime/proba/tests/test_base_default_methods.py
@@ -34,7 +34,7 @@ class _DistrDefaultMethodTester(BaseDistribution):
         self.index = index
         self.columns = columns
 
-        self._mu, self._sigma = self._get_bc_params([self.mu, self.sigma])
+        self._mu, self._sigma = self._get_bc_params(*(self.mu, self.sigma))
         shape = self._mu.shape
 
         if index is None:

--- a/sktime/proba/tfp.py
+++ b/sktime/proba/tfp.py
@@ -53,7 +53,7 @@ class TFNormal(_BaseTFDistribution):
         # move this functionality to the base class
         # 0.19.0?
         self._mu, self._sigma = self._get_bc_params(
-            [self.mu, self.sigma], dtype="float"
+            *(self.mu, self.sigma), dtype="float"
         )
         distr = tfd.Normal(loc=self._mu, scale=self._sigma)
         shape = self._mu.shape

--- a/sktime/proba/tfp.py
+++ b/sktime/proba/tfp.py
@@ -52,7 +52,9 @@ class TFNormal(_BaseTFDistribution):
         # and broadcast of parameters.
         # move this functionality to the base class
         # 0.19.0?
-        self._mu, self._sigma = self._get_bc_params()
+        self._mu, self._sigma = self._get_bc_params(
+            [self.mu, self.sigma], dtype="float"
+        )
         distr = tfd.Normal(loc=self._mu, scale=self._sigma)
         shape = self._mu.shape
 
@@ -63,16 +65,6 @@ class TFNormal(_BaseTFDistribution):
             columns = pd.RangeIndex(shape[1])
 
         super().__init__(index=index, columns=columns, distr=distr)
-
-    def _get_bc_params(self):
-        """Fully broadcast parameters of self, given param shapes and index, columns."""
-        to_broadcast = [self.mu, self.sigma]
-        if hasattr(self, "index") and self.index is not None:
-            to_broadcast += [self.index.to_numpy().reshape(-1, 1)]
-        if hasattr(self, "columns") and self.columns is not None:
-            to_broadcast += [self.columns.to_numpy()]
-        bc = np.broadcast_arrays(*to_broadcast)
-        return np.array(bc[0], dtype="float"), np.array(bc[1], dtype="float")
 
     def energy(self, x=None):
         r"""Energy of self, w.r.t. self or a constant frame x.

--- a/sktime/proba/tfp.py
+++ b/sktime/proba/tfp.py
@@ -52,7 +52,9 @@ class TFNormal(_BaseTFDistribution):
         # and broadcast of parameters.
         # move this functionality to the base class
         # 0.19.0?
-        self._mu, self._sigma = self._get_bc_params(self.mu, self.sigma, dtype="float")
+        self._mu, self._sigma = self._get_bc_params(
+            *(self.mu, self.sigma), dtype="float"
+        )
         distr = tfd.Normal(loc=self._mu, scale=self._sigma)
         shape = self._mu.shape
 

--- a/sktime/proba/tfp.py
+++ b/sktime/proba/tfp.py
@@ -52,9 +52,7 @@ class TFNormal(_BaseTFDistribution):
         # and broadcast of parameters.
         # move this functionality to the base class
         # 0.19.0?
-        self._mu, self._sigma = self._get_bc_params(
-            *(self.mu, self.sigma), dtype="float"
-        )
+        self._mu, self._sigma = self._get_bc_params(self.mu, self.sigma, dtype="float")
         distr = tfd.Normal(loc=self._mu, scale=self._sigma)
         shape = self._mu.shape
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related issue [https://github.com/sktime/skpro/issues/21](https://github.com/sktime/skpro/issues/21)

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Moves the `_get_bc_params` method from child distributions to the parent distribtion class, `BaseDistribution`.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

This implementation is quite simple and doesn't use `_tags` and still means the child distributions have to call the `_get_bc_params` method.

Would you prefer the child distributions to not have to call the `_get_bc_params` method. This will mean putting the parameter names that need to broadcasted in `_tags` dictionary then writing the broadcasted parameters from `BaseDistribution`. Personally I think this is slightly over complicated although this approach follows the DRY principles more closely. I am open to intput here and happy to implement whatever is preferred.

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

Altered the `_DistrDefaultMethodTester` class to use the parent `_get_bc_params` method.

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
