### PR TITLE
[BUG] fix missing epochs parameter in MCDCNNClassifier._fit (#4996)

### DIFF
--- a/sktime/classification/deep_learning/mcdcnn.py
+++ b/sktime/classification/deep_learning/mcdcnn.py
@@ -215,6 +215,7 @@ class MCDCNNClassifier(BaseDeepClassifier):
         self.history = self.model_.fit(
             X,
             y_onehot,
+            epochs=self.n_epochs,
             batch_size=self.batch_size,
             verbose=self.verbose,
             callbacks=self.callbacks_,


### PR DESCRIPTION
Fixes #4996

The fix is very simple.
The problem is that model.n_epochs is not passed to self.model_.fit in MCDCNNClassifier._fit (mcdcnn.py):

```
    def _fit(self, X, y):
        ...

        self.history = self.model_.fit(
            X,
            y_onehot,
            epochs=self.n_epochs, **#<<<-----------------THIS LINS IS MISSING #**
            batch_size=self.batch_size,
            verbose=self.verbose,
            callbacks=self.callbacks_,
        )

        return self
```
