### PR TITLE
[ENH] Correct inference of `TransformerPipeline` output type tag

### DIFF
--- a/sktime/transformations/compose/_pipeline.py
+++ b/sktime/transformations/compose/_pipeline.py
@@ -153,7 +153,7 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
         # if "Primitives" occur in the middle, then output is set to that too
         # this is in a case where "Series-to-Series" is applied to primitive df
         #   e.g., in a case of pipelining with scikit-learn transformers
-        last_out = last_trafo.get_tag("scitype:transform-output")
+        last_out = self._trafo_out()
         self._anytagis_then_set(
             "scitype:transform-output", "Primitives", last_out, ests
         )
@@ -397,3 +397,38 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
         params3 = {"steps": [("foo", t1), ("foo", t2), ("foo_1", t3)]}
 
         return [params1, params2, params3]
+
+    def _to_dim(self, x):
+        """Translate scitype:transform-input or output tag to data dimension."""
+        if x == "Series":
+            return 1
+        elif x == "Panel":
+            return 2
+        else:
+            return 3
+
+    def _dim_diff(self, obj):
+        """Compute difference between input and output dimension."""
+        inp = obj.get_tag("scitype:transform-input")
+        out = obj.get_tag("scitype:transform-output")
+        return self._to_dim(out) - self._to_dim(inp)
+
+    def _dim_to_sci(self, d):
+        """Translate data dimension to scitype:transform-output tag."""
+        if d <= 1:
+            return "Series"
+        elif d == 2:
+            return "Panel"
+        else:
+            return "Hierarchical"
+
+    def _trafo_out(self):
+        """Utility to correctly infer scitype:transform-output tag."""
+        ests = self.steps_
+        est_list = [x[1] for x in ests]
+        inp_dim = self._to_dim(est_list[0].get_tag("scitype:transform-input"))
+        out_dim = inp_dim
+        for est in est_list:
+            dim_diff = self._dim_diff(est)
+            out_dim = out_dim + dim_diff
+        return self._dim_to_sci(out_dim)

--- a/sktime/transformations/compose/_pipeline.py
+++ b/sktime/transformations/compose/_pipeline.py
@@ -145,7 +145,6 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
         # abbreviate for readability
         ests = self.steps_
         first_trafo = ests[0][1]
-        last_trafo = ests[-1][1]
 
         # input mtype and input type are as of the first estimator
         self.clone_tags(first_trafo, ["scitype:transform-input"])

--- a/sktime/transformations/compose/_pipeline.py
+++ b/sktime/transformations/compose/_pipeline.py
@@ -398,7 +398,18 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
         return [params1, params2, params3]
 
     def _to_dim(self, x):
-        """Translate scitype:transform-input or output tag to data dimension."""
+        """Translate scitype:transform-input or output tag to data dimension.
+
+        Parameters
+        ----------
+        x : str, one of "Series", "Panel", "Hierarchical"
+            scitype:transform-input or output tag
+
+        Returns
+        -------
+        int
+            data dimension corresponding to x
+        """
         if x == "Series":
             return 1
         elif x == "Panel":
@@ -413,7 +424,18 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
         return self._to_dim(out) - self._to_dim(inp)
 
     def _dim_to_sci(self, d):
-        """Translate data dimension to scitype:transform-output tag."""
+        """Translate data dimension to scitype:transform-output tag.
+
+        Parameters
+        ----------
+        d : int
+            data dimension
+
+        Returns
+        -------
+        str
+            scitype:transform-output tag corresponding to data dimension
+        """
         if d <= 1:
             return "Series"
         elif d == 2:
@@ -422,7 +444,10 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
             return "Hierarchical"
 
     def _trafo_out(self):
-        """Utility to correctly infer scitype:transform-output tag."""
+        """Infer scitype:transform-output tag.
+
+        Uses the self.steps_ attribute, assumes it is initialized already.
+        """
         ests = self.steps_
         est_list = [x[1] for x in ests]
         inp_dim = self._to_dim(est_list[0].get_tag("scitype:transform-input"))

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -5,6 +5,7 @@ __author__ = ["fkiraly"]
 __all__ = []
 
 import pandas as pd
+import pytest
 from sklearn.preprocessing import StandardScaler
 
 from sktime.datasets import load_airline
@@ -24,6 +25,7 @@ from sktime.transformations.series.summarize import SummaryTransformer
 from sktime.transformations.series.theta import ThetaLinesTransformer
 from sktime.utils._testing.deep_equals import deep_equals
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 
 def test_dunder_mul():
@@ -262,3 +264,27 @@ def test_dunder_neg():
     assert isinstance(tp.get_params()["transformer"], ExponentTransformer)
 
     _assert_array_almost_equal(tp.fit_transform(X), X)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodel", severity="none"),
+    reason="skip test if required soft dependency for statsmodels not available",
+)
+def test_input_output_series_panel_chain():
+    """Test that series-to-panel can be chained with series-to-series trafos.
+
+    Failure case of #5624.
+    """
+    from sktime.datasets import load_airline
+    from sktime.transformations.series.impute import Imputer
+    from sktime.transformations.bootstrap import STLBootstrapTransformer
+
+    X = load_airline()
+    bootstrap_trafo = STLBootstrapTransformer(4, sp = 4) * Imputer(method="nearest")
+
+    assert bootstrap_trafo.get_tags()["scitype:transform-input"] == "Series"
+    assert bootstrap_trafo.get_tags()["scitype:transform-output"] == "Panel"
+
+    Xt = bootstrap_trafo.fit_transform(y)
+    assert isinstance(Xt, pd.DataFrame)
+    assert isinstance(Xt.index, pd.MultiIndex)

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -276,15 +276,15 @@ def test_input_output_series_panel_chain():
     Failure case of #5624.
     """
     from sktime.datasets import load_airline
-    from sktime.transformations.series.impute import Imputer
     from sktime.transformations.bootstrap import STLBootstrapTransformer
+    from sktime.transformations.series.impute import Imputer
 
     X = load_airline()
-    bootstrap_trafo = STLBootstrapTransformer(4, sp = 4) * Imputer(method="nearest")
+    bootstrap_trafo = STLBootstrapTransformer(4, sp=4) * Imputer(method="nearest")
 
     assert bootstrap_trafo.get_tags()["scitype:transform-input"] == "Series"
     assert bootstrap_trafo.get_tags()["scitype:transform-output"] == "Panel"
 
-    Xt = bootstrap_trafo.fit_transform(y)
+    Xt = bootstrap_trafo.fit_transform(X)
     assert isinstance(Xt, pd.DataFrame)
     assert isinstance(Xt.index, pd.MultiIndex)


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/5624.

The output tag would not be correctly inferred if a series-to-panel transformer is followed by series-to-series.
This has been corrected.

Unfortunately, the solution is somewhat involved. I think this hints that we may want to incode the input/output type information differently, using number of dimensions or similar.