### PR TITLE
[DOC] fix all import failures in API docs and related missing exports

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -258,6 +258,8 @@ All "ARIMA" and "Auto-ARIMA" models below include SARIMAX capability.
 Auto-ARIMA models
 ~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: sktime.forecasting.arima
+
 .. autosummary::
     :toctree: auto_generated/
     :template: class.rst

--- a/sktime/regression/deep_learning/__init__.py
+++ b/sktime/regression/deep_learning/__init__.py
@@ -5,4 +5,7 @@ __all__ = [
 ]
 
 from sktime.regression.deep_learning.cnn import CNNRegressor
+from sktime.regression.deep_learning.mcdcnn import MCDCNNRegressor
+from sktime.regression.deep_learning.resnet import ResNetRegressor
+from sktime.regression.deep_learning.rnn import SimpleRNNRegressor
 from sktime.regression.deep_learning.tapnet import TapNetRegressor


### PR DESCRIPTION
This PR fixes all warnings from the API docs:

* `AutoARIMA` estimator had the wrong module indicated, likely a merge accident
* multiple exports in the `regression.deep_learning` module were missing, these were added