### PR TITLE
[ENH] `prophet` adapter - safer handling of `fit_kwargs`

### DIFF
--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -116,7 +116,10 @@ class _ProphetAdapter(BaseForecaster):
             df["cap"] = self.growth_cap
             df["floor"] = self.growth_floor
 
-        fit_kwargs = self.fit_kwargs or {}
+        if hasattr(self, "fit_kwargs") and isinstance(self.fit_kwargs, dict):
+            fit_kwargs = self.fit_kwargs
+        else:
+            fit_kwargs = {}
         if self.verbose:
             self._forecaster.fit(df=df, **fit_kwargs)
         else:


### PR DESCRIPTION
This makes a minor change to code introduced in #5597 that prevents breakeage if `self.fit_kwargs` are not available in a descendant of the `_ProphetAdapter`, such as in the piecewise linear trend forecaster, in https://github.com/sktime/sktime/pull/5592