### PR TITLE
[ENH] `ExpandingGreedySplitter` reverse folds option

### DIFF
--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -73,6 +73,8 @@ class ExpandingGreedySplitter(BaseSplitter):
 
         if isinstance(test_size, float):
             _test_size = round(len(y) * test_size)
+        else:
+            _test_size = test_size
 
         if isinstance(y, pd.MultiIndex):
             groups = pd.Series(index=y).groupby(y.names[:-1])

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -40,6 +40,9 @@ class ExpandingGreedySplitter(BaseSplitter):
         The number of folds.
     step_length : int, optional
         The number of steps advanced for each fold. Defaults to `test_size`.
+    reverse : bool, default = False
+        Whether to reverse order of indices. If True, the test sets will be taken
+        from the start of the data, rather than the end.
 
     Examples
     --------
@@ -57,19 +60,28 @@ class ExpandingGreedySplitter(BaseSplitter):
 
     _tags = {"split_hierarchical": True}
 
-    def __init__(self, test_size: int, folds: int = 5, step_length: int = None):
+    def __init__(
+        self,
+        test_size: int,
+        folds: int = 5,
+        step_length: int = None,
+        reverse: bool = False,
+    ):
         super().__init__()
         self.test_size = test_size
         self.folds = folds
         self.step_length = step_length
+        self.reverse = reverse
         self.fh = np.arange(test_size) + 1
 
         # no algorithm implemented that is faster for float than naive iteration
-        if isinstance(test_size, float):
+        # if we reverse, we also use a naive algorithm
+        if isinstance(test_size, float) or reverse:
             self.set_tags(**{"split_hierarchical": False})
 
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
         test_size = self.test_size
+        reverse = self.reverse
 
         if isinstance(test_size, float):
             _test_size = round(len(y) * test_size)
@@ -91,7 +103,11 @@ class ExpandingGreedySplitter(BaseSplitter):
             tst_indices = np.flatnonzero(
                 (reverse_idx < trn_end) & (reverse_idx >= tst_end)
             )
-            yield trn_indices, tst_indices
+            if not reverse:
+                yield trn_indices, tst_indices
+            else:
+                rev_ix = np.arange(len(y))[::-1]
+                yield np.sort(rev_ix[trn_indices]), np.sort(rev_ix[tst_indices])
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -114,4 +130,5 @@ class ExpandingGreedySplitter(BaseSplitter):
         params1 = {"test_size": 1}
         params2 = {"test_size": 3, "folds": 2, "step_length": 2}
         params3 = {"test_size": 0.2, "folds": 2}
-        return [params1, params2, params3]
+        params4 = {"test_size": 0.2, "folds": 2, "reverse": True}
+        return [params1, params2, params3, params4]

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -5,6 +5,7 @@
 __all__ = [
     "ExpandingGreedySplitter",
 ]
+__author__ = ["davidgilbertson"]
 
 import numpy as np
 import pandas as pd
@@ -16,21 +17,25 @@ from sktime.split.base._config import SPLIT_GENERATOR_TYPE
 class ExpandingGreedySplitter(BaseSplitter):
     """Splitter that uses all available data.
 
-    Takes an integer `test_size` that defines the number of steps included in the
+    Takes an integer ``test_size`` that defines the number of steps included in the
     test set of each fold. The train set of each fold will contain all data before
-    the test set. If the data contains multiple instances, `test_size` is
+    the test set. If the data contains multiple instances, ``test_size`` is
     _per instance_.
 
-    If no `step_length` is defined, the test sets (one for each fold) will be
-    adjacent, taken from the end of the dataset.
+    If no ``step_length`` is defined, the test sets (one for each fold) will be
+    adjacent and disjoint, taken from the end of the dataset.
 
-    For example, with `test_size=7` and `folds=5`, the test sets in total will cover
+    For example, with ``test_size=7`` and ``folds=5``, the test sets in total will cover
     the last 35 steps of the data with no overlap.
 
     Parameters
     ----------
-    test_size : int
-        The number of steps included in the test set of each fold.
+    test_size : int or float
+        If int: the number of steps included in the test set of each fold.
+            Formally, steps are consecutive ``iloc`` indices.
+        If float: the proportion of steps included in the test set of each fold,
+            as a proportion of the total number of index values.
+            Cave: not the ``loc`` proportion between start and end.
     folds : int, default = 5
         The number of folds.
     step_length : int, optional
@@ -39,7 +44,7 @@ class ExpandingGreedySplitter(BaseSplitter):
     Examples
     --------
     >>> import numpy as np
-    >>> from sktime.split import ExpandingGreedySplitter
+    >>> from sktime.forecasting.model_selection import ExpandingGreedySplitter
 
     >>> ts = np.arange(10)
     >>> splitter = ExpandingGreedySplitter(test_size=3, folds=2)
@@ -59,18 +64,28 @@ class ExpandingGreedySplitter(BaseSplitter):
         self.step_length = step_length
         self.fh = np.arange(test_size) + 1
 
+        # no algorithm implemented that is faster for float than naive iteration
+        if isinstance(test_size, float):
+            self.set_tags(**{"split_hierarchical", False})
+
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+
+        test_size = self.test_size
+
+        if isinstance(test_size, float):
+            _test_size = round(len(y) * test_size)
+
         if isinstance(y, pd.MultiIndex):
             groups = pd.Series(index=y).groupby(y.names[:-1])
             reverse_idx = groups.transform("size") - groups.cumcount() - 1
         else:
             reverse_idx = np.arange(len(y))[::-1]
 
-        step_length = self.step_length or self.test_size
+        step_length = self.step_length or _test_size
 
         for i in reversed(range(self.folds)):
             tst_end = i * step_length
-            trn_end = tst_end + self.test_size
+            trn_end = tst_end + _test_size
             trn_indices = np.flatnonzero(reverse_idx >= trn_end)
             tst_indices = np.flatnonzero(
                 (reverse_idx < trn_end) & (reverse_idx >= tst_end)
@@ -97,4 +112,5 @@ class ExpandingGreedySplitter(BaseSplitter):
         """
         params1 = {"test_size": 1}
         params2 = {"test_size": 3, "folds": 2, "step_length": 2}
-        return [params1, params2]
+        params3 = {"test_size": 0.2, "folds": 2}
+        return [params1, params2, params3]

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -69,7 +69,6 @@ class ExpandingGreedySplitter(BaseSplitter):
             self.set_tags(**{"split_hierarchical", False})
 
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
-
         test_size = self.test_size
 
         if isinstance(test_size, float):

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -66,7 +66,7 @@ class ExpandingGreedySplitter(BaseSplitter):
 
         # no algorithm implemented that is faster for float than naive iteration
         if isinstance(test_size, float):
-            self.set_tags(**{"split_hierarchical", False})
+            self.set_tags(**{"split_hierarchical": False})
 
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
         test_size = self.test_size


### PR DESCRIPTION
This adds a reverse fold option to `ExpandingGreedySplitter`. Originally part of https://github.com/sktime/sktime/pull/5330, I think we don't actually want it - but parking it here for now.