### PR TITLE
[DOC] updated algorithm inclusion guide

### DIFF
--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -672,7 +672,7 @@ the guide for implmenting compatible estimators (see :ref:`developer_guide_add_e
 We are happy to list any compatible open source project under `related
 software <https://github.com/sktime/sktime/wiki/related-software>`__.
 Contributions are also welcome to any one of `our companion
-repositories <https://github.com/sktime>`__ on GitHub. 
+repositories <https://github.com/sktime>`__ on GitHub.
 
 Dependencies are managed on the level of estimators, hence it is entirely possible
 to maintain an algorithm primarily in a third or second party package, and add a

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -665,7 +665,7 @@ We have the following guidelines:
    `decision making process <#Decision-making>`__ for major changes.
 
 Note that an algorithm need not be in sktime to be fully compatible with
-sktime intefaces. You can implement your favorite algorithm in a sktime
+sktime interfaces. You can implement your favorite algorithm in a sktime
 compatible way in a third party codebase - open or closed - following
 the guide for implmenting compatible estimators (see :ref:`developer_guide_add_estimators:`).
 

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -664,18 +664,19 @@ We have the following guidelines:
    will have to be extended first. For extending current API, see the
    `decision making process <#Decision-making>`__ for major changes.
 
-Note that your implementation need not be in sktime to be used together
-with sktime tools. You can implement your favorite algorithm in a sktime
-compatible way in one of `our companion
-repositories <https://github.com/sktime>`__ on GitHub. We will be happy
-to list it under `related
-software <https://github.com/sktime/sktime/wiki/related-software>`__.
+Note that an algorithm need not be in sktime to be fully compatible with
+sktime intefaces. You can implement your favorite algorithm in a sktime
+compatible way in a third party codebase - open or closed - following
+the guide for implmenting compatible estimators (see :ref:`developer_guide_add_estimators:`).
 
-If algorithms require major dependencies, we encourage to create a
-separate companion repository. For smaller
-dependencies which are limited to a few files, we encourage to use soft
-dependencies, which are only required for particular modules, but not
-for most of sktime's functionality and not for installing sktime.
+We are happy to list any compatible open source project under `related
+software <https://github.com/sktime/sktime/wiki/related-software>`__.
+Contributions are also welcome to any one of `our companion
+repositories <https://github.com/sktime>`__ on GitHub. 
+
+Dependencies are managed on the level of estimators, hence it is entirely possible
+to maintain an algorithm primarily in a third or second party package, and add a
+thin interface to sktime proper which has that package as a dependency.
 
 .. _acknowledging-contributions:
 


### PR DESCRIPTION
This PR updates the algorithm inclusion guide, changes are primarily of technical nature, due to last year's developments in dependency management on the level of estimators.

The decision making part is not changed.

Changes relate to:

* explaining that dependencies are managed on estimator level
* therefore additional options are available to power users, such as maintaining an estimator in a third party codebase. Dependency management within `sktime` is also more lenient due to depedency isolation.
* in consequence, first party companion packages like `sktime-dl` are no longer a primary means to manage soft dependencies, in first party code this is also addressed in the text. For third party code, no companion package is necessary either.