### PR TITLE
[ENH] `joblib` and `dask` backends in broadcasting of estimators in multivariate or hierarchical case - part 1, `VectorizedDF.vectorize_est`

### DIFF
--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -655,12 +655,12 @@ class VectorizedDF:
         ret = [self._vectorize_est_single(vec_tuple, meta) for vec_tuple in vec_zip]
         return ret
 
-    def _vectorize_est_joblib(self, vec_zip, backend):
+    def _vectorize_est_joblib(self, vec_zip, meta, backend):
         """Vectorize application of estimator method via joblib Parallel."""
         from joblib import Parallel, delayed
 
         ret = Parallel(n_jobs=-1, backend=backend)(
-            delayed(self._vectorize_est_single)(vec_tuple) for vec_tuple in vec_zip
+            delayed(self._vectorize_est_single)(vec_tpl, meta) for vec_tpl in vec_zip
         )
         return ret
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -666,7 +666,7 @@ class VectorizedDF:
 
     def _vectorize_est_dask(self, vec_zip, meta, backend):
         """Vectorize application of estimator method via dask."""
-        from dask import delayed, compute
+        from dask import compute, delayed
 
         lazy = [
             delayed(self._vectorize_est_single)(vec_tuple, meta=meta)

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -650,9 +650,9 @@ class VectorizedDF:
 
         return (group_name, col_name, est_i_result)
 
-    def _vectorize_est_none(self, vec_zip):
+    def _vectorize_est_none(self, vec_zip, meta):
         """Vectorize application of estimator method via simple loop."""
-        ret = [self._vectorize_est_single(vec_tuple) for vec_tuple in vec_zip]
+        ret = [self._vectorize_est_single(vec_tuple, meta) for vec_tuple in vec_zip]
         return ret
 
     def _vectorize_est_joblib(self, vec_zip, backend):

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -444,6 +444,7 @@ class VectorizedDF:
         rowname_default="estimators",
         colname_default="estimators",
         varname_of_self=None,
+        backend=None,
         **kwargs,
     ):
         """Vectorize application of estimator method, return results DataFrame or list.
@@ -503,6 +504,11 @@ class VectorizedDF:
             used as index name of single column if no column vectorization is performed
         varname_of_self : str, optional, default=None
             if not None, self will be passed as kwarg under name "varname_of_self"
+        backend : {"dask", "loky", "multiprocessing", "threading"}, by default None.
+            Runs parallel evaluate if specified and `strategy` is set as "refit".
+            - "loky", "multiprocessing" and "threading": uses `joblib` Parallel loops
+            - "dask": uses `dask`, requires `dask` package in environment
+            - "dask_lazy": same as "dask", but returns delayed object instead
         kwargs : will be passed to invoked methods of estimator(s) in `estimator`
 
         Returns
@@ -513,6 +519,9 @@ class VectorizedDF:
           Entries are identity references to entries of `estimator`,
           after `method` executed with arguments as above.
         """
+        iterate_as = self.iterate_as
+        iterate_cols = self.iterate_cols
+
         if args is None:
             args = kwargs
         else:
@@ -567,28 +576,29 @@ class VectorizedDF:
         else:
             estimators = itertools.cycle([estimator])
 
-        ret = []
-
-        for (group_name, col_name, group), args_i, args_i_rowvec, est_i in zip(
+        vec_zip = zip(
             self.items(),
-            explode(args, iterate_as=self.iterate_as, iterate_cols=self.iterate_cols),
-            explode(args_rowvec, iterate_as=self.iterate_as, iterate_cols=False),
+            explode(args, iterate_as=iterate_as, iterate_cols=iterate_cols),
+            explode(args_rowvec, iterate_as=iterate_as, iterate_cols=False),
             estimators,
-        ):
-            args_i.update(args_i_rowvec)
+        )
 
-            if varname_of_self is not None:
-                args_i[varname_of_self] = group
+        meta = {
+            "method": method,
+            "varname_of_self": varname_of_self,
+            "rowname_default": rowname_default,
+            "colname_default": colname_default,
+        }
 
-            est_i_method = getattr(est_i, method)
-            est_i_result = est_i_method(**args_i)
+        if backend is None:
+            ret = self._vectorize_est_none(vec_zip, meta=meta)
+        elif backend in ["loky", "multiprocessing", "threading"]:
+            ret = self._vectorize_est_joblib(vec_zip, meta=meta, backend=backend)
+        elif backend in ["dask", "dask_lazy"]:
+            ret = self._vectorize_est_dask(vec_zip, meta=meta, backend=backend)
 
