### PR TITLE
[ENH] `joblib` and `dask` backends in broadcasting of estimators in multivariate or hierarchical case - part 2, base class config

### DIFF
--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -655,12 +655,12 @@ class VectorizedDF:
         ret = [self._vectorize_est_single(vec_tuple, meta) for vec_tuple in vec_zip]
         return ret
 
-    def _vectorize_est_joblib(self, vec_zip, backend):
+    def _vectorize_est_joblib(self, vec_zip, meta, backend):
         """Vectorize application of estimator method via joblib Parallel."""
         from joblib import Parallel, delayed
 
         ret = Parallel(n_jobs=-1, backend=backend)(
-            delayed(self._vectorize_est_single)(vec_tuple) for vec_tuple in vec_zip
+            delayed(self._vectorize_est_single)(vec_tpl, meta) for vec_tpl in vec_zip
         )
         return ret
 

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -666,7 +666,7 @@ class VectorizedDF:
 
     def _vectorize_est_dask(self, vec_zip, meta, backend):
         """Vectorize application of estimator method via dask."""
-        from dask import delayed, compute
+        from dask import compute, delayed
 
         lazy = [
             delayed(self._vectorize_est_single)(vec_tuple, meta=meta)

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -650,9 +650,9 @@ class VectorizedDF:
 
         return (group_name, col_name, est_i_result)
 
-    def _vectorize_est_none(self, vec_zip):
+    def _vectorize_est_none(self, vec_zip, meta):
         """Vectorize application of estimator method via simple loop."""
-        ret = [self._vectorize_est_single(vec_tuple) for vec_tuple in vec_zip]
+        ret = [self._vectorize_est_single(vec_tuple, meta) for vec_tuple in vec_zip]
         return ret
 
     def _vectorize_est_joblib(self, vec_zip, backend):

--- a/sktime/datatypes/_vectorize.py
+++ b/sktime/datatypes/_vectorize.py
@@ -444,6 +444,7 @@ class VectorizedDF:
         rowname_default="estimators",
         colname_default="estimators",
         varname_of_self=None,
+        backend=None,
         **kwargs,
     ):
         """Vectorize application of estimator method, return results DataFrame or list.
@@ -503,6 +504,11 @@ class VectorizedDF:
             used as index name of single column if no column vectorization is performed
         varname_of_self : str, optional, default=None
             if not None, self will be passed as kwarg under name "varname_of_self"
+        backend : {"dask", "loky", "multiprocessing", "threading"}, by default None.
+            Runs parallel evaluate if specified and `strategy` is set as "refit".
+            - "loky", "multiprocessing" and "threading": uses `joblib` Parallel loops
+            - "dask": uses `dask`, requires `dask` package in environment
+            - "dask_lazy": same as "dask", but returns delayed object instead
         kwargs : will be passed to invoked methods of estimator(s) in `estimator`
 
         Returns
@@ -513,6 +519,9 @@ class VectorizedDF:
           Entries are identity references to entries of `estimator`,
           after `method` executed with arguments as above.
         """
+        iterate_as = self.iterate_as
+        iterate_cols = self.iterate_cols
+
         if args is None:
             args = kwargs
         else:
@@ -567,28 +576,29 @@ class VectorizedDF:
         else:
             estimators = itertools.cycle([estimator])
 
-        ret = []
-
-        for (group_name, col_name, group), args_i, args_i_rowvec, est_i in zip(
+        vec_zip = zip(
             self.items(),
-            explode(args, iterate_as=self.iterate_as, iterate_cols=self.iterate_cols),
-            explode(args_rowvec, iterate_as=self.iterate_as, iterate_cols=False),
+            explode(args, iterate_as=iterate_as, iterate_cols=iterate_cols),
+            explode(args_rowvec, iterate_as=iterate_as, iterate_cols=False),
             estimators,
-        ):
-            args_i.update(args_i_rowvec)
+        )
 
-            if varname_of_self is not None:
-                args_i[varname_of_self] = group
+        meta = {
+            "method": method,
+            "varname_of_self": varname_of_self,
+            "rowname_default": rowname_default,
+            "colname_default": colname_default,
+        }
 
