### PR TITLE
[BUG] fix scitype inference utility for all cases

### DIFF
--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -40,10 +40,14 @@ def scitype(obj, force_single_scitype=True, coerce_to_list=False):
         else:
             tag_type = obj.get_tag("object_type", None, raise_error=False)
         if tag_type is not None:
-            if coerce_to_list and not isinstance(tag_type, list):
-                return [tag_type]
-            else:
+            if not isinstance(tag_type, list):
+                tag_type = [tag_type]
+            if force_single_scitype and len(tag_type) > 1:
+                tag_type = [tag_type[0]]
+            if coerce_to_list:
                 return tag_type
+            else:
+                return tag_type[0]
 
     # if the tag is not present, determine scitype from legacy base class logic
     if isclass(obj):

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -18,15 +18,16 @@ def scitype(obj, force_single_scitype=True, coerce_to_list=False):
         if True, only the *first* scitype found will be returned
         order is determined by the order in BASE_CLASS_REGISTER
     coerce_to_list : bool, optional, default = False
-        whether return should be coerced to list, even if only one scitype is identified
+        determines the return type: if True, returns a single str,
+        if False, returns a list of str
 
     Returns
     -------
     scitype : str, or list of str of sktime scitype strings from BASE_CLASS_REGISTER
         str, sktime scitype string, if exactly one scitype can be determined for obj
-            or force_single_scitype is True, and if coerce_to_list is False
+        or force_single_scitype is True, and if coerce_to_list is False
         list of str, of scitype strings, if more than one scitype are determined,
-            or if coerce_to_list is True
+        or if coerce_to_list is True
         obj has scitype if it inherits from class in same row of BASE_CLASS_REGISTER
 
     Raises

--- a/sktime/registry/tests/test_scitype.py
+++ b/sktime/registry/tests/test_scitype.py
@@ -35,3 +35,45 @@ def test_scitype(coerce_to_list):
         assert "transformer" == result_transformer[0]
     else:
         assert "transformer" == result_transformer
+
+
+
+@pytest.mark.parametrize("force_single_scitype", [True, False])
+@pytest.mark.parametrize("coerce_to_list", [True, False])
+def test_scitype(force_single_scitype, coerce_to_list):
+    """Test that the scitype function recovers the correct scitype(s)."""
+    from sktime.base import BaseObject
+
+    class _DummyClass(BaseObject):
+        _tags = {"object_type": ["foo", "bar"]}
+
+    scitype_inferred = scitype(
+        _DummyClass(),
+        force_single_scitype=force_single_scitype,
+        coerce_to_list=coerce_to_list,
+    )
+
+    if force_single_scitype and coerce_to_list:
+        expected = ["foo"]
+    if force_single_scitype and not coerce_to_list:
+        expected = "foo"
+    if not force_single_scitype:
+        expected = ["foo", "bar"]
+
+    assert scitype_inferred == expected
+
+    class _DummyClass2(BaseObject):
+        _tags = {"object_type": "foo"}
+
+    scitype_inferred = scitype(
+        _DummyClass2(),
+        force_single_scitype=force_single_scitype,
+        coerce_to_list=coerce_to_list,
+    )
+
+    if force_single_scitype and coerce_to_list:
+        expected = ["foo"]
+    if not coerce_to_list:
+        expected = "foo"
+
+    assert scitype_inferred == expected

--- a/sktime/registry/tests/test_scitype.py
+++ b/sktime/registry/tests/test_scitype.py
@@ -54,10 +54,10 @@ def test_scitype_generic(force_single_scitype, coerce_to_list):
 
     if force_single_scitype and coerce_to_list:
         expected = ["foo"]
-    if force_single_scitype and not coerce_to_list:
-        expected = "foo"
-    if not force_single_scitype:
+    if not force_single_scitype and coerce_to_list:
         expected = ["foo", "bar"]
+    if not coerce_to_list:
+        expected = "foo"
 
     assert scitype_inferred == expected
 
@@ -70,7 +70,7 @@ def test_scitype_generic(force_single_scitype, coerce_to_list):
         coerce_to_list=coerce_to_list,
     )
 
-    if force_single_scitype and coerce_to_list:
+    if coerce_to_list:
         expected = ["foo"]
     if not coerce_to_list:
         expected = "foo"

--- a/sktime/registry/tests/test_scitype.py
+++ b/sktime/registry/tests/test_scitype.py
@@ -37,7 +37,6 @@ def test_scitype(coerce_to_list):
         assert "transformer" == result_transformer
 
 
-
 @pytest.mark.parametrize("force_single_scitype", [True, False])
 @pytest.mark.parametrize("coerce_to_list", [True, False])
 def test_scitype(force_single_scitype, coerce_to_list):

--- a/sktime/registry/tests/test_scitype.py
+++ b/sktime/registry/tests/test_scitype.py
@@ -39,7 +39,7 @@ def test_scitype(coerce_to_list):
 
 @pytest.mark.parametrize("force_single_scitype", [True, False])
 @pytest.mark.parametrize("coerce_to_list", [True, False])
-def test_scitype(force_single_scitype, coerce_to_list):
+def test_scitype_generic(force_single_scitype, coerce_to_list):
     """Test that the scitype function recovers the correct scitype(s)."""
     from sktime.base import BaseObject
 

--- a/sktime/registry/tests/test_scitype.py
+++ b/sktime/registry/tests/test_scitype.py
@@ -77,3 +77,19 @@ def test_scitype(force_single_scitype, coerce_to_list):
         expected = "foo"
 
     assert scitype_inferred == expected
+
+    class _DummyClass3(BaseObject):
+        _tags = {"object_type": ["foo"]}
+
+    scitype_inferred = scitype(
+        _DummyClass3(),
+        force_single_scitype=force_single_scitype,
+        coerce_to_list=coerce_to_list,
+    )
+
+    if coerce_to_list:
+        expected = ["foo"]
+    if not coerce_to_list:
+        expected = "foo"
+
+    assert scitype_inferred == expected


### PR DESCRIPTION
This PR fixes the `scitype` inteference utility for all combinations of `coerce_to_list`, `force_single_scitype`, and adds a generic test for the cases where the tag is a list (multiple/polymorphic), as well as when there is only one tag.