### PR TITLE
[ENH] test class register, refactor `check_estimator` test gathering to central location

### DIFF
--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -40,7 +40,7 @@ def scitype(obj, force_single_scitype=True, coerce_to_list=False):
         else:
             tag_type = obj.get_tag("object_type", None, raise_error=False)
         if tag_type is not None:
-            if not isinstance(tag_type, list):
+            if coerce_to_list and not isinstance(tag_type, list):
                 return [tag_type]
             else:
                 return tag_type

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -40,7 +40,10 @@ def scitype(obj, force_single_scitype=True, coerce_to_list=False):
         else:
             tag_type = obj.get_tag("object_type", None, raise_error=False)
         if tag_type is not None:
-            return tag_type
+            if not isinstance(tag_type, list):
+                return [tag_type]
+            else:
+                return tag_type
 
     # if the tag is not present, determine scitype from legacy base class logic
     if isclass(obj):

--- a/sktime/registry/tests/test_scitype.py
+++ b/sktime/registry/tests/test_scitype.py
@@ -1,0 +1,37 @@
+"""Tests for scitype typipng function."""
+
+import pytest
+
+from sktime.registry._scitype import scitype
+
+
+@pytest.mark.parametrize("coerce_to_list", [True, False])
+def test_scitype(coerce_to_list):
+    """Test that the scitype function recovers the correct scitype(s)."""
+    from sktime.forecasting.arima import ARIMA
+    from sktime.forecasting.naive import NaiveForecaster
+    from sktime.transformations.series.exponent import ExponentTransformer
+
+    # test that scitype works for classes with soft dependencies
+    result_arima = scitype(ARIMA, coerce_to_list=coerce_to_list)
+    if coerce_to_list:
+        assert isinstance(result_arima, list)
+        assert "forecaster" == result_arima[0]
+    else:
+        assert "forecaster" == result_arima
+
+    # test that scitype works for instances
+    result_naive = scitype(NaiveForecaster(), coerce_to_list=coerce_to_list)
+    if coerce_to_list:
+        assert isinstance(result_naive, list)
+        assert "forecaster" == result_naive[0]
+    else:
+        assert "forecaster" == result_naive
+
+    # test transformer object
+    result_transformer = scitype(ExponentTransformer, coerce_to_list=coerce_to_list)
+    if coerce_to_list:
+        assert isinstance(result_transformer, list)
+        assert "transformer" == result_transformer[0]
+    else:
+        assert "transformer" == result_transformer

--- a/sktime/registry/tests/test_tags.py
+++ b/sktime/registry/tests/test_tags.py
@@ -1,4 +1,4 @@
-"""Tests for tag register an tag functionality."""
+"""Tests for tag register and tag functionality."""
 
 from sktime.registry._tags import ESTIMATOR_TAG_REGISTER
 

--- a/sktime/tests/test_class_register.py
+++ b/sktime/tests/test_class_register.py
@@ -74,6 +74,7 @@ def get_test_classes_for_obj(obj):
     test_classes : list of test classes
         list of test classes relevant for obj
         these are references to the actual classes, not strings
