### PR TITLE
[ENH] author and maintainer tags

### DIFF
--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -82,6 +82,12 @@ class MyTimeSeriesClassifier(BaseClassifier):
         "capability:contractable": False,
         "capability:multithreading": False,
         "python_version": None,  # PEP 440 python version specifier to limit versions
+        # specify one or multiple authors and maintainers, only for sktime contribution
+        "author": ["author1", "author2"]  # authors, GitHub handles
+        "maintainer": ["maintainer1", "maintainer2"]  # maintainers, GitHub handles
+        # author = significant contribution to code at some point
+        # maintainer = algorithm maintainer role, "owner"
+        # remove maintainer tag if maintained by sktime core team
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -83,8 +83,8 @@ class MyTimeSeriesClassifier(BaseClassifier):
         "capability:multithreading": False,
         "python_version": None,  # PEP 440 python version specifier to limit versions
         # specify one or multiple authors and maintainers, only for sktime contribution
-        "author": ["author1", "author2"],  # authors, GitHub handles
-        "maintainer": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
+        "authors": ["author1", "author2"],  # authors, GitHub handles
+        "maintainers": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
         # author = significant contribution to code at some point
         # maintainer = algorithm maintainer role, "owner"
         # remove maintainer tag if maintained by sktime core team

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -83,8 +83,8 @@ class MyTimeSeriesClassifier(BaseClassifier):
         "capability:multithreading": False,
         "python_version": None,  # PEP 440 python version specifier to limit versions
         # specify one or multiple authors and maintainers, only for sktime contribution
-        "author": ["author1", "author2"]  # authors, GitHub handles
-        "maintainer": ["maintainer1", "maintainer2"]  # maintainers, GitHub handles
+        "author": ["author1", "author2"],  # authors, GitHub handles
+        "maintainer": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
         # author = significant contribution to code at some point
         # maintainer = algorithm maintainer role, "owner"
         # remove maintainer tag if maintained by sktime core team

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -73,8 +73,8 @@ class MyClusterer(BaseClusterer):
         "capability:missing_values": False,
         "capability:multithreading": False,
         # specify one or multiple authors and maintainers, only for sktime contribution
-        "author": ["author1", "author2"],  # authors, GitHub handles
-        "maintainer": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
+        "authors": ["author1", "author2"],  # authors, GitHub handles
+        "maintainers": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
         # author = significant contribution to code at some point
         # maintainer = algorithm maintainer role, "owner"
         # remove maintainer tag if maintained by sktime core team

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -73,8 +73,8 @@ class MyClusterer(BaseClusterer):
         "capability:missing_values": False,
         "capability:multithreading": False,
         # specify one or multiple authors and maintainers, only for sktime contribution
-        "author": ["author1", "author2"]  # authors, GitHub handles
-        "maintainer": ["maintainer1", "maintainer2"]  # maintainers, GitHub handles
+        "author": ["author1", "author2"],  # authors, GitHub handles
+        "maintainer": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
         # author = significant contribution to code at some point
         # maintainer = algorithm maintainer role, "owner"
         # remove maintainer tag if maintained by sktime core team

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -72,6 +72,12 @@ class MyClusterer(BaseClusterer):
         "capability:unequal_length": False,
         "capability:missing_values": False,
         "capability:multithreading": False,
+        # specify one or multiple authors and maintainers, only for sktime contribution
+        "author": ["author1", "author2"]  # authors, GitHub handles
+        "maintainer": ["maintainer1", "maintainer2"]  # maintainers, GitHub handles
+        # author = significant contribution to code at some point
+        # maintainer = algorithm maintainer role, "owner"
+        # remove maintainer tag if maintained by sktime core team
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -57,9 +57,14 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
 
     # todo: fill out transformer tags here
     #  delete the tags that you *didn't* change - these defaults are inherited
