### PR TITLE
[ENH] forecaster `fit_predict` with `X_pred` argument for `predict`

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -459,8 +459,12 @@ class BaseForecaster(BaseEstimator):
 
         return y_out
 
-    def fit_predict(self, y, X=None, fh=None):
+    def fit_predict(self, y, X=None, fh=None, X_test=None):
         """Fit and forecast time series at future horizon.
+
+        Same as ``fit(y, X, fh).predict(X_test)``.
+        If ````X_test`` is not passed, same as
+        ``fit(y, fh, X).predict(X_test)``.
 
         State change:
             Changes state to "fitted".
@@ -475,32 +479,36 @@ class BaseForecaster(BaseEstimator):
         Parameters
         ----------
         y : time series in sktime compatible data container format
-                Time series to which to fit the forecaster.
+            Time series to which to fit the forecaster.
             y can be in one of the following formats:
             Series scitype: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
-                for vanilla forecasting, one time series
+            for vanilla forecasting, one time series
             Panel scitype: pd.DataFrame with 2-level row MultiIndex,
-                3D np.ndarray, list of Series pd.DataFrame, or nested pd.DataFrame
-                for global or panel forecasting
+            3D np.ndarray, list of Series pd.DataFrame, or nested pd.DataFrame
+            for global or panel forecasting
             Hierarchical scitype: pd.DataFrame with 3 or more level row MultiIndex
-                for hierarchical forecasting
+            for hierarchical forecasting
             Number of columns admissible depend on the "scitype:y" tag:
-                if self.get_tag("scitype:y")=="univariate":
-                    y must have a single column/variable
-                if self.get_tag("scitype:y")=="multivariate":
-                    y must have 2 or more columns
-                if self.get_tag("scitype:y")=="both": no restrictions on columns apply
+            if self.get_tag("scitype:y")=="univariate":
+            y must have a single column/variable
+            if self.get_tag("scitype:y")=="multivariate":
+            y must have 2 or more columns
+            if self.get_tag("scitype:y")=="both": no restrictions on columns apply
             For further details:
-                on usage, see forecasting tutorial examples/01_forecasting.ipynb
-                on specification of formats, examples/AA_datatypes_and_datasets.ipynb
+            on usage, see forecasting tutorial examples/01_forecasting.ipynb
+            on specification of formats, examples/AA_datatypes_and_datasets.ipynb
         fh : int, list, np.array or ForecastingHorizon (not optional)
             The forecasting horizon encoding the time stamps to forecast at.
             if has not been passed in fit, must be passed, not optional
         X : time series in sktime compatible format, optional (default=None)
-                Exogeneous time series to fit to
+            Exogeneous time series to fit to
             Should be of same scitype (Series, Panel, or Hierarchical) as y in fit
-            if self.get_tag("X-y-must-have-same-index"),
-                X.index must contain fh.index and y.index both
+            If self.get_tag("X-y-must-have-same-index"),
+            X.index must contain y.index.
+            If, in addition, X_test is not passed, X must also contain fh.index.
+        X_test : time series in sktime compatible format, optional (default=None)
+            Exogeneous time series to use in predict
+            If passed, will be used in predict instead of X.
 
         Returns
         -------
@@ -509,6 +517,12 @@ class BaseForecaster(BaseEstimator):
             y_pred has same type as the y that has been passed most recently:
                 Series, Panel, Hierarchical scitype, same format (see above)
         """
+        # if X_test is passed, run fit/predict with different X
+        if X_test is not None:
+            return self.fit(y=y, X=X, fh=fh).predict(X=X_test)
+        # otherwise, we use the same X for fit and predict
+        # below code carries out conversion and checks for X only once
+
         # if fit is called, fitted state is re-set
         self._is_fitted = False
 

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -459,12 +459,12 @@ class BaseForecaster(BaseEstimator):
 
         return y_out
 
-    def fit_predict(self, y, X=None, fh=None, X_test=None):
+    def fit_predict(self, y, X=None, fh=None, X_pred=None):
         """Fit and forecast time series at future horizon.
 
-        Same as ``fit(y, X, fh).predict(X_test)``.
-        If ````X_test`` is not passed, same as
-        ``fit(y, fh, X).predict(X_test)``.
+        Same as ``fit(y, X, fh).predict(X_pred)``.
+        If ``X_pred`` is not passed, same as
+        ``fit(y, fh, X).predict(X)``.
 
         State change:
             Changes state to "fitted".
@@ -503,12 +503,14 @@ class BaseForecaster(BaseEstimator):
         X : time series in sktime compatible format, optional (default=None)
             Exogeneous time series to fit to
             Should be of same scitype (Series, Panel, or Hierarchical) as y in fit
-            If self.get_tag("X-y-must-have-same-index"),
+            If ``self.get_tag("X-y-must-have-same-index")`` is True,
             X.index must contain y.index.
-            If, in addition, X_test is not passed, X must also contain fh.index.
-        X_test : time series in sktime compatible format, optional (default=None)
+            If, in addition, X_pred is not passed, X must also contain fh.index.
+        X_pred : time series in sktime compatible format, optional (default=None)
             Exogeneous time series to use in predict
             If passed, will be used in predict instead of X.
+            If ``self.get_tag("X-y-must-have-same-index")`` is True,
+            X_pred.index must contain fh.index.
 
         Returns
         -------
@@ -517,9 +519,9 @@ class BaseForecaster(BaseEstimator):
             y_pred has same type as the y that has been passed most recently:
                 Series, Panel, Hierarchical scitype, same format (see above)
         """
