### PR TITLE
[ENH] refactor index generation in reducers to use `ForecastingHorizon` method

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -746,6 +746,8 @@ class ForecastingHorizon:
                 fh_df = pd.DataFrame(index=fh_idx)
                 fh_idx = fh_df.sort_index(level=-1).index
 
+            fh_idx.names = y_index.names
+
         # replicating index names
         if hasattr(y_index, "names") and y_index.names is not None:
             fh_idx.names = y_index.names

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -674,6 +674,84 @@ class ForecastingHorizon:
             relative = self.to_relative(cutoff)
             return relative - relative.to_pandas()[0]
 
+    def get_expected_pred_idx(self, y=None, cutoff=None, sort_by_time=False):
+        """Construct DataFrame Index expected in y_pred, return of _predict.
+
+        Parameters
+        ----------
+        y : pd.DataFrame, pd.Series, pd.Index, or None
+            data to compute fh relative to,
+            assumed in sktime pandas based mtype or index thereof
+        cutoff : pd.Period, pd.Timestamp, int, optional (default=None)
+            Cutoff value to use in computing resulting index.
+            If cutoff is not provided, is computed from ``y`` via ``get_cutoff``.
+        sort_by_time : bool, optional (default=False)
+            for MultiIndex returns, whether to sort by time index (level -1)
+            - If True, result Index is sorted sort by time index (level -1)
+            - If False, result Index is sorted overall
+
+        Returns
+        -------
+        fh_idx : pd.Index, expected index of y_pred returned by predict
+            assumes pandas based return mtype
+        """
+        from sktime.datatypes import get_cutoff
+
+        def _make_y_pred(y_single):
+            """Make y_pred from single instance y, used in list comprehension."""
+            cutoff = get_cutoff(y_single)
+            return pd.Index(self.to_absolute_index(cutoff))
+
+        if hasattr(y, "index"):
+            y_index = y.index
+        elif isinstance(y, pd.Index):
+            y_index = y
+            y = pd.DataFrame(index=y_index)
+        else:
+            y_index = pd.Index(y)
+            y = pd.DataFrame(index=y_index)
+
+        if cutoff is None and not isinstance(y_index, pd.MultiIndex):
+            _cutoff = get_cutoff(y)
+        else:
+            _cutoff = cutoff
+
+        if cutoff is not None or not isinstance(y_index, pd.MultiIndex):
+            fh_idx = pd.Index(self.to_absolute_index(_cutoff))
+
+        if cutoff is not None and isinstance(y_index, pd.MultiIndex):
+            y_inst_idx = y_index.droplevel(-1).unique()
+            if isinstance(y_inst_idx, pd.MultiIndex) and sort_by_time:
+                fh_list = [x + (y,) for x in y_inst_idx for y in fh_idx]
+            elif isinstance(y_inst_idx, pd.MultiIndex) and not sort_by_time:
+                fh_list = [x + (y,) for y in fh_idx for x in y_inst_idx]
+            elif sort_by_time:  # and not isinstance(y_inst_idx, pd.MultiIndex):
+                fh_list = [(x, y) for x in y_inst_idx for y in fh_idx]
+            else:  # not sort_by_time and not isinstance(y_inst_idx, pd.MultiIndex):
+                fh_list = [(x, y) for y in fh_idx for x in y_inst_idx]
+
+            fh_idx = pd.Index(fh_list)
+
+        elif isinstance(y_index, pd.MultiIndex):
+            y_inst_idx = y_index.droplevel(-1).unique()
+
+            if isinstance(y_inst_idx, pd.MultiIndex):
+                fh_list = [x + (z,) for x in y_inst_idx for z in _make_y_pred(y.loc[x])]
+            else:
+                fh_list = [(x, z) for x in y_inst_idx for z in _make_y_pred(y.loc[x])]
+
+            fh_idx = pd.Index(fh_list)
+
+            if sort_by_time:
+                fh_df = pd.DataFrame(index=fh_idx)
+                fh_idx = fh_df.sort_index(level=-1).index
+
+        # replicating index names
+        if hasattr(y_index, "names") and y_index.names is not None:
+            fh_idx.names = y_index.names
+
+        return fh_idx
+
     def __repr__(self):
         """Generate repr based on wrapped index repr."""
         class_name = self.__class__.__name__

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -746,8 +746,6 @@ class ForecastingHorizon:
                 fh_df = pd.DataFrame(index=fh_idx)
                 fh_idx = fh_df.sort_index(level=-1).index
 
-            fh_idx.names = y_index.names
-
         # replicating index names
         if hasattr(y_index, "names") and y_index.names is not None:
             fh_idx.names = y_index.names

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -728,3 +728,49 @@ def test_empty_range_in_fh():
     """Test when ``range`` has zero length."""
     empty_range = ForecastingHorizon(values=range(-5))
     assert (empty_range == ForecastingHorizon(values=[])).all()
