### PR TITLE
[MNT] change cycle for making `SAX2` and `PAA2` primary implementation renamed to `SAX`, `PAA`

### DIFF
--- a/sktime/classification/distance_based/_shape_dtw.py
+++ b/sktime/classification/distance_based/_shape_dtw.py
@@ -15,7 +15,7 @@ from sktime.classification.distance_based._time_series_neighbors import (
     KNeighborsTimeSeriesClassifier,
 )
 from sktime.datatypes import convert
-from sktime.transformations.panel.dictionary_based._paa import PAA
+from sktime.transformations.panel.dictionary_based._paa import PAAlegacy as PAA
 from sktime.transformations.panel.dwt import DWTTransformer
 from sktime.transformations.panel.hog1d import HOG1DTransformer
 

--- a/sktime/transformations/panel/dictionary_based/__init__.py
+++ b/sktime/transformations/panel/dictionary_based/__init__.py
@@ -1,7 +1,10 @@
 """Transformers."""
-__all__ = ["PAA", "SFA", "SFAFast", "SAX"]
 
-from sktime.transformations.panel.dictionary_based._paa import PAA
-from sktime.transformations.panel.dictionary_based._sax import SAX
+#TODO 0.28.0 - remove exports of PAA, SAX
+__all__ = ["PAA", "SFA", "SFAFast", "SAX", "PAAlegacy", "SAXlegacy"]
+
+#TODO 0.28.0 - remove exports of PAA, SAX
+from sktime.transformations.panel.dictionary_based._paa import PAA, PAAlegacy
+from sktime.transformations.panel.dictionary_based._sax import SAX, SAXlegacy
 from sktime.transformations.panel.dictionary_based._sfa import SFA
 from sktime.transformations.panel.dictionary_based._sfa_fast import SFAFast

--- a/sktime/transformations/panel/dictionary_based/__init__.py
+++ b/sktime/transformations/panel/dictionary_based/__init__.py
@@ -1,9 +1,9 @@
 """Transformers."""
 
-#TODO 0.28.0 - remove exports of PAA, SAX
+# TODO 0.28.0 - remove exports of PAA, SAX
 __all__ = ["PAA", "SFA", "SFAFast", "SAX", "PAAlegacy", "SAXlegacy"]
 
-#TODO 0.28.0 - remove exports of PAA, SAX
+# TODO 0.28.0 - remove exports of PAA, SAX
 from sktime.transformations.panel.dictionary_based._paa import PAA, PAAlegacy
 from sktime.transformations.panel.dictionary_based._sax import SAX, SAXlegacy
 from sktime.transformations.panel.dictionary_based._sfa import SFA

--- a/sktime/transformations/panel/dictionary_based/_paa.py
+++ b/sktime/transformations/panel/dictionary_based/_paa.py
@@ -61,7 +61,6 @@ class PAA(BaseTransformer):
             obj=self,
         )
 
-
     def set_num_intervals(self, n):
         """Set self.num_intervals to n."""
         self.num_intervals = n

--- a/sktime/transformations/panel/dictionary_based/_paa.py
+++ b/sktime/transformations/panel/dictionary_based/_paa.py
@@ -8,7 +8,7 @@ from sktime.utils.warnings import warn
 __author__ = ["MatthewMiddlehurst"]
 
 
-#TODO 0.27.0: rename the class PAA to PAAlegacy
+# TODO 0.27.0: rename the class PAA to PAAlegacy
 class PAA(BaseTransformer):
     """Piecewise Aggregate Approximation Transformer (PAA).
 
@@ -173,6 +173,6 @@ class PAA(BaseTransformer):
             )
 
 
-#TODO 0.27.0: switch the line to PAA = PAAlegacy
-#TODO 0.28.0: remove this alias altogether
+# TODO 0.27.0: switch the line to PAA = PAAlegacy
+# TODO 0.28.0: remove this alias altogether
 PAAlegacy = PAA

--- a/sktime/transformations/panel/dictionary_based/_paa.py
+++ b/sktime/transformations/panel/dictionary_based/_paa.py
@@ -3,10 +3,12 @@ import pandas as pd
 
 from sktime.datatypes._panel._convert import from_nested_to_2d_array
 from sktime.transformations.base import BaseTransformer
+from sktime.utils.warnings import warn
 
 __author__ = ["MatthewMiddlehurst"]
 
 
+#TODO 0.27.0: rename the class PAA to PAAlegacy
 class PAA(BaseTransformer):
     """Piecewise Aggregate Approximation Transformer (PAA).
 
