### PR TITLE
[MNT] Revert " [Dependabot](deps): Bump codecov/codecov-action from 3 to 4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,7 +162,7 @@ jobs:
         run: make PYTESTOPTIONS="--cov --cov-report=xml --only_cython_estimators=True --matrixdesign=False --timeout=600" test_check_suite
 
       - name: Publish code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
 
   test-windows:
     needs: test-nosoftdeps
@@ -212,7 +212,7 @@ jobs:
           python -m pytest
 
       - name: Publish code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
 
   test-unix:
     needs: test-nosoftdeps
@@ -251,7 +251,7 @@ jobs:
         run: make test
 
       - name: Publish code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
 
   test-unix-pandas1:
     needs: test-nosoftdeps
@@ -289,4 +289,4 @@ jobs:
         run: make test
 
       - name: Publish code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
This reverts PR #5241 and addresses https://github.com/sktime/sktime/issues/5257

Strange that the PR CI passed originally, but now it fails everywhere.