### PR TITLE
[ENH] Link `test_interval_wrappers.py` to changes in `evaluate` for conditional testing

### DIFF
--- a/sktime/forecasting/tests/test_interval_wrappers.py
+++ b/sktime/forecasting/tests/test_interval_wrappers.py
@@ -65,7 +65,7 @@ def test_wrapper_series_mtype(wrapper, override_y_mtype, mtype):
 
 
 @pytest.mark.skipif(
-    not run_test_for_class(INTERVAL_WRAPPERS),
+    not run_test_for_class(INTERVAL_WRAPPERS + [evaluate]),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 @pytest.mark.parametrize("wrapper", INTERVAL_WRAPPERS)


### PR DESCRIPTION
This PR manually links one test in `test_interval_wrappers` reliant on `evaluate` to changes in `evaluate`, i.e., that the respective test is run when code in `evaluate` changes.

This is to prevent a future occurrence of https://github.com/sktime/sktime/issues/5336, i.e., improvements to `evaluate`.

Optimally, the tests in `test_evaluate` would cover the case here, ut that does ot seem e the status quo.