### PR TITLE
[BUG] fix `deep_equals` for `np.array` with `dtype="object"`

### DIFF
--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -180,7 +180,10 @@ def deep_equals(x, y, return_msg=False):
     elif isinstance(x, np.ndarray):
         if x.dtype != y.dtype:
             return ret(False, f".dtype, x.dtype = {x.dtype} != y.dtype = {y.dtype}")
-        return ret(np.array_equal(x, y, equal_nan=True), ".values")
+        if x.dtype in ["object", "str"]:
+            return ret(np.array_equal(x, y), ".values")
+        else:
+            return ret(np.array_equal(x, y, equal_nan=True), ".values")
     # recursion through lists, tuples and dicts
     elif isinstance(x, (list, tuple)):
         return ret(*_tuple_equals(x, y, return_msg=True))

--- a/sktime/utils/_testing/tests/test_deep_equals.py
+++ b/sktime/utils/_testing/tests/test_deep_equals.py
@@ -26,6 +26,10 @@ EXAMPLES = [
     ForecastingHorizon([1, 2, 3], is_relative=False),
     {"foo": [42], "bar": pd.Series([1, 2])},
     {"bar": [42], "foo": pd.Series([1, 2])},
+    pd.Index([1, 2, 3]),
+    pd.Index([2, 3, 4]),
+    np.array([0.1, 1], dtype="object"),
+    np.array([0.2, 1], dtype="object"),
 ]
 
 


### PR DESCRIPTION
This PR fixes an unreported bug where `deep_equals` would break on `np.array` with `dtype="object"`, this is due to the `equal_nan=True` setting in `np.array_equal` which will lead to an exception if dtype="object"`.

Also includes test cases covering this.

Required for https://github.com/sktime/sktime/pull/4596, as the TSC grid search will produce object typed arrays internally.