-            est_i_method = getattr(est_i, method)
-            est_i_result = est_i_method(**args_i)
+        if backend is None:
+            ret = self._vectorize_est_none(vec_zip, meta=meta)
+        elif backend in ["loky", "multiprocessing", "threading"]:
+            ret = self._vectorize_est_joblib(vec_zip, meta=meta, backend=backend)
+        elif backend in ["dask", "dask_lazy"]:
+            ret = self._vectorize_est_dask(vec_zip, meta=meta, backend=backend)
 
-            if group_name is None:
-                group_name = rowname_default
-            if col_name is None:
-                col_name = colname_default
-
-            ret.append((group_name, col_name, est_i_result))
+        if backend == "dask_lazy":
+            return ret
 
         if return_type == "pd.DataFrame":
             df_long = pd.DataFrame(ret)
@@ -616,6 +626,56 @@ class VectorizedDF:
             return df
         else:  # if return_type == "list"
             return [result for _, _, result in ret]
+
+    def _vectorize_est_single(self, vec_tuple, meta):
+        """Single loop iteration of _vectorize_est_[backend]."""
+        method = meta["method"]
+        varname_of_self = meta["varname_of_self"]
+        rowname_default = meta["rowname_default"]
+        colname_default = meta["colname_default"]
+
+        (group_name, col_name, group), args_i, args_i_rowvec, est_i = vec_tuple
+        args_i.update(args_i_rowvec)
+
+        if varname_of_self is not None:
+            args_i[varname_of_self] = group
+
+        est_i_method = getattr(est_i, method)
+        est_i_result = est_i_method(**args_i)
+
+        if group_name is None:
+            group_name = rowname_default
+        if col_name is None:
+            col_name = colname_default
+
+        return (group_name, col_name, est_i_result)
+
+    def _vectorize_est_none(self, vec_zip):
+        """Vectorize application of estimator method via simple loop."""
+        ret = [self._vectorize_est_single(vec_tuple) for vec_tuple in vec_zip]
+        return ret
+
+    def _vectorize_est_joblib(self, vec_zip, backend):
+        """Vectorize application of estimator method via joblib Parallel."""
+        from joblib import Parallel, delayed
+
+        ret = Parallel(n_jobs=-1, backend=backend)(
+            delayed(self._vectorize_est_single)(vec_tuple) for vec_tuple in vec_zip
+        )
+        return ret
+
+    def _vectorize_est_dask(self, vec_zip, meta, backend):
+        """Vectorize application of estimator method via dask."""
+        from dask import delayed, compute
+
+        lazy = [
+            delayed(self._vectorize_est_single)(vec_tuple, meta=meta)
+            for vec_tuple in vec_zip
+        ]
+        if backend == "dask":
+            return compute(*lazy)
+        else:
+            return lazy
 
 
 def _enforce_index_freq(item: pd.Series) -> pd.Series:

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -11,6 +11,7 @@ from sktime.datatypes._check import AMBIGUOUS_MTYPES, check_is_mtype
 from sktime.datatypes._examples import get_examples
 from sktime.datatypes._vectorize import VectorizedDF, _enforce_index_freq
 from sktime.utils._testing.deep_equals import deep_equals
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 SCITYPES = ["Panel", "Hierarchical"]
 
@@ -414,9 +415,10 @@ def test_enforce_index_freq(item, freq):
     assert item.index.freq == freq
 
 
