### PR TITLE
[ENH] Add Merger Transformation

### DIFF
--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -657,6 +657,19 @@ Bootstrap transformations
     SplitterBootstrapTransformer
     STLBootstrapTransformer
 
+Panel-to-Series transformers
+----------------------------
+
+These transformers create a single series from a panel.
+
+.. currentmodule:: sktime.transformations.merger
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    Merger
+
 Outlier detection, changepoint detection
 ----------------------------------------
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1221,9 +1221,9 @@ class BaseTransformer(BaseEstimator):
             elif self.get_tags()["scitype:transform-input"] == "Panel":
                 # Input has always to be Panel
                 X_output_mtype = "pd.DataFrame"
-            elif X_input_scitype == "Panel":
-                # Input can be Panel, since it is supported by the used mtype
-                output_scitype = "Panel"
+            else:
+                # Input can be Panel or Hierachical, since it is supported by the used mtype
+                output_scitype = X_input_scitype
                 # Xt_mtype = metadata["mtype"]
             # else:
             #     Xt_mtype = X_input_mtype

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1222,7 +1222,8 @@ class BaseTransformer(BaseEstimator):
                 # Input has always to be Panel
                 X_output_mtype = "pd.DataFrame"
             else:
-                # Input can be Panel or Hierachical, since it is supported by the used mtype
+                # Input can be Panel or Hierachical, since it is supported
+                # by the used mtype
                 output_scitype = X_input_scitype
                 # Xt_mtype = metadata["mtype"]
             # else:

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1194,7 +1194,6 @@ class BaseTransformer(BaseEstimator):
         if output_scitype == "Series":
             # output mtype is input mtype
             X_output_mtype = X_input_mtype
-
             # exception to this: if the transformer outputs multivariate series,
             #   we cannot convert back to pd.Series, do pd.DataFrame instead then
             #   this happens only for Series, not Panel
@@ -1219,8 +1218,12 @@ class BaseTransformer(BaseEstimator):
                     )
                 if X_input_mtype == "pd.Series" and not metadata["is_univariate"]:
                     X_output_mtype = "pd.DataFrame"
-            elif X_input_scitype == "Panel":
+            elif self.get_tags()["scitype:transform-input"] == "Panel":
+                # Input has always to be Panel
                 X_output_mtype = "pd.DataFrame"
+            elif X_input_scitype == "Panel":
+                # Input can be Panel, since it is supported by the used mtype
+                output_scitype = "Panel"
                 # Xt_mtype = metadata["mtype"]
             # else:
             #     Xt_mtype = X_input_mtype
@@ -1233,7 +1236,7 @@ class BaseTransformer(BaseEstimator):
             #     store=_converter_store_X,
             #     store_behaviour="freeze",
             # )
