### PR TITLE
[MNT] move `Pipeline` exception from `test_all_estimators` to test `_config`

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -177,6 +177,7 @@ EXCLUDED_TESTS = {
     "VECM": [
         "test_hierarchical_with_exogeneous",  # refer to #4743
     ],
+    "Pipeline": ["test_inheritance"],  # does not inherit from intermediate base classes
 }
 
 # We use estimator tags in addition to class hierarchies to further distinguish

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -26,7 +26,6 @@ from sktime.dists_kernels.base import (
 )
 from sktime.exceptions import NotFittedError
 from sktime.forecasting.base import BaseForecaster
-from sktime.pipeline.pipeline import Pipeline
 from sktime.registry import all_estimators
 from sktime.regression.deep_learning.base import BaseDeepRegressor
 from sktime.tests._config import (
@@ -895,8 +894,6 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
                 f"estimator: {estimator_class} has fit method, but"
                 f"is not a sub-class of BaseEstimator."
             )
-        if isinstance(Pipeline(), estimator_class):
-            return
 
         # Usually estimators inherit only from one BaseEstimator type, but in some cases
         # they may be predictor and transformer at the same time (e.g. pipelines)


### PR DESCRIPTION
This moves the `Pipeline` exception from `test_all_estimators` to test `_config`.

Aware that some lines are being tested until the exception, although to me that rather indicates that we may perhaps like to rewrite the test instead of excepting in the middle of it.

FYI @benHeid 