### PR TITLE
[DOC] update soft dependency handling guide for tests with tag based dependency checking

### DIFF
--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -54,7 +54,7 @@ Estimators with a soft dependency need to ensure the following:
    consider exposing the doctest example as a pytest test function instead, see below how to handle soft dependencies in pytest functions.
 *  Decorate all ``pytest`` tests that import soft dependencies with a ``@pytest.mark.skipif(...)`` conditional on a soft dependency check.
    If the test is specific to a single estimator or object, use ``run_test_for_class`` from ``sktime.tests.test_switch``
-   to mediate the condition through the class tags. 
+   to mediate the condition through the class tags.
    Otherwise, use ``_check_soft_dependencies`` for your new soft dependency, with ``severity="none"``.
    Be sure that all soft dependencies imported for testing are imported within the test function itself,
    rather than at root level (at the top) of the module.

--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -52,11 +52,19 @@ Estimators with a soft dependency need to ensure the following:
    To do this, add a ``# doctest: +SKIP`` to the end of each line in the doctest to skip it entirely.
    See ``forecasting.arima.ARIMA`` as as an example. If concerned that skipping the test will reduce test coverage,
    consider exposing the doctest example as a pytest test function instead, see below how to handle soft dependencies in pytest functions.
-*  Decorate all ``pytest`` tests that import soft dependencies with a ``@pytest.mark.skipif(...)`` conditional on a check to ``_check_soft_dependencies``
-   for your new soft dependency, with ``severity="none"``.  Be sure that all soft dependencies imported for testing are imported within the test function itself,
-   rather than for the whole module!  This decorator will then skip your test, including imports, unless the system has the required packages installed.
-   This prevents crashes for any users running ``check_estimator`` on all estimators, or a full local ``pytest`` run without the required soft dependency.
-   See the tests in ``forecasting.tests.test_pmdarima`` for a concrete example.
+*  Decorate all ``pytest`` tests that import soft dependencies with a ``@pytest.mark.skipif(...)`` conditional on a soft dependency check.
+   If the test is specific to a single estimator or object, use ``run_test_for_class`` from ``sktime.tests.test_switch``
+   to mediate the condition through the class tags. 
+   Otherwise, use ``_check_soft_dependencies`` for your new soft dependency, with ``severity="none"``.
+   Be sure that all soft dependencies imported for testing are imported within the test function itself,
+   rather than at root level (at the top) of the module.
+   This decorator will then skip your test, including imports,
+   unless the system has the required packages installed.
+   This prevents crashes for any users running ``check_estimator`` on all estimators,
+   or a full local ``pytest`` run without the required soft dependency.
+   See the tests in ``forecasting.tests.test_pmdarima`` for a concrete example of
+   ``run_test_for_class`` usage to decorate a test. See ``utils.tests.test_plotting``
+   for an example of ``_check_soft_dependencies`` usage.
 
 Adding and maintaining soft dependencies
 ----------------------------------------


### PR DESCRIPTION
This updates the soft dependency handling guide for tests with current practice - which is class tag based depedency checking, as opposed to manually duplicating the soft dependency information.