### PR TITLE
[DOC] Correct code block formatting for pre-commit install command

### DIFF
--- a/doc-format
+++ b/doc-format
@@ -1,1 +1,0 @@
-Branch 'doc-format' set up to track remote branch 'main' from 'origin'.

--- a/doc-format
+++ b/doc-format
@@ -1,0 +1,1 @@
+Branch 'doc-format' set up to track remote branch 'main' from 'origin'.

--- a/docs/source/developer_guide/continuous_integration.rst
+++ b/docs/source/developer_guide/continuous_integration.rst
@@ -66,9 +66,9 @@ We recommend that you also set this up locally as it will ensure that you never 
 These checks run automatically before you make a new commit.
 To setup, simply navigate to the sktime folder and install our pre-commit configuration:
 
-.. code:: bash
-   
-   pre-commit install
+   .. code:: bash
+
+      pre-commit install
 
 pre-commit should now automatically run anything you make a commit! Please let us know if you encounter any issues getting this setup.
 

--- a/docs/source/developer_guide/continuous_integration.rst
+++ b/docs/source/developer_guide/continuous_integration.rst
@@ -66,7 +66,7 @@ We recommend that you also set this up locally as it will ensure that you never 
 These checks run automatically before you make a new commit.
 To setup, simply navigate to the sktime folder and install our pre-commit configuration:
 
-::
+.. code:: bash
    pre-commit install
 
 pre-commit should now automatically run anything you make a commit! Please let us know if you encounter any issues getting this setup.

--- a/docs/source/developer_guide/continuous_integration.rst
+++ b/docs/source/developer_guide/continuous_integration.rst
@@ -67,6 +67,7 @@ These checks run automatically before you make a new commit.
 To setup, simply navigate to the sktime folder and install our pre-commit configuration:
 
 .. code:: bash
+   
    pre-commit install
 
 pre-commit should now automatically run anything you make a commit! Please let us know if you encounter any issues getting this setup.


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #5308

#### What does this implement/fix? 
This PR corrects the code block formatting for the `pre-commit install` command in the developer guide. The command was not properly formatted as a code block, which could cause confusion for readers. The command is now enclosed in a code block, making it clear that it's a command to be executed in the terminal.