### PR TITLE
[MNT] `xfail` sporadic failure in `RandomShapeletTransform` exact output test

### DIFF
--- a/sktime/transformations/panel/tests/test_shapelet_transform.py
+++ b/sktime/transformations/panel/tests/test_shapelet_transform.py
@@ -31,6 +31,7 @@ def test_st_on_unit_test():
     )
 
 
+@pytest.mark.xfail(reason="known sporadic failure, likely pseudo-random instability)
 @pytest.mark.skipif(
     not run_test_for_class(RandomShapeletTransform),
     reason="run test only if softdeps are present and incrementally (if requested)",

--- a/sktime/transformations/panel/tests/test_shapelet_transform.py
+++ b/sktime/transformations/panel/tests/test_shapelet_transform.py
@@ -31,7 +31,7 @@ def test_st_on_unit_test():
     )
 
 
-@pytest.mark.xfail(reason="known sporadic failure, likely pseudo-random instability)
+@pytest.mark.xfail(reason="known sporadic failure, likely pseudo-random instability")
 @pytest.mark.skipif(
     not run_test_for_class(RandomShapeletTransform),
     reason="run test only if softdeps are present and incrementally (if requested)",


### PR DESCRIPTION
This adds an `xfail` to except sporadic failures in the `RandomShapeletTransform` exact output test.