### PR TITLE
[ENH] Add Hyperbolic Sine transformation and its inverse (ScaledAsinhTransformer)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,53 +1,52 @@
 # The file lists sktime's algorithm maintainers as specified in GOVERNANCE.md.
-
 # Each line is a file pattern followed by one or more owners.
 
-- @achieveordie @benheid @fkiraly @yarnabrina
+* @achieveordie @benheid @fkiraly @yarnabrina
 
 sktime/annotation/hmm_learn/ @miraep8
 sktime/annotation/clasp.py @patrickzib @ermshaua
 sktime/annotation/eagglo.py @KatieBuc
 sktime/annotation/stray.py @KatieBuc
 
-sktime/classification/dictionary_based/\_boss.py @patrickzib @MatthewMiddlehurst
-sktime/classification/dictionary_based/\_cboss.py @patrickzib @MatthewMiddlehurst
-sktime/classification/dictionary_based/\_muse.py @patrickzib @MatthewMiddlehurst
-sktime/classification/dictionary_based/\_tde.py @patrickzib @MatthewMiddlehurst
-sktime/classification/dictionary_based/\_weasel.py @patrickzib @MatthewMiddlehurst
+sktime/classification/dictionary_based/_boss.py @patrickzib @MatthewMiddlehurst
+sktime/classification/dictionary_based/_cboss.py @patrickzib @MatthewMiddlehurst
+sktime/classification/dictionary_based/_muse.py @patrickzib @MatthewMiddlehurst
+sktime/classification/dictionary_based/_tde.py @patrickzib @MatthewMiddlehurst
+sktime/classification/dictionary_based/_weasel.py @patrickzib @MatthewMiddlehurst
 sktime/classification/distance_based/ @goastler
 sktime/classification/dummy/ @ZiyaoWei
-sktime/classification/early_classification/\_probability_threshold.py @MatthewMiddlehurst
-sktime/classification/early_classification/\_teaser.py @patrickzib @MatthewMiddlehurst
-sktime/classification/feature_based/\_catch22_classifier.py @MatthewMiddlehurst
-sktime/classification/feature_based/\_fresh_prince.py @MatthewMiddlehurst
-sktime/classification/feature_based/\_matrix_profile_classifier.py @MatthewMiddlehurst
-sktime/classification/feature_based/\_random_interval_classifier.py @MatthewMiddlehurst
-sktime/classification/feature_based/\_signature_classifier.py @jambo6
-sktime/classification/feature_based/\_summary_classifier.py @MatthewMiddlehurst
-sktime/classification/feature_based/\_tsfresh_classifier.py @MatthewMiddlehurst
-sktime/classification/hybrid/\_hivecote_v1.py @MatthewMiddlehurst
-sktime/classification/hybrid/\_hivecote_v2.py @MatthewMiddlehurst
-sktime/classification/interval_based/\_cif.py @MatthewMiddlehurst
-sktime/classification/interval_based/\_drcif.py @MatthewMiddlehurst
-sktime/classification/interval_based/\_rise.py @MatthewMiddlehurst
-sktime/classification/interval_based/\_stsf.py @MatthewMiddlehurst
-sktime/classification/interval_based/\_tsf.py @MatthewMiddlehurst
-sktime/classification/kernel_based/\_arsenal.py @MatthewMiddlehurst
-sktime/classification/kernel_based/\_rocket_classifier.py @MatthewMiddlehurst
-sktime/classification/shapelet_based/\_stc.py @ABostrom @MatthewMiddlehurst
-sktime/classification/sklearn/\_continuous_interval_tree.py @MatthewMiddlehurst
-sktime/classification/sklearn/\_rotation_forest.py @MatthewMiddlehurst
+sktime/classification/early_classification/_probability_threshold.py @MatthewMiddlehurst
+sktime/classification/early_classification/_teaser.py @patrickzib @MatthewMiddlehurst
+sktime/classification/feature_based/_catch22_classifier.py @MatthewMiddlehurst
+sktime/classification/feature_based/_fresh_prince.py @MatthewMiddlehurst
+sktime/classification/feature_based/_matrix_profile_classifier.py @MatthewMiddlehurst
+sktime/classification/feature_based/_random_interval_classifier.py @MatthewMiddlehurst
+sktime/classification/feature_based/_signature_classifier.py @jambo6
+sktime/classification/feature_based/_summary_classifier.py @MatthewMiddlehurst
+sktime/classification/feature_based/_tsfresh_classifier.py @MatthewMiddlehurst
+sktime/classification/hybrid/_hivecote_v1.py @MatthewMiddlehurst
+sktime/classification/hybrid/_hivecote_v2.py @MatthewMiddlehurst
+sktime/classification/interval_based/_cif.py @MatthewMiddlehurst
+sktime/classification/interval_based/_drcif.py @MatthewMiddlehurst
+sktime/classification/interval_based/_rise.py @MatthewMiddlehurst
+sktime/classification/interval_based/_stsf.py @MatthewMiddlehurst
+sktime/classification/interval_based/_tsf.py @MatthewMiddlehurst
+sktime/classification/kernel_based/_arsenal.py @MatthewMiddlehurst
+sktime/classification/kernel_based/_rocket_classifier.py @MatthewMiddlehurst
+sktime/classification/shapelet_based/_stc.py @ABostrom @MatthewMiddlehurst
+sktime/classification/sklearn/_continuous_interval_tree.py @MatthewMiddlehurst
+sktime/classification/sklearn/_rotation_forest.py @MatthewMiddlehurst
 
