### PR TITLE
[ENH] enable tag related registry tests for `splitter` and `clusterer` type

### DIFF
--- a/sktime/registry/tests/test_lookup.py
+++ b/sktime/registry/tests/test_lookup.py
@@ -21,9 +21,7 @@ VALID_SCITYPES_SET = set(
 # some scitypes have no associated tags yet
 SCITYPES_WITHOUT_TAGS = [
     "series-annotator",
-    "clusterer",
     "object",
-    "splitter",
     "network",
 ]
 


### PR DESCRIPTION
This PR enables tag related registry tests for `splitter` and `clusterer` type, removing a skip from some time back where these objects did not have tags.