### PR TITLE
[MNT] update python version in binder dockerfile to 3.11

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -1,9 +1,7 @@
 # This Dockerfile is used to build sktime when launching binder.
 # Find out more at: https://mybinder.readthedocs.io/en/latest/index.html
 
-# Load jupyter python 3.8 image
-# 3.8 is the highest currently supported version we can use
-FROM  jupyter/scipy-notebook:python-3.8.8
+FROM  jupyter/scipy-notebook:python-3.11.7
 # Set up user to avoid running as root
 ARG NB_USER
 ARG NB_UID

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used to build sktime when launching binder.
 # Find out more at: https://mybinder.readthedocs.io/en/latest/index.html
 
-FROM  jupyter/scipy-notebook:python-3.11.7
+FROM  jupyter/scipy-notebook:python-3.11.6
 # Set up user to avoid running as root
 ARG NB_USER
 ARG NB_UID


### PR DESCRIPTION
This changes the python version in the binder dockerfile to most recent 3.11.

Fixes https://github.com/sktime/sktime/issues/5761 - hopefully