### PR TITLE
[BUG] Fix typos in mtype tags `np.ndarray`, from erroneous `nd.array`

### DIFF
--- a/sktime/classification/interval_based/_stsf.py
+++ b/sktime/classification/interval_based/_stsf.py
@@ -205,7 +205,7 @@ class SupervisedTimeSeriesForest(BaseClassifier):
 
         Returns
         -------
-        output : nd.array of shape = (n_instances, n_classes)
+        output : np.ndarray of shape = (n_instances, n_classes)
             Predicted probabilities
         """
         X = X.squeeze(1)

--- a/sktime/classification/interval_based/_tsf.py
+++ b/sktime/classification/interval_based/_tsf.py
@@ -170,7 +170,7 @@ class TimeSeriesForestClassifier(
 
         Returns
         -------
-        output : nd.array of shape = (n_instances, n_classes)
+        output : np.ndarray of shape = (n_instances, n_classes)
             Predicted probabilities
         """
         X = X.squeeze(1)

--- a/sktime/param_est/stationarity/_arch.py
+++ b/sktime/param_est/stationarity/_arch.py
@@ -83,7 +83,7 @@ class StationarityADFArch(BaseParamFitter):
     """
 
     _tags = {
-        "X_inner_mtype": ["pd.Series", "nd.array"],
+        "X_inner_mtype": ["pd.Series", "np.array"],
         "scitype:X": "Series",
         "python_dependencies": "arch",
     }
@@ -233,7 +233,7 @@ class StationarityDFGLS(BaseParamFitter):
     """
 
     _tags = {
-        "X_inner_mtype": ["pd.Series", "nd.array"],
+        "X_inner_mtype": ["pd.Series", "np.array"],
         "scitype:X": "Series",
         "python_dependencies": "arch",
     }
@@ -374,7 +374,7 @@ class StationarityPhillipsPerron(BaseParamFitter):
     """
 
     _tags = {
-        "X_inner_mtype": ["pd.Series", "nd.array"],
+        "X_inner_mtype": ["pd.Series", "np.array"],
         "scitype:X": "Series",
         "python_dependencies": "arch",
     }
@@ -507,7 +507,7 @@ class StationarityKPSSArch(BaseParamFitter):
     """
 
     _tags = {
-        "X_inner_mtype": ["pd.Series", "nd.array"],
+        "X_inner_mtype": ["pd.Series", "np.array"],
         "scitype:X": "Series",
         "python_dependencies": "arch",
     }
@@ -647,7 +647,7 @@ class StationarityZivotAndrews(BaseParamFitter):
     """
 
     _tags = {
-        "X_inner_mtype": ["pd.Series", "nd.array"],
+        "X_inner_mtype": ["pd.Series", "np.array"],
         "scitype:X": "Series",
         "python_dependencies": "arch",
     }
@@ -794,7 +794,7 @@ class StationarityVarianceRatio(BaseParamFitter):
     """
 
     _tags = {
-        "X_inner_mtype": ["pd.Series", "nd.array"],
+        "X_inner_mtype": ["pd.Series", "np.array"],
         "scitype:X": "Series",
         "python_dependencies": "arch",
     }


### PR DESCRIPTION
Towards #5643

Note: this does not handle the fact that `np.array` is not a type, and `np.ndarray` is. This is not changed as it is mentioned that way here, and may have recursive effects elsewhere:

https://github.com/sktime/sktime/blob/b999b1048e516de497dfd7dddec1e375b0139152/sktime/registry/_tags.py#L161

(and L138 as well)