### PR TITLE
[DOC] extension template for time series splitters

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ sktime also provides **interfaces to related libraries**, for example [scikit-le
 | **[Time Series Distances/Kernels]** | maturing | [Tutorial](https://github.com/sktime/sktime/blob/main/examples/03_transformers.ipynb) · [API Reference](https://www.sktime.net/en/latest/api_reference/dists_kernels.html) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/dist_kern_panel.py) |
 | **[Time Series Alignment]** | experimental | [API Reference](https://www.sktime.net/en/latest/api_reference/alignment.html) · [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/alignment.py) |
 | **[Annotation]** | experimental | [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/annotation.py) |
+| **[Time Series Splitters]** | maturing | [Extension Template](https://github.com/sktime/sktime/blob/main/extension_templates/split.py) | |
 | **[Distributions and simulation]** | experimental |  |
 
 [forecasting]: https://github.com/sktime/sktime/tree/main/sktime/forecasting
@@ -93,6 +94,7 @@ sktime also provides **interfaces to related libraries**, for example [scikit-le
 [time series alignment]: https://github.com/sktime/sktime/tree/main/sktime/alignment
 [transformations]: https://github.com/sktime/sktime/tree/main/sktime/transformations
 [distributions and simulation]: https://github.com/sktime/sktime/tree/main/sktime/proba
+[time series splitters]: https://github.com/sktime/sktime/tree/main/sktime/split
 [parameter fitting]: https://github.com/sktime/sktime/tree/main/sktime/param_est
 
 

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -1,0 +1,271 @@
+"""Extension template for parameter estimators.
+
+Purpose of this implementation template:
+    quick implementation of new estimators following the template
+    NOT a concrete class to import! This is NOT a base class or concrete class!
+    This is to be used as a "fill-in" coding template.
+
+How to use this implementation template to implement a new estimator:
+- make a copy of the template in a suitable location, give it a descriptive name.
+- work through all the "todo" comments below
+- fill in code for mandatory methods, and optionally for optional methods
+- do not write to reserved variables: is_fitted, _is_fitted, _tags, _tags_dynamic, _X
+- you can add more private methods, but do not override BaseEstimator's private methods
+    an easy way to be safe is to prefix your methods with "_custom"
+- change docstrings for functions and the file
+- ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
+- once complete: use as a local library, or contribute to sktime via PR
+- more details:
+  https://www.sktime.net/en/stable/developer_guide/add_estimators.html
+
+Mandatory implements:
+    fitting                 - _fit(self, X)
+
+Optional implements:
+    updating                              - _update(self, X)
+    data conversion and capabilities tags - _tags
+    fitted parameter inspection           - _get_fitted_params()
+
+Testing - required for sktime test framework and check_estimator usage:
+    get default parameters for test instance(s) - get_test_params()
+
+copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""
+# todo: write an informative docstring for the file or module, remove the above
+# todo: add an appropriate copyright notice for your estimator
+#       estimators contributed to sktime should have the copyright notice at the top
+#       estimators of your own do not need to have permissive or BSD-3 copyright
+
+# todo: uncomment the following line, enter authors' GitHub IDs
+# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+
+
+from sktime.split.base import BaseSplitter
+
+# todo: add any necessary imports here
+
+# todo: if any imports are sktime soft dependencies:
+# make sure to fill in the "python_dependencies" tag with the package import name
+
+
+class MySplitter(BaseSplitter):
+    """Custom splitter. todo: write docstring.
+
+    todo: describe your custom splitter here
+
+    Parameters
+    ----------
+    parama : int
+        descriptive explanation of parama
+    paramb : string, optional (default='default')
+        descriptive explanation of paramb
+    paramc : boolean, optional (default= whether paramb is not the default)
+        descriptive explanation of paramc
+    and so on
+    est : sktime.estimator, BaseEstimator descendant
+        descriptive explanation of est
+    est2: another estimator
+        descriptive explanation of est2
+    and so on
+    """
+
+    # todo: fill out estimator tags here
+    #  tags are inherited from parent class if they are not set
+    _tags = {
+        #
+        # behavioural tags
+        # ----------------
+        #
+        # internal support for hierarchical and panel data
+        "split_hierarchical": False,
+        # valid values: True, False
+        # if False, splitter broadcasts over instances for hierarchical data
+        # if True, internal _split must support pd.MultiIndex
+        #
+        # which of _split and _split_loc is called in split_series by default
+        "split_series_uses": "iloc",
+        # valid values: "iloc" or "loc"
+        # determines whether split_series under the hood
+        # calls split ("iloc") or split_loc ("loc"). Setting this can give
+        # performance advantages, e.g., if "loc" is faster to obtain.
+        #
+        # dependency tags: python version and soft dependencies
+        # -----------------------------------------------------
+        #
+        # python version requirement
+        "python_version": None,
+        # valid values: str, PEP 440 valid python version specifiers
+        # raises exception at construction if local python version is incompatible
+        #
+        # soft dependency requirement
+        "python_dependencies": None
+        # valid values: str or list of str
+        # raises exception at construction if modules at strings cannot be imported
+    }
+
+
+    # todo: add any hyper-parameters and components to constructor
+    def __init__(self, est, parama, est2=None, paramb="default", paramc=None):
+        # estimators should precede parameters
+        #  if estimators have default values, set None and initialize below
+
+        # todo: write any hyper-parameters and components to self
+        self.est = est
+        self.parama = parama
+        self.paramb = paramb
+        self.paramc = paramc
+
+        # leave this as is
+        super().__init__()
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
+
+        # todo: default estimators should have None arg defaults
+        #  and be initialized here
+        #  do this only with default estimators, not with parameters
+        # if est2 is None:
+        #     self.estimator = MyDefaultEstimator()
+
+        # todo: if tags of estimator depend on component tags, set these here
+        #  only needed if estimator is a composite
+        #  tags set in the constructor apply to the object and override the class
+        #
+        # example 1: conditional setting of a tag
+        # if est.foo == 42:
+        #   self.set_tags(handles-missing-data=True)
+        # example 2: cloning tags from component
+        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
+
+    # todo: implement this, mandatory
+    def _split(self, y):
+        """Get iloc references to train/test splits of `y`.
+
+        private _split containing the core logic, called from split
+
+        Parameters
+        ----------
+        y : pd.Index
+            Index of time series to split
+
+        Yields
+        ------
+        train : 1D np.ndarray of dtype int
+            Training window indices, iloc references to training indices in y
+        test : 1D np.ndarray of dtype int
+            Test window indices, iloc references to test indices in y
+        """
+        # todo: implement the core logic of your splitter here
+        # ensure to avoid side effects to self or y
+        #
+        # example:
+        # for train, test in some_logic(y):
+        #     yield train, test
+
+    # todo: consider implementing this, optional
+    # if not implementing, delete this - default is as below and present in base class
+    def _split_loc(self, y):
+        """Get loc references to train/test splits of `y`.
+
+        private _split containing the core logic, called from split_loc
+
+        Default implements using split and y.index to look up the loc indices.
+        Can be overridden for faster implementation.
+
+        Parameters
+        ----------
+        y : pd.Index
+            index of time series to split
+
+        Yields
+        ------
+        train : pd.Index
+            Training window indices, loc references to training indices in y
+        test : pd.Index
+            Test window indices, loc references to test indices in y
+        """
+        for train, test in self.split(y):
+            # default gets loc index from iloc index
+            yield y[train], y[test]
+
+    # todo: consider implementing this, optional
+    # only implement if the result does not depend on y
+    # if not implementing, delete this - default is as below and present in base class
+    def get_n_splits(self, y) -> int:
+        """Return the number of splits.
+
+        Parameters
+        ----------
+        y : pd.Series or pd.Index, optional (default=None)
+            Time series to split
+
+        Returns
+        -------
+        n_splits : int
+            The number of splits.
+        """
+        return len(list(self.split(y)))
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the splitter.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+
+        # todo: set the testing parameters for the object
+        # Testing parameters can be dictionary or list of dictionaries
+        # Testing parameter choice should cover internal cases well.
+        #
+        # this method can, if required, use:
+        #   class properties (e.g., inherited); parent class test case
+        #   imported objects such as estimators from sktime or sklearn
+        # important: all such imports should be *inside get_test_params*, not at the top
+        #            since imports are used only at testing time
+        #
+        # The parameter_set argument is not used for automated, module level tests.
+        #   It can be used in custom, estimator specific tests, for "special" settings.
+        # A parameter dictionary must be returned *for all values* of parameter_set,
+        #   i.e., "parameter_set not available" errors should never be raised.
+        #
+        # A good parameter set should primarily satisfy two criteria,
+        #   1. Chosen set of parameters should have a low testing time,
+        #      ideally in the magnitude of few seconds for the entire test suite.
+        #       This is vital for the cases where default values result in
+        #       "big" models which not only increases test time but also
+        #       run into the risk of test workers crashing.
+        #   2. There should be a minimum two such parameter sets with different
+        #      sets of values to ensure a wide range of code coverage is provided.
+        #
+        # example 1: specify params as dictionary
+        # any number of params can be specified
+        # params = {"est": value0, "parama": value1, "paramb": value2}
+        #
+        # example 2: specify params as list of dictionary
+        # note: Only first dictionary will be used by create_test_instance
+        # params = [{"est": value1, "parama": value2},
+        #           {"est": value3, "parama": value4}]
+        # return params
+        #
+        # example 3: parameter set depending on param_set value
+        #   note: only needed if a separate parameter set is needed in tests
+        # if parameter_set == "special_param_set":
+        #     params = {"est": value1, "parama": value2}
+        #     return params
+        #
+        # # "default" params - always returned except for "special_param_set" value
+        # params = {"est": value3, "parama": value4}
+        # return params

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -9,7 +9,7 @@ How to use this implementation template to implement a new estimator:
 - make a copy of the template in a suitable location, give it a descriptive name.
 - work through all the "todo" comments below
 - fill in code for mandatory methods, and optionally for optional methods
-- do not write to reserved variables: is_fitted, _is_fitted, _tags, _tags_dynamic, _X
+- do not write to reserved variables: _tags, _tags_dynamic
 - you can add more private methods, but do not override BaseEstimator's private methods
     an easy way to be safe is to prefix your methods with "_custom"
 - change docstrings for functions and the file

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -102,7 +102,6 @@ class MySplitter(BaseSplitter):
         # raises exception at construction if modules at strings cannot be imported
     }
 
-
     # todo: add any hyper-parameters and components to constructor
     def __init__(self, est, parama, est2=None, paramb="default", paramc=None):
         # estimators should precede parameters

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -19,15 +19,14 @@ How to use this implementation template to implement a new estimator:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
 Mandatory implements:
-    fitting                 - _fit(self, X)
+    splitting (iloc reference)            - _split(self, y)
 
 Optional implements:
-    updating                              - _update(self, X)
-    data conversion and capabilities tags - _tags
-    fitted parameter inspection           - _get_fitted_params()
+    splitting (loc reference)             - _split_loc(self, y)
+    get number of splits                  - get_n_splits(self, y)
 
 Testing - required for sktime test framework and check_estimator usage:
-    get default parameters for test instance(s) - get_test_params()
+    get default parameters for test instance(s) - get_test_params(cls)
 
 copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -113,10 +113,10 @@ class BaseSplitter(BaseObject):
         Parameters
         ----------
         y : pd.Index or time series in sktime compatible time series format,
-                time series can be in any Series, Panel, or Hierarchical mtype format
+            time series can be in any Series, Panel, or Hierarchical mtype format
             Index of time series to split, or time series to split
             If time series, considered as index of equivalent pandas type container:
-                pd.DataFrame, pd.Series, pd-multiindex, or pd_multiindex_hier mtype
+            pd.DataFrame, pd.Series, pd-multiindex, or pd_multiindex_hier mtype
 
         Yields
         ------
@@ -144,8 +144,8 @@ class BaseSplitter(BaseObject):
 
         Parameters
         ----------
-        y : pd.Index or time series in sktime compatible time series format
-            Time series to split, or index of time series to split
+        y : pd.Index
+            Index of time series to split
 
         Yields
         ------
@@ -197,8 +197,10 @@ class BaseSplitter(BaseObject):
         Parameters
         ----------
         y : pd.Index or time series in sktime compatible time series format,
-                time series can be in any Series, Panel, or Hierarchical mtype format
-            Time series to split, or index of time series to split
+            time series can be in any Series, Panel, or Hierarchical mtype format
+            Index of time series to split, or time series to split
+            If time series, considered as index of equivalent pandas type container:
+            pd.DataFrame, pd.Series, pd-multiindex, or pd_multiindex_hier mtype
 
         Yields
         ------
@@ -240,10 +242,11 @@ class BaseSplitter(BaseObject):
 
         Parameters
         ----------
-        y : time series in sktime compatible time series format,
-                time series can be in any Series, Panel, or Hierarchical mtype format
-            e.g., pd.Series, pd.DataFrame, np.ndarray
-            Time series to split, or index of time series to split
+        y : pd.Index or time series in sktime compatible time series format,
+            time series can be in any Series, Panel, or Hierarchical mtype format
+            Index of time series to split, or time series to split
+            If time series, considered as index of equivalent pandas type container:
+            pd.DataFrame, pd.Series, pd-multiindex, or pd_multiindex_hier mtype
 
         Yields
         ------
@@ -387,8 +390,11 @@ class BaseSplitter(BaseObject):
 
         Parameters
         ----------
-        y : pd.Series or pd.Index, optional (default=None)
-            Time series to split
+        y : pd.Index or time series in sktime compatible time series format,
+            time series can be in any Series, Panel, or Hierarchical mtype format
+            Index of time series to split, or time series to split
+            If time series, considered as index of equivalent pandas type container:
+            pd.DataFrame, pd.Series, pd-multiindex, or pd_multiindex_hier mtype
 
         Returns
         -------


### PR DESCRIPTION
This PR adds an extension template for time series splitters.

Minor additional changes:

* docstring formatting for splitters
* adding splitters as an object type in the table in the readme