### PR TITLE
[BUG] alternate fix for `tslearn` `lcss` error

### DIFF
--- a/sktime/dists_kernels/base/adapters/_tslearn.py
+++ b/sktime/dists_kernels/base/adapters/_tslearn.py
@@ -140,4 +140,7 @@ class _TslearnPwTrafoAdapter:
         if isinstance(X2, list):
             X2 = self._coerce_df_list_to_list_of_arr(X2)
 
-        return self._eval_tslearn_pwtrafo(X, X2)
+        if self._is_cdist:
+            return self._eval_tslearn_pwtrafo(X, X2)
+        else:
+            return self._eval_tslearn_pwtrafo_vectorized(X, X2)


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/5367, alternative fix.

This restores the vectorization patch we had a while ago for `lcss`.

I think this was introduced in order to cope with interface non-compliance of `lcss` in the first place.