### PR TITLE
[MNT] Change label to label1 to address matplotlib deprecation

### DIFF
--- a/sktime/annotation/plotting/utils.py
+++ b/sktime/annotation/plotting/utils.py
@@ -139,10 +139,10 @@ def plot_time_series_with_profiles(
 
     for a in ax:
         for tick in a.xaxis.get_major_ticks():
-            tick.label.set_fontsize(font_size)
+            tick.label1.set_fontsize(font_size)
 
         for tick in a.yaxis.get_major_ticks():
-            tick.label.set_fontsize(font_size)
+            tick.label1.set_fontsize(font_size)
 
     if true_cps is not None:
         for idx, true_cp in enumerate(true_cps):


### PR DESCRIPTION
Change label to label1 in plot_time_series_with_profiles to address the matplotlib deprecation. 