### PR TITLE
[ENH] `VmdTransformer` add decompose-forecast-recompose as a docstring example and test

### DIFF
--- a/sktime/transformations/series/vmd/_vmd.py
+++ b/sktime/transformations/series/vmd/_vmd.py
@@ -87,6 +87,13 @@ class VmdTransformer(BaseTransformer):
     >>> y = load_solar()  # doctest: +SKIP
     >>> transformer = VmdTransformer()  # doctest: +SKIP
     >>> modes = transformer.fit_transform(y)  # doctest: +SKIP
+
+    VmdTransformer can be used in a forecasting pipeline,
+    to decompose, forecast individual components, then recompose:
+    >>> from sktime.forecasting.trend import TrendForecaster  # doctest: +SKIP
+    >>> pipe = VmdTransformer() * TrendForecaster()  # doctest: +SKIP
+    >>> pipe.fit(y, fh=[1, 2, 3])  # doctest: +SKIP
+    >>> y_pred = pipe.predict()  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/transformations/series/vmd/test_vmd.py
+++ b/sktime/transformations/series/vmd/test_vmd.py
@@ -28,14 +28,13 @@ def _generate_vmd_testdata(T=1000, f_1=2, f_2=24, f_3=288, noise=0.1):
     noise : float
         noise level
     """
-
-    #. Time Domain 0 to T
+    # Time Domain 0 to T
     T = 1000
     fs = 1/T
     t = np.arange(1, T + 1) /T
     freqs = 2*np.pi*(t-0.5-fs)/(fs)
 
-    #. modes
+    # modes
     v_1 = (np.cos(2 * np.pi * f_1 * t))
     v_2 = 1/4*(np.cos(2 * np.pi * f_2 * t))
     v_3 = 1/16*(np.cos(2 * np.pi * f_3 * t))

--- a/sktime/transformations/series/vmd/test_vmd.py
+++ b/sktime/transformations/series/vmd/test_vmd.py
@@ -1,0 +1,60 @@
+"""Tests for VmdTransformer."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file).
+
+__author__ = ["fkiraly", "DaneLyttinen"]
+
+import pandas as pd
+import numpy as np
+
+from sktime.forecasting.compose import TransformedTargetForecaster
+from sktime.forecasting.trend import TrendForecaster
+from sktime.transformations.series.vmd import VmdTransformer
+
+
+def _generate_vmd_testdata(T=1000, f_1=2, f_2=24, f_3=288, noise=0.1):
+    """Generate test data for VMD tests.
+
+    Based on example of DaneLyttinen in #5128
+
+    Parameters
+    ----------
+    T : int
+        length of time series
+    f_1 : int
+    f_2 : int
+    f_3 : int
+        center frequencies of components
+        f_i = frequency of component i
+    noise : float
+        noise level
+    """
+
+    #. Time Domain 0 to T
+    T = 1000
+    fs = 1/T
+    t = np.arange(1, T + 1) /T
+    freqs = 2*np.pi*(t-0.5-fs)/(fs)
+
+    #. modes
+    v_1 = (np.cos(2 * np.pi * f_1 * t))
+    v_2 = 1/4*(np.cos(2 * np.pi * f_2 * t))
+    v_3 = 1/16*(np.cos(2 * np.pi * f_3 * t))
+
+    f = v_1 + v_2 + v_3 + noise * np.random.randn(v_1.size)
+
+    return pd.DataFrame(data={"y": f})
+
+
+def test_vmd_in_pipeline():
+    """Test vmd as part of a TransformedTargetForecaster pipeline."""
+    y = _generate_vmd_testdata()
+
+    pipe = TransformedTargetForecaster(
+        steps=[
+            ("vmd", VmdTransformer()),
+            ("forecaster", TrendForecaster()),
+        ]
+    )
+
+    pipe.fit(y, fh=[1, 2, 3])
+    pipe.predict()

--- a/sktime/transformations/series/vmd/test_vmd.py
+++ b/sktime/transformations/series/vmd/test_vmd.py
@@ -3,8 +3,8 @@
 
 __author__ = ["fkiraly", "DaneLyttinen"]
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 from sktime.forecasting.compose import TransformedTargetForecaster
 from sktime.forecasting.trend import TrendForecaster
@@ -30,14 +30,12 @@ def _generate_vmd_testdata(T=1000, f_1=2, f_2=24, f_3=288, noise=0.1):
     """
     # Time Domain 0 to T
     T = 1000
-    fs = 1/T
-    t = np.arange(1, T + 1) /T
-    freqs = 2*np.pi*(t-0.5-fs)/(fs)
+    t = np.arange(1, T + 1) / T
 
     # modes
-    v_1 = (np.cos(2 * np.pi * f_1 * t))
-    v_2 = 1/4*(np.cos(2 * np.pi * f_2 * t))
-    v_3 = 1/16*(np.cos(2 * np.pi * f_3 * t))
+    v_1 = np.cos(2 * np.pi * f_1 * t)
+    v_2 = 1 / 4 * (np.cos(2 * np.pi * f_2 * t))
+    v_3 = 1 / 16 * (np.cos(2 * np.pi * f_3 * t))
 
     f = v_1 + v_2 + v_3 + noise * np.random.randn(v_1.size)
 


### PR DESCRIPTION
This adds @davelyttinen's original example in https://github.com/sktime/sktime/issues/5128 on using the `VmdTransformer` for decomposition, forecast, then recomposition as a docstring example in the transformer, and a test case in a new `vmd` specific test module.

We should have added this with the `VmdTransformer`, not sure why we didn't - but now that we're showing the example at pycon Prague it should be continuously tested.