### PR TITLE
[ENH] parallel backend selection for forecasting tuners

### DIFF
--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -250,7 +250,6 @@ class BaseGridSearch(_DelegatedForecaster):
             out = parallelize(
                 fun=_fit_and_score,
                 iterable=candidate_params,
-                meta=params,
                 backend=backend,
                 backend_params=backend_params,
             )

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -249,7 +249,7 @@ class BaseGridSearch(_DelegatedForecaster):
 
             out = parallelize(
                 fun=_fit_and_score,
-                iterable=candidate_params,
+                iter=candidate_params,
                 backend=backend,
                 backend_params=backend_params,
             )

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -204,7 +204,7 @@ class BaseGridSearch(_DelegatedForecaster):
                     stacklevel=2,
                 )
 
-        def _fit_and_score(params):
+        def _fit_and_score(params, meta):
             # Clone forecaster.
             forecaster = self.forecaster.clone()
 

--- a/sktime/forecasting/model_selection/tests/test_tune.py
+++ b/sktime/forecasting/model_selection/tests/test_tune.py
@@ -36,8 +36,8 @@ from sktime.split import SingleWindowSplitter, SlidingWindowSplitter
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.series.detrend import Detrender
 from sktime.transformations.series.impute import Imputer
-from sktime.utils.parallel import _get_parallel_test_fixtures
 from sktime.utils._testing.hierarchical import _make_hierarchical
+from sktime.utils.parallel import _get_parallel_test_fixtures
 
 TEST_METRICS = [MeanAbsolutePercentageError(symmetric=True), MeanSquaredError()]
 TEST_METRICS_PROBA = [CRPS(), PinballLoss()]

--- a/sktime/utils/parallel.py
+++ b/sktime/utils/parallel.py
@@ -125,6 +125,7 @@ def _get_parallel_test_fixtures():
     is a dict with keys "backend" and "backend_params".
     """
     from sktime.utils.validation._dependencies import _check_soft_dependencies
+
     fixtures = []
 
     # test no parallelization

--- a/sktime/utils/parallel.py
+++ b/sktime/utils/parallel.py
@@ -116,3 +116,29 @@ def _parallelize_dask(fun, iter, meta, backend, backend_params):
 
 
 para_dict["dask"] = _parallelize_dask
+
+
+def _get_parallel_test_fixtures():
+    """Return fixtures for parallelization tests.
+
+    Returns a list of parameter fixtures, where each fixture
+    is a dict with keys "backend" and "backend_params".
+    """
+    from sktime.utils.validation._dependencies import _check_soft_dependencies
+    fixtures = []
+
+    # test no parallelization
+    fixtures.append({"backend": "None", "backend_params": {}})
+
+    # test joblib backends
+    for backend in ["loky", "multiprocessing", "threading"]:
+        fixtures.append({"backend": backend, "backend_params": {}})
+        fixtures.append({"backend": backend, "backend_params": {"n_jobs": 2}})
+        fixtures.append({"backend": backend, "backend_params": {"n_jobs": -1}})
+
+    # test dask backends
+    if _check_soft_dependencies("dask"):
+        fixtures.append({"backend": "dask", "backend_params": {}})
+        fixtures.append({"backend": "dask", "backend_params": {"scheduler": "sync"}})
+
+    return fixtures

--- a/sktime/utils/parallel.py
+++ b/sktime/utils/parallel.py
@@ -138,7 +138,7 @@ def _get_parallel_test_fixtures():
         fixtures.append({"backend": backend, "backend_params": {"n_jobs": -1}})
 
     # test dask backends
-    if _check_soft_dependencies("dask"):
+    if _check_soft_dependencies("dask", severity="none"):
         fixtures.append({"backend": "dask", "backend_params": {}})
         fixtures.append({"backend": "dask", "backend_params": {"scheduler": "sync"}})
 


### PR DESCRIPTION
This PR adds parallel backend selection for forecasting tuners, using the `parallelize` utility module.

Towards https://github.com/sktime/sktime/issues/5380

Also makes the following changes:
* in tuners, deprecates some of the "backend parameters" for 0.26.0 in order to make the backend parameter interface consistent across the codebase.
* adds default fixtures for different parallel backend settings, also exported by the `utils.parallel` module
* tests that run the tuners with those parallelization settings