-sktime/forecasting/adapters/\_hcrystalball.py @MichalChromcak
-sktime/forecasting/arch/\_uarch.py @Vasudeva-bit
+sktime/forecasting/adapters/_hcrystalball.py @MichalChromcak
+sktime/forecasting/arch/_uarch.py @Vasudeva-bit
 sktime/forecasting/arima.py @HYang1996
-sktime/forecasting/base/adapters/\_statsforecast.py @FedericoGarza
+sktime/forecasting/base/adapters/_statsforecast.py @FedericoGarza
 sktime/forecasting/bats.py @aiwalter
-sktime/forecasting/compose/\_ensemble.py @aiwalter
-sktime/forecasting/compose/\_hierarchy_ensemble.py @VyomkeshVyas
+sktime/forecasting/compose/_ensemble.py @aiwalter
+sktime/forecasting/compose/_hierarchy_ensemble.py @VyomkeshVyas
 sktime/forecasting/ets.py @HYang1996
 sktime/forecasting/fbprophet.py @aiwalter
-sktime/forecasting/model_selection/\_split @koralturkk
+sktime/forecasting/model_selection/_split @koralturkk
 sktime/forecasting/online_learning/ @magittan
 sktime/forecasting/sarimax.py @TNTran92
 sktime/forecasting/statsforecast.py @FedericoGarza
@@ -61,14 +60,14 @@ sktime/transformations/panel/augmenter.py @MrPr3ntice @iljamaurer
 sktime/transformations/panel/catch22.py @MatthewMiddlehurst
 sktime/transformations/panel/catch22wrapper.py @MatthewMiddlehurst
 sktime/transformations/panel/channel_selection.py @haskarb @a-pasos-ruiz
-sktime/transformations/panel/dictionary_based/\_paa.py @patrickzib @MatthewMiddlehurst
-sktime/transformations/panel/dictionary_based/\_sax.py @patrickzib @MatthewMiddlehurst
-sktime/transformations/panel/dictionary_based/\_sfa.py @patrickzib @MatthewMiddlehurst
-sktime/transformations/panel/dictionary_based/\_sfa_fast.py @patrickzib @MatthewMiddlehurst
+sktime/transformations/panel/dictionary_based/_paa.py @patrickzib @MatthewMiddlehurst
+sktime/transformations/panel/dictionary_based/_sax.py @patrickzib @MatthewMiddlehurst
+sktime/transformations/panel/dictionary_based/_sfa.py @patrickzib @MatthewMiddlehurst
+sktime/transformations/panel/dictionary_based/_sfa_fast.py @patrickzib @MatthewMiddlehurst
 sktime/transformations/panel/random_intervals.py @MatthewMiddlehurst
 sktime/transformations/panel/rocket/ @angus924
-sktime/transformations/panel/rocket/\_multirocket.py @ChangWeiTan @fstinner @angus924
-sktime/transformations/panel/rocket/\_multirocket_multivariate.py @ChangWeiTan @fstinner @angus924
+sktime/transformations/panel/rocket/_multirocket.py @ChangWeiTan @fstinner @angus924
+sktime/transformations/panel/rocket/_multirocket_multivariate.py @ChangWeiTan @fstinner @angus924
 sktime/transformations/panel/signature_based/ @jambo6
 sktime/transformations/panel/shapelet_transform.py @ABostrom @MatthewMiddlehurst
 sktime/transformations/panel/supervised_intervals.py @MatthewMiddlehurst
@@ -85,6 +84,5 @@ sktime/transformations/series/outlier_detection.py @aiwalter
 sktime/transformations/series/scaledlogit.py @ltsaprounis
 sktime/transformations/series/time_since.py @KishManani
 sktime/transformations/series/theta.py @GuzalBulatova
-sktime/transformations/series/scaledasinh.py @ali-parizad
 
 sktime/utils/mlflow_sktime.py @benjaminbluhm

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,52 +1,53 @@
 # The file lists sktime's algorithm maintainers as specified in GOVERNANCE.md.
+
 # Each line is a file pattern followed by one or more owners.
 
-* @achieveordie @benheid @fkiraly @yarnabrina
+- @achieveordie @benheid @fkiraly @yarnabrina
 
 sktime/annotation/hmm_learn/ @miraep8
 sktime/annotation/clasp.py @patrickzib @ermshaua
 sktime/annotation/eagglo.py @KatieBuc
 sktime/annotation/stray.py @KatieBuc
 
-sktime/classification/dictionary_based/_boss.py @patrickzib @MatthewMiddlehurst
-sktime/classification/dictionary_based/_cboss.py @patrickzib @MatthewMiddlehurst
-sktime/classification/dictionary_based/_muse.py @patrickzib @MatthewMiddlehurst
-sktime/classification/dictionary_based/_tde.py @patrickzib @MatthewMiddlehurst
-sktime/classification/dictionary_based/_weasel.py @patrickzib @MatthewMiddlehurst
+sktime/classification/dictionary_based/\_boss.py @patrickzib @MatthewMiddlehurst
+sktime/classification/dictionary_based/\_cboss.py @patrickzib @MatthewMiddlehurst
+sktime/classification/dictionary_based/\_muse.py @patrickzib @MatthewMiddlehurst
+sktime/classification/dictionary_based/\_tde.py @patrickzib @MatthewMiddlehurst
+sktime/classification/dictionary_based/\_weasel.py @patrickzib @MatthewMiddlehurst
 sktime/classification/distance_based/ @goastler
 sktime/classification/dummy/ @ZiyaoWei
