### PR TITLE
[DOC] streamlining API reference, fixing minor issues

### DIFF
--- a/docs/source/api_reference/dists_kernels.rst
+++ b/docs/source/api_reference/dists_kernels.rst
@@ -10,7 +10,7 @@ Distances and kernel functions are treated the same, as they have the same forma
 
 Below, we list separately pairwise transformers for time series, and pairwise transformers for tabular data.
 
-.. automodule:: sktime.dists_kernels
+.. autosummary:: sktime.dists_kernels
    :no-members:
    :no-inherited-members:
 
@@ -24,7 +24,7 @@ Standalone, performant ``numba`` distance functions are available in the :mod:`s
 These are not wrapped in the ``sktime`` ``BaseObject`` interface and can therefore
 be used within other ``numba`` compiled functions for end-to-end compilation.
 
-.. automodule:: sktime.distances
+.. autosummary:: sktime.distances
    :no-members:
    :no-inherited-members:
 

--- a/docs/source/api_reference/dists_kernels.rst
+++ b/docs/source/api_reference/dists_kernels.rst
@@ -10,10 +10,6 @@ Distances and kernel functions are treated the same, as they have the same forma
 
 Below, we list separately pairwise transformers for time series, and pairwise transformers for tabular data.
 
-.. autosummary:: sktime.dists_kernels
-   :no-members:
-   :no-inherited-members:
-
 All time series distances and kernels in ``sktime`` can be listed using the ``sktime.registry.all_estimators`` utility,
 using ``estimator_types="transformer-pairwise-panel"``, optionally filtered by tags.
 Valid tags can be listed using ``sktime.registry.all_tags``.
@@ -23,10 +19,6 @@ Distances and kernels for vector-valued features can be listed using ``estimator
 Standalone, performant ``numba`` distance functions are available in the :mod:`sktime.distance` module.
 These are not wrapped in the ``sktime`` ``BaseObject`` interface and can therefore
 be used within other ``numba`` compiled functions for end-to-end compilation.
-
-.. autosummary:: sktime.distances
-   :no-members:
-   :no-inherited-members:
 
 Time series distances/kernels
 -----------------------------

--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -6,10 +6,6 @@ Time series transformations
 The :mod:`sktime.transformations` module contains classes for data
 transformations.
 
-.. automodule:: sktime.transformations
-   :no-members:
-   :no-inherited-members:
-
 All (simple) transformers in ``sktime`` can be listed using the ``sktime.registry.all_estimators`` utility,
 using ``estimator_types="regressor"``, optionally filtered by tags.
 Valid tags can be listed using ``sktime.registry.all_tags``.

--- a/sktime/dists_kernels/dtw/_dtw_tslearn.py
+++ b/sktime/dists_kernels/dtw/_dtw_tslearn.py
@@ -101,7 +101,7 @@ class DtwDistTslearn(_TslearnPwTrafoAdapter, BasePairwiseTransformerPanel):
 
 
 class SoftDtwDistTslearn(_TslearnPwTrafoAdapter, BasePairwiseTransformerPanel):
-    """Dynamic time warping distance, from tslearn.
+    """Soft dynamic time warping distance, from tslearn.
 
     Direct interface to ``tslearn.metrics.cdist_soft_dtw`` and
     ``tslearn.metrics.cdist_soft_dtw_normalized``.

--- a/sktime/dists_kernels/signature_kernel.py
+++ b/sktime/dists_kernels/signature_kernel.py
@@ -867,7 +867,7 @@ class SeqKernelizer(BaseEstimator, TransformerMixin):
 
 
 class SignatureKernel(BasePairwiseTransformerPanel):
-    """Compute the sequential kernel matrix row features on collection of series.
+    """Time series signature kernel, including high-order and low-rank variants.
 
     Implements the signature kernel of Kiraly et al, see [1]_ and [2]_,
     including higher-order and low-rank approximation variants described therein.


### PR DESCRIPTION
This PR makes some minor improvements to the API reference and fixes issues:

* making estimator mini-summaries consistent and meaningful
* removing `automodule` statements, as it would produce not a link but a confusing contextless abstract