### PR TITLE
[BUG] fix `plot_series` prediction interval plotting for 3 or less points in forecasting horizon

### DIFF
--- a/sktime/utils/plotting.py
+++ b/sktime/utils/plotting.py
@@ -176,20 +176,27 @@ def plot_series(
         ax.legend()
     if pred_interval is not None:
         check_interval_df(pred_interval, series[-1].index)
-        ax = plot_interval(ax, pred_interval)
+        ax = plot_interval(ax, pred_interval, index)
     if _ax_kwarg_is_none:
         return fig, ax
     else:
         return ax
 
 
-def plot_interval(ax, interval_df):
+def plot_interval(ax, interval_df, ix=None):
     cov = interval_df.columns.levels[1][0]
     var_name = interval_df.columns.levels[0][0]
+    print(ix)
+    x_ix = np.argwhere(ix.isin(interval_df.index)).ravel()
+    x_ix = np.array(x_ix)
+
+    print(x_ix)
+
     ax.fill_between(
-        ax.get_lines()[-1].get_xdata(),
-        interval_df[var_name][cov]["lower"].astype("float64"),
-        interval_df[var_name][cov]["upper"].astype("float64"),
+        # ax.get_lines()[-1].get_xdata()[-3:],
+        x_ix,
+        interval_df[var_name][cov]["lower"].astype("float64").to_numpy(),
+        interval_df[var_name][cov]["upper"].astype("float64").to_numpy(),
         alpha=0.2,
         color=ax.get_lines()[-1].get_c(),
         label=f"{int(cov * 100)}% prediction interval",

--- a/sktime/utils/plotting.py
+++ b/sktime/utils/plotting.py
@@ -186,14 +186,10 @@ def plot_series(
 def plot_interval(ax, interval_df, ix=None):
     cov = interval_df.columns.levels[1][0]
     var_name = interval_df.columns.levels[0][0]
-    print(ix)
     x_ix = np.argwhere(ix.isin(interval_df.index)).ravel()
     x_ix = np.array(x_ix)
 
-    print(x_ix)
-
     ax.fill_between(
-        # ax.get_lines()[-1].get_xdata()[-3:],
         x_ix,
         interval_df[var_name][cov]["lower"].astype("float64").to_numpy(),
         interval_df[var_name][cov]["upper"].astype("float64").to_numpy(),

--- a/sktime/utils/tests/test_plotting.py
+++ b/sktime/utils/tests/test_plotting.py
@@ -244,6 +244,28 @@ def test_plot_series_uniform_treatment_of_int64_range_index_types():
     plt.close()
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(plot_series),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.skipif(
+    not _check_soft_dependencies("matplotlib", severity="none"),
+    reason="skip test if required soft dependency for matplotlib not available",
+)
+def test_plot_series_interval():
+    """Test prediction interval plotting functionality in plot_series."""
+    from sktime.forecasting.base import ForecastingHorizon
+    from sktime.forecasting.naive import NaiveForecaster
+
+    model = NaiveForecaster()
+    y = load_airline()
+    model.fit(y[:-3])
+    fh = ForecastingHorizon(y[-3:].index, is_relative=False)
+    pred = model.predict(fh)
+    interval = model.predict_interval(fh)
+    plot_series(y[:-3], y[-3:], pred, pred_interval=interval)
+
+
 # Generically test whether plots only accepting univariate input run
 @pytest.mark.skipif(
     not run_test_for_class(univariate_plots),


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/5493.

The deeper reason was that the `plot_interval` logic seemed broken, it is unclear why it was working at all even in the case of 4 or more points. Possibly some fallback functionality in `numpy` which was kicking in, e.g., using the last indices if broadcast sizes do not match.

Also adds a test with the failure case from #5493.