-sktime/classification/early_classification/_probability_threshold.py @MatthewMiddlehurst
-sktime/classification/early_classification/_teaser.py @patrickzib @MatthewMiddlehurst
-sktime/classification/feature_based/_catch22_classifier.py @MatthewMiddlehurst
-sktime/classification/feature_based/_fresh_prince.py @MatthewMiddlehurst
-sktime/classification/feature_based/_matrix_profile_classifier.py @MatthewMiddlehurst
-sktime/classification/feature_based/_random_interval_classifier.py @MatthewMiddlehurst
-sktime/classification/feature_based/_signature_classifier.py @jambo6
-sktime/classification/feature_based/_summary_classifier.py @MatthewMiddlehurst
-sktime/classification/feature_based/_tsfresh_classifier.py @MatthewMiddlehurst
-sktime/classification/hybrid/_hivecote_v1.py @MatthewMiddlehurst
-sktime/classification/hybrid/_hivecote_v2.py @MatthewMiddlehurst
-sktime/classification/interval_based/_cif.py @MatthewMiddlehurst
-sktime/classification/interval_based/_drcif.py @MatthewMiddlehurst
-sktime/classification/interval_based/_rise.py @MatthewMiddlehurst
-sktime/classification/interval_based/_stsf.py @MatthewMiddlehurst
-sktime/classification/interval_based/_tsf.py @MatthewMiddlehurst
-sktime/classification/kernel_based/_arsenal.py @MatthewMiddlehurst
-sktime/classification/kernel_based/_rocket_classifier.py @MatthewMiddlehurst
-sktime/classification/shapelet_based/_stc.py @ABostrom @MatthewMiddlehurst
-sktime/classification/sklearn/_continuous_interval_tree.py @MatthewMiddlehurst
-sktime/classification/sklearn/_rotation_forest.py @MatthewMiddlehurst
+sktime/classification/early_classification/\_probability_threshold.py @MatthewMiddlehurst
+sktime/classification/early_classification/\_teaser.py @patrickzib @MatthewMiddlehurst
+sktime/classification/feature_based/\_catch22_classifier.py @MatthewMiddlehurst
+sktime/classification/feature_based/\_fresh_prince.py @MatthewMiddlehurst
+sktime/classification/feature_based/\_matrix_profile_classifier.py @MatthewMiddlehurst
+sktime/classification/feature_based/\_random_interval_classifier.py @MatthewMiddlehurst
+sktime/classification/feature_based/\_signature_classifier.py @jambo6
+sktime/classification/feature_based/\_summary_classifier.py @MatthewMiddlehurst
+sktime/classification/feature_based/\_tsfresh_classifier.py @MatthewMiddlehurst
+sktime/classification/hybrid/\_hivecote_v1.py @MatthewMiddlehurst
+sktime/classification/hybrid/\_hivecote_v2.py @MatthewMiddlehurst
+sktime/classification/interval_based/\_cif.py @MatthewMiddlehurst
+sktime/classification/interval_based/\_drcif.py @MatthewMiddlehurst
+sktime/classification/interval_based/\_rise.py @MatthewMiddlehurst
+sktime/classification/interval_based/\_stsf.py @MatthewMiddlehurst
+sktime/classification/interval_based/\_tsf.py @MatthewMiddlehurst
+sktime/classification/kernel_based/\_arsenal.py @MatthewMiddlehurst
+sktime/classification/kernel_based/\_rocket_classifier.py @MatthewMiddlehurst
+sktime/classification/shapelet_based/\_stc.py @ABostrom @MatthewMiddlehurst
+sktime/classification/sklearn/\_continuous_interval_tree.py @MatthewMiddlehurst
+sktime/classification/sklearn/\_rotation_forest.py @MatthewMiddlehurst
 
-sktime/forecasting/adapters/_hcrystalball.py @MichalChromcak
-sktime/forecasting/arch/_uarch.py @Vasudeva-bit
+sktime/forecasting/adapters/\_hcrystalball.py @MichalChromcak
+sktime/forecasting/arch/\_uarch.py @Vasudeva-bit
 sktime/forecasting/arima.py @HYang1996
-sktime/forecasting/base/adapters/_statsforecast.py @FedericoGarza
+sktime/forecasting/base/adapters/\_statsforecast.py @FedericoGarza
 sktime/forecasting/bats.py @aiwalter
-sktime/forecasting/compose/_ensemble.py @aiwalter
-sktime/forecasting/compose/_hierarchy_ensemble.py @VyomkeshVyas
+sktime/forecasting/compose/\_ensemble.py @aiwalter
+sktime/forecasting/compose/\_hierarchy_ensemble.py @VyomkeshVyas
 sktime/forecasting/ets.py @HYang1996
 sktime/forecasting/fbprophet.py @aiwalter
-sktime/forecasting/model_selection/_split @koralturkk
+sktime/forecasting/model_selection/\_split @koralturkk
 sktime/forecasting/online_learning/ @magittan
 sktime/forecasting/sarimax.py @TNTran92
 sktime/forecasting/statsforecast.py @FedericoGarza
@@ -60,14 +61,14 @@ sktime/transformations/panel/augmenter.py @MrPr3ntice @iljamaurer
 sktime/transformations/panel/catch22.py @MatthewMiddlehurst
 sktime/transformations/panel/catch22wrapper.py @MatthewMiddlehurst
 sktime/transformations/panel/channel_selection.py @haskarb @a-pasos-ruiz
