### PR TITLE
[MNT] simplified CI - merge windows CI step with test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,63 +169,13 @@ jobs:
       - name: Publish code coverage
         uses: codecov/codecov-action@v3
 
-  test-windows:
-    needs: test-nosoftdeps
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false  # to not fail all combinations if just one fail
-      matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - run: git remote set-branches origin 'main'
-
-      - run: git fetch --depth 1
-
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          channels: anaconda, conda-forge,
-
-      - run: conda --version
-      - run: which python
-
-      - name: Fix windows paths
-        if: ${{ runner.os == 'Windows' }}
-        run: echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Install conda libpython
-        run: conda install -c anaconda libpython
-
-      - name: Install sktime and dependencies
-        run: python -m pip install .[all_extras_pandas2,dev]
-
-      - name: Show dependencies
-        run: python -m pip list
-
-      - name: Show available branches
-        run: git branch -a
-
-      - name: Run tests
-        run: |
-          mkdir -p testdir/
-          cp .coveragerc testdir/
-          cp setup.cfg testdir/
-          python -m pytest
-
-      - name: Publish code coverage
-        uses: codecov/codecov-action@v3
-
-  test-unix:
+  test-full:
     needs: test-nosoftdeps
     strategy:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR simplifies the CI setup, by merging the windows CI step into the test matrix.

As a side effect, this removes the dependency on conda in the windows CI.