### PR TITLE
[ENH] conditional testing of objects - test if covering test class has changed

### DIFF
--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -40,7 +40,7 @@ def scitype(obj, force_single_scitype=True, coerce_to_list=False):
         else:
             tag_type = obj.get_tag("object_type", None, raise_error=False)
         if tag_type is not None:
-            if not isinstance(tag_type, list):
+            if coerce_to_list and not isinstance(tag_type, list):
                 return [tag_type]
             else:
                 return tag_type

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -40,7 +40,10 @@ def scitype(obj, force_single_scitype=True, coerce_to_list=False):
         else:
             tag_type = obj.get_tag("object_type", None, raise_error=False)
         if tag_type is not None:
-            return tag_type
+            if not isinstance(tag_type, list):
+                return [tag_type]
+            else:
+                return tag_type
 
     # if the tag is not present, determine scitype from legacy base class logic
     if isclass(obj):

--- a/sktime/registry/tests/test_scitype.py
+++ b/sktime/registry/tests/test_scitype.py
@@ -1,0 +1,37 @@
+"""Tests for scitype typipng function."""
+
+import pytest
+
+from sktime.registry._scitype import scitype
+
+
+@pytest.mark.parametrize("coerce_to_list", [True, False])
+def test_scitype(coerce_to_list):
+    """Test that the scitype function recovers the correct scitype(s)."""
+    from sktime.forecasting.arima import ARIMA
+    from sktime.forecasting.naive import NaiveForecaster
+    from sktime.transformations.series.exponent import ExponentTransformer
+
+    # test that scitype works for classes with soft dependencies
+    result_arima = scitype(ARIMA, coerce_to_list=coerce_to_list)
+    if coerce_to_list:
+        assert isinstance(result_arima, list)
+        assert "forecaster" == result_arima[0]
+    else:
+        assert "forecaster" == result_arima
+
+    # test that scitype works for instances
+    result_naive = scitype(NaiveForecaster(), coerce_to_list=coerce_to_list)
+    if coerce_to_list:
+        assert isinstance(result_naive, list)
+        assert "forecaster" == result_naive[0]
+    else:
+        assert "forecaster" == result_naive
+
+    # test transformer object
+    result_transformer = scitype(ExponentTransformer, coerce_to_list=coerce_to_list)
+    if coerce_to_list:
+        assert isinstance(result_transformer, list)
+        assert "transformer" == result_transformer[0]
+    else:
+        assert "transformer" == result_transformer

--- a/sktime/registry/tests/test_tags.py
+++ b/sktime/registry/tests/test_tags.py
@@ -1,4 +1,4 @@
-"""Tests for tag register an tag functionality."""
+"""Tests for tag register and tag functionality."""
 
 from sktime.registry._tags import ESTIMATOR_TAG_REGISTER
 

--- a/sktime/tests/test_class_register.py
+++ b/sktime/tests/test_class_register.py
@@ -74,6 +74,7 @@ def get_test_classes_for_obj(obj):
     test_classes : list of test classes
         list of test classes relevant for obj
         these are references to the actual classes, not strings
