### PR TITLE
[ENH] Sensible default for `BaseSplitter.get_n_splits`

### DIFF
--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -395,7 +395,7 @@ class BaseSplitter(BaseObject):
         n_splits : int
             The number of splits.
         """
-        raise NotImplementedError("abstract method")
+        return len(list(self.split(y)))
 
     def get_cutoffs(self, y: Optional[ACCEPTED_Y_TYPES] = None) -> np.ndarray:
         """Return the cutoff points in .iloc[] context.


### PR DESCRIPTION
Adds a default implementation for `get_n_splits`, which simply calculates the splits and gets the length.

In consequence, fixes https://github.com/sktime/sktime/issues/5254.

I have also opened an issue for proper general testing of the issue that we are fixing here: https://github.com/sktime/sktime/issues/5411