### PR TITLE
[DOC] various minor API reference improvements

### DIFF
--- a/docs/source/api_reference/alignment.rst
+++ b/docs/source/api_reference/alignment.rst
@@ -6,6 +6,12 @@ Time series alignment
 The :mod:`sktime.alignment` module contains time series aligners, such as
 dynamic time warping aligners.
 
+All time series aligners in ``sktime`` can be listed using the
+``sktime.registry.all_estimators`` utility,
+using ``estimator_types="aligner"``, optionally filtered by tags.
+Valid tags can be listed using ``sktime.registry.all_tags``.
+
+
 Naive aligners
 --------------
 

--- a/docs/source/api_reference/param_est.rst
+++ b/docs/source/api_reference/param_est.rst
@@ -14,10 +14,6 @@ All parameter estimators in ``sktime`` can be listed using the
 using ``estimator_types="param_est"``, optionally filtered by tags.
 Valid tags can be listed using ``sktime.registry.all_tags``.
 
-.. automodule:: sktime.param_est
-    :no-members:
-    :no-inherited-members:
-
 Parameter estimators
 --------------------
 

--- a/docs/source/api_reference/split.rst
+++ b/docs/source/api_reference/split.rst
@@ -21,6 +21,8 @@ Forecasting users interested in performance evaluation are advised
 to use full backtesting instead of a single split, e.g., via ``evaluate``,
 see :ref:`forecasting API reference <forecasting_ref>`.
 
+.. currentmodule:: sktime.split
+
 .. autosummary::
     :toctree: auto_generated/
     :template: function.rst

--- a/sktime/param_est/stationarity/_statsmodels.py
+++ b/sktime/param_est/stationarity/_statsmodels.py
@@ -158,7 +158,7 @@ class StationarityADF(BaseParamFitter):
 class StationarityKPSS(BaseParamFitter):
     """Test for stationarity via the Kwiatkowski-Phillips-Schmidt-Shin Test.
 
-    Uses ``statsmodels.tsa.stattools.kpss`` as a test for trend-stationairty,
+    Uses ``statsmodels.tsa.stattools.kpss`` as a test for trend-stationarity,
     and derives a boolean statement whether a series is (trend-)stationary.
 
     Also returns test results for the trend-stationarity test as fitted parameters.


### PR DESCRIPTION
This PR makes various minor improvements to the API reference docs:

* add missing reference to `all_estimators` in alignment
* fix broken link to `temporal_train_test_split` in the splitter docs
* remove superfluous line in preamble of parameter estimators list
* typo fixes