### PR TITLE
[BUG] `TsFreshFeatureExtractor` - correct wrong forwarded parameter name `profiling`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2470,6 +2470,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "sssilvar",
+      "name": "Santiago Smith Silva",
+      "avatar_url": "https://avatars.githubusercontent.com/u/16252054?v=4",
+      "profile": "https://github.com/sssilvar",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/sktime/transformations/panel/tsfresh.py
+++ b/sktime/transformations/panel/tsfresh.py
@@ -97,6 +97,12 @@ class _TSFreshFeatureExtractor(BaseTransformer):
                 value = getattr(self, name)
                 if value is not None:
                     extraction_params[name] = value
+            
+            # Fixes key missmatch between tsfresh and sktime
+            # tsfresh uses "profile" while sktime uses "profiling"
+            # This fix keeps compatibility
+            if name == "profile":
+                extraction_params[name] = self.profiling
 
         self.n_jobs = n_jobs
 

--- a/sktime/transformations/panel/tsfresh.py
+++ b/sktime/transformations/panel/tsfresh.py
@@ -98,7 +98,7 @@ class _TSFreshFeatureExtractor(BaseTransformer):
                 if value is not None:
                     extraction_params[name] = value
             
-            # Fixes key missmatch between tsfresh and sktime
+            # Fixes key mismatch between tsfresh and sktime
             # tsfresh uses "profile" while sktime uses "profiling"
             # This fix keeps compatibility
             if name == "profile":

--- a/sktime/transformations/panel/tsfresh.py
+++ b/sktime/transformations/panel/tsfresh.py
@@ -97,7 +97,7 @@ class _TSFreshFeatureExtractor(BaseTransformer):
                 value = getattr(self, name)
                 if value is not None:
                     extraction_params[name] = value
-            
+
             # Fixes key mismatch between tsfresh and sktime
             # tsfresh uses "profile" while sktime uses "profiling"
             # This fix keeps compatibility


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fixes the argument nomenclatutre mismatch that interfaces `sktime` with `tsfresh` that enables profiling ([`TSFreshFeatureExtractor`](https://www.sktime.net/en/latest/api_reference/auto_generated/sktime.transformations.panel.tsfresh.TSFreshFeatureExtractor.html)). Current fix keeps compatibility does not alter `sktime` signatures.


#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
Functionality (enabling profiling and storing the profiling file) and backwards compatibility (no alterations in signatures for the `TSFreshFeatureExtractor` class.


#### Did you add any tests for the change?
No

#### Any other comments?
No

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

