### PR TITLE
[ENH] add missing exports and API reference entries for five deep learning classifiers

### DIFF
--- a/docs/source/api_reference/classification.rst
+++ b/docs/source/api_reference/classification.rst
@@ -51,6 +51,7 @@ Deep learning
     MACNNClassifier
     MLPClassifier
     MCDCNNClassifier
+    ResNetClassifier
     SimpleRNNClassifier
     TapNetClassifier
 

--- a/sktime/classification/deep_learning/__init__.py
+++ b/sktime/classification/deep_learning/__init__.py
@@ -4,7 +4,11 @@ __all__ = [
     "FCNClassifier",
     "InceptionTimeClassifier",
     "LSTMFCNClassifier",
+    "MACNNClassifier",
+    "MCDCNNClassifier",
     "MLPClassifier",
+    "ResNetClassifier",
+    "SimpleRNNClassifier",
     "TapNetClassifier",
 ]
 
@@ -12,5 +16,9 @@ from sktime.classification.deep_learning.cnn import CNNClassifier
 from sktime.classification.deep_learning.fcn import FCNClassifier
 from sktime.classification.deep_learning.inceptiontime import InceptionTimeClassifier
 from sktime.classification.deep_learning.lstmfcn import LSTMFCNClassifier
+from sktime.classification.deep_learning.macnn import MACNNClassifier
+from sktime.classification.deep_learning.mcdcnn import MCDCNNClassifier
 from sktime.classification.deep_learning.mlp import MLPClassifier
+from sktime.classification.deep_learning.resnet import ResNetClassifier
+from sktime.classification.deep_learning.rnn import SimpleRNNClassifier
 from sktime.classification.deep_learning.tapnet import TapNetClassifier


### PR DESCRIPTION
Five deep learning classifiers were erroneously missing API reference entries and module exports.

This has been rectified.