### PR TITLE
[ENH] skip `load_solar` in doctests

### DIFF
--- a/sktime/transformations/series/peak.py
+++ b/sktime/transformations/series/peak.py
@@ -132,11 +132,11 @@ class PeakTimeFeature(BaseTransformer):
 
     Examples
     --------
-    >>> from sktime.transformations.series.peak import PeakTimeFeature
-    >>> from sktime.datasets import load_solar
-    >>> y = load_solar()
-    >>> y = y.tz_localize(None)
-    >>> y = y.asfreq("H")
+    >>> from sktime.transformations.series.peak import PeakTimeFeature  # doctest: +SKIP
+    >>> from sktime.datasets import   # doctest: +SKIP
+    >>> y = load_solar()  # doctest: +SKIP
+    >>> y = y.tz_localize(None)  # doctest: +SKIP
+    >>> y = y.asfreq("H")  # doctest: +SKIP
 
     Example 1: one interval for peak hour and working hour.
     (based on one start/end interval)
@@ -146,8 +146,8 @@ class PeakTimeFeature(BaseTransformer):
     >>> transformer = PeakTimeFeature(ts_freq="H",
     ... peak_hour_start=[6], peak_hour_end=[9],
     ... working_hour_start=[8], working_hour_end=[16]
-    ... )
-    >>> y_hat_peak = transformer.fit_transform(y)
+    ... )  # doctest: +SKIP
+    >>> y_hat_peak = transformer.fit_transform(y)  # doctest: +SKIP
 
     Example 2: two intervals for peak hour and  working hour.
     (based on two start/end intervals)
@@ -157,8 +157,8 @@ class PeakTimeFeature(BaseTransformer):
     >>> transformer = PeakTimeFeature(ts_freq="H",
     ... peak_hour_start=[6, 16], peak_hour_end=[9, 20],
     ... working_hour_start=[8, 15], working_hour_end=[12, 19]
-    ... )
-    >>> y_hat_peak = transformer.fit_transform(y)
+    ... )  # doctest: +SKIP
+    >>> y_hat_peak = transformer.fit_transform(y)  # doctest: +SKIP
 
     Example 3: We may have peak for different seasonality
     Here is an example for peak hour, peak day, peak week, peak month for
@@ -171,8 +171,8 @@ class PeakTimeFeature(BaseTransformer):
     ... peak_day_start=[1, 2], peak_day_end=[2, 3],
     ... peak_week_start=[35, 45], peak_week_end=[40, 52],
     ... peak_month_start=[1, 7], peak_month_end=[6, 12]
-    ... )
-    >>> y_hat_peak = transformer.fit_transform(y)
+    ... )  # doctest: +SKIP
+    >>> y_hat_peak = transformer.fit_transform(y)  # doctest: +SKIP
     """
 
     _tags = {


### PR DESCRIPTION
This PR skips the downloader `load_solar` in doctests to avoid downloading data in doctests and keep download tests localized to the respective CI element.

See https://github.com/sktime/sktime/issues/5527#issuecomment-1793365055