### PR TITLE
[BUG] fix `scitype` `coerce_to_list` parameter, add test coverage

### DIFF
--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -40,7 +40,7 @@ def scitype(obj, force_single_scitype=True, coerce_to_list=False):
         else:
             tag_type = obj.get_tag("object_type", None, raise_error=False)
         if tag_type is not None:
-            if not isinstance(tag_type, list):
+            if coerce_to_list and not isinstance(tag_type, list):
                 return [tag_type]
             else:
                 return tag_type

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -40,7 +40,10 @@ def scitype(obj, force_single_scitype=True, coerce_to_list=False):
         else:
             tag_type = obj.get_tag("object_type", None, raise_error=False)
         if tag_type is not None:
-            return tag_type
+            if not isinstance(tag_type, list):
+                return [tag_type]
+            else:
+                return tag_type
 
     # if the tag is not present, determine scitype from legacy base class logic
     if isclass(obj):

--- a/sktime/registry/tests/test_scitype.py
+++ b/sktime/registry/tests/test_scitype.py
@@ -1,0 +1,35 @@
+"""Tests for scitype typipng function."""
+
+from sktime.registry._scitype import scitype
+
+
+@pytest.mark.parametrize("coerce_to_list", [True, False])
+def test_scitype(coerce_to_list):
+    """Test that the scitype function recovers the correct scitype(s)."""
+    from sktime.forecasting.arima import ARIMA
+    from sktime.forecasting.naive import NaiveForecaster
+    from sktime.transformations.series.exponent import ExponentTransformer
+
+    # test that scitype works for classes with soft dependencies
+    result_arima = scitype(ARIMA, coerce_to_list=coerce_to_list)
+    if coerce_to_list:
+        assert isinstance(result_arima, list)
+        assert "forecaster" == result_arima[0]
+    else:
+        assert "forecaster" == result_arima
+
+    # test that scitype works for instances
+    result_naive = scitype(NaiveForecaster(), coerce_to_list=coerce_to_list)
+    if coerce_to_list:
+        assert isinstance(result_naive, list)
+        assert "forecaster" == result_naive[0]
+    else:
+        assert "forecaster" == result_naive
+
+    # test transformer object
+    result_transformer = scitype(ExponentTransformer, coerce_to_list=coerce_to_list)
+    if coerce_to_list:
+        assert isinstance(result_transformer, list)
+        assert "transformer" == result_transformer[0]
+    else:
+        assert "transformer" == result_transformer

--- a/sktime/registry/tests/test_scitype.py
+++ b/sktime/registry/tests/test_scitype.py
@@ -1,5 +1,7 @@
 """Tests for scitype typipng function."""
 
+import pytest
+
 from sktime.registry._scitype import scitype
 
 

--- a/sktime/registry/tests/test_tags.py
+++ b/sktime/registry/tests/test_tags.py
@@ -1,4 +1,4 @@
-"""Tests for tag register an tag functionality."""
+"""Tests for tag register and tag functionality."""
 
 from sktime.registry._tags import ESTIMATOR_TAG_REGISTER
 


### PR DESCRIPTION
This PR fixes an unreported bug where `registry.scitype` would return strings even if `coerce_to_list=True`.

To ensure future coverage, a test is also added.