### PR TITLE
[ENH] in `mlflow` plugin, improve informativity of `ModuleNotFoundError` messages

### DIFF
--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -52,9 +52,12 @@ import yaml
 import sktime
 from sktime import utils
 from sktime.utils.multiindex import flatten_multiindex
-from sktime.utils.validation._dependencies import _check_soft_dependencies
+from sktime.utils.validation._dependencies import (
+    _check_mlflow_dependencies,
+    _check_soft_dependencies,
+)
 
-if _check_soft_dependencies("mlflow", severity="warning"):
+if _check_mlflow_dependencies(severity="warning"):
     from mlflow import pyfunc
 
 FLAVOR_NAME = "mlflow_sktime"
@@ -93,7 +96,7 @@ def get_default_pip_requirements(include_cloudpickle=False):
     Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
     that, at a minimum, contains these requirements.
     """
-    _check_soft_dependencies("mlflow", severity="error")
+    _check_mlflow_dependencies(severity="error")
     from mlflow.utils.requirements_utils import _get_pinned_requirement
 
     pip_deps = [_get_pinned_requirement("sktime")]
@@ -111,7 +114,7 @@ def get_default_conda_env(include_cloudpickle=False):
     The default Conda environment for MLflow Models produced by calls to
     :func:`save_model()` and :func:`log_model()`
     """