+        if obj was not a descendant of BaseObject or BaseEstimator, returns empty list
     """
     from sktime.base import BaseEstimator, BaseObject
     from sktime.registry import scitype
@@ -93,11 +94,7 @@ def get_test_classes_for_obj(obj):
             return isinstance(obj, BaseEstimator)
 
     if not is_object(obj):
-        raise TypeError(
-            "In get_test_classes, obj must be an sktime object or estimator, "
-            "descendant of sktime BaseObject or BaseEstimator. "
-            f"Found obj of type {type(obj).__name__} instead."
-        )
+        return []
 
     testclass_dict = get_test_class_registry()
 

--- a/sktime/tests/test_class_register.py
+++ b/sktime/tests/test_class_register.py
@@ -1,0 +1,118 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Registry and dispatcher for test classes.
+
+Module does not contain tests, only test utilities.
+"""
+
+__author__ = ["fkiraly"]
+
+from inspect import getmro, isclass
+
+
+def get_test_class_registry():
+    """Return test class registry.
+
+    Wrapped in a function to avoid circular imports.
+
+    Returns
+    -------
+    testclass_dict : dict
+        test class registry
+        keys are scitypes, values are test classes TestAll[Scitype]
+    """
+    from sktime.alignment.tests.test_all_aligners import TestAllAligners
+    from sktime.classification.early_classification.tests.test_all_early_classifiers import (  # noqa E501
+        TestAllEarlyClassifiers,
+    )
+    from sktime.classification.tests.test_all_classifiers import TestAllClassifiers
+    from sktime.dists_kernels.tests.test_all_dist_kernels import (
+        TestAllPairwiseTransformers,
+        TestAllPanelTransformers,
+    )
+    from sktime.forecasting.tests.test_all_forecasters import TestAllForecasters
+    from sktime.param_est.tests.test_all_param_est import TestAllParamFitters
+    from sktime.proba.tests.test_all_distrs import TestAllDistributions
+    from sktime.regression.tests.test_all_regressors import TestAllRegressors
+    from sktime.tests.test_all_estimators import TestAllEstimators, TestAllObjects
+    from sktime.transformations.tests.test_all_transformers import TestAllTransformers
+
+    testclass_dict = dict()
+    # every object in sktime inherits from BaseObject
+    # "object" tests are run for all objects
+    testclass_dict["object"] = TestAllObjects
+    # fittable objects inherit from BaseEstimator
+    # "estimator" tests are run for all estimators
+    # estimators are also objects
+    testclass_dict["estimator"] = TestAllEstimators
+    # more specific base classes
+    # these inherit either from BaseEstimator or BaseObject,
+    # so also imply estimator and object tests, or only object tests
+    testclass_dict["aligner"] = TestAllAligners
+    testclass_dict["classifier"] = TestAllClassifiers
+    testclass_dict["distribution"] = TestAllDistributions
+    testclass_dict["early_classifier"] = TestAllEarlyClassifiers
+    testclass_dict["forecaster"] = TestAllForecasters
+    testclass_dict["param_est"] = TestAllParamFitters
+    testclass_dict["regressor"] = TestAllRegressors
+    testclass_dict["transformer"] = TestAllTransformers
+    testclass_dict["transformer-pairwise"] = TestAllPairwiseTransformers
+    testclass_dict["transformer-pairwise-panel"] = TestAllPanelTransformers
+
+    return testclass_dict
+
+def get_test_classes(obj):
+    """Get all test classes relevant for an object or estimator.
+
+    Parameters
+    ----------
+    obj : object or estimator, descendant of sktime BaseObject or BaseEstimator
+        object or estimator for which to get test classes
+
+    Returns
+    -------
+    test_classes : list of test classes
+        list of test classes relevant for obj
+        these are references to the actual classes, not strings    
+    """
+    from sktime.base import BaseEstimator, BaseObject
+    from sktime.registry import scitype
+
+    def is_object(obj):
+        """Return whether obj is an estimator class or estimator object."""
+        if isclass(obj):
+            return issubclass(obj, BaseObject)
+        else:
+            return isinstance(obj, BaseObject)
+
+    def is_estimator(obj):
+        """Return whether obj is an estimator class or estimator object."""
+        if isclass(obj):
+            return issubclass(obj, BaseEstimator)
+        else:
+            return isinstance(obj, BaseEstimator)
+
+    if not is_object(obj):
+        raise TypeError(
+            "In get_test_classes, obj must be an sktime object or estimator, "
+            "descendant of sktime BaseObject or BaseEstimator. "
+            f"Found obj of type {type(obj).__name__} instead."
+        )
+ 
+    testclass_dict = get_test_class_registry()
+
+    # we always need to run "object" tests
+    test_clss = [testclass_dict["object"]]
+
+    if is_estimator(obj):
+        test_clss += [testclass_dict["estimator"]]
+
+    try:
+        obj_scitypes = scitype(obj, force_single_scitype=False, coerce_to_list=True)
+    except Exception:
+        obj_scitypes = []
+
+    for obj_scitype in obj_scitypes:
+        if obj_scitype in testclass_dict:
+            test_clss += [testclass_dict[obj_scitype]]
+
+    return test_clss

