### PR TITLE
[ENH] improved error messages for input checks in base classes

### DIFF
--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -32,7 +32,7 @@ from sktime.base import BaseEstimator
 from sktime.datatypes import (
     MTYPE_LIST_PANEL,
     check_is_scitype,
-    check_is_scitype_error_msg,
+    check_is_error_msg,
     convert_to,
 )
 from sktime.utils.sklearn import is_sklearn_transformer
@@ -730,7 +730,7 @@ class BaseClassifier(BaseEstimator, ABC):
             f"Allowed compatible mtype format specifications are: {MTYPE_LIST_PANEL} ."
         )
         if not X_valid:
-            check_is_scitype_error_msg(
+            check_is_error_msg(
                 msg, var_name="X", allowed_msg=allowed_msg, raise_exception=True
             )
 

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -29,7 +29,12 @@ import numpy as np
 import pandas as pd
 
 from sktime.base import BaseEstimator
-from sktime.datatypes import check_is_scitype, convert_to
+from sktime.datatypes import (
+    MTYPE_LIST_PANEL,
+    check_is_scitype,
+    check_is_scitype_error_msg,
+    convert_to,
+)
 from sktime.utils.sklearn import is_sklearn_transformer
 from sktime.utils.validation import check_n_jobs
 from sktime.utils.validation._dependencies import _check_estimator_deps
@@ -714,16 +719,21 @@ class BaseClassifier(BaseEstimator, ABC):
             If y or X is invalid input data type, or there is not enough data
         """
         # Check X is valid input type and recover the data characteristics
-        X_valid, _, X_metadata = check_is_scitype(
+        X_valid, msg, X_metadata = check_is_scitype(
             X, scitype="Panel", return_metadata=return_metadata
         )
+        # raise informative error message if X is in wrong format
+        allowed_msg = (
+            f"Allowed scitypes for classifiers are Panel mtypes, "
+            f"for instance a pandas.DataFrame with MultiIndex and last(-1) "
+            f"level an sktime compatible time index. "
+            f"Allowed compatible mtype format specifications are: {MTYPE_LIST_PANEL} ."
+        )
         if not X_valid:
-            raise TypeError(
-                f"X is not of a supported input data type."
-                f"X must be in a supported mtype format for Panel, found {type(X)}"
-                f"Use datatypes.check_is_mtype to check conformance "
-                "with specifications."
+            check_is_scitype_error_msg(
+                msg, var_name="X", allowed_msg=allowed_msg, raise_exception=True
             )
+
         n_cases = X_metadata["n_instances"]
         if n_cases < enforce_min_instances:
             raise ValueError(

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -31,8 +31,8 @@ import pandas as pd
 from sktime.base import BaseEstimator
 from sktime.datatypes import (
     MTYPE_LIST_PANEL,
-    check_is_scitype,
     check_is_error_msg,
+    check_is_scitype,
     convert_to,
 )
 from sktime.utils.sklearn import is_sklearn_transformer

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -287,9 +287,7 @@ def test__check_classifier_input():
         _check_classifier_input(test_X5, test_y1)
     # 4. Test incorrect data type: y is a List
     test_y3 = [1, 2, 3, 4, 5]
-    with pytest.raises(
-        TypeError, match=r".*X is not of a supported input data " r"type.*"
-    ):
+    with pytest.raises(TypeError, match="must be in an sktime compatible format"):
         _check_classifier_input(test_X1, test_y3)
     # 5. Test incorrect: too few cases or too short a series
     with pytest.raises(ValueError, match=r".*Minimum number of cases required*."):

--- a/sktime/datatypes/__init__.py
+++ b/sktime/datatypes/__init__.py
@@ -3,9 +3,9 @@
 __author__ = ["fkiraly"]
 
 from sktime.datatypes._check import (
+    check_is_error_msg,
     check_is_mtype,
     check_is_scitype,
-    check_is_error_msg,
     check_raise,
     mtype,
     scitype,

--- a/sktime/datatypes/__init__.py
+++ b/sktime/datatypes/__init__.py
@@ -5,6 +5,7 @@ __author__ = ["fkiraly"]
 from sktime.datatypes._check import (
     check_is_mtype,
     check_is_scitype,
+    check_is_scitype_error_msg,
     check_raise,
     mtype,
     scitype,
@@ -31,6 +32,7 @@ __all__ = [
     "ALL_TIME_SERIES_MTYPES",
     "check_is_mtype",
     "check_is_scitype",
+    "check_is_scitype_error_msg",
     "check_raise",
     "convert",
     "convert_to",

--- a/sktime/datatypes/__init__.py
+++ b/sktime/datatypes/__init__.py
@@ -5,7 +5,7 @@ __author__ = ["fkiraly"]
 from sktime.datatypes._check import (
     check_is_mtype,
     check_is_scitype,
-    check_is_scitype_error_msg,
+    check_is_error_msg,
     check_raise,
     mtype,
     scitype,
@@ -32,7 +32,7 @@ __all__ = [
     "ALL_TIME_SERIES_MTYPES",
     "check_is_mtype",
     "check_is_scitype",
-    "check_is_scitype_error_msg",
+    "check_is_error_msg",
     "check_raise",
     "convert",
     "convert_to",

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -437,6 +437,48 @@ def check_is_scitype(
         return _ret(False, msg, None, return_metadata)
 
 
+def check_is_scitype_error_msg(
+    msg, var_name="obj", allowed_msg=None, raise_exception=False
+):
+    """Format and possibly raise error message from check_is_scitype.
+
+    Parameters
+    ----------
+    msg: dict[str, str]
+        error message from check_is_scitype
+    var_name: str, optional, default="obj"
+        name of input in error messages
+    allowed_msg: str, optional, default=None
+        message component detailing allowed mtypes or scitype combinations
+    raise_exception: bool or Exception, optional, default=False
+        whether to raise exception or return error message
+        if False, returns formatted error message
+        if True, raises TypeError with formatted error message
+        if Exception, raises that Exception with formatted error message
+
+    Returns
+    -------
+    str - formatted error message
+    """
+    msg_invalid_input = (
+        f"{var_name} must be in an sktime compatible format. {allowed_msg}"
+        f" See the data format tutorial examples/AA_datatypes_and_datasets.ipynb. "
+        f"If you think the data is already in an sktime supported input format, "
+        f"run sktime.datatypes.check_raise(data, mtype) to diagnose the error, "
+        f"where mtype is the string of the type specification you want. "
+        f"Error message for checked mtypes, in format [mtype: message], as follows:"
+    )
+    for mtype, err in msg.items():
+        msg_invalid_input += f" [{mtype}: {err}] "
+
+    if raise_exception is True:
+        raise TypeError(msg_invalid_input)
+    elif raise_exception is False:
+        return msg_invalid_input
+    else:
+        raise raise_exception(msg_invalid_input)
+
+
 def scitype(obj, candidate_scitypes=SCITYPE_LIST, exclude_mtypes=AMBIGUOUS_MTYPES):
     """Infer the scitype of an object.
 

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -233,7 +233,8 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj", panel=T
         ):
             msg = (
                 f"The (time) index of {var_name} must be sorted monotonically "
-                f"increasing, but found: {index}"
+                f"increasing. Use {var_name}.sort_index() to sort the index, or "
+                f"{var_name}.duplicated() to find duplicates."
             )
             return _ret(False, msg, None, return_metadata)
 