+@pytest.mark.parametrize("backend", [None, "loky", "threading", "dask"])
 @pytest.mark.parametrize("varname_used", [True, False])
 def test_vectorize_est(
-    scitype, mtype, fixture_index, iterate_as, iterate_cols, varname_used
+    scitype, mtype, fixture_index, iterate_as, iterate_cols, varname_used, backend
 ):
     """Tests vectorize_est method of VectorizeDF, for method = clone, fit.
 
@@ -440,6 +442,10 @@ def test_vectorize_est(
     if not _is_valid_iterate_as(scitype, iterate_as):
         return None
 
+    # escape test for dask backend if dask is not installed
+    if backend == "dask" and not _check_soft_dependencies("dask", severity="none"):
+        return None
+
     # retrieve fixture for checking
     fixture = get_examples(mtype=mtype, as_scitype=scitype).get(fixture_index)
     X_vect = VectorizedDF(
@@ -454,7 +460,7 @@ def test_vectorize_est(
         kwargs["y"] = X_vect
 
     est_clones = X_vect.vectorize_est(NaiveForecaster(), method="clone")
-    result = X_vect.vectorize_est(est_clones, method="fit", **kwargs)
+    result = X_vect.vectorize_est(est_clones, method="fit", backend=backend, **kwargs)
 
     def _len(x):
         if x is None:

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -98,6 +98,15 @@ class BaseForecaster(BaseEstimator):
         "python_dependencies": None,  # str or list of str, package soft dependencies
     }
 
+    # configs and default config values
+    _config = {
+        "backend:parallel": None,  # parallelization backend for broadcasting
+        #  {None, "dask", "loky", "multiprocessing", "threading"}
+        #  None: no parallelization
+        #  "loky", "multiprocessing" and "threading": uses `joblib` Parallel loops
+        #  "dask": uses `dask`, requires `dask` package in environment
+    }
+
     def __init__(self):
         self._is_fitted = False
 
@@ -1736,12 +1745,16 @@ class BaseForecaster(BaseEstimator):
                     method="clone",
                     rowname_default="forecasters",
                     colname_default="forecasters",
+                    backend = self.get_config()["backend:parallel"],
                 )
             else:
                 forecasters_ = self.forecasters_
 
             self.forecasters_ = y.vectorize_est(
-                forecasters_, method=methodname, **kwargs
+                forecasters_,
+                method=methodname,
+                backend = self.get_config()["backend:parallel"],
+                **kwargs,
             )
             return self
 
@@ -1752,7 +1765,11 @@ class BaseForecaster(BaseEstimator):
                 self._yvec = y
 
             y_preds = self._yvec.vectorize_est(
-                self.forecasters_, method=methodname, return_type="list", **kwargs
+                self.forecasters_,
+                method=methodname,
+                return_type="list",
+                backend = self.get_config()["backend:parallel"],
+                **kwargs,
             )
 
             # if we vectorize over columns,

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1745,7 +1745,7 @@ class BaseForecaster(BaseEstimator):
                     method="clone",
                     rowname_default="forecasters",
                     colname_default="forecasters",
-                    backend = self.get_config()["backend:parallel"],
+                    backend=self.get_config()["backend:parallel"],
                 )
             else:
                 forecasters_ = self.forecasters_
@@ -1753,7 +1753,7 @@ class BaseForecaster(BaseEstimator):
             self.forecasters_ = y.vectorize_est(
                 forecasters_,
                 method=methodname,
-                backend = self.get_config()["backend:parallel"],
+                backend=self.get_config()["backend:parallel"],
                 **kwargs,
             )
             return self
@@ -1768,7 +1768,7 @@ class BaseForecaster(BaseEstimator):
                 self.forecasters_,
                 method=methodname,
                 return_type="list",
-                backend = self.get_config()["backend:parallel"],
+                backend=self.get_config()["backend:parallel"],
                 **kwargs,
             )
 

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -30,8 +30,9 @@ HIER_MTYPES = ["pd_multiindex_hier"]
     not _check_estimator_deps(ARIMA, severity="none"),
     reason="skip test if required soft dependency for ARIMA not available",
 )
+@pytest.mark.parametrize("backend", [None, "joblib", "loky", "threading"])
 @pytest.mark.parametrize("mtype", PANEL_MTYPES)
-def test_vectorization_series_to_panel(mtype):
+def test_vectorization_series_to_panel(mtype, backend):
     """Test that forecaster vectorization works for Panel data.
 
     This test passes Panel data to the ARIMA forecaster which internally has an
@@ -42,6 +43,7 @@ def test_vectorization_series_to_panel(mtype):
     y = _make_panel(n_instances=n_instances, random_state=42, return_mtype=mtype)
 
     f = ARIMA()
+    f.set_config(**{"backend:parallel": backend})
     y_pred = f.fit(y).predict([1, 2, 3])
     valid, _, metadata = check_is_mtype(y_pred, mtype, return_metadata=True)
 
@@ -79,8 +81,9 @@ def test_vectorization_series_to_panel(mtype):
     not _check_estimator_deps(ARIMA, severity="none"),
     reason="skip test if required soft dependency for ARIMA not available",
 )