-sktime/transformations/panel/dictionary_based/_paa.py @patrickzib @MatthewMiddlehurst
-sktime/transformations/panel/dictionary_based/_sax.py @patrickzib @MatthewMiddlehurst
-sktime/transformations/panel/dictionary_based/_sfa.py @patrickzib @MatthewMiddlehurst
-sktime/transformations/panel/dictionary_based/_sfa_fast.py @patrickzib @MatthewMiddlehurst
+sktime/transformations/panel/dictionary_based/\_paa.py @patrickzib @MatthewMiddlehurst
+sktime/transformations/panel/dictionary_based/\_sax.py @patrickzib @MatthewMiddlehurst
+sktime/transformations/panel/dictionary_based/\_sfa.py @patrickzib @MatthewMiddlehurst
+sktime/transformations/panel/dictionary_based/\_sfa_fast.py @patrickzib @MatthewMiddlehurst
 sktime/transformations/panel/random_intervals.py @MatthewMiddlehurst
 sktime/transformations/panel/rocket/ @angus924
-sktime/transformations/panel/rocket/_multirocket.py @ChangWeiTan @fstinner @angus924
-sktime/transformations/panel/rocket/_multirocket_multivariate.py @ChangWeiTan @fstinner @angus924
+sktime/transformations/panel/rocket/\_multirocket.py @ChangWeiTan @fstinner @angus924
+sktime/transformations/panel/rocket/\_multirocket_multivariate.py @ChangWeiTan @fstinner @angus924
 sktime/transformations/panel/signature_based/ @jambo6
 sktime/transformations/panel/shapelet_transform.py @ABostrom @MatthewMiddlehurst
 sktime/transformations/panel/supervised_intervals.py @MatthewMiddlehurst
@@ -84,5 +85,6 @@ sktime/transformations/series/outlier_detection.py @aiwalter
 sktime/transformations/series/scaledlogit.py @ltsaprounis
 sktime/transformations/series/time_since.py @KishManani
 sktime/transformations/series/theta.py @GuzalBulatova
+sktime/transformations/series/scaledasinh.py @ali-parizad
 
 sktime/utils/mlflow_sktime.py @benjaminbluhm

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -84,5 +84,6 @@ sktime/transformations/series/outlier_detection.py @aiwalter
 sktime/transformations/series/scaledlogit.py @ltsaprounis
 sktime/transformations/series/time_since.py @KishManani
 sktime/transformations/series/theta.py @GuzalBulatova
+sktime/transformations/series/scaledasinh.py @ali-parizad
 
 sktime/utils/mlflow_sktime.py @benjaminbluhm

--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -288,6 +288,14 @@ Depending on the transformer, the transformation parameters can be fitted.
     ExponentTransformer
     SqrtTransformer
 
+.. currentmodule:: sktime.transformations.series.scaledasinh
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    ScaledAsinhTransformer
+
 Detrending and Decomposition
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -187,8 +187,6 @@ class ScaledAsinhTransformer(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        test_params = [
-            {},
-            {"mad_normalization_factor": 2.1},
-        ]
-        return test_params
+        params1 = {}
+
+        return [params1]

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -31,7 +31,6 @@ class ScaledAsinhTransformer(BaseTransformer):
         b= median_abs_deviation(sample data) * 1.4826).
         It is fitted, based on the data provided in "fit".
 
-
     See Also
     --------
     sktime.transformations.series.boxcox.LogTransformer :

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -68,18 +68,11 @@ class ScaledAsinhTransformer(BaseTransformer):
 
     Examples
     --------
-    >>> import numpy as np
-    >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.scaledasinh import ScaledAsinhTransformer
-    >>> from sktime.forecasting.trend import PolynomialTrendForecaster
-    >>> from sktime.forecasting.compose import TransformedTargetForecaster
+    >>> from sktime.datasets import load_airline
     >>> y = load_airline()
