### PR TITLE
[ENH] fix `test_set_freq_hier` for `pandas 2.1.0`

### DIFF
--- a/sktime/utils/tests/test_datetime.py
+++ b/sktime/utils/tests/test_datetime.py
@@ -17,6 +17,7 @@ from sktime.utils.datetime import (
     infer_freq,
     set_hier_freq,
 )
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 
 def test_get_freq():
@@ -126,20 +127,27 @@ def test_set_freq() -> None:
 
 def test_set_freq_hier():
     """Test that setting frequency on a DatetimeIndex MultiIndex works."""
+    # from pandas 2.1.0 on, freq is preserved correctly,
+    # so in that case we artificially destroy the freq attribute
+    pandas_210 = _check_soft_dependencies("pandas>2.1.0", severity="none")
+
     y = load_airline()
 
     assert get_time_index(y).freq is not None
 
     # Convert to DatetimeIndex
-    y.index = y.index.to_timestamp()
+    y_index = y.index.to_timestamp()
 
     assert get_time_index(y).freq is not None
 
+    if pandas_210:
+        y_index.freq = None
+
     # Create MultiIndex
-    mi = pd.MultiIndex.from_product([[0], y.index], names=["instances", "timepoints"])
+    mi = pd.MultiIndex.from_product([[0], y_index], names=["instances", "timepoints"])
     y_group1 = pd.DataFrame(y.values, index=mi, columns=["y"])
 
-    mi = pd.MultiIndex.from_product([[1], y.index], names=["instances", "timepoints"])
+    mi = pd.MultiIndex.from_product([[1], y_index], names=["instances", "timepoints"])
     y_group2 = pd.DataFrame(y.values, index=mi, columns=["y"])
 
     y_train_grp = pd.concat([y_group1, y_group2])

--- a/sktime/utils/tests/test_datetime.py
+++ b/sktime/utils/tests/test_datetime.py
@@ -129,7 +129,7 @@ def test_set_freq_hier():
     """Test that setting frequency on a DatetimeIndex MultiIndex works."""
     # from pandas 2.1.0 on, freq is preserved correctly,
     # so in that case we artificially destroy the freq attribute
-    pandas_210 = _check_soft_dependencies("pandas>2.1.0", severity="none")
+    pandas_210 = _check_soft_dependencies("pandas>=2.1.0", severity="none")
 
     y = load_airline()
 


### PR DESCRIPTION
`test_set_freq_hier` fails since `pandas 2.1.0` as the condition for the test - a `freq` is set to `none` - is not anymore established. This is due to a change in `pandas` that preserves this attribute more widely.

To ensure equivalent test coverage, the fix is to set the `freq` to `none` manually in the relevant case.