### PR TITLE
[ENH] enable `all_tags` to retrieve estimator and object tags

### DIFF
--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -302,11 +302,13 @@ def all_tags(
         must be in _base_classes.BASE_CLASS_SCITYPE_LIST
         c : string - expected type of the tag value
         should be one of:
-            "bool" - valid values are True/False
-            "int" - valid values are all integers
-            "str" - valid values are all strings
-            ("str", list_of_string) - any string in list_of_string is valid
-            ("list", list_of_string) - any individual string and sub-list is valid
+
+            * ``"bool"`` - valid values are True/False
+            * ``"int"`` - valid values are all integers
+            * ``"str"`` - valid values are all strings
+            * ``("str", "list_of_string")`` - any string in ``list_of_string`` is valid
+            * ``("list", "list_of_string")`` - any string element or sub-list is valid
+
         d : string - plain English description of the tag
     """
 

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -313,7 +313,6 @@ def all_tags(
     """
 
     def is_tag_for_type(tag, estimator_types):
-        """"""
         tag_types = tag[1]
         tag_types = _check_list_of_str_or_error(tag_types, "tag_types")
 

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -62,35 +62,46 @@ def all_estimators(
         Which kind of estimators should be returned.
         if None, no filter is applied and all estimators are returned.
         if str or list of str, strings define scitypes specified in search
-                only estimators that are of (at least) one of the scitypes are returned
-            possible str values are entries of registry.BASE_CLASS_REGISTER (first col)
-                for instance 'classifier', 'regressor', 'transformer', 'forecaster'
+        only estimators that are of (at least) one of the scitypes are returned
+        possible str values are entries of registry.BASE_CLASS_REGISTER (first col)
+        for instance 'classifier', 'regressor', 'transformer', 'forecaster'
+
     return_names: bool, optional (default=True)
-        if True, estimator class name is included in the all_estimators()
-            return in the order: name, estimator class, optional tags, either as
-            a tuple or as pandas.DataFrame columns
-        if False, estimator class name is removed from the all_estimators()
-            return.
+
+        if True, estimator class name is included in the ``all_estimators``
+        return in the order: name, estimator class, optional tags, either as
+        a tuple or as pandas.DataFrame columns
+
+        if False, estimator class name is removed from the ``all_estimators`` return.
+
     filter_tags: dict of (str or list of str), optional (default=None)
         For a list of valid tag strings, use the registry.all_tags utility.
-        subsets the returned estimators as follows:
-            each key/value pair is statement in "and"/conjunction
-                key is tag name to sub-set on
-                value str or list of string are tag values
-                condition is "key must be equal to value, or in set(value)"
+
+        ``filter_tags`` subsets the returned estimators as follows:
+
+        * each key/value pair is statement in "and"/conjunction
+        * key is tag name to sub-set on
+        * value str or list of string are tag values
+        * condition is "key must be equal to value, or in set(value)"
+
     exclude_estimators: str, list of str, optional (default=None)
         Names of estimators to exclude.
+
     as_dataframe: bool, optional (default=False)
-        if True, all_estimators will return a pandas.DataFrame with named
-            columns for all of the attributes being returned.
-        if False, all_estimators will return a list (either a list of
-            estimators or a list of tuples, see Returns)
+
+        True: ``all_estimators`` will return a pandas.DataFrame with named
+        columns for all of the attributes being returned.
+
+        False: ``all_estimators`` will return a list (either a list of
+        estimators or a list of tuples, see Returns)
+
     return_tags: str or list of str, optional (default=None)
         Names of tags to fetch and return each estimator's value of.
         For a list of valid tag strings, use the registry.all_tags utility.
         if str or list of str,
-            the tag values named in return_tags will be fetched for each
-            estimator and will be appended as either columns or tuple entries.
+        the tag values named in return_tags will be fetched for each
+        estimator and will be appended as either columns or tuple entries.
+
     suppress_import_stdout : bool, optional. Default=True
         whether to suppress stdout printout upon import.
 
@@ -99,7 +110,7 @@ def all_estimators(
     all_estimators will return one of the following:
         1. list of estimators, if return_names=False, and return_tags is None
         2. list of tuples (optional estimator name, class, ~optional estimator
-                tags), if return_names=True or return_tags is not None.
+          tags), if return_names=True or return_tags is not None.
         3. pandas.DataFrame if as_dataframe = True
         if list of estimators:
             entries are estimators matching the query,
@@ -109,10 +120,10 @@ def all_estimators(
             tags) matching the query, in alphabetical order of estimator name,
             where
             ``name`` is the estimator name as string, and is an
-                optional return
+            optional return
             ``estimator`` is the actual estimator
             ``tags`` are the estimator's values for each tag in return_tags
-                and is an optional return.
+            and is an optional return.
         if dataframe:
             all_estimators will return a pandas.DataFrame.
             column names represent the attributes contained in each column.
@@ -271,15 +282,16 @@ def all_tags(
     Parameters
     ----------
     estimator_types: string, list of string, optional (default=None)
-        Which kind of estimators should be returned.
-        - If None, no filter is applied and all estimators are returned.
+        Ta gs for hich kind of estimators should be returned.
+
+        - If None, no filter is applied and tags for all estimators are returned.
         - Possible values are 'classifier', 'regressor', 'transformer' and
-        'forecaster' to get estimators only of these specific types, or a list of
-        these to get the estimators that fit at least one of the types.
+        'forecaster' to get estimator tags only fo these specific types, or a list of
+        these to get tags for estimators that fit at least one of the types.
+
     as_dataframe: bool, optional (default=False)
-                if False, return is as described below;
-                if True, return is converted into a pandas.DataFrame for pretty
-                display
+        if False, return is as described below;
+        if True, return is converted into a pandas.DataFrame for pretty display
 
     Returns
     -------
@@ -287,23 +299,28 @@ def all_tags(
         in alphabetical order by a
         a : string - name of the tag as used in the _tags dictionary
         b : string - name of the scitype this tag applies to
-                    must be in _base_classes.BASE_CLASS_SCITYPE_LIST
+        must be in _base_classes.BASE_CLASS_SCITYPE_LIST
         c : string - expected type of the tag value
-            should be one of:
-                "bool" - valid values are True/False
-                "int" - valid values are all integers
-                "str" - valid values are all strings
-                ("str", list_of_string) - any string in list_of_string is valid
-                ("list", list_of_string) - any individual string and sub-list is valid
+        should be one of:
+            "bool" - valid values are True/False
+            "int" - valid values are all integers
+            "str" - valid values are all strings
+            ("str", list_of_string) - any string in list_of_string is valid
+            ("list", list_of_string) - any individual string and sub-list is valid
         d : string - plain English description of the tag
     """
 
     def is_tag_for_type(tag, estimator_types):
+        """"""
         tag_types = tag[1]
         tag_types = _check_list_of_str_or_error(tag_types, "tag_types")
 
         if isinstance(estimator_types, str):
             estimator_types = [estimator_types]
+
+        # also retrieve all tags for topmost base classes
+        # "estimator" has also been used for object tags, so is always included
+        estimator_types += ["estimator", "object"]
 
         tag_types = set(tag_types)
         estimator_types = set(estimator_types)

--- a/sktime/registry/tests/test_lookup.py
+++ b/sktime/registry/tests/test_lookup.py
@@ -15,15 +15,8 @@ from sktime.registry._base_classes import (
 from sktime.registry._lookup import _check_estimator_types
 
 VALID_SCITYPES_SET = set(
-    BASE_CLASS_SCITYPE_LIST + TRANSFORMER_MIXIN_SCITYPE_LIST + ["estimator"]
+    BASE_CLASS_SCITYPE_LIST + TRANSFORMER_MIXIN_SCITYPE_LIST + ["estimator", "object"]
 )
-
-# some scitypes have no associated tags yet
-SCITYPES_WITHOUT_TAGS = [
-    "series-annotator",
-    "object",
-    "network",
-]
 
 # shorthands for easy reading
 b = BASE_CLASS_SCITYPE_LIST
@@ -99,14 +92,8 @@ def test_all_tags(estimator_scitype):
     assert isinstance(tags, list)
 
     # there should be at least one tag returned
-    # exception: scitypes which we know don't have tags associated
-    est_list = (
-        estimator_scitype
-        if isinstance(estimator_scitype, list)
-        else [estimator_scitype]
-    )
-    if not set(est_list).issubset(SCITYPES_WITHOUT_TAGS):
-        assert len(tags) > 0
+    # even scitypes without tags should return those for "object"
+    assert len(tags) > 0
 
     # checks return type specification (see docstring)
     for tag in tags:
@@ -119,6 +106,11 @@ def test_all_tags(estimator_scitype):
             assert isinstance(tag[2][0], str)
             assert isinstance(tag[2][1], (str, list))
         assert isinstance(tag[3], str)
+
+    # check some tags that all object types should have
+    tags_strs = [tag[0] for tag in tags]
+    assert "python_dependencies" in tags_strs
+    assert "python_version" in tags_strs
 
 
 @pytest.mark.parametrize("return_names", [True, False])


### PR DESCRIPTION
This PR enables the `all_tags` utility to retrieve estimator and object tags, this was previously not the case.

Fixes https://github.com/sktime/sktime/issues/5755.