### PR TITLE
[ENH] Change GGS to inherit from BaseSeriesAnnotator

### DIFF
--- a/sktime/annotation/ggs.py
+++ b/sktime/annotation/ggs.py
@@ -410,10 +410,6 @@ class GreedyGaussianSegmentation(BaseSeriesAnnotator):
     change_points_: array_like, default=[]
         Locations of change points as integer indexes. By convention change points
         include the identity segmentation, i.e. first and last index + 1 values.
-    _intermediate_change_points: List[List[int]], default=[]
-        Intermediate values of change points for each value of k = 1...k_max
-    _intermediate_ll: List[float], default=[]
-        Intermediate values for log-likelihood for each value of k = 1...k_max
 
     Notes
     -----
@@ -457,6 +453,22 @@ class GreedyGaussianSegmentation(BaseSeriesAnnotator):
             verbose=verbose,
             random_state=random_state,
         )
+
+    @property
+    def _intermediate_change_points(self) -> List[List[int]]:
+        """Intermediate values of change points for each value of k = 1...k_max.
+
+        Default value is an empty list.
+        """
+        return self._adaptee._intermediate_change_points
+
+    @property
+    def _intermediate_ll(self) -> List[float]:
+        """Intermediate values for log-likelihood for each value of k = 1...k_max.
+
+        Default value is an empty list.
+        """
+        return self._adaptee._intermediate_ll
 
     def _fit(self, X, Y=None):
         """Fit method for compatibility with sklearn-type estimator interface.

--- a/sktime/annotation/ggs.py
+++ b/sktime/annotation/ggs.py
@@ -34,8 +34,8 @@ References
 
 import logging
 import math
-from dataclasses import asdict, dataclass, field
-from typing import Dict, List, Tuple
+from dataclasses import dataclass, field
+from typing import List, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -528,47 +528,6 @@ class GreedyGaussianSegmentation(BaseSeriesAnnotator):
             labels for each of the data points.
         """
         return self.fit(X, None).predict(X)
-
-    def get_params(self, deep: bool = True) -> Dict:
-        """Return initialization parameters.
-
-        Parameters
-        ----------
-        deep: bool
-            Dummy argument for compatibility with sklearn-api, not used.
-
-        Returns
-        -------
-        params: dict
-            Dictionary with the estimator's initialization parameters, with
-            keys being argument names and values being argument values.
-        """
-        attrs_to_ignore = [
-            "change_points_",
-            "_intermediate_change_points",
-            "_intermediate_ll",
-        ]
-        params = asdict(self._adaptee)
-        params = {
-            key: value for key, value in params.items() if key not in attrs_to_ignore
-        }
-        return params
-
-    def set_params(self, **parameters):
-        """Set the parameters of this object.
-
-        Parameters
-        ----------
-        parameters : dict
-            Initialization parameters for th estimator.
-
-        Returns
-        -------
-        self : reference to self (after parameters have been set)
-        """
-        for key, value in parameters.items():
-            setattr(self._adaptee, key, value)
-        return self
 
     def __repr__(self) -> str:
         """Return a string representation of the estimator."""

--- a/sktime/annotation/ggs.py
+++ b/sktime/annotation/ggs.py
@@ -540,10 +540,6 @@ class GreedyGaussianSegmentation(BaseSeriesAnnotator):
         """
         return self.fit(X, None).predict(X)
 
-    def __repr__(self) -> str:
-        """Return a string representation of the estimator."""
-        return self._adaptee.__repr__()
-
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.

--- a/sktime/annotation/ggs.py
+++ b/sktime/annotation/ggs.py
@@ -42,7 +42,6 @@ import numpy.typing as npt
 import pandas as pd
 from sklearn.utils.validation import check_random_state
 
-# from sktime.base import BaseEstimator
 from sktime.annotation.base._base import BaseSeriesAnnotator
 from sktime.utils.validation._dependencies import _check_estimator_deps
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#5296 must be merged before this PR can.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Updates `GreedyGaussianSegmentation` to inherit from `BaseSerieAnnotator` following the `HMM` class as a guide.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Currently type check and conversion is done in the `_predict` method. It would be good to refactor this out into the `BaseSeriesAnnotator` class but I think that is a job for another PR.
* This PR makes no attempt to convert the `GGS` class to inherit from `BaseSeriesAnnotator` class. It would be good for this to be done but again I think this is a job for another PR.

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
No but I had to add the type conversions in the `_predict` method to get the `annotation` tests to pass locally.

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

This changes means that, similarly to the `HMM` class, the `fit` method has to be called before the `predict` method even though `fit` does not contain any essential logic. Perhaps these classes should only have a `fit_predict` method and neither a `fit` or `predict` method. Here is the example from the `HMM` docstring demontstrating this.

```python
>>> from sktime.annotation.hmm import HMM
>>> from scipy.stats import norm
>>> from numpy import asarray
>>> # define the emission probs for our HMM model:
>>> centers = [3.5,-5]
>>> sd = [.25 for i in centers]
>>> emi_funcs = [(norm.pdf, {'loc': mean,
...  'scale': sd[ind]}) for ind, mean in enumerate(centers)]
>>> hmm_est = HMM(emi_funcs, asarray([[0.25,0.75], [0.666, 0.333]]))
>>> # generate synthetic data (or of course use your own!)
>>> obs = asarray([3.7,3.2,3.4,3.6,-5.1,-5.2,-4.9])
>>> hmm_est = hmm_est.fit(obs)
>>> labels = hmm_est.predict(obs)
```

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
