### PR TITLE
[ENH] `deep_equals` - clearer return on diffs from `dtypes` and `index`, relaxation of `MultiIndex` equality check

### DIFF
--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -68,7 +68,7 @@ example_dict[("pd-multiindex", "Panel", 0)] = X
 example_dict_lossy[("pd-multiindex", "Panel", 0)] = False
 
 cols = [f"var_{i}" for i in range(2)]
-X = pd.DataFrame(columns=cols, index=[0, 1, 2])
+X = pd.DataFrame(columns=cols, index=pd.RangeIndex(3))
 X["var_0"] = pd.Series(
     [pd.Series([1, 2, 3]), pd.Series([1, 2, 3]), pd.Series([1, 2, 3])]
 )
@@ -143,7 +143,7 @@ example_dict[("pd-multiindex", "Panel", 1)] = X
 example_dict_lossy[("pd-multiindex", "Panel", 1)] = False
 
 cols = [f"var_{i}" for i in range(1)]
-X = pd.DataFrame(columns=cols, index=[0, 1, 2])
+X = pd.DataFrame(columns=cols, index=pd.RangeIndex(3))
 X["var_0"] = pd.Series(
     [pd.Series([4, 5, 6]), pd.Series([4, 55, 6]), pd.Series([42, 5, 6])]
 )
@@ -211,7 +211,7 @@ example_dict[("pd-multiindex", "Panel", 2)] = X
 example_dict_lossy[("pd-multiindex", "Panel", 2)] = False
 
 cols = [f"var_{i}" for i in range(1)]
-X = pd.DataFrame(columns=cols, index=[0])
+X = pd.DataFrame(columns=cols, index=pd.RangeIndex(1))
 X["var_0"] = pd.Series([pd.Series([4, 5, 6])])
 
 example_dict[("nested_univ", "Panel", 2)] = X

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -128,7 +128,9 @@ def deep_equals(x, y, return_msg=False):
                     ".index.dtypes, x.dtypes = {} != y.index.dtypes = {}",
                     [xix.dtypes, yix.dtypes],
                 )
-        return ret(xix.equals(yix), ".index.values" + msg)
+        ix_eq = xix.equals(yix)
+        if not ix_eq:
+            return ret(False, ".index.values, x = {} != y = {}", [xix, yix])
         # if columns, dtypes are equal and at least one is object, recurse over Series
         if sum(x.dtypes == "object") > 0:
             for c in x.columns:

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -98,11 +98,17 @@ def deep_equals(x, y, return_msg=False):
         else:
             return ret(x.equals(y), ".series_equals, x = {} != y = {}", [x, y])
     elif isinstance(x, pd.DataFrame):
+        # check column names for equality
         if not x.columns.equals(y.columns):
             return ret(
                 False, f".columns, x.columns = {x.columns} != y.columns = {y.columns}"
             )
-        # if columns are equal and at least one is object, recurse over Series
+        # check dtypes for equality
+        if not x.dtypes.equals(y.dtypes):
+            return ret(
+                False, f".dtypes, x.dtypes = {x.dtypes} != y.dtypes = {y.dtypes}"
+            )
+        # if columns, dtypes are equal and at least one is object, recurse over Series
         if sum(x.dtypes == "object") > 0:
             for c in x.columns:
                 is_equal, msg = deep_equals(x[c], y[c], return_msg=True)

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -111,7 +111,7 @@ def deep_equals(x, y, return_msg=False):
         # check index for equality
         eq, msg = deep_equals(x.index, y.index, return_msg=True)
         if not eq:
-            return ret(False, f".index" + msg)
+            return ret(False, ".index" + msg)
         # if columns, dtypes are equal and at least one is object, recurse over Series
         if sum(x.dtypes == "object") > 0:
             for c in x.columns:

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -108,6 +108,10 @@ def deep_equals(x, y, return_msg=False):
             return ret(
                 False, f".dtypes, x.dtypes = {x.dtypes} != y.dtypes = {y.dtypes}"
             )
+        # check index for equality
+        eq, msg = deep_equals(x.index, y.index, return_msg=True)
+        if not eq:
+            return ret(False, f".index" + msg)
         # if columns, dtypes are equal and at least one is object, recurse over Series
         if sum(x.dtypes == "object") > 0:
             for c in x.columns:

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -114,7 +114,7 @@ def deep_equals(x, y, return_msg=False):
         # and would upset the type check, e.g., RangeIndex(2) vs Index([0, 1])
         xix = x.index
         yix = y.index
-        if hasattr(x, "dtype") and hasattr(y, "dtype"):
+        if hasattr(xix, "dtype") and hasattr(xix, "dtype"):
             if not xix.dtype == yix.dtype:
                 return ret(
                     False,
@@ -130,7 +130,34 @@ def deep_equals(x, y, return_msg=False):
                 )
         ix_eq = xix.equals(yix)
         if not ix_eq:
