### PR TITLE
[ENH] expected forecast prediction index utility in `ForecastingHorizon`

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -704,28 +704,33 @@ class ForecastingHorizon:
 
         if hasattr(y, "index"):
             y_index = y.index
+        elif isinstance(y, pd.Index):
+            y_index = y
+        else:
+            y_index = pd.Index(y)
 
         if cutoff is None and not isinstance(y_index, pd.MultiIndex):
             _cutoff = get_cutoff(y)
+        else:
+            _cutoff = cutoff
 
-        if cutoff is not None:
-
+        if cutoff is not None or not isinstance(y_index, pd.MultiIndex):
             fh_idx = pd.Index(self.to_absolute_index(_cutoff))
 
-            if isinstance(y_index, pd.MultiIndex):
-                y_inst_idx = y_index.droplevel(-1).unique()
-                if isinstance(y_inst_idx, pd.MultiIndex) and sort_by_time:
-                    fh_list = [x + (y,) for x in y_inst_idx for y in fh_idx]
-                elif isinstance(y_inst_idx, pd.MultiIndex) and not sort_by_time:
-                    fh_list = [x + (y,) for y in fh_idx for x in y_inst_idx]
-                elif sort_by_time:  # and not isinstance(y_inst_idx, pd.MultiIndex):
-                    fh_list = [(x, y) for x in y_inst_idx for y in fh_idx]
-                else:  # not sort_by_time and not isinstance(y_inst_idx, pd.MultiIndex):
-                    fh_list = [(x, y) for y in fh_idx for x in y_inst_idx]
+        if cutoff is not None and isinstance(y_index, pd.MultiIndex):
+            y_inst_idx = y_index.droplevel(-1).unique()
+            if isinstance(y_inst_idx, pd.MultiIndex) and sort_by_time:
+                fh_list = [x + (y,) for x in y_inst_idx for y in fh_idx]
+            elif isinstance(y_inst_idx, pd.MultiIndex) and not sort_by_time:
+                fh_list = [x + (y,) for y in fh_idx for x in y_inst_idx]
+            elif sort_by_time:  # and not isinstance(y_inst_idx, pd.MultiIndex):
+                fh_list = [(x, y) for x in y_inst_idx for y in fh_idx]
+            else:  # not sort_by_time and not isinstance(y_inst_idx, pd.MultiIndex):
+                fh_list = [(x, y) for y in fh_idx for x in y_inst_idx]
 
-                fh_idx = pd.Index(fh_list)
+            fh_idx = pd.Index(fh_list)
 
-        else:  # cutoff is None and isinstance(y_index, pd.MultiIndex)
+        elif isinstance(y_index, pd.MultiIndex):
 
             y_inst_idx = y_index.droplevel(-1).unique()
 

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -706,8 +706,10 @@ class ForecastingHorizon:
             y_index = y.index
         elif isinstance(y, pd.Index):
             y_index = y
+            y = pd.DataFrame(index=y_index)
         else:
             y_index = pd.Index(y)
+            y = pd.DataFrame(index=y_index)
 
         if cutoff is None and not isinstance(y_index, pd.MultiIndex):
             _cutoff = get_cutoff(y)
@@ -735,14 +737,15 @@ class ForecastingHorizon:
             y_inst_idx = y_index.droplevel(-1).unique()
 
             if isinstance(y_inst_idx, pd.MultiIndex):
-                fh_list = [x + (y,) for x in y_inst_idx for y in _make_y_pred(x)]
+                fh_list = [x + (z,) for x in y_inst_idx for z in _make_y_pred(y.loc[x])]
             else:
-                fh_list = [(x, y) for x in y_inst_idx for y in _make_y_pred(x)]
+                fh_list = [(x, z) for x in y_inst_idx for z in _make_y_pred(y.loc[x])]
 
             fh_idx = pd.Index(fh_list)
 
-            if not sort_by_time:
-                fh_idx = fh_idx.sort_values()
+            if sort_by_time:
+                fh_df = pd.DataFrame(index=fh_idx)
+                fh_idx = fh_df.sort_index(level=-1).index
 
         # replicating index names
         if hasattr(y_index, "names") and y_index.names is not None:

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -674,6 +674,54 @@ class ForecastingHorizon:
             relative = self.to_relative(cutoff)
             return relative - relative.to_pandas()[0]
 
