### PR TITLE
[MNT] addressing various `pandas` related deprecations

### DIFF
--- a/sktime/benchmarking/evaluation.py
+++ b/sktime/benchmarking/evaluation.py
@@ -111,7 +111,7 @@ class Evaluator:
         # aggregate over cv folds
         metrics_by_strategy_dataset = (
             self._metrics.groupby(["dataset", "strategy"], as_index=False)
-            .agg(np.mean)
+            .agg("mean")
             .drop(columns="cv_fold")
         )
         self._metrics_by_strategy_dataset = self._metrics_by_strategy_dataset.merge(
@@ -123,7 +123,7 @@ class Evaluator:
         )
         metrics_by_strategy = metrics_by_strategy_dataset_wo_ds.groupby(
             ["strategy"], as_index=False
-        ).agg(np.mean)
+        ).agg("mean")
         self._metrics_by_strategy = self._metrics_by_strategy.merge(
             metrics_by_strategy, how="outer"
         )
@@ -521,7 +521,7 @@ class Evaluator:
         # # aggregate over cv folds
         # metrics_by_strategy_dataset = (
         #     self._metrics.groupby(["dataset", "strategy"], as_index=False)
-        #     .agg(np.mean)
+        #     .agg("mean")
         #     .drop(columns="cv_fold")
         # )
         # self._metrics_by_strategy_dataset = self._metrics_by_strategy_dataset.merge(
@@ -530,7 +530,7 @@ class Evaluator:
         # # aggregate over cv folds and datasets
         # metrics_by_strategy = metrics_by_strategy_dataset.groupby(
         #     ["strategy"], as_index=False
-        # ).agg(np.mean)
+        # ).agg("mean")
         # self._metrics_by_strategy = self._metrics_by_strategy.merge(
         #     metrics_by_strategy, how="outer"
         # )

