### PR TITLE
[MNT] changes pandas `groupby(axis=1)` in `EnsembleForecaster`

### DIFF
--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -364,15 +364,11 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
         """
         names, _ = self._check_forecasters()
         y_pred = pd.concat(self._predict_forecasters(fh, X), axis=1, keys=names)
-        y_pred = pd.concat(
-            [
-                pd.DataFrame(
-                    _aggregate(group.T, self.aggfunc, self.weights), columns=[i]
-                )
-                for i, (_, group) in enumerate(y_pred.T.groupby(level=1))
-            ],
-            axis=1
-        )
+        y_pred = y_pred.T.groupby(level=1).agg(
+            lambda y, aggfunc, weights: _aggregate(y.T, aggfunc, weights),
+            self.aggfunc,
+            self.weights
+        ).T
         return y_pred
 
     @classmethod

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -364,8 +364,10 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
         """
         names, _ = self._check_forecasters()
         y_pred = pd.concat(self._predict_forecasters(fh, X), axis=1, keys=names)
-        y_pred = y_pred.groupby(level=1, axis=1).agg(
-            _aggregate, self.aggfunc, self.weights
+        y_pred = pd.concat(
+            [pd.DataFrame(_aggregate(group.T, self.aggfunc, self.weights), columns=[i])
+             for i, (_, group) in enumerate(y_pred.T.groupby(level=1))],
+            axis=1
         )
         return y_pred
 

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -364,11 +364,15 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
         """
         names, _ = self._check_forecasters()
         y_pred = pd.concat(self._predict_forecasters(fh, X), axis=1, keys=names)
-        y_pred = y_pred.T.groupby(level=1).agg(
-            lambda y, aggfunc, weights: _aggregate(y.T, aggfunc, weights),
-            self.aggfunc,
-            self.weights
-        ).T
+        y_pred = (
+            y_pred.T.groupby(level=1)
+            .agg(
+                lambda y, aggfunc, weights: _aggregate(y.T, aggfunc, weights),
+                self.aggfunc,
+                self.weights,
+            )
+            .T
+        )
         return y_pred
 
     @classmethod

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -365,8 +365,12 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
         names, _ = self._check_forecasters()
         y_pred = pd.concat(self._predict_forecasters(fh, X), axis=1, keys=names)
         y_pred = pd.concat(
-            [pd.DataFrame(_aggregate(group.T, self.aggfunc, self.weights), columns=[i])
-             for i, (_, group) in enumerate(y_pred.T.groupby(level=1))],
+            [
+                pd.DataFrame(
+                    _aggregate(group.T, self.aggfunc, self.weights), columns=[i]
+                )
+                for i, (_, group) in enumerate(y_pred.T.groupby(level=1))
+            ],
             axis=1
         )
         return y_pred


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/5701

Changes accommodate deprecation of `pandas.DataFrame.groupby(axis=1)` introduced in pandas 2.1.0. 

References: 

- https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.groupby.html and https://github.com/pandas-dev/pandas/blob/d711b1d2ff9ee2c3faf0e118535d3d6218886a9d/pandas/core/frame.py#L9105-L9111