-        # if X_test is passed, run fit/predict with different X
-        if X_test is not None:
-            return self.fit(y=y, X=X, fh=fh).predict(X=X_test)
+        # if X_pred is passed, run fit/predict with different X
+        if X_pred is not None:
+            return self.fit(y=y, X=X, fh=fh).predict(X=X_pred)
         # otherwise, we use the same X for fit and predict
         # below code carries out conversion and checks for X only once
 

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -887,7 +887,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         estimator_instance.fit(y=y_train, X=X_train, fh=fh)
         y_pred_expected = estimator_instance.predict(X=X_test)
 
-        eq, msg_de = deep_equals(y_pred, y_pred_expected)
+        eq, msg_de = deep_equals(y_pred, y_pred_expected, return_msg=True)
         if not eq:
             msg = (
                 f"in estimator {type(estimator_instance).__name__}, "

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -29,6 +29,7 @@ from sktime.split import (
     temporal_train_test_split,
 )
 from sktime.tests.test_all_estimators import BaseFixtureGenerator, QuickTester
+from sktime.utils._testing.deep_equals import deep_equals
 from sktime.utils._testing.forecasting import (
     _assert_correct_columns,
     _assert_correct_pred_time_index,
@@ -38,7 +39,6 @@ from sktime.utils._testing.forecasting import (
     make_forecasting_problem,
 )
 from sktime.utils._testing.series import _make_series
-from sktime.utils.deep_equals import deep_equals
 from sktime.utils.validation.forecasting import check_fh
 
 # get all forecasters

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -29,7 +29,6 @@ from sktime.split import (
     temporal_train_test_split,
 )
 from sktime.tests.test_all_estimators import BaseFixtureGenerator, QuickTester
-from sktime.utils._testing.deep_equals import deep_equals
 from sktime.utils._testing.forecasting import (
     _assert_correct_columns,
     _assert_correct_pred_time_index,

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -871,7 +871,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
                 assert set(X_test.index).issubset(y_pred_q.index)
 
     def test_fit_predict(self, estimator_instance, n_columns):
-        """Check fit_predict method."""
+        """Check fit_predict method against fit and predict."""
         y = _make_series(n_columns=n_columns)
         X = _make_series(n_columns=3)
 
@@ -895,4 +895,3 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
                 f"reason: {msg_de}"
             )
             raise AssertionError(msg)
- 

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -871,7 +871,11 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
                 assert set(X_test.index).issubset(y_pred_q.index)
 
     def test_fit_predict(self, estimator_instance, n_columns):
-        """Check fit_predict method against fit and predict."""
+        """Check fit_predict method against interface expectations.
+
+        Does not check directly against fit and predict, as either may
+        be stochastic and not return the same result each time.
+        """
         y = _make_series(n_columns=n_columns)
         X = _make_series(n_columns=3)
 
@@ -883,15 +887,6 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
             y=y_train, X=X_train, fh=fh, X_pred=X_test
         )
 
-        # check that fit_predict returns the same as fit and predict
-        estimator_instance.fit(y=y_train, X=X_train, fh=fh)
-        y_pred_expected = estimator_instance.predict(X=X_test)
-
-        eq, msg_de = deep_equals(y_pred, y_pred_expected, return_msg=True)
-        if not eq:
-            msg = (
-                f"in estimator {type(estimator_instance).__name__}, "
-                "fit_predict does not return the same as fit and predict. "
-                f"reason: {msg_de}"
-            )
-            raise AssertionError(msg)
+        cutoff = get_cutoff(y_train, return_index=True)
+        _assert_correct_pred_time_index(y_pred.index, cutoff, fh)
+        _assert_correct_columns(y_pred, y_train)


### PR DESCRIPTION
This PR adds an `X_pred` argument to `fit_predict`, which allows to pass different `X` to `predict`.

This should partially address https://github.com/sktime/sktime/issues/4839