### PR TITLE
[BUG] consistent use of `np.ndarray` for mtype tags

### DIFF
--- a/sktime/param_est/stationarity/_arch.py
+++ b/sktime/param_est/stationarity/_arch.py
@@ -83,7 +83,7 @@ class StationarityADFArch(BaseParamFitter):
     """
 
     _tags = {
-        "X_inner_mtype": ["pd.Series", "np.array"],
+        "X_inner_mtype": ["pd.Series", "np.ndarray"],
         "scitype:X": "Series",
         "python_dependencies": "arch",
     }
@@ -233,7 +233,7 @@ class StationarityDFGLS(BaseParamFitter):
     """
 
     _tags = {
-        "X_inner_mtype": ["pd.Series", "np.array"],
+        "X_inner_mtype": ["pd.Series", "np.ndarray"],
         "scitype:X": "Series",
         "python_dependencies": "arch",
     }
@@ -374,7 +374,7 @@ class StationarityPhillipsPerron(BaseParamFitter):
     """
 
     _tags = {
-        "X_inner_mtype": ["pd.Series", "np.array"],
+        "X_inner_mtype": ["pd.Series", "np.ndarray"],
         "scitype:X": "Series",
         "python_dependencies": "arch",
     }
@@ -507,7 +507,7 @@ class StationarityKPSSArch(BaseParamFitter):
     """
 
     _tags = {
-        "X_inner_mtype": ["pd.Series", "np.array"],
+        "X_inner_mtype": ["pd.Series", "np.ndarray"],
         "scitype:X": "Series",
         "python_dependencies": "arch",
     }
@@ -647,7 +647,7 @@ class StationarityZivotAndrews(BaseParamFitter):
     """
 
     _tags = {
-        "X_inner_mtype": ["pd.Series", "np.array"],
+        "X_inner_mtype": ["pd.Series", "np.ndarray"],
         "scitype:X": "Series",
         "python_dependencies": "arch",
     }
@@ -794,7 +794,7 @@ class StationarityVarianceRatio(BaseParamFitter):
     """
 
     _tags = {
-        "X_inner_mtype": ["pd.Series", "np.array"],
+        "X_inner_mtype": ["pd.Series", "np.ndarray"],
         "scitype:X": "Series",
         "python_dependencies": "arch",
     }

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -135,7 +135,7 @@ ESTIMATOR_TAG_REGISTER = [
             [
                 "pd.Series",
                 "pd.DataFrame",
-                "np.array",
+                "np.ndarray",
                 "nested_univ",
                 "pd-multiindex",
                 "numpy3D",
@@ -158,7 +158,7 @@ ESTIMATOR_TAG_REGISTER = [
             [
                 "pd.Series",
                 "pd.DataFrame",
-                "np.array",
+                "np.ndarray",
                 "nested_univ",
                 "pd-multiindex",
                 "numpy3D",


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/5643,

related: https://github.com/sktime/sktime/pull/5645 - see discussion there on remaining locatios.