### PR TITLE
[DOC] add explanation about fit/transform instance linking behaviour of rocket transformers

### DIFF
--- a/sktime/transformations/panel/rocket/_minirocket.py
+++ b/sktime/transformations/panel/rocket/_minirocket.py
@@ -20,6 +20,14 @@ class MiniRocket(BaseTransformer):
     MiniRocket is for unviariate time series only.  Use class MiniRocketMultivariate
     for multivariate time series.
 
+    This transformer fits one set of paramereters per individual series,
+    and applies them to series of the same number in the test set.
+
+    To fit and transform at the same time,
+    without an identification of fit/transform instances,
+    wrap this transformer in ``FitInTransform``,
+    from ``sktime.transformations.compose``.
+
     Parameters
     ----------
     num_kernels : int, default=10,000

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate.py
@@ -19,6 +19,15 @@ class MiniRocketMultivariate(BaseTransformer):
     convolutions with six of one weight, three of the second weight to seed dilations.
     MiniRocketMultivariate works with univariate and multivariate time series.
 
+    This transformer fits one set of paramereters per individual series,
+    and applies the transform with fitted parameter i to the i-th series in transform.
+    Vanilla use requies same number of series in fit and transform.
+
+    To fit and transform series at the same time,
+    without an identification of fit/transform instances,
+    wrap this transformer in ``FitInTransform``,
+    from ``sktime.transformations.compose``.
+
     Parameters
     ----------
     num_kernels : int, default=10,000

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
@@ -25,6 +25,15 @@ class MiniRocketMultivariateVariable(BaseTransformer):
     performance, use the sktime class MiniRocket for univariate input,
     and MiniRocketMultivariate to equal length multivariate input.
 
+    This transformer fits one set of paramereters per individual series,
+    and applies the transform with fitted parameter i to the i-th series in transform.
+    Vanilla use requies same number of series in fit and transform.
+
+    To fit and transform series at the same time,
+    without an identification of fit/transform instances,
+    wrap this transformer in ``FitInTransform``,
+    from ``sktime.transformations.compose``.
+
     Parameters
     ----------
     num_kernels : int, default=10,000

--- a/sktime/transformations/panel/rocket/_multirocket.py
+++ b/sktime/transformations/panel/rocket/_multirocket.py
@@ -20,6 +20,15 @@ class MultiRocket(BaseTransformer):
     Positive Values (LSPV). This version is for univariate time series only. Use class
     MultiRocketMultivariate for multivariate input.
 
+    This transformer fits one set of paramereters per individual series,
+    and applies the transform with fitted parameter i to the i-th series in transform.
+    Vanilla use requies same number of series in fit and transform.
+
+    To fit and transform series at the same time,
+    without an identification of fit/transform instances,
+    wrap this transformer in ``FitInTransform``,
+    from ``sktime.transformations.compose``.
+
     Parameters
     ----------
     num_kernels : int, default = 6,250
@@ -44,7 +53,6 @@ class MultiRocket(BaseTransformer):
     parameter1 : tuple
         parameter (dilations, num_features_per_dilation, biases) for
         transformation of input X1 = np.diff(X, 1)
-
 
     See Also
     --------

--- a/sktime/transformations/panel/rocket/_multirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_multirocket_multivariate.py
@@ -16,6 +16,15 @@ class MultiRocketMultivariate(BaseTransformer):
     Values (MPV); Mean of Indices of Positive Values (MIPV); and Longest Stretch of
     Positive Values (LSPV). This version is the multivariate version.
 
+    This transformer fits one set of paramereters per individual series,
+    and applies the transform with fitted parameter i to the i-th series in transform.
+    Vanilla use requies same number of series in fit and transform.
+
+    To fit and transform series at the same time,
+    without an identification of fit/transform instances,
+    wrap this transformer in ``FitInTransform``,
+    from ``sktime.transformations.compose``.
+
     Parameters
     ----------
     num_kernels : int, default=6,250
@@ -40,7 +49,6 @@ class MultiRocketMultivariate(BaseTransformer):
     parameter1 : tuple
         parameter (dilations, num_features_per_dilation, biases) for
         transformation of input X1 = np.diff(X, 1)
-
 
     See Also
     --------

--- a/sktime/transformations/panel/rocket/_rocket.py
+++ b/sktime/transformations/panel/rocket/_rocket.py
@@ -18,6 +18,14 @@ class Rocket(BaseTransformer):
     dilation. It transforms the time series with two features per kernel. The first
     feature is global max pooling and the second is proportion of positive values.
 
+    This transformer fits one set of paramereters per individual series,
+    and applies the transform with fitted parameter i to the i-th series in transform.
+    Vanilla use requies same number of series in fit and transform.
+
+    To fit and transform series at the same time,
+    without an identification of fit/transform instances,
+    wrap this transformer in ``FitInTransform``,
+    from ``sktime.transformations.compose``.
 
     Parameters
     ----------


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/5606, by adding an explanation to the documentation on how fitted parameters of instances in fit and predict are linked.