### PR TITLE
[DOC] fix `scitype` string of transformers in API ref

### DIFF
--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -7,7 +7,7 @@ The :mod:`sktime.transformations` module contains classes for data
 transformations.
 
 All (simple) transformers in ``sktime`` can be listed using the ``sktime.registry.all_estimators`` utility,
-using ``estimator_types="regressor"``, optionally filtered by tags.
+using ``estimator_types="transformer"``, optionally filtered by tags.
 Valid tags can be listed using ``sktime.registry.all_tags``.
 
 For pairwise transformers (time series distances, kernels), instead see :ref:`_transformations_pairwise_ref`.


### PR DESCRIPTION
Fixes a consequential typo in the API reference - the scitype for transformers was wrong, at the top of the API reference page.