### PR TITLE
[ENH] further refactor parallelization backend test fixtures to use central location

### DIFF
--- a/sktime/datatypes/tests/test_vectorize.py
+++ b/sktime/datatypes/tests/test_vectorize.py
@@ -12,9 +12,12 @@ from sktime.datatypes._examples import get_examples
 from sktime.datatypes._vectorize import VectorizedDF, _enforce_index_freq
 from sktime.utils._testing.deep_equals import deep_equals
 from sktime.utils.pandas import df_map
-from sktime.utils.validation._dependencies import _check_soft_dependencies
+from sktime.utils.parallel import _get_parallel_test_fixtures
 
 SCITYPES = ["Panel", "Hierarchical"]
+
+# list of parallelization backends to test
+BACKENDS = _get_parallel_test_fixtures("estimator")
 
 
 def _get_all_mtypes_for_scitype(scitype):
@@ -433,7 +436,7 @@ def test_enforce_index_freq(item, freq):
     assert item.index.freq == freq
 
 
-@pytest.mark.parametrize("backend", [None, "loky", "threading", "dask"])
+@pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("varname_used", [True, False])
 def test_vectorize_est(
     scitype, mtype, fixture_index, iterate_as, iterate_cols, varname_used, backend
@@ -460,10 +463,6 @@ def test_vectorize_est(
     if not _is_valid_iterate_as(scitype, iterate_as):
         return None
 
-    # escape test for dask backend if dask is not installed
-    if backend == "dask" and not _check_soft_dependencies("dask", severity="none"):
-        return None
-
     # retrieve fixture for checking
     fixture = get_examples(mtype=mtype, as_scitype=scitype).get(fixture_index)
     X_vect = VectorizedDF(
@@ -477,8 +476,10 @@ def test_vectorize_est(
     else:
         kwargs["y"] = X_vect
 
+    kwargs.update(backend)
+
     est_clones = X_vect.vectorize_est(NaiveForecaster(), method="clone")
-    result = X_vect.vectorize_est(est_clones, method="fit", backend=backend, **kwargs)
+    result = X_vect.vectorize_est(est_clones, method="fit", **kwargs)
 
     def _len(x):
         if x is None:

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -26,12 +26,15 @@ from sktime.utils.validation._dependencies import _check_estimator_deps
 PANEL_MTYPES = ["pd-multiindex", "nested_univ", "numpy3D"]
 HIER_MTYPES = ["pd_multiindex_hier"]
 
+# list of parallelization backends to test
+BACKENDS = _get_parallel_test_fixtures("config")
+
 
 @pytest.mark.skipif(
     not _check_estimator_deps(ARIMA, severity="none"),
     reason="skip test if required soft dependency for ARIMA not available",
 )
-@pytest.mark.parametrize("backend", _get_parallel_test_fixtures("config"))
+@pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("mtype", PANEL_MTYPES)
 def test_vectorization_series_to_panel(mtype, backend):
     """Test that forecaster vectorization works for Panel data.
@@ -84,7 +87,7 @@ def test_vectorization_series_to_panel(mtype, backend):
     not _check_estimator_deps(ARIMA, severity="none"),
     reason="skip test if required soft dependency for ARIMA not available",
 )
-@pytest.mark.parametrize("backend", [None, "joblib", "loky", "threading"])
+@pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("mtype", HIER_MTYPES)
 def test_vectorization_series_to_hier(mtype, backend):
     """Test that forecaster vectorization works for Hierarchical data.

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -47,10 +47,14 @@ from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 from sktime.utils._testing.forecasting import make_forecasting_problem
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.series import _make_series
+from sktime.utils.parallel import _get_parallel_test_fixtures
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 METRICS = [MeanAbsolutePercentageError(symmetric=True), MeanAbsoluteScaledError()]
 PROBA_METRICS = [CRPS(), EmpiricalCoverage(), LogLoss(), PinballLoss()]
+
+# list of parallelization backends to test
+BACKENDS = _get_parallel_test_fixtures("estimator")
 
 
 def _check_evaluate_output(out, cv, y, scoring, return_data):
@@ -103,7 +107,7 @@ def _check_evaluate_output(out, cv, y, scoring, return_data):
 @pytest.mark.parametrize("step_length", TEST_STEP_LENGTHS_INT)
 @pytest.mark.parametrize("strategy", ["refit", "update", "no-update_params"])
 @pytest.mark.parametrize("scoring", METRICS)
-@pytest.mark.parametrize("backend", [None, "dask", "loky", "threading"])
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_evaluate_common_configs(
     CV, fh, window_length, step_length, strategy, scoring, backend
 ):
@@ -122,7 +126,7 @@ def test_evaluate_common_configs(
         cv=cv,
         strategy=strategy,
         scoring=scoring,
-        backend=backend,
+        **backend,
     )
     _check_evaluate_output(out, cv, y, scoring, False)
 
@@ -216,7 +220,7 @@ def test_evaluate_no_exog_against_with_exog():
 @pytest.mark.parametrize("error_score", [np.nan, "raise", 1000])
 @pytest.mark.parametrize("return_data", [True, False])
 @pytest.mark.parametrize("strategy", ["refit", "update", "no-update_params"])
-@pytest.mark.parametrize("backend", [None, "dask", "loky", "threading"])
+@pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("scores", [[MeanAbsolutePercentageError()], METRICS])
 def test_evaluate_error_score(error_score, return_data, strategy, backend, scores):
     """Test evaluate to raise warnings and exceptions according to error_score value."""
@@ -240,8 +244,8 @@ def test_evaluate_error_score(error_score, return_data, strategy, backend, score
         "return_data": return_data,
         "error_score": error_score,
         "strategy": strategy,
-        "backend": backend,
     }
+    args.update(backend)
 
     if error_score in [np.nan, 1000]:
         # known bug - loky backend does not pass on warnings, #5307
@@ -264,7 +268,7 @@ def test_evaluate_error_score(error_score, return_data, strategy, backend, score
     not run_test_for_class(evaluate),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-@pytest.mark.parametrize("backend", [None, "dask", "loky", "threading"])
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_evaluate_hierarchical(backend):
     """Check that evaluate works with hierarchical data."""
     # skip test for dask backend if dask is not installed
@@ -284,10 +288,10 @@ def test_evaluate_hierarchical(backend):
     cv = SlidingWindowSplitter()
     scoring = MeanAbsolutePercentageError(symmetric=True)
     out_exog = evaluate(
-        forecaster, cv, y, X=X, scoring=scoring, error_score="raise", backend=backend
+        forecaster, cv, y, X=X, scoring=scoring, error_score="raise", **backend
     )
     out_no_exog = evaluate(
-        forecaster, cv, y, X=None, scoring=scoring, error_score="raise", backend=backend
+        forecaster, cv, y, X=None, scoring=scoring, error_score="raise", **backend
     )
 
     scoring_name = f"test_{scoring.name}"

--- a/sktime/utils/parallel.py
+++ b/sktime/utils/parallel.py
@@ -170,6 +170,8 @@ def _get_parallel_test_fixtures(naming="estimator"):
     fixtures : list of dict
         list of backend parameter fixtures
         keys depend on ``naming`` parameter, see above
+        either ``backend`` and ``backend_params`` (``naming="estimator"``),
+        or ``backend:parallel`` and ``backend:parallel:params`` (``naming="config"``)
         values are backend strings and backend parameter dicts
         only backends that are available in the environment are included
     """


### PR DESCRIPTION
This PR continues refactoring locations where backend fixtures are used to retrieve them from the central location, `_get_parallel_test_fixtures`.