--- a/sktime/benchmarking/tests/test_orchestration.py
+++ b/sktime/benchmarking/tests/test_orchestration.py
@@ -193,8 +193,8 @@ def test_stat():
     _, sign_test_df = analyse.sign_test()
 
     sign_array = [
-        [sign_test_df["pf"][0], sign_test_df["pf"][1]],
-        [sign_test_df["tsf"][0], sign_test_df["tsf"][1]],
+        [sign_test_df["pf"].iloc[0], sign_test_df["pf"].iloc[1]],
+        [sign_test_df["tsf"].iloc[0], sign_test_df["tsf"].iloc[1]],
     ]
     sign_array_test = [[1, 1], [1, 1]]
     np.testing.assert_equal(

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -36,6 +36,7 @@ __all__ = [
 from sktime.datatypes._convert_utils._coerce import _coerce_df_dtypes
 from sktime.datatypes._convert_utils._convert import _extend_conversions
 from sktime.datatypes._panel._registry import MTYPE_LIST_PANEL
+from sktime.utils.pandas import df_map
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 # dictionary indexed by triples of types
@@ -71,7 +72,7 @@ def _cell_is_series_or_array(cell):
 
 
 def _nested_cell_mask(X):
-    return X.map(_cell_is_series_or_array)
+    return df_map(X)(_cell_is_series_or_array)
 
 
 def are_columns_nested(X):
@@ -886,7 +887,7 @@ def from_nested_to_3d_numpy(X):
     # If all the columns are nested in structure
     if nested_col_mask.count(True) == len(nested_col_mask):
         X_3d = np.stack(
-            X.map(_convert_series_cell_to_numpy)
+            df_map(X)(_convert_series_cell_to_numpy)
             .apply(lambda row: np.stack(row), axis=1)
             .to_numpy()
         )

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -71,7 +71,7 @@ def _cell_is_series_or_array(cell):
 
 
 def _nested_cell_mask(X):
-    return X.applymap(_cell_is_series_or_array)
+    return X.map(_cell_is_series_or_array)
 
 
 def are_columns_nested(X):
@@ -820,7 +820,7 @@ def from_nested_to_multi_index(X, instance_index=None, time_index=None):
         X_col = X_col.infer_objects()
 
         # create the right MultiIndex and assign to X_mi
-        idx_df = X[[c]].applymap(lambda x: x.index).explode(c)
+        idx_df = X[[c]].map(lambda x: x.index).explode(c)
         index = pd.MultiIndex.from_arrays([idx_df.index, idx_df[c].values])
         index = index.set_names([instance_index, time_index])
         X_col.index = index
@@ -886,7 +886,7 @@ def from_nested_to_3d_numpy(X):
     # If all the columns are nested in structure
     if nested_col_mask.count(True) == len(nested_col_mask):
         X_3d = np.stack(
-            X.applymap(_convert_series_cell_to_numpy)
+            X.map(_convert_series_cell_to_numpy)
             .apply(lambda row: np.stack(row), axis=1)
             .to_numpy()
         )

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -821,7 +821,7 @@ def from_nested_to_multi_index(X, instance_index=None, time_index=None):
         X_col = X_col.infer_objects()
 
         # create the right MultiIndex and assign to X_mi
-        idx_df = X[[c]].map(lambda x: x.index).explode(c)
+        idx_df = df_map(X[[c]])(lambda x: x.index).explode(c)
         index = pd.MultiIndex.from_arrays([idx_df.index, idx_df[c].values])
         index = index.set_names([instance_index, time_index])
         X_col.index = index

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -266,9 +266,11 @@ def get_cutoff(
     if reverse_order:
         ix = 0
         agg = min
+        agg_str = "min"
     else:
         ix = -1
         agg = max
+        agg_str = "max"
 
     def sub_idx(idx, ix, return_index=True):
         """Like sub-setting pd.index, but preserves freq attribute."""
@@ -309,7 +311,7 @@ def get_cutoff(
             .groupby(level=inst_levels, sort=False)
             .nth(ix)
             .iloc[:, -1]
-            .agg(agg)
+            .agg(agg_str)
         )
         if return_index:
             cuttoff_idx = ensure_index([cutoff])

--- a/sktime/datatypes/tests/test_panel_converters.py
+++ b/sktime/datatypes/tests/test_panel_converters.py
@@ -167,7 +167,7 @@ def test_from_nested_to_multi_index(n_instances, n_columns, n_timepoints):
         nested, instance_index="case_id", time_index="reading_id"
     )
 
-    # n_timepoints_max = nested.applymap(_nested_cell_timepoints).sum().max()
+    # n_timepoints_max = nested.map(_nested_cell_timepoints).sum().max()
 
     assert isinstance(mi_df, pd.DataFrame)
     assert mi_df.shape == (n_instances * n_timepoints, n_columns)

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -11,6 +11,7 @@ from sktime.datatypes._check import AMBIGUOUS_MTYPES, check_is_mtype
 from sktime.datatypes._examples import get_examples
 from sktime.datatypes._vectorize import VectorizedDF, _enforce_index_freq
 from sktime.utils._testing.deep_equals import deep_equals
+from sktime.utils.pandas import df_map
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 SCITYPES = ["Panel", "Hierarchical"]
@@ -492,5 +493,5 @@ def test_vectorize_est(
     n_cols = _len(cols)
     assert isinstance(result, pd.DataFrame)
     assert result.shape == (n_rows, n_cols)
-    is_fcst_frame = result.map(lambda x: isinstance(x, NaiveForecaster))
+    is_fcst_frame = df_map(result)(lambda x: isinstance(x, NaiveForecaster))
     assert is_fcst_frame.all().all()

--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -492,5 +492,5 @@ def test_vectorize_est(
     n_cols = _len(cols)
     assert isinstance(result, pd.DataFrame)
     assert result.shape == (n_rows, n_cols)
-    is_fcst_frame = result.applymap(lambda x: isinstance(x, NaiveForecaster))
+    is_fcst_frame = result.map(lambda x: isinstance(x, NaiveForecaster))
     assert is_fcst_frame.all().all()

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -373,7 +373,7 @@ def test_tag_handles_missing_data():
     forecaster.set_tags(**{"handles-missing-data": False})
 
     y = _make_series()
-    y[10] = np.nan
+    y.iloc[10] = np.nan
 
     # test only TransformedTargetForecaster
     y_pipe = TransformedTargetForecaster(

--- a/sktime/forecasting/tests/test_naive.py
+++ b/sktime/forecasting/tests/test_naive.py
@@ -213,7 +213,7 @@ def test_strategy_mean_and_last_seasonal_additional_combinations(
     # For selected cases, remove a redundant data point by making it NaN
     if window_length > sp:
         # create a trailing NaN value in the training set
-        data[window_length - 1] = np.nan
+        data.iloc[window_length - 1] = np.nan
 
     # Split into train and test data
     train_data = data[:window_length]

--- a/sktime/proba/base.py
+++ b/sktime/proba/base.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.base import BaseObject
+from sktime.utils.pandas import df_map
 from sktime.utils.validation._dependencies import _check_estimator_deps
 
 
@@ -225,7 +226,7 @@ class BaseDistribution(BaseObject):
                 "this may be numerically unstable"
             )
             warn(self._method_error_msg("pdf", fill_in=approx_method))
-            return self.log_pdf(x=x).map(np.exp)
+            return df_map(self.log_pdf(x=x))(np.exp)
 
         raise NotImplementedError(self._method_error_msg("pdf", "error"))
 
@@ -265,7 +266,7 @@ class BaseDistribution(BaseObject):
             )
             warn(self._method_error_msg("log_pdf", fill_in=approx_method))
 
-            return self.pdf(x=x).map(np.log)
+            return df_map(self.pdf(x=x))(np.log)
 
         raise NotImplementedError(self._method_error_msg("log_pdf", "error"))
 

--- a/sktime/proba/base.py
+++ b/sktime/proba/base.py
@@ -225,7 +225,7 @@ class BaseDistribution(BaseObject):
                 "this may be numerically unstable"
             )
             warn(self._method_error_msg("pdf", fill_in=approx_method))
-            return self.log_pdf(x=x).applymap(np.exp)
+            return self.log_pdf(x=x).map(np.exp)
 
         raise NotImplementedError(self._method_error_msg("pdf", "error"))
 
@@ -265,7 +265,7 @@ class BaseDistribution(BaseObject):
             )
             warn(self._method_error_msg("log_pdf", fill_in=approx_method))
 
-            return self.pdf(x=x).applymap(np.log)
+            return self.pdf(x=x).map(np.log)
 
         raise NotImplementedError(self._method_error_msg("log_pdf", "error"))
 

--- a/sktime/transformations/compose/_ixtox.py
+++ b/sktime/transformations/compose/_ixtox.py
@@ -4,7 +4,8 @@
 __author__ = ["fkiraly"]
 __all__ = ["IxToX"]
 
-from pandas.api.types import is_datetime64_any_dtype, is_period_dtype
+import pandas as pd
+from pandas.api.types import is_datetime64_any_dtype
 
 from sktime.transformations.base import BaseTransformer
 
@@ -101,7 +102,7 @@ class IxToX(BaseTransformer):
         level = self.level
 
         def is_date_like(x):
-            return is_datetime64_any_dtype(x) or is_period_dtype(x)
+            return is_datetime64_any_dtype(x) or isinstance(x, pd.PeriodDtype)
 
         if ix_source == "y" and y is not None:
             X = y

--- a/sktime/transformations/panel/interpolate.py
+++ b/sktime/transformations/panel/interpolate.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.transformations.base import BaseTransformer
+from sktime.utils.pandas import df_map
 
 __author__ = ["mloning"]
 
@@ -84,7 +85,7 @@ class TSInterpolator(BaseTransformer):
         pandas DataFrame : Transformed pandas DataFrame of shape [n_samples, n_features]
             follows nested_univ format
         """
-        return X.map(self._resize_cell)
+        return df_map(X)(self._resize_cell)
 
     @classmethod
     def get_test_params(cls):

--- a/sktime/transformations/panel/interpolate.py
+++ b/sktime/transformations/panel/interpolate.py
@@ -84,7 +84,7 @@ class TSInterpolator(BaseTransformer):
         pandas DataFrame : Transformed pandas DataFrame of shape [n_samples, n_features]
             follows nested_univ format
         """
-        return X.applymap(self._resize_cell)
+        return X.map(self._resize_cell)
 
     @classmethod
     def get_test_params(cls):

--- a/sktime/transformations/panel/padder.py
+++ b/sktime/transformations/panel/padder.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.transformations.base import BaseTransformer
+from sktime.utils.pandas import df_map
 
 __all__ = ["PaddingTransformer"]
 __author__ = ["abostrom"]
@@ -103,7 +104,7 @@ class PaddingTransformer(BaseTransformer):
             )
 
         pad = [pd.Series([self._create_pad(series) for series in out]) for out in arr]
-        Xt = pd.DataFrame(pad).map(pd.Series)
+        Xt = df_map(pd.DataFrame(pad))(pd.Series)
 
         return Xt
 

--- a/sktime/transformations/panel/padder.py
+++ b/sktime/transformations/panel/padder.py
@@ -103,7 +103,7 @@ class PaddingTransformer(BaseTransformer):
             )
 
         pad = [pd.Series([self._create_pad(series) for series in out]) for out in arr]