-    # _tags = {
-    #   currently there are no tags for pairwise transformers
-    # }
+    _tags = {
+        # specify one or multiple authors and maintainers, only for sktime contribution
+        "author": ["author1", "author2"]  # authors, GitHub handles
+        "maintainer": ["maintainer1", "maintainer2"]  # maintainers, GitHub handles
+        # author = significant contribution to code at some point
+        # maintainer = algorithm maintainer role, "owner"
+        # remove maintainer tag if maintained by sktime core team
+    }
     # in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__ (avoid this if possible)
 

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -59,8 +59,8 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
     #  delete the tags that you *didn't* change - these defaults are inherited
     _tags = {
         # specify one or multiple authors and maintainers, only for sktime contribution
-        "author": ["author1", "author2"]  # authors, GitHub handles
-        "maintainer": ["maintainer1", "maintainer2"]  # maintainers, GitHub handles
+        "author": ["author1", "author2"],  # authors, GitHub handles
+        "maintainer": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
         # author = significant contribution to code at some point
         # maintainer = algorithm maintainer role, "owner"
         # remove maintainer tag if maintained by sktime core team

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -59,8 +59,8 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
     #  delete the tags that you *didn't* change - these defaults are inherited
     _tags = {
         # specify one or multiple authors and maintainers, only for sktime contribution
-        "author": ["author1", "author2"],  # authors, GitHub handles
-        "maintainer": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
+        "authors": ["author1", "author2"],  # authors, GitHub handles
+        "maintainers": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
         # author = significant contribution to code at some point
         # maintainer = algorithm maintainer role, "owner"
         # remove maintainer tag if maintained by sktime core team

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -57,9 +57,14 @@ class MyTrafoPw(BasePairwiseTransformer):
 
     # todo: fill out transformer tags here
     #  delete the tags that you *didn't* change - these defaults are inherited
-    # _tags = {
-    #    currently there are no tags for pairwise transformers
-    # }
+    _tags = {
+        # specify one or multiple authors and maintainers, only for sktime contribution
+        "author": ["author1", "author2"]  # authors, GitHub handles
+        "maintainer": ["maintainer1", "maintainer2"]  # maintainers, GitHub handles
+        # author = significant contribution to code at some point
+        # maintainer = algorithm maintainer role, "owner"
+        # remove maintainer tag if maintained by sktime core team
+    }
     # in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__ (avoid this if possible)
 

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -59,8 +59,8 @@ class MyTrafoPw(BasePairwiseTransformer):
     #  delete the tags that you *didn't* change - these defaults are inherited
     _tags = {
         # specify one or multiple authors and maintainers, only for sktime contribution
-        "author": ["author1", "author2"],  # authors, GitHub handles
-        "maintainer": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
+        "authors": ["author1", "author2"],  # authors, GitHub handles
+        "maintainers": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
         # author = significant contribution to code at some point
         # maintainer = algorithm maintainer role, "owner"
         # remove maintainer tag if maintained by sktime core team

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -59,8 +59,8 @@ class MyTrafoPw(BasePairwiseTransformer):
     #  delete the tags that you *didn't* change - these defaults are inherited
     _tags = {
         # specify one or multiple authors and maintainers, only for sktime contribution
-        "author": ["author1", "author2"]  # authors, GitHub handles
-        "maintainer": ["maintainer1", "maintainer2"]  # maintainers, GitHub handles
+        "author": ["author1", "author2"],  # authors, GitHub handles
+        "maintainer": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
         # author = significant contribution to code at some point
         # maintainer = algorithm maintainer role, "owner"
         # remove maintainer tag if maintained by sktime core team

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -161,7 +161,7 @@ class MyForecaster(BaseForecaster):
         # raises exception at construction if local python version is incompatible
         #
         # soft dependency requirement
-        "python_dependencies": None
+        "python_dependencies": None,
         # valid values: str or list of str
         # raises exception at construction if modules at strings cannot be imported
         #

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -164,6 +164,23 @@ class MyForecaster(BaseForecaster):
         "python_dependencies": None
         # valid values: str or list of str
         # raises exception at construction if modules at strings cannot be imported
+        #
+        # ownership and contribution tags
+        # -------------------------------
+        #
+        # author = author(s) of th estimator
+        # an author is anyon with significant contribution to the code at some point
+        "author": ["author1", "author2"]
+        # valid values: str or list of str, should be GitHub handles
+        # this should follow best scientific contribution practices
+        # scope is the code, not the methodology (method is per paper citation)
+        #
+        # maintainer = current maintainer(s) of the estimator
+        # per algorithm maintainer role, see governance document
+        # this is an "owner" type role, with rights and maintenance duties
+        "maintainer": ["maintainer1", "maintainer2"]
+        # valid values: str or list of str, should be GitHub handles
+        # remove tag if maintained by sktime core team
     }
     #  in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__ (avoid this if possible)

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -169,7 +169,7 @@ class MyForecaster(BaseForecaster):
         # -------------------------------
         #
         # author = author(s) of th estimator
-        # an author is anyon with significant contribution to the code at some point
+        # an author is anyone with significant contribution to the code at some point
         "authors": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -170,7 +170,7 @@ class MyForecaster(BaseForecaster):
         #
         # author = author(s) of th estimator
         # an author is anyon with significant contribution to the code at some point
-        "author": ["author1", "author2"]
+        "author": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices
         # scope is the code, not the methodology (method is per paper citation)
@@ -178,7 +178,7 @@ class MyForecaster(BaseForecaster):
         # maintainer = current maintainer(s) of the estimator
         # per algorithm maintainer role, see governance document
         # this is an "owner" type role, with rights and maintenance duties
-        "maintainer": ["maintainer1", "maintainer2"]
+        "maintainer": ["maintainer1", "maintainer2"],
         # valid values: str or list of str, should be GitHub handles
         # remove tag if maintained by sktime core team
     }

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -170,7 +170,7 @@ class MyForecaster(BaseForecaster):
         #
         # author = author(s) of th estimator
         # an author is anyon with significant contribution to the code at some point
-        "author": ["author1", "author2"],
+        "authors": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices
         # scope is the code, not the methodology (method is per paper citation)
@@ -178,7 +178,7 @@ class MyForecaster(BaseForecaster):
         # maintainer = current maintainer(s) of the estimator
         # per algorithm maintainer role, see governance document
         # this is an "owner" type role, with rights and maintenance duties
-        "maintainer": ["maintainer1", "maintainer2"],
+        "maintainers": ["maintainer1", "maintainer2"],
         # valid values: str or list of str, should be GitHub handles
         # remove tag if maintained by sktime core team
     }

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -112,7 +112,7 @@ class MyForecaster(BaseForecaster):
         # -------------------------------
         #
         # author = author(s) of th estimator
-        # an author is anyon with significant contribution to the code at some point
+        # an author is anyone with significant contribution to the code at some point
         "authors": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -113,7 +113,7 @@ class MyForecaster(BaseForecaster):
         #
         # author = author(s) of th estimator
         # an author is anyon with significant contribution to the code at some point
-        "author": ["author1", "author2"]
+        "author": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices
         # scope is the code, not the methodology (method is per paper citation)
@@ -121,7 +121,7 @@ class MyForecaster(BaseForecaster):
         # maintainer = current maintainer(s) of the estimator
         # per algorithm maintainer role, see governance document
         # this is an "owner" type role, with rights and maintenance duties
-        "maintainer": ["maintainer1", "maintainer2"]
+        "maintainer": ["maintainer1", "maintainer2"],
         # valid values: str or list of str, should be GitHub handles
         # remove tag if maintained by sktime core team
     }

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -107,6 +107,23 @@ class MyForecaster(BaseForecaster):
         "requires-fh-in-fit": True,
         # valid values: boolean True (yes), False (no)
         # if True, raises exception in fit if fh has not been passed
