### PR TITLE
[ENH] forecasting compositor to ignore exogenous data

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -51,6 +51,7 @@ Pipelines can also be constructed using ``*``, ``+``, and ``|`` dunders.
     Permute
     HierarchyEnsembleForecaster
     FhPlexForecaster
+    IgnoreX
 
 Reduction
 ---------

--- a/sktime/forecasting/compose/__init__.py
+++ b/sktime/forecasting/compose/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     "ForecastByLevel",
     "Permute",
     "YfromX",
+    "IgnoreX",
 ]
 
 from sktime.forecasting.compose._bagging import BaggingForecaster
@@ -38,6 +39,7 @@ from sktime.forecasting.compose._ensemble import (
 from sktime.forecasting.compose._fhplex import FhPlexForecaster
 from sktime.forecasting.compose._grouped import ForecastByLevel
 from sktime.forecasting.compose._hierarchy_ensemble import HierarchyEnsembleForecaster
+from sktime.forecasting.compose._ignore_x import IgnoreX
 from sktime.forecasting.compose._multiplexer import MultiplexForecaster
 from sktime.forecasting.compose._pipeline import (
     ForecastingPipeline,

--- a/sktime/forecasting/compose/_ignore_x.py
+++ b/sktime/forecasting/compose/_ignore_x.py
@@ -18,7 +18,7 @@ class IgnoreX(_DelegatedForecaster):
     forecaster : sktime forecaster, BaseForecaster descendant instance
         The forecaster to wrap.
     ignore_x : bool, optional (default=True)
-        Whether to ignore exogenous data or not, useful for tuning.
+        Whether to ignore exogenous data or not, this parameter is useful for tuning.
         True: ignore exogenous data, X is not passed on to forecastere
         False: use exogenous data, X is passed on to forecasters
 

--- a/sktime/forecasting/compose/_ignore_x.py
+++ b/sktime/forecasting/compose/_ignore_x.py
@@ -28,6 +28,11 @@ class IgnoreX(_DelegatedForecaster):
         The fitted forecaster.
     """
 
+    # attribute for _DelegatedForecaster, which then delegates
+    #     all non-overridden methods are same as of getattr(self, _delegate_name)
+    #     see further details in _DelegatedForecaster docstring
+    _delegate_name = "forecaster_"
+
     _tags = {
         "ignores-exogeneous-X": True,
     }

--- a/sktime/forecasting/compose/_ignore_x.py
+++ b/sktime/forecasting/compose/_ignore_x.py
@@ -1,0 +1,66 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Implements compositor for ignoring exogenous data."""
+
+__author__ = ["fkiraly"]
+
+from sktime.forecasting.base._delegate import _DelegatedForecaster
+
+
+class IgnoreX(_DelegatedForecaster):
+    """Compositor for ignoring exogenous variables.
+
+    Composing with IgnoreX instructs the wrapped forecaster to ignore exogenous
+    data. This is useful for testing the impact of exogenous data on forecasts,
+    or for use in tuning hyperparameters of the forecaster.
+
+    Parameters
+    ----------
+    forecaster : sktime forecaster, BaseForecaster descendant instance
+        The forecaster to wrap.
+    ignore_x : bool, optional (default=True)
+        Whether to ignore exogenous data or not, useful for tuning.
+        True: ignore exogenous data, X is not passed on to forecastere
+        False: use exogenous data, X is passed on to forecasters
+
+    Attributes
+    ----------
+    forecaster_ : clone of forecaster
+        The fitted forecaster.
+    """
+
+    _tags = {"ignores-exogeneous-X": True,}
+
+    def __init__(self, forecaster, ignore_x=True):
+        self.forecaster = forecaster
+        self.ignore_x = ignore_x
+
+        super().__init__()
+
+        self.forecaster_ = forecaster.clone()
+
+        if not ignore_x:
+            self.set_tags(**{"ignores-exogeneous-X": ignore_x})
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+
+        Returns
+        -------
+        params : dict or list of dict
+        """
+        from sktime.forecasting.naive import NaiveForecaster
+
+        f = NaiveForecaster()
+
+        params1 = {"forecaster": f}
+        params2 = {"forecaster": f, "ignore_x": False}
+
+        return params

--- a/sktime/forecasting/compose/_ignore_x.py
+++ b/sktime/forecasting/compose/_ignore_x.py
@@ -28,7 +28,9 @@ class IgnoreX(_DelegatedForecaster):
         The fitted forecaster.
     """
 
-    _tags = {"ignores-exogeneous-X": True,}
+    _tags = {
+        "ignores-exogeneous-X": True,
+    }
 
     def __init__(self, forecaster, ignore_x=True):
         self.forecaster = forecaster

--- a/sktime/forecasting/compose/_ignore_x.py
+++ b/sktime/forecasting/compose/_ignore_x.py
@@ -19,8 +19,8 @@ class IgnoreX(_DelegatedForecaster):
         The forecaster to wrap.
     ignore_x : bool, optional (default=True)
         Whether to ignore exogenous data or not, this parameter is useful for tuning.
-        True: ignore exogenous data, X is not passed on to forecastere
-        False: use exogenous data, X is passed on to forecasters
+        True: ignore exogenous data, X is not passed on to ``forecaster``
+        False: use exogenous data, X is passed on to ``forecaster``
 
     Attributes
     ----------

--- a/sktime/forecasting/compose/_ignore_x.py
+++ b/sktime/forecasting/compose/_ignore_x.py
@@ -65,4 +65,4 @@ class IgnoreX(_DelegatedForecaster):
         params1 = {"forecaster": f}
         params2 = {"forecaster": f, "ignore_x": False}
 
-        return params
+        return [params1, params2]

--- a/sktime/forecasting/compose/tests/test_ignorex.py
+++ b/sktime/forecasting/compose/tests/test_ignorex.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3 -u
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for Bagging Forecasters."""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from sktime.datasets import load_airline
+from sktime.forecasting.compose import IgnoreX
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(IgnoreX),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize("ignore_x", [True, False, None])
+def test_ignoreX(ignore_x):
+    """Test that indeed X=None is passed iff the args of IgnoreX claim to do so."""
+    y = load_airline()
+
+    fcst = MagicMock()
+
+    if ignore_x is None:
+        igx = IgnoreX(forecaster=fcst)
+    else:
+        igx = IgnoreX(forecaster=fcst, ignore_x=ignore_x)
+
+    igx.fit(y, fh=[1, 2, 3])
+
+    mock_fitted = igx.forecaster_.fit
+    call_args_list = mock_fitted.call_args_list
+    all_calls_X_none = all(call_args[1]['X'] is None for call_args in call_args_list)
+    any_calls_X_none = any(call_args[1]['X'] is None for call_args in call_args_list)
+
+    if ignore_x in [True, None]:
+        assert all_calls_X_none
+    else:
+        assert not any_calls_X_none

--- a/sktime/forecasting/compose/tests/test_ignorex.py
+++ b/sktime/forecasting/compose/tests/test_ignorex.py
@@ -3,11 +3,11 @@
 
 from unittest.mock import MagicMock
 
-import pandas as pd
 import pytest
 
 from sktime.datasets import load_airline
 from sktime.forecasting.compose import IgnoreX
+from sktime.tests.test_switch import run_test_for_class
 
 
 @pytest.mark.skipif(

--- a/sktime/forecasting/compose/tests/test_ignorex.py
+++ b/sktime/forecasting/compose/tests/test_ignorex.py
@@ -30,8 +30,8 @@ def test_ignoreX(ignore_x):
 
     mock_fitted = igx.forecaster_.fit
     call_args_list = mock_fitted.call_args_list
-    all_calls_X_none = all(call_args[1]['X'] is None for call_args in call_args_list)
-    any_calls_X_none = any(call_args[1]['X'] is None for call_args in call_args_list)
+    all_calls_X_none = all(call_args[1]["X"] is None for call_args in call_args_list)
+    any_calls_X_none = any(call_args[1]["X"] is None for call_args in call_args_list)
 
     if ignore_x in [True, None]:
         assert all_calls_X_none

--- a/sktime/forecasting/compose/tests/test_ignorex.py
+++ b/sktime/forecasting/compose/tests/test_ignorex.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python3 -u
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Tests for Bagging Forecasters."""
+"""Tests for IgnoreX."""
 
 from unittest.mock import MagicMock
 

--- a/sktime/forecasting/compose/tests/test_ignorex.py
+++ b/sktime/forecasting/compose/tests/test_ignorex.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from sktime.datasets import load_airline
+from sktime.datasets import load_longley
 from sktime.forecasting.compose import IgnoreX
 from sktime.tests.test_switch import run_test_for_class
 
@@ -17,7 +17,7 @@ from sktime.tests.test_switch import run_test_for_class
 @pytest.mark.parametrize("ignore_x", [True, False, None])
 def test_ignoreX(ignore_x):
     """Test that indeed X=None is passed iff the args of IgnoreX claim to do so."""
-    y = load_airline()
+    y, X = load_longley()
 
     fcst = MagicMock()
 
@@ -26,7 +26,7 @@ def test_ignoreX(ignore_x):
     else:
         igx = IgnoreX(forecaster=fcst, ignore_x=ignore_x)
 
-    igx.fit(y, fh=[1, 2, 3])
+    igx.fit(y, fh=[1, 2, 3], X=X)
 
     mock_fitted = igx.forecaster_.fit
     call_args_list = mock_fitted.call_args_list


### PR DESCRIPTION
This PR adds `IgnoreX`, a forecasting compositor that allows a user to control whether exogenous data is ignored.

As indirectly requestd by @hliebert in https://github.com/sktime/sktime/discussions/5768