### PR TITLE
[MNT] bound `numba<0.58`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ all_extras = [
     "kotsu>=0.3.1",
     "matplotlib>=3.3.2",
     "mne",
-    "numba>=0.53",
+    "numba>=0.53,<0.58",
     "pmdarima>=1.8.0,!=1.8.1,<3.0.0",
     "prophet>=1.1",
     "pycatch22",
@@ -157,7 +157,7 @@ all_extras_pandas2 = [
     "kotsu>=0.3.1",
     "matplotlib>=3.3.2",
     "mne",
-    "numba>=0.53",
+    "numba>=0.53,<0.58",
     "pmdarima>=1.8.0,!=1.8.1,<3.0.0",
     "prophet>=1.1",
     "pycatch22",
@@ -179,7 +179,7 @@ all_extras_pandas2 = [
 cython_extras = [
     "mrseql",
     "mrsqm; python_version < '3.11'",
-    "numba",
+    "numba<0.58",
 ]
 
 dev = [


### PR DESCRIPTION
Adds a bound `numba<0.58` - currently `numba 0.58` causes failures.