### PR TITLE
[DOC] fix broken docstring example of `AlignerDtwNumba`

### DIFF
--- a/sktime/alignment/dtw_numba.py
+++ b/sktime/alignment/dtw_numba.py
@@ -110,8 +110,8 @@ class AlignerDtwNumba(BaseAligner):
     >>> from sktime.utils._testing.series import _make_series
     >>> from sktime.alignment.dtw_numba import AlignerDtwNumba
     >>>
-    >>> X0 = _make_series()  # doctest: +SKIP
-    >>> X1 = _make_series()  # doctest: +SKIP
+    >>> X0 = _make_series(return_mtype="pd.DataFrame")  # doctest: +SKIP
+    >>> X1 = _make_series(return_mtype="pd.DataFrame")  # doctest: +SKIP
     >>> d = AlignerDtwNumba(weighted=True, derivative=True)  # doctest: +SKIP
     >>> align = d.fit([X0, X1]).get_alignment()  # doctest: +SKIP
     """


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/5363 by replacing the list of `pd.Series` with a list of `pd.DataFrame`, which is a supported panel mtype.