@@ -396,10 +397,10 @@ def is_nested_dataframe(obj, return_metadata=False, var_name="obj"):
 
     # Check instance index is unique
     if not obj.index.is_unique:
-        duplicates = obj.index[obj.index.duplicated()].unique().to_list()
         msg = (
             f"The instance index of {var_name} must be unique, "
-            f"but found duplicates: {duplicates}"
+            f"but found duplicates. Use {var_name}.duplicated() "
+            f"to find the duplicates."
         )
         return _ret(False, msg, None, return_metadata)
 

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -29,7 +29,12 @@ import numpy as np
 import pandas as pd
 
 from sktime.base import BaseEstimator
-from sktime.datatypes import check_is_scitype, convert_to
+from sktime.datatypes import (
+    MTYPE_LIST_PANEL,
+    check_is_scitype,
+    check_is_scitype_error_msg,
+    convert_to,
+)
 from sktime.utils.sklearn import is_sklearn_transformer
 from sktime.utils.validation import check_n_jobs
 from sktime.utils.warnings import warn
@@ -411,15 +416,21 @@ def _check_regressor_input(
         If y or X is invalid input data type, or there is not enough data
     """
     # Check X is valid input type and recover the data characteristics
-    X_valid, _, X_metadata = check_is_scitype(
+    X_valid, msg, X_metadata = check_is_scitype(
         X, scitype="Panel", return_metadata=return_metadata
     )
+    # raise informative error message if X is in wrong format
+    allowed_msg = (
+        f"Allowed scitypes for classifiers are Panel mtypes, "
+        f"for instance a pandas.DataFrame with MultiIndex and last(-1) "
+        f"level an sktime compatible time index. "
+        f"Allowed compatible mtype format specifications are: {MTYPE_LIST_PANEL} ."
+    )
     if not X_valid:
-        raise TypeError(
-            f"X is not of a supported input data type."
-            f"X must be in a supported mtype format for Panel, found {type(X)}"
-            f"Use datatypes.check_is_mtype to check conformance with specifications."
+        check_is_scitype_error_msg(
+            msg, var_name="X", allowed_msg=allowed_msg, raise_exception=True
         )
+
     n_cases = X_metadata["n_instances"]
     if n_cases < enforce_min_instances:
         raise ValueError(

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -32,7 +32,7 @@ from sktime.base import BaseEstimator
 from sktime.datatypes import (
     MTYPE_LIST_PANEL,
     check_is_scitype,
-    check_is_scitype_error_msg,
+    check_is_error_msg,
     convert_to,
 )
 from sktime.utils.sklearn import is_sklearn_transformer
@@ -427,7 +427,7 @@ def _check_regressor_input(
         f"Allowed compatible mtype format specifications are: {MTYPE_LIST_PANEL} ."
     )
     if not X_valid:
-        check_is_scitype_error_msg(
+        check_is_error_msg(
             msg, var_name="X", allowed_msg=allowed_msg, raise_exception=True
         )
 

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -31,8 +31,8 @@ import pandas as pd
 from sktime.base import BaseEstimator
 from sktime.datatypes import (
     MTYPE_LIST_PANEL,
-    check_is_scitype,
     check_is_error_msg,
+    check_is_scitype,
     convert_to,
 )
 from sktime.utils.sklearn import is_sklearn_transformer

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -58,7 +58,7 @@ from sktime.datatypes import (
     VectorizedDF,
     check_is_mtype,
     check_is_scitype,
-    check_is_scitype_error_msg,
+    check_is_error_msg,
     convert,
     convert_to,
     mtype_to_scitype,
@@ -999,7 +999,7 @@ class BaseTransformer(BaseEstimator):
         )
         msg = {k: v for k, v in msg.items() if k in ALLOWED_MTYPES}
         if not X_valid or X_mtype not in ALLOWED_MTYPES:
-            check_is_scitype_error_msg(
+            check_is_error_msg(
                 msg, var_name="X", allowed_msg=allowed_msg, raise_exception=True
             )
 
@@ -1040,7 +1040,7 @@ class BaseTransformer(BaseEstimator):
             # raise informative error message if y is is in wrong format
             msg = {k: v for k, v in msg.items() if k in ALLOWED_MTYPES}
             if not y_valid or y_mtype not in ALLOWED_MTYPES:
-                check_is_scitype_error_msg(
+                check_is_error_msg(
                     msg, var_name="y", allowed_msg=allowed_msg, raise_exception=True
                 )
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -997,8 +997,8 @@ class BaseTransformer(BaseEstimator):
             f"or with MultiIndex and last(-1) level an sktime compatible time index. "
             f"Allowed compatible mtype format specifications are: {ALLOWED_MTYPES} ."
         )
-        msg = {k: v for k, v in msg.items() if k in ALLOWED_MTYPES}
         if not X_valid or X_mtype not in ALLOWED_MTYPES:
+            msg = {k: v for k, v in msg.items() if k in ALLOWED_MTYPES}
             check_is_error_msg(
                 msg, var_name="X", allowed_msg=allowed_msg, raise_exception=True
             )
@@ -1038,8 +1038,8 @@ class BaseTransformer(BaseEstimator):
             y_mtype = y_metadata["mtype"]
 
             # raise informative error message if y is is in wrong format
-            msg = {k: v for k, v in msg.items() if k in ALLOWED_MTYPES}
             if not y_valid or y_mtype not in ALLOWED_MTYPES:
+                msg = {k: v for k, v in msg.items() if k in ALLOWED_MTYPES}
                 check_is_error_msg(
                     msg, var_name="y", allowed_msg=allowed_msg, raise_exception=True
                 )

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -992,7 +992,8 @@ class BaseTransformer(BaseEstimator):
 
         # raise informative error message if X is in wrong format
         allowed_msg = (
-            f"Allowed scitypes for transformations are Series, Panel or Hierarchical, "
+            f"Allowed scitypes for X in transformations are "
+            f"Series, Panel or Hierarchical, "
             f"for instance a pandas.DataFrame with sktime compatible time indices, "
             f"or with MultiIndex and last(-1) level an sktime compatible time index. "
             f"Allowed compatible mtype format specifications are: {ALLOWED_MTYPES} ."
@@ -1038,8 +1039,12 @@ class BaseTransformer(BaseEstimator):
             y_mtype = y_metadata["mtype"]
 
             # raise informative error message if y is is in wrong format
-            if not y_valid or y_mtype not in ALLOWED_MTYPES:
-                msg = {k: v for k, v in msg.items() if k in ALLOWED_MTYPES}
+            if not y_valid:
+                allowed_msg = (
+                    f"Allowed scitypes for y in transformations depend on X passed. "
+                    f"Passed X scitype was {X_scitype}, "
+                    f"so allowed scitypes for y are {y_possible_scitypes}. "
+                )
                 check_is_error_msg(
                     msg, var_name="y", allowed_msg=allowed_msg, raise_exception=True
                 )

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -56,9 +56,9 @@ import pandas as pd
 from sktime.base import BaseEstimator
 from sktime.datatypes import (
     VectorizedDF,
+    check_is_error_msg,
     check_is_mtype,
     check_is_scitype,
-    check_is_error_msg,
     convert,
     convert_to,
     mtype_to_scitype,


### PR DESCRIPTION
This PR improves error messages for input checks in base classes, an localizes the generation of informative error messages on how to improve and check inputs in the `datatypes` module.

In particular, this fixes https://github.com/sktime/sktime/issues/5506 by changing the error message generation to the improved logic.

Further changes:

* improved error mesages in forecasters, transformations
* `check_is_mtype` gets an option to return multiple error messages in same format as `check_is_scitype`, with a deprecation for this as the default if multiple `mtypes` to check against are passed.