+        #
+        # ownership and contribution tags
+        # -------------------------------
+        #
+        # author = author(s) of th estimator
+        # an author is anyon with significant contribution to the code at some point
+        "author": ["author1", "author2"]
+        # valid values: str or list of str, should be GitHub handles
+        # this should follow best scientific contribution practices
+        # scope is the code, not the methodology (method is per paper citation)
+        #
+        # maintainer = current maintainer(s) of the estimator
+        # per algorithm maintainer role, see governance document
+        # this is an "owner" type role, with rights and maintenance duties
+        "maintainer": ["maintainer1", "maintainer2"]
+        # valid values: str or list of str, should be GitHub handles
+        # remove tag if maintained by sktime core team
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -113,7 +113,7 @@ class MyForecaster(BaseForecaster):
         #
         # author = author(s) of th estimator
         # an author is anyon with significant contribution to the code at some point
-        "author": ["author1", "author2"],
+        "authors": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices
         # scope is the code, not the methodology (method is per paper citation)
@@ -121,7 +121,7 @@ class MyForecaster(BaseForecaster):
         # maintainer = current maintainer(s) of the estimator
         # per algorithm maintainer role, see governance document
         # this is an "owner" type role, with rights and maintenance duties
-        "maintainer": ["maintainer1", "maintainer2"],
+        "maintainers": ["maintainer1", "maintainer2"],
         # valid values: str or list of str, should be GitHub handles
         # remove tag if maintained by sktime core team
     }

--- a/extension_templates/forecasting_supersimple.py
+++ b/extension_templates/forecasting_supersimple.py
@@ -73,8 +73,8 @@ class MyForecaster(BaseForecaster):
         #   "both": inner _predict gets pd.DataFrame series with any number of columns
         #
         # specify one or multiple authors and maintainers, only for sktime contribution
-        "author": ["author1", "author2"],  # authors, GitHub handles
-        "maintainer": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
+        "authors": ["author1", "author2"],  # authors, GitHub handles
+        "maintainers": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
         # author = significant contribution to code at some point
         # maintainer = algorithm maintainer role, "owner"
         # remove maintainer tag if maintained by sktime core team

--- a/extension_templates/forecasting_supersimple.py
+++ b/extension_templates/forecasting_supersimple.py
@@ -73,8 +73,8 @@ class MyForecaster(BaseForecaster):
         #   "both": inner _predict gets pd.DataFrame series with any number of columns
         #
         # specify one or multiple authors and maintainers, only for sktime contribution
-        "author": ["author1", "author2"]  # authors, GitHub handles
-        "maintainer": ["maintainer1", "maintainer2"]  # maintainers, GitHub handles
+        "author": ["author1", "author2"],  # authors, GitHub handles
+        "maintainer": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
         # author = significant contribution to code at some point
         # maintainer = algorithm maintainer role, "owner"
         # remove maintainer tag if maintained by sktime core team

--- a/extension_templates/forecasting_supersimple.py
+++ b/extension_templates/forecasting_supersimple.py
@@ -72,6 +72,13 @@ class MyForecaster(BaseForecaster):
         #   "univariate": inner _fit, _predict, receives only single-column DataFrame
         #   "both": inner _predict gets pd.DataFrame series with any number of columns
         #
+        # specify one or multiple authors and maintainers, only for sktime contribution
+        "author": ["author1", "author2"]  # authors, GitHub handles
+        "maintainer": ["maintainer1", "maintainer2"]  # maintainers, GitHub handles
+        # author = significant contribution to code at some point
+        # maintainer = algorithm maintainer role, "owner"
+        # remove maintainer tag if maintained by sktime core team
+        #
         # do not change these:
         # (look at advanced templates if you think these should change)
         "y_inner_mtype": "pd.DataFrame",

--- a/extension_templates/param_est.py
+++ b/extension_templates/param_est.py
@@ -112,7 +112,7 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
         # raises exception at construction if local python version is incompatible
         #
         # soft dependency requirement
-        "python_dependencies": None
+        "python_dependencies": None,
         # valid values: str or list of str
         # raises exception at construction if modules at strings cannot be imported
         #

--- a/extension_templates/param_est.py
+++ b/extension_templates/param_est.py
@@ -120,7 +120,7 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
         # -------------------------------
         #
         # author = author(s) of th estimator
-        # an author is anyon with significant contribution to the code at some point
+        # an author is anyone with significant contribution to the code at some point
         "authors": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices

--- a/extension_templates/param_est.py
+++ b/extension_templates/param_est.py
@@ -121,7 +121,7 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
         #
         # author = author(s) of th estimator
         # an author is anyon with significant contribution to the code at some point
