### PR TITLE
[ENH] fix loss of time zone attribute in `ForecastingHorizon.to_absolute`

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -870,6 +870,12 @@ def _to_absolute(fh: ForecastingHorizon, cutoff) -> ForecastingHorizon:
         _check_cutoff(cutoff, relative)
         is_timestamp = isinstance(cutoff, pd.DatetimeIndex)
 
+        # remembert timezone to restore it later
+        if hasattr(cutoff, "tz"):
+            old_tz = cutoff.tz
+        else:
+            old_tz = None
+
         if is_timestamp:
             # coerce to pd.Period for reliable arithmetic operations and
             # computations of time deltas
@@ -883,6 +889,9 @@ def _to_absolute(fh: ForecastingHorizon, cutoff) -> ForecastingHorizon:
         if is_timestamp:
             # coerce back to DatetimeIndex after operation
             absolute = absolute.to_timestamp(fh.freq)
+
+        if old_tz is not None:
+            absolute = absolute.tz_localize(old_tz)
 
         return fh._new(absolute, is_relative=False, freq=fh.freq)
 

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -870,7 +870,7 @@ def _to_absolute(fh: ForecastingHorizon, cutoff) -> ForecastingHorizon:
         _check_cutoff(cutoff, relative)
         is_timestamp = isinstance(cutoff, pd.DatetimeIndex)
 
-        # remembert timezone to restore it later
+        # remember timezone to restore it later
         if hasattr(cutoff, "tz"):
             old_tz = cutoff.tz
         else:

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -774,3 +774,14 @@ def test_fh_expected_pred():
         [("a", 3, 6), ("a", 3, 7), ("b", 5, 7), ("a", 3, 8), ("b", 5, 8), ("b", 5, 9)]
     )
     assert y_pred_idx.equals(y_pred_idx_expected)
+
+
+def test_tz_preserved():
+    """Test that time zone information is preserved in to_absolute.
+
+    Failure case in issue #5584.
+    """
+    cutoff = pd.Timestamp("2020-01-01", tz="utc")
+    fh_absolute = ForecastingHorizon(range(100), freq="h").to_absolute(cutoff)
+
+    assert fh_absolute[0].tz == cutoff.tz


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/5584.

`tz` information can be lost in an intermediate step where the index is coerced to period.
The fix is to restore it later, in this case.