-            Xt = convert_to(
+            return convert_to(
                 Xt,
                 to_type=X_output_mtype,
                 as_scitype=output_scitype,
@@ -1252,7 +1255,7 @@ class BaseTransformer(BaseEstimator):
                 # else this is only zeros and should be reset to RangeIndex
                 else:
                     Xt = Xt.reset_index(drop=True)
-            Xt = convert_to(
+            return convert_to(
                 Xt,
                 to_type="pd_DataFrame_Table",
                 as_scitype="Table",

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1177,10 +1177,20 @@ class BaseTransformer(BaseEstimator):
         #   skipped for output_scitype = "Primitives"
         #       since then the output always is a pd.DataFrame
         if case == "case 2: higher scitype supported" and output_scitype == "Series":
-            Xt = convert_to(
-                Xt,
-                to_type=["pd-multiindex", "numpy3D", "df-list", "pd_multiindex_hier"],
-            )
+            if self.get_tags()["scitype:transform-input"] == "Panel":
+                # Conversion from Series to Panel done for being compatible with
+                # algorithm. Thus, the returned Series should stay a Series.
+                pass
+            else:
+                Xt = convert_to(
+                    Xt,
+                    to_type=[
+                        "pd-multiindex",
+                        "numpy3D",
+                        "df-list",
+                        "pd_multiindex_hier",
+                    ],
+                )
             Xt = convert_to_scitype(Xt, to_scitype=X_input_scitype)
 
         # now, in all cases, Xt is in the right scitype,

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1219,6 +1219,8 @@ class BaseTransformer(BaseEstimator):
                     )
                 if X_input_mtype == "pd.Series" and not metadata["is_univariate"]:
                     X_output_mtype = "pd.DataFrame"
+            elif X_input_scitype == "Panel":
+                X_output_mtype = "pd.DataFrame"
                 # Xt_mtype = metadata["mtype"]
             # else:
             #     Xt_mtype = X_input_mtype
@@ -1234,7 +1236,7 @@ class BaseTransformer(BaseEstimator):
             Xt = convert_to(
                 Xt,
                 to_type=X_output_mtype,
-                as_scitype=X_input_scitype,
+                as_scitype=output_scitype,
                 store=_converter_store_X,
                 store_behaviour="freeze",
             )

--- a/sktime/transformations/merger.py
+++ b/sktime/transformations/merger.py
@@ -1,0 +1,100 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Implements a merger for panel data."""
+import numpy as np
+
+__author__ = ["benHeid"]
+
+
+from sktime.transformations.base import BaseTransformer
+
+
+class Merger(BaseTransformer):
+    """Aggregates Panel data containing overlapping windows of one time series.
+
+    The input data contains multiple overlapping time series elements that could
+    arranged as follows:
+    xxxx.....
+    .xxxx....
+    ..xxxx...
+    ...xxxx..
+    ....xxxx.
+    .....xxxx
+    The merger aggregates the data by aligning the time series windows as shown above
+    and applying a aggregation function to the overlapping data points.
+    The aggregation function can be one of "mean" or "median". I.e., the `mean` or
+    `median` of each column is calculated, resulting in a univariate time series.
+
+    Parameters
+    ----------
+    method : {`median`, `mean`}, default="median"
+        The method to use for aggregation. Can be one of "mean" or "median".
+    """
+
+    _tags = {
+        "scitype:y": "Panel",
+        "y_inner_mtype": "pd.Series",
+        "X_inner_mtype": "pd.DataFrame",
+        "ignores-exogeneous-X": False,
+        "requires-fh-in-fit": False,
+    }
+
+    def __init__(self, method="median"):
+        if method not in ["median", "mean"]:
+            raise ValueError(f"{method} must be 'mean' or 'median'.")
+        self.method = method
+        super().__init__()
+
+    def _transform(self, X=None, y=None):
+        """Merge the Panel data by aligning them temporally.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The input panel data.
+        y : pd.Series
+            ignored
+
+        Returns
+        -------
+        returns a single time series
+        """
+        horizon = X.shape[-1]
+
+        if self.method == "mean":
+            return np.nanmean(self._align_temporal(horizon, X), axis=0)
+        elif self.method == "median":
+            return np.nanmedian(self._align_temporal(horizon, X), axis=0)
+
+    def _align_temporal(self, horizon, x):
+        r = []
+        for i in range(horizon):
+            _res = np.concatenate(
+                [
+                    np.full(fill_value=np.nan, shape=(i,)),
+                    x.values[:, i],
+                    np.full(fill_value=np.nan, shape=(horizon - 1 - i,)),
+                ]
+            )
+            r.append(_res)
+        return np.stack(r)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for forecasters.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        return [{"method": "mean"}, {"method": "median"}]

--- a/sktime/transformations/merger.py
+++ b/sktime/transformations/merger.py
@@ -33,7 +33,7 @@ class Merger(BaseTransformer):
     --------
     >>> from sktime.transformations.merger import Merger
     >>> from sktime.utils._testing.panel import _make_panel
-    >>> y = make_panel(n_instances=10, n_columns=3, n_timepoints=5)
+    >>> y = _make_panel(n_instances=10, n_columns=3, n_timepoints=5)
     >>> result = Merger(method="median").transform(y)
     >>> result.shape
     (14, 3, 1)

--- a/sktime/transformations/merger.py
+++ b/sktime/transformations/merger.py
@@ -45,7 +45,6 @@ class Merger(BaseTransformer):
 
     _tags = {
         "scitype:transform-input": "Panel",
-        "scitype:transform-output": "Series",
         "X_inner_mtype": "numpy3D",
         "fit_is_empty": True,
     }

--- a/sktime/transformations/merger.py
+++ b/sktime/transformations/merger.py
@@ -56,6 +56,7 @@ class Merger(BaseTransformer):
 
     _tags = {
         "scitype:transform-input": "Panel",
+        "scitype:transform-output": "Series",
         "X_inner_mtype": "numpy3D",
         "fit_is_empty": True,
     }
@@ -89,7 +90,7 @@ class Merger(BaseTransformer):
             result = np.nanmedian(self._align_temporal(horizon, X), axis=0)
         else:
             raise ValueError(f"{self.method} must be 'mean' or 'median'.")
-        return result.reshape((*result.shape, 1))
+        return result
 
     def _align_temporal(self, horizon, x):
         x = x.astype(float)

--- a/sktime/transformations/merger.py
+++ b/sktime/transformations/merger.py
@@ -73,6 +73,7 @@ class Merger(BaseTransformer):
         else:
             raise ValueError(f"{self.method} must be 'mean' or 'median'.")
         return result.reshape((*result.shape, 1))
+
     def _align_temporal(self, horizon, x):
         r = []
         for i in range(horizon):

--- a/sktime/transformations/merger.py
+++ b/sktime/transformations/merger.py
@@ -51,7 +51,7 @@ class Merger(BaseTransformer):
     >>> y = _make_panel(n_instances=10, n_columns=3, n_timepoints=5)
     >>> result = Merger(method="median", stride=1).fit_transform(y)
     >>> result.shape
-    (14, 3, 1)
+    (14, 3)
     """
 
     _tags = {

--- a/sktime/transformations/merger.py
+++ b/sktime/transformations/merger.py
@@ -32,6 +32,10 @@ class Merger(BaseTransformer):
     ----------
     method : {`median`, `mean`}, default="median"
         The method to use for aggregation. Can be one of "mean" or "median".
+    stride : int, default=0
+        The stride to use for the aggregation. The stride determines the number of
+        shifts between consecutive instances. A stride of 0 means no shift. A
+        stride of 1 means that the time series is aggregated as above.
 
     Examples
     --------
@@ -39,6 +43,13 @@ class Merger(BaseTransformer):
     >>> from sktime.utils._testing.panel import _make_panel
     >>> y = _make_panel(n_instances=10, n_columns=3, n_timepoints=5)
     >>> result = Merger(method="median").fit_transform(y)
+    >>> result.shape
+    (3, 5)
+
+    >>> from sktime.transformations.merger import Merger
+    >>> from sktime.utils._testing.panel import _make_panel
+    >>> y = _make_panel(n_instances=10, n_columns=3, n_timepoints=5)
+    >>> result = Merger(method="median", stride=1).fit_transform(y)
     >>> result.shape
     (14, 3, 1)
     """

--- a/sktime/transformations/tests/test_all_transformers.py
+++ b/sktime/transformations/tests/test_all_transformers.py
@@ -78,6 +78,8 @@ class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
                 return "Panel"
             if X_scitype in ["Panel", "Hierarchical"]:
                 return "Hierarchical"
+        if trafo_input == "Panel" and trafo_output == "Series":
+            return "Series"
 
     def test_fit_transform_output(self, estimator_instance, scenario):
         """Test that transform output is of expected scitype."""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
fixes #5350 
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
It implements a merger to create a single time series out of a panel. To enable it , it introduces Transformers that require Panels as input and transform them to Series. Thus the following adaption to base classes are needed:
* Determine the output scitype. Thus, in base.py `convert_output` an elif/else are added.
* In `_convert_output` of base.py, a check is added if the input conversion was executed based on incompatibilities to the scitype required by the algorithm or not. If due to incompatibilities, we assume that the output type of the algorithm should not be changed! Otherwise, we assume that this conversion is done because of the input data provided!

Moreover, the expected scitype for the tests is adapted to reflect the new kind of transformer!

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

* Is there a better name for this transfomer? 
  * I am unsure if the name is really telling what the transformer does.

#### Did you add any tests for the change?
I added additional test params



##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.


<!--
Thanks for contributing!
-->