-        "author": ["author1", "author2"],
+        "authors": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices
         # scope is the code, not the methodology (method is per paper citation)
@@ -129,7 +129,7 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
         # maintainer = current maintainer(s) of the estimator
         # per algorithm maintainer role, see governance document
         # this is an "owner" type role, with rights and maintenance duties
-        "maintainer": ["maintainer1", "maintainer2"],
+        "maintainers": ["maintainer1", "maintainer2"],
         # valid values: str or list of str, should be GitHub handles
         # remove tag if maintained by sktime core team
     }

--- a/extension_templates/param_est.py
+++ b/extension_templates/param_est.py
@@ -121,7 +121,7 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
         #
         # author = author(s) of th estimator
         # an author is anyon with significant contribution to the code at some point
-        "author": ["author1", "author2"]
+        "author": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices
         # scope is the code, not the methodology (method is per paper citation)
@@ -129,7 +129,7 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
         # maintainer = current maintainer(s) of the estimator
         # per algorithm maintainer role, see governance document
         # this is an "owner" type role, with rights and maintenance duties
-        "maintainer": ["maintainer1", "maintainer2"]
+        "maintainer": ["maintainer1", "maintainer2"],
         # valid values: str or list of str, should be GitHub handles
         # remove tag if maintained by sktime core team
     }

--- a/extension_templates/param_est.py
+++ b/extension_templates/param_est.py
@@ -115,6 +115,23 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
         "python_dependencies": None
         # valid values: str or list of str
         # raises exception at construction if modules at strings cannot be imported
+        #
+        # ownership and contribution tags
+        # -------------------------------
+        #
+        # author = author(s) of th estimator
+        # an author is anyon with significant contribution to the code at some point
+        "author": ["author1", "author2"]
+        # valid values: str or list of str, should be GitHub handles
+        # this should follow best scientific contribution practices
+        # scope is the code, not the methodology (method is per paper citation)
+        #
+        # maintainer = current maintainer(s) of the estimator
+        # per algorithm maintainer role, see governance document
+        # this is an "owner" type role, with rights and maintenance duties
+        "maintainer": ["maintainer1", "maintainer2"]
+        # valid values: str or list of str, should be GitHub handles
+        # remove tag if maintained by sktime core team
     }
     #  in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__ (avoid this if possible)

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -97,7 +97,7 @@ class MySplitter(BaseSplitter):
         # raises exception at construction if local python version is incompatible
         #
         # soft dependency requirement
-        "python_dependencies": None
+        "python_dependencies": None,
         # valid values: str or list of str
         # raises exception at construction if modules at strings cannot be imported
         #

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -106,7 +106,7 @@ class MySplitter(BaseSplitter):
         #
         # author = author(s) of th estimator
         # an author is anyon with significant contribution to the code at some point
-        "author": ["author1", "author2"],
+        "authors": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices
         # scope is the code, not the methodology (method is per paper citation)
@@ -114,7 +114,7 @@ class MySplitter(BaseSplitter):
         # maintainer = current maintainer(s) of the estimator
         # per algorithm maintainer role, see governance document
         # this is an "owner" type role, with rights and maintenance duties
-        "maintainer": ["maintainer1", "maintainer2"],
+        "maintainers": ["maintainer1", "maintainer2"],
         # valid values: str or list of str, should be GitHub handles
         # remove tag if maintained by sktime core team
     }

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -100,6 +100,23 @@ class MySplitter(BaseSplitter):
         "python_dependencies": None
         # valid values: str or list of str
         # raises exception at construction if modules at strings cannot be imported
+        #
+        # ownership and contribution tags
+        # -------------------------------
+        #
+        # author = author(s) of th estimator
+        # an author is anyon with significant contribution to the code at some point
+        "author": ["author1", "author2"]
+        # valid values: str or list of str, should be GitHub handles
+        # this should follow best scientific contribution practices
+        # scope is the code, not the methodology (method is per paper citation)
+        #
+        # maintainer = current maintainer(s) of the estimator
+        # per algorithm maintainer role, see governance document
+        # this is an "owner" type role, with rights and maintenance duties
+        "maintainer": ["maintainer1", "maintainer2"]
+        # valid values: str or list of str, should be GitHub handles
+        # remove tag if maintained by sktime core team
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -106,7 +106,7 @@ class MySplitter(BaseSplitter):
         #
         # author = author(s) of th estimator
         # an author is anyon with significant contribution to the code at some point
-        "author": ["author1", "author2"]
+        "author": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices
         # scope is the code, not the methodology (method is per paper citation)
@@ -114,7 +114,7 @@ class MySplitter(BaseSplitter):
         # maintainer = current maintainer(s) of the estimator
         # per algorithm maintainer role, see governance document
         # this is an "owner" type role, with rights and maintenance duties
-        "maintainer": ["maintainer1", "maintainer2"]
+        "maintainer": ["maintainer1", "maintainer2"],
         # valid values: str or list of str, should be GitHub handles
         # remove tag if maintained by sktime core team
     }

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -105,7 +105,7 @@ class MySplitter(BaseSplitter):
         # -------------------------------
         #
         # author = author(s) of th estimator
-        # an author is anyon with significant contribution to the code at some point
+        # an author is anyone with significant contribution to the code at some point
         "authors": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -257,7 +257,7 @@ class MyTransformer(BaseTransformer):
         # -------------------------------
         #
         # author = author(s) of th estimator
