### PR TITLE
[DOC] fix typo in `AA_datatypes_and_datasets.ipynb` panel data loading example

### DIFF
--- a/examples/AA_datatypes_and_datasets.ipynb
+++ b/examples/AA_datatypes_and_datasets.ipynb
@@ -3166,7 +3166,7 @@
     }
    ],
    "source": [
-    "df_panel = df_panel.set_index([\"timepoints\", \"level_0\"])\n",
+    "df_panel = df_panel.set_index([\"level_0\", \"timepoints\"])\n",
     "type(df_panel.index)"
    ]
   },


### PR DESCRIPTION
This PR fixes a typo in the `AA_datatypes_and_datasets.ipynb` panel data loading example - the `set_index` call had the instance and time lable in the wrong sequence.