### PR TITLE
[ENH] Refactor of `DateTimeFeatures` tests to `pytest` fixtures

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2414,6 +2414,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "adamkells",
+      "name": "Adam Kells",
+      "avatar_url": "https://avatars.githubusercontent.com/u/19709277?v=4",
+      "profile": "https://github.com/adamkells",
+      "contributions": [
+        "test"
+      ]
     }
   ]
 }

--- a/sktime/transformations/series/date.py
+++ b/sktime/transformations/series/date.py
@@ -34,7 +34,7 @@ _RAW_DUMMIES = [
 
 
 class DateTimeFeatures(BaseTransformer):
-    """DateTime feature extraction for use in e.g. tree based models.
+    """DateTime feature extraction, e.g., for use as exogenous data in forecasting.
 
     DateTimeFeatures uses a date index column and generates date features
     identifying e.g. year, week of the year, day of the week.

--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -157,16 +157,6 @@ def test_multivariate_eval(test_input, expected):
     assert all(a == b for a, b in zip(test_input, expected))
 
 
-# (
-#     test_full,
-#     all_args,
-# ),
-# (
-#     test_types,
-#     all_args[1:],
-# ),
-
-
 class UnivariateDataPipelineTests:
     all_args = [
         "Number of airline passengers",

--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -13,131 +13,109 @@ from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.series.date import DateTimeFeatures
 from sktime.utils._testing.hierarchical import _make_hierarchical
 
-if run_test_for_class(DateTimeFeatures):
-    # Load multivariate dataset longley and apply calendar extraction
 
-    y, X = load_longley()
-    y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
+class MultivariateDataPipelineTests:
+    @pytest.fixture
+    def load_split_data(self):
+        y, X = load_longley()
+        y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
+        return X_train
 
-    # Test that comprehensive feature_scope works for weeks
-    pipe = DateTimeFeatures(
-        ts_freq="W", feature_scope="comprehensive", keep_original_columns=True
-    )
-    pipe.fit(X_train)
-    test_full_featurescope = pipe.transform(X_train).columns.to_list()
+    @pytest.fixture
+    def featurescope_step(self, x_train=load_split_data):
+        # Test that comprehensive feature_scope works for weeks
+        pipe = DateTimeFeatures(
+            ts_freq="W", feature_scope="comprehensive", keep_original_columns=True
+        )
+        test_full_featurescope = pipe.fit_transform(x_train).columns.to_list()
+        return test_full_featurescope
 
-    # Test that minimal feature_scope works for weeks
-    pipe = DateTimeFeatures(
-        ts_freq="W", feature_scope="minimal", keep_original_columns=True
-    )
-    pipe.fit(X_train)
-    test_reduced_featurescope = pipe.transform(X_train).columns.to_list()
+    @pytest.fixture
+    def featurescope_step_output(self):
+        return [
+            "GNPDEFL",
+            "GNP",
+            "UNEMP",
+            "ARMED",
+            "POP",
+            "year",
+            "quarter_of_year",
+            "month_of_year",
+            "week_of_year",
+            "month_of_quarter",
+            "week_of_quarter",
+            "week_of_month",
+        ]
 
-    # Test that comprehensive feature_scope works for months
-    pipe = DateTimeFeatures(
-        ts_freq="M", feature_scope="comprehensive", keep_original_columns=True
-    )
-    pipe.fit(X_train)
-    test_changing_frequency = pipe.transform(X_train).columns.to_list()
+    @pytest.fixture
+    def reduced_featurescope_step(self, x_train=featurescope_step):
+        # Test that minimal feature_scope works for weeks
+        pipe = DateTimeFeatures(
+            ts_freq="W", feature_scope="minimal", keep_original_columns=True
+        )
+        test_reduced_featurescope = pipe.fit_transform(x_train).columns.to_list()
+        return test_reduced_featurescope
 
-    # Test that manual_selection works for with provided arguments
-    # Should ignore feature scope and raise warning for second_of_minute,
-    # since ts_freq = "M" is provided.
-    # (dummies with frequency higher than ts_freq)
-    pipe = DateTimeFeatures(
-        ts_freq="M",
-        feature_scope="comprehensive",
-        manual_selection=["year", "second_of_minute"],
-        keep_original_columns=True,
-    )
-    pipe.fit(X_train)
-    test_manspec_with_tsfreq = pipe.transform(X_train).columns.to_list()
+    @pytest.fixture
+    def reduced_featurescope_step_output(self):
+        return ["GNPDEFL", "GNP", "UNEMP", "ARMED", "POP", "year", "month_of_year"]
 
-    # Test that manual_selection works for with provided arguments
-    # Should ignore feature scope and raise no warning for second_of_minute,
-    # since ts_freq is not provided.
+    @pytest.fixture
+    def test_changing_frequency_step(self, x_train=reduced_featurescope_step):
+        # Test that comprehensive feature_scope works for months
+        pipe = DateTimeFeatures(
+            ts_freq="M", feature_scope="comprehensive", keep_original_columns=True
+        )
+        test_changing_frequency = pipe.fit_transform(x_train).columns.to_list()
+        return test_changing_frequency
 
-    pipe = DateTimeFeatures(
-        manual_selection=["year", "second_of_minute"], keep_original_columns=True
-    )
-    pipe.fit(X_train)
-    test_manspec_wo_tsfreq = pipe.transform(X_train).columns.to_list()
+    @pytest.fixture
+    def test_changing_frequency_step_output(self):
+        return [
+            "GNPDEFL",
+            "GNP",
+            "UNEMP",
+            "ARMED",
+            "POP",
+            "year",
+            "quarter_of_year",
+            "month_of_year",
+            "month_of_quarter",
+        ]
 
-    # Test that prior test works for with univariate dataset
-    y = load_airline()
-    y_train, y_test = temporal_train_test_split(y)
+    @pytest.fixture
+    def test_manspec_with_tsfreq_step(self, x_train=test_changing_frequency_step):
+        # Test that manual_selection works for with provided arguments
+        # Should ignore feature scope and raise warning for second_of_minute,
+        # since ts_freq = "M" is provided.
+        # (dummies with frequency higher than ts_freq)
+        pipe = DateTimeFeatures(
+            ts_freq="M",
+            feature_scope="comprehensive",
+            manual_selection=["year", "second_of_minute"],
+            keep_original_columns=True,
+        )
+        test_manspec_with_tsfreq = pipe.fit_transform(x_train).columns.to_list()
+        return test_manspec_with_tsfreq
 
-    pipe = DateTimeFeatures(
-        manual_selection=["year", "second_of_minute"], keep_original_columns=True
-    )
-    pipe.fit(y_train)
-    test_univariate_data = pipe.transform(y_train).columns.to_list()
+    @pytest.fixture
+    def test_manspec_with_tsfreq_step_output(self):
+        return ["GNPDEFL", "GNP", "UNEMP", "ARMED", "POP", "year", "second_of_minute"]
 
-    # Test that prior test also works when Index is converted to DateTime index
-    y.index = y.index.to_timestamp().astype("datetime64[ns]")
-    y_train, y_test = temporal_train_test_split(y)
-    pipe = DateTimeFeatures(
-        manual_selection=["year", "second_of_minute"], keep_original_columns=True
-    )
-    pipe.fit(y_train)
-    test_diffdateformat = pipe.transform(y_train).columns.to_list()
+    @pytest.fixture
+    def test_manspec_wo_tsfreq_step(self, x_train=test_manspec_with_tsfreq_step):
+        # Test that manual_selection works for with provided arguments
+        # Should ignore feature scope and raise no warning for second_of_minute,
+        # since ts_freq is not provided.
+        pipe = DateTimeFeatures(
+            manual_selection=["year", "second_of_minute"], keep_original_columns=True
+        )
+        test_manspec_wo_tsfreq = pipe.fit_transform(x_train).columns.to_list()
+        return test_manspec_wo_tsfreq
 
-    pipe = DateTimeFeatures(
-        ts_freq="L", feature_scope="comprehensive", keep_original_columns=True
-    )
-    pipe.fit(y_train)
-    y_train_t = pipe.transform(y_train)
-    test_full = y_train_t.columns.to_list()
-    test_types = y_train_t.select_dtypes(include=["int64"]).columns.to_list()
-
-else:
-    test_full_featurescope = []
-    test_reduced_featurescope = []
-    test_changing_frequency = []
-    test_manspec_with_tsfreq = []
-    test_manspec_wo_tsfreq = []
-    test_univariate_data = []
-    test_diffdateformat = []
-    test_full = []
-    test_types = []
-
-
-# Test `is_weekend` works in manual selection
-@pytest.fixture
-def df_datetime_daily_idx():
-    """Create timeseries with Datetime index, daily frequency."""
-    return pd.DataFrame(
-        data={"y": [1, 1, 1, 1, 1, 1, 1]},
-        index=pd.date_range(start="2000-01-01", freq="D", periods=7),
-    )
-
-
-@pytest.fixture()
-def df_panel():
-    """Create panel data of two time series using pd-multiindex mtype."""
-    return _make_hierarchical(hierarchy_levels=(2,), min_timepoints=3, max_timepoints=3)
-
-
-all_args = [
-    "Number of airline passengers",
-    "year",
-    "quarter_of_year",
-    "month_of_year",
-    "week_of_year",
-    "day_of_year",
-    "month_of_quarter",
-    "week_of_quarter",
-    "day_of_quarter",
-    "week_of_month",
-    "day_of_month",
-    "day_of_week",
-    "hour_of_day",
-    "hour_of_week",
-    "minute_of_hour",
-    "second_of_minute",
-    "millisecond_of_second",
-    "is_weekend",
-]
+    @pytest.fixture
+    def test_manspec_wo_tsfreq_step_output(self):
+        return ["GNPDEFL", "GNP", "UNEMP", "ARMED", "POP", "year", "second_of_minute"]
 
 
 @pytest.mark.skipif(
@@ -148,74 +126,158 @@ all_args = [
     "test_input,expected",
     [
         (
-            test_full_featurescope,
-            [
-                "GNPDEFL",
-                "GNP",
-                "UNEMP",
-                "ARMED",
-                "POP",
-                "year",
-                "quarter_of_year",
-                "month_of_year",
-                "week_of_year",
-                "month_of_quarter",
-                "week_of_quarter",
-                "week_of_month",
-            ],
+            MultivariateDataPipelineTests.featurescope_step,
+            MultivariateDataPipelineTests.featurescope_step_output,
         ),
         (
-            test_reduced_featurescope,
-            ["GNPDEFL", "GNP", "UNEMP", "ARMED", "POP", "year", "month_of_year"],
+            MultivariateDataPipelineTests.reduced_featurescope_step,
+            MultivariateDataPipelineTests.reduced_featurescope_step_output,
         ),
         (
-            test_changing_frequency,
-            [
-                "GNPDEFL",
-                "GNP",
-                "UNEMP",
-                "ARMED",
-                "POP",
-                "year",
-                "quarter_of_year",
-                "month_of_year",
-                "month_of_quarter",
-            ],
+            MultivariateDataPipelineTests.test_changing_frequency_step,
+            MultivariateDataPipelineTests.test_changing_frequency_step_output,
         ),
         (
-            test_manspec_with_tsfreq,
-            ["GNPDEFL", "GNP", "UNEMP", "ARMED", "POP", "year", "second_of_minute"],
+            MultivariateDataPipelineTests.test_manspec_with_tsfreq_step,
+            MultivariateDataPipelineTests.test_manspec_with_tsfreq_step_output,
         ),
         (
-            test_manspec_wo_tsfreq,
-            ["GNPDEFL", "GNP", "UNEMP", "ARMED", "POP", "year", "second_of_minute"],
-        ),
-        (
-            test_univariate_data,
-            ["Number of airline passengers", "year", "second_of_minute"],
-        ),
-        (
-            test_diffdateformat,
-            ["Number of airline passengers", "year", "second_of_minute"],
-        ),
-        (
-            test_full,
-            all_args,
-        ),
-        (
-            test_types,
-            all_args[1:],
+            MultivariateDataPipelineTests.test_manspec_wo_tsfreq_step,
+            MultivariateDataPipelineTests.test_manspec_wo_tsfreq_step_output,
         ),
     ],
 )
-def test_eval(test_input, expected):
+def test_multivariate_eval(test_input, expected):
     """Tests which columns are returned for different arguments.
 
-    For a detailed description what these arguments do, and how they interact see
-    docstring of DateTimeFeatures.
+    For a detailed description of what these arguments do, and how they interact, see
+    the docstring of DateTimeFeatures.
     """
     assert len(test_input) == len(expected)
-    assert all([a == b for a, b in zip(test_input, expected)])
+    assert all(a == b for a, b in zip(test_input, expected))
+
+
+# (
+#     test_full,
+#     all_args,
+# ),
+# (
+#     test_types,
+#     all_args[1:],
+# ),
+
+
+#
+# # Test `is_weekend` works in manual selection
+#
+# all_args = [
+#     "Number of airline passengers",
+#     "year",
+#     "quarter_of_year",
+#     "month_of_year",
+#     "week_of_year",
+#     "day_of_year",
+#     "month_of_quarter",
+#     "week_of_quarter",
+#     "day_of_quarter",
+#     "week_of_month",
+#     "day_of_month",
+#     "day_of_week",
+#     "hour_of_day",
+#     "hour_of_week",
+#     "minute_of_hour",
+#     "second_of_minute",
+#     "millisecond_of_second",
+#     "is_weekend",
+# ]
+#
+
+
+class UnivariateDataPipelineTests:
+    @pytest.fixture
+    def test_univariate_data_step(self):
+        y = load_airline()
+        # Test that prior test works for with univariate dataset
+        y_train, y_test = temporal_train_test_split(y)
+        pipe = DateTimeFeatures(
+            manual_selection=["year", "second_of_minute"], keep_original_columns=True
+        )
+        test_univariate_data = pipe.fit_transform(y_train).columns.to_list()
+        return test_univariate_data
+
+    @pytest.fixture
+    def test_univariate_data_step_output(self):
+        pass
+
+    @pytest.fixture
+    def test_diffdateformat(self):
+        y = load_airline()
+        # Test that prior test also works when Index is converted to DateTime index
+        y.index = y.index.to_timestamp().astype("datetime64[ns]")
+        y_train, y_test = temporal_train_test_split(y)
+        pipe = DateTimeFeatures(
+            manual_selection=["year", "second_of_minute"], keep_original_columns=True
+        )
+        test_diffdateformat = pipe.fit_transform(y_train).columns.to_list()
+        return test_diffdateformat
+
+    @pytest.fixture
+    def test_diffdateformat_output(self):
+        return ["Number of airline passengers", "year", "second_of_minute"]
+
+    # @pytest.fixture
+    # def test_full(self, y_train=test_diffdateformat):
+    #     pipe = DateTimeFeatures(
+    #         ts_freq="L", feature_scope="comprehensive", keep_original_columns=True
+    #     )
+    #     y_train_t = pipe.fit_transform(y_train)
+    #     test_full = y_train_t.columns.to_list()
+    #     return test_full
+    #
+    # def test_types
+    #     test_types = y_train_t.select_dtypes(include=["int64"]).columns.to_list()
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DateTimeFeatures),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (
+            UnivariateDataPipelineTests.test_univariate_data_step,
+            UnivariateDataPipelineTests.test_univariate_data_step_output,
+        ),
+        (
+            UnivariateDataPipelineTests.test_diffdateformat,
+            UnivariateDataPipelineTests.test_diffdateformat_output,
+        ),
+    ],
+)
+def test_uniivariate_eval(test_input, expected):
+    """Tests which columns are returned for different arguments.
+
+    For a detailed description of what these arguments do, and how they interact, see
+    the docstring of DateTimeFeatures.
+    """
+    assert len(test_input) == len(expected)
+    assert all(a == b for a, b in zip(test_input, expected))
+
+
+@pytest.fixture
+def df_datetime_daily_idx():
+    """Create timeseries with Datetime index, daily frequency."""
+    return pd.DataFrame(
+        data={"y": [1, 1, 1, 1, 1, 1, 1]},
+        index=pd.date_range(start="2000-01-01", freq="D", periods=7),
+    )
+
+
+@pytest.fixture
+def df_panel():
+    """Create panel data of two time series using pd-multiindex mtype."""
+    return _make_hierarchical(hierarchy_levels=(2,), min_timepoints=3, max_timepoints=3)
 
 
 @pytest.mark.skipif(

--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -14,227 +14,117 @@ from sktime.transformations.series.date import DateTimeFeatures
 from sktime.utils._testing.hierarchical import _make_hierarchical
 
 
-class MultivariateDataPipelineTests:
-    @pytest.fixture
-    def load_split_data(self):
-        y, X = load_longley()
-        y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
-        return X_train
-
-    @pytest.fixture
-    def featurescope_step(self, x_train=load_split_data):
-        # Test that comprehensive feature_scope works for weeks
-        pipe = DateTimeFeatures(
-            ts_freq="W", feature_scope="comprehensive", keep_original_columns=True
-        )
-        test_full_featurescope = pipe.fit_transform(x_train).columns.to_list()
-        return test_full_featurescope
-
-    @pytest.fixture
-    def featurescope_step_output(self):
-        return [
-            "GNPDEFL",
-            "GNP",
-            "UNEMP",
-            "ARMED",
-            "POP",
-            "year",
-            "quarter_of_year",
-            "month_of_year",
-            "week_of_year",
-            "month_of_quarter",
-            "week_of_quarter",
-            "week_of_month",
-        ]
-
-    @pytest.fixture
-    def reduced_featurescope_step(self, x_train=featurescope_step):
-        # Test that minimal feature_scope works for weeks
-        pipe = DateTimeFeatures(
-            ts_freq="W", feature_scope="minimal", keep_original_columns=True
-        )
-        test_reduced_featurescope = pipe.fit_transform(x_train).columns.to_list()
-        return test_reduced_featurescope
-
-    @pytest.fixture
-    def reduced_featurescope_step_output(self):
-        return ["GNPDEFL", "GNP", "UNEMP", "ARMED", "POP", "year", "month_of_year"]
-
-    @pytest.fixture
-    def test_changing_frequency_step(self, x_train=reduced_featurescope_step):
-        # Test that comprehensive feature_scope works for months
-        pipe = DateTimeFeatures(
-            ts_freq="M", feature_scope="comprehensive", keep_original_columns=True
-        )
-        test_changing_frequency = pipe.fit_transform(x_train).columns.to_list()
-        return test_changing_frequency
-
-    @pytest.fixture
-    def test_changing_frequency_step_output(self):
-        return [
-            "GNPDEFL",
-            "GNP",
-            "UNEMP",
-            "ARMED",
-            "POP",
-            "year",
-            "quarter_of_year",
-            "month_of_year",
-            "month_of_quarter",
-        ]
-
-    @pytest.fixture
-    def test_manspec_with_tsfreq_step(self, x_train=test_changing_frequency_step):
-        # Test that manual_selection works for with provided arguments
-        # Should ignore feature scope and raise warning for second_of_minute,
-        # since ts_freq = "M" is provided.
-        # (dummies with frequency higher than ts_freq)
-        pipe = DateTimeFeatures(
-            ts_freq="M",
-            feature_scope="comprehensive",
-            manual_selection=["year", "second_of_minute"],
-            keep_original_columns=True,
-        )
-        test_manspec_with_tsfreq = pipe.fit_transform(x_train).columns.to_list()
-        return test_manspec_with_tsfreq
-
-    @pytest.fixture
-    def test_manspec_with_tsfreq_step_output(self):
-        return ["GNPDEFL", "GNP", "UNEMP", "ARMED", "POP", "year", "second_of_minute"]
-
-    @pytest.fixture
-    def test_manspec_wo_tsfreq_step(self, x_train=test_manspec_with_tsfreq_step):
-        # Test that manual_selection works for with provided arguments
-        # Should ignore feature scope and raise no warning for second_of_minute,
-        # since ts_freq is not provided.
-        pipe = DateTimeFeatures(
-            manual_selection=["year", "second_of_minute"], keep_original_columns=True
-        )
-        test_manspec_wo_tsfreq = pipe.fit_transform(x_train).columns.to_list()
-        return test_manspec_wo_tsfreq
-
-    @pytest.fixture
-    def test_manspec_wo_tsfreq_step_output(self):
-        return ["GNPDEFL", "GNP", "UNEMP", "ARMED", "POP", "year", "second_of_minute"]
+@pytest.fixture
+def load_split_data():
+    y, X = load_longley()
+    y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
+    return X_train
 
 
-@pytest.mark.skipif(
-    not run_test_for_class(DateTimeFeatures),
-    reason="run test only if softdeps are present and incrementally (if requested)",
-)
-@pytest.mark.parametrize(
-    "test_input,expected",
-    [
-        (
-            MultivariateDataPipelineTests.featurescope_step,
-            MultivariateDataPipelineTests.featurescope_step_output,
-        ),
-        (
-            MultivariateDataPipelineTests.reduced_featurescope_step,
-            MultivariateDataPipelineTests.reduced_featurescope_step_output,
-        ),
-        (
-            MultivariateDataPipelineTests.test_changing_frequency_step,
-            MultivariateDataPipelineTests.test_changing_frequency_step_output,
-        ),
-        (
-            MultivariateDataPipelineTests.test_manspec_with_tsfreq_step,
-            MultivariateDataPipelineTests.test_manspec_with_tsfreq_step_output,
-        ),
-        (
-            MultivariateDataPipelineTests.test_manspec_wo_tsfreq_step,
-            MultivariateDataPipelineTests.test_manspec_wo_tsfreq_step_output,
-        ),
-    ],
-)
-def test_multivariate_eval(test_input, expected):
-    """Tests which columns are returned for different arguments.
-
-    For a detailed description of what these arguments do, and how they interact, see
-    the docstring of DateTimeFeatures.
-    """
-    assert len(test_input) == len(expected)
-    assert all(a == b for a, b in zip(test_input, expected))
+@pytest.fixture
+def featurescope_step(load_split_data):
+    # Test that comprehensive feature_scope works for weeks
+    pipe = DateTimeFeatures(
+        ts_freq="W", feature_scope="comprehensive", keep_original_columns=True
+    )
+    test_full_featurescope = pipe.fit_transform(load_split_data)
+    return test_full_featurescope
 
 
-class UnivariateDataPipelineTests:
-    all_args = [
-        "Number of airline passengers",
+@pytest.fixture
+def featurescope_step_output():
+    return [
+        "GNPDEFL",
+        "GNP",
+        "UNEMP",
+        "ARMED",
+        "POP",
         "year",
         "quarter_of_year",
         "month_of_year",
         "week_of_year",
-        "day_of_year",
         "month_of_quarter",
         "week_of_quarter",
-        "day_of_quarter",
         "week_of_month",
-        "day_of_month",
-        "day_of_week",
-        "hour_of_day",
-        "hour_of_week",
-        "minute_of_hour",
-        "second_of_minute",
-        "millisecond_of_second",
-        "is_weekend",
     ]
 
-    @pytest.fixture
-    def test_univariate_data_step(self):
-        y = load_airline()
-        # Test that prior test works for with univariate dataset
-        y_train, y_test = temporal_train_test_split(y)
-        pipe = DateTimeFeatures(
-            manual_selection=["year", "second_of_minute"], keep_original_columns=True
-        )
-        test_univariate_data = pipe.fit_transform(y_train).columns.to_list()
-        return test_univariate_data
 
-    @pytest.fixture
-    def test_univariate_data_step_output(self):
-        return self.all_args
+@pytest.fixture
+def reduced_featurescope_step(load_split_data):
+    # Test that minimal feature_scope works for weeks
+    pipe = DateTimeFeatures(
+        ts_freq="W", feature_scope="minimal", keep_original_columns=True
+    )
+    test_reduced_featurescope = pipe.fit_transform(load_split_data)
+    return test_reduced_featurescope
 
-    @pytest.fixture
-    def test_diffdateformat(self):
-        y = load_airline()
-        # Test that prior test also works when Index is converted to DateTime index
-        y.index = y.index.to_timestamp().astype("datetime64[ns]")
-        y_train, y_test = temporal_train_test_split(y)
-        pipe = DateTimeFeatures(
-            manual_selection=["year", "second_of_minute"], keep_original_columns=True
-        )
-        test_diffdateformat = pipe.fit_transform(y_train).columns.to_list()
-        return test_diffdateformat
 
-    @pytest.fixture
-    def test_diffdateformat_output(self):
-        return ["Number of airline passengers", "year", "second_of_minute"]
+@pytest.fixture
+def reduced_featurescope_step_output():
+    return ["GNPDEFL", "GNP", "UNEMP", "ARMED", "POP", "year", "month_of_year"]
 
-    @pytest.fixture
-    def test_comprehensive_transform(self, y_train=test_diffdateformat):
-        pipe = DateTimeFeatures(
-            ts_freq="L", feature_scope="comprehensive", keep_original_columns=True
-        )
-        y_train_t = pipe.fit_transform(y_train)
-        return y_train_t
 
-    @pytest.fixture
-    def test_full(self, y_train=test_comprehensive_transform):
-        test_full = y_train.columns.to_list()
-        return test_full
+@pytest.fixture
+def test_changing_frequency_step(load_split_data):
+    # Test that comprehensive feature_scope works for months
+    pipe = DateTimeFeatures(
+        ts_freq="M", feature_scope="comprehensive", keep_original_columns=True
+    )
+    test_changing_frequency = pipe.fit_transform(load_split_data)
+    return test_changing_frequency
 
-    @pytest.fixture
-    def test_full_output(self):
-        return self.all_args
 
-    @pytest.fixture
-    def test_types(self, y_train=test_comprehensive_transform):
-        test_types = y_train.select_dtypes(include=["int64"]).columns.to_list()
-        return test_types
+@pytest.fixture
+def test_changing_frequency_step_output():
+    return [
+        "GNPDEFL",
+        "GNP",
+        "UNEMP",
+        "ARMED",
+        "POP",
+        "year",
+        "quarter_of_year",
+        "month_of_year",
+        "month_of_quarter",
+    ]
 
-    @pytest.fixture
-    def test_types_output(self):
-        return self.all_args[1:]
+
+@pytest.fixture
+def test_manspec_with_tsfreq_step(load_split_data):
+    # Test that manual_selection works for with provided arguments
+    # Should ignore feature scope and raise warning for second_of_minute,
+    # since ts_freq = "M" is provided.
+    # (dummies with frequency higher than ts_freq)
+    pipe = DateTimeFeatures(
+        ts_freq="M",
+        feature_scope="comprehensive",
+        manual_selection=["year", "second_of_minute"],
+        keep_original_columns=True,
+    )
+    test_manspec_with_tsfreq = pipe.fit_transform(load_split_data)
+    return test_manspec_with_tsfreq
+
+
+@pytest.fixture
+def test_manspec_with_tsfreq_step_output():
+    return ["GNPDEFL", "GNP", "UNEMP", "ARMED", "POP", "year", "second_of_minute"]
+
+
+@pytest.fixture
+def test_manspec_wo_tsfreq_step(load_split_data):
+    # Test that manual_selection works for with provided arguments
+    # Should ignore feature scope and raise no warning for second_of_minute,
+    # since ts_freq is not provided.
+    pipe = DateTimeFeatures(
+        manual_selection=["year", "second_of_minute"], keep_original_columns=True
+    )
+    test_manspec_wo_tsfreq = pipe.fit_transform(load_split_data)
+    return test_manspec_wo_tsfreq
+
+
+@pytest.fixture
+def test_manspec_wo_tsfreq_step_output():
+    return ["GNPDEFL", "GNP", "UNEMP", "ARMED", "POP", "year", "second_of_minute"]
 
 
 @pytest.mark.skipif(
@@ -245,29 +135,158 @@ class UnivariateDataPipelineTests:
     "test_input,expected",
     [
         (
-            UnivariateDataPipelineTests.test_univariate_data_step,
-            UnivariateDataPipelineTests.test_univariate_data_step_output,
+            "featurescope_step",
+            "featurescope_step_output",
         ),
         (
-            UnivariateDataPipelineTests.test_diffdateformat,
-            UnivariateDataPipelineTests.test_diffdateformat_output,
+            "reduced_featurescope_step",
+            "reduced_featurescope_step_output",
         ),
         (
-            UnivariateDataPipelineTests.test_full,
-            UnivariateDataPipelineTests.test_full_output,
+            "test_changing_frequency_step",
+            "test_changing_frequency_step_output",
         ),
         (
-            UnivariateDataPipelineTests.test_types,
-            UnivariateDataPipelineTests.test_types_output,
+            "test_manspec_with_tsfreq_step",
+            "test_manspec_with_tsfreq_step_output",
+        ),
+        (
+            "test_manspec_wo_tsfreq_step",
+            "test_manspec_wo_tsfreq_step_output",
         ),
     ],
 )
-def test_uniivariate_eval(test_input, expected):
+def test_multivariate_eval(test_input, expected, request):
     """Tests which columns are returned for different arguments.
 
     For a detailed description of what these arguments do, and how they interact, see
     the docstring of DateTimeFeatures.
     """
+    test_input = request.getfixturevalue(test_input).columns.to_list()
+    expected = request.getfixturevalue(expected)
+    assert len(test_input) == len(expected)
+    assert all(a == b for a, b in zip(test_input, expected))
+
+
+all_args = [
+    "Number of airline passengers",
+    "year",
+    "quarter_of_year",
+    "month_of_year",
+    "week_of_year",
+    "day_of_year",
+    "month_of_quarter",
+    "week_of_quarter",
+    "day_of_quarter",
+    "week_of_month",
+    "day_of_month",
+    "day_of_week",
+    "hour_of_day",
+    "hour_of_week",
+    "minute_of_hour",
+    "second_of_minute",
+    "millisecond_of_second",
+    "is_weekend",
+]
+
+
+@pytest.fixture
+def test_univariate_data_step():
+    y = load_airline()
+    # Test that prior test works for with univariate dataset
+    y_train, y_test = temporal_train_test_split(y)
+    pipe = DateTimeFeatures(
+        manual_selection=["year", "second_of_minute"], keep_original_columns=True
+    )
+    test_univariate_data = pipe.fit_transform(y_train)
+    return test_univariate_data
+
+
+@pytest.fixture
+def test_univariate_data_step_output():
+    return ["Number of airline passengers", "year", "second_of_minute"]
+
+
+@pytest.fixture()
+def test_diffdateformat():
+    y = load_airline()
+    # Test that prior test also works when Index is converted to DateTime index
+    y.index = y.index.to_timestamp().astype("datetime64[ns]")
+    y_train, y_test = temporal_train_test_split(y)
+    pipe = DateTimeFeatures(
+        manual_selection=["year", "second_of_minute"], keep_original_columns=True
+    )
+    test_diffdateformat = pipe.fit_transform(y_train)
+    return test_diffdateformat
+
+
+@pytest.fixture
+def test_diffdateformat_output():
+    return ["Number of airline passengers", "year", "second_of_minute"]
+
+
+@pytest.fixture
+def test_comprehensive_transform():
+    y = load_airline()
+    # Test that prior test also works when Index is converted to DateTime index
+    y.index = y.index.to_timestamp().astype("datetime64[ns]")
+    y_train, y_test = temporal_train_test_split(y)
+    pipe = DateTimeFeatures(
+        ts_freq="L", feature_scope="comprehensive", keep_original_columns=True
+    )
+    y_train_t = pipe.fit_transform(y_train)
+    return y_train_t
+
+
+@pytest.fixture
+def test_comprehensive_transform_output():
+    return all_args
+
+
+@pytest.fixture
+def test_types(test_comprehensive_transform):
+    test_types = test_comprehensive_transform.select_dtypes(include=["int64"])
+    return test_types
+
+
+@pytest.fixture
+def test_types_output():
+    return all_args[1:]
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(DateTimeFeatures),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (
+            "test_univariate_data_step",
+            "test_univariate_data_step_output",
+        ),
+        (
+            "test_diffdateformat",
+            "test_diffdateformat_output",
+        ),
+        (
+            "test_comprehensive_transform",
+            "test_comprehensive_transform_output",
+        ),
+        (
+            "test_types",
+            "test_types_output",
+        ),
+    ],
+)
+def test_uniivariate_eval(test_input, expected, request):
+    """Tests which columns are returned for different arguments.
+
+    For a detailed description of what these arguments do, and how they interact, see
+    the docstring of DateTimeFeatures.
+    """
+    test_input = request.getfixturevalue(test_input).columns.to_list()
+    expected = request.getfixturevalue(expected)
     assert len(test_input) == len(expected)
     assert all(a == b for a, b in zip(test_input, expected))
 