-        # an author is anyon with significant contribution to the code at some point
+        # an author is anyone with significant contribution to the code at some point
         "authors": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -249,7 +249,7 @@ class MyTransformer(BaseTransformer):
         # raises exception at construction if local python version is incompatible
         #
         # soft dependency requirement
-        "python_dependencies": None
+        "python_dependencies": None,
         # valid values: str or list of str
         # raises exception at construction if modules at strings cannot be imported
         #

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -258,7 +258,7 @@ class MyTransformer(BaseTransformer):
         #
         # author = author(s) of th estimator
         # an author is anyon with significant contribution to the code at some point
-        "author": ["author1", "author2"]
+        "author": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices
         # scope is the code, not the methodology (method is per paper citation)
@@ -266,7 +266,7 @@ class MyTransformer(BaseTransformer):
         # maintainer = current maintainer(s) of the estimator
         # per algorithm maintainer role, see governance document
         # this is an "owner" type role, with rights and maintenance duties
-        "maintainer": ["maintainer1", "maintainer2"]
+        "maintainer": ["maintainer1", "maintainer2"],
         # valid values: str or list of str, should be GitHub handles
         # remove tag if maintained by sktime core team
     }

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -252,6 +252,23 @@ class MyTransformer(BaseTransformer):
         "python_dependencies": None
         # valid values: str or list of str
         # raises exception at construction if modules at strings cannot be imported
+        #
+        # ownership and contribution tags
+        # -------------------------------
+        #
+        # author = author(s) of th estimator
+        # an author is anyon with significant contribution to the code at some point
+        "author": ["author1", "author2"]
+        # valid values: str or list of str, should be GitHub handles
+        # this should follow best scientific contribution practices
+        # scope is the code, not the methodology (method is per paper citation)
+        #
+        # maintainer = current maintainer(s) of the estimator
+        # per algorithm maintainer role, see governance document
+        # this is an "owner" type role, with rights and maintenance duties
+        "maintainer": ["maintainer1", "maintainer2"]
+        # valid values: str or list of str, should be GitHub handles
+        # remove tag if maintained by sktime core team
     }
     # in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -258,7 +258,7 @@ class MyTransformer(BaseTransformer):
         #
         # author = author(s) of th estimator
         # an author is anyon with significant contribution to the code at some point
-        "author": ["author1", "author2"],
+        "authors": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices
         # scope is the code, not the methodology (method is per paper citation)
@@ -266,7 +266,7 @@ class MyTransformer(BaseTransformer):
         # maintainer = current maintainer(s) of the estimator
         # per algorithm maintainer role, see governance document
         # this is an "owner" type role, with rights and maintenance duties
-        "maintainer": ["maintainer1", "maintainer2"],
+        "maintainers": ["maintainer1", "maintainer2"],
         # valid values: str or list of str, should be GitHub handles
         # remove tag if maintained by sktime core team
     }

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -178,7 +178,7 @@ class MyTransformer(BaseTransformer):
         #
         # author = author(s) of th estimator
         # an author is anyon with significant contribution to the code at some point
-        "author": ["author1", "author2"],
+        "authors": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices
         # scope is the code, not the methodology (method is per paper citation)
@@ -186,7 +186,7 @@ class MyTransformer(BaseTransformer):
         # maintainer = current maintainer(s) of the estimator
         # per algorithm maintainer role, see governance document
         # this is an "owner" type role, with rights and maintenance duties
-        "maintainer": ["maintainer1", "maintainer2"],
+        "maintainers": ["maintainer1", "maintainer2"],
         # valid values: str or list of str, should be GitHub handles
         # remove tag if maintained by sktime core team
     }

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -172,6 +172,23 @@ class MyTransformer(BaseTransformer):
         "handles-missing-data": False,  # can estimator handle missing data?
         # valid values: boolean True (yes), False (no)
         # if False, may raise exception when passed time series with missing values
+        #
+        # ownership and contribution tags
+        # -------------------------------
+        #
+        # author = author(s) of th estimator
+        # an author is anyon with significant contribution to the code at some point
+        "author": ["author1", "author2"]
+        # valid values: str or list of str, should be GitHub handles
+        # this should follow best scientific contribution practices
+        # scope is the code, not the methodology (method is per paper citation)
+        #
+        # maintainer = current maintainer(s) of the estimator
+        # per algorithm maintainer role, see governance document
+        # this is an "owner" type role, with rights and maintenance duties
+        "maintainer": ["maintainer1", "maintainer2"]
+        # valid values: str or list of str, should be GitHub handles
+        # remove tag if maintained by sktime core team
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -178,7 +178,7 @@ class MyTransformer(BaseTransformer):
         #
         # author = author(s) of th estimator
         # an author is anyon with significant contribution to the code at some point
-        "author": ["author1", "author2"]
+        "author": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices
         # scope is the code, not the methodology (method is per paper citation)
@@ -186,7 +186,7 @@ class MyTransformer(BaseTransformer):
         # maintainer = current maintainer(s) of the estimator
         # per algorithm maintainer role, see governance document
         # this is an "owner" type role, with rights and maintenance duties
-        "maintainer": ["maintainer1", "maintainer2"]
+        "maintainer": ["maintainer1", "maintainer2"],
         # valid values: str or list of str, should be GitHub handles
         # remove tag if maintained by sktime core team
     }

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -177,7 +177,7 @@ class MyTransformer(BaseTransformer):
         # -------------------------------
         #
         # author = author(s) of th estimator