--- a/sktime/tests/test_class_register.py
+++ b/sktime/tests/test_class_register.py
@@ -60,7 +60,7 @@ def get_test_class_registry():
 
     return testclass_dict
 
-def get_test_classes(obj):
+def get_test_classes_for_obj(obj):
     """Get all test classes relevant for an object or estimator.
 
     Parameters

--- a/sktime/tests/test_class_register.py
+++ b/sktime/tests/test_class_register.py
@@ -6,7 +6,7 @@ Module does not contain tests, only test utilities.
 
 __author__ = ["fkiraly"]
 
-from inspect import getmro, isclass
+from inspect import isclass
 
 
 def get_test_class_registry():

--- a/sktime/tests/test_class_register.py
+++ b/sktime/tests/test_class_register.py
@@ -60,6 +60,7 @@ def get_test_class_registry():
 
     return testclass_dict
 
+
 def get_test_classes_for_obj(obj):
     """Get all test classes relevant for an object or estimator.
 
@@ -72,7 +73,7 @@ def get_test_classes_for_obj(obj):
     -------
     test_classes : list of test classes
         list of test classes relevant for obj
-        these are references to the actual classes, not strings    
+        these are references to the actual classes, not strings
     """
     from sktime.base import BaseEstimator, BaseObject
     from sktime.registry import scitype
@@ -97,7 +98,7 @@ def get_test_classes_for_obj(obj):
             "descendant of sktime BaseObject or BaseEstimator. "
             f"Found obj of type {type(obj).__name__} instead."
         )
- 
+
     testclass_dict = get_test_class_registry()
 
     # we always need to run "object" tests

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -1,5 +1,8 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Switch utility for determining whether tests for a class should be run or not."""
+"""Switch utility for determining whether tests for a class should be run or not.
+
+Module does not contain tests, only test utilities.
+"""
 
 __author__ = ["fkiraly"]
 

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -3,8 +3,6 @@
 __author__ = ["fkiraly"]
 __all__ = ["check_estimator"]
 
