### PR TITLE
[ENH] feature upgrade for `SplitterSummarizer` - granular control of inner `fit`/`transform` input

### DIFF
--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -764,6 +764,7 @@ class SummaryTransformer(BaseTransformer):
         return [params1, params2, params3, params4]
 
 
+# TODO 0.27.0: remove remember_data from docstring and __init__
 class SplitterSummarizer(BaseTransformer):
     """Create summary values of a time series' splits.
 
@@ -890,7 +891,7 @@ class SplitterSummarizer(BaseTransformer):
                 "should be an BaseSplitter descendant with a split_series method"
             )
 
-        #TODO 0.27.0: remove remember_data and related logic
+        # TODO 0.27.0: remove remember_data and related logic
         # remove next lie
         need_to_remember_data = remember_data is not None and remember_data
         # replace next two lines by
@@ -902,7 +903,7 @@ class SplitterSummarizer(BaseTransformer):
         if need_to_remember_data:
             self.set_tags(**{"remember_data": True, "fit_is_empty": False})
 
-        #TODO 0.27.0: remove remember_data and related logic
+        # TODO 0.27.0: remove remember_data and related logic
         if remember_data is not None:
             warn(
                 "remember_data is deprecated and will be removed in 0.27.0. "

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -964,7 +964,7 @@ class SplitterSummarizer(BaseTransformer):
             X_fit = split_fit[fit_on_ix]
             X_transform = split_transform[transform_on_ix]
             transformed_split = tf.fit(X_fit).transform(X_transform)
-            transformed_split.index = [X_transform[0].index[-1]]
+            transformed_split.index = [X_transform.index[-1]]
             transformed_series.append(transformed_split)
 
         Xt = pd.concat(transformed_series)


### PR DESCRIPTION
This PR upgrades `SplitterSummarizer`, adding granular control of inner `fit`/`transform` input:

* add `fit_on` and `transform_on` argumennt that allows to specify the `X` that internally `fit` and `transform` are called on.
* deprecate `remember_data` - unintuitively named - in favour of the two new parameters. Deprecation is scheduled for 0.27.0.