-        # an author is anyon with significant contribution to the code at some point
+        # an author is anyone with significant contribution to the code at some point
         "authors": ["author1", "author2"],
         # valid values: str or list of str, should be GitHub handles
         # this should follow best scientific contribution practices

--- a/extension_templates/transformer_supersimple.py
+++ b/extension_templates/transformer_supersimple.py
@@ -76,8 +76,8 @@ class MyTransformer(BaseTransformer):
         #   False: inner _predict gets pd.DataFrame series with any number of columns
         #
         # specify one or multiple authors and maintainers, only for sktime contribution
-        "author": ["author1", "author2"],  # authors, GitHub handles
-        "maintainer": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
+        "authors": ["author1", "author2"],  # authors, GitHub handles
+        "maintainers": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
         # author = significant contribution to code at some point
         # maintainer = algorithm maintainer role, "owner"
         # remove maintainer tag if maintained by sktime core team

--- a/extension_templates/transformer_supersimple.py
+++ b/extension_templates/transformer_supersimple.py
@@ -75,6 +75,13 @@ class MyTransformer(BaseTransformer):
         #   True: inner _fit, _predict, receives only single-column DataFrame
         #   False: inner _predict gets pd.DataFrame series with any number of columns
         #
+        # specify one or multiple authors and maintainers, only for sktime contribution
+        "author": ["author1", "author2"]  # authors, GitHub handles
+        "maintainer": ["maintainer1", "maintainer2"]  # maintainers, GitHub handles
+        # author = significant contribution to code at some point
+        # maintainer = algorithm maintainer role, "owner"
+        # remove maintainer tag if maintained by sktime core team
+        #
         # do not change these:
         # (look at advanced templates if you think these should change)
         "scitype:transform-input": "Series",

--- a/extension_templates/transformer_supersimple.py
+++ b/extension_templates/transformer_supersimple.py
@@ -76,8 +76,8 @@ class MyTransformer(BaseTransformer):
         #   False: inner _predict gets pd.DataFrame series with any number of columns
         #
         # specify one or multiple authors and maintainers, only for sktime contribution
-        "author": ["author1", "author2"]  # authors, GitHub handles
-        "maintainer": ["maintainer1", "maintainer2"]  # maintainers, GitHub handles
+        "author": ["author1", "author2"],  # authors, GitHub handles
+        "maintainer": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
         # author = significant contribution to code at some point
         # maintainer = algorithm maintainer role, "owner"
         # remove maintainer tag if maintained by sktime core team

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -78,6 +78,11 @@ class BaseObject(_BaseObject):
     Extends skbase BaseObject with additional features.
     """
 
+    _tags = {
+        "author": "sktime developers",  # author(s) of the object
+        "maintainer": "sktime developers",  # current maintainer(s) of the object
+    }
+
     _config = {
         "warnings": "on",
         "backend:parallel": None,  # parallelization backend for broadcasting

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -78,11 +78,6 @@ class BaseObject(_BaseObject):
     Extends skbase BaseObject with additional features.
     """
 
-    _tags = {
-        "author": "sktime developers",  # author(s) of the object
-        "maintainer": "sktime developers",  # current maintainer(s) of the object
-    }
-
     _config = {
         "warnings": "on",
         "backend:parallel": None,  # parallelization backend for broadcasting

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -64,6 +64,8 @@ class BaseClassifier(BasePanelMixin):
         "capability:predict_proba": False,
         "python_version": None,  # PEP 440 python version specifier to limit versions
         "requires_cython": False,  # whether C compiler is required in env, e.g., gcc
+        "author": "sktime developers",  # author(s) of the object
+        "maintainer": "sktime developers",  # current maintainer(s) of the object
     }
 
     # convenience constant to control which metadata of input data

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -64,8 +64,8 @@ class BaseClassifier(BasePanelMixin):
         "capability:predict_proba": False,
         "python_version": None,  # PEP 440 python version specifier to limit versions
         "requires_cython": False,  # whether C compiler is required in env, e.g., gcc
-        "author": "sktime developers",  # author(s) of the object
-        "maintainer": "sktime developers",  # current maintainer(s) of the object
+        "authors": "sktime developers",  # author(s) of the object
+        "maintainers": "sktime developers",  # current maintainer(s) of the object
     }
 
     # convenience constant to control which metadata of input data

--- a/sktime/clustering/base.py
+++ b/sktime/clustering/base.py
@@ -36,8 +36,8 @@ class BaseClusterer(BaseEstimator):
         "capability:unequal_length": False,
         "capability:missing_values": False,
         "capability:multithreading": False,
-        "author": "sktime developers",  # author(s) of the object
-        "maintainer": "sktime developers",  # current maintainer(s) of the object
+        "authors": "sktime developers",  # author(s) of the object
+        "maintainers": "sktime developers",  # current maintainer(s) of the object
     }
 
     def __init__(self, n_clusters: int = None):

--- a/sktime/clustering/base.py
+++ b/sktime/clustering/base.py
@@ -36,6 +36,8 @@ class BaseClusterer(BaseEstimator):
         "capability:unequal_length": False,
         "capability:missing_values": False,
         "capability:multithreading": False,
+        "author": "sktime developers",  # author(s) of the object
+        "maintainer": "sktime developers",  # current maintainer(s) of the object
     }
 
     def __init__(self, n_clusters: int = None):