+@pytest.mark.parametrize("backend", [None, "joblib", "loky", "threading"])
 @pytest.mark.parametrize("mtype", HIER_MTYPES)
-def test_vectorization_series_to_hier(mtype):
+def test_vectorization_series_to_hier(mtype, backend):
     """Test that forecaster vectorization works for Hierarchical data.
 
     This test passes Hierarchical data to the ARIMA forecaster which internally has an
@@ -93,6 +96,7 @@ def test_vectorization_series_to_hier(mtype):
     y = convert(y, from_type="pd_multiindex_hier", to_type=mtype)
 
     f = ARIMA()
+    f.set_config(**{"backend:parallel": backend})
     y_pred = f.fit(y).predict([1, 2, 3])
     valid, _, metadata = check_is_mtype(y_pred, mtype, return_metadata=True)
 

--- a/sktime/transformations/tests/test_base.py
+++ b/sktime/transformations/tests/test_base.py
@@ -183,7 +183,8 @@ def test_panel_in_panel_out_supported():
     # todo: possibly, add mtype check, use metadata return
 
 
-def test_panel_in_panel_out_not_supported_but_series():
+@pytest.mark.parametrize("backend", [None, "joblib", "loky", "threading"])
+def test_panel_in_panel_out_not_supported_but_series(backend):
     """Test that fit/transform runs and returns the correct output type.
 
     Setting: transformer has tags
@@ -198,6 +199,7 @@ def test_panel_in_panel_out_not_supported_but_series():
     # one example for a transformer which supports Series internally but not Panel
     cls = BoxCoxTransformer
     est = cls.create_test_instance()
+    est.set_config(**{"backend:parallel": backend})
     # ensure cls is a good example, if this fails, choose another example
     #   (if this changes, it may be due to implementing more scitypes)
     #   (then this is not a failure of cls, but we need to choose another example)
@@ -251,7 +253,8 @@ def test_series_in_primitives_out_supported_fit_in_transform():
     assert len(Xt) == 1
 
 
-def test_panel_in_primitives_out_not_supported_fit_in_transform():
+@pytest.mark.parametrize("backend", [None, "joblib", "loky", "threading"])
+def test_panel_in_primitives_out_not_supported_fit_in_transform(backend):
     """Test that fit/transform runs and returns the correct output type.
 
     Setting: transformer has tags
@@ -266,6 +269,7 @@ def test_panel_in_primitives_out_not_supported_fit_in_transform():
     # one example for a transformer which supports Series internally but not Panel
     cls = SummaryTransformer
     est = cls.create_test_instance()
+    est.set_config(**{"backend:parallel": backend})
     # ensure cls is a good example, if this fails, choose another example
     #   (if this changes, it may be due to implementing more scitypes)
     #   (then this is not a failure of cls, but we need to choose another example)
@@ -366,7 +370,8 @@ def test_panel_in_primitives_out_supported_with_y_in_fit_but_not_transform():
     assert len(Xt) == 7
 
 
-def test_hierarchical_in_hierarchical_out_not_supported_but_series():
+@pytest.mark.parametrize("backend", [None, "joblib", "loky", "threading"])
+def test_hierarchical_in_hierarchical_out_not_supported_but_series(backend):
     """Test that fit/transform runs and returns the correct output type.
 
     Setting: transformer has tags
@@ -381,6 +386,7 @@ def test_hierarchical_in_hierarchical_out_not_supported_but_series():
     # one example for a transformer which supports Series internally
     cls = BoxCoxTransformer
     est = cls.create_test_instance()
+    est.set_config(**{"backend:parallel": backend})
     # ensure cls is a good example, if this fails, choose another example
     #   (if this changes, it may be due to implementing more scitypes)
     #   (then this is not a failure of cls, but we need to choose another example)
@@ -438,7 +444,8 @@ def test_hierarchical_in_hierarchical_out_not_supported_but_series_fit_in_transf
     assert len(Xt) == 2 * 4 * 12
 
 
