### PR TITLE
[BUG] Fixing dockerized tests

### DIFF
--- a/build_tools/docker/py37.dockerfile
+++ b/build_tools/docker/py37.dockerfile
@@ -1,8 +1,0 @@
-FROM python:3.7.16-bullseye
-
-WORKDIR /usr/src/sktime
-
-COPY . .
-
-RUN python -m pip install -U pip
-RUN python -m pip install .[all_extras,dev,binder]

--- a/docs/source/developer_guide/continuous_integration.rst
+++ b/docs/source/developer_guide/continuous_integration.rst
@@ -156,8 +156,6 @@ with the image of name ``PYTHON_VERSION`` based on the following python versions
 +----------------+----------------+
 | Python version | PYTHON_VERSION |
 +================+================+
-|     3.7.16     |      py37      |
-+----------------+----------------+
 |     3.8.16     |      py38      |
 +----------------+----------------+
 |     3.9.16     |      py39      |
@@ -170,8 +168,8 @@ with the image of name ``PYTHON_VERSION`` based on the following python versions
 The dockerized tests can be also executed via `make <https://www.gnu.org/software/make/>`_,
 via the command ``make dockertest PYTHON_VERSION=<python version>``.
 The ``PYTHON_VERSION`` argument specifies the python version and is the same string as in the table above.
-For example, to execute the tests in the Python version ``3.7.16``,
-use ``make dockertest PYTHON_VERSION=py37``.
+For example, to execute the tests in the Python version ``3.8.16``,
+use ``make dockertest PYTHON_VERSION=py38``.
 
 
 Continuous integration


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #5352 

#### What does this implement/fix? Explain your changes.
Tests fail to run because of a `git diff` command in the tests and the docker image is not a git repo

#### What should a reviewer concentrate their feedback on?
Currently I've added a new build target in the Makefile `full_test` which runs all the tests.
What else should I do?