+    def get_expected_pred_idx(self, y=None, cutoff=None, sort_by_time=False):
+        """Construct DataFrame Index expected in y_pred, return of _predict.
+
+        Parameters
+        ----------
+        y : pd.DataFrame, pd.Series, pd.Index, or None
+            data to compute fh relative to,
+            assumed in sktime pandas based mtype or index thereof
+        cutoff : pd.Period, pd.Timestamp, int, optional (default=None)
+            Cutoff value to use in computing resulting index.
+            If cutoff is not provided, is computed from ``y`` via ``get_cutoff``.
+        sort_by_time : bool, optional (default=False)
+            for MultiIndex returns, whether to sort by time index (level -1)
+            - If True, result Index is sorted sort by time index (level -1)
+            - If False, result Index is sorted overall
+
+        Returns
+        -------
+        fh_idx : pd.Index, expected index of y_pred returned by predict
+            assumes pandas based return mtype
+        """
+        if cutoff is None:
+            from sktime.datatypes import get_cutoff
+
+            cutoff = get_cutoff(y)
+
+        fh_idx = pd.Index(self.to_absolute_index(cutoff))
+        y_index = y.index
+
+        if isinstance(y_index, pd.MultiIndex):
+            y_inst_idx = y_index.droplevel(-1).unique()
+            if isinstance(y_inst_idx, pd.MultiIndex) and sort_by_time:
+                fh_list = [x + (y,) for x in y_inst_idx for y in fh_idx]
+            elif isinstance(y_inst_idx, pd.MultiIndex) and not sort_by_time:
+                fh_list = [x + (y,) for y in fh_idx for x in y_inst_idx]
+            elif sort_by_time:  # and not isinstance(y_inst_idx, pd.MultiIndex):
+                fh_list = [(x, y) for x in y_inst_idx for y in fh_idx]
+            else:  # not sort_by_time and not isinstance(y_inst_idx, pd.MultiIndex):
+                fh_list = [(x, y) for y in fh_idx for x in y_inst_idx]
+
+        fh_idx = pd.Index(fh_list)
+
+        # replicaging index names
+        if hasattr(y_index, "names") and y_index.names is not None:
+            fh_idx.names = y_index.names
+
+        return fh_idx
+
     def __repr__(self):
         """Generate repr based on wrapped index repr."""
         class_name = self.__class__.__name__

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -733,7 +733,6 @@ class ForecastingHorizon:
             fh_idx = pd.Index(fh_list)
 
         elif isinstance(y_index, pd.MultiIndex):
-
             y_inst_idx = y_index.droplevel(-1).unique()
 
             if isinstance(y_inst_idx, pd.MultiIndex):

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -716,7 +716,7 @@ class ForecastingHorizon:
 
         fh_idx = pd.Index(fh_list)
 
-        # replicaging index names
+        # replicating index names
         if hasattr(y_index, "names") and y_index.names is not None:
             fh_idx.names = y_index.names
 

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -728,3 +728,49 @@ def test_empty_range_in_fh():
     """Test when ``range`` has zero length."""
     empty_range = ForecastingHorizon(values=range(-5))
     assert (empty_range == ForecastingHorizon(values=[])).all()
+
+
+def test_fh_expected_pred():
+    """Test for expected prediction index method."""
+    fh = ForecastingHorizon([1, 2, 3])
+    y_pred_idx = fh.get_expected_pred_idx(pd.Index([2, 3, 4]))
+
+    assert y_pred_idx.equals(pd.Index([5, 6, 7]))
+
+    y_df = pd.DataFrame([1, 2, 3], index=[2, 3, 4])
+    y_pred_idx = fh.get_expected_pred_idx(y_df)
+
+    assert y_pred_idx.equals(pd.Index([5, 6, 7]))
+
+    # pd.MultiIndex case, 2 levels
+    idx = pd.MultiIndex.from_tuples([("a", 3), ("a", 5), ("b", 4), ("b", 5), ("b", 6)])
+    y_pred_idx = fh.get_expected_pred_idx(idx)
+
+    y_pred_idx_expected = pd.MultiIndex.from_tuples(
+        [("a", 6), ("a", 7), ("a", 8), ("b", 7), ("b", 8), ("b", 9)]
+    )
+    assert y_pred_idx.equals(y_pred_idx_expected)
+
+    y_pred_idx = fh.get_expected_pred_idx(idx, sort_by_time=True)
+    y_pred_idx_expected = pd.MultiIndex.from_tuples(
+        [("a", 6), ("a", 7), ("b", 7), ("a", 8), ("b", 8), ("b", 9)]
+    )
+    assert y_pred_idx.equals(y_pred_idx_expected)
+
+    # pd.MultiIndex case, 3 levels
+    idx = pd.MultiIndex.from_tuples(
+        [("a", 3, 4), ("a", 3, 5), ("b", 5, 4), ("b", 5, 5), ("b", 5, 6)]
+    )
+    y_pred_idx = fh.get_expected_pred_idx(idx)
+
+    y_pred_idx_expected = pd.MultiIndex.from_tuples(
+        [("a", 3, 6), ("a", 3, 7), ("a", 3, 8), ("b", 5, 7), ("b", 5, 8), ("b", 5, 9)]
+    )
+    assert y_pred_idx.equals(y_pred_idx_expected)
+
+    y_pred_idx = fh.get_expected_pred_idx(idx, sort_by_time=True)
+
+    y_pred_idx_expected = pd.MultiIndex.from_tuples(
+        [("a", 3, 6), ("a", 3, 7), ("b", 5, 7), ("a", 3, 8), ("b", 5, 8), ("b", 5, 9)]
+    )
+    assert y_pred_idx.equals(y_pred_idx_expected)


### PR DESCRIPTION
This PR adds a method `get_expected_pred_idx` to `ForecastingHorizon` which can be used to obtain the expected forecast index, including in the case of multi-index or multi-instance data.

This is the actual `pandas.Index` used for `pandas` based mtypes, or the "ideal" index if a non-`pandas` type is used.