### PR TITLE
[ENH] incremental testing to also test if any parent class in sktime has changed

### DIFF
--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -51,12 +51,10 @@ from sktime.utils._testing.estimator_checks import (
     _list_required_methods,
 )
 from sktime.utils._testing.scenarios_getter import retrieve_scenarios
-from sktime.utils.git_diff import is_class_changed
 from sktime.utils.random_state import set_random_state
 from sktime.utils.sampling import random_partition
 from sktime.utils.validation._dependencies import (
     _check_dl_dependencies,
-    _check_estimator_deps,
     _check_soft_dependencies,
 )
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -38,6 +38,7 @@ from sktime.tests._config import (
     VALID_ESTIMATOR_TYPES,
     VALID_TRANSFORMER_TYPES,
 )
+from sktime.tests.test_switch import run_test_for_class
 from sktime.utils._testing._conditional_fixtures import (
     create_conditional_fixtures_and_names,
 )
@@ -220,10 +221,11 @@ class BaseFixtureGenerator:
         if MATRIXDESIGN:
             est_list = subsample_by_version_os(est_list)
 
-        # this setting ensures that only estimators are tested that have changed
-        # in the sense that any line in the module is different from main
-        if ONLY_CHANGED_MODULES:
-            est_list = [est for est in est_list if is_class_changed(est)]
+        # run_test_for_class selects the estimators to run
+        # based on whether they have changed, and whether they have all dependencies
+        # internally, uses the ONLY_CHANGED_MODULES flag,
+        # and checks the python env against python_dependencies tag
+        est_list = [est for est in est_list if run_test_for_class(est)]
 
         return est_list
 
@@ -272,13 +274,6 @@ class BaseFixtureGenerator:
             est
             for est in self._all_estimators()
             if not self.is_excluded(test_name, est)
-        ]
-
-        # exclude classes based on python version compatibility
-        estimator_classes_to_test = [
-            est
-            for est in estimator_classes_to_test
-            if _check_estimator_deps(est, severity="none")
         ]
 
         estimator_names = [est.__name__ for est in estimator_classes_to_test]

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -3,6 +3,8 @@
 
 __author__ = ["fkiraly"]
 
+import inspect
+
 
 def run_test_for_class(cls):
     """Check if test should run for a class or function.
@@ -41,10 +43,19 @@ def run_test_for_class(cls):
     from sktime.utils.validation._dependencies import _check_estimator_deps
 
     def _required_deps_present(obj):
+        """Check if all required soft dependencies are present, return bool."""
         if hasattr(obj, "get_class_tag"):
             return _check_estimator_deps(obj, severity="none")
         else:
             return True
+
+    def _is_class_changed_or_sktime_parents(cls):
+        """Check if class or any of its sktime parents have changed, return bool."""
+        cls_and_parents = inspect.getmro(cls)
+        cls_and_sktime_parents = [
+            x for x in cls_and_parents if x.__module__.startswith("sktime")
+        ]
+        return any(is_class_changed(x) for x in cls_and_sktime_parents)
 
     # if any of the required soft dependencies are not present, do not run the test
     if not all(_required_deps_present(x) for x in cls):
@@ -53,7 +64,7 @@ def run_test_for_class(cls):
     # if ONLY_CHANGED_MODULES is on, run the test if and only if
     # any of the modules containing any of the classes in the list have changed
     if ONLY_CHANGED_MODULES:
-        return any(is_class_changed(x) for x in cls)
+        return any(_is_class_changed_or_sktime_parents(x) for x in cls)
 
     # otherwise
     # i.e., dependencies are present, and differential testing is disabled

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -3,7 +3,7 @@
 
 __author__ = ["fkiraly"]
 
-import inspect
+from inspect import getmro, isclass
 
 
 def run_test_for_class(cls):
@@ -51,7 +51,12 @@ def run_test_for_class(cls):
 
     def _is_class_changed_or_sktime_parents(cls):
         """Check if class or any of its sktime parents have changed, return bool."""
-        cls_and_parents = inspect.getmro(cls)
+        # if cls is a function, not a class, default to is_class_changed
+        if not isclass(cls):
+            return is_class_changed(cls)
+
+        # now we know cls is a class, so has an mro
+        cls_and_parents = getmro(cls)
         cls_and_sktime_parents = [
             x for x in cls_and_parents if x.__module__.startswith("sktime")
         ]


### PR DESCRIPTION
This PR widens the condition scope in incremental testing: estimators are now tested also if a module containing a parent class in `sktime` has changed, not only if the module containing the estimator itself has changed.

The test framework, with this change, would also discover issues like https://github.com/sktime/sktime/issues/5367, where changes are made to an adapter class.

This would also cover the case of a base class change, in this case all descendants are tested too.