-    _check_soft_dependencies("mlflow", severity="error")
+    _check_mlflow_dependencies(severity="error")
     from mlflow.utils.environment import _mlflow_conda_env
 
     return _mlflow_conda_env(
@@ -211,7 +214,7 @@ def save_model(
     >>> loaded_model = mlflow_sktime.load_model(model_uri=model_path)  # doctest: +SKIP
     >>> loaded_model.predict(fh=[1, 2, 3])  # doctest: +SKIP
     """  # noqa: E501
-    _check_soft_dependencies("mlflow", severity="error")
+    _check_mlflow_dependencies(severity="error")
     from mlflow.exceptions import MlflowException
     from mlflow.models import Model
     from mlflow.models.model import MLMODEL_FILE_NAME
@@ -420,7 +423,7 @@ def log_model(
     ...     sktime_model=forecaster,
     ...     artifact_path=artifact_path)  # doctest: +SKIP
     """  # noqa: E501
-    _check_soft_dependencies("mlflow", severity="error")
+    _check_mlflow_dependencies(severity="error")
     from mlflow.models import Model
 
     if await_registration_for is None:
@@ -493,7 +496,7 @@ def load_model(model_uri, dst_path=None):
     ...     path=model_path)
     >>> loaded_model = mlflow_sktime.load_model(model_uri=model_path)  # doctest: +SKIP
     """  # noqa: E501
-    _check_soft_dependencies("mlflow", severity="error")
+    _check_mlflow_dependencies(severity="error")
     from mlflow.tracking.artifact_utils import _download_artifact_from_uri
     from mlflow.utils.model_utils import (
         _add_code_from_conf_to_system_path,
@@ -519,7 +522,7 @@ def load_model(model_uri, dst_path=None):
 
 
 def _save_model(model, path, serialization_format):
-    _check_soft_dependencies("mlflow", severity="error")
+    _check_mlflow_dependencies(severity="error")
     from mlflow.exceptions import MlflowException
     from mlflow.protos.databricks_pb2 import INTERNAL_ERROR
 
@@ -542,7 +545,7 @@ def _save_model(model, path, serialization_format):
 
 
 def _load_model(path, serialization_format):
-    _check_soft_dependencies("mlflow", severity="error")
+    _check_mlflow_dependencies(severity="error")
     from mlflow.exceptions import MlflowException
     from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
@@ -585,7 +588,7 @@ def _load_pyfunc(path):
     ----------
     .. [1] https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.load_model
     """  # noqa: E501
-    _check_soft_dependencies("mlflow", severity="error")
+    _check_mlflow_dependencies(severity="error")
     from mlflow.exceptions import MlflowException
     from mlflow.utils.model_utils import _get_flavor_configuration
 
@@ -621,7 +624,7 @@ def _load_pyfunc(path):
 
 class _SktimeModelWrapper:
     def __init__(self, sktime_model):
-        _check_soft_dependencies("mlflow", severity="error")
+        _check_mlflow_dependencies(severity="error")
         self.sktime_model = sktime_model
 
     def predict(self, X):

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -50,7 +50,7 @@ def mock_s3_bucket():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.fixture
@@ -94,7 +94,7 @@ def naive_forecaster_model_with_regressor(test_data_longley):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("serialization_format", ["pickle", "cloudpickle"])
@@ -117,7 +117,7 @@ def test_auto_arima_model_save_and_load(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("serialization_format", ["pickle", "cloudpickle"])
@@ -169,7 +169,7 @@ def test_auto_arima_model_pyfunc_output(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_auto_arima_model_pyfunc_with_params_output(auto_arima_model, model_path):
@@ -223,7 +223,7 @@ def test_auto_arima_model_pyfunc_with_params_output(auto_arima_model, model_path
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_auto_arima_model_pyfunc_without_params_output(auto_arima_model, model_path):
@@ -277,7 +277,7 @@ def test_auto_arima_model_pyfunc_without_params_output(auto_arima_model, model_p
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_auto_arima_model_pyfunc_without_conf_output(auto_arima_model, model_path):
@@ -300,7 +300,7 @@ def test_auto_arima_model_pyfunc_without_conf_output(auto_arima_model, model_pat
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_naive_forecaster_model_with_regressor_pyfunc_output(
@@ -355,7 +355,7 @@ def test_naive_forecaster_model_with_regressor_pyfunc_output(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("use_signature", [True, False])
@@ -390,7 +390,7 @@ def test_signature_and_examples_saved_correctly(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("use_signature", [True, False])
@@ -413,7 +413,7 @@ def test_predict_var_signature_saved_correctly(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("use_signature", [True, False])
@@ -461,7 +461,7 @@ def test_signature_and_example_for_pyfunc_predict(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_load_from_remote_uri_succeeds(auto_arima_model, model_path, mock_s3_bucket):
@@ -487,7 +487,7 @@ def test_load_from_remote_uri_succeeds(auto_arima_model, model_path, mock_s3_buc
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("should_start_run", [True, False])
@@ -531,7 +531,7 @@ def test_log_model(auto_arima_model, tmp_path, should_start_run, serialization_f
 
 @pytest.mark.xfail(reason="known failure to be debugged, see #4904")
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_log_model_calls_register_model(auto_arima_model, tmp_path):
@@ -562,7 +562,7 @@ def test_log_model_calls_register_model(auto_arima_model, tmp_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_log_model_no_registered_model_name(auto_arima_model, tmp_path):
@@ -586,7 +586,7 @@ def test_log_model_no_registered_model_name(auto_arima_model, tmp_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_raises_invalid_attribute_type(auto_arima_model, model_path):
@@ -607,7 +607,7 @@ def test_pyfunc_raises_invalid_attribute_type(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_raises_invalid_dict_key(auto_arima_model, model_path):
@@ -628,7 +628,7 @@ def test_pyfunc_raises_invalid_dict_key(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_raises_invalid_dict_value_type(auto_arima_model, model_path):
@@ -648,7 +648,7 @@ def test_pyfunc_raises_invalid_dict_value_type(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_raises_invalid_dict_value(auto_arima_model, model_path):
@@ -669,7 +669,7 @@ def test_pyfunc_raises_invalid_dict_value(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_predict_proba_raises_invalid_attribute_type(
@@ -693,7 +693,7 @@ def test_pyfunc_predict_proba_raises_invalid_attribute_type(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(severity="none"),
+    not _check_soft_dependencies("mlflow", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_predict_proba_raises_invalid_dict_value(auto_arima_model, model_path):

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -16,14 +16,9 @@ from sktime.forecasting.arima import AutoARIMA
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.split import temporal_train_test_split
 from sktime.utils.multiindex import flatten_multiindex
-from sktime.utils.validation._dependencies import (
-    _check_mlflow_dependencies,
-    _check_soft_dependencies,
-)
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-if _check_mlflow_dependencies(severity="none") and _check_soft_dependencies(
-    "boto3", "moto", "botocore", severity="none"
-):
+if _check_soft_dependencies("mlflow", "boto3", "moto", "botocore", severity="none"):
     import boto3
     import moto
     from botocore.config import Config
@@ -55,7 +50,7 @@ def mock_s3_bucket():
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.fixture
@@ -99,7 +94,7 @@ def naive_forecaster_model_with_regressor(test_data_longley):
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("serialization_format", ["pickle", "cloudpickle"])
@@ -122,7 +117,7 @@ def test_auto_arima_model_save_and_load(
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("serialization_format", ["pickle", "cloudpickle"])
@@ -174,7 +169,7 @@ def test_auto_arima_model_pyfunc_output(
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_auto_arima_model_pyfunc_with_params_output(auto_arima_model, model_path):
@@ -228,7 +223,7 @@ def test_auto_arima_model_pyfunc_with_params_output(auto_arima_model, model_path
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_auto_arima_model_pyfunc_without_params_output(auto_arima_model, model_path):
@@ -282,7 +277,7 @@ def test_auto_arima_model_pyfunc_without_params_output(auto_arima_model, model_p
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_auto_arima_model_pyfunc_without_conf_output(auto_arima_model, model_path):
@@ -305,7 +300,7 @@ def test_auto_arima_model_pyfunc_without_conf_output(auto_arima_model, model_pat
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_naive_forecaster_model_with_regressor_pyfunc_output(
@@ -360,7 +355,7 @@ def test_naive_forecaster_model_with_regressor_pyfunc_output(
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("use_signature", [True, False])
@@ -395,7 +390,7 @@ def test_signature_and_examples_saved_correctly(
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("use_signature", [True, False])
@@ -418,7 +413,7 @@ def test_predict_var_signature_saved_correctly(
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("use_signature", [True, False])
@@ -466,7 +461,7 @@ def test_signature_and_example_for_pyfunc_predict(
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_load_from_remote_uri_succeeds(auto_arima_model, model_path, mock_s3_bucket):
@@ -492,7 +487,7 @@ def test_load_from_remote_uri_succeeds(auto_arima_model, model_path, mock_s3_buc
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("should_start_run", [True, False])
@@ -536,7 +531,7 @@ def test_log_model(auto_arima_model, tmp_path, should_start_run, serialization_f
 
 @pytest.mark.xfail(reason="known failure to be debugged, see #4904")
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_log_model_calls_register_model(auto_arima_model, tmp_path):
@@ -567,7 +562,7 @@ def test_log_model_calls_register_model(auto_arima_model, tmp_path):
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_log_model_no_registered_model_name(auto_arima_model, tmp_path):
@@ -591,7 +586,7 @@ def test_log_model_no_registered_model_name(auto_arima_model, tmp_path):
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_raises_invalid_attribute_type(auto_arima_model, model_path):
@@ -612,7 +607,7 @@ def test_pyfunc_raises_invalid_attribute_type(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_raises_invalid_dict_key(auto_arima_model, model_path):
@@ -633,7 +628,7 @@ def test_pyfunc_raises_invalid_dict_key(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_raises_invalid_dict_value_type(auto_arima_model, model_path):
@@ -653,7 +648,7 @@ def test_pyfunc_raises_invalid_dict_value_type(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_raises_invalid_dict_value(auto_arima_model, model_path):
@@ -674,7 +669,7 @@ def test_pyfunc_raises_invalid_dict_value(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_predict_proba_raises_invalid_attribute_type(
@@ -698,7 +693,7 @@ def test_pyfunc_predict_proba_raises_invalid_attribute_type(
 
 
 @pytest.mark.skipif(
-    not _check_mlflow_dependencies(severity="none"),
+    not _check_soft_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_predict_proba_raises_invalid_dict_value(auto_arima_model, model_path):

--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -16,9 +16,14 @@ from sktime.forecasting.arima import AutoARIMA
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.split import temporal_train_test_split
 from sktime.utils.multiindex import flatten_multiindex
-from sktime.utils.validation._dependencies import _check_soft_dependencies
+from sktime.utils.validation._dependencies import (
+    _check_mlflow_dependencies,
+    _check_soft_dependencies,
+)
 
-if _check_soft_dependencies("mlflow", "boto3", "moto", "botocore", severity="none"):
+if _check_mlflow_dependencies(severity="none") and _check_soft_dependencies(
+    "boto3", "moto", "botocore", severity="none"
+):
     import boto3
     import moto
     from botocore.config import Config
@@ -50,7 +55,7 @@ def mock_s3_bucket():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.fixture
@@ -94,7 +99,7 @@ def naive_forecaster_model_with_regressor(test_data_longley):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("serialization_format", ["pickle", "cloudpickle"])
@@ -117,7 +122,7 @@ def test_auto_arima_model_save_and_load(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("serialization_format", ["pickle", "cloudpickle"])
@@ -169,7 +174,7 @@ def test_auto_arima_model_pyfunc_output(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_auto_arima_model_pyfunc_with_params_output(auto_arima_model, model_path):
@@ -223,7 +228,7 @@ def test_auto_arima_model_pyfunc_with_params_output(auto_arima_model, model_path
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_auto_arima_model_pyfunc_without_params_output(auto_arima_model, model_path):
@@ -277,7 +282,7 @@ def test_auto_arima_model_pyfunc_without_params_output(auto_arima_model, model_p
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_auto_arima_model_pyfunc_without_conf_output(auto_arima_model, model_path):
@@ -300,7 +305,7 @@ def test_auto_arima_model_pyfunc_without_conf_output(auto_arima_model, model_pat
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_naive_forecaster_model_with_regressor_pyfunc_output(
@@ -355,7 +360,7 @@ def test_naive_forecaster_model_with_regressor_pyfunc_output(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("use_signature", [True, False])
@@ -390,7 +395,7 @@ def test_signature_and_examples_saved_correctly(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("use_signature", [True, False])
@@ -413,7 +418,7 @@ def test_predict_var_signature_saved_correctly(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("use_signature", [True, False])
@@ -461,7 +466,7 @@ def test_signature_and_example_for_pyfunc_predict(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_load_from_remote_uri_succeeds(auto_arima_model, model_path, mock_s3_bucket):
@@ -487,7 +492,7 @@ def test_load_from_remote_uri_succeeds(auto_arima_model, model_path, mock_s3_buc
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("should_start_run", [True, False])
@@ -531,7 +536,7 @@ def test_log_model(auto_arima_model, tmp_path, should_start_run, serialization_f
 
 @pytest.mark.xfail(reason="known failure to be debugged, see #4904")
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_log_model_calls_register_model(auto_arima_model, tmp_path):
@@ -562,7 +567,7 @@ def test_log_model_calls_register_model(auto_arima_model, tmp_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_log_model_no_registered_model_name(auto_arima_model, tmp_path):
@@ -586,7 +591,7 @@ def test_log_model_no_registered_model_name(auto_arima_model, tmp_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_raises_invalid_attribute_type(auto_arima_model, model_path):
@@ -607,7 +612,7 @@ def test_pyfunc_raises_invalid_attribute_type(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_raises_invalid_dict_key(auto_arima_model, model_path):
@@ -628,7 +633,7 @@ def test_pyfunc_raises_invalid_dict_key(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_raises_invalid_dict_value_type(auto_arima_model, model_path):
@@ -648,7 +653,7 @@ def test_pyfunc_raises_invalid_dict_value_type(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_raises_invalid_dict_value(auto_arima_model, model_path):
@@ -669,7 +674,7 @@ def test_pyfunc_raises_invalid_dict_value(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_predict_proba_raises_invalid_attribute_type(
@@ -693,7 +698,7 @@ def test_pyfunc_predict_proba_raises_invalid_attribute_type(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
+    not _check_mlflow_dependencies(severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_pyfunc_predict_proba_raises_invalid_dict_value(auto_arima_model, model_path):

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -40,7 +40,7 @@ def _check_soft_dependencies(
         should be provided if import name differs from package name
     severity : str, "error" (default), "warning", "none"
         behaviour for raising errors or warnings
-        "error" - raises a `ModuleNotFoundException` if one of packages is not installed
+        "error" - raises a `ModuleNotFoundError` if one of packages is not installed
         "warning" - raises a warning if one of packages is not installed
             function returns False if one of packages is not installed, otherwise True
         "none" - does not raise exception or warning
@@ -216,7 +216,7 @@ def _check_dl_dependencies(msg=None, severity="error"):
         error message to be returned in the `ModuleNotFoundError`, overrides default
     severity : str, "error" (default), "warning", "none"
         behaviour for raising errors or warnings
-        "error" - raises a ModuleNotFoundException if one of packages is not installed
+        "error" - raises a ModuleNotFoundError if one of packages is not installed
         "warning" - raises a warning if one of packages is not installed
             function returns False if one of packages is not installed, otherwise True
         "none" - does not raise exception or warning
@@ -257,7 +257,30 @@ def _check_dl_dependencies(msg=None, severity="error"):
 def _check_mlflow_dependencies(
     msg=None, severity="error", suppress_import_stdout=False
 ):
-    """Check if `mlflow` is installed."""
+    """Check if `mlflow` and its dependencies are installed.
+
+    Parameters
+    ----------
+    msg: str, optional, default= default message (msg below)
+        error message to be returned when `ModuleNotFoundError` is raised.
+    severity: str, either of "error", "warning" or "none"
+        behaviour for raising errors or warnings
+        "error" - raises a `ModuleNotFound` if mlflow-related packages are not found.
+        "warning" - raises a warning message if any mlflow-related package is not
+            installed also returns False. In case all packages are present,
+            returns True.
+        "none" - does not raise any exception or warning and simply returns True
+            if all packages are installed otherwise return False.
+
+    Raise
+    -----
+    ModuleNotFoundError
+        User Friendly error with a suggested action to install mlflow dependencies
+
+    Returns
+    -------
+    boolean - whether all mlflow-related packages are installed.
+    """
     if not isinstance(msg, str):
         msg = (
             "`mlflow` is an extra dependency and is not included "
@@ -363,7 +386,7 @@ def _check_estimator_deps(obj, msg=None, severity="error"):
         error message to be returned in the `ModuleNotFoundError`, overrides default
     severity : str, "error" (default), "warning", or "none"
         behaviour for raising errors or warnings
-        "error" - raises a ModuleNotFoundException if environment is incompatible
+        "error" - raises a `ModuleNotFoundError` if environment is incompatible
         "warning" - raises a warning if environment is incompatible
             function returns False if environment is incompatible, otherwise True
         "none" - does not raise exception or warning

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -138,17 +138,7 @@ def _check_soft_dependencies(
                 pkg_ref = import_module(package_import_name)
         # if package cannot be imported, make the user aware of installation requirement
         except ModuleNotFoundError as e:
-            # Handle mlflow differently since it is not included with other soft
-            # dependencies hence should be treated as an extra dependency
-            if package == "mlflow":
-                if msg is None:
-                    msg = (
-                        f"{e}. `mlflow` is an extra dependency and is not included "
-                        "in the base sktime installation. "
-                        "Please run `pip install mlflow` "
-                        "or `pip install sktime[mlflow]` to install the package."
-                    )
-            elif obj is None and msg is None:
+            if obj is None and msg is None:
                 msg = (
                     f"{e}. '{package}' is a soft dependency and not included in the "
                     f"base sktime installation. Please run: `pip install {package}` to "
@@ -262,6 +252,26 @@ def _check_dl_dependencies(msg=None, severity="error"):
                 "Error in calling _check_dl_dependencies, severity "
                 f'argument must be "error", "warning", or "none", found "{severity}".'
             )
+
+
+def _check_mlflow_dependencies(
+    msg=None, severity="error", suppress_import_stdout=False
+):
+    """Check if `mlflow` is installed."""
+    if not isinstance(msg, str):
+        msg = (
+            "`mlflow` is an extra dependency and is not included "
+            "in the base sktime installation. "
+            "Please run `pip install mlflow` "
+            "or `pip install sktime[mlflow]` to install the package."
+        )
+
+        return _check_soft_dependencies(
+            "mlflow",
+            msg=msg,
+            severity=severity,
+            suppress_import_stdout=suppress_import_stdout,
+        )
 
 
 def _check_python_version(obj, package=None, msg=None, severity="error"):

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -289,12 +289,12 @@ def _check_mlflow_dependencies(
             "or `pip install sktime[mlflow]` to install the package."
         )
 
-        return _check_soft_dependencies(
-            "mlflow",
-            msg=msg,
-            severity=severity,
-            suppress_import_stdout=suppress_import_stdout,
-        )
+    return _check_soft_dependencies(
+        "mlflow",
+        msg=msg,
+        severity=severity,
+        suppress_import_stdout=suppress_import_stdout,
+    )
 
 
 def _check_python_version(obj, package=None, msg=None, severity="error"):

--- a/sktime/utils/validation/_dependencies.py
+++ b/sktime/utils/validation/_dependencies.py
@@ -138,7 +138,17 @@ def _check_soft_dependencies(
                 pkg_ref = import_module(package_import_name)
         # if package cannot be imported, make the user aware of installation requirement
         except ModuleNotFoundError as e:
-            if obj is None and msg is None:
+            # Handle mlflow differently since it is not included with other soft
+            # dependencies hence should be treated as an extra dependency
+            if package == "mlflow":
+                if msg is None:
+                    msg = (
+                        f"{e}. `mlflow` is an extra dependency and is not included "
+                        "in the base sktime installation. "
+                        "Please run `pip install mlflow` "
+                        "or `pip install sktime[mlflow]` to install the package."
+                    )
+            elif obj is None and msg is None:
                 msg = (
                     f"{e}. '{package}' is a soft dependency and not included in the "
                     f"base sktime installation. Please run: `pip install {package}` to "


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
Fixes #5417

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
I believe the original `ModuleNotFoundError` message was not accurate for `mlflow` since the error it gave made it seem like `mlflow` can be installed in the soft-dependencies bundle. I've added a more accurate message that points the user to use `pip install sktime[mlflow]`.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