@@ -41,6 +43,24 @@ class PAA(BaseTransformer):
     def __init__(self, num_intervals=8):
         self.num_intervals = num_intervals
         super().__init__()
+
+        warn(
+            "panel.dictionary_based.PAA will be renamed to PAAlegacy in sktime 0.27.0, "
+            "while sktime.transformations.series.PAA2 will be renamed to PAA. "
+            "PAA2 will become the primary PAA implementation in sktime, "
+            "while the current PAA will continue to be available as PAAlegacy. "
+            "Both estimators are also available under their future name at their "
+            "current location, and will be available under their deprecated name "
+            "until 0.28.0. "
+            "To prepare for the name change, do one of the following: "
+            "1. replace use of PAA from sktime.transformations.panel.dictionary_based "
+            "by use of PAA2 from sktime.transformations.series.paa, or "
+            "2. replace use of PAA from sktime.transformations.panel.dictionary_based "
+            "by use of PAAlegacy from sktime.transformations.panel.dictionary_based. ",
+            DeprecationWarning,
+            obj=self,
+        )
+
 
     def set_num_intervals(self, n):
         """Set self.num_intervals to n."""
@@ -151,3 +171,8 @@ class PAA(BaseTransformer):
                 + type(self.num_intervals).__name__
                 + "' instead."
             )
+
+
+#TODO 0.27.0: switch the line to PAA = PAAlegacy
+#TODO 0.28.0: remove this alias altogether
+PAAlegacy = PAA

--- a/sktime/transformations/panel/dictionary_based/_sax.py
+++ b/sktime/transformations/panel/dictionary_based/_sax.py
@@ -7,17 +7,13 @@ import pandas as pd
 import scipy.stats
 
 from sktime.transformations.base import BaseTransformer
-from sktime.transformations.panel.dictionary_based import PAA
-
-#    TO DO: verify this returned pandas is consistent with sktime
-#    definition. Timestamps?
-
-# from numba import types
-# from numba.experimental import jitclass
+from sktime.transformations.panel.dictionary_based import PAAlegacy as PAA
+from sktime.utils.warnings import warn
 
 __author__ = ["MatthewMiddlehurst"]
 
 
+#TODO 0.27.0: rename the class SAX to SAXlegacy
 class SAX(BaseTransformer):
     """Symbolic Aggregate approXimation (SAX) transformer.
 
@@ -89,6 +85,24 @@ class SAX(BaseTransformer):
         self.words = []
 
         super().__init__()
+
+        warn(
+            "panel.dictionary_based.SAX will be renamed to SAXlegacy in sktime 0.27.0, "
+            "while sktime.transformations.series.SAX2 will be renamed to SAX. "
+            "SAX2 will become the primary SAX implementation in sktime, "
+            "while the current SAX will continue to be available as SAXlegacy. "
+            "Both estimators are also available under their future name at their "
+            "current location, and will be available under their deprecated name "
+            "until 0.28.0. "
+            "To prepare for the name change, do one of the following: "
+            "1. replace use of SAX from sktime.transformations.panel.dictionary_based "
+            "by use of SAX2 from sktime.transformations.series.sax, or "
+            "2. replace use of SAX from sktime.transformations.panel.dictionary_based "
+            "by use of SAXlegacy from sktime.transformations.panel.dictionary_based. ",
+            DeprecationWarning,
+            obj=self,
+        )
+
         self.set_config(**{"output_conversion": "off"})
 
     # todo: looks like this just loops over series instances
@@ -219,3 +233,8 @@ class SAX(BaseTransformer):
         # small word length, window size for testing
         params = {"word_length": 2, "window_size": 4}
         return params
+
+
+#TODO 0.27.0: switch the line to SAX = SAXlegacy
+#TODO 0.28.0: remove this alias altogether
+SAXlegacy = SAX

--- a/sktime/transformations/panel/dictionary_based/_sax.py
+++ b/sktime/transformations/panel/dictionary_based/_sax.py
@@ -13,7 +13,7 @@ from sktime.utils.warnings import warn
 __author__ = ["MatthewMiddlehurst"]
 
 
-#TODO 0.27.0: rename the class SAX to SAXlegacy
+# TODO 0.27.0: rename the class SAX to SAXlegacy
 class SAX(BaseTransformer):
     """Symbolic Aggregate approXimation (SAX) transformer.
 
