### PR TITLE
[BUG] fix type error in parallelization backend test fixture refactor

### DIFF
--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -102,7 +102,7 @@ def test_vectorization_series_to_hier(mtype, backend):
     y = convert(y, from_type="pd_multiindex_hier", to_type=mtype)
 
     f = ARIMA()
-    f.set_config(**{"backend:parallel": backend})
+    f.set_config(**backend.copy())
     y_pred = f.fit(y).predict([1, 2, 3])
     valid, _, metadata = check_is_mtype(
         y_pred, mtype, return_metadata=True, msg_return_dict="list"


### PR DESCRIPTION
This PR fixes an error on main arising from the parallelization backend test fixture refactor.

The tests did not pick it up due to the bug with `set_config` fixed in `scikit-base` 0.8.0, and `scikit-base` bound has not yet been upgraded on `main`.