### PR TITLE
[BUG] fix missing `Pipeline` export in `sktime.pipeline`

### DIFF
--- a/sktime/pipeline/__init__.py
+++ b/sktime/pipeline/__init__.py
@@ -1,6 +1,7 @@
 """Pipeline maker utility."""
 
-__all__ = ["make_pipeline", "sklearn_to_sktime"]
+__all__ = ["make_pipeline", "sklearn_to_sktime", "Pipeline"]
 
 from sktime.pipeline._make_pipeline import make_pipeline
 from sktime.pipeline._sklearn_to_sktime import sklearn_to_sktime
+from sktime.pipeline.pipeline import Pipeline

--- a/sktime/pipeline/pipeline.py
+++ b/sktime/pipeline/pipeline.py
@@ -92,7 +92,7 @@ class Pipeline(BaseEstimator):
     >>> from sktime.datasets import load_arrow_head, load_longley
     >>> from sktime.forecasting.model_selection import temporal_train_test_split
     >>> from sktime.forecasting.naive import NaiveForecaster
-    >>> from sktime.pipeline.pipeline import Pipeline
+    >>> from sktime.pipeline import Pipeline
     >>> from sktime.transformations.compose import Id
     >>> from sktime.transformations.series.boxcox import BoxCoxTransformer
     >>> from sktime.transformations.series.exponent import ExponentTransformer


### PR DESCRIPTION
Fixes #5229.

`Pipeline` is now exported by `sktime.pipeline`.

FYI @benHeid - I would agree with the implicit issue that @ujohn33 has, `pipeline.pipeline.Pipeline` is unintuitive as a location...