### PR TITLE
[ENH] in `NaiveForecaster`, add valid variance prediction for in-sample forecasts

### DIFF
--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -553,7 +553,7 @@ class NaiveForecaster(_BaseWindowForecaster):
 
         def sqrt_flr(x):
             """Square root of x, floored at 1 - to deal with in-sample predictions."""
-            return np.sqrt(np.max(x, 1))
+            return np.sqrt(np.maximum(x, 1))
 
         # Formulas from:
         # https://otexts.com/fpp3/prediction-intervals.html (Table 5.2)

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -550,14 +550,19 @@ class NaiveForecaster(_BaseWindowForecaster):
         se_res = np.sqrt(mse_res)
 
         window_length = self.window_length or T
+
+        def sqrt_flr(x):
+            """Square root of x, floored at 1 - to deal with in-sample predictions."""
+            return np.sqrt(max(x, 1))
+
         # Formulas from:
         # https://otexts.com/fpp3/prediction-intervals.html (Table 5.2)
         partial_se_formulas = {
-            "last": lambda h: np.sqrt(h)
+            "last": sqrt_flr
             if sp == 1
-            else np.sqrt(np.floor((h - 1) / sp) + 1),
-            "mean": lambda h: np.repeat(np.sqrt(1 + (1 / window_length)), len(h)),
-            "drift": lambda h: np.sqrt(h * (1 + (h / (T - 1)))),
+            else sqrt_flr(np.floor((h - 1) / sp) + 1),
+            "mean": lambda h: np.repeat(sqrt_flr(1 + (1 / window_length)), len(h)),
+            "drift": lambda h: sqrt_flr(h * (1 + (h / (T - 1)))),
         }
 
         fh_periods = np.array(fh.to_relative(self.cutoff))

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -553,7 +553,7 @@ class NaiveForecaster(_BaseWindowForecaster):
 
         def sqrt_flr(x):
             """Square root of x, floored at 1 - to deal with in-sample predictions."""
-            return np.sqrt(max(x, 1))
+            return np.sqrt(np.max(x, 1))
 
         # Formulas from:
         # https://otexts.com/fpp3/prediction-intervals.html (Table 5.2)

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -558,7 +558,9 @@ class NaiveForecaster(_BaseWindowForecaster):
         # Formulas from:
         # https://otexts.com/fpp3/prediction-intervals.html (Table 5.2)
         partial_se_formulas = {
-            "last": sqrt_flr if sp == 1 else sqrt_flr(np.floor((h - 1) / sp) + 1),
+            "last": sqrt_flr
+            if sp == 1
+            else lambda h: sqrt_flr(np.floor((h - 1) / sp) + 1),
             "mean": lambda h: np.repeat(sqrt_flr(1 + (1 / window_length)), len(h)),
             "drift": lambda h: sqrt_flr(h * (1 + (h / (T - 1)))),
         }

--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -558,9 +558,7 @@ class NaiveForecaster(_BaseWindowForecaster):
         # Formulas from:
         # https://otexts.com/fpp3/prediction-intervals.html (Table 5.2)
         partial_se_formulas = {
-            "last": sqrt_flr
-            if sp == 1
-            else sqrt_flr(np.floor((h - 1) / sp) + 1),
+            "last": sqrt_flr if sp == 1 else sqrt_flr(np.floor((h - 1) / sp) + 1),
             "mean": lambda h: np.repeat(sqrt_flr(1 + (1 / window_length)), len(h)),
             "drift": lambda h: sqrt_flr(h * (1 + (h / (T - 1)))),
         }


### PR DESCRIPTION
This PR addresses warnings arising from testing `NaiveForecaster`, as sqrt-s of negative fh-indices are taken.

The reason for this was that the standard deviation formula was taking sqrt-s of the fh-index, so this is addressed by correcting the formula for in-sample values.

For this, the error term standard deviation is used with a multiplying factor of 1. This should be mathematically sensible, and finally silence the warning.