### PR TITLE
[ENH] remove outdated `sktime-dl` reference in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ Our objective is to enhance the interoperability and usability of the time serie
 
 sktime also provides **interfaces to related libraries**, for example [scikit-learn], [statsmodels], [tsfresh], [PyOD], and [fbprophet], among others.
 
-For **deep learning**, see our companion package: [sktime-dl](https://github.com/sktime/sktime-dl).
-
 [statsmodels]: https://www.statsmodels.org/stable/index.html
 [tsfresh]: https://tsfresh.readthedocs.io/en/latest/
 [pyod]: https://pyod.readthedocs.io/en/latest/


### PR DESCRIPTION
This PR removes the outdated `sktime-dl` reference in `README.md`.

`sktime-dl` is superseded by `sktime` proper, since we introduced dependency management on the level of estimators.

Also, most, if not all, estimators from `sktime-dl` are obtainable via `sktime` directly.

Therefore, the reference is misleading and can be removed.