-def test_vectorization_multivariate_no_row_vectorization():
+@pytest.mark.parametrize("backend", [None, "joblib", "loky", "threading"])
+def test_vectorization_multivariate_no_row_vectorization(backend):
     """Test that multivariate vectorization of univariate transformers works.
 
     This test should trigger column (variable) vectorization, but not row vectorization.
@@ -456,6 +463,7 @@ def test_vectorization_multivariate_no_row_vectorization():
     # one example for a transformer which supports Series internally
     cls = BoxCoxTransformer
     est = cls.create_test_instance()
+    est.set_config(**{"backend:parallel": backend})
     # ensure cls is a good example, if this fails, choose another example
     #   (if this changes, it may be due to implementing multivariate functionality)
     #   (then this is not a failure of cls, but we need to choose another example)
@@ -477,7 +485,8 @@ def test_vectorization_multivariate_no_row_vectorization():
     assert len(Xt.columns) == len(scenario.args["fit"]["X"].columns)
 
 
-def test_vectorization_multivariate_and_hierarchical():
+@pytest.mark.parametrize("backend", [None, "joblib", "loky", "threading"])
+def test_vectorization_multivariate_and_hierarchical(backend):
     """Test that fit/transform runs and returns the correct output type.
 
     This test should trigger both column (variable) and row (hierarchy) vectorization.
@@ -495,6 +504,7 @@ def test_vectorization_multivariate_and_hierarchical():
     # one example for a transformer which supports Series internally
     cls = BoxCoxTransformer
     est = cls.create_test_instance()
+    est.set_config(**{"backend:parallel": backend})
     # ensure cls is a good example, if this fails, choose another example
     #   (if this changes, it may be due to implementing more scitypes)
     #   (then this is not a failure of cls, but we need to choose another example)
@@ -518,7 +528,8 @@ def test_vectorization_multivariate_and_hierarchical():
     assert len(Xt.columns) == len(scenario.args["fit"]["X"].columns)
 
 
-def test_vectorization_multivariate_no_row_vectorization_empty_fit():
+@pytest.mark.parametrize("backend", [None, "joblib", "loky", "threading"])
+def test_vectorization_multivariate_no_row_vectorization_empty_fit(backend):
     """Test that multivariate vectorization of univariate transformers works.
 
     This test should trigger column (variable) vectorization, but not row vectorization.
@@ -536,6 +547,7 @@ def test_vectorization_multivariate_no_row_vectorization_empty_fit():
     # one example for a transformer which supports Series internally
     cls = BoxCoxTransformer
     est = FitInTransform(cls.create_test_instance())
+    est.set_config(**{"backend:parallel": backend})
     # ensure cls is a good example, if this fails, choose another example
     #   (if this changes, it may be due to implementing multivariate functionality)
     #   (then this is not a failure of cls, but we need to choose another example)
@@ -557,7 +569,8 @@ def test_vectorization_multivariate_no_row_vectorization_empty_fit():
     assert len(Xt.columns) == len(scenario.args["fit"]["X"].columns)
 
 
-def test_vectorization_multivariate_and_hierarchical_empty_fit():
+@pytest.mark.parametrize("backend", [None, "joblib", "loky", "threading"])
+def test_vectorization_multivariate_and_hierarchical_empty_fit(backend):
     """Test that fit/transform runs and returns the correct output type.
 
     This test should trigger both column (variable) and row (hierarchy) vectorization.
@@ -575,6 +588,7 @@ def test_vectorization_multivariate_and_hierarchical_empty_fit():
     # one example for a transformer which supports Series internally
     cls = BoxCoxTransformer
     est = FitInTransform(cls.create_test_instance())
+    est.set_config(**{"backend:parallel": backend})
     # ensure cls is a good example, if this fails, choose another example
     #   (if this changes, it may be due to implementing more scitypes)
     #   (then this is not a failure of cls, but we need to choose another example)


### PR DESCRIPTION
Part 2 of a sequence of PR to enable parallelization backends for any estimator that is hierarchical or multivariate via broadcast.

This PR adds the option to choose a `joblib` or `dask` based parallelization backend in forecaster and transformer base classes, which is used in case of hierarchical instance broadcasting or variable broadcasting.

This PR also adds tests for the backends in forecasters and transformers.

Depends on https://github.com/sktime/sktime/pull/5267 which introduces abstract parallelization in the brodcasting framework.