### PR TITLE
[BUG] fix `STLForecaster` tag `ignores-exogenous-X` to be correctly set for composites

### DIFF
--- a/sktime/forecasting/trend/_stl_forecaster.py
+++ b/sktime/forecasting/trend/_stl_forecaster.py
@@ -135,6 +135,7 @@ class STLForecaster(BaseForecaster):
 
     _tags = {
         "scitype:y": "univariate",  # which y are fine? univariate/multivariate/both
+        "ignores-exogeneous-X": False,  # does estimator ignore the exogeneous X?
         "handles-missing-data": False,  # can estimator handle missing data?
         "y_inner_mtype": "pd.Series",  # which types do _fit, _predict, assume for y?
         "X_inner_mtype": "pd.DataFrame",  # which types do _fit, _predict, assume for X?


### PR DESCRIPTION
Sets the tag to `False` if and only if at least one of the used forecaster has it as `False`, and `True` otherwise.