### PR TITLE
&benheid [BUG] allow `alpha` and `coverage` to be passed again via metrics to `evaluate`

### DIFF
--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -234,7 +234,7 @@ def _evaluate_window(
                 # make prediction
                 if y_pred_key not in y_preds_cache.keys():
                     start_pred = time.perf_counter()
-                    y_pred = method(fh, X_test)
+                    y_pred = method(fh, X_test, **pred_args)
                     pred_time = time.perf_counter() - start_pred
                     temp_result[time_key] = [pred_time]
                     y_preds_cache[y_pred_key] = [y_pred]

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -237,9 +237,9 @@ def _evaluate_window(
                     y_pred = method(fh, X_test)
                     pred_time = time.perf_counter() - start_pred
                     temp_result[time_key] = [pred_time]
-                    y_preds_cache[y_pred_key] = y_pred
+                    y_preds_cache[y_pred_key] = [y_pred]
                 else:
-                    y_pred = y_preds_cache[y_pred_key]
+                    y_pred = y_preds_cache[y_pred_key][0]
 
                 score = metric(y_test, y_pred, y_train=y_train)
                 temp_result[result_key] = [score]

--- a/sktime/forecasting/tests/test_interval_wrappers.py
+++ b/sktime/forecasting/tests/test_interval_wrappers.py
@@ -65,7 +65,7 @@ def test_wrapper_series_mtype(wrapper, override_y_mtype, mtype):
 
 
 @pytest.mark.skipif(
-    not run_test_for_class(INTERVAL_WRAPPERS),
+    not run_test_for_class(INTERVAL_WRAPPERS + [evaluate]),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 @pytest.mark.parametrize("wrapper", INTERVAL_WRAPPERS)


### PR DESCRIPTION
This PR ensures pre-existing syntax to pass `alpha` and `coverage` via metrics to `evaluate` works again, fixing https://github.com/sktime/sktime/issues/5336.

Not commenting here on whether the status quo is a good idea or not (I think it was cleaner to remove it, or is, in the long run), but such a change should not happen without deprecation.

FYI @hazrulakmal.

Question to the reviewers, especially @hazrulakmal: do we need to change the naming convention to something else to ensure we do not change the names - or their order - again, accidentally?

Depends on https://github.com/sktime/sktime/pull/5337, so this change should trigger the test that is failing on `main`.