### PR TITLE
[ENH] fix index name check for reduction forecasters

### DIFF
--- a/sktime/forecasting/compose/tests/test_reduce_global.py
+++ b/sktime/forecasting/compose/tests/test_reduce_global.py
@@ -106,6 +106,7 @@ def y_dict():
     # Create integer index data
     y_numeric = y_train.copy()
     y_numeric.index = pd.to_numeric(y_numeric.index)
+    y_numeric.index.names = [None]  # setting None to cover "no index name" case
     y_dict["y_numeric"] = y_numeric
 
     return y_dict
@@ -139,7 +140,7 @@ def check_eval(test_input, expected):
         ),
         (
             "y_train",
-            [None],
+            ["Period"],
         ),
         (
             "y_numeric",
@@ -186,7 +187,7 @@ def test_recursive_reduction(y, index_names, y_dict):
         ),
         (
             "y_train",
-            [None],
+            ["Period"],
         ),
         (
             "y_numeric",
@@ -232,7 +233,7 @@ def test_direct_reduction(y, index_names, y_dict):
         ),
         (
             "y_train",
-            [None],
+            ["Period"],
         ),
         (
             "y_numeric",


### PR DESCRIPTION
This PR fixes a faulty check for reduction forecasters' output, the current test checks against the wrong expectation.

As the test with the wrong expectation currently passes, this PR will cause it to fail.

The change in
https://github.com/sktime/sktime/pull/5539
should make it pass again.

The current state incorrectly expects `none` where the level name should e `"Period"`, in two places.

To keep coverage either way, one of the expcetation iss changed to the latter expectation `"Period"`, whereas in the other occurrence the data is changed to make the current expectation  `none` correct.