### PR TITLE
[MNT] 0.24.0 deprecations and change actions

### DIFF
--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -20,7 +20,7 @@ from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.utils.validation.panel import check_X
 
 
-# TODO: fix this in 0.24.0
+# TODO: fix this in 0.25.0
 # base class should have been changed to BaseEarlyClassifier
 class ProbabilityThresholdEarlyClassifier(BaseClassifier):
     """Probability Threshold Early Classifier.

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -728,7 +728,7 @@ def _to_relative(fh: ForecastingHorizon, cutoff=None) -> ForecastingHorizon:
             absolute = _coerce_to_period(absolute, freq=fh.freq)
             cutoff = _coerce_to_period(cutoff, freq=fh.freq)
 
-        # TODO: 0.24.0:
+        # TODO: 0.25.0:
         # Check at every minor release whether lower pandas bound >=0.15.0
         # if yes, can remove the workaround in the "else" condition and the check
         #

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -162,7 +162,7 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                         if len(levels) == 1:
                             levels = levels[0]
                         yt[ix] = y.xs(ix, level=levels, axis=1)
-                        # todo 0.24.0 - check why this cannot be easily removed
+                        # todo 0.25.0 - check why this cannot be easily removed
                         # in theory, we should get rid of the "Coverage" case treatment
                         # (the legacy naming convention was removed in 0.23.0)
                         # deal with the "Coverage" case, we need to get rid of this

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -11,7 +11,6 @@ __all__ = [
 
 from collections.abc import Sequence
 from typing import Dict, List, Optional, Union
-from warnings import warn
 
 import numpy as np
 import pandas as pd

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -37,8 +37,6 @@ class BaseGridSearch(_DelegatedForecaster):
         "capability:pred_int:insample": True,
     }
 
-    # todo 0.24.0: replace all tune_by_variable defaults in this file with False
-    # remove deprecation message in BaseGridSearch.__init__
     def __init__(
         self,
         forecaster,
@@ -54,7 +52,7 @@ class BaseGridSearch(_DelegatedForecaster):
         update_behaviour="full_refit",
         error_score=np.nan,
         tune_by_instance=False,
-        tune_by_variable=None,
+        tune_by_variable=False,
     ):
         self.forecaster = forecaster
         self.cv = cv
@@ -72,20 +70,6 @@ class BaseGridSearch(_DelegatedForecaster):
         self.tune_by_variable = tune_by_variable
 
         super().__init__()
-
-        # todo 0.24.0: remove this
-        if tune_by_variable is None:
-            warn(
-                f"in {self.__class__.__name__}, the default for tune_by_variable "
-                "will change from True to False in 0.24.0. "
-                "This will tune one parameter setting for all variables, while "
-                "currently it tunes one parameter per variable. "
-                "In order to maintain the current behaviour, ensure to set "
-                "the parameter tune_by_variable to True explicitly before upgrading "
-                "to version 0.24.0.",
-                DeprecationWarning,
-            )
-            tune_by_variable = True
 
         tags_to_clone = [
             "requires-fh-in-fit",
@@ -468,7 +452,7 @@ class ForecastingGridSearchCV(BaseGridSearch):
         and are available in fields of the forecasters_ attribute.
         Has the same effect as applying ForecastByLevel wrapper to self.
         If False, the same best parameter is selected for all instances.
-    tune_by_variable : bool, optional (default=True)
+    tune_by_variable : bool, optional (default=False)
         Whether to tune parameter by each time series variable separately,
         in case of multivariate data passed to the tuning estimator.
         Only applies if time series passed are strictly multivariate.
@@ -585,7 +569,7 @@ class ForecastingGridSearchCV(BaseGridSearch):
         update_behaviour="full_refit",
         error_score=np.nan,
         tune_by_instance=False,
-        tune_by_variable=None,
+        tune_by_variable=False,
     ):
         super().__init__(
             forecaster=forecaster,
@@ -777,7 +761,7 @@ class ForecastingRandomizedSearchCV(BaseGridSearch):
         and are available in fields of the forecasters_ attribute.
         Has the same effect as applying ForecastByLevel wrapper to self.
         If False, the same best parameter is selected for all instances.
-    tune_by_variable : bool, optional (default=True)
+    tune_by_variable : bool, optional (default=False)
         Whether to tune parameter by each time series variable separately,
         in case of multivariate data passed to the tuning estimator.
         Only applies if time series passed are strictly multivariate.
@@ -828,7 +812,7 @@ class ForecastingRandomizedSearchCV(BaseGridSearch):
         update_behaviour="full_refit",
         error_score=np.nan,
         tune_by_instance=False,
-        tune_by_variable=None,
+        tune_by_variable=False,
     ):
         super().__init__(
             forecaster=forecaster,
@@ -1008,7 +992,7 @@ class ForecastingSkoptSearchCV(BaseGridSearch):
         and are available in fields of the forecasters_ attribute.
         Has the same effect as applying ForecastByLevel wrapper to self.
         If False, the same best parameter is selected for all instances.
-    tune_by_variable : bool, optional (default=True)
+    tune_by_variable : bool, optional (default=False)
         Whether to tune parameter by each time series variable separately,
         in case of multivariate data passed to the tuning estimator.
         Only applies if time series passed are strictly multivariate.
@@ -1098,7 +1082,7 @@ class ForecastingSkoptSearchCV(BaseGridSearch):
         update_behaviour: str = "full_refit",
         error_score=np.nan,
         tune_by_instance=False,
-        tune_by_variable=None,
+        tune_by_variable=False,
     ):
         self.param_distributions = param_distributions
         self.n_iter = n_iter

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -142,10 +142,6 @@ def test_gscv(forecaster, param_grid, cv, scoring, error_score, multivariate):
         cv=cv,
         scoring=scoring,
         error_score=error_score,
-        # todo 0.24.0: remove this
-        # and/or add a test for tune_by_variable=True
-        # in this case, the forecaster is expeceted to vectorize over columns
-        tune_by_variable=False,
     )
     gscv.fit(y, X)
 
@@ -211,10 +207,6 @@ def test_gscv_hierarchical(forecaster, param_grid, cv, scoring, error_score, n_c
         cv=cv,
         scoring=scoring,
         error_score=error_score,
-        # todo 0.24.0: remove this
-        # and/or add a test for tune_by_variable=True
-        # in this case, the forecaster is expeceted to vectorize over columns
-        tune_by_variable=False,
     )
     gscv.fit(y, X)
 


### PR DESCRIPTION
0.24.0 release deprecations and change actions:

* in forecasting tuners, change of `tune_by_variable` default to `False`
* bump tracking todos