### PR TITLE
[BUG] fix predict function of `make reduction` (recursive, global) to work with tz aware data

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -343,8 +343,9 @@ class _Reducer(_BaseWindowForecaster):
         # first observation after the window (this is what the window is summarized to).
 
         index_range = _index_range(relative_int, cutoff)
-        if cutoff.tzinfo is not None:
-            index_range = index_range.tz_localize(cutoff.tzinfo)
+        if isinstance(cutoff, pd.DatetimeIndex):
+            if cutoff.tzinfo is not None:
+                index_range = index_range.tz_localize(cutoff.tzinfo)
         # index_range will convert the indices to the date format of cutoff
 
         y_raw = _create_fcst_df(index_range, self._y)
@@ -871,8 +872,9 @@ class _RecursiveReducer(_Reducer):
             fh_max = fh.to_relative(self.cutoff)[-1]
             relative = pd.Index(list(map(int, range(1, fh_max + 1))))
             index_range = _index_range(relative, self.cutoff)
-            if self.cutoff.tzinfo is not None:
-                index_range = index_range.tz_localize(self.cutoff.tzinfo)
+            if isinstance(self.cutoff, pd.DatetimeIndex):
+                if self.cutoff.tzinfo is not None:
+                    index_range = index_range.tz_localize(self.cutoff.tzinfo)
 
             y_pred = _create_fcst_df(index_range, self._y)
 

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -343,6 +343,8 @@ class _Reducer(_BaseWindowForecaster):
         # first observation after the window (this is what the window is summarized to).
 
         index_range = _index_range(relative_int, cutoff)
+        if cutoff.tzinfo is not None:
+            index_range = index_range.tz_localize(cutoff.tzinfo)
         # index_range will convert the indices to the date format of cutoff
 
         y_raw = _create_fcst_df(index_range, self._y)
@@ -869,6 +871,8 @@ class _RecursiveReducer(_Reducer):
             fh_max = fh.to_relative(self.cutoff)[-1]
             relative = pd.Index(list(map(int, range(1, fh_max + 1))))
             index_range = _index_range(relative, self.cutoff)
+            if self.cutoff.tzinfo is not None:
+                index_range = index_range.tz_localize(self.cutoff.tzinfo)
 
             y_pred = _create_fcst_df(index_range, self._y)
 

--- a/sktime/forecasting/compose/tests/test_reduce_global.py
+++ b/sktime/forecasting/compose/tests/test_reduce_global.py
@@ -21,7 +21,7 @@ from sklearn.ensemble import (
 from sklearn.linear_model import LinearRegression
 from sklearn.pipeline import make_pipeline
 
-from sktime.datasets import load_airline
+from sktime.datasets import load_airline, load_solar
 from sktime.datatypes import get_examples
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.compose import make_reduction
@@ -358,3 +358,30 @@ def test_nofreq_pass():
     np.testing.assert_almost_equal(
         y_pred_global["c0"].values, y_pred_nofreq["c0"].values
     )
+
+
+def test_timezoneaware_index():
+    y = load_solar(api_version=None)
+    y_notz = y.copy().tz_localize(None)
+
+    window_trafo = WindowSummarizer(n_jobs=1, **{"lag_feature": {"lag": [1, 2, 48]}})
+    regressor = LinearRegression()
+    forecaster = make_reduction(
+        estimator=regressor,
+        strategy="recursive",
+        transformers=[window_trafo],
+        window_length=None,
+        pooling="global",
+    )
+
+    # check coefficients
+    tzaware = forecaster.clone().fit(y).get_fitted_params()["estimator__coef"]
+    tznaive = forecaster.clone().fit(y_notz).get_fitted_params()["estimator__coef"]
+    np.testing.assert_almost_equal(tzaware, tznaive)
+
+    fh = np.arange(1, 97)
+    pred_tzaware = forecaster.clone().fit_predict(y, fh=fh)
+    pred_tznaive = forecaster.clone().fit_predict(y_notz, fh=fh)
+
+    # These should give us identical predictions
+    np.testing.assert_almost_equal(pred_tzaware.values, pred_tznaive.values)


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->

Fixes #5463  

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Added
- the time zone info (if present) after the index range is calculated in `_get_shifted_window()` and `_predict_last_window()`
- a test for the bug

#### Does your contribution introduce a new dependency? If yes, which one?

No

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

Yes

