### PR TITLE
[ENH] `n_features` and `feature_names` metadata field for time series mtypes

### DIFF
--- a/sktime/datatypes/_adapter/dask_to_pd.py
+++ b/sktime/datatypes/_adapter/dask_to_pd.py
@@ -175,6 +175,10 @@ def check_dask_frame(
         metadata["is_empty"] = len(obj.index) < 1 or len(obj.columns) < 1
     if _req("is_univariate", return_metadata):
         metadata["is_univariate"] = len(obj.columns) == 1
+    if _req("n_features", return_metadata):
+        metadata["n_features"] = len(obj.columns)
+    if _req("feature_names", return_metadata):
+        metadata["feature_names"] = obj.columns.to_list()
 
     # check that columns are unique
     if not obj.columns.is_unique:

--- a/sktime/datatypes/_examples.py
+++ b/sktime/datatypes/_examples.py
@@ -97,9 +97,9 @@ def get_examples(
     fixtures: dict with integer keys, elements being
         fixture - example for mtype `mtype`, scitype `as_scitype`
         if return_lossy=True, elements are pairs with fixture and
-            lossy: bool - whether the example is a lossy representation
+        lossy: bool - whether the example is a lossy representation
         if return_metadata=True, elements are triples with fixture, lossy, and
-            metadata: dict - metadata dict that would be returned by check_is_mtype
+        metadata: dict - metadata dict that would be returned by check_is_mtype
     """
     # if as_scitype is None, infer from mtype
     if as_scitype is None:

--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -36,6 +36,8 @@ metadata: dict - metadata about obj if valid, otherwise None
         "has_nans": bool, True iff the panel contains NaN values
         "n_instances": int, number of instances in the hierarchical panel
         "n_panels": int, number of flat panels in the hierarchical panel
+        "n_features": int, number of variables in series
+        "feature_names": list of int or object, names of variables in series
 """
 
 __author__ = ["fkiraly"]

--- a/sktime/datatypes/_hierarchical/_examples.py
+++ b/sktime/datatypes/_hierarchical/_examples.py
@@ -114,6 +114,8 @@ example_dict_metadata[("Hierarchical", 0)] = {
     "has_nans": False,
     "n_instances": 6,
     "n_panels": 2,
+    "n_features": 2,
+    "feature_names": ["var_0", "var_1"],
 }
 
 
@@ -156,4 +158,6 @@ example_dict_metadata[("Hierarchical", 1)] = {
     "has_nans": False,
     "n_instances": 6,
     "n_panels": 2,
+    "n_features": 1,
+    "feature_names": ["var_0"],
 }

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -34,6 +34,8 @@ metadata: dict - metadata about obj if valid, otherwise None
         "is_one_series": bool, True iff there is only one series in the panel
         "has_nans": bool, True iff the panel contains NaN values
         "n_instances": int, number of instances in the panel
+        "n_features": int, number of variables in series
+        "feature_names": list of int or object, names of variables in series
 """
 
 __author__ = ["fkiraly", "TonyBagnall"]
@@ -124,6 +126,10 @@ def check_dflist_panel(obj, return_metadata=False, var_name="obj"):
         metadata["is_one_panel"] = True
     if _req("n_instances", return_metadata):
         metadata["n_instances"] = n
+    if _req("n_features", return_metadata):
+        metadata["n_features"] = len(obj[0].columns)
+    if _req("feature_names", return_metadata):
+        metadata["feature_names"] = obj[0].columns.to_list()
 
     return _ret(True, None, metadata, return_metadata)
 
@@ -160,6 +166,10 @@ def check_numpy3d_panel(obj, return_metadata=False, var_name="obj"):
         metadata["n_panels"] = 1
     if _req("is_one_panel", return_metadata):
         metadata["is_one_panel"] = True
+    if _req("n_features", return_metadata):
+        metadata["n_features"] = obj.shape[1]
+    if _req("feature_names", return_metadata):
+        metadata["feature_names"] = list(range(obj.shape[1]))
 
     # check whether there any nans; only if requested
     if _req("has_nans", return_metadata):
@@ -246,6 +256,10 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj", panel=T
         metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
     if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
+    if _req("n_features", return_metadata):
+        metadata["n_features"] = len(obj.columns)
+    if _req("feature_names", return_metadata):
+        metadata["feature_names"] = obj.columns.to_list()
 
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed
@@ -419,6 +433,10 @@ def is_nested_dataframe(obj, return_metadata=False, var_name="obj"):
         metadata["has_nans"] = _nested_dataframe_has_nans(obj)
     if _req("is_equal_length", return_metadata):
         metadata["is_equal_length"] = not _nested_dataframe_has_unequal(obj)
+    if _req("n_features", return_metadata):
+        metadata["n_features"] = len(obj.columns)
+    if _req("feature_names", return_metadata):
+        metadata["feature_names"] = obj.columns.to_list()
 
     # todo: this is temporary override, proper is_empty logic needs to be added
     if _req("is_empty", return_metadata):
@@ -448,6 +466,10 @@ def check_numpyflat_Panel(obj, return_metadata=False, var_name="obj"):
         metadata["is_empty"] = len(obj) < 1 or obj.shape[1] < 1
     if _req("is_univariate", return_metadata):
         metadata["is_univariate"] = True
+    if _req("n_features", return_metadata):
+        metadata["n_features"] = 1
+    if _req("feature_names", return_metadata):
+        metadata["feature_names"] = [0]
     # np.arrays are considered equally spaced, equal length, by assumption
     if _req("is_equally_spaced", return_metadata):
         metadata["is_equally_spaced"] = True

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -188,12 +188,12 @@ X = np.array(
 )
 
 example_dict[("numpy3D", "Panel", 2)] = X
-example_dict_lossy[("numpy3D", "Panel", 2)] = False
+example_dict_lossy[("numpy3D", "Panel", 2)] = True
 
 X = np.array([[4, 5, 6]], dtype=np.int64)
 
 example_dict[("numpyflat", "Panel", 2)] = X
-example_dict_lossy[("numpyflat", "Panel", 2)] = False
+example_dict_lossy[("numpyflat", "Panel", 2)] = True
 
 cols = [f"var_{i}" for i in range(1)]
 Xlist = [

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -39,10 +39,10 @@ X = np.array(
 )
 
 example_dict[("numpy3D", "Panel", 0)] = X
-example_dict_lossy[("numpy3D", "Panel", 0)] = False
+example_dict_lossy[("numpy3D", "Panel", 0)] = True
 
 example_dict[("numpyflat", "Panel", 0)] = None
-example_dict_lossy[("numpyflat", "Panel", 0)] = None
+example_dict_lossy[("numpyflat", "Panel", 0)] = True
 
 cols = [f"var_{i}" for i in range(2)]
 Xlist = [
@@ -114,12 +114,12 @@ X = np.array(
 )
 
 example_dict[("numpy3D", "Panel", 1)] = X
-example_dict_lossy[("numpy3D", "Panel", 1)] = False
+example_dict_lossy[("numpy3D", "Panel", 1)] = True
 
 X = np.array([[4, 5, 6], [4, 55, 6], [42, 5, 6]], dtype=np.int64)
 
 example_dict[("numpyflat", "Panel", 1)] = X
-example_dict_lossy[("numpyflat", "Panel", 1)] = False
+example_dict_lossy[("numpyflat", "Panel", 1)] = True
 
 cols = [f"var_{i}" for i in range(1)]
 Xlist = [

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -101,6 +101,8 @@ example_dict_metadata[("Panel", 0)] = {
     "is_empty": False,
     "has_nans": False,
     "n_instances": 3,
+    "n_features": 2,
+    "feature_names": ["var_0", "var_1"],
 }
 
 ###
@@ -173,6 +175,8 @@ example_dict_metadata[("Panel", 1)] = {
     "is_empty": False,
     "has_nans": False,
     "n_instances": 3,
+    "n_features": 1,
+    "feature_names": ["var_0"],
 }
 
 ###
@@ -238,6 +242,8 @@ example_dict_metadata[("Panel", 2)] = {
     "is_empty": False,
     "has_nans": False,
     "n_instances": 1,
+    "n_features": 1,
+    "feature_names": ["var_0"],
 }
 
 ###
@@ -266,4 +272,6 @@ example_dict_metadata[("Panel", 3)] = {
     "is_empty": False,
     "has_nans": False,
     "n_instances": 3,
+    "n_features": 1,
+    "feature_names": ["var_0"],
 }

--- a/sktime/datatypes/_series/_examples.py
+++ b/sktime/datatypes/_series/_examples.py
@@ -80,6 +80,7 @@ example_dict_metadata[("Series", 0)] = {
     "is_equally_spaced": True,
     "is_empty": False,
     "has_nans": False,
+    "n_features": 1,
 }
 
 ###
@@ -121,6 +122,7 @@ example_dict_metadata[("Series", 1)] = {
     "is_equally_spaced": True,
     "is_empty": False,
     "has_nans": False,
+    "n_features": 2,
 }
 
 
@@ -165,6 +167,7 @@ example_dict_metadata[("Series", 2)] = {
     "is_equally_spaced": True,
     "is_empty": False,
     "has_nans": False,
+    "n_features": 2,
 }
 
 ###
@@ -201,4 +204,5 @@ example_dict_metadata[("Series", 3)] = {
     "is_equally_spaced": True,
     "is_empty": False,
     "has_nans": False,
+    "n_features": 1,
 }

--- a/sktime/datatypes/_series/_examples.py
+++ b/sktime/datatypes/_series/_examples.py
@@ -81,6 +81,7 @@ example_dict_metadata[("Series", 0)] = {
     "is_empty": False,
     "has_nans": False,
     "n_features": 1,
+    "feature_names": ["a"],
 }
 
 ###
@@ -123,6 +124,7 @@ example_dict_metadata[("Series", 1)] = {
     "is_empty": False,
     "has_nans": False,
     "n_features": 2,
+    "feature_names": ["a", "b"],
 }
 
 
@@ -168,6 +170,7 @@ example_dict_metadata[("Series", 2)] = {
     "is_empty": False,
     "has_nans": False,
     "n_features": 2,
+    "feature_names": ["a", "b"],
 }
 
 ###
@@ -205,4 +208,5 @@ example_dict_metadata[("Series", 3)] = {
     "is_empty": False,
     "has_nans": False,
     "n_features": 1,
+    "feature_names": ["a"],
 }

--- a/sktime/datatypes/tests/test_check.py
+++ b/sktime/datatypes/tests/test_check.py
@@ -217,7 +217,7 @@ def test_check_metadata_inference(scitype, mtype, fixture_index):
     error if check itself raises an error
     """
     # retrieve fixture for checking
-    fixture, _, expected_metadata = get_examples(
+    fixture, lossy, expected_metadata = get_examples(
         mtype=mtype, as_scitype=scitype, return_metadata=True
     ).get(fixture_index)
 
@@ -230,13 +230,14 @@ def test_check_metadata_inference(scitype, mtype, fixture_index):
     # is_equal_index is not fully supported yet in inference
     EXCLUDE_KEYS = ["is_equal_index"]
 
-    # metadata keys to ignore for specific mtypes
-    EXCLUDE_KEYS_BY_MTYPE = {
-        "np.ndarray": ["feature_names"],
-    }
+    # metadata keys to ignore if mtype is lossy
+    EXCLUDE_IF_LOSSY = [
+        "feature_names",  # lossy mtypes do not have feature names
+    ]
+
     # if mtype is in the list, add mtype specific keys to exclude
-    if mtype in EXCLUDE_KEYS_BY_MTYPE:
-        EXCLUDE_KEYS += EXCLUDE_KEYS_BY_MTYPE[mtype]
+    if lossy:
+        EXCLUDE_KEYS += EXCLUDE_IF_LOSSY
 
     if metadata_provided:
         expected_metadata = expected_metadata.copy()

--- a/sktime/datatypes/tests/test_check.py
+++ b/sktime/datatypes/tests/test_check.py
@@ -257,6 +257,11 @@ def test_check_metadata_inference(scitype, mtype, fixture_index):
         if "scitype" in metadata:
             del metadata["scitype"]
 
+        # remove keys that are not checked
+        for key in EXCLUDE_KEYS:
+            if key in metadata:
+                del metadata[key]
+
         # currently we do not check this field in metadata inference
 
         msg = (

--- a/sktime/datatypes/tests/test_check.py
+++ b/sktime/datatypes/tests/test_check.py
@@ -230,6 +230,14 @@ def test_check_metadata_inference(scitype, mtype, fixture_index):
     # is_equal_index is not fully supported yet in inference
     EXCLUDE_KEYS = ["is_equal_index"]
 
+    # metadata keys to ignore for specific mtypes
+    EXCLUDE_KEYS_BY_MTYPE = {
+        "np.ndarray": ["feature_names"],
+    }
+    # if mtype is in the list, add mtype specific keys to exclude
+    if mtype in EXCLUDE_KEYS_BY_MTYPE:
+        EXCLUDE_KEYS += EXCLUDE_KEYS_BY_MTYPE[mtype]
+
     if metadata_provided:
         expected_metadata = expected_metadata.copy()
         subset_keys = set(expected_metadata.keys()).difference(EXCLUDE_KEYS)


### PR DESCRIPTION
This PR adds `n_features` and `feature_names` metadat field for time series mtypes - similar to the attributes of the same name in `sklearn`.

This will be useful for cleaner input/output queriability in a variety of places, and further `sklearn` compatibility.

Also makes following changes:

* docstring formatting in `get_examples`
* extends test `test_check_metadata_inference` to allow specification of keys not checked if mtype is lossy.