+
+
+def test_fh_expected_pred():
+    """Test for expected prediction index method."""
+    fh = ForecastingHorizon([1, 2, 3])
+    y_pred_idx = fh.get_expected_pred_idx(pd.Index([2, 3, 4]))
+
+    assert y_pred_idx.equals(pd.Index([5, 6, 7]))
+
+    y_df = pd.DataFrame([1, 2, 3], index=[2, 3, 4])
+    y_pred_idx = fh.get_expected_pred_idx(y_df)
+
+    assert y_pred_idx.equals(pd.Index([5, 6, 7]))
+
+    # pd.MultiIndex case, 2 levels
+    idx = pd.MultiIndex.from_tuples([("a", 3), ("a", 5), ("b", 4), ("b", 5), ("b", 6)])
+    y_pred_idx = fh.get_expected_pred_idx(idx)
+
+    y_pred_idx_expected = pd.MultiIndex.from_tuples(
+        [("a", 6), ("a", 7), ("a", 8), ("b", 7), ("b", 8), ("b", 9)]
+    )
+    assert y_pred_idx.equals(y_pred_idx_expected)
+
+    y_pred_idx = fh.get_expected_pred_idx(idx, sort_by_time=True)
+    y_pred_idx_expected = pd.MultiIndex.from_tuples(
+        [("a", 6), ("a", 7), ("b", 7), ("a", 8), ("b", 8), ("b", 9)]
+    )
+    assert y_pred_idx.equals(y_pred_idx_expected)
+
+    # pd.MultiIndex case, 3 levels
+    idx = pd.MultiIndex.from_tuples(
+        [("a", 3, 4), ("a", 3, 5), ("b", 5, 4), ("b", 5, 5), ("b", 5, 6)]
+    )
+    y_pred_idx = fh.get_expected_pred_idx(idx)
+
+    y_pred_idx_expected = pd.MultiIndex.from_tuples(
+        [("a", 3, 6), ("a", 3, 7), ("a", 3, 8), ("b", 5, 7), ("b", 5, 8), ("b", 5, 9)]
+    )
+    assert y_pred_idx.equals(y_pred_idx_expected)
+
+    y_pred_idx = fh.get_expected_pred_idx(idx, sort_by_time=True)
+
+    y_pred_idx_expected = pd.MultiIndex.from_tuples(
+        [("a", 3, 6), ("a", 3, 7), ("b", 5, 7), ("a", 3, 8), ("b", 5, 8), ("b", 5, 9)]
+    )
+    assert y_pred_idx.equals(y_pred_idx_expected)

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -200,7 +200,6 @@ class _Reducer(_BaseWindowForecaster):
         "ignores-exogeneous-X": False,  # reduction uses X in non-trivial way
         "handles-missing-data": True,
         "capability:insample": False,