-        Xt = pd.DataFrame(pad).applymap(pd.Series)
+        Xt = pd.DataFrame(pad).map(pd.Series)
 
         return Xt
 

--- a/sktime/transformations/panel/reduce.py
+++ b/sktime/transformations/panel/reduce.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from sktime.datatypes import convert, convert_to
 from sktime.transformations.base import BaseTransformer
+from sktime.utils.pandas import df_map
 
 
 class Tabularizer(BaseTransformer):
@@ -150,7 +151,7 @@ class TimeBinner(BaseTransformer):
         transformed version of X
         """
         idx = pd.cut(X.iloc[0, 0].index, bins=self.idx, include_lowest=True)
-        Xt = X.map(lambda x: x.groupby(idx).apply(self._aggfunc))
+        Xt = df_map(X)(lambda x: x.groupby(idx).apply(self._aggfunc))
         Xt = convert_to(Xt, to_type="numpyflat", as_scitype="Panel")
         return Xt
 

--- a/sktime/transformations/panel/reduce.py
+++ b/sktime/transformations/panel/reduce.py
@@ -150,7 +150,7 @@ class TimeBinner(BaseTransformer):
         transformed version of X
         """
         idx = pd.cut(X.iloc[0, 0].index, bins=self.idx, include_lowest=True)
