### PR TITLE
[BUG] fixed typo in `pytest.mark.skipif`

### DIFF
--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -95,7 +95,7 @@ def auto_arima_model(test_data_airline):
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("tensorflow", severity="none"),
-    reaons="skip test if required soft dependency is not available.",
+    reason="skip test if required soft dependency is not available.",
 )
 @pytest.fixture(scope="module")
 def cnn_model(test_data_arrow_head):


### PR DESCRIPTION
`pytest.mark.skipif` supports specification of `reason`, and it was specified as `reaons` as a typo here:

https://github.com/sktime/sktime/blob/99a80dec85232817e2ff67b58a1165bdd0313bef/sktime/utils/tests/test_mlflow_sktime_model_export.py#L98

Ref. https://docs.pytest.org/en/stable/how-to/skipping.html#id1