### PR TITLE
[BUG] CLASP logic: remove indexes from exclusion zone that are out of range

### DIFF
--- a/sktime/transformations/series/_clasp_numba.py
+++ b/sktime/transformations/series/_clasp_numba.py
@@ -161,7 +161,13 @@ def _calc_knn_labels(knn_mask, split_idx, m):
 
     # apply exclusion zone at split point
     exclusion_zone = np.arange(split_idx - m, split_idx)
-    y_pred[exclusion_zone] = np.ones(m, dtype=np.int64)
+
+    # Remove indexes outside the range of y_pred
+    exclusion_zone = exclusion_zone[
+        (exclusion_zone >= -len(y_pred)) & (exclusion_zone < len(y_pred))
+    ]
+
+    y_pred[exclusion_zone] = np.ones(len(exclusion_zone), dtype=np.int64)
 
     return y_true, y_pred
 


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->

Fixes #5451.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Sometimes, the `exclusion_zone` array can contain indexes that are out of the range of `y_pred`. This causes a segmentation fault from numba when trying to access the elements of `y_pred` using `exclusion_zone`.

To fix this, any indexes that are outside the range of `y_pred` are removed from `exclusion_zone`.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

No.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

No, it doesn't look like there are any clasp specific tests in `sktime/transformations/series`? Should there be a test for this change?

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

<!--
Thanks for contributing!
-->