-            return ret(False, ".index.values, x = {} != y = {}", [xix, yix])
+            if not len(xix) == len(yix):
+                return ret(
+                    False,
+                    ".index.len, x.index.len = {} != y.index.len = {}",
+                    [len(xix), len(yix)],
+                )
+            if hasattr(xix, "name") and hasattr(yix, "name"):
+                if not xix.name == yix.name:
+                    return ret(
+                        False,
+                        ".index.name, x.index.name = {} != y.index.name = {}",
+                        [xix.name, yix.name],
+                    )
+            if hasattr(xix, "names") and hasattr(yix, "names"):
+                if not len(xix.names) == len(yix.names):
+                    return ret(
+                        False,
+                        ".index.names, x.index.names = {} != y.index.name = {}",
+                        [xix.names, yix.names],
+                    )
+                if not np.all(xix.names == yix.names):
+                    return ret(
+                        False,
+                        ".index.names, x.index.names = {} != y.index.name = {}",
+                        [xix.names, yix.names],
+                    )
+            elts_eq = np.all(xix == yix)
+            return ret(elts_eq, ".index.equals, x = {} != y = {}", [xix, yix])
         # if columns, dtypes are equal and at least one is object, recurse over Series
         if sum(x.dtypes == "object") > 0:
             for c in x.columns:

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -109,6 +109,9 @@ def deep_equals(x, y, return_msg=False):
                 False, f".dtypes, x.dtypes = {x.dtypes} != y.dtypes = {y.dtypes}"
             )
         # check index for equality
+        # we are not recursing due to ambiguity in integer index types
+        # which may differ from pandas version to pandas version
+        # and would upset the type check, e.g., RangeIndex(2) vs Index([0, 1])
         xix = x.index
         yix = y.index
         if hasattr(x, "dtype") and hasattr(y, "dtype"):
@@ -125,9 +128,7 @@ def deep_equals(x, y, return_msg=False):
                     ".index.dtypes, x.dtypes = {} != y.index.dtypes = {}",
                     [xix.dtypes, yix.dtypes],
                 )
-        eq, msg = deep_equals(xix.values, yix.values, return_msg=True)
-        if not eq:
-            return ret(False, ".index.values" + msg)
+        return ret(xix.equals(yix), ".index.values" + msg)
         # if columns, dtypes are equal and at least one is object, recurse over Series
         if sum(x.dtypes == "object") > 0:
             for c in x.columns:

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -109,9 +109,25 @@ def deep_equals(x, y, return_msg=False):
                 False, f".dtypes, x.dtypes = {x.dtypes} != y.dtypes = {y.dtypes}"
             )
         # check index for equality
-        eq, msg = deep_equals(x.index, y.index, return_msg=True)
+        xix = x.index
+        yix = y.index
+        if hasattr(x, "dtype") and hasattr(y, "dtype"):
+            if not xix.dtype == yix.dtype:
+                return ret(
+                    False,
+                    ".index.dtype, x.index.dtype = {} != y.index.dtype = {}",
+                    [xix.dtype, yix.dtype],
+                )
+        if hasattr(xix, "dtypes") and hasattr(yix, "dtypes"):
+            if not x.dtypes.equals(y.dtypes):
+                return ret(
+                    False,
+                    ".index.dtypes, x.dtypes = {} != y.index.dtypes = {}",
+                    [xix.dtypes, yix.dtypes],
+                )
+        eq, msg = deep_equals(xix.values, yix.values, return_msg=True)
         if not eq:
-            return ret(False, ".index" + msg)
+            return ret(False, ".index.values" + msg)
         # if columns, dtypes are equal and at least one is object, recurse over Series
         if sum(x.dtypes == "object") > 0:
             for c in x.columns:

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -124,9 +124,7 @@ def deep_equals(x, y, return_msg=False):
     elif isinstance(x, pd.Index):
         if hasattr(x, "dtype") and hasattr(y, "dtype"):
             if not x.dtype == y.dtype:
-                return ret(
-                    False, f".dtype, x.dtype = {x.dtype} != y.dtype = {y.dtype}"
-                )
+                return ret(False, f".dtype, x.dtype = {x.dtype} != y.dtype = {y.dtype}")
         if hasattr(x, "dtypes") and hasattr(y, "dtypes"):
             if not x.dtypes.equals(y.dtypes):
                 return ret(

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -122,6 +122,16 @@ def deep_equals(x, y, return_msg=False):
         else:
             return ret(x.equals(y), ".df_equals, x = {} != y = {}", [x, y])
     elif isinstance(x, pd.Index):
+        if hasattr(x, "dtype") and hasattr(y, "dtype"):
+            if not x.dtype == y.dtype:
+                return ret(
+                    False, f".dtype, x.dtype = {x.dtype} != y.dtype = {y.dtype}"
+                )
+        if hasattr(x, "dtypes") and hasattr(y, "dtypes"):
+            if not x.dtypes.equals(y.dtypes):
+                return ret(
+                    False, f".dtypes, x.dtypes = {x.dtypes} != y.dtypes = {y.dtypes}"
+                )
         return ret(x.equals(y), ".index_equals, x = {} != y = {}", [x, y])
     elif isinstance(x, np.ndarray):
         if x.dtype != y.dtype:


### PR DESCRIPTION
This PR improves error messaging in `deep_equals` and makes checks on `pandas` based indices stricter.

Changes:

* `dtypes` of `pd.DataFrame`-s are now checked explicitly
* providing a clearer return on `pd.DataFrame` `dtypes` no being equal
* `pd.Index` `dtypes` are now checked explicitly
* index equality check is slightly relaxed. `DataFrame.equals` may consider `MultiIndex` as unequal due to irrelevant typing in some `python` versions, so instead we now explicitly check equality in names, values

This should help diagnose the `dask` inconsistency in `VectorizedDF.reconstruct` return, I suspect it is the `dtype`.
Example of test failure (only on certain python versions) here: https://github.com/sktime/sktime/pull/5552
(update: this was due to `MultiIndex` type ambiguity, with the relaxation of the `deep_equals` check this should be fine now)

Depends on #5561 which fixes issues inconsistencies uncovered through the above.