+        if obj was not a descendant of BaseObject or BaseEstimator, returns empty list
     """
     from sktime.base import BaseEstimator, BaseObject
     from sktime.registry import scitype
@@ -93,11 +94,7 @@ def get_test_classes_for_obj(obj):
             return isinstance(obj, BaseEstimator)
 
     if not is_object(obj):
-        raise TypeError(
-            "In get_test_classes, obj must be an sktime object or estimator, "
-            "descendant of sktime BaseObject or BaseEstimator. "
-            f"Found obj of type {type(obj).__name__} instead."
-        )
+        return []
 
     testclass_dict = get_test_class_registry()
 

--- a/sktime/tests/test_class_register.py
+++ b/sktime/tests/test_class_register.py
@@ -1,0 +1,119 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Registry and dispatcher for test classes.
+
+Module does not contain tests, only test utilities.
+"""
+
+__author__ = ["fkiraly"]
+
+from inspect import isclass
+
+
+def get_test_class_registry():
+    """Return test class registry.
+
+    Wrapped in a function to avoid circular imports.
+
+    Returns
+    -------
+    testclass_dict : dict
+        test class registry
+        keys are scitypes, values are test classes TestAll[Scitype]
+    """
+    from sktime.alignment.tests.test_all_aligners import TestAllAligners
+    from sktime.classification.early_classification.tests.test_all_early_classifiers import (  # noqa E501
+        TestAllEarlyClassifiers,
+    )
+    from sktime.classification.tests.test_all_classifiers import TestAllClassifiers
+    from sktime.dists_kernels.tests.test_all_dist_kernels import (
+        TestAllPairwiseTransformers,
+        TestAllPanelTransformers,
+    )
+    from sktime.forecasting.tests.test_all_forecasters import TestAllForecasters
+    from sktime.param_est.tests.test_all_param_est import TestAllParamFitters
+    from sktime.proba.tests.test_all_distrs import TestAllDistributions
+    from sktime.regression.tests.test_all_regressors import TestAllRegressors
+    from sktime.tests.test_all_estimators import TestAllEstimators, TestAllObjects
+    from sktime.transformations.tests.test_all_transformers import TestAllTransformers
+
+    testclass_dict = dict()
+    # every object in sktime inherits from BaseObject
+    # "object" tests are run for all objects
+    testclass_dict["object"] = TestAllObjects
+    # fittable objects inherit from BaseEstimator
+    # "estimator" tests are run for all estimators
+    # estimators are also objects
+    testclass_dict["estimator"] = TestAllEstimators
+    # more specific base classes
+    # these inherit either from BaseEstimator or BaseObject,
+    # so also imply estimator and object tests, or only object tests
+    testclass_dict["aligner"] = TestAllAligners
+    testclass_dict["classifier"] = TestAllClassifiers
+    testclass_dict["distribution"] = TestAllDistributions
+    testclass_dict["early_classifier"] = TestAllEarlyClassifiers
+    testclass_dict["forecaster"] = TestAllForecasters
+    testclass_dict["param_est"] = TestAllParamFitters
+    testclass_dict["regressor"] = TestAllRegressors
+    testclass_dict["transformer"] = TestAllTransformers
+    testclass_dict["transformer-pairwise"] = TestAllPairwiseTransformers
+    testclass_dict["transformer-pairwise-panel"] = TestAllPanelTransformers
+
+    return testclass_dict
+
+
+def get_test_classes_for_obj(obj):
+    """Get all test classes relevant for an object or estimator.
+
+    Parameters
+    ----------
+    obj : object or estimator, descendant of sktime BaseObject or BaseEstimator
+        object or estimator for which to get test classes
+
+    Returns
+    -------
+    test_classes : list of test classes
+        list of test classes relevant for obj
+        these are references to the actual classes, not strings
+    """
+    from sktime.base import BaseEstimator, BaseObject
+    from sktime.registry import scitype
+
+    def is_object(obj):
+        """Return whether obj is an estimator class or estimator object."""
+        if isclass(obj):
+            return issubclass(obj, BaseObject)
+        else:
+            return isinstance(obj, BaseObject)
+
+    def is_estimator(obj):
+        """Return whether obj is an estimator class or estimator object."""
+        if isclass(obj):
+            return issubclass(obj, BaseEstimator)
+        else:
+            return isinstance(obj, BaseEstimator)
+
+    if not is_object(obj):
+        raise TypeError(
+            "In get_test_classes, obj must be an sktime object or estimator, "
+            "descendant of sktime BaseObject or BaseEstimator. "
+            f"Found obj of type {type(obj).__name__} instead."
+        )
+
+    testclass_dict = get_test_class_registry()
+
+    # we always need to run "object" tests
+    test_clss = [testclass_dict["object"]]
+
+    if is_estimator(obj):
+        test_clss += [testclass_dict["estimator"]]
+
+    try:
+        obj_scitypes = scitype(obj, force_single_scitype=False, coerce_to_list=True)
+    except Exception:
+        obj_scitypes = []
+
+    for obj_scitype in obj_scitypes:
+        if obj_scitype in testclass_dict:
+            test_clss += [testclass_dict[obj_scitype]]
+
+    return test_clss

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -1,5 +1,8 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Switch utility for determining whether tests for a class should be run or not."""
+"""Switch utility for determining whether tests for a class should be run or not.
+
+Module does not contain tests, only test utilities.
+"""
 
 __author__ = ["fkiraly"]
 

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -13,17 +13,26 @@ def run_test_for_class(cls):
 
     1. whether all required soft dependencies are present.
        If not, does not run the test.
-    2. If yes:
-      * if ONLY_CHANGED_MODULES setting is on, runs the test if and only
+       If yes, runs the test if and only if
+       at least one of conditions 2, 3 below are met.
+
+    2. Condition 2:
+
+      * if ONLY_CHANGED_MODULES setting is on, condition 2 is met if and only
       if the module containing the class/func has changed according to is_class_changed
-      * if ONLY_CHANGED_MODULES if off, always runs the test if all soft dependencies
-      are present.
+      * if ONLY_CHANGED_MODULES if off, condition 2 is always met.
+
+    3. Condition 3:
+
+      If the object is an sktime BaseObject, and one of the test classes
+      covering the class have changed, then condition 3 is met.
 
     cls can also be a list of classes or functions,
     in this case the test is run if and only if:
 
     * all required soft dependencies are present
-    * if yes, if any of the estimators in the list should be tested by criterion 2 above
+    * if yes, if any of the estimators in the list should be tested by
+      criterion 2 or 3 above
 
     Parameters
     ----------
@@ -62,15 +71,31 @@ def run_test_for_class(cls):
         ]
         return any(is_class_changed(x) for x in cls_and_sktime_parents)
 
+    def _tests_covering_class_changed(cls):
+        """Check if any of the tests covering cls have changed, return bool."""
+        from sktime.tests.test_class_register import get_test_classes_for_obj
+
+        test_classes = get_test_classes_for_obj(cls)
+        return any(is_class_changed(x) for x in test_classes)
+
+    # Condition 1:
     # if any of the required soft dependencies are not present, do not run the test
     if not all(_required_deps_present(x) for x in cls):
         return False
+    # otherwise, continue
 
+    # Condition 2:
     # if ONLY_CHANGED_MODULES is on, run the test if and only if
     # any of the modules containing any of the classes in the list have changed
     if ONLY_CHANGED_MODULES:
-        return any(_is_class_changed_or_sktime_parents(x) for x in cls)
+        cond2 = any(_is_class_changed_or_sktime_parents(x) for x in cls)
+    else:
+        cond2 = True
 
-    # otherwise
-    # i.e., dependencies are present, and differential testing is disabled
-    return True
+    # Condition 3:
+    # if the object is an sktime BaseObject, and one of the test classes
+    # covering the class have changed, then run the test
+    cond3 = any(_tests_covering_class_changed(x) for x in cls)
+
+    # run the test if and only if at least one of the conditions 2, 3 are met
+    return cond2 or cond3


### PR DESCRIPTION
Currently, in the differential testing logic via `run_tests_for_class`, we do not cause a test to be run if the class has remained unchanged, but the covering test has changed.

To ensure we properly test changes in tests, I've extended the logic so suite tests for all estimators covered by them are always run if the test class itself changes.

Relies on https://github.com/sktime/sktime/pull/5574 for easy access to the test classes covering an estimator.