### PR TITLE
[DOC] fixing `conftest.py` docstrings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,26 @@
 """Main configuration file for pytest.
 
 Contents:
-adds a --matrixdesign option to pytest
-this allows to turn on/off the sub-sampling in the tests (for shorter runtime)
-"on" condition is partition/block design to ensure each estimator full tests are run
+adds the following options to pytest
+--matrixdesign : bool, default False
+    allows to turn on/off the sub-sampling in the tests (for shorter runtime)
+    "on" condition is partition/block design to ensure each estimator full tests are run
     on each operating system at least once, and on each python version at least once,
     but not necessarily on each operating system / python version combination
-by default, this is off, including for default local runs of pytest
+--only_cython_estimators : bool, default False
+    "on" = runs tests only for estimators that require cython to run
+    i.e., estimators with tag requires_cython=True
+    "off" = runs tests for all estimators that do not require cython to run
+--only_changed_modules : bool, default False
+    turns on/off differential testing (for shorter runtime)
+    "on" condition ensures that only estimators are tested that have changed,
+    more precisely, only estimators whose class is in a module
+    that has changed compared to the main branch
+    "off" = runs tests for all estimators
+
+by default, all options are off, including for default local runs of pytest
+if multiple options are turned on, they are combined with AND,
+i.e., intersection of estimators satisfying the conditions
 """
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
@@ -28,7 +42,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--only_changed_modules",
         default=False,
-        help="test only cython estimators, with tag requires_cython=True",
+        help="test only estimators from modules that have changed compared to main",
     )
 
 


### PR DESCRIPTION
This PR fixes the `conftest.py` docstrings which were missing two of the three `pytest` flags.