### PR TITLE
Revert "[MNT] instant release action"

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,10 +27,112 @@ jobs:
           name: wheels
           path: wheelhouse/*
 
+  test_unix_wheels:
+    needs: build_wheels
+    name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false  # to not fail all combinations if just one fail
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Get wheel filename
+        run: echo "WHEELNAME=$(ls ./wheelhouse/sktime-*none-any.whl)" >> $GITHUB_ENV
+
+      - name: Install wheel and extras
+        run: python -m pip install "${{ env.WHEELNAME }}[all_extras_pandas2,dev]"
+
+      - name: Run tests
+        run: make test
+
+  test_windows_wheels:
+    needs: build_wheels
+    name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false  # to not fail all combinations if just one fail
+      matrix:
+        include:
+          # Window 64 bit
+          - os: windows-latest
+            python: 38
+            python-version: '3.8'
+            bitness: 64
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 39
+            python-version: '3.9'
+            bitness: 64
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 310
+            python-version: '3.10'
+            bitness: 64
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 311
+            python-version: '3.11'
+            bitness: 64
+            platform_id: win_amd64
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: test
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          channels: anaconda, conda-forge,
+
+      - run: conda --version
+      - run: which python
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Install conda libpython
+        run: conda install -c anaconda -n test -y libpython
+
+      - name: Display downloaded artifacts
+        run: ls -l wheelhouse
+
+      - name: Get wheel filename
+        run: echo "WHEELNAME=$(ls ./wheelhouse/sktime-*none-any.whl)" >> $env:GITHUB_ENV
+
+      - name: Activate conda env
+        run: conda activate test
+
+      - name: Install wheel and extras
+        run: python -m pip install "${env:WHEELNAME}[all_extras_pandas2,dev]"
+
+      - name: Show conda packages
+        run: conda list -n test
+
+      - name: Run tests
+        run: |
+          mkdir -p testdir/
+          cp .coveragerc testdir/
+          cp setup.cfg testdir/
+          python -m pytest
+
   upload_wheels:
     name: Upload wheels to PyPI
     runs-on: ubuntu-latest
-    needs: build_wheels
+    needs: [build_wheels,test_unix_wheels,test_windows_wheels]
 
     steps:
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
This PR changes the release action back to an release after testing wheels.

This might be useful for changing the current workflow to one where all tests are run manually, or in CRON batches.

Reverts sktime/sktime#5265. Same as removing https://github.com/sktime/sktime/pull/5262 (was temporary)