### PR TITLE
[BUG] fix sporadic permutation of internal feature columns in `TSFreshClassifier.predict`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ all_extras = [
   'stumpy>=1.5.1; python_version < "3.11"',
   'tbats>=1.1; python_version < "3.12"',
   'tensorflow; python_version < "3.12"',
-  'tsfresh>=0.17',
+  'tsfresh>=0.17; python_version < "3.12"',
   'tslearn<0.6.0,>=0.5.2; python_version < "3.11"',
   "xarray",
 ]
@@ -143,7 +143,7 @@ all_extras_pandas2 = [
   'stumpy>=1.5.1; python_version < "3.11"',
   'tbats>=1.1; python_version < "3.12"',
   'tensorflow; python_version < "3.12"',
-  'tsfresh>=0.17',
+  'tsfresh>=0.17; python_version < "3.12"',
   'tslearn<0.6.0,>=0.5.2; python_version < "3.11"',
   "xarray",
 ]
@@ -170,7 +170,7 @@ classification = [
   'esig<0.10,>=0.9.7; python_version < "3.11"',
   'numba<0.59,>=0.53; python_version < "3.12"',
   'tensorflow<=2.14,>=2; python_version < "3.12"',
-  'tsfresh<0.21,>=0.17',
+  'tsfresh<0.21,>=0.17; python_version < "3.12"',
 ]
 clustering = [
   'numba<0.59,>=0.53; python_version < "3.12"',
@@ -207,7 +207,7 @@ transformations = [
   "pykalman-bardo<0.10,>=0.9.7",
   "statsmodels<0.15,>=0.12.1",
   'stumpy<1.13,>=1.5.1; python_version < "3.12"',
-  'tsfresh<0.21,>=0.17',
+  'tsfresh<0.21,>=0.17; python_version < "3.12"',
 ]
 
 # dev - the developer dependency set, for contributors to sktime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ all_extras = [
   'stumpy>=1.5.1; python_version < "3.11"',
   'tbats>=1.1; python_version < "3.12"',
   'tensorflow; python_version < "3.12"',
-  'tsfresh>=0.17; python_version < "3.12"',
+  'tsfresh>=0.17',
   'tslearn<0.6.0,>=0.5.2; python_version < "3.11"',
   "xarray",
 ]
@@ -143,7 +143,7 @@ all_extras_pandas2 = [
   'stumpy>=1.5.1; python_version < "3.11"',
   'tbats>=1.1; python_version < "3.12"',
   'tensorflow; python_version < "3.12"',
-  'tsfresh>=0.17; python_version < "3.12"',
+  'tsfresh>=0.17',
   'tslearn<0.6.0,>=0.5.2; python_version < "3.11"',
   "xarray",
 ]
@@ -170,7 +170,7 @@ classification = [
   'esig<0.10,>=0.9.7; python_version < "3.11"',
   'numba<0.59,>=0.53; python_version < "3.12"',
   'tensorflow<=2.14,>=2; python_version < "3.12"',
-  'tsfresh<0.21,>=0.17; python_version < "3.12"',
+  'tsfresh<0.21,>=0.17',
 ]
 clustering = [
   'numba<0.59,>=0.53; python_version < "3.12"',
@@ -207,7 +207,7 @@ transformations = [
   "pykalman-bardo<0.10,>=0.9.7",
   "statsmodels<0.15,>=0.12.1",
   'stumpy<1.13,>=1.5.1; python_version < "3.12"',
-  'tsfresh<0.21,>=0.17; python_version < "3.12"',
+  'tsfresh<0.21,>=0.17',
 ]
 
 # dev - the developer dependency set, for contributors to sktime

--- a/sktime/classification/feature_based/_tsfresh_classifier.py
+++ b/sktime/classification/feature_based/_tsfresh_classifier.py
@@ -185,7 +185,7 @@ class TSFreshClassifier(BaseClassifier):
 
         X_t = self._transformer.transform(X)
         X_t = X_t.reindex(self._Xt_colnames, axis=1, fill_value=0)
-        return self._estimator.predict()
+        return self._estimator.predict(X_t)
 
     def _predict_proba(self, X) -> np.ndarray:
         """Predict class probabilities for n instances in X.

--- a/sktime/classification/feature_based/_tsfresh_classifier.py
+++ b/sktime/classification/feature_based/_tsfresh_classifier.py
@@ -149,6 +149,7 @@ class TSFreshClassifier(BaseClassifier):
             self._estimator.n_jobs = self._threads_to_use
 
         X_t = self._transformer.fit_transform(X, y)
+        self._Xt_colnames = X_t.columns
 
         if X_t.shape[1] == 0:
             warn(
@@ -182,7 +183,9 @@ class TSFreshClassifier(BaseClassifier):
         if self._return_majority_class:
             return np.full(X.shape[0], self.classes_[self._majority_class])
 
-        return self._estimator.predict(self._transformer.transform(X))
+        X_t = self._transformer.transform(X)
+        X_t = X_t.reindex(self._Xt_colnames, axis=1, fill_value=0)
+        return self._estimator.predict()
 
     def _predict_proba(self, X) -> np.ndarray:
         """Predict class probabilities for n instances in X.
@@ -207,7 +210,9 @@ class TSFreshClassifier(BaseClassifier):
             return self._estimator.predict_proba(self._transformer.transform(X))
         else:
             dists = np.zeros((X.shape[0], self.n_classes_))
-            preds = self._estimator.predict(self._transformer.transform(X))
+            X_t = self._transformer.transform(X)
+            X_t = X_t.reindex(self._Xt_colnames, axis=1, fill_value=0)
+            preds = self._estimator.predict(X_t)
             for i in range(0, X.shape[0]):
                 dists[i, self._class_dictionary[preds[i]]] = 1
             return dists


### PR DESCRIPTION
This fixes an unreported issue where internal feature columns in `TSFreshClassifier.predict` would sporadically be permuted.

This would result in an exception, or wrong predictions, depending on `sklearn` version.