### PR TITLE
[ENH] exclude downloads in "no soft dependencies" CI element

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,12 @@ test_softdeps: ## Run unit tests to check soft dependency handling in estimators
 	python -m pytest -v -n auto --showlocals -k 'test_check_estimator_does_not_raise' $(PYTESTOPTIONS) --pyargs sktime.utils.tests
 	python -m pytest -v -n auto --showlocals $(PYTESTOPTIONS) --pyargs sktime.tests.test_softdeps
 
-test_softdeps_full: ## Run all non-suite unit tests without soft dependencies
+test_softdeps_full: ## Run all non-suite unit tests without soft dependencies or downloading datasets
 	-rm -rf ${TEST_DIR}
 	mkdir -p ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
 	cd ${TEST_DIR}
-	python -m pytest -v --showlocals -k 'not TestAll' $(PYTESTOPTIONS)
+	python -m pytest -v --showlocals --ignore sktime/datasets -k 'not TestAll' $(PYTESTOPTIONS)
 
 test_mlflow: ## Run mlflow integration tests
 	-rm -rf ${TEST_DIR}


### PR DESCRIPTION
This PR excludes download tests the "no soft dependencies" CI element, as downloads are now tested in a regular cron.

Also prevents the current failure arising from
https://github.com/sktime/sktime/issues/5527
in PR CI.