### PR TITLE
Revert "[ENN] Improve memory efficiency of `ConformalIntervals` using sparse matrices"

### DIFF
--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -11,7 +11,6 @@ from math import floor
 
 import numpy as np
 import pandas as pd
-import scipy
 from joblib import Parallel, delayed
 from sklearn.base import clone
 
@@ -418,10 +417,8 @@ class ConformalIntervals(BaseForecaster):
 
         full_y_index = y.iloc[n_initial_window:].index
 
-        residuals_matrix = pd.DataFrame.sparse.from_spmatrix(
-            scipy.sparse.csr_array((len(full_y_index), len(full_y_index))),
-            index=full_y_index,
-            columns=full_y_index,
+        residuals_matrix = pd.DataFrame(
+            columns=full_y_index, index=full_y_index, dtype="float"
         )
 
         if update and hasattr(self, "residuals_matrix_") and not sample_frac:
@@ -430,9 +427,9 @@ class ConformalIntervals(BaseForecaster):
                 overlapping_index = pd.Index(
                     self.residuals_matrix_.index.intersection(full_y_index)
                 ).sort_values()
-                residuals_matrix = self.residuals_matrix_.loc[
+                residuals_matrix.loc[
                     overlapping_index, overlapping_index
-                ].combine_first(residuals_matrix)
+                ] = self.residuals_matrix_.loc[overlapping_index, overlapping_index]
             else:
                 overlapping_index = None
             y_index = remaining_y_index
@@ -469,10 +466,8 @@ class ConformalIntervals(BaseForecaster):
             delayed(_get_residuals_matrix_row)(forecaster.clone(), y, X, id)
             for id in y_index
         )
-        all_residuals = pd.concat(all_residuals, axis=1, ignore_index=True).T
-        all_residuals.index = y_index
-        all_residuals = all_residuals.astype(pd.SparseDtype("float", 0))
-        residuals_matrix = all_residuals.combine_first(residuals_matrix)
+        for idx, id in enumerate(y_index):
+            residuals_matrix.loc[id] = all_residuals[idx]
 
         if overlapping_index is not None:
 
@@ -499,10 +494,9 @@ class ConformalIntervals(BaseForecaster):
                 delayed(_extend_residuals_matrix_row)(y, X, id)
                 for id in overlapping_index
             )
-            extend_residuals = pd.concat(extend_residuals, axis=1, ignore_index=True).T
-            extend_residuals.index = overlapping_index
-            extend_residuals = extend_residuals.astype(pd.SparseDtype("float", 0))
-            residuals_matrix = extend_residuals.combine_first(residuals_matrix)
+
+            for idx, id in enumerate(overlapping_index):
+                residuals_matrix.loc[id] = extend_residuals[idx]
 
         return residuals_matrix
 


### PR DESCRIPTION
Reverts sktime/sktime#5570

I found a bug introduced by this PR. Scipy sparse matrices' default value is zero and not none.  In Line 209, we are fetching the residuals of our residuals matrix and consider only values that are not Nan `resids = resids[~np.isnan(resids)]`. Due to the PR, the default values are not filtered anymore, and we are considering the zeros as normal residuals. This leads to too sharp intervals. 

I think the problem occurs if `sample_freq` is set in a way that not for all time steps a forecast is made. 

I see three possible fixes:
* Revert the PR
* Consider the zero as default value and filter for zeros. However, zero may also be a valid value. Thus, I think this would introduce an additional bug. 
* We store for which values residuals are calculated. Thus, we need not to rely on the nan value in line 209.


Thus, I propose to revert the original enhancement.