### PR TITLE
&hliebert [ENH] allow `BaseTransformer._transform` to return `None`

### DIFF
--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -770,5 +770,5 @@ def test_pipeline_exogenous_none():
     )
 
     pipe.fit(y_train, X_train, fh=[1, 2, 3])
-	y_pred = pipe.predict(X_test)
+    y_pred = pipe.predict(X_test)
     assert np.all(y_pred.index == y_test.index)

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -749,3 +749,26 @@ def test_exogenousx_ignore_tag_set():
     assert not pipe8.get_tag("ignores-exogeneous-X")
     assert not pipe9.get_tag("ignores-exogeneous-X")
     assert pipe10.get_tag("ignores-exogeneous-X")
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency is not available",
+)
+def test_pipeline_exogenous_none():
+    """Test ForecastingPipeline works with a transformer returning None."""
+    from sktime.transformations.series.feature_selection import FeatureSelection
+
+    y, X = load_longley()
+    y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, test_size=3)
+
+    pipe = ForecastingPipeline(
+        [
+            ("select_X", FeatureSelection(method="none")),
+            ("arima", ARIMA()),
+        ]
+    )
+
+    pipe.fit(y_train, X_train, fh=[1, 2, 3])
+	y_pred = pipe.predict(X_test)
+    assert np.all(y_pred.index == y_test.index)

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -752,7 +752,7 @@ def test_exogenousx_ignore_tag_set():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("statsmodels", severity="none"),
+    not _check_soft_dependencies("pmdarima", severity="none"),
     reason="skip test if required soft dependency is not available",
 )
 def test_pipeline_exogenous_none():

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -770,5 +770,5 @@ def test_pipeline_exogenous_none():
     )
 
     pipe.fit(y_train, X_train, fh=[1, 2, 3])
-    y_pred = pipe.predict(X_test)
+    y_pred = pipe.predict(X=X_test)
     assert np.all(y_pred.index == y_test.index)

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -573,7 +573,7 @@ class BaseTransformer(BaseEstimator):
         output_conv = configs["output_conversion"]
 
         # convert to output mtype
-        if X is None:
+        if X is None or Xt is None:
             X_out = Xt
         elif input_conv and output_conv:
             X_out = self._convert_output(Xt, metadata=metadata)

--- a/sktime/transformations/series/feature_selection.py
+++ b/sktime/transformations/series/feature_selection.py
@@ -30,7 +30,7 @@ class FeatureSelection(BaseTransformer):
           Requires parameter n_columns.
         * "random": Randomly select n_columns features. Requires parameter n_columns.
         * "columns": Select features by given names.
-        * "none": Remove all columns by setting Z to None.
+        * "none": Remove all columns, transform returns None.
         * "all": Select all given features.
     regressor : sklearn-like regressor, optional, default=None.
         Used as meta-model for the method "feature-importances". The given


### PR DESCRIPTION
This PR allows `BaseTransformer._transform` to return `None`, and adds a test that this plays well together with `ForecastingPipeline`.

The test case is the suggested example by @hliebert: https://github.com/sktime/sktime/discussions/5768#discussioncomment-8157485