### PR TITLE
[DOC] installation instruction docs for learning task specific dependency sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,20 @@ pip install sktime[forecasting]  # for selected forecasting dependencies
 pip install sktime[forecasting,transformations]  # forecasters and transformers
 ```
 
-or similar. Valid sets are `forecasting`, `transformations`, `classification`,
-`regression`, `clustering`, `param_est`,`networks`, `annotation`, `alignment`.
+or similar. Valid sets are:
+
+* `forecasting`
+* `transformations`
+* `classification`
+* `regression`
+* `clustering`
+* `param_est`
+* `networks`
+* `annotation`
+* `alignment`
+
+Cave: in general, not all soft dependencies for a learning task are installed,
+only a curated selection.
 
 ### conda
 You can also install sktime from `conda` via the `conda-forge` channel.

--- a/README.md
+++ b/README.md
@@ -123,14 +123,17 @@ pip install sktime[all_extras]
 For curated sets of soft dependencies for specific learning tasks:
 
 ```bash
-pip install sktime[forecasting]
+pip install sktime[forecasting]  # for selected forecasting dependencies
+pip install sktime[forecasting,transformations]  # forecasters and transformers
 ```
 
 or similar. Valid sets are `forecasting`, `transformations`, `classification`,
 `regression`, `clustering`, `param_est`,`networks`, `annotation`, `alignment`.
 
 ### conda
-You can also install sktime from `conda` via the `conda-forge` channel. For the feedstock including the build recipe and configuration, check out [this repository](https://github.com/conda-forge/sktime-feedstock).
+You can also install sktime from `conda` via the `conda-forge` channel.
+The feedstock including the build recipe and configuration is maintained
+in [this conda-forge repository](https://github.com/conda-forge/sktime-feedstock).
 
 ```bash
 conda install -c conda-forge sktime
@@ -141,6 +144,9 @@ or, with maximum dependencies,
 ```bash
 conda install -c conda-forge sktime-all-extras
 ```
+
+(as `conda` does not support dependency sets,
+flexible choice of soft dependencies is unavailable via `conda`)
 
 ## :zap: Quickstart
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ For troubleshooting and detailed installation instructions, see the [documentati
 [conda]: https://docs.conda.io/en/latest/
 
 ### pip
-Using pip, sktime releases are available as source packages and binary wheels. You can see all available wheels [here](https://pypi.org/simple/sktime/).
+Using pip, sktime releases are available as source packages and binary wheels.
+Available wheels are listed [here](https://pypi.org/simple/sktime/).
 
 ```bash
 pip install sktime
@@ -118,6 +119,15 @@ or, with maximum dependencies,
 ```bash
 pip install sktime[all_extras]
 ```
+
+For curated sets of soft dependencies for specific learning tasks:
+
+```bash
+pip install sktime[forecasting]
+```
+
+or similar. Valid sets are `forecasting`, `transformations`, `classification`,
+`regression`, `clustering`, `param_est`,`networks`, `annotation`, `alignment`.
 
 ### conda
 You can also install sktime from `conda` via the `conda-forge` channel. For the feedstock including the build recipe and configuration, check out [this repository](https://github.com/conda-forge/sktime-feedstock).

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -44,8 +44,14 @@ To install ``sktime`` with maximum dependencies, including soft dependencies, in
 
     pip install sktime[all_extras]
 
+``sktime`` also comes with dependency sets specific to learning task, i.e., estimator scitype.
+These are curated selections of the most common soft dependencies for the respective learning task.
+The available dependency sets are of the same names as the respective modules:
+``forecasting``, ``transformations``, ``classification``, ``regression``, ``clustering``, ``param_est``,
+``networks``, ``annotation``, ``alignment``.
+
 .. warning::
-    Some of the dependencies included in ``all_extras`` do not work on mac ARM-based processors, such
+    Some of the soft dependencies included in ``all_extras`` and the curated soft dependency sets do not work on mac ARM-based processors, such
     as M1, M2, M1Pro, M1Max or M1Ultra. This may cause an error during installation. Mode details can
     be found in the :ref:`troubleshooting section<Dependency error on mac ARM>` below.
 
@@ -53,8 +59,8 @@ To install ``sktime`` with maximum dependencies, including soft dependencies, in
     The soft dependencies with ``all_extras`` are only necessary to have all estimators available, or to run all tests.
     However, this slows down the downloads, and multiples test time.
     For most user or developer scenarios, downloading ``all_extras`` will
-    not be necessary.
-
+    not be necessary. If you are unsure, install ``sktime`` with core dependencies, and install soft dependencies as needed.
+    Alternatively, install dependency sets specific to learning task, see above.
 
 Installing sktime from conda
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR adds documentation in the two main installation instructions of the granular soft dependency sets introduced with
https://github.com/sktime/sktime/pull/5136