### PR TITLE
[BUG] fix bug in deprecation logic of `kwargs` in `evaluate` that always set backend to `dask_lazy`

### DIFF
--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -527,7 +527,6 @@ def evaluate(
             DeprecationWarning,
             stacklevel=2,
         )
-        backend = "dask_lazy"
 
     # todo 0.25.0: remove compute argument and logic, and remove this warning
     if compute is not None:
@@ -646,6 +645,7 @@ def evaluate(
             backend_params=backend_params,
         )
 
+    print(backend)
     # final formatting of dask dataframes
     if backend in ["dask", "dask_lazy"] and not not_parallel:
         import dask.dataframe as dd


### PR DESCRIPTION
A buggy line in `evaluate` (benchmarking utility) would set the parallel backend to `dask_lazy` whenever deprecated `kwargs` were passed.

This fixes #5456.