### PR TITLE
[MNT] address deprecation of `pd.DataFrame.fillna` with `method` arg

### DIFF
--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -348,7 +348,7 @@ class NaiveForecaster(_BaseWindowForecaster):
             y_old = lagger.fit_transform(_y)
             y_new = pd.DataFrame(index=expected_index, columns=[0], dtype="float64")
             full_y = pd.concat([y_old, y_new], keys=["a", "b"]).sort_index(level=-1)
-            y_filled = full_y.fillna(method="ffill").fillna(method="bfill")
+            y_filled = full_y.ffill().bfill()
             # subset to rows that contain elements we wanted to fill
             y_pred = y_filled.loc["b"]
             # convert to pd.Series from pd.DataFrame
@@ -361,7 +361,7 @@ class NaiveForecaster(_BaseWindowForecaster):
             y_new_mask = pd.Series(index=expected_index, dtype="float64")
             y_new = _pivot_sp(y_new_mask, sp, anchor=_y, anchor_side="end")
             full_y = pd.concat([y_old, y_new], keys=["a", "b"]).sort_index(level=-1)
-            y_filled = full_y.fillna(method="ffill").fillna(method="bfill")
+            y_filled = full_y.ffill().bfill()
             # subset to rows that contain elements we wanted to fill
             y_pred = y_filled.loc["b"]
             # reformat to wide

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -220,13 +220,13 @@ class Imputer(BaseTransformer):
             X_grouped = X.groupby(level=list(range(index.nlevels - 1)))
 
             if self.method in ["backfill", "bfill"]:
-                X = X_grouped.fillna(method="bfill")
+                X = X_grouped.bfill()
                 # fill trailing NAs of panel instances with reverse method
-                return X.fillna(method="ffill")
+                return X.ffill()
             elif self.method in ["pad", "ffill"]:
-                X = X_grouped.fillna(method="ffill")
+                X = X_grouped.ffill()
                 # fill leading NAs of panel instances with reverse method
-                return X.fillna(method="bfill")
+                return X.bfill()
             elif self.method == "mean":
                 return X_grouped.fillna(value=self._mean)
             elif self.method == "median":
@@ -234,8 +234,10 @@ class Imputer(BaseTransformer):
             else:
                 raise AssertionError("Code should not be reached")
         else:
-            if self.method in ["backfill", "bfill", "pad", "ffill"]:
-                X = X.fillna(method=self.method)
+            if self.method in ["backfill", "bfill"]:
+                X = X.bfill()
+            elif self.method in ["pad", "ffill"]:
+                X = X.ffill()
             elif self.method == "drift":
                 X = self._impute_with_forecaster(X, y)
             elif self.method == "forecaster":
@@ -251,7 +253,7 @@ class Imputer(BaseTransformer):
 
             # fill first/last elements of series,
             # as some methods (e.g. "linear") can't impute those
-            X = X.fillna(method="ffill").fillna(method="backfill")
+            X = X.ffill().bfill()
 
             return X
 
@@ -344,8 +346,8 @@ class Imputer(BaseTransformer):
                 # fill NaN before fitting with ffill and backfill (heuristic)
 
                 self._forecaster.fit(
-                    y=self._X[col].fillna(method="ffill").fillna(method="backfill"),
-                    X=self._y[col].fillna(method="ffill").fillna(method="backfill")
+                    y=self._X[col].ffill().fillna(method="backfill"),
+                    X=self._y[col].ffill().fillna(method="backfill")
                     if self._y is not None
                     else None,
                     fh=fh,

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -455,7 +455,7 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
             else:
                 feat = getattr(
                     Z.shift(lag)
-                    .fillna(method="bfill")
+                    .bfill()
                     .rolling(window=window_length, min_periods=window_length),
                     summarizer,
                 )()
@@ -474,7 +474,7 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
                 feat = Z.apply(
                     lambda x: getattr(
                         x.shift(lag)
-                        .fillna(method="bfill")
+                        .bfill()
                         .rolling(window=window_length, min_periods=window_length),
                         summarizer,
                     )()
@@ -483,7 +483,7 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
         if bfill is False:
             feat = Z.shift(lag)
         else:
-            feat = Z.shift(lag).fillna(method="bfill")
+            feat = Z.shift(lag).bfill()
         if isinstance(Z, pd.core.groupby.generic.SeriesGroupBy) and callable(
             summarizer
         ):
@@ -498,7 +498,7 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
             )
         feat = pd.DataFrame(feat)
     if bfill is True:
-        feat = feat.fillna(method="bfill")
+        feat = feat.bfill()
 
     if callable(summarizer):
         name = summarizer.__name__


### PR DESCRIPTION
`pd.DataFrame.fillna` with `method` arg is deprecated and will be removed.

This PR addresses the deprecation by replacing `fillna` with `method` arg with suitable alternatives.