### PR TITLE
[ENH] allow object `dtype`-s in `pandas` based `Table` mtype-s

### DIFF
--- a/sktime/datatypes/_table/_check.py
+++ b/sktime/datatypes/_table/_check.py
@@ -65,11 +65,6 @@ def check_pddataframe_table(obj, return_metadata=False, var_name="obj"):
     if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
 
-    # check that no dtype is object
-    if "object" in obj.dtypes.values:
-        msg = f"{var_name} should not have column of 'object' dtype"
-        return _ret(False, msg, None, return_metadata)
-
     return _ret(True, None, metadata, return_metadata)
 
 
@@ -91,11 +86,6 @@ def check_pdseries_table(obj, return_metadata=False, var_name="obj"):
         metadata["is_univariate"] = True
     if _req("n_instances", return_metadata):
         metadata["n_instances"] = len(index)
-
-    # check that dtype is not object
-    if "object" == obj.dtypes:
-        msg = f"{var_name} should not be of 'object' dtype"
-        return _ret(False, msg, None, return_metadata)
 
     # check whether index is equally spaced or if there are any nans
     #   compute only if needed


### PR DESCRIPTION
This PR relaxes the `pandas` based `Table` mtype-s to also allow object `dtype`-s.

The reason for this is to allow programmatic support of type checking of `y` in time series classification and regression, and since the current implicitly defined interface supported object (e.g., string) `dtype`-s for classification outputs.

Also required for the multioutput extension in https://github.com/sktime/sktime/pull/5408.