### PR TITLE
[BUG] Fix dynamic `make_forecasting_scorer` for newer `sklearn` metrics

### DIFF
--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -573,7 +573,7 @@ class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
         else:
             func = self.func
 
-        self._evaluate_func(func=func, y_true=y_true, y_pred=y_pred, **params)
+        return self._evaluate_func(func=func, y_true=y_true, y_pred=y_pred, **params)
 
     def _evaluate_func(self, func, y_true, y_pred, **params):
         """Call func with kwargs subset to func parameters."""
@@ -630,7 +630,7 @@ class _DynamicForecastingErrorMetric(BaseForecastingErrorMetricFunc):
 
         func = self.func
 
-        self._evaluate_func(func=func, y_true=y_true, y_pred=y_pred, **params)
+        return self._evaluate_func(func=func, y_true=y_true, y_pred=y_pred, **params)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -573,6 +573,10 @@ class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
         else:
             func = self.func
 
+        self._evaluate_func(func=func, y_true=y_true, y_pred=y_pred, **params)
+
+    def _evaluate_func(self, func, y_true, y_pred, **params):
+        """Call func with kwargs subset to func parameters."""
         # import here for now to avoid interaction with getmembers in tests
         # todo: clean up ancient getmembers in test_metrics_classes
         from functools import partial
@@ -583,6 +587,15 @@ class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
             func_params = set(func_params).difference(["y_true", "y_pred"])
             func_params = func_params.intersection(params.keys())
             params = {key: params[key] for key in func_params}
+
+        # deal with sklearn specific parameter constraints
+        # as these are a signature, they obfuscate python native inspection
+        # via signature, so have to be dealt with separately
+        if hasattr(func, "_skl_parameter_constraints"):
+            constr = func._skl_parameter_constraints
+            if isinstance(constr, dict):
+                constr_params = set(constr.keys()).intersection(params.keys())
+                params = {key: params[key] for key in constr_params}
 
         res = func(y_true=y_true, y_pred=y_pred, **params)
         return res
@@ -608,6 +621,14 @@ class _DynamicForecastingErrorMetric(BaseForecastingErrorMetricFunc):
         super().__init__(multioutput=multioutput, multilevel=multilevel)
 
         self.set_tags(**{"lower_is_better": lower_is_better})
+
+    def _evaluate(self, y_true, y_pred, **kwargs):
+        """Evaluate the desired metric on given inputs."""
+        # this dict should contain all parameters
+        params = kwargs
+        func = self.func
+
+        self._evaluate_func(func=func, y_true=y_true, y_pred=y_pred, **params)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -589,7 +589,7 @@ class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
             params = {key: params[key] for key in func_params}
 
         # deal with sklearn specific parameter constraints
-        # as these are a signature, they obfuscate python native inspection
+        # as these are a decorator, they obfuscate python native inspection
         # via signature, so have to be dealt with separately
         if hasattr(func, "_skl_parameter_constraints"):
             constr = func._skl_parameter_constraints

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -626,6 +626,8 @@ class _DynamicForecastingErrorMetric(BaseForecastingErrorMetricFunc):
         """Evaluate the desired metric on given inputs."""
         # this dict should contain all parameters
         params = kwargs
+        params.update({"multioutput": self.multioutput, "multilevel": self.multilevel})
+
         func = self.func
 
         self._evaluate_func(func=func, y_true=y_true, y_pred=y_pred, **params)

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -129,3 +129,18 @@ def test_make_scorer():
     scorer = make_forecasting_scorer(rmsle, name="RMSLE")
 
     scorer.evaluate(pd.Series([1, 2, 3]), pd.Series([1, 2, 4]))
+
+
+def test_make_scorer_sklearn():
+    """Test make_forecasting_scorer and the failure case in #5715.
+
+    Naive adaptation fails on newer sklearn versions due to
+    decoration with sklearn's custom input constraint wrapper.
+    """
+    from sklearn.metrics import mean_absolute_error
+
+    from sktime.performance_metrics.forecasting import make_forecasting_scorer
+
+    scorer = make_forecasting_scorer(mean_absolute_error, name="RMSLE")
+
+    scorer.evaluate(pd.Series([1, 2, 3]), pd.Series([1, 2, 4]))


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/5715.

The issue with `sklearn` metrics is coming from their decorator which no longer allows inspection of admissible arguments via `python` native `sigature`.

Question for reviewers: is there an `sklearn` native way to inspect permissible signature, without reading private attriutes?