### PR TITLE
[MNT] update numba requirement from <0.58,>=0.53 to >=0.53,<0.59""

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,23 +55,23 @@ dependencies = [
 [project.optional-dependencies]
 alignment = [
     "dtw-python>=1.3,<1.4",
-    "numba>=0.53,<0.58",
+    "numba>=0.53,<0.59",
 ]
 annotation = [
     "attrs>=23,<23.2",
     "hmmlearn>=0.2.7,<0.4",
-    "numba>=0.53,<0.58",
+    "numba>=0.53,<0.59",
     "pyod>=0.8.0,<1.2",
 ]
 classification = [
     "esig>=0.9.7,<0.10",
     "mrsqm>=0.0.3,<0.1",
-    "numba>=0.53,<0.58",
+    "numba>=0.53,<0.59",
     "tensorflow>=2,<=2.14",
     "tsfresh>=0.17,<0.21",
 ]
 clustering = [
-    "numba>=0.53,<0.58",
+    "numba>=0.53,<0.59",
     "tslearn>=0.5.2,<0.6.3",
 ]
 forecasting = [
@@ -90,7 +90,7 @@ param_est = [
     "statsmodels>=0.12.1,<0.15",
 ]
 regression = [
-    "numba>=0.53,<0.58",
+    "numba>=0.53,<0.59",
     "tensorflow>=2,<=2.14",
 ]
 transformations = [
@@ -98,7 +98,7 @@ transformations = [
     "filterpy>=1.4.5,<1.5",
     "holidays>=0.29,<0.34",
     "mne>=1.5,<1.6",
-    "numba>=0.53,<0.58",
+    "numba>=0.53,<0.59",
     "pycatch22>=0.4,<0.5",
     "pykalman>=0.9.5,<0.10",
     "statsmodels>=0.12.1,<0.15",


### PR DESCRIPTION
Bumps the `numba` version bound to `<0.59`, allowing `0.58`.

This should be merged only if https://github.com/sktime/sktime/issues/5298 is resolved, or it will cause failures on `main`.

The tests are passing since no estimators are changed, instead the tests should be run on all estimator to ascertain compatibility.