### PR TITLE
[ENH] add tests for `temporal_train_test_split`

### DIFF
--- a/sktime/split/tests/test_temporaltraintest.py
+++ b/sktime/split/tests/test_temporaltraintest.py
@@ -78,7 +78,7 @@ def test_temporal_train_test_split_float_only_y():
     assert len(y_train) == 43
     assert len(y_test) == 29
     assert (y[:43] == y_train).all()
-    assert (y[43:(43 + 29)] == y_test).all()
+    assert (y[43 : (43 + 29)] == y_test).all()
 
 
 def test_temporal_train_test_split_int_only_y():
@@ -110,4 +110,4 @@ def test_temporal_train_test_split_int_only_y():
     assert len(y_train) == 43
     assert len(y_test) == 29
     assert (y[:43] == y_train).all()
-    assert (y[43:(43 + 29)] == y_test).all()
+    assert (y[43 : (43 + 29)] == y_test).all()

--- a/sktime/split/tests/test_temporaltraintest.py
+++ b/sktime/split/tests/test_temporaltraintest.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from sktime.datasets import load_airline
 from sktime.datatypes._utilities import get_cutoff
 from sktime.forecasting.tests._config import TEST_OOS_FHS, VALID_INDEX_FH_COMBINATIONS
 from sktime.split import temporal_train_test_split
@@ -46,3 +47,35 @@ def test_split_by_fh(index_type, fh_type, is_relative, values):
     fh = _make_fh(cutoff, values, fh_type, is_relative)
     split = temporal_train_test_split(y, fh=fh)
     _check_train_test_split_y(fh, split)
+
+
+def test_temporal_train_test_split_float_only_y:
+    """Test temporal_train_test_split expected output on float size inputs."""
+    y = load_airline()
+
+    # only test_size
+    y_train, y_test = temporal_train_test_split(y, test_size=0.2)
+    assert isinstance(y_train, pd.Series)
+    assert isinstance(y_test, pd.Series)
+    assert len(y_train) == 115
+    assert len(y_test) == 29
+    assert (y[:115] == y_train).all()
+    assert (y[-29:] == y_test).all()
+
+    # only train_size
+    y_train, y_test = temporal_train_test_split(y, train_size=0.8)
+    assert isinstance(y_train, pd.Series)
+    assert isinstance(y_test, pd.Series)
+    assert len(y_train) == 115
+    assert len(y_test) == 29
+    assert (y[:115] == y_train).all()
+    assert (y[-29:] == y_test).all()
+
+    # both train and test size
+    y_train, y_test = temporal_train_test_split(y, train_size=0.3, test_size=0.2)
+    assert isinstance(y_train, pd.Series)
+    assert isinstance(y_test, pd.Series)
+    assert len(y_train) == 43
+    assert len(y_test) == 29
+    assert (y[:43] == y_train).all()
+    assert (y[43:(43 + 29)] == y_test).all()

--- a/sktime/split/tests/test_temporaltraintest.py
+++ b/sktime/split/tests/test_temporaltraintest.py
@@ -49,7 +49,7 @@ def test_split_by_fh(index_type, fh_type, is_relative, values):
     _check_train_test_split_y(fh, split)
 
 
-def test_temporal_train_test_split_float_only_y:
+def test_temporal_train_test_split_float_only_y():
     """Test temporal_train_test_split expected output on float size inputs."""
     y = load_airline()
 
@@ -73,6 +73,38 @@ def test_temporal_train_test_split_float_only_y:
 
     # both train and test size
     y_train, y_test = temporal_train_test_split(y, train_size=0.3, test_size=0.2)
+    assert isinstance(y_train, pd.Series)
+    assert isinstance(y_test, pd.Series)
+    assert len(y_train) == 43
+    assert len(y_test) == 29
+    assert (y[:43] == y_train).all()
+    assert (y[43:(43 + 29)] == y_test).all()
+
+
+def test_temporal_train_test_split_int_only_y():
+    """Test temporal_train_test_split expected output on float size inputs."""
+    y = load_airline()
+
+    # only test_size
+    y_train, y_test = temporal_train_test_split(y, test_size=29)
+    assert isinstance(y_train, pd.Series)
+    assert isinstance(y_test, pd.Series)
+    assert len(y_train) == 115
+    assert len(y_test) == 29
+    assert (y[:115] == y_train).all()
+    assert (y[-29:] == y_test).all()
+
+    # only train_size
+    y_train, y_test = temporal_train_test_split(y, train_size=115)
+    assert isinstance(y_train, pd.Series)
+    assert isinstance(y_test, pd.Series)
+    assert len(y_train) == 115
+    assert len(y_test) == 29
+    assert (y[:115] == y_train).all()
+    assert (y[-29:] == y_test).all()
+
+    # both train and test size
+    y_train, y_test = temporal_train_test_split(y, train_size=43, test_size=29)
     assert isinstance(y_train, pd.Series)
     assert isinstance(y_test, pd.Series)
     assert len(y_train) == 43


### PR DESCRIPTION
This PR adds tests for `temporal_train_test_split` expected outputs.

Curiously, it does not seem the function was previously covered by tests in the case `fh=None`.