### PR TITLE
[ENH] export and test `DirectReductionForecaster`

### DIFF
--- a/sktime/forecasting/compose/__init__.py
+++ b/sktime/forecasting/compose/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "RecursiveTimeSeriesRegressionForecaster",
     "DirRecTabularRegressionForecaster",
     "DirRecTimeSeriesRegressionForecaster",
+    "DirectReductionForecaster",
     "StackingForecaster",
     "MultiplexForecaster",
     "make_reduction",
@@ -45,6 +46,7 @@ from sktime.forecasting.compose._pipeline import (
     TransformedTargetForecaster,
 )
 from sktime.forecasting.compose._reduce import (
+    DirectReductionForecaster,
     DirectTabularRegressionForecaster,
     DirectTimeSeriesRegressionForecaster,
     DirRecTabularRegressionForecaster,

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1725,7 +1725,7 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         to obtain a prediction for `y(c+h)`, for each `h` in the forecasting horizon
     if `X_treatment = "shifted":
         applies fitted estimator's predict to
-        features = `y(c)`, `y(c-1)`, ..., `y(c-window_size)`, if provided: `X(t)`
+        features = `y(c)`, `y(c-1)`, ..., `y(c-window_size)`, if provided: `X(c)`
         to obtain prediction for `y(c+h_1)`, ..., `y(c+h_k)` for `h_j` in forec. horizon
 
     Parameters


### PR DESCRIPTION
This PR adds `DirectReductionForecaster` as an export to `compose`, ensuring regular testing

The typo fix in the class' module ensures the test is also triggered by the diff testing.

Same as https://github.com/sktime/sktime/pull/5581 without refactor, as an intermediate step, or for testing and diagnostics.