### PR TITLE
[BUG] Fix missing `y_train` key in `y_dict` in tests for composite forecasters

### DIFF
--- a/sktime/forecasting/compose/tests/test_reduce_global.py
+++ b/sktime/forecasting/compose/tests/test_reduce_global.py
@@ -44,6 +44,7 @@ def y_dict():
 
     # y train will be univariate data set
     y_train, y_test = temporal_train_test_split(y)
+    y_dict["y_train"] = y_train
 
     # Create train and test panel sample data
     mi = pd.MultiIndex.from_product(


### PR DESCRIPTION
Fixes missing `y_train` key in `y_dict` in tests for composite forecasters.

Related: https://github.com/sktime/sktime/pull/5253