### PR TITLE
[BUG] fix test excepts for `SignatureTransformer`

### DIFF
--- a/sktime/transformations/panel/signature_based/tests/test_method.py
+++ b/sktime/transformations/panel/signature_based/tests/test_method.py
@@ -3,13 +3,13 @@
 import numpy as np
 import pytest
 
+from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.panel.signature_based import SignatureTransformer
-from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("esig", severity="none"),
-    reason="skip test if required soft dependency esig not available",
+    not run_test_for_class(SignatureTransformer),
+    reason="skip test if python environment requirements for estimator are not met",
 )
 def test_generalised_signature_method():
     """Check that dimension and dim of output are correct."""
@@ -41,8 +41,8 @@ def test_generalised_signature_method():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("esig", severity="none"),
-    reason="skip test if required soft dependency esig not available",
+    not run_test_for_class(SignatureTransformer),
+    reason="skip test if python environment requirements for estimator are not met",
 )
 def test_window_error():
     """Test that wrong window parameters raise error."""


### PR DESCRIPTION
The test execution conditions for the estimator specific tests of `SignatureTransformer` were checking presence of `esig` rather than full environment compatibility.

This could lead to an unexpected test failure under the condition that `esig` was present but the more restrictive conditions required by `SignatureTransformer` were not satisfied.

This is fixed by checking the latter and not the former.