-    >>> forecaster = TransformedTargetForecaster([
-    ... ("scaled_Asinh", ScaledAsinhTransformer()),
-    ... ("poly", PolynomialTrendForecaster(degree=2))
-    ... ])
-    >>> forecaster.fit(y)
-    >>> y_pred = forecaster.predict(fh = np.arange(32))
+    >>> transformer = ScaledAsinhTransformer()
+    >>> y_hat = transformer.fit_transform(y)
     """
 
     _tags = {

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -187,6 +187,7 @@ class ScaledAsinhTransformer(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        params1 = {}
-
-        return params1
+        test_params = [
+            {},
+        ]
+        return test_params

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -54,15 +54,21 @@ class ScaledAsinhTransformer(BaseTransformer):
     Examples
     --------
     >>> import numpy as np
-    >>> from sktime.transformations.series.scaledasinh import ScaledAsinhTransformer
     >>> from sktime.datasets import load_airline
+    >>> from sktime.transformations.series.scaledasinh import ScaledAsinhTransformer
+    >>> from sktime.forecasting.trend import PolynomialTrendForecaster
+    >>> from sktime.forecasting.compose import TransformedTargetForecaster
     >>> from scipy import stats
-    >>> y =  load_airline()
+    >>> y = load_airline()
     >>> shift_parameter_asinh = np.median(y)
     >>> scale_parameter_asinh = stats.median_abs_deviation(y) * 1.4826
-    >>> transformer = ScaledAsinhTransformer(shift_parameter_asinh,
-    ... scale_parameter_asinh)
-    >>> y_hat = transformer.fit_transform(y)
+    >>> forecaster = TransformedTargetForecaster([
+    ... ("scaled_Asinh", ScaledAsinhTransformer(shift_parameter_asinh,
+    ... scale_parameter_asinh)),
+    ... ("poly", PolynomialTrendForecaster(degree=2))
+    ... ])
+    >>> forecaster.fit(y)
+    >>> y_pred = forecaster.predict(fh = np.arange(32))
     """
 
     _tags = {

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -42,6 +42,14 @@ class ScaledAsinhTransformer(BaseTransformer):
         Transform input data by taking its square root. Can help compress
         variance of input series.
 
+    Notes
+    -----
+    | The Hyperbolic Sine transformation is applied if both shift_parameter_asinh and
+    | scale_parameter_asinh are not None:
+    |   :math:`X_transform  = asinh(\frac{X - a}{b})`
+    |   :math:`X_inverse_transform  = b . sinh(X) + a`
+    | where a is the shift parameter and b is the scale parameter [1]_.
+
     References
     ----------
     .. [1] Ziel F, Weron R. Day-ahead electricity price forecasting with
@@ -54,21 +62,15 @@ class ScaledAsinhTransformer(BaseTransformer):
     Examples
     --------
     >>> import numpy as np
-    >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.scaledasinh import ScaledAsinhTransformer
-    >>> from sktime.forecasting.trend import PolynomialTrendForecaster
-    >>> from sktime.forecasting.compose import TransformedTargetForecaster
+    >>> from sktime.datasets import load_airline
     >>> from scipy import stats
-    >>> y = load_airline()
+    >>> y =  load_airline()
     >>> shift_parameter_asinh = np.median(y)
     >>> scale_parameter_asinh = stats.median_abs_deviation(y) * 1.4826
-    >>> forecaster = TransformedTargetForecaster([
-    ... ("scaled_Asinh", ScaledAsinhTransformer(shift_parameter_asinh,
-    ... scale_parameter_asinh)),
-    ... ("poly", PolynomialTrendForecaster(degree=2))
-    ... ])
-    >>> forecaster.fit(y)
-    >>> y_pred = forecaster.predict(fh = np.arange(32))
+    >>> transformer = ScaledAsinhTransformer(shift_parameter_asinh,
+    ... scale_parameter_asinh)
+    >>> y_hat = transformer.fit_transform(y)
     """
 
     _tags = {

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -14,7 +14,7 @@ from sktime.transformations.base import BaseTransformer
 class ScaledAsinhTransformer(BaseTransformer):
     r"""Hyperbolic sine transformation and its inverse [1]_.
 
-    Known as variance stabilizing transformation [2]_,
+    Known as variance stabilizing transformation,
     Combined with an sktime.forecasting.compose.TransformedTargetForecaster,
     can be usefull in time series that exhibit spikes [1]_, [2]_
 
@@ -35,7 +35,7 @@ class ScaledAsinhTransformer(BaseTransformer):
         scale parameter, denoted as "b" in [1]_, the median absolute deviation
         (MAD) around the sample median adjusted by a factor for asymptotically
         normal consistency to the standard deviation (Based on [1]_, [2]_
-        b = median_abs_deviation(sample data) . mad_normalization_factor).
+        b = median_abs_deviation(sample data) :math:`\times` mad_normalization_factor).
         It is fitted, based on the data provided in "fit".
 
     See Also
@@ -61,7 +61,7 @@ class ScaledAsinhTransformer(BaseTransformer):
     |   :math:`b . sinh(x) + a`
     | where "a" is the shift parameter and "b" is the scale parameter [1]_.
     | a = median(sample data)
-    | b = median_abs_deviation(sample data) . mad_normalization_factor
+    | b = median_abs_deviation(sample data) :math:`\times` mad_normalization_factor
 
     References
     ----------
@@ -187,7 +187,7 @@ class ScaledAsinhTransformer(BaseTransformer):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        test_params = [
-            {},
-        ]
-        return test_params
+        params1 = {}
+        params2 = {"mad_normalization_factor": 1.6}
+
+        return [params1, params2]

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -25,7 +25,8 @@ class ScaledAsinhTransformer(BaseTransformer):
     scale_parameter_asinh : float, optional, default=None
         scale parameter, denoted as "b" in [1]_, the median absolute deviation
         (MAD) around the sample median adjusted by a factor for asymptotically
-        normal consistency to the standard deviation (Based on [2]_, b= 1.4826)
+        normal consistency to the standard deviation (Based on [2]_,
+        b= median_abs_deviation(sample data) * 1.4826)
 
     See Also
     --------
@@ -49,6 +50,8 @@ class ScaledAsinhTransformer(BaseTransformer):
     |   :math:`transform  = asinh(\frac{x- a}{b})`
     |   :math:`inverse_transform  = b . sinh(x) + a`
     | where "a" is the shift parameter and "b" is the scale parameter [1]_.
+    | a = median(sample data)
+    | b = median_abs_deviation(sample data) * 1.4826
 
     References
     ----------

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -1,0 +1,163 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Implements the Hyperbolic Sine transformation and its inverse."""
+
+__author__ = ["Ali Parizad"]
+__all__ = ["ScaledAsinhTransformer"]
+
+from copy import deepcopy
+
+import numpy as np
+
+from sktime.transformations.base import BaseTransformer
+
+
+class ScaledAsinhTransformer(BaseTransformer):
+    """Hyperbolic sine transformation and its inverse [1]_.
+
+    Known as variance stabilizing transformation [2]_,
+    Combined with an sktime.forecasting.compose.TransformedTargetForecaster,
+    can be usefull in time series that exhibit spikes [1]_, [2]_
+
+    Parameters
+    ----------
+    shift_parameter_asinh : float, optional, default=None
+        shift parameter, denoted as "a" in [1]_, the median of sample data.
+    scale_parameter_asinh : float, optional, default=None
+        scale parameter, denoted as "b" in [1]_, the median absolute deviation
+        (MAD) around the sample median adjusted by a factor for asymptotically
+        normal consistency to the standard deviation (Based on [2]_, b= 1.4826)
+
+    See Also
+    --------
+    sktime.transformations.series.boxcox.LogTransformer :
+        Transformer input data using natural log. Can help normalize data and
+        compress variance of the series.
+    sktime.transformations.series.boxcox.BoxCoxTransformer :
+        Applies Box-Cox power transformation. Can help normalize data and
+        compress variance of the series.
+    sktime.transformations.series.exponent.ExponentTransformer :
+        Transform input data by raising it to an exponent. Can help compress
+        variance of series if a fractional exponent is supplied.
+    sktime.transformations.series.exponent.SqrtTransformer :
+        Transform input data by taking its square root. Can help compress
+        variance of input series.
+
+    References
+    ----------
+    .. [1] Ziel F, Weron R. Day-ahead electricity price forecasting with
+        high-dimensional structures: Univariate vs. multivariate modeling
+        frameworks. Energy Economics. 2018 Feb 1;70:396-420.
+    .. [2] Uniejewski, B., Weron, R., Ziel, F., 2017. Variance stabilizing
+        transformations for electricity spot price forecasting.
+        IEEE Transactions on Power Systems, DOI: 10.1109/TPWRS.2017.2734563
+
+    Examples
+    --------
+    >>> from sktime.transformations.series.scaledasinh import ScaledAsinhTransformer
+    >>> from sktime.datasets import load_airline
+    >>> import numpy as np
+    >>> from scipy import stats
+    >>> y =  load_airline()
+    >>> shift_parameter_asinh = np.median(y)
+    >>> scale_parameter_asinh = stats.median_abs_deviation(y) * 1.4826
+    >>> transformer = ScaledAsinhTransformer(shift_parameter_asinh,
+    ... scale_parameter_asinh)
+    >>> y_hat = transformer.fit_transform(y)
+    """
+
+    _tags = {
+        "scitype:transform-input": "Series",
+        # what is the scitype of X: Series, or Panel
+        "scitype:transform-output": "Series",
+        # what scitype is returned: Primitives, Series, Panel
+        "scitype:instancewise": True,  # is this an instance-wise transform?
+        "X_inner_mtype": "np.ndarray",  # which mtypes do _fit/_predict support for X?
+        "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
+        "transform-returns-same-time-index": True,
+        "fit_is_empty": True,
+        "univariate-only": False,
+        "capability:inverse_transform": True,
+        "skip-inverse-transform": False,
+    }
+
+    def __init__(self, shift_parameter_asinh=None, scale_parameter_asinh=None):
+        self.shift_parameter_asinh = shift_parameter_asinh
+        self.scale_parameter_asinh = scale_parameter_asinh
+        super().__init__()
+
+    def _transform(self, X, y=None):
+        """Transform X and return a transformed version.
+
+        private _transform containing core logic, called from transform
+
+        Parameters
+        ----------
+        X : 2D np.ndarray
+            Data to be transformed
+        y : Series or Panel of mtype y_inner_mtype, default=None
+            Ignored argument for interface compatibility
+
+        Returns
+        -------
+        transformed version of X
+        """
+        if self.scale_parameter_asinh and self.shift_parameter_asinh:
+            X_transformed = np.arcsinh(
+                (X - self.shift_parameter_asinh) / self.scale_parameter_asinh
+            )
+
+        else:
+            X_transformed = deepcopy(X)
+
+        return X_transformed
+
+    def _inverse_transform(self, X, y=None):
+        """Inverse transform, inverse operation to transform.
+
+        private _inverse_transform containing core logic, called from inverse_transform
+
+        Parameters
+        ----------
+        X : 2D np.ndarray
+            Data to be inverse transformed
+        y : Series or Panel of mtype y_inner_mtype, optional (default=None)
+            Ignored argument for interface compatibility
+
+        Returns
+        -------
+        inverse transformed version of X
+        """
+        if self.scale_parameter_asinh and self.shift_parameter_asinh:
+            X_inv_transformed = (
+                self.scale_parameter_asinh * np.sinh(X) + self.shift_parameter_asinh
+            )
+
+        else:
+            X_inv_transformed = deepcopy(X)
+
+        return X_inv_transformed
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        test_params = [
+            {"shift_parameter_asinh": None, "scale_parameter_asinh": None},
+            {"shift_parameter_asinh": 5.4, "scale_parameter_asinh": 3.7},
+        ]
+        return test_params

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -61,16 +61,22 @@ class ScaledAsinhTransformer(BaseTransformer):
 
     Examples
     --------
-    >>> from sktime.transformations.series.scaledasinh import ScaledAsinhTransformer
-    >>> from sktime.datasets import load_airline
     >>> import numpy as np
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.transformations.series.scaledasinh import ScaledAsinhTransformer
+    >>> from sktime.forecasting.trend import PolynomialTrendForecaster
+    >>> from sktime.forecasting.compose import TransformedTargetForecaster
     >>> from scipy import stats
-    >>> y =  load_airline()
+    >>> y = load_airline()
     >>> shift_parameter_asinh = np.median(y)
     >>> scale_parameter_asinh = stats.median_abs_deviation(y) * 1.4826
-    >>> transformer = ScaledAsinhTransformer(shift_parameter_asinh,
-    ... scale_parameter_asinh)
-    >>> y_hat = transformer.fit_transform(y)
+    >>> forecaster = TransformedTargetForecaster([
+    ... ("scaled_Asinh", ScaledAsinhTransformer(shift_parameter_asinh,
+    ... scale_parameter_asinh)),
+    ... ("poly", PolynomialTrendForecaster(degree=2))
+    ... ])
+    >>> forecaster.fit(y)
+    >>> y_pred = forecaster.predict(fh = np.arange(32))
     """
 
     _tags = {

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -51,7 +51,7 @@ class ScaledAsinhTransformer(BaseTransformer):
     |   :math:`inverse_transform  = b . sinh(x) + a`
     | where "a" is the shift parameter and "b" is the scale parameter [1]_.
     | a = median(sample data)
-    | b = median_abs_deviation(sample data) * 1.4826
+    | b = median_abs_deviation(sample data) . 1.4826
 
     References
     ----------

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -189,6 +189,4 @@ class ScaledAsinhTransformer(BaseTransformer):
         """
         params1 = {}
 
-        params2 = {"mad_normalization_factor": 1.5}
-
-        return [params1, params2]
+        return [params1]

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -42,14 +42,6 @@ class ScaledAsinhTransformer(BaseTransformer):
         Transform input data by taking its square root. Can help compress
         variance of input series.
 
-    Notes
-    -----
-    | The Hyperbolic Sine transformation is applied if both shift_parameter_asinh and
-    | scale_parameter_asinh are not None:
-    |   :math:`X_transform  = asinh(\frac{X - a}{b})`
-    |   :math:`X_inverse_transform  = b . sinh(X) + a`
-    | where a is the shift parameter and b is the scale parameter [1]_.
-
     References
     ----------
     .. [1] Ziel F, Weron R. Day-ahead electricity price forecasting with
@@ -62,21 +54,15 @@ class ScaledAsinhTransformer(BaseTransformer):
     Examples
     --------
     >>> import numpy as np
-    >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.scaledasinh import ScaledAsinhTransformer
-    >>> from sktime.forecasting.trend import PolynomialTrendForecaster
-    >>> from sktime.forecasting.compose import TransformedTargetForecaster
+    >>> from sktime.datasets import load_airline
     >>> from scipy import stats
-    >>> y = load_airline()
+    >>> y =  load_airline()
     >>> shift_parameter_asinh = np.median(y)
     >>> scale_parameter_asinh = stats.median_abs_deviation(y) * 1.4826
-    >>> forecaster = TransformedTargetForecaster([
-    ... ("scaled_Asinh", ScaledAsinhTransformer(shift_parameter_asinh,
-    ... scale_parameter_asinh)),
-    ... ("poly", PolynomialTrendForecaster(degree=2))
-    ... ])
-    >>> forecaster.fit(y)
-    >>> y_pred = forecaster.predict(fh = np.arange(32))
+    >>> transformer = ScaledAsinhTransformer(shift_parameter_asinh,
+    ... scale_parameter_asinh)
+    >>> y_hat = transformer.fit_transform(y)
     """
 
     _tags = {

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -189,4 +189,4 @@ class ScaledAsinhTransformer(BaseTransformer):
         """
         params1 = {}
 
-        return [params1]
+        return params1

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -35,7 +35,7 @@ class ScaledAsinhTransformer(BaseTransformer):
         scale parameter, denoted as "b" in [1]_, the median absolute deviation
         (MAD) around the sample median adjusted by a factor for asymptotically
         normal consistency to the standard deviation (Based on [1]_, [2]_
-        b = median_abs_deviation(sample data) :math:`\times` mad_normalization_factor
+        b = median_abs_deviation(sample data) . mad_normalization_factor).
         It is fitted, based on the data provided in "fit".
 
     See Also
@@ -61,7 +61,7 @@ class ScaledAsinhTransformer(BaseTransformer):
     |   :math:`b . sinh(x) + a`
     | where "a" is the shift parameter and "b" is the scale parameter [1]_.
     | a = median(sample data)
-    | b = median_abs_deviation(sample data) :math:`\times` mad_normalization_factor
+    | b = median_abs_deviation(sample data) . mad_normalization_factor
 
     References
     ----------

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -18,17 +18,24 @@ class ScaledAsinhTransformer(BaseTransformer):
     Combined with an sktime.forecasting.compose.TransformedTargetForecaster,
     can be usefull in time series that exhibit spikes [1]_, [2]_
 
+    Parameters
+    ----------
+    mad_normalization_factor : float, default = 1.4826
+        The normalization factor used to adjust the median absolute deviation
+        (MAD) for asymptotically normal consistency to the standard deviation.
+        The default value based on [1]_, [2]_ is 1.4826.
+
     Attributes
     ----------
     shift_parameter_asinh_ : float
         shift parameter, denoted as "a" in [1]_, the median of sample data.
         It is fitted, based on the data provided in "fit".
 
-    scale_parameter_asinh : float
+    scale_parameter_asinh_ : float
         scale parameter, denoted as "b" in [1]_, the median absolute deviation
         (MAD) around the sample median adjusted by a factor for asymptotically
         normal consistency to the standard deviation (Based on [1]_, [2]_
-        b= median_abs_deviation(sample data) * 1.4826).
+        b= median_abs_deviation(sample data) * mad_normalization_factor).
         It is fitted, based on the data provided in "fit".
 
     See Also
@@ -54,7 +61,7 @@ class ScaledAsinhTransformer(BaseTransformer):
     |   :math:`b . sinh(x) + a`
     | where "a" is the shift parameter and "b" is the scale parameter [1]_.
     | a = median(sample data)
-    | b = median_abs_deviation(sample data) :math:`. 1.4826`
+    | b = median_abs_deviation(sample data) * mad_normalization_factor
 
     References
     ----------
@@ -89,8 +96,9 @@ class ScaledAsinhTransformer(BaseTransformer):
         "skip-inverse-transform": False,
     }
 
-    def __init__(self):
+    def __init__(self, mad_normalization_factor=1.4826):
         super().__init__()
+        self.mad_normalization_factor = mad_normalization_factor
 
     def _fit(self, X, y=None):
         """Fit transformer to X and y.
@@ -110,7 +118,9 @@ class ScaledAsinhTransformer(BaseTransformer):
         """
         self.shift_parameter_asinh_ = np.median(X)
 
-        self.scale_parameter_asinh_ = stats.median_abs_deviation(X) * 1.4826
+        self.scale_parameter_asinh_ = (
+            stats.median_abs_deviation(X) * self.mad_normalization_factor
+        )
 
         return self
 

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -35,7 +35,7 @@ class ScaledAsinhTransformer(BaseTransformer):
         scale parameter, denoted as "b" in [1]_, the median absolute deviation
         (MAD) around the sample median adjusted by a factor for asymptotically
         normal consistency to the standard deviation (Based on [1]_, [2]_
-        b= median_abs_deviation(sample data) * mad_normalization_factor).
+        b = median_abs_deviation(sample data) :math:`\times` mad_normalization_factor
         It is fitted, based on the data provided in "fit".
 
     See Also
@@ -61,7 +61,7 @@ class ScaledAsinhTransformer(BaseTransformer):
     |   :math:`b . sinh(x) + a`
     | where "a" is the shift parameter and "b" is the scale parameter [1]_.
     | a = median(sample data)
-    | b = median_abs_deviation(sample data) * mad_normalization_factor
+    | b = median_abs_deviation(sample data) :math:`\times` mad_normalization_factor
 
     References
     ----------
@@ -189,5 +189,6 @@ class ScaledAsinhTransformer(BaseTransformer):
         """
         test_params = [
             {},
+            {"mad_normalization_factor": 2.1},
         ]
         return test_params

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -188,5 +188,6 @@ class ScaledAsinhTransformer(BaseTransformer):
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
         params1 = {}
+        params2 = {"mad_normalization_factor": 1.5}
 
-        return [params1]
+        return [params1, params2]

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -12,7 +12,7 @@ from sktime.transformations.base import BaseTransformer
 
 
 class ScaledAsinhTransformer(BaseTransformer):
-    """Hyperbolic sine transformation and its inverse [1]_.
+    r"""Hyperbolic sine transformation and its inverse [1]_.
 
     Known as variance stabilizing transformation [2]_,
     Combined with an sktime.forecasting.compose.TransformedTargetForecaster,
@@ -41,6 +41,14 @@ class ScaledAsinhTransformer(BaseTransformer):
     sktime.transformations.series.exponent.SqrtTransformer :
         Transform input data by taking its square root. Can help compress
         variance of input series.
+
+    Notes
+    -----
+    | The Hyperbolic Sine transformation is applied if both shift_parameter_asinh and
+    | scale_parameter_asinh are not None:
+    |   :math:`X_transform  = asinh(\frac{X - a}{b})`
+    |   :math:`X_inverse_transform  = b . sinh(X) + a`
+    | where a is the shift parameter and b is the scale parameter [1]_.
 
     References
     ----------

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -48,10 +48,10 @@ class ScaledAsinhTransformer(BaseTransformer):
     | The Hyperbolic Sine transformation is applied if both shift_parameter_asinh and
     | scale_parameter_asinh are not None:
     |   :math:`transform  = asinh(\frac{x- a}{b})`
-    |   :math:`inverse_transform  = b . sinh(x) + a`
+    |   :math:`inverse transform  = b . sinh(x) + a`
     | where "a" is the shift parameter and "b" is the scale parameter [1]_.
     | a = median(sample data)
-    | b = median_abs_deviation(sample data) . 1.4826
+    | b = median_abs_deviation(sample data) :math:`. 1.4826`
 
     References
     ----------

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -188,6 +188,7 @@ class ScaledAsinhTransformer(BaseTransformer):
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
         params1 = {}
+
         params2 = {"mad_normalization_factor": 1.5}
 
         return [params1, params2]

--- a/sktime/transformations/series/scaledasinh.py
+++ b/sktime/transformations/series/scaledasinh.py
@@ -46,9 +46,9 @@ class ScaledAsinhTransformer(BaseTransformer):
     -----
     | The Hyperbolic Sine transformation is applied if both shift_parameter_asinh and
     | scale_parameter_asinh are not None:
-    |   :math:`X_transform  = asinh(\frac{X - a}{b})`
-    |   :math:`X_inverse_transform  = b . sinh(X) + a`
-    | where a is the shift parameter and b is the scale parameter [1]_.
+    |   :math:`transform  = asinh(\frac{x- a}{b})`
+    |   :math:`inverse_transform  = b . sinh(x) + a`
+    | where "a" is the shift parameter and "b" is the scale parameter [1]_.
 
     References
     ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Implements the Hyperbolic Sine transformation and its inverse


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Based on Ref. [1],  Hyperbolic sine transformation and its inverse can be useful in time series that exhibit spikes. ASinh transformation has two parameters known as "a" and "b" where “a” is the shift parameter and “b” is the scale parameter 
a = median(sample data)
b = median_abs_deviation(sample data) . 1.4826 [2] 

[1] Ziel F, Weron R. Day-ahead electricity price forecasting with high-dimensional structures: Univariate vs. multivariate modeling frameworks. Energy Economics. 2018 Feb 1;70:396-420.

[2] Uniejewski, B., Weron, R., Ziel, F., 2017. Variance stabilizing transformations for electricity spot price forecasting. IEEE Transactions on Power Systems, DOI: 10.1109/TPWRS.2017.2734563

#### Does your contribution introduce a new dependency? If yes, which one?
No

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?
Functionality of ScaledAsinhTransformer

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