--- a/sktime/dists_kernels/base/_base.py
+++ b/sktime/dists_kernels/base/_base.py
@@ -55,8 +55,8 @@ class BasePairwiseTransformer(BaseEstimator):
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "pwtrafo_type": "distance",  # type of pw. transformer, "kernel" or "distance"
-        "author": "sktime developers",  # author(s) of the object
-        "maintainer": "sktime developers",  # current maintainer(s) of the object
+        "authors": "sktime developers",  # author(s) of the object
+        "maintainers": "sktime developers",  # current maintainer(s) of the object
     }
 
     def __init__(self):
@@ -193,8 +193,8 @@ class BasePairwiseTransformerPanel(BaseEstimator):
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "capability:unequal_length": True,  # can dist handle unequal length panels?
         "pwtrafo_type": "distance",  # type of pw. transformer, "kernel" or "distance"
-        "author": "sktime developers",  # author(s) of the object
-        "maintainer": "sktime developers",  # current maintainer(s) of the object
+        "authors": "sktime developers",  # author(s) of the object
+        "maintainers": "sktime developers",  # current maintainer(s) of the object
     }
 
     def __init__(self):

--- a/sktime/dists_kernels/base/_base.py
+++ b/sktime/dists_kernels/base/_base.py
@@ -55,6 +55,8 @@ class BasePairwiseTransformer(BaseEstimator):
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "pwtrafo_type": "distance",  # type of pw. transformer, "kernel" or "distance"
+        "author": "sktime developers",  # author(s) of the object
+        "maintainer": "sktime developers",  # current maintainer(s) of the object
     }
 
     def __init__(self):
@@ -191,6 +193,8 @@ class BasePairwiseTransformerPanel(BaseEstimator):
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "capability:unequal_length": True,  # can dist handle unequal length panels?
         "pwtrafo_type": "distance",  # type of pw. transformer, "kernel" or "distance"
+        "author": "sktime developers",  # author(s) of the object
+        "maintainer": "sktime developers",  # current maintainer(s) of the object
     }
 
     def __init__(self):

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -97,6 +97,8 @@ class BaseForecaster(BaseEstimator):
         "fit_is_empty": False,  # is fit empty and can be skipped?
         "python_version": None,  # PEP 440 python version specifier to limit versions
         "python_dependencies": None,  # str or list of str, package soft dependencies
+        "author": "sktime developers",  # author(s) of the object
+        "maintainer": "sktime developers",  # current maintainer(s) of the object
     }
 
     # configs and default config values

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -97,8 +97,8 @@ class BaseForecaster(BaseEstimator):
         "fit_is_empty": False,  # is fit empty and can be skipped?
         "python_version": None,  # PEP 440 python version specifier to limit versions
         "python_dependencies": None,  # str or list of str, package soft dependencies
-        "author": "sktime developers",  # author(s) of the object
-        "maintainer": "sktime developers",  # current maintainer(s) of the object
+        "authors": "sktime developers",  # author(s) of the object
+        "maintainers": "sktime developers",  # current maintainer(s) of the object
     }
 
     # configs and default config values

--- a/sktime/param_est/base.py
+++ b/sktime/param_est/base.py
@@ -60,8 +60,8 @@ class BaseParamFitter(BaseEstimator):
         "capability:multivariate": False,  # can estimator handle multivariate data?
         "python_version": None,  # PEP 440 python version specifier to limit versions
         "python_dependencies": None,  # string or str list of pkg soft dependencies
-        "author": "sktime developers",  # author(s) of the object
-        "maintainer": "sktime developers",  # current maintainer(s) of the object
+        "authors": "sktime developers",  # author(s) of the object
+        "maintainers": "sktime developers",  # current maintainer(s) of the object
     }
 
     def __init__(self):

--- a/sktime/param_est/base.py
+++ b/sktime/param_est/base.py
@@ -60,6 +60,8 @@ class BaseParamFitter(BaseEstimator):
         "capability:multivariate": False,  # can estimator handle multivariate data?
         "python_version": None,  # PEP 440 python version specifier to limit versions
         "python_dependencies": None,  # string or str list of pkg soft dependencies
+        "author": "sktime developers",  # author(s) of the object
+        "maintainer": "sktime developers",  # current maintainer(s) of the object
     }
 
     def __init__(self):

--- a/sktime/performance_metrics/base/_base.py
+++ b/sktime/performance_metrics/base/_base.py
@@ -15,8 +15,8 @@ class BaseMetric(BaseObject):
 
     _tags = {
         "object_type": "metric",
-        "author": "sktime developers",  # author(s) of the object
-        "maintainer": "sktime developers",  # current maintainer(s) of the object
+        "authors": "sktime developers",  # author(s) of the object
+        "maintainers": "sktime developers",  # current maintainer(s) of the object
     }
 
     def __init__(self):

