### PR TITLE
[DOC] comment in `CONTRIBUTORS.md` that source file is `all-contributorsrc`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,7 +2,7 @@ Contributors
 ============
 
 <!-- IMPORTANT - DO NOT MODIFY THIS FILE DIRECTLY. -->
-<!-- This file is updated automatically from .all-contributosrc -->
+<!-- This file is updated automatically from .all-contributorsrc -->
 <!-- Please add your badges to .all-contibutorsrc -->
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,10 @@
 Contributors
 ============
 
+<!-- IMPORTANT - DO NOT MODIFY THIS FILE DIRECTLY. -->
+<!-- This file is updated automatically from .all-contributosrc -->
+<!-- Please add your badges to .all-contibutorsrc -->
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-246-orange.svg)](#contributors)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->


### PR DESCRIPTION
There have been multiple instances where new contributors accidentally updated `CONTRIBUTORS.md` instead of `all-contributorsrc` - since the former is auto-updated from the latter, this means their credit will be erased by accident if we do not catch this.

To reduce the risk of the same issue reoccurring, I added a comment at the top of `CONTRIBUTORS.md` that explains this.