### PR TITLE
[ENH] in `ExpandingGreedySplitter`, allow `float` `step_size`

### DIFF
--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -75,6 +75,8 @@ class ExpandingGreedySplitter(BaseSplitter):
 
         if isinstance(test_size, float):
             _test_size = round(len(y) * test_size)
+        else:
+            _test_size = test_size
 
         if isinstance(y, pd.MultiIndex):
             groups = pd.Series(index=y).groupby(y.names[:-1])

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -7,6 +7,7 @@ __author__ = ["davidgilbertson"]
 __all__ = [
     "ExpandingGreedySplitter",
 ]
+__author__ = ["davidgilbertson"]
 
 import numpy as np
 import pandas as pd
@@ -18,21 +19,25 @@ from sktime.split.base._common import SPLIT_GENERATOR_TYPE
 class ExpandingGreedySplitter(BaseSplitter):
     """Splitter that successively cuts test folds off the end of the series.
 
-    Takes an integer `test_size` that defines the number of steps included in the
+    Takes an integer ``test_size`` that defines the number of steps included in the
     test set of each fold. The train set of each fold will contain all data before
-    the test set. If the data contains multiple instances, `test_size` is
+    the test set. If the data contains multiple instances, ``test_size`` is
     _per instance_.
 
-    If no `step_length` is defined, the test sets (one for each fold) will be
-    adjacent, taken from the end of the dataset.
+    If no ``step_length`` is defined, the test sets (one for each fold) will be
+    adjacent and disjoint, taken from the end of the dataset.
 
-    For example, with `test_size=7` and `folds=5`, the test sets in total will cover
+    For example, with ``test_size=7`` and ``folds=5``, the test sets in total will cover
     the last 35 steps of the data with no overlap.
 
     Parameters
     ----------
-    test_size : int
-        The number of steps included in the test set of each fold.
+    test_size : int or float
+        If int: the number of steps included in the test set of each fold.
+            Formally, steps are consecutive ``iloc`` indices.
+        If float: the proportion of steps included in the test set of each fold,
+            as a proportion of the total number of index values.
+            Cave: not the ``loc`` proportion between start and end.
     folds : int, default = 5
         The number of folds.
     step_length : int, optional
@@ -41,7 +46,7 @@ class ExpandingGreedySplitter(BaseSplitter):
     Examples
     --------
     >>> import numpy as np
-    >>> from sktime.split import ExpandingGreedySplitter
+    >>> from sktime.forecasting.model_selection import ExpandingGreedySplitter
 
     >>> ts = np.arange(10)
     >>> splitter = ExpandingGreedySplitter(test_size=3, folds=2)
@@ -61,18 +66,28 @@ class ExpandingGreedySplitter(BaseSplitter):
         self.step_length = step_length
         self.fh = np.arange(test_size) + 1
 
+        # no algorithm implemented that is faster for float than naive iteration
+        if isinstance(test_size, float):
+            self.set_tags(**{"split_hierarchical", False})
+
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+
+        test_size = self.test_size
+
+        if isinstance(test_size, float):
+            _test_size = round(len(y) * test_size)
+
         if isinstance(y, pd.MultiIndex):
             groups = pd.Series(index=y).groupby(y.names[:-1])
             reverse_idx = groups.transform("size") - groups.cumcount() - 1
         else:
             reverse_idx = np.arange(len(y))[::-1]
 
-        step_length = self.step_length or self.test_size
+        step_length = self.step_length or _test_size
 
         for i in reversed(range(self.folds)):
             tst_end = i * step_length
-            trn_end = tst_end + self.test_size
+            trn_end = tst_end + _test_size
             trn_indices = np.flatnonzero(reverse_idx >= trn_end)
             tst_indices = np.flatnonzero(
                 (reverse_idx < trn_end) & (reverse_idx >= tst_end)
@@ -99,4 +114,5 @@ class ExpandingGreedySplitter(BaseSplitter):
         """
         params1 = {"test_size": 1}
         params2 = {"test_size": 3, "folds": 2, "step_length": 2}
-        return [params1, params2]
+        params3 = {"test_size": 0.2, "folds": 2}
+        return [params1, params2, params3]

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -71,7 +71,6 @@ class ExpandingGreedySplitter(BaseSplitter):
             self.set_tags(**{"split_hierarchical", False})
 
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
-
         test_size = self.test_size
 
         if isinstance(test_size, float):

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -68,7 +68,7 @@ class ExpandingGreedySplitter(BaseSplitter):
 
         # no algorithm implemented that is faster for float than naive iteration
         if isinstance(test_size, float):
-            self.set_tags(**{"split_hierarchical", False})
+            self.set_tags(**{"split_hierarchical": False})
 
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
         test_size = self.test_size

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -36,8 +36,11 @@ class ExpandingGreedySplitter(BaseSplitter):
         If int: the number of steps included in the test set of each fold.
             Formally, steps are consecutive ``iloc`` indices.
         If float: the proportion of steps included in the test set of each fold,
-            as a proportion of the total number of index values.
-            Cave: not the ``loc`` proportion between start and end.
+            as a proportion of the total number of consecutive ``iloc`` indices.
+            Must be between 0.0 and 1.0. Proportions are rounded to the
+            next higher integer count of samples (ceil).
+            Cave: not the ``loc`` proportion between start and end locations,
+            but a proportion of total number of consecutive ``iloc`` indices.
     folds : int, default = 5
         The number of folds.
     step_length : int, optional
@@ -46,7 +49,7 @@ class ExpandingGreedySplitter(BaseSplitter):
     Examples
     --------
     >>> import numpy as np
-    >>> from sktime.forecasting.model_selection import ExpandingGreedySplitter
+    >>> from sktime.split import ExpandingGreedySplitter
 
     >>> ts = np.arange(10)
     >>> splitter = ExpandingGreedySplitter(test_size=3, folds=2)
@@ -74,7 +77,7 @@ class ExpandingGreedySplitter(BaseSplitter):
         test_size = self.test_size
 
         if isinstance(test_size, float):
-            _test_size = round(len(y) * test_size)
+            _test_size = np.ceil(len(y) * test_size)
         else:
             _test_size = test_size
 


### PR DESCRIPTION
This PR adds logic to allow `float` `step_size` in `ExpandingGreedySplitter`.

Also makes minor changes:

* docstring formatting
* adds missing author credit for @davidgilbertson 

Questions for reviewers:

* I originally added this to help https://github.com/sktime/sktime/issues/5107, by later making `temporal_train_test_split` default to `ExpandingGreedySplitter` instances. Thi is no longer needed for #5107 though

* is there a more elegant algorithm for the fraction case along the lines of @davidgilbertson's neat algorithm for the integer case, perhaps @davidgilbertson can see this? Also, would you be fine with adding the `float` option?

Also FYI @BensHamza (splitters) and @hazrulakmal (for benchmarking and `temporal_train_test_split` connection).