### PR TITLE
[MNT] xfail remote data loaders to silence sporadic failures

### DIFF
--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -47,7 +47,6 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
-import pytest
 
 from sktime.datasets._data_io import (
     _download_and_extract,
@@ -63,7 +62,6 @@ DIRNAME = "data"
 MODULE = os.path.dirname(__file__)
 
 
-@pytest.mark.xfail(reason="known sporadic failure of unknown cause, see #5460")
 def load_UCR_UEA_dataset(
     name, split=None, return_X_y=True, return_type=None, extract_path=None
 ):

--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -47,6 +47,7 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from sktime.datasets._data_io import (
     _download_and_extract,
@@ -62,6 +63,7 @@ DIRNAME = "data"
 MODULE = os.path.dirname(__file__)
 
 
+@pytest.mark.xfail(reason="known sporadic failure of unknown cause, see #5460")
 def load_UCR_UEA_dataset(
     name, split=None, return_X_y=True, return_type=None, extract_path=None
 ):

--- a/sktime/datasets/tests/test_single_problem_loaders.py
+++ b/sktime/datasets/tests/test_single_problem_loaders.py
@@ -115,6 +115,7 @@ def test_load_forecastingdata():
     assert metadata["contain_equal_length"] is False
 
 
+@pytest.mark.xfail(reason="known sporadic failure of unknown cause, see #5460")
 @pytest.mark.parametrize("name", TSF_SUBSAMPLE)
 def test_check_link_downloadable(name):
     """Test dataset URL from forecasting.org is downloadable and exits."""

--- a/sktime/datasets/tests/test_single_problem_loaders.py
+++ b/sktime/datasets/tests/test_single_problem_loaders.py
@@ -115,7 +115,7 @@ def test_load_forecastingdata():
     assert metadata["contain_equal_length"] is False
 
 
-@pytest.mark.xfail(reason="known sporadic failure of unknown cause, see #5460")
+@pytest.mark.xfail(reason="known sporadic failure of unknown cause, see #5462")
 @pytest.mark.parametrize("name", TSF_SUBSAMPLE)
 def test_check_link_downloadable(name):
     """Test dataset URL from forecasting.org is downloadable and exits."""

--- a/sktime/datasets/tests/test_single_problem_loaders.py
+++ b/sktime/datasets/tests/test_single_problem_loaders.py
@@ -81,6 +81,7 @@ def test_load_numpy2d_multivariate_raises(loader):
         X, y = loader(return_type="numpy2d")
 
 
+@pytest.mark.xfail(reason="known sporadic failure of unknown cause, see #5460")
 def test_load_UEA():
     """Test loading of a random subset of the UEA data, to check API."""
     from sktime.datasets.tsc_dataset_names import multivariate, univariate


### PR DESCRIPTION
This PR adds an xfail to the UCR loader and the Monash loader - both retrieving benchmark data from the internet - in order to silence the sporadic failures described in bug reports #5460 and #5462.

Only a temporary measure, possibly also rectified by the CI refactor with a separate data testing element.