### PR TITLE
[BUG] in `Imputer`, fix `y` not being passed in `method="forecaster"`

### DIFF
--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -137,6 +137,9 @@ class Imputer(BaseTransformer):
                 }
             )
 
+        if method in "forecaster":
+            self.set_tags(**{"y_inner_mtype": ["pd.DataFrame"]})
+
     def _fit(self, X, y=None):
         """Fit transformer to X and y.
 

--- a/sktime/transformations/series/tests/test_imputer.py
+++ b/sktime/transformations/series/tests/test_imputer.py
@@ -63,9 +63,8 @@ def test_imputer_forecaster_y():
     """
     from sklearn.linear_model import LinearRegression
 
-    from sktime.transformations.compose import YtoX
-
     from sktime.datasets import load_airline
+    from sktime.transformations.compose import YtoX
 
     X = load_airline()
     y = load_airline()

--- a/sktime/transformations/series/tests/test_imputer.py
+++ b/sktime/transformations/series/tests/test_imputer.py
@@ -64,7 +64,7 @@ def test_imputer_forecaster_y():
     from sklearn.linear_model import LinearRegression
 
     from sktime.datasets import load_airline
-    from sktime.transformations.compose import YtoX
+    from sktime.forecasting.compose import YfromX
 
     X = load_airline()
     y = load_airline()

--- a/sktime/transformations/series/tests/test_imputer.py
+++ b/sktime/transformations/series/tests/test_imputer.py
@@ -54,3 +54,25 @@ def test_imputer(method, Z):
     t = Imputer(method=method, forecaster=forecaster, value=value)
     y_hat = t.fit_transform(Z)
     assert not y_hat.isnull().to_numpy().any()
+
+
+def test_imputer_forecaster_y():
+    """Test that forecaster imputer works with y.
+
+    Failure case in bug #5284.
+    """
+    from sklearn.linear_model import LinearRegression
+
+    from sktime.transformations.compose import YtoX
+
+    from sktime.datasets import load_airline
+
+    X = load_airline()
+    y = load_airline()
+
+    model_reg = YfromX(LinearRegression())
+    model_reg.fit(X, y)
+    transformer = Imputer(method="forecaster", forecaster=model_reg)
+
+    transformer.fit(X=X, y=y)
+    transformer.transform(X=X, y=y)


### PR DESCRIPTION
This fixes #5284.

The reason that `y` was not passed is the `y_inner_mtype` tag which always said that internally `y` is not needed (or passed). However, `method="forecaster"` may require it as example #5284 shows, and this is a bug. The fix is setting the tag correctly, in this case.

Adds the failure case from #5284 as a test.