### PR TITLE
[ENH] sensible default `_get_distance_matrix` for time series aligners

### DIFF
--- a/sktime/alignment/base.py
+++ b/sktime/alignment/base.py
@@ -336,6 +336,11 @@ class BaseAligner(BaseEstimator):
         distmat: an (n x n) np.array of floats, where n is length of X passed to fit
             [i,j]-th entry is alignment distance between X[i] and X[j] passed to fit
         """
+        # the default implementation assumes
+        # that the aligner can only align two sequences
+        if self.get_tag("capability:multiple-alignment", False):
+            raise NotImplementedError
+
         import numpy as np
 
         dist = self.get_distance()

--- a/sktime/alignment/base.py
+++ b/sktime/alignment/base.py
@@ -336,4 +336,12 @@ class BaseAligner(BaseEstimator):
         distmat: an (n x n) np.array of floats, where n is length of X passed to fit
             [i,j]-th entry is alignment distance between X[i] and X[j] passed to fit
         """
-        raise NotImplementedError
+        import numpy as np
+
+        dist = self.get_distance()
+
+        distmat = np.zeros((2, 2), dtype="float")
+        distmat[0, 1] = dist
+        distmat[1, 0] = dist
+
+        return distmat


### PR DESCRIPTION
This adds a sensible default `_get_distance_matrix` for time series aligners as a default in `BaseAligner` - a 2x2 matrix with the distance off-diagonals. Users should override this when a multiple alignment is computed.