-        Xt = X.applymap(lambda x: x.groupby(idx).apply(self._aggfunc))
+        Xt = X.map(lambda x: x.groupby(idx).apply(self._aggfunc))
         Xt = convert_to(Xt, to_type="numpyflat", as_scitype="Panel")
         return Xt
 

--- a/sktime/transformations/panel/summarize/_extract.py
+++ b/sktime/transformations/panel/summarize/_extract.py
@@ -10,6 +10,7 @@ from joblib import Parallel, delayed
 from sktime.datatypes import convert_to
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.panel.segment import RandomIntervalSegmenter
+from sktime.utils.pandas import df_map
 
 
 class PlateauFinder(BaseTransformer):
@@ -103,7 +104,7 @@ class PlateauFinder(BaseTransformer):
         Xt["%s_starts" % column_prefix] = pd.Series(self._starts)
         Xt["%s_lengths" % column_prefix] = pd.Series(self._lengths)
 
-        Xt = Xt.map(lambda x: pd.Series(x))
+        Xt = df_map(Xt)(lambda x: pd.Series(x))
         return Xt
 
 

--- a/sktime/transformations/panel/summarize/_extract.py
+++ b/sktime/transformations/panel/summarize/_extract.py
@@ -103,7 +103,7 @@ class PlateauFinder(BaseTransformer):
         Xt["%s_starts" % column_prefix] = pd.Series(self._starts)
         Xt["%s_lengths" % column_prefix] = pd.Series(self._lengths)
 
