### PR TITLE
[MNT] add missing `__author__` field for `MultiRocket` and `MultiRocketMultivariate`

### DIFF
--- a/sktime/transformations/panel/rocket/_multirocket.py
+++ b/sktime/transformations/panel/rocket/_multirocket.py
@@ -8,7 +8,6 @@ import pandas as pd
 from sktime.datatypes import convert
 from sktime.transformations.base import BaseTransformer
 
-
 __author__ = ["ChangWeiTan", "fstinner", "angus924"]
 
 

--- a/sktime/transformations/panel/rocket/_multirocket.py
+++ b/sktime/transformations/panel/rocket/_multirocket.py
@@ -9,6 +9,9 @@ from sktime.datatypes import convert
 from sktime.transformations.base import BaseTransformer
 
 
+__author__ = ["ChangWeiTan", "fstinner", "angus924"]
+
+
 class MultiRocket(BaseTransformer):
     """Multi RandOm Convolutional KErnel Transform (MultiRocket).
 

--- a/sktime/transformations/panel/rocket/_multirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_multirocket_multivariate.py
@@ -5,6 +5,8 @@ import pandas as pd
 
 from sktime.transformations.base import BaseTransformer
 
+__author__ = ["ChangWeiTan", "fstinner", "angus924"]
+
 
 class MultiRocketMultivariate(BaseTransformer):
     """Multi RandOm Convolutional KErnel Transform (MultiRocket).


### PR DESCRIPTION
The `__author__` field for `MultiRocket` and `MultiRocketMultivariate` was missing, hence authors would not be displayed in the estimator overview. This has been fixed (I took the authors from the `CODEOWNERS`).

FYI @ChangWeiTan @fstinner @angus924