@@ -235,6 +235,6 @@ class SAX(BaseTransformer):
         return params
 
 
-#TODO 0.27.0: switch the line to SAX = SAXlegacy
-#TODO 0.28.0: remove this alias altogether
+# TODO 0.27.0: switch the line to SAX = SAXlegacy
+# TODO 0.28.0: remove this alias altogether
 SAXlegacy = SAX

--- a/sktime/transformations/panel/dictionary_based/tests/test_paa.py
+++ b/sktime/transformations/panel/dictionary_based/tests/test_paa.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from sktime.transformations.panel.dictionary_based._paa import PAA
+from sktime.transformations.panel.dictionary_based._paa import PAAlegacy as PAA
 from sktime.utils._testing.panel import _make_nested_from_array
 
 

--- a/sktime/transformations/series/paa.py
+++ b/sktime/transformations/series/paa.py
@@ -8,7 +8,7 @@ from sktime.transformations.base import BaseTransformer
 from sktime.utils.warnings import warn
 
 
-#TODO 0.27.0: rename the class PAA2 to PAA
+# TODO 0.27.0: rename the class PAA2 to PAA
 class PAA2(BaseTransformer):
     """Piecewise Aggregate Approximation Transformer (PAA).
 
@@ -166,6 +166,6 @@ class PAA2(BaseTransformer):
             raise ValueError("frames must be at least 1.")
 
 
-#TODO 0.27.0: switch to PAA2 = PAA
-#TODO 0.28.0: remove the alias line altogether
+# TODO 0.27.0: switch to PAA2 = PAA
+# TODO 0.28.0: remove the alias line altogether
 PAA = PAA2

--- a/sktime/transformations/series/paa.py
+++ b/sktime/transformations/series/paa.py
@@ -1,10 +1,14 @@
 """Piecewise Aggregate Approximation Transformer."""
+
 __author__ = ["steenrotsman"]
+
 import numpy as np
 
 from sktime.transformations.base import BaseTransformer
+from sktime.utils.warnings import warn
 
 
+#TODO 0.27.0: rename the class PAA2 to PAA
 class PAA2(BaseTransformer):
     """Piecewise Aggregate Approximation Transformer (PAA).
 
@@ -64,6 +68,19 @@ class PAA2(BaseTransformer):
         self.frame_size = frame_size
 
         super().__init__()
+
+        warn(
+            "In sktime 0.27.0, PAA2 will become the primary PAA implementation in "
+            "sktime, and will be renamed to PAA. "
+            "PAA2 is available under both its current and future name at its "
+            "current location, imports under the deprecated name PAA2 will be possible"
+            "until 0.28.0. "
+            "To prepare for the name change, replace imports of PAA2 from "
+            "sktime.transformations.series.paa by imports of PAA from the same "
+            "module.",
+            DeprecationWarning,
+            obj=self,
+        )
 
         self._check_params()
 
@@ -147,3 +164,8 @@ class PAA2(BaseTransformer):
 
         if self.frames < 1 and not self.frame_size:
             raise ValueError("frames must be at least 1.")