-        "capability:pred_int": True,
     }
 
     def __init__(
@@ -221,26 +220,6 @@ class _Reducer(_BaseWindowForecaster):
         # see discussion in PR #3405 and issue #3402
         # therefore this is commented out until sktime and sklearn are better aligned
         # self.set_tags(**{"handles-missing-data": estimator._get_tags()["allow_nan"]})
-
-        # for dealing with probabilistic regressors:
-        # self._est_type encodes information what type of estimator is passed
-        if hasattr(estimator, "get_tags"):
-            _est_type = estimator.get_tag("object_type", "regressor", False)
-        else:
-            _est_type = "regressor"
-
-        if _est_type not in ["regressor", "regressor_proba"]:
-            raise TypeError(
-                f"error in {type(self).__name}, "
-                "estimator must be either an sklearn compatible "
-                "regressor, or an skpro probabilistic regressor."
-            )
-
-        # has probabilistic mode iff the estimator is of type regressor_proba
-        self.set_tags(**{"capability:pred_int": _est_type == "regressor_proba"})
-
-        self._est_type = _est_type
-
 
     def _is_predictable(self, last_window):
         """Check if we can make predictions from last window."""

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -241,6 +241,7 @@ class _Reducer(_BaseWindowForecaster):
 
         self._est_type = _est_type
 
+
     def _is_predictable(self, last_window):
         """Check if we can make predictions from last window."""
         return (

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1573,7 +1573,8 @@ def _create_fcst_df(target_date, origin_df, fill=None):
     A pandas dataframe or series
     """
     if not isinstance(target_date, ForecastingHorizon):
-        fh = ForecastingHorizon(target_date, is_relative=False)
+        ix = pd.Index(target_date)
+        fh = ForecastingHorizon(ix, is_relative=False)
     else:
         fh = target_date.to_absolute()
 

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1572,68 +1572,30 @@ def _create_fcst_df(target_date, origin_df, fill=None):
     -------
     A pandas dataframe or series
     """
-    oi = origin_df.index
-    if not isinstance(oi, pd.MultiIndex):
-        if isinstance(origin_df, pd.Series):
-            if fill is None:
-                template = pd.Series(np.zeros(len(target_date)), index=target_date)
-            else:
-                template = pd.Series(fill, index=target_date)
-            template.name = origin_df.name
-            return template
-        else:
-            if fill is None:
-                template = pd.DataFrame(
-                    np.zeros((len(target_date), len(origin_df.columns))),
-                    index=target_date,
-                    columns=origin_df.columns.to_list(),
-                )
-            else:
-                template = pd.DataFrame(
-                    fill, index=target_date, columns=origin_df.columns.to_list()
-                )
-            return template
+    if not isinstance(target_date, ForecastingHorizon):
+        fh = ForecastingHorizon(target_date)
     else:
-        idx = origin_df.index.to_frame(index=False)
-        instance_names = idx.columns[0:-1].to_list()
-        time_names = idx.columns[-1]
-        idx = idx[instance_names].drop_duplicates()
+        fh = target_date
 
-        timeframe = pd.DataFrame(target_date, columns=[time_names])
-        target_frame = idx.merge(timeframe, how="cross")
-        if hasattr(target_date, "freq"):
-            freq_inferred = target_date.freq
-            mi = (
-                target_frame.groupby(instance_names, as_index=True)
-                .apply(
-                    lambda df: df.drop(instance_names, axis=1)
-                    .set_index(time_names)
-                    .asfreq(freq_inferred)
-                )
-                .index
-            )
-        else:
-            mi = (
-                target_frame.groupby(instance_names, as_index=True)
-                .apply(lambda df: df.drop(instance_names, axis=1).set_index(time_names))
-                .index
-            )
+    index = fh.get_expected_pred_idx(origin_df)
 
-        if fill is None:
-            template = pd.DataFrame(
-                np.zeros((len(target_date) * idx.shape[0], len(origin_df.columns))),
-                index=mi,
-                columns=origin_df.columns.to_list(),
-            )
-        else:
-            template = pd.DataFrame(
-                fill,
-                index=mi,
-                columns=origin_df.columns.to_list(),
-            )
+    if isinstance(origin_df, pd.Series):
+        columns = [origin_df.name]
+    else:
+        columns = origin_df.columns.to_list()
 
-        template = template.astype(origin_df.dtypes.to_dict())
-        return template
+    if fill is None:
+        values = 0
+    else:
+        values = fill
+
+    res = pd.DataFrame(values, index=index, columns=columns)
+
+    if isinstance(origin_df, pd.Series) and not isinstance(index, pd.MultiIndex):
+        res = res.iloc[:, 0]
+        res.name = origin_df.name
+
+    return res
 
 
 def _coerce_col_str(X):

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -200,6 +200,7 @@ class _Reducer(_BaseWindowForecaster):
         "ignores-exogeneous-X": False,  # reduction uses X in non-trivial way
         "handles-missing-data": True,
         "capability:insample": False,
+        "capability:pred_int": True,
     }
 
     def __init__(
@@ -220,6 +221,26 @@ class _Reducer(_BaseWindowForecaster):
         # see discussion in PR #3405 and issue #3402
         # therefore this is commented out until sktime and sklearn are better aligned
         # self.set_tags(**{"handles-missing-data": estimator._get_tags()["allow_nan"]})
+
+        # for dealing with probabilistic regressors:
+        # self._est_type encodes information what type of estimator is passed
+        if hasattr(estimator, "get_tags"):
+            _est_type = estimator.get_tag("object_type", "regressor", False)
+        else:
+            _est_type = "regressor"
+
+        if _est_type not in ["regressor", "regressor_proba"]:
+            raise TypeError(
+                f"error in {type(self).__name}, "
+                "estimator must be either an sklearn compatible "
+                "regressor, or an skpro probabilistic regressor."
+            )
+
+        # has probabilistic mode iff the estimator is of type regressor_proba
+        self.set_tags(**{"capability:pred_int": _est_type == "regressor_proba"})
+
+        self._est_type = _est_type
+
 
     def _is_predictable(self, last_window):
         """Check if we can make predictions from last window."""

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -241,7 +241,6 @@ class _Reducer(_BaseWindowForecaster):
 
         self._est_type = _est_type
 
-
     def _is_predictable(self, last_window):
         """Check if we can make predictions from last window."""
         return (

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1573,9 +1573,9 @@ def _create_fcst_df(target_date, origin_df, fill=None):
     A pandas dataframe or series
     """
     if not isinstance(target_date, ForecastingHorizon):
-        fh = ForecastingHorizon(target_date)
+        fh = ForecastingHorizon(target_date, is_relative=False)
     else:
-        fh = target_date
+        fh = target_date.to_absolute()
 
     index = fh.get_expected_pred_idx(origin_df)
 


### PR DESCRIPTION
This PR refactors index generation in reducers to use the `ForecastingHorizon` method instead of custom functionality.

Also useful as a test for the former logic.

Depends on https://github.com/sktime/sktime/pull/5543 due to an incorrect test.