### PR TITLE
[MNT] restore old export location of `temporal_train_test_split`

### DIFF
--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -2,11 +2,11 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements functionality for selecting forecasting models."""
 
-__author__ = ["mloning", "kkoralturk"]
 __all__ = [
     "ForecastingGridSearchCV",
     "ForecastingRandomizedSearchCV",
     "ForecastingSkoptSearchCV",
+    "temporal_train_test_split",
 ]
 
 from sktime.forecasting.model_selection._tune import (
@@ -14,3 +14,4 @@ from sktime.forecasting.model_selection._tune import (
     ForecastingRandomizedSearchCV,
     ForecastingSkoptSearchCV,
 )
+from sktime.split import temporal_train_test_split

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -15,9 +15,10 @@ from sktime.forecasting.model_selection._tune import (
     ForecastingSkoptSearchCV,
 )
 
+
 # todo 0.26.0 - check whether we should remove, otherwise bump
 def temporal_train_test_split(
-        y, X=None, test_size=None, train_size=None, fh=None, anchor="start"
+    y, X=None, test_size=None, train_size=None, fh=None, anchor="start"
 ):
     """Split time series data into temporal train and test sets."""
     from warnings import warn

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -14,4 +14,25 @@ from sktime.forecasting.model_selection._tune import (
     ForecastingRandomizedSearchCV,
     ForecastingSkoptSearchCV,
 )
-from sktime.split import temporal_train_test_split
+
+# todo 0.26.0 - check whether we should remove, otherwise bump
+def temporal_train_test_split(
+        y, X=None, test_size=None, train_size=None, fh=None, anchor="start"
+):
+    """Split time series data into temporal train and test sets."""
+    from warnings import warn
+
+    from sktime.split import temporal_train_test_split as _tts
+
+    warn(
+        "WARNING - the old location of temporal_train_test_split in "
+        "sktime.forecasting.model_selection is deprecated and is scheduled "
+        "imminent removal in a MINOR version. "
+        "Please update any import statements to "
+        "from sktime.split import temporal_train_test_split.",
+        DeprecationWarning,
+    )
+
+    return _tts(
+        y=y, X=X, test_size=test_size, train_size=train_size, fh=fh, anchor=anchor
+    )

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -26,7 +26,7 @@ def temporal_train_test_split(
 
     warn(
         "WARNING - the old location of temporal_train_test_split in "
-        "sktime.forecasting.model_selection is deprecated and is scheduled "
+        "sktime.forecasting.model_selection is deprecated and is scheduled for "
         "imminent removal in a MINOR version. "
         "Please update any import statements to "
         "from sktime.split import temporal_train_test_split.",


### PR DESCRIPTION
This PR restores the old export location of `temporal_train_test_split`, in `forecasting.model_selection`.

This is following the rationale that it might be a popular import, therefore leaving the export as silent will prevent breakage in legacy code such as the blog post tested here: https://github.com/sktime/sktime/pull/5663

Also removes author credits from the respective `__init__` which are not accurate anymore since splitters moved to `split` (author credits moved there).