### PR TITLE
[ENH] Remove attrs dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ transformations = [
     "tsfresh>=0.17,<0.21",
 ]
 all_extras = [
-    "attrs",
     "cloudpickle",
     "dash!=2.9.0",
     "dask",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,6 @@ all_extras = [
 ]
 
 all_extras_pandas2 = [
-    "attrs",
     "cloudpickle",
     "dash!=2.9.0",
     "dask<2023.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ alignment = [
     "numba>=0.53,<0.59",
 ]
 annotation = [
-    "attrs>=23,<23.2",
     "hmmlearn>=0.2.7,<0.4",
     "numba>=0.53,<0.59",
     "pyod>=0.8.0,<1.2",

--- a/sktime/annotation/ggs.py
+++ b/sktime/annotation/ggs.py
@@ -34,6 +34,7 @@ References
 
 import logging
 import math
+from dataclasses import asdict, dataclass, field
 from typing import Dict, List, Tuple
 
 import numpy as np
@@ -46,334 +47,324 @@ from sktime.utils.validation._dependencies import _check_estimator_deps
 logger = logging.getLogger(__name__)
 
 
-def get_GGS():
-    """Return GGS class, wrapper to isolate attrs."""
-    from attrs import define, field
+@dataclass
+class GGS:
+    """Greedy Gaussian Segmentation.
 
-    @define
-    class GGS:
-        """Greedy Gaussian Segmentation.
+    The method approxmates solutions for the problem of breaking a
+    multivariate time series into segments, where the data in each segment
+    could be modeled as independent samples from a multivariate Gaussian
+    distribution. It uses a dynamic programming search algorithm with
+    a heuristic that allows finding approximate solution in linear time with
+    respect to the data length and always yields locally optimal choice.
 
-        The method approxmates solutions for the problem of breaking a
-        multivariate time series into segments, where the data in each segment
-        could be modeled as independent samples from a multivariate Gaussian
-        distribution. It uses a dynamic programming search algorithm with
-        a heuristic that allows finding approximate solution in linear time with
-        respect to the data length and always yields locally optimal choice.
+    Greedy Gaussian Segmentation (GGS) fits a segmented gaussian model (SGM)
+    to the data by computing the approximate solution to the combinatorial
+    problem of finding the approximate covariance-regularized  maximum
+    log-likelihood for fixed number of change points and a reagularization
+    strength. It follows an interative procedure
+    where a new breakpoint is added and then adjusting all breakpoints to
+    (approximately) maximize the objective. It is similar to the top-down
+    search used in other change point detection problems.
 
-        Greedy Gaussian Segmentation (GGS) fits a segmented gaussian model (SGM)
-        to the data by computing the approximate solution to the combinatorial
-        problem of finding the approximate covariance-regularized  maximum
-        log-likelihood for fixed number of change points and a reagularization
-        strength. It follows an interative procedure
-        where a new breakpoint is added and then adjusting all breakpoints to
-        (approximately) maximize the objective. It is similar to the top-down
-        search used in other change point detection problems.
+    Parameters
+    ----------
+    k_max: int, default=10
+        Maximum number of change points to find. The number of segments is thus k+1.
+    lamb: : float, default=1.0
+        Regularization parameter lambda (>= 0), which controls the amount of
+        (inverse) covariance regularization, see Eq (1) in [1]_. Regularization
+        is introduced to reduce issues for high-dimensional problems. Setting
+        ``lamb`` to zero will ignore regularization, whereas large values of
+        lambda will favour simpler models.
+    max_shuffles: int, default=250
+        Maximum number of shuffles
+    verbose: bool, default=False
+        If ``True`` verbose output is enabled.
+    random_state: int or np.random.RandomState, default=None
+        Either random seed or an instance of ``np.random.RandomState``
+
+    Attributes
+    ----------
+    change_points_: array_like, default=[]
+        Locations of change points as integer indexes. By convention change points
+        include the identity segmentation, i.e. first and last index + 1 values.
+    _intermediate_change_points: List[List[int]], default=[]
+        Intermediate values of change points for each value of k = 1...k_max
+    _intermediate_ll: List[float], default=[]
+        Intermediate values for log-likelihood for each value of k = 1...k_max
+
+    Notes
+    -----
+    Based on the work from [1]_.
+
+    - source code adapted based on: https://github.com/cvxgrp/GGS
+    - paper available at: https://stanford.edu/~boyd/papers/pdf/ggs.pdf
+
+    References
+    ----------
+    .. [1] Hallac, D., Nystrup, P. & Boyd, S.,
+    "Greedy Gaussian segmentation of multivariate time series.",
+    Adv Data Anal Classif 13, 727–751 (2019).
+    https://doi.org/10.1007/s11634-018-0335-0
+    """
+
+    k_max: int = 10
+    lamb: float = 1.0
+    max_shuffles: int = 250
+    verbose: bool = False
+    random_state: int = None
+
+    change_points_: npt.ArrayLike = field(init=False, default_factory=list)
+    _intermediate_change_points: List[List[int]] = field(
+        init=False, default_factory=list
+    )
+    _intermediate_ll: List[float] = field(init=False, default_factory=list)
+
+    def initialize_intermediates(self) -> None:
+        """Initialize the state fo the estimator."""
+        self._intermediate_change_points = []
+        self._intermediate_ll = []
+
+    def log_likelihood(self, data: npt.ArrayLike) -> float:
+        """Compute the GGS log-likelihood of the segmented Gaussian model.
 
         Parameters
         ----------
-        k_max: int, default=10
-            Maximum number of change points to find. The number of segments is thus k+1.
-        lamb: : float, default=1.0
-            Regularization parameter lambda (>= 0), which controls the amount of
-            (inverse) covariance regularization, see Eq (1) in [1]_. Regularization
-            is introduced to reduce issues for high-dimensional problems. Setting
-            ``lamb`` to zero will ignore regularization, whereas large values of
-            lambda will favour simpler models.
-        max_shuffles: int, default=250
-            Maximum number of shuffles
-        verbose: bool, default=False
-            If ``True`` verbose output is enabled.
-        random_state: int or np.random.RandomState, default=None
-            Either random seed or an instance of ``np.random.RandomState``
+        data: array_like
+            2D `array_like` representing time series with sequence index along
+            the first dimension and value series as columns.
 
-        Attributes
-        ----------
-        change_points_: array_like, default=[]
-            Locations of change points as integer indexes. By convention change points
-            include the identity segmentation, i.e. first and last index + 1 values.
-        _intermediate_change_points: List[List[int]], default=[]
-            Intermediate values of change points for each value of k = 1...k_max
-        _intermediate_ll: List[float], default=[]
-            Intermediate values for log-likelihood for each value of k = 1...k_max
-
-        Notes
-        -----
-        Based on the work from [1]_.
-
-        - source code adapted based on: https://github.com/cvxgrp/GGS
-        - paper available at: https://stanford.edu/~boyd/papers/pdf/ggs.pdf
-
-        References
-        ----------
-        .. [1] Hallac, D., Nystrup, P. & Boyd, S.,
-        "Greedy Gaussian segmentation of multivariate time series.",
-        Adv Data Anal Classif 13, 727–751 (2019).
-        https://doi.org/10.1007/s11634-018-0335-0
+        Returns
+        -------
+        log_likelihood
         """
+        nrows, ncols = data.shape
+        cov = np.cov(data.T, bias=True)
+        (_, logdet) = np.linalg.slogdet(
+            cov + float(self.lamb) * np.identity(ncols) / nrows
+        )
 
-        k_max: int = 10
-        lamb: float = 1.0
-        max_shuffles: int = 250
-        verbose: bool = False
-        random_state: int = None
+        return nrows * logdet - float(self.lamb) * np.trace(
+            np.linalg.inv(cov + float(self.lamb) * np.identity(ncols) / nrows)
+        )
 
-        change_points_: npt.ArrayLike = field(init=False, default=[])
-        _intermediate_change_points: List[List[int]] = field(init=False, default=[])
-        _intermediate_ll: List[float] = field(init=False, default=[])
+    def cumulative_log_likelihood(
+        self, data: npt.ArrayLike, change_points: List[int]
+    ) -> float:
+        """Calculate cumulative GGS log-likelihood for all segments.
 
-        def initialize_intermediates(self) -> None:
-            """Initialize the state fo the estimator."""
-            self._intermediate_change_points = []
-            self._intermediate_ll = []
+        Args
+        ----
+        data: array_like
+            2D `array_like` representing time series with sequence index along
+            the first dimension and value series as columns.
+        change_points: list of ints
+            Locations of change points as integer indexes.
+            By convention, change points
+            include the identity segmentation, i.e. first and last index + 1 values.
 
-        def log_likelihood(self, data: npt.ArrayLike) -> float:
-            """Compute the GGS log-likelihood of the segmented Gaussian model.
+        Returns
+        -------
+        log_likelihood: cumulative log likelihood
+        """
+        log_likelihood = 0
+        for start, stop in zip(change_points[:-1], change_points[1:]):
+            segment = data[start:stop, :]
+            log_likelihood -= self.log_likelihood(segment)
+        return log_likelihood
 
-            Parameters
-            ----------
-            data: array_like
-                2D `array_like` representing time series with sequence index along
-                the first dimension and value series as columns.
+    def add_new_change_point(self, data: npt.ArrayLike) -> Tuple[int, float]:
+        """Add change point.
 
-            Returns
-            -------
-            log_likelihood
-            """
-            nrows, ncols = data.shape
-            cov = np.cov(data.T, bias=True)
-            (_, logdet) = np.linalg.slogdet(
-                cov + float(self.lamb) * np.identity(ncols) / nrows
+        This methods finds a new change point by that splits the segment and
+        optimizes the objective function. See section 3.1 on split subroutine
+        in [1]_.
+
+        Parameters
+        ----------
+        data: array_like
+            2D `array_like` representing time series with sequence index along
+            the first dimension and value series as columns.
+
+        Returns
+        -------
+        index: change point index
+        gll: gained log likelihood
+        """
+        # Initialize parameters
+        m, n = data.shape
+        orig_mean = np.mean(data, axis=0)
+        orig_cov = np.cov(data.T, bias=True)
+        orig_ll = self.log_likelihood(data)
+        total_sum = m * (orig_cov + np.outer(orig_mean, orig_mean))
+        mu_left = data[0, :] / n
+        mu_right = (m * orig_mean - data[0, :]) / (m - 1)
+        runSum = np.outer(data[0, :], data[0, :])
+        # Loop through all samples
+        # find point where breaking the segment would have the largest LL increase
+        min_ll = orig_ll
+        new_index = 0
+        for i in range(2, m - 1):
+            # Update parameters
+            runSum = runSum + np.outer(data[i - 1, :], data[i - 1, :])
+            mu_left = ((i - 1) * mu_left + data[i - 1, :]) / (i)
+            mu_right = ((m - i + 1) * mu_right - data[i - 1, :]) / (m - i)
+            sigLeft = runSum / (i) - np.outer(mu_left, mu_left)
+            sigRight = (total_sum - runSum) / (m - i) - np.outer(mu_right, mu_right)
+
+            # Compute Cholesky, LogDet, and Trace
+            Lleft = np.linalg.cholesky(sigLeft + float(self.lamb) * np.identity(n) / i)
+            Lright = np.linalg.cholesky(
+                sigRight + float(self.lamb) * np.identity(n) / (m - i)
             )
-
-            return nrows * logdet - float(self.lamb) * np.trace(
-                np.linalg.inv(cov + float(self.lamb) * np.identity(ncols) / nrows)
+            ll_left = 2 * sum(map(math.log, np.diag(Lleft)))
+            ll_right = 2 * sum(map(math.log, np.diag(Lright)))
+            (trace_left, trace_right) = (0, 0)
+            if self.lamb > 0:
+                trace_left = math.pow(np.linalg.norm(np.linalg.inv(Lleft)), 2)
+                trace_right = math.pow(np.linalg.norm(np.linalg.inv(Lright)), 2)
+            LL = (
+                i * ll_left
+                - float(self.lamb) * trace_left
+                + (m - i) * ll_right
+                - float(self.lamb) * trace_right
             )
+            # Keep track of the best point so far
+            if LL < min_ll:
+                min_ll = LL
+                new_index = i
+        # Return break, increase in LL
+        return new_index, min_ll - orig_ll
 
-        def cumulative_log_likelihood(
-            self, data: npt.ArrayLike, change_points: List[int]
-        ) -> float:
-            """Calculate cumulative GGS log-likelihood for all segments.
+    def adjust_change_points(
+        self, data: npt.ArrayLike, change_points: List[int], new_index: List[int]
+    ) -> List[int]:
+        """Adjust change points.
 
-            Args
-            ----
-            data: array_like
-                2D `array_like` representing time series with sequence index along
-                the first dimension and value series as columns.
-            change_points: list of ints
-                Locations of change points as integer indexes.
-                By convention, change points
-                include the identity segmentation, i.e. first and last index + 1 values.
+        This method adjusts the positions of all change points until the
+        result is 1-OPT, i.e., no change of any one breakpoint improves
+        the objective.
 
-            Returns
-            -------
-            log_likelihood: cumulative log likelihood
-            """
-            log_likelihood = 0
+        Parameters
+        ----------
+        data: array_like
+            2D `array_like` representing time series with sequence index along
+            the first dimension and value series as columns.
+        change_points: list of ints
+            Locations of change points as integer indexes.
+            By convention, change points
+            include the identity segmentation, i.e. first and last index + 1 values.
+        new_index: list of ints
+            New change points
+
+        Returns
+        -------
+        change_points: list of ints
+            Locations of change points as integer indexes.
+            By convention, change points
+            include the identity segmentation, i.e. first and last index + 1 values.
+        """
+        rng = check_random_state(self.random_state)
+        bp = change_points[:]
+
+        # Just one breakpoint, no need to adjust anything
+        if len(bp) == 3:
+            return bp
+        # Keep track of what change_points have changed,
+        # so that we don't have to adjust ones which we know are constant
+        last_pass = {}
+        this_pass = {b: 0 for b in bp}
+        for i in new_index:
+            this_pass[i] = 1
+        for _ in range(self.max_shuffles):
+            last_pass = dict(this_pass)
+            this_pass = {b: 0 for b in bp}
+            switch_any = False
+            ordering = list(range(1, len(bp) - 1))
+            rng.shuffle(ordering)
+            for i in ordering:
+                # Check if we need to adjust it
+                if (
+                    last_pass[bp[i - 1]] == 1
+                    or last_pass[bp[i + 1]] == 1
+                    or this_pass[bp[i - 1]] == 1
+                    or this_pass[bp[i + 1]] == 1
+                ):
+                    tempData = data[bp[i - 1] : bp[i + 1], :]
+                    ind, val = self.add_new_change_point(tempData)
+                    if bp[i] != ind + bp[i - 1] and val != 0:
+                        last_pass[ind + bp[i - 1]] = last_pass[bp[i]]
+                        del last_pass[bp[i]]
+                        del this_pass[bp[i]]
+                        this_pass[ind + bp[i - 1]] = 1
+                        if self.verbose:
+                            logger.info(
+                                f"Moving {bp[i]} to {ind + bp[i - 1]}"
+                                f"length = {tempData.shape[0]}, {ind}"
+                            )
+                        bp[i] = ind + bp[i - 1]
+                        switch_any = True
+            if not switch_any:
+                return bp
+        return bp
+
+    def identity_segmentation(self, data: npt.ArrayLike) -> List[int]:
+        """Initialize change points."""
+        return [0, data.shape[0] + 1]
+
+    def find_change_points(self, data: npt.ArrayLike) -> List[int]:
+        """
+        Search iteratively  for up to ``k_max`` change points.
+
+        Parameters
+        ----------
+        data: array_like
+            2D `array_like` representing time series with sequence index along
+            the first dimension and value series as columns.
+
+        Returns
+        -------
+        The K change points, along with all intermediate change points (for k < K)
+        and their corresponding covariance-regularized maximum likelihoods.
+        """
+        change_points = self.identity_segmentation(data)
+        self._intermediate_change_points = [change_points[:]]
+        self._intermediate_ll = [self.cumulative_log_likelihood(data, change_points)]
+
+        # Start GGS Algorithm
+        for _ in range(self.k_max):
+            new_index = -1
+            new_value = +1
+            # For each segment, find change point and increase in LL
             for start, stop in zip(change_points[:-1], change_points[1:]):
                 segment = data[start:stop, :]
-                log_likelihood -= self.log_likelihood(segment)
-            return log_likelihood
+                ind, val = self.add_new_change_point(segment)
+                if val < new_value:
+                    new_index = ind + start
+                    new_value = val
 
-        def add_new_change_point(self, data: npt.ArrayLike) -> Tuple[int, float]:
-            """Add change point.
+            # Check if our algorithm is finished
+            if new_value == 0:
+                logger.info("Adding change points!")
+                return change_points
 
-            This methods finds a new change point by that splits the segment and
-            optimizes the objective function. See section 3.1 on split subroutine
-            in [1]_.
+            # Add new change point
+            change_points.append(new_index)
+            change_points.sort()
+            if self.verbose:
+                logger.info(f"Change point occurs at: {new_index}, LL: {new_value}")
 
-            Parameters
-            ----------
-            data: array_like
-                2D `array_like` representing time series with sequence index along
-                the first dimension and value series as columns.
+            # Adjust current locations of the change points
+            change_points = self.adjust_change_points(data, change_points, [new_index])
+            change_points = change_points[:]
 
-            Returns
-            -------
-            index: change point index
-            gll: gained log likelihood
-            """
-            # Initialize parameters
-            m, n = data.shape
-            orig_mean = np.mean(data, axis=0)
-            orig_cov = np.cov(data.T, bias=True)
-            orig_ll = self.log_likelihood(data)
-            total_sum = m * (orig_cov + np.outer(orig_mean, orig_mean))
-            mu_left = data[0, :] / n
-            mu_right = (m * orig_mean - data[0, :]) / (m - 1)
-            runSum = np.outer(data[0, :], data[0, :])
-            # Loop through all samples
-            # find point where breaking the segment would have the largest LL increase
-            min_ll = orig_ll
-            new_index = 0
-            for i in range(2, m - 1):
-                # Update parameters
-                runSum = runSum + np.outer(data[i - 1, :], data[i - 1, :])
-                mu_left = ((i - 1) * mu_left + data[i - 1, :]) / (i)
-                mu_right = ((m - i + 1) * mu_right - data[i - 1, :]) / (m - i)
-                sigLeft = runSum / (i) - np.outer(mu_left, mu_left)
-                sigRight = (total_sum - runSum) / (m - i) - np.outer(mu_right, mu_right)
+            # Calculate likelihood
+            ll = self.cumulative_log_likelihood(data, change_points)
+            self._intermediate_change_points.append(change_points[:])
+            self._intermediate_ll.append(ll)
 
-                # Compute Cholesky, LogDet, and Trace
-                Lleft = np.linalg.cholesky(
-                    sigLeft + float(self.lamb) * np.identity(n) / i
-                )
-                Lright = np.linalg.cholesky(
-                    sigRight + float(self.lamb) * np.identity(n) / (m - i)
-                )
-                ll_left = 2 * sum(map(math.log, np.diag(Lleft)))
-                ll_right = 2 * sum(map(math.log, np.diag(Lright)))
-                (trace_left, trace_right) = (0, 0)
-                if self.lamb > 0:
-                    trace_left = math.pow(np.linalg.norm(np.linalg.inv(Lleft)), 2)
-                    trace_right = math.pow(np.linalg.norm(np.linalg.inv(Lright)), 2)
-                LL = (
-                    i * ll_left
-                    - float(self.lamb) * trace_left
-                    + (m - i) * ll_right
-                    - float(self.lamb) * trace_right
-                )
-                # Keep track of the best point so far
-                if LL < min_ll:
-                    min_ll = LL
-                    new_index = i
-            # Return break, increase in LL
-            return new_index, min_ll - orig_ll
-
-        def adjust_change_points(
-            self, data: npt.ArrayLike, change_points: List[int], new_index: List[int]
-        ) -> List[int]:
-            """Adjust change points.
-
-            This method adjusts the positions of all change points until the
-            result is 1-OPT, i.e., no change of any one breakpoint improves
-            the objective.
-
-            Parameters
-            ----------
-            data: array_like
-                2D `array_like` representing time series with sequence index along
-                the first dimension and value series as columns.
-            change_points: list of ints
-                Locations of change points as integer indexes.
-                By convention, change points
-                include the identity segmentation, i.e. first and last index + 1 values.
-            new_index: list of ints
-                New change points
-
-            Returns
-            -------
-            change_points: list of ints
-                Locations of change points as integer indexes.
-                By convention, change points
-                include the identity segmentation, i.e. first and last index + 1 values.
-            """
-            rng = check_random_state(self.random_state)
-            bp = change_points[:]
-
-            # Just one breakpoint, no need to adjust anything
-            if len(bp) == 3:
-                return bp
-            # Keep track of what change_points have changed,
-            # so that we don't have to adjust ones which we know are constant
-            last_pass = {}
-            this_pass = {b: 0 for b in bp}
-            for i in new_index:
-                this_pass[i] = 1
-            for _ in range(self.max_shuffles):
-                last_pass = dict(this_pass)
-                this_pass = {b: 0 for b in bp}
-                switch_any = False
-                ordering = list(range(1, len(bp) - 1))
-                rng.shuffle(ordering)
-                for i in ordering:
-                    # Check if we need to adjust it
-                    if (
-                        last_pass[bp[i - 1]] == 1
-                        or last_pass[bp[i + 1]] == 1
-                        or this_pass[bp[i - 1]] == 1
-                        or this_pass[bp[i + 1]] == 1
-                    ):
-                        tempData = data[bp[i - 1] : bp[i + 1], :]
-                        ind, val = self.add_new_change_point(tempData)
-                        if bp[i] != ind + bp[i - 1] and val != 0:
-                            last_pass[ind + bp[i - 1]] = last_pass[bp[i]]
-                            del last_pass[bp[i]]
-                            del this_pass[bp[i]]
-                            this_pass[ind + bp[i - 1]] = 1
-                            if self.verbose:
-                                logger.info(
-                                    f"Moving {bp[i]} to {ind + bp[i - 1]}"
-                                    f"length = {tempData.shape[0]}, {ind}"
-                                )
-                            bp[i] = ind + bp[i - 1]
-                            switch_any = True
-                if not switch_any:
-                    return bp
-            return bp
-
-        def identity_segmentation(self, data: npt.ArrayLike) -> List[int]:
-            """Initialize change points."""
-            return [0, data.shape[0] + 1]
-
-        def find_change_points(self, data: npt.ArrayLike) -> List[int]:
-            """
-            Search iteratively  for up to ``k_max`` change points.
-
-            Parameters
-            ----------
-            data: array_like
-                2D `array_like` representing time series with sequence index along
-                the first dimension and value series as columns.
-
-            Returns
-            -------
-            The K change points, along with all intermediate change points (for k < K)
-            and their corresponding covariance-regularized maximum likelihoods.
-            """
-            change_points = self.identity_segmentation(data)
-            self._intermediate_change_points = [change_points[:]]
-            self._intermediate_ll = [
-                self.cumulative_log_likelihood(data, change_points)
-            ]
-
-            # Start GGS Algorithm
-            for _ in range(self.k_max):
-                new_index = -1
-                new_value = +1
-                # For each segment, find change point and increase in LL
-                for start, stop in zip(change_points[:-1], change_points[1:]):
-                    segment = data[start:stop, :]
-                    ind, val = self.add_new_change_point(segment)
-                    if val < new_value:
-                        new_index = ind + start
-                        new_value = val
-
-                # Check if our algorithm is finished
-                if new_value == 0:
-                    logger.info("Adding change points!")
-                    return change_points
-
-                # Add new change point
-                change_points.append(new_index)
-                change_points.sort()
-                if self.verbose:
-                    logger.info(f"Change point occurs at: {new_index}, LL: {new_value}")
-
-                # Adjust current locations of the change points
-                change_points = self.adjust_change_points(
-                    data, change_points, [new_index]
-                )
-                change_points = change_points[:]
-
-                # Calculate likelihood
-                ll = self.cumulative_log_likelihood(data, change_points)
-                self._intermediate_change_points.append(change_points[:])
-                self._intermediate_ll.append(ll)
-
-            return change_points
-
-    return GGS
+        return change_points
 
 
 class GreedyGaussianSegmentation(BaseEstimator):
@@ -437,8 +428,6 @@ class GreedyGaussianSegmentation(BaseEstimator):
        https://doi.org/10.1007/s11634-018-0335-0
     """
 
-    _tags = {"python_dependencies": "attrs"}
-
     def __init__(
         self,
         k_max: int = 10,
@@ -457,8 +446,7 @@ class GreedyGaussianSegmentation(BaseEstimator):
         _check_estimator_deps(self)
         super().__init__()
 
-        self._adaptee_class = get_GGS()
-        self._adaptee = self._adaptee_class(
+        self._adaptee = GGS(
             k_max=k_max,
             lamb=lamb,
             max_shuffles=max_shuffles,
@@ -544,9 +532,16 @@ class GreedyGaussianSegmentation(BaseEstimator):
             Dictionary with the estimator's initialization parameters, with
             keys being argument names and values being argument values.
         """
-        from attrs import asdict
-
-        return asdict(self._adaptee, filter=lambda attr, value: attr.init is True)
+        attrs_to_ignore = [
+            "change_points_",
+            "_intermediate_change_points",
+            "_intermediate_ll",
+        ]
+        params = asdict(self._adaptee)
+        params = {
+            key: value for key, value in params.items() if key not in attrs_to_ignore
+        }
+        return params
 
     def set_params(self, **parameters):
         """Set the parameters of this object.

--- a/sktime/annotation/igts.py
+++ b/sktime/annotation/igts.py
@@ -15,7 +15,7 @@ References
     https://www.sciencedirect.com/science/article/abs/pii/S1574119217300081
 """
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Dict, List
 
 import numpy as np
@@ -101,189 +101,183 @@ def generate_segments_pandas(X: npt.ArrayLike, change_points: List) -> npt.Array
         yield X[interval.left : interval.right, :]
 
 
-def get_IGTS():
-    """Return IGTS class, wrapper to isolate attrs."""
-    from attrs import define, field
+@dataclass
+class IGTS:
+    """Information Gain based Temporal Segmentation (IGTS).
 
-    @define
-    class IGTS:
-        """Information Gain based Temporal Segmentation (IGTS).
+    IGTS is a n unsupervised method for segmenting multivariate time series
+    into non-overlapping segments by locating change points that for which
+    the information gain is maximized.
 
-        IGTS is a n unsupervised method for segmenting multivariate time series
-        into non-overlapping segments by locating change points that for which
-        the information gain is maximized.
+    Information gain (IG) is defined as the amount of entropy lost by the
+    segmentation.
+    The aim is to find the segmentation that have the maximum information
+    gain for a specified number of segments.
 
-        Information gain (IG) is defined as the amount of entropy lost by the
-        segmentation.
-        The aim is to find the segmentation that have the maximum information
-        gain for a specified number of segments.
+    IGTS uses top-down search method to greedily find the next change point
+    location that creates the maximum information gain. Once this is found, it
+    repeats the process until it finds `k_max` splits of the time series.
 
-        IGTS uses top-down search method to greedily find the next change point
-        location that creates the maximum information gain. Once this is found, it
-        repeats the process until it finds `k_max` splits of the time series.
+    .. note::
 
-        .. note::
+    IGTS does not work very well for univariate series but it can still be
+    used if the original univariate series are augmented by an extra feature
+    dimensions. A technique proposed in the paper [1]_ us to subtract the
+    series from it's largest element and append to the series.
 
-        IGTS does not work very well for univariate series but it can still be
-        used if the original univariate series are augmented by an extra feature
-        dimensions. A technique proposed in the paper [1]_ us to subtract the
-        series from it's largest element and append to the series.
+    Parameters
+    ----------
+    k_max: int, default=10
+        Maximum number of change points to find. The number of segments is thus k+1.
+    step: : int, default=5
+        Step size, or stride for selecting candidate locations of change points.
+        Fox example a `step=5` would produce candidates [0, 5, 10, ...].
+        Has the same meaning as `step` in `range` function.
+
+    Attributes
+    ----------
+    intermediate_results_: list of `ChangePointResult`
+        Intermediate segmentation results for each k value, where k=1, 2, ..., k_max
+
+    Notes
+    -----
+    Based on the work from [1]_.
+    - alt. py implementation: https://github.com/cruiseresearchgroup/IGTS-python
+    - MATLAB version: https://github.com/cruiseresearchgroup/IGTS-matlab
+    - paper available at:
+
+    References
+    ----------
+    .. [1] Sadri, Amin, Yongli Ren, and Flora D. Salim.
+    "Information gain-based metric for recognizing transitions in human
+    activities.", Pervasive and Mobile Computing, 38, 92-109, (2017).
+    https://www.sciencedirect.com/science/article/abs/pii/S1574119217300081
+
+    Example
+    -------
+    >>> from sktime.annotation.datagen import piecewise_normal_multivariate
+    >>> from sklearn.preprocessing import MinMaxScaler
+    >>> X = piecewise_normal_multivariate(lengths=[10, 10, 10, 10],
+    ... means=[[0.0, 1.0], [11.0, 10.0], [5.0, 3.0], [2.0, 2.0]],
+    ... variances=0.5)
+    >>> X_scaled = MinMaxScaler(feature_range=(0, 1)).fit_transform(X)
+    >>> from sktime.annotation.igts import InformationGainSegmentation
+    >>> igts = InformationGainSegmentation(k_max=3, step=2)
+    >>> y = igts.fit_predict(X_scaled)
+    """
+
+    # init attributes
+    k_max: int = 10
+    step: int = 5
+
+    # computed attributes
+    intermediate_results_: List = field(init=False, default_factory=list)
+
+    def identity(self, X: npt.ArrayLike) -> List[int]:
+        """Return identity segmentation, i.e. terminal indexes of the data."""
+        return sorted([0, X.shape[0]])
+
+    def get_candidates(self, n_samples: int, change_points: List[int]) -> List[int]:
+        """Generate candidate change points.
+
+        Also exclude existing change points.
 
         Parameters
         ----------
-        k_max: int, default=10
-            Maximum number of change points to find. The number of segments is thus k+1.
-        step: : int, default=5
-            Step size, or stride for selecting candidate locations of change points.
-            Fox example a `step=5` would produce candidates [0, 5, 10, ...].
-            Has the same meaning as `step` in `range` function.
+        n_samples: int
+            Length of the time series.
+        change_points: list of ints
+            Current set of change points, that will be used to exclude values
+            from candidates.
 
-        Attributes
-        ----------
-        intermediate_results_: list of `ChangePointResult`
-            Intermediate segmentation results for each k value, where k=1, 2, ..., k_max
-
-        Notes
-        -----
-        Based on the work from [1]_.
-        - alt. py implementation: https://github.com/cruiseresearchgroup/IGTS-python
-        - MATLAB version: https://github.com/cruiseresearchgroup/IGTS-matlab
-        - paper available at:
-
-        References
-        ----------
-        .. [1] Sadri, Amin, Yongli Ren, and Flora D. Salim.
-        "Information gain-based metric for recognizing transitions in human
-        activities.", Pervasive and Mobile Computing, 38, 92-109, (2017).
-        https://www.sciencedirect.com/science/article/abs/pii/S1574119217300081
-
-        Example
-        -------
-        >>> from sktime.annotation.datagen import piecewise_normal_multivariate
-        >>> from sklearn.preprocessing import MinMaxScaler
-        >>> X = piecewise_normal_multivariate(lengths=[10, 10, 10, 10],
-        ... means=[[0.0, 1.0], [11.0, 10.0], [5.0, 3.0], [2.0, 2.0]],
-        ... variances=0.5)
-        >>> X_scaled = MinMaxScaler(feature_range=(0, 1)).fit_transform(X)
-        >>> from sktime.annotation.igts import InformationGainSegmentation
-        >>> igts = InformationGainSegmentation(k_max=3, step=2)
-        >>> y = igts.fit_predict(X_scaled)
+        TODO: exclude points within a neighborhood of existing
+        change points with neighborhood radius
         """
+        return sorted(
+            set(range(0, n_samples, self.step)).difference(set(change_points))
+        )
 
-        # init attributes
-        k_max: int = 10
-        step: int = 5
+    @staticmethod
+    def information_gain_score(X: npt.ArrayLike, change_points: List[int]) -> float:
+        """Calculate the information gain score.
 
-        # computed attributes
-        intermediate_results_: List = field(init=False, default=[])
+        The formula is based on equation (2) from [1]_.
 
-        def identity(self, X: npt.ArrayLike) -> List[int]:
-            """Return identity segmentation, i.e. terminal indexes of the data."""
-            return sorted([0, X.shape[0]])
+        Parameters
+        ----------
+        X: array_like
+            Time series data as a 2D numpy array with sequence index along rows
+            and value series in columns.
 
-        def get_candidates(self, n_samples: int, change_points: List[int]) -> List[int]:
-            """Generate candidate change points.
+        change_points: list of ints
+            Locations of change points as integer indexes.
+            By convention, change points
+            include the identity segmentation, i.e. first and last index + 1 values.
 
-            Also exclude existing change points.
+        Returns
+        -------
+        information_gain: float
+            Information gain score for the segmentation corresponding to the change
+            points.
+        """
+        cp = change_points
+        segment_entropies = [
+            seg.shape[0] * entropy(seg) for seg in generate_segments(X, cp)
+        ]
+        return entropy(X) - sum(segment_entropies) / X.shape[0]
 
-            Parameters
-            ----------
-            n_samples: int
-                Length of the time series.
-            change_points: list of ints
-                Current set of change points, that will be used to exclude values
-                from candidates.
+    def find_change_points(self, X: npt.ArrayLike) -> List[int]:
+        """Find change points.
 
-            TODO: exclude points within a neighborhood of existing
-            change points with neighborhood radius
-            """
-            return sorted(
-                set(range(0, n_samples, self.step)).difference(set(change_points))
+        Using a top-down search method, iteratively identify at most
+        `k_max` change points that increase the information gain score
+        the most.
+
+        Parameters
+        ----------
+        X: array_like
+            Time series data as a 2D numpy array with sequence index along rows
+            and value series in columns.
+
+        Returns
+        -------
+        change_points: list of ints
+            Locations of change points as integer indexes.
+            By convention, change points
+            include the identity segmentation, i.e. first and last index + 1 values.
+        """
+        n_samples, n_series = X.shape
+        if n_series == 1:
+            raise ValueError(
+                "Detected univariate series, IGTS will not work properly"
+                " in this case. Consider augmenting your series to multivariate."
+            )
+        self.intermediate_results_ = []
+
+        # by convention initialize with the identity segmentation
+        current_change_points = self.identity(X)
+
+        for k in range(self.k_max):
+            ig_max = 0
+            # find a point which maximizes score
+            for candidate in self.get_candidates(n_samples, current_change_points):
+                try_change_points = {candidate}
+                try_change_points.update(current_change_points)
+                try_change_points = sorted(try_change_points)
+                ig = self.information_gain_score(X, try_change_points)
+                if ig > ig_max:
+                    ig_max = ig
+                    best_candidate = candidate
+
+            current_change_points.append(best_candidate)
+            current_change_points.sort()
+            self.intermediate_results_.append(
+                ChangePointResult(
+                    k=k, score=ig_max, change_points=current_change_points.copy()
+                )
             )
 
-        @staticmethod
-        def information_gain_score(X: npt.ArrayLike, change_points: List[int]) -> float:
-            """Calculate the information gain score.
-
-            The formula is based on equation (2) from [1]_.
-
-            Parameters
-            ----------
-            X: array_like
-                Time series data as a 2D numpy array with sequence index along rows
-                and value series in columns.
-
-            change_points: list of ints
-                Locations of change points as integer indexes.
-                By convention, change points
-                include the identity segmentation, i.e. first and last index + 1 values.
-
-            Returns
-            -------
-            information_gain: float
-                Information gain score for the segmentation corresponding to the change
-                points.
-            """
-            cp = change_points
-            segment_entropies = [
-                seg.shape[0] * entropy(seg) for seg in generate_segments(X, cp)
-            ]
-            return entropy(X) - sum(segment_entropies) / X.shape[0]
-
-        def find_change_points(self, X: npt.ArrayLike) -> List[int]:
-            """Find change points.
-
-            Using a top-down search method, iteratively identify at most
-            `k_max` change points that increase the information gain score
-            the most.
-
-            Parameters
-            ----------
-            X: array_like
-                Time series data as a 2D numpy array with sequence index along rows
-                and value series in columns.
-
-            Returns
-            -------
-            change_points: list of ints
-                Locations of change points as integer indexes.
-                By convention, change points
-                include the identity segmentation, i.e. first and last index + 1 values.
-            """
-            n_samples, n_series = X.shape
-            if n_series == 1:
-                raise ValueError(
-                    "Detected univariate series, IGTS will not work properly"
-                    " in this case. Consider augmenting your series to multivariate."
-                )
-            self.intermediate_results_ = []
-
-            # by convention initialize with the identity segmentation
-            current_change_points = self.identity(X)
-
-            for k in range(self.k_max):
-                ig_max = 0
-                # find a point which maximizes score
-                for candidate in self.get_candidates(n_samples, current_change_points):
-                    try_change_points = {candidate}
-                    try_change_points.update(current_change_points)
-                    try_change_points = sorted(try_change_points)
-                    ig = self.information_gain_score(X, try_change_points)
-                    if ig > ig_max:
-                        ig_max = ig
-                        best_candidate = candidate
-
-                current_change_points.append(best_candidate)
-                current_change_points.sort()
-                self.intermediate_results_.append(
-                    ChangePointResult(
-                        k=k, score=ig_max, change_points=current_change_points.copy()
-                    )
-                )
-
-            return current_change_points
-
-    return IGTS
+        return current_change_points
 
 
 class SegmentationMixin:
@@ -388,8 +382,6 @@ class InformationGainSegmentation(SegmentationMixin, BaseEstimator):
     >>> y = igts.fit_predict(X_scaled) # doctest: +SKIP
     """
 
-    _tags = {"python_dependencies": "attrs"}
-
     def __init__(
         self,
         k_max: int = 10,
@@ -401,8 +393,7 @@ class InformationGainSegmentation(SegmentationMixin, BaseEstimator):
         _check_estimator_deps(self)
         super().__init__()
 
-        self._adaptee_class = get_IGTS()
-        self._adaptee = self._adaptee_class(
+        self._adaptee = IGTS(
             k_max=k_max,
             step=step,
         )
@@ -484,9 +475,13 @@ class InformationGainSegmentation(SegmentationMixin, BaseEstimator):
             Dictionary with the estimator's initialization parameters, with
             keys being argument names and values being argument values.
         """
-        from attrs import asdict
-
-        return asdict(self._adaptee, filter=lambda attr, value: attr.init is True)
+        params = asdict(self._adaptee)
+        params = {
+            key: value
+            for key, value in params.items()
+            if key != "intermediate_results_"
+        }
+        return params
 
     def set_params(self, **parameters):
         """Set the parameters of this object.

--- a/sktime/annotation/tests/test_ggs.py
+++ b/sktime/annotation/tests/test_ggs.py
@@ -3,8 +3,7 @@
 import numpy as np
 import pytest
 
-from sktime.annotation.ggs import GreedyGaussianSegmentation, get_GGS
-from sktime.utils.validation._dependencies import _check_soft_dependencies
+from sktime.annotation.ggs import GGS, GreedyGaussianSegmentation
 
 
 @pytest.fixture
@@ -14,23 +13,14 @@ def univariate_mean_shift():
     return x[:, np.newaxis]
 
 
-@pytest.mark.skipif(
-    not _check_soft_dependencies("attrs", severity="none"),
-    reason="skip test if required soft dependencies not available",
-)
 def test_GGS_find_change_points(univariate_mean_shift):
     """Test the GGS core estimator."""
-    GGS = get_GGS()
     ggs = GGS(k_max=10, lamb=1.0)
     pred = ggs.find_change_points(univariate_mean_shift)
     assert isinstance(pred, list)
     assert len(pred) == 5
 
 
-@pytest.mark.skipif(
-    not _check_soft_dependencies("attrs", severity="none"),
-    reason="skip test if required soft dependencies not available",
-)
 def test_GreedyGaussianSegmentation(univariate_mean_shift):
     """Test the GreedyGaussianSegmentation."""
     ggs = GreedyGaussianSegmentation(k_max=5, lamb=0.5)

--- a/sktime/annotation/tests/test_igts.py
+++ b/sktime/annotation/tests/test_igts.py
@@ -3,8 +3,7 @@
 import numpy as np
 import pytest
 
-from sktime.annotation.igts import InformationGainSegmentation, entropy, get_IGTS
-from sktime.utils.validation._dependencies import _check_soft_dependencies
+from sktime.annotation.igts import IGTS, InformationGainSegmentation, entropy
 
 
 @pytest.fixture
@@ -19,46 +18,27 @@ def test_entropy():
     assert entropy(np.ones((10, 1))) == 0.0
 
 
-@pytest.mark.skipif(
-    not _check_soft_dependencies("attrs", severity="none"),
-    reason="skip test if required soft dependencies not available",
-)
 def test_igts_identity():
     """Test identity segmentation."""
-    IGTS = get_IGTS()
     X = np.random.random(12).reshape(4, 3)
     id_change_points = IGTS().identity(X)
     assert id_change_points == [0, 4]
 
 
-@pytest.mark.skipif(
-    not _check_soft_dependencies("attrs", severity="none"),
-    reason="skip test if required soft dependencies not available",
-)
 def test_igts_get_candidates():
     """Test get_candidates function."""
-    IGTS = get_IGTS()
     candidates = IGTS(step=2).get_candidates(n_samples=10, change_points=[0, 4, 6])
     assert candidates == [2, 8]
 
 
-@pytest.mark.skipif(
-    not _check_soft_dependencies("attrs", severity="none"),
-    reason="skip test if required soft dependencies not available",
-)
 def test_IGTS_find_change_points(multivariate_mean_shift):
     """Test the IGTS core estimator."""
-    IGTS = get_IGTS()
     igts = IGTS(k_max=3, step=1)
     pred = igts.find_change_points(multivariate_mean_shift)
     assert isinstance(pred, list)
     assert len(pred) == 5
 
 
-@pytest.mark.skipif(
-    not _check_soft_dependencies("attrs", severity="none"),
-    reason="skip test if required soft dependencies not available",
-)
 def test_InformationGainSegmentation(multivariate_mean_shift):
     """Test the InformationGainSegmentation."""
     igts = InformationGainSegmentation(k_max=3, step=1)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Closes #5290.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

* Replaces `attrs` with `dataclasses` in the `igts` and `ggs` modules of the `annotation` module.

#### Does your contribution introduce a new dependency? If yes, which one?

No, but it removes `attrs` as a dependency for the `annotation` module.

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

I would like feedback on the `get_params` methods for the `InformationGainSegmentation` and `GreedyGaussianSegmentation` classes. Using `attrs`, one can easily filter attributes where `init` is `False`. That is not so easy with `dataclasses` so I filtered the unwanted attributes manually. We could have tags in the `GSS` and `IGTS` classes called something like `__attributes_to_ignore__` which would be a list of attributes to ignore in the `get_params` methods. But, since the pattern used for `GGS` and `IGTS` is likely going to change soon, I didn't think it necessary to use the tags approach.

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

No, but I changed the `test_ggs.py` and `test_igts.py` files to reflect the refactoring in `ggs.py` and `igts.py` respectively.

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

Can `attrs` be removed from the `all_extras` and `all_extras_pandas2` lists of dependencies in `pyproject.toml`?

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
