### PR TITLE
[ENH] add exports of common utilities in `utils` module

### DIFF
--- a/sktime/utils/__init__.py
+++ b/sktime/utils/__init__.py
@@ -1,1 +1,10 @@
 """Utility functionality."""
+
+from sktime.utils.estimator_checks import check_estimator
+from sktime.utils.plotting import plot_series, plot_windows
+
+__all__ = [
+    "check_estimator",
+    "plot_series",
+    "plot_windows",
+]


### PR DESCRIPTION
This PR adds exports of common utilities in `utils` module.

The selection aims at those that users or developers would frequently import.