-            if group_name is None:
-                group_name = rowname_default
-            if col_name is None:
-                col_name = colname_default
-
-            ret.append((group_name, col_name, est_i_result))
+        if backend == "dask_lazy":
+            return ret
 
         if return_type == "pd.DataFrame":
             df_long = pd.DataFrame(ret)
@@ -616,6 +626,56 @@ class VectorizedDF:
             return df
         else:  # if return_type == "list"
             return [result for _, _, result in ret]
+
+    def _vectorize_est_single(self, vec_tuple, meta):
+        """Single loop iteration of _vectorize_est_[backend]."""
+        method = meta["method"]
+        varname_of_self = meta["varname_of_self"]
+        rowname_default = meta["rowname_default"]
+        colname_default = meta["colname_default"]
+
+        (group_name, col_name, group), args_i, args_i_rowvec, est_i = vec_tuple
+        args_i.update(args_i_rowvec)
+
+        if varname_of_self is not None:
+            args_i[varname_of_self] = group
+
+        est_i_method = getattr(est_i, method)
+        est_i_result = est_i_method(**args_i)
+
+        if group_name is None:
+            group_name = rowname_default
+        if col_name is None:
+            col_name = colname_default
+
+        return (group_name, col_name, est_i_result)
+
+    def _vectorize_est_none(self, vec_zip):
+        """Vectorize application of estimator method via simple loop."""
+        ret = [self._vectorize_est_single(vec_tuple) for vec_tuple in vec_zip]
+        return ret
+
+    def _vectorize_est_joblib(self, vec_zip, backend):
+        """Vectorize application of estimator method via joblib Parallel."""
+        from joblib import Parallel, delayed
+
+        ret = Parallel(n_jobs=-1, backend=backend)(
+            delayed(self._vectorize_est_single)(vec_tuple) for vec_tuple in vec_zip
+        )
+        return ret
+
+    def _vectorize_est_dask(self, vec_zip, meta, backend):
+        """Vectorize application of estimator method via dask."""
+        from dask import delayed, compute
+
+        lazy = [
+            delayed(self._vectorize_est_single)(vec_tuple, meta=meta)
+            for vec_tuple in vec_zip
+        ]
+        if backend == "dask":
+            return compute(*lazy)
+        else:
+            return lazy
 
 
 def _enforce_index_freq(item: pd.Series) -> pd.Series:

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -11,6 +11,7 @@ from sktime.datatypes._check import AMBIGUOUS_MTYPES, check_is_mtype
 from sktime.datatypes._examples import get_examples
 from sktime.datatypes._vectorize import VectorizedDF, _enforce_index_freq
 from sktime.utils._testing.deep_equals import deep_equals
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 SCITYPES = ["Panel", "Hierarchical"]
 
@@ -414,9 +415,10 @@ def test_enforce_index_freq(item, freq):
     assert item.index.freq == freq
 
 
+@pytest.mark.parametrize("backend", [None, "loky", "threading", "dask"])
 @pytest.mark.parametrize("varname_used", [True, False])
 def test_vectorize_est(
-    scitype, mtype, fixture_index, iterate_as, iterate_cols, varname_used
+    scitype, mtype, fixture_index, iterate_as, iterate_cols, varname_used, backend
 ):
     """Tests vectorize_est method of VectorizeDF, for method = clone, fit.
 
@@ -440,6 +442,10 @@ def test_vectorize_est(
     if not _is_valid_iterate_as(scitype, iterate_as):
         return None
 
+    # escape test for dask backend if dask is not installed
+    if backend == "dask" and not _check_soft_dependencies("dask", severity="none"):
+        return None
+
     # retrieve fixture for checking
     fixture = get_examples(mtype=mtype, as_scitype=scitype).get(fixture_index)
     X_vect = VectorizedDF(
@@ -454,7 +460,7 @@ def test_vectorize_est(
         kwargs["y"] = X_vect
 
     est_clones = X_vect.vectorize_est(NaiveForecaster(), method="clone")
-    result = X_vect.vectorize_est(est_clones, method="fit", **kwargs)
+    result = X_vect.vectorize_est(est_clones, method="fit", backend=backend, **kwargs)
 
     def _len(x):
         if x is None:


### PR DESCRIPTION
Part 1 of a sequence of PR to enable parallelization backends for any estimator that is hierarchical or multivariate via broadcast.

This adds the option to choose a `joblib` or `dask` based parallelization backend in `VectorizedDF.vectorize_est`, which is used to broadcast estimators across hierarchy levels or variables.

This PR also extends the test for `vectorize_est` to test the parallelization backends.

Part 2 then, later, needs to connect the parallelization to the relevant estimator base classes.