### PR TITLE
[MNT] restore old location to some splitters

### DIFF
--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -47,7 +47,7 @@ def temporal_train_test_split(
 
 # todo 0.26.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
-def ExpandingWindowSplitter(fh, initial_window, step_length):
+def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
     """Legacy export of Expanding window splitter.
 
     DEPRECATED - use sktime.split.ExpandingWindowSplitter instead.
@@ -71,7 +71,7 @@ def ExpandingWindowSplitter(fh, initial_window, step_length):
 # todo 0.26.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def SlidingWindowSplitter(
-    fh, window_length, step_length, initial_window, start_with_window
+    fh, window_length, step_length=1, initial_window=None, start_with_window=True
 ):
     """Legacy export of Sliding window splitter.
 

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -71,7 +71,7 @@ def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
 # todo 0.26.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def SlidingWindowSplitter(
-    fh, window_length, step_length=1, initial_window=None, start_with_window=True
+    fh=1, window_length=10, step_length=1, initial_window=None, start_with_window=True
 ):
     """Legacy export of Sliding window splitter.
 

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -48,7 +48,7 @@ def temporal_train_test_split(
 # todo 0.26.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def ExpandingWindowSplitter(fh, initial_window, step_length):
-    """Expanding window splitter.
+    """Legacy export of Expanding window splitter.
 
     DEPRECATED - use sktime.split.ExpandingWindowSplitter instead.
     """
@@ -73,7 +73,7 @@ def ExpandingWindowSplitter(fh, initial_window, step_length):
 def SlidingWindowSplitter(
     fh, window_length, step_length, initial_window, start_with_window
 ):
-    """Sliding window splitter.
+    """Legacy export of Sliding window splitter.
 
     DEPRECATED - use sktime.split.ExpandingWindowSplitter instead.
     """

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -7,6 +7,9 @@ __all__ = [
     "ForecastingGridSearchCV",
     "ForecastingRandomizedSearchCV",
     "ForecastingSkoptSearchCV",
+    "ExpandingWindowSplitter",
+    "SlidingWindowSplitter",
+    "temporal_train_test_split",
 ]
 
 from sktime.forecasting.model_selection._tune import (
@@ -14,3 +17,84 @@ from sktime.forecasting.model_selection._tune import (
     ForecastingRandomizedSearchCV,
     ForecastingSkoptSearchCV,
 )
+
+
+# todo 0.26.0 - check whether we should remove, otherwise bump
+# still used in blog posts and old tutorials
+def temporal_train_test_split(
+    y, X=None, test_size=None, train_size=None, fh=None, anchor="start"
+):
+    """Split time series data into temporal train and test sets.
+
+    DEPRECATED - use sktime.split.temporal_train_test_split instead.
+    """
+    from warnings import warn
+
+    from sktime.split import temporal_train_test_split as _tts
+
+    warn(
+        "WARNING - the old location of temporal_train_test_split in "
+        "sktime.forecasting.model_selection is deprecated and is scheduled for "
+        "imminent removal in a MINOR version. "
+        "Please update any import statements to "
+        "from sktime.split import temporal_train_test_split.",
+        DeprecationWarning,
+    )
+
+    return _tts(
+        y=y, X=X, test_size=test_size, train_size=train_size, fh=fh, anchor=anchor
+    )
+
+
+# todo 0.26.0 - check whether we should remove, otherwise bump
+# still used in blog posts and old tutorials
+def ExpandingWindowSplitter(fh, initial_window, step_length):
+    """Expanding window splitter.
+
+    DEPRECATED - use sktime.split.ExpandingWindowSplitter instead.
+    """
+    from warnings import warn
+
+    from sktime.split import ExpandingWindowSplitter as _EWSplitter
+
+    warn(
+        "WARNING - the old location of ExpandingWindowSplitter in "
+        "sktime.forecasting.model_selection is deprecated and is scheduled for "
+        "imminent removal in a MINOR version. "
+        "Please update any import statements to "
+        "from sktime.split import ExpandingWindowSplitter.",
+        DeprecationWarning,
+    )
+
+    return _EWSplitter(fh=fh, initial_window=initial_window, step_length=step_length)
+
+
+# todo 0.26.0 - check whether we should remove, otherwise bump
+# still used in blog posts and old tutorials
+def SlidingWindowSplitter(
+    fh, window_length, step_length, initial_window, start_with_window
+):
+    """Sliding window splitter.
+
+    DEPRECATED - use sktime.split.ExpandingWindowSplitter instead.
+    """
+    from warnings import warn
+
+    from sktime.split import SlidingWindowSplitter as _SWSplitter
+
+    warn(
+        "WARNING - the old location of SlidingWindowSplitter in "
+        "sktime.forecasting.model_selection is deprecated and is scheduled for "
+        "imminent removal in a MINOR version. "
+        "Please update any import statements to "
+        "from sktime.split import SlidingWindowSplitter.",
+        DeprecationWarning,
+    )
+
+    return _SWSplitter(
+        fh=fh,
+        window_length=window_length,
+        step_length=step_length,
+        initial_window=initial_window,
+        start_with_window=start_with_window,
+    )

--- a/sktime/split/slidingwindow.py
+++ b/sktime/split/slidingwindow.py
@@ -51,9 +51,9 @@ class SlidingWindowSplitter(BaseWindowSplitter):
 
     Parameters
     ----------
-    fh : int, list or np.array
+    fh : int, list or np.array, optional (default=1)
         Forecasting horizon
-    window_length : int or timedelta or pd.DateOffset
+    window_length : int or timedelta or pd.DateOffset, optional (default=10)
         Window length
     step_length : int or timedelta or pd.DateOffset, optional (default=1)
         Step length between windows


### PR DESCRIPTION
This PR restores the old export location of `ExpandingWindowSplitter` and `SlidingWindowSplitter`, in `forecasting.model_selection`.

This is following the rationale that it might be a popular import, therefore leaving the export as silent will prevent breakage in legacy code such as the blog post tested here: https://github.com/sktime/sktime/pull/5663