### PR TITLE
[MNT] address `pandas` constructor deprecation message from `ExpandingGreedySplitter`

### DIFF
--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -63,7 +63,7 @@ class ExpandingGreedySplitter(BaseSplitter):
 
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
         if isinstance(y, pd.MultiIndex):
-            groups = pd.Series(index=y).groupby(y.names[:-1])
+            groups = pd.Series(index=y, dtype="float64").groupby(y.names[:-1])
             reverse_idx = groups.transform("size") - groups.cumcount() - 1
         else:
             reverse_idx = np.arange(len(y))[::-1]


### PR DESCRIPTION
This PR addresses a `pandas` constructor deprecation message from `ExpandingGreedySplitter`, by explicitly specifying the `dtype` in the constructor.