### PR TITLE
[MNT] set output format parameter in `sktime` internal `check_is_mtype` calls to silence deprecation warnings

### DIFF
--- a/sktime/alignment/utils/utils_align.py
+++ b/sktime/alignment/utils/utils_align.py
@@ -67,7 +67,13 @@ def convert_align_to_align_loc(align, X, align_name="align", df_name="X", copy=T
     """
     from sktime.datatypes import check_is_mtype
 
-    check_is_mtype(align, "alignment", scitype="Alignment", var_name=align_name)
+    check_is_mtype(
+        align,
+        "alignment",
+        scitype="Alignment",
+        var_name=align_name,
+        msg_return_dict="list",
+    )
 
     if not isinstance(X, list):
         raise ValueError(f"{df_name} must be a list of pandas.DataFrame")

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -229,7 +229,9 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
             # "X may be a sparse graph, in which case only "nonzero" elements
             #   may be considered neighbors."
             X_inner_mtype = self.get_tag("X_inner_mtype")
-            _, _, X_meta = check_is_mtype(X, X_inner_mtype, return_metadata=True)
+            _, _, X_meta = check_is_mtype(
+                X, X_inner_mtype, return_metadata=True, msg_return_dict="list"
+            )
             n = X_meta["n_instances"]
             dist_mat = np.zeros([n, n], dtype="float")
 

--- a/sktime/datasets/tests/test_data_io.py
+++ b/sktime/datasets/tests/test_data_io.py
@@ -36,7 +36,9 @@ def test_load_provided_dataset(return_X_y, return_type):
         X = _load_provided_dataset("UnitTest", "TRAIN", return_X_y, return_type)
 
     # Check whether object is same mtype or not, via bool
-    valid, check_msg, _ = check_is_mtype(X, return_type, return_metadata=True)
+    valid, check_msg, _ = check_is_mtype(
+        X, return_type, return_metadata=True, msg_return_dict="list"
+    )
     msg = (
         "load_basic_motions return has unexpected type on "
         f"return_X_y = {return_X_y}, return_type = {return_type}. "
@@ -60,7 +62,9 @@ def test_load_basic_motions(return_X_y, return_type):
         X = load_basic_motions("TRAIN", return_X_y, return_type)
 
     # Check whether object is same mtype or not, via bool
-    valid, check_msg, _ = check_is_mtype(X, return_type, return_metadata=True)
+    valid, check_msg, _ = check_is_mtype(
+        X, return_type, return_metadata=True, msg_return_dict="list"
+    )
     msg = (
         "load_basic_motions return has unexpected type on "
         f"return_X_y = {return_X_y}, return_type = {return_type}. "

--- a/sktime/datasets/tests/test_readers_writers.py
+++ b/sktime/datasets/tests/test_readers_writers.py
@@ -1186,7 +1186,7 @@ def test_load_tsf_to_dataframe(input_path, return_type, output_df):
     assert_frame_equal(df, output_df, check_dtype=False)
     assert metadata == expected_metadata
     if return_type != "default_tsf":
-        assert check_is_mtype(obj=df, mtype=return_type)
+        assert check_is_mtype(obj=df, mtype=return_type, msg_return_dict="list")
 
 
 @pytest.mark.parametrize("freq", [None, "YS"])

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -333,6 +333,7 @@ def mtype(
             mtype=m_plus_scitype[0],
             scitype=m_plus_scitype[1],
             return_metadata=[],
+            msg_return_dict="list"
         )
         if valid:
             mtypes_positive += [m_plus_scitype[0]]

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -269,6 +269,7 @@ def check_raise(obj, mtype: str, scitype: str = None, var_name: str = "input"):
         scitype=scitype,
         return_metadata=[],
         var_name=var_name,
+        msg_return_dict="list",
     )
 
     if valid:
@@ -333,7 +334,7 @@ def mtype(
             mtype=m_plus_scitype[0],
             scitype=m_plus_scitype[1],
             return_metadata=[],
-            msg_return_dict="list"
+            msg_return_dict="list",
         )
         if valid:
             mtypes_positive += [m_plus_scitype[0]]

--- a/sktime/datatypes/tests/test_check.py
+++ b/sktime/datatypes/tests/test_check.py
@@ -127,7 +127,9 @@ def test_check_positive(scitype, mtype, fixture_index):
 
     # check fixtures that exist against checks that exist, when full metadata is queried
     if fixture is not None and check_is_defined:
-        check_result = check_is_mtype(fixture, mtype, scitype, return_metadata=True)
+        check_result = check_is_mtype(
+            fixture, mtype, scitype, return_metadata=True, msg_return_dict="list"
+        )
         if not check_result[0]:
             msg = (
                 f"check_is_mtype returns False on scitype {scitype}, mtype {mtype} "
@@ -138,7 +140,9 @@ def test_check_positive(scitype, mtype, fixture_index):
 
     # check fixtures that exist against checks that exist, when no metadata is queried
     if fixture is not None and check_is_defined:
-        check_result = check_is_mtype(fixture, mtype, scitype, return_metadata=[])
+        check_result = check_is_mtype(
+            fixture, mtype, scitype, return_metadata=[], msg_return_dict="list"
+        )
         if not check_result[0]:
             msg = (
                 f"check_is_mtype returns False on scitype {scitype}, mtype {mtype} "
@@ -233,7 +237,9 @@ def test_check_metadata_inference(scitype, mtype, fixture_index):
 
     # check fixtures that exist against checks that exist, full metadata query
     if fixture is not None and check_is_defined and metadata_provided:
-        check_result = check_is_mtype(fixture, mtype, scitype, return_metadata=True)
+        check_result = check_is_mtype(
+            fixture, mtype, scitype, return_metadata=True, msg_return_dict="list"
+        )
         metadata = check_result[2]
 
         # remove mtype & scitype key if exists, since comparison is on scitype level
@@ -256,7 +262,11 @@ def test_check_metadata_inference(scitype, mtype, fixture_index):
     if fixture is not None and check_is_defined and metadata_provided:
         for metadata_key in subset_keys:
             check_result = check_is_mtype(
-                fixture, mtype, scitype, return_metadata=[metadata_key]
+                fixture,
+                mtype,
+                scitype,
+                return_metadata=[metadata_key],
+                msg_return_dict="list",
             )
             metadata = check_result[2]
 
@@ -317,7 +327,9 @@ def test_check_negative(scitype, mtype):
 
             # check fixtures that exist against checks that exist
             if fixture_wrong_type is not None and check_is_defined:
-                assert not check_is_mtype(fixture_wrong_type, mtype, scitype), (
+                assert not check_is_mtype(
+                    fixture_wrong_type, mtype, scitype, msg_return_dict="list"
+                ), (
                     f"check_is_mtype {mtype} returns True "
                     f"on {wrong_mtype} fixture {i}"
                 )
@@ -325,7 +337,11 @@ def test_check_negative(scitype, mtype):
             # check fixtures that exist against checks that exist
             if fixture_wrong_type is not None and check_is_defined:
                 result = check_is_mtype(
-                    fixture_wrong_type, mtype, scitype, return_metadata=[]
+                    fixture_wrong_type,
+                    mtype,
+                    scitype,
+                    return_metadata=[],
+                    msg_return_dict="list",
                 )[0]
                 assert not result, (
                     f"check_is_mtype {mtype} returns True "

--- a/sktime/datatypes/tests/test_utils.py
+++ b/sktime/datatypes/tests/test_utils.py
@@ -280,7 +280,9 @@ def test_get_window_output_type(scitype, mtype, window_length, lag):
     # retrieve example fixture
     fixture = get_examples(mtype=mtype, as_scitype=scitype, return_lossy=False)[0]
     X = get_window(fixture, window_length=window_length, lag=lag)
-    valid, err, _ = check_is_mtype(X, mtype=mtype, return_metadata=True)
+    valid, err, _ = check_is_mtype(
+        X, mtype=mtype, return_metadata=True, msg_return_dict="list"
+    )
 
     msg = (
         f"get_window should return an output of mtype {mtype} for that type of input, "
@@ -352,7 +354,9 @@ def test_get_slice_output_type(scitype, mtype):
     # retrieve example fixture
     fixture = get_examples(mtype=mtype, as_scitype=scitype, return_lossy=False)[0]
     X = get_slice(fixture)
-    valid, err, _ = check_is_mtype(X, mtype=mtype, return_metadata=True)
+    valid, err, _ = check_is_mtype(
+        X, mtype=mtype, return_metadata=True, msg_return_dict="list"
+    )
 
     msg = (
         f"get_slice should return an output of mtype {mtype} for that type of input, "

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -228,12 +228,20 @@ def test_item_len(scitype, mtype, fixture_index, iterate_as, iterate_cols):
         true_length = 1
     elif iterate_as == "Series":
         _, _, metadata = check_is_mtype(
-            fixture, mtype=mtype, scitype=scitype, return_metadata=True
+            fixture,
+            mtype=mtype,
+            scitype=scitype,
+            return_metadata=True,
+            msg_return_dict="list",
         )
         true_length = metadata["n_instances"]
     elif iterate_as == "Panel":
         _, _, metadata = check_is_mtype(
-            fixture, mtype=mtype, scitype=scitype, return_metadata=True
+            fixture,
+            mtype=mtype,
+            scitype=scitype,
+            return_metadata=True,
+            msg_return_dict="list",
         )
         true_length = metadata["n_panels"]
 
@@ -330,7 +338,10 @@ def test_series_item_mtype(scitype, mtype, fixture_index, iterate_as, iterate_co
         raise RuntimeError(f"found unexpected iterate_as value: {iterate_as}")
 
     X_list_valid = [
-        check_is_mtype(X, mtype=correct_mtype, scitype=iterate_as) for X in X_list
+        check_is_mtype(
+            X, mtype=correct_mtype, scitype=iterate_as, msg_return_dict="list"
+        )
+        for X in X_list
     ]
 
     assert np.all(

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -45,7 +45,9 @@ def test_vectorization_series_to_panel(mtype, backend):
     f = ARIMA()
     f.set_config(**{"backend:parallel": backend})
     y_pred = f.fit(y).predict([1, 2, 3])
-    valid, _, metadata = check_is_mtype(y_pred, mtype, return_metadata=True)
+    valid, _, metadata = check_is_mtype(
+        y_pred, mtype, return_metadata=True, msg_return_dict="list"
+    )
 
     msg = (
         f"vectorization of forecasters does not work for test example "
@@ -98,7 +100,9 @@ def test_vectorization_series_to_hier(mtype, backend):
     f = ARIMA()
     f.set_config(**{"backend:parallel": backend})
     y_pred = f.fit(y).predict([1, 2, 3])
-    valid, _, metadata = check_is_mtype(y_pred, mtype, return_metadata=True)
+    valid, _, metadata = check_is_mtype(
+        y_pred, mtype, return_metadata=True, msg_return_dict="list"
+    )
 
     msg = (
         f"vectorization of forecasters does not work for test example "
@@ -158,7 +162,9 @@ def test_vectorization_series_to_panel_proba(method, mtype):
     else:
         RuntimeError(f"bug in test, unreachable state, method {method} queried")
 
-    valid, _, _ = check_is_mtype(y_pred, expected_mtype, return_metadata=True)
+    valid, _, _ = check_is_mtype(
+        y_pred, expected_mtype, return_metadata=True, msg_return_dict="list"
+    )
 
     msg = (
         f"vectorization of forecaster method {method} does not work for test example "
@@ -194,7 +200,9 @@ def test_vectorization_series_to_hier_proba(method, mtype):
     else:
         RuntimeError(f"bug in test, unreachable state, method {method} queried")
 
-    valid, _, _ = check_is_mtype(y_pred, expected_mtype, return_metadata=True)
+    valid, _, _ = check_is_mtype(
+        y_pred, expected_mtype, return_metadata=True, msg_return_dict="list"
+    )
 
     msg = (
         f"vectorization of forecaster method {method} does not work for test example "
@@ -251,7 +259,9 @@ def test_vectorization_multivariate(mtype, exogeneous):
 
     est = ARIMA().fit(y=y_fit, X=X_fit, fh=[1, 2, 3])
     y_pred = est.predict(X=X_pred)
-    valid, _, metadata = check_is_mtype(y_pred, mtype, return_metadata=True)
+    valid, _, metadata = check_is_mtype(
+        y_pred, mtype, return_metadata=True, msg_return_dict="list"
+    )
 
     msg = (
         f"vectorization of forecasters does not work for test example "

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -830,7 +830,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         y_pred = estimator_instance.predict(X=X_test)
 
         assert isinstance(y_pred, pd.DataFrame)
-        assert check_is_mtype(y_pred, "pd_multiindex_hier")
+        assert check_is_mtype(y_pred, "pd_multiindex_hier", msg_return_dict="list")
         msg = (
             "returned columns after predict are not as expected. "
             f"expected: {y_train.columns}. Found: {y_pred.columns}"

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -350,7 +350,11 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         """Check expected interval prediction output."""
         # check expected type
         valid, msg, _ = check_is_mtype(
-            pred_ints, mtype="pred_interval", scitype="Proba", return_metadata=True
+            pred_ints,
+            mtype="pred_interval",
+            scitype="Proba",
+            return_metadata=True,
+            msg_return_dict="list",
         )  # type: ignore
         assert valid, msg
 
@@ -436,6 +440,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
             mtype="pred_quantiles",
             scitype="Proba",
             return_metadata=True,
+            msg_return_dict="list",
         )  # type: ignore
         assert valid, msg
 
@@ -851,7 +856,9 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
             y_pred_int = estimator_instance.predict_interval(X=X_test)
 
             assert isinstance(y_pred_int, pd.DataFrame)
-            assert check_is_mtype(y_pred_int, "pd_multiindex_hier")
+            assert check_is_mtype(
+                y_pred_int, "pd_multiindex_hier", msg_return_dict="list"
+            )
 
             if len(y_pred_int.index) == len(X_test.index):
                 assert np.all(y_pred_int.index == X_test.index)
@@ -861,7 +868,9 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
             y_pred_q = estimator_instance.predict_quantiles(X=X_test)
 
             assert isinstance(y_pred_q, pd.DataFrame)
-            assert check_is_mtype(y_pred_q, "pd_multiindex_hier")
+            assert check_is_mtype(
+                y_pred_q, "pd_multiindex_hier", msg_return_dict="list"
+            )
 
             if len(y_pred_q.index) == len(X_test.index):
                 assert np.all(y_pred_q.index == X_test.index)

--- a/sktime/forecasting/tests/test_conformal.py
+++ b/sktime/forecasting/tests/test_conformal.py
@@ -23,7 +23,7 @@ def test_conformal_standard():
     conformal_forecaster.fit(y, fh=[1, 2, 3])
     pred_int = conformal_forecaster.predict_interval()
 
-    assert check_is_mtype(pred_int, "pred_interval", "Proba")
+    assert check_is_mtype(pred_int, "pred_interval", "Proba", msg_return_dict="list")
 
 
 @pytest.mark.skipif(
@@ -60,7 +60,9 @@ def test_conformal_with_gscv():
 
     y_pred_quantiles = gscv_with_conformal.predict_quantiles()
 
-    assert check_is_mtype(y_pred_quantiles, "pred_quantiles", "Proba")
+    assert check_is_mtype(
+        y_pred_quantiles, "pred_quantiles", "Proba", msg_return_dict="list"
+    )
 
 
 @pytest.mark.skipif(

--- a/sktime/proba/tests/test_all_distrs.py
+++ b/sktime/proba/tests/test_all_distrs.py
@@ -117,7 +117,9 @@ class TestAllDistributions(DistributionFixtureGenerator, QuickTester):
         d = estimator_instance
 
         def _check_quantile_output(obj, q):
-            assert check_is_mtype(obj, "pred_quantiles", "Proba")
+            assert check_is_mtype(
+                obj, "pred_quantiles", "Proba", msg_return_dict="list"
+            )
             assert (obj.index == d.index).all()
 
             if not isinstance(q, list):

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1216,6 +1216,7 @@ class BaseTransformer(BaseEstimator):
                 valid, msg, metadata = check_is_mtype(
                     Xt,
                     ["pd.DataFrame", "pd.Series", "np.ndarray"],
+                    msg_return_dict="list",
                     return_metadata=Xt_metadata_required,
                 )
 

--- a/sktime/utils/_testing/tests/test_panel.py
+++ b/sktime/utils/_testing/tests/test_panel.py
@@ -58,7 +58,9 @@ def test_make_panel(n_instances, n_columns, n_timepoints, return_mtype):
         return_mtype=return_mtype,
     )
 
-    valid, _, metadata = check_is_mtype(X, mtype=return_mtype, return_metadata=True)
+    valid, _, metadata = check_is_mtype(
+        X, mtype=return_mtype, return_metadata=True, msg_return_dict="list"
+    )
     msg = f"_make_panel_X generated data does not comply with mtype {return_mtype}"
     assert valid, msg
     assert metadata["n_instances"] == n_instances

--- a/sktime/utils/validation/forecasting.py
+++ b/sktime/utils/validation/forecasting.py
@@ -511,7 +511,9 @@ def check_interval_df(interval_df, index_to_match):
     """
     from sktime.datatypes import check_is_mtype
 
-    checked = check_is_mtype(interval_df, "pred_interval", return_metadata=True)
+    checked = check_is_mtype(
+        interval_df, "pred_interval", return_metadata=True, msg_return_dict="list"
+    )
     if not checked[0]:
         raise ValueError(checked[1])
     df_idx = interval_df.index


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs

Fixes non reported warnings that are internally created due to missing parameters in call of `check_is_mtype`.

**Note** set the parameter to the old default that is working. Please prove if the `dict` argument is better.
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