-from inspect import isclass
-
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -116,14 +116,13 @@ def check_estimator(
 
     for test_cls in test_clss_for_est:
         test_cls_results = test_cls().run_tests(
-            test_cls().run_tests(
-                estimator=estimator,
-                raise_exceptions=raise_exceptions,
-                tests_to_run=tests_to_run,
-                fixtures_to_run=fixtures_to_run,
-                tests_to_exclude=tests_to_exclude,
-                fixtures_to_exclude=fixtures_to_exclude,
-            )
+            estimator=estimator,
+            raise_exceptions=raise_exceptions,
+            tests_to_run=tests_to_run,
+            fixtures_to_run=fixtures_to_run,
+            tests_to_exclude=tests_to_exclude,
+            fixtures_to_exclude=fixtures_to_exclude,
+        )
         results.update(test_cls_results)
 
     failed_tests = [key for key in results.keys() if results[key] != "PASSED"]

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -108,78 +108,23 @@ def check_estimator(
     )
     _check_soft_dependencies("pytest", msg=msg)
 
-    from sktime.alignment.tests.test_all_aligners import TestAllAligners
-    from sktime.base import BaseEstimator
-    from sktime.classification.early_classification.tests.test_all_early_classifiers import (  # noqa E501
-        TestAllEarlyClassifiers,
-    )
-    from sktime.classification.tests.test_all_classifiers import TestAllClassifiers
-    from sktime.dists_kernels.tests.test_all_dist_kernels import (
-        TestAllPairwiseTransformers,
-        TestAllPanelTransformers,
-    )
-    from sktime.forecasting.tests.test_all_forecasters import TestAllForecasters
-    from sktime.param_est.tests.test_all_param_est import TestAllParamFitters
-    from sktime.proba.tests.test_all_distrs import TestAllDistributions
-    from sktime.registry import scitype
-    from sktime.regression.tests.test_all_regressors import TestAllRegressors
-    from sktime.tests.test_all_estimators import TestAllEstimators, TestAllObjects
-    from sktime.transformations.tests.test_all_transformers import TestAllTransformers
+    from sktime.tests.test_class_register import get_test_classes_for_obj
 
-    testclass_dict = dict()
-    testclass_dict["aligner"] = TestAllAligners
-    testclass_dict["classifier"] = TestAllClassifiers
-    testclass_dict["distribution"] = TestAllDistributions
-    testclass_dict["early_classifier"] = TestAllEarlyClassifiers
-    testclass_dict["forecaster"] = TestAllForecasters
-    testclass_dict["param_est"] = TestAllParamFitters
-    testclass_dict["regressor"] = TestAllRegressors
-    testclass_dict["transformer"] = TestAllTransformers
-    testclass_dict["transformer-pairwise"] = TestAllPairwiseTransformers
-    testclass_dict["transformer-pairwise-panel"] = TestAllPanelTransformers
+    test_clss_for_est = get_test_classes_for_obj(estimator)
 
-    results = TestAllObjects().run_tests(
-        estimator=estimator,
-        raise_exceptions=raise_exceptions,
-        tests_to_run=tests_to_run,
-        fixtures_to_run=fixtures_to_run,
-        tests_to_exclude=tests_to_exclude,
-        fixtures_to_exclude=fixtures_to_exclude,
-    )
+    results = {}
 
-    def is_estimator(obj):
-        """Return whether obj is an estimator class or estimator object."""
-        if isclass(obj):
-            return issubclass(obj, BaseEstimator)
-        else:
-            return isinstance(obj, BaseEstimator)
-
-    if is_estimator(estimator):
-        results_estimator = TestAllEstimators().run_tests(
-            estimator=estimator,
-            raise_exceptions=raise_exceptions,
-            tests_to_run=tests_to_run,
-            fixtures_to_run=fixtures_to_run,
-            tests_to_exclude=tests_to_exclude,
-            fixtures_to_exclude=fixtures_to_exclude,
-        )
-        results.update(results_estimator)
-
-    try:
-        scitype_of_estimator = scitype(estimator)
-    except Exception:
-        scitype_of_estimator = ""
-
-    if scitype_of_estimator in testclass_dict.keys():
-        results_scitype = testclass_dict[scitype_of_estimator]().run_tests(
-            estimator=estimator,
-            raise_exceptions=raise_exceptions,
-            tests_to_run=tests_to_run,
-            fixtures_to_run=fixtures_to_run,
-            tests_to_exclude=tests_to_exclude,
-            fixtures_to_exclude=fixtures_to_exclude,
-        )
-        results.update(results_scitype)
+    for test_cls in test_clss_for_est:
+        test_cls_results = test_cls().run_tests(
+            test_cls().run_tests(
+                estimator=estimator,
+                raise_exceptions=raise_exceptions,
+                tests_to_run=tests_to_run,
+                fixtures_to_run=fixtures_to_run,
+                tests_to_exclude=tests_to_exclude,
+                fixtures_to_exclude=fixtures_to_exclude,
+            )
+        results.update(test_cls_results)
 
     failed_tests = [key for key in results.keys() if results[key] != "PASSED"]
     if len(failed_tests) > 0:


### PR DESCRIPTION
This PR adds a test class register in the main `tests` folder, and refactors `check_estimator` test gathering to that central location.

This is in anticipation of:

* test gathering potentially across `python` packages, e.g., polymorphic pipelines with components across packages
* unified `check_estimator` interfaces across packages
* simplifying extension pattern when adding more scitypes
* logic for switching on tests for all affected estimators when test classes are changed

Depends on https://github.com/sktime/sktime/pull/5578 due to a bug in the `scitype` utility that needed to be fixed.