-        Xt = Xt.applymap(lambda x: pd.Series(x))
+        Xt = Xt.map(lambda x: pd.Series(x))
         return Xt
 
 

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -347,7 +347,7 @@ class Imputer(BaseTransformer):
 
                 self._forecaster.fit(
                     y=self._X[col].ffill().bfill(),
-                    X=self._y[col].ffill().bfill(),
+                    X=self._y[col].ffill().bfill()
                     if self._y is not None
                     else None,
                     fh=fh,

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -346,8 +346,8 @@ class Imputer(BaseTransformer):
                 # fill NaN before fitting with ffill and backfill (heuristic)
 
                 self._forecaster.fit(
-                    y=self._X[col].ffill().fillna(method="backfill"),
-                    X=self._y[col].ffill().fillna(method="backfill")
+                    y=self._X[col].ffill().bfill(),
+                    X=self._y[col].ffill().bfill(),
                     if self._y is not None
                     else None,
                     fh=fh,

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -347,9 +347,7 @@ class Imputer(BaseTransformer):
 
                 self._forecaster.fit(
                     y=self._X[col].ffill().bfill(),
-                    X=self._y[col].ffill().bfill()
-                    if self._y is not None
-                    else None,
+                    X=self._y[col].ffill().bfill() if self._y is not None else None,
                     fh=fh,
                 )
 

--- a/sktime/transformations/series/outlier_detection.py
+++ b/sktime/transformations/series/outlier_detection.py
@@ -172,7 +172,7 @@ def _hampel_filter(Z, cv, n_sigma, half_window_length, k):
     for i in cv.split(Z):
         cv_window = i[0]
         cv_median = np.nanmedian(Z[cv_window])
-        cv_sigma = k * np.nanmedian(np.abs(Z[cv_window] - cv_median))
+        cv_sigma = k * np.nanmedian(np.abs(Z.iloc[cv_window] - cv_median))
 
         is_start_window = cv_window[-1] == cv.window_length - 1
         is_end_window = cv_window[-1] == len(Z) - 1

--- a/sktime/utils/pandas.py
+++ b/sktime/utils/pandas.py
@@ -7,7 +7,7 @@ __author__ = ["fkiraly"]
 def df_map(x):
     """Access map or applymap, of DataFrame.
 
-    In pandas 2.1.0, applymap was deprecated in favor of map.
+    In pandas 2.1.0, applymap was deprecated in favor of the newly introduced map.
     To ensure compatibility with older versions, we use map if available,
     otherwise applymap.
 

--- a/sktime/utils/pandas.py
+++ b/sktime/utils/pandas.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3 -u
+"""Utilities for pandas adapbation."""
+
+__author__ = ["fkiraly"]
+
+
+def df_map(x):
+    """Access map or applymap, of DataFrame.
+
+    In pandas 2.1.0, applymap was deprecated in favor of map.
+    To ensure compatibility with older versions, we use map if available,
+    otherwise applymap.
+
+    Parameters
+    ----------
+    x : assumed pd.DataFrame
+
+    Returns
+    -------
+    x.map, if available, otherwise x.applymap
+        Note: returns method itself, not result of method call
+    """
+    if hasattr(x, "map"):
+        return x.map
+    else:
+        return x.applymap


### PR DESCRIPTION
This PR addresses various deprecation warnings from `pandas`:

* deprecation of integer `__getitem__` based `iloc` access of `DataFrame`, `Series`
* deprecation of `GroupBy.agg` with function arg
* deprecation of `applymap` methods
* deprecation of imputation `method` arg in favour of `ffill`, `bfill` methods
* deprecation of `is_period_dtype`

The changes should be downwards compatible due to historical duplication of functionality in `pandas`, except for:

* the change of `applymap` to `map` breaks below 2.1.0. For this reason, an adapter utility has been introduced which keeps downwards compatibility.