--- a/sktime/performance_metrics/base/_base.py
+++ b/sktime/performance_metrics/base/_base.py
@@ -13,7 +13,11 @@ class BaseMetric(BaseObject):
     Extends sktime BaseObject.
     """
 
-    _tags = {"object_type": "metric"}
+    _tags = {
+        "object_type": "metric",
+        "author": "sktime developers",  # author(s) of the object
+        "maintainer": "sktime developers",  # current maintainer(s) of the object
+    }
 
     def __init__(self):
         super().__init__()

--- a/sktime/proba/base.py
+++ b/sktime/proba/base.py
@@ -30,6 +30,8 @@ class BaseDistribution(BaseObject):
         "approx_energy_spl": 1000,  # sample size used in MC estimates of energy
         "approx_spl": 1000,  # sample size used in other MC estimates
         "bisect_iter": 1000,  # max iters for bisection method in ppf
+        "author": "sktime developers",  # author(s) of the object
+        "maintainer": "sktime developers",  # current maintainer(s) of the object
     }
 
     def __init__(self, index=None, columns=None):

--- a/sktime/proba/base.py
+++ b/sktime/proba/base.py
@@ -30,8 +30,8 @@ class BaseDistribution(BaseObject):
         "approx_energy_spl": 1000,  # sample size used in MC estimates of energy
         "approx_spl": 1000,  # sample size used in other MC estimates
         "bisect_iter": 1000,  # max iters for bisection method in ppf
-        "author": "sktime developers",  # author(s) of the object
-        "maintainer": "sktime developers",  # current maintainer(s) of the object
+        "authors": "sktime developers",  # author(s) of the object
+        "maintainers": "sktime developers",  # current maintainer(s) of the object
     }
 
     def __init__(self, index=None, columns=None):

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -505,13 +505,13 @@ ESTIMATOR_TAG_REGISTER = [
         "can the estimator handle multioutput data?",
     ),
     (
-        "maintainer",
+        "maintainers",
         "object",
         ("list", "str"),
         "list of current maintainers of the object, each maintainer a GitHub handle",
     ),
     (
-        "author",
+        "authors",
         "object",
         ("list", "str"),
         "list of authors of the object, each author a GitHub handle",

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -504,6 +504,18 @@ ESTIMATOR_TAG_REGISTER = [
         "bool",
         "can the estimator handle multioutput data?",
     ),
+    (
+        "maintainer",
+        "object",
+        ("list", "str"),
+        "list of current maintainers of the object, each maintainer a GitHub handle",
+    ),
+    (
+        "author",
+        "object",
+        ("list", "str"),
+        "list of authors of the object, each author a GitHub handle",
+    ),
 ]
 
 ESTIMATOR_TAG_TABLE = pd.DataFrame(ESTIMATOR_TAG_REGISTER)

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -58,8 +58,8 @@ class BaseRegressor(BasePanelMixin):
         "capability:train_estimate": False,
         "capability:contractable": False,
         "capability:multithreading": False,
-        "author": "sktime developers",  # author(s) of the object
-        "maintainer": "sktime developers",  # current maintainer(s) of the object
+        "authors": "sktime developers",  # author(s) of the object
+        "maintainers": "sktime developers",  # current maintainer(s) of the object
     }
 
     # convenience constant to control which metadata of input data

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -58,6 +58,8 @@ class BaseRegressor(BasePanelMixin):
         "capability:train_estimate": False,
         "capability:contractable": False,
         "capability:multithreading": False,
+        "author": "sktime developers",  # author(s) of the object
+        "maintainer": "sktime developers",  # current maintainer(s) of the object
     }
 
     # convenience constant to control which metadata of input data

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -95,8 +95,8 @@ class BaseSplitter(BaseObject):
         # split_series_uses: "iloc" or "loc", whether split_series under the hood
         # calls split ("iloc") or split_loc ("loc"). Setting this can give
         # performance advantages, e.g., if "loc" is faster to obtain.
-        "author": "sktime developers",  # author(s) of the object
-        "maintainer": "sktime developers",  # current maintainer(s) of the object
+        "authors": "sktime developers",  # author(s) of the object
+        "maintainers": "sktime developers",  # current maintainer(s) of the object
     }
 
     def __init__(

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -95,6 +95,8 @@ class BaseSplitter(BaseObject):
         # split_series_uses: "iloc" or "loc", whether split_series under the hood
         # calls split ("iloc") or split_loc ("loc"). Setting this can give
         # performance advantages, e.g., if "loc" is faster to obtain.
+        "author": "sktime developers",  # author(s) of the object
+        "maintainer": "sktime developers",  # current maintainer(s) of the object
     }
 
     def __init__(

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -133,8 +133,10 @@ class BaseTransformer(BaseEstimator):
         # todo: rename to capability:missing_values
         "capability:missing_values:removes": False,
         # is transform result always guaranteed to contain no missing values?
-        "python_version": None,  # PEP 440 python version specifier to limit versions
         "remember_data": False,  # whether all data seen is remembered as self._X
+        "python_version": None,  # PEP 440 python version specifier to limit versions
+        "author": "sktime developers",  # author(s) of the object
+        "maintainer": "sktime developers",  # current maintainer(s) of the object
     }
 
     # default config values

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -135,8 +135,8 @@ class BaseTransformer(BaseEstimator):
         # is transform result always guaranteed to contain no missing values?
         "remember_data": False,  # whether all data seen is remembered as self._X
         "python_version": None,  # PEP 440 python version specifier to limit versions
-        "author": "sktime developers",  # author(s) of the object
-        "maintainer": "sktime developers",  # current maintainer(s) of the object
+        "authors": "sktime developers",  # author(s) of the object
+        "maintainers": "sktime developers",  # current maintainer(s) of the object
     }
 
     # default config values


### PR DESCRIPTION
Adds author and maintainer tags to registry and extension templates.

This implements, on the code base side, a proposal for the "tag based" approach discussed in issue https://github.com/sktime/sktime/issues/5746.

This also makes estimators directly searchable by author or maintainer.

However, none of the tags have currently been filled, this is pending discussion as it would be some work.