--- a/sktime/transformations/series/tests/test_date.py
+++ b/sktime/transformations/series/tests/test_date.py
@@ -167,33 +167,28 @@ def test_multivariate_eval(test_input, expected):
 # ),
 
 
-#
-# # Test `is_weekend` works in manual selection
-#
-# all_args = [
-#     "Number of airline passengers",
-#     "year",
-#     "quarter_of_year",
-#     "month_of_year",
-#     "week_of_year",
-#     "day_of_year",
-#     "month_of_quarter",
-#     "week_of_quarter",
-#     "day_of_quarter",
-#     "week_of_month",
-#     "day_of_month",
-#     "day_of_week",
-#     "hour_of_day",
-#     "hour_of_week",
-#     "minute_of_hour",
-#     "second_of_minute",
-#     "millisecond_of_second",
-#     "is_weekend",
-# ]
-#
-
-
 class UnivariateDataPipelineTests:
+    all_args = [
+        "Number of airline passengers",
+        "year",
+        "quarter_of_year",
+        "month_of_year",
+        "week_of_year",
+        "day_of_year",
+        "month_of_quarter",
+        "week_of_quarter",
+        "day_of_quarter",
+        "week_of_month",
+        "day_of_month",
+        "day_of_week",
+        "hour_of_day",
+        "hour_of_week",
+        "minute_of_hour",
+        "second_of_minute",
+        "millisecond_of_second",
+        "is_weekend",
+    ]
+
     @pytest.fixture
     def test_univariate_data_step(self):
         y = load_airline()
@@ -207,7 +202,7 @@ class UnivariateDataPipelineTests:
 
     @pytest.fixture
     def test_univariate_data_step_output(self):
-        pass
+        return self.all_args
 
     @pytest.fixture
     def test_diffdateformat(self):
@@ -225,17 +220,31 @@ class UnivariateDataPipelineTests:
     def test_diffdateformat_output(self):
         return ["Number of airline passengers", "year", "second_of_minute"]
 
-    # @pytest.fixture
-    # def test_full(self, y_train=test_diffdateformat):
-    #     pipe = DateTimeFeatures(
-    #         ts_freq="L", feature_scope="comprehensive", keep_original_columns=True
-    #     )
-    #     y_train_t = pipe.fit_transform(y_train)
-    #     test_full = y_train_t.columns.to_list()
-    #     return test_full
-    #
-    # def test_types
-    #     test_types = y_train_t.select_dtypes(include=["int64"]).columns.to_list()
+    @pytest.fixture
+    def test_comprehensive_transform(self, y_train=test_diffdateformat):
+        pipe = DateTimeFeatures(
+            ts_freq="L", feature_scope="comprehensive", keep_original_columns=True
+        )
+        y_train_t = pipe.fit_transform(y_train)
+        return y_train_t
+
+    @pytest.fixture
+    def test_full(self, y_train=test_comprehensive_transform):
+        test_full = y_train.columns.to_list()
+        return test_full
+
+    @pytest.fixture
+    def test_full_output(self):
+        return self.all_args
+
+    @pytest.fixture
+    def test_types(self, y_train=test_comprehensive_transform):
+        test_types = y_train.select_dtypes(include=["int64"]).columns.to_list()
+        return test_types
+
+    @pytest.fixture
+    def test_types_output(self):
+        return self.all_args[1:]
 
 
 @pytest.mark.skipif(
@@ -252,6 +261,14 @@ class UnivariateDataPipelineTests:
         (
             UnivariateDataPipelineTests.test_diffdateformat,
             UnivariateDataPipelineTests.test_diffdateformat_output,
+        ),
+        (
+            UnivariateDataPipelineTests.test_full,
+            UnivariateDataPipelineTests.test_full_output,
+        ),
+        (
+            UnivariateDataPipelineTests.test_types,
+            UnivariateDataPipelineTests.test_types_output,
         ),
     ],
 )


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #5155. 


#### What does this implement/fix? Explain your changes.

This breaks apart the large if statement which creates the data objects for the tests into two classes consisting of pytest fixtures. These fixtures include the transformed data to be tested and the expected outputs.

#### Does your contribution introduce a new dependency? If yes, which one?

N/A

#### What should a reviewer concentrate their feedback on?

Is the proposed reformatting an acceptable solution? In particular, the use of classes for storing the Multivariate and Univariate inputs and outputs.

#### Did you add any tests for the change?

N/A

#### Any other comments?

N/A

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

