### PR TITLE
[ENH] add proper `inverse_transform` to `STLTransformer`

### DIFF
--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -597,7 +597,7 @@ class STLTransformer(BaseTransformer):
                 }
             )
         else:
-            ret = transformed
+            ret = pd.DataFrame(transformed, columns=self._X.columns)
 
         return ret
 

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -580,7 +580,7 @@ class STLTransformer(BaseTransformer):
 
     def _make_return_object(self, X, stl):
         # deseasonalize only
-        transformed = pd.Series(X.values - stl.seasonal, index=X.index)
+        transformed = pd.Series(X.values.flatten() - stl.seasonal, index=X.index)
         # transformed = pd.Series(X.values - stl.seasonal - stl.trend, index=X.index)
 
         if self.return_components:


### PR DESCRIPTION
This PR fixes https://github.com/sktime/sktime/issues/5247 by implementing a proper `inverse_transform` for `STLTransformer`. This is simply "sum up the components again", and makes it possible to use it in `TransformedTargetForecaster`, i.e., a signal decomposition forecaster with different forecaster per component.

Some minor changes to the transformer:

* `X_inner_mtype` is changed to `pd.DataFrame` for more consistent handling of one or multiple components
* `y_inner_mtype` is changed to `"None"` as `y` is not used internally