+
+
+#TODO 0.27.0: switch to PAA2 = PAA
+#TODO 0.28.0: remove the alias line altogether
+PAA = PAA2

--- a/sktime/transformations/series/sax.py
+++ b/sktime/transformations/series/sax.py
@@ -4,9 +4,11 @@ import numpy as np
 from scipy.stats import norm, zscore
 
 from sktime.transformations.base import BaseTransformer
-from sktime.transformations.series.paa import PAA2
+from sktime.transformations.series.paa import PAA
+from sktime.utils.warnings import warn
 
 
+#TODO 0.27.0: rename the class SAX2 to SAX
 class SAX2(BaseTransformer):
     """Symbolic Aggregate approXimation Transformer (SAX).
 
@@ -77,6 +79,19 @@ class SAX2(BaseTransformer):
 
         super().__init__()
 
+        warn(
+            "In sktime 0.27.0, SAX2 will become the primary SAX implementation in "
+            "sktime, and will be renamed to SAX. "
+            "SAX2 is available under both its current and future name at its "
+            "current location, imports under the deprecated name SAX2 will be possible"
+            "until 0.28.0. "
+            "To prepare for the name change, replace imports of SAX2 from "
+            "sktime.transformations.series.sax by imports of SAX from the same "
+            "module.",
+            DeprecationWarning,
+            obj=self,
+        )
+
         self._check_params()
 
     def _transform(self, X, y=None):
@@ -97,7 +112,7 @@ class SAX2(BaseTransformer):
             transformed version of X
         """
         X_transformed = zscore(X)
-        paa = PAA2(self.word_size, self.frame_size)
+        paa = PAA(self.word_size, self.frame_size)
         X_transformed = paa.fit_transform(X_transformed)
         X_transformed = np.digitize(X_transformed, self._get_breakpoints())
         return X_transformed
@@ -139,3 +154,8 @@ class SAX2(BaseTransformer):
             raise ValueError("alphabet_size must be at least 2.")
         if self.frame_size < 0:
             raise ValueError("frame_size must be at least 0.")
+
+
+#TODO 0.27.0: switch to SAX2 = SAX
+#TODO 0.28.0: remove the alias line altogether
+SAX = SAX2

--- a/sktime/transformations/series/sax.py
+++ b/sktime/transformations/series/sax.py
@@ -8,7 +8,7 @@ from sktime.transformations.series.paa import PAA
 from sktime.utils.warnings import warn
 
 
-#TODO 0.27.0: rename the class SAX2 to SAX
+# TODO 0.27.0: rename the class SAX2 to SAX
 class SAX2(BaseTransformer):
     """Symbolic Aggregate approXimation Transformer (SAX).
 
@@ -156,6 +156,6 @@ class SAX2(BaseTransformer):
             raise ValueError("frame_size must be at least 0.")
 
 
-#TODO 0.27.0: switch to SAX2 = SAX
-#TODO 0.28.0: remove the alias line altogether
+# TODO 0.27.0: switch to SAX2 = SAX
+# TODO 0.28.0: remove the alias line altogether
 SAX = SAX2


### PR DESCRIPTION
This PR adds instructions for a full rename/deprecation cycle for the new `SAX2` and `PAA2` transformers to replace `SAX` and `PAA` as primary implmentations. The new transformers are renamed to `SAX`, `PAA`, while the legacy implementations are renamed to `SAXlegacy`, `PAAlegacy`.

Implements https://github.com/sktime/sktime/issues/5778,

in detail:

* the future names are added as aliases to the current locations
* warning messages are displayed to any user constructing any of the estimators, with detailed change instructions. These messages can be turned off using `set_config`, as usual.
* this PR is released with 0.26.0
* at 0.27.0, the classes are renamed, and aliasing direction is switched. This will make the classes appear under their new names in `all_estimators` returns etc.
* at 0.28.0, the aliases are removed, leaving the classes under their post-change names.

FYI @steenrotsman