### PR TITLE
[ENH] second test parameter set for `TSFreshRelevantFeatureExtractor`

### DIFF
--- a/sktime/transformations/panel/tsfresh.py
+++ b/sktime/transformations/panel/tsfresh.py
@@ -708,4 +708,9 @@ class TSFreshRelevantFeatureExtractor(_TSFreshFeatureExtractor):
             "show_warnings": False,
             "fdr_level": 0.01,
         }
-        return params
+        params2 = {
+            "default_fc_parameters": "minimal",
+            "disable_progressbar": True,
+            "show_warnings": False,
+        }
+        return [params, params2]


### PR DESCRIPTION
Adds a second test parameter set for `TSFreshRelevantFeatureExtractor`

Towards https://github.com/sktime/sktime/issues/3429