### PR TITLE
[MNT] remove maintainer information from `CODEOWNERS` in favour of estimator tags

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,89 +1,14 @@
-# The file lists sktime's algorithm maintainers as specified in GOVERNANCE.md.
-# Each line is a file pattern followed by one or more owners.
+# The file specifies framework level core developers for automated review requests
+#
+# Note: historically, this file has been used to maintain a list of
+# algorithm maintainers as specified in GOVERNANCE.md.
+# This is no longer the case, algorithm maintainers are now
+# specified directly in the estimator,
+# in the "maintainers" tag of the respective scikit-base object.
+#
+# Algorithm maintainers are programmatically queriable
+# via Estimator.get_class_tag("maintainers").
+# Further lookup such as "which algorithms does M maintain"
+# can be carried out using registry.all_estimators
 
 * @achieveordie @benheid @fkiraly @yarnabrina
-
-sktime/annotation/hmm_learn/ @miraep8
-sktime/annotation/clasp.py @patrickzib @ermshaua
-sktime/annotation/eagglo.py @KatieBuc
-sktime/annotation/stray.py @KatieBuc
-
-sktime/classification/dictionary_based/_boss.py @patrickzib @MatthewMiddlehurst
-sktime/classification/dictionary_based/_cboss.py @patrickzib @MatthewMiddlehurst
-sktime/classification/dictionary_based/_muse.py @patrickzib @MatthewMiddlehurst
-sktime/classification/dictionary_based/_tde.py @patrickzib @MatthewMiddlehurst
-sktime/classification/dictionary_based/_weasel.py @patrickzib @MatthewMiddlehurst
-sktime/classification/distance_based/ @goastler
-sktime/classification/dummy/ @ZiyaoWei
-sktime/classification/early_classification/_probability_threshold.py @MatthewMiddlehurst
-sktime/classification/early_classification/_teaser.py @patrickzib @MatthewMiddlehurst
-sktime/classification/feature_based/_catch22_classifier.py @MatthewMiddlehurst
-sktime/classification/feature_based/_fresh_prince.py @MatthewMiddlehurst
-sktime/classification/feature_based/_matrix_profile_classifier.py @MatthewMiddlehurst
-sktime/classification/feature_based/_random_interval_classifier.py @MatthewMiddlehurst
-sktime/classification/feature_based/_signature_classifier.py @jambo6
-sktime/classification/feature_based/_summary_classifier.py @MatthewMiddlehurst
-sktime/classification/feature_based/_tsfresh_classifier.py @MatthewMiddlehurst
-sktime/classification/hybrid/_hivecote_v1.py @MatthewMiddlehurst
-sktime/classification/hybrid/_hivecote_v2.py @MatthewMiddlehurst
-sktime/classification/interval_based/_cif.py @MatthewMiddlehurst
-sktime/classification/interval_based/_drcif.py @MatthewMiddlehurst
-sktime/classification/interval_based/_rise.py @MatthewMiddlehurst
-sktime/classification/interval_based/_stsf.py @MatthewMiddlehurst
-sktime/classification/interval_based/_tsf.py @MatthewMiddlehurst
-sktime/classification/kernel_based/_arsenal.py @MatthewMiddlehurst
-sktime/classification/kernel_based/_rocket_classifier.py @MatthewMiddlehurst
-sktime/classification/shapelet_based/_stc.py @ABostrom @MatthewMiddlehurst
-sktime/classification/sklearn/_continuous_interval_tree.py @MatthewMiddlehurst
-sktime/classification/sklearn/_rotation_forest.py @MatthewMiddlehurst
-
-sktime/forecasting/adapters/_hcrystalball.py @MichalChromcak
-sktime/forecasting/arch/_uarch.py @Vasudeva-bit
-sktime/forecasting/arima.py @HYang1996
-sktime/forecasting/base/adapters/_statsforecast.py @FedericoGarza
-sktime/forecasting/bats.py @aiwalter
-sktime/forecasting/compose/_ensemble.py @aiwalter
-sktime/forecasting/compose/_hierarchy_ensemble.py @VyomkeshVyas
-sktime/forecasting/ets.py @HYang1996
-sktime/forecasting/fbprophet.py @aiwalter
-sktime/forecasting/model_selection/_split @koralturkk
-sktime/forecasting/online_learning/ @magittan
-sktime/forecasting/sarimax.py @TNTran92
-sktime/forecasting/statsforecast.py @FedericoGarza
-sktime/forecasting/structural.py @juanitorduz
-sktime/forecasting/tests/test_ets.py @HYang1996
-sktime/forecasting/tbats.py @aiwalter
-
-sktime/regression/dummy/ @badrmarani
-
-sktime/transformations/panel/augmenter.py @MrPr3ntice @iljamaurer
-sktime/transformations/panel/catch22.py @MatthewMiddlehurst
-sktime/transformations/panel/catch22wrapper.py @MatthewMiddlehurst
-sktime/transformations/panel/channel_selection.py @haskarb @a-pasos-ruiz
-sktime/transformations/panel/dictionary_based/_paa.py @patrickzib @MatthewMiddlehurst
-sktime/transformations/panel/dictionary_based/_sax.py @patrickzib @MatthewMiddlehurst
-sktime/transformations/panel/dictionary_based/_sfa.py @patrickzib @MatthewMiddlehurst
-sktime/transformations/panel/dictionary_based/_sfa_fast.py @patrickzib @MatthewMiddlehurst
-sktime/transformations/panel/random_intervals.py @MatthewMiddlehurst
-sktime/transformations/panel/rocket/ @angus924
-sktime/transformations/panel/rocket/_multirocket.py @ChangWeiTan @fstinner @angus924
-sktime/transformations/panel/rocket/_multirocket_multivariate.py @ChangWeiTan @fstinner @angus924
-sktime/transformations/panel/signature_based/ @jambo6
-sktime/transformations/panel/shapelet_transform.py @ABostrom @MatthewMiddlehurst
-sktime/transformations/panel/supervised_intervals.py @MatthewMiddlehurst
-
-sktime/transformations/series/clear_sky.py @ciaran-g
-sktime/transformations/series/clasp.py @patrickzib @ermshaua
-sktime/transformations/series/date.py @danbartl @KishManani
-sktime/transformations/series/difference.py @rnkuhns
-sktime/transformations/series/exponent.py @rnkuhns
-sktime/transformations/series/feature_selection.py @aiwalter
-sktime/transformations/series/impute.py @aiwalter
-sktime/transformations/series/kalman_filter.py @NoaBenAmi
-sktime/transformations/series/outlier_detection.py @aiwalter
-sktime/transformations/series/scaledlogit.py @ltsaprounis
-sktime/transformations/series/time_since.py @KishManani
-sktime/transformations/series/theta.py @GuzalBulatova
-sktime/transformations/series/scaledasinh.py @ali-parizad
-
-sktime/utils/mlflow_sktime.py @benjaminbluhm

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -160,11 +160,17 @@ Appointment
 The contributor who contributes an algorithm is automatically appointed
 as its first maintainer.
 
-Algorithm maintainers are listed in the `CODEOWNERS <https://github
-.com/alan-turing-institute/sktime/blob/main/CODEOWNERS>`__ file.
+Algorithm maintainers are listed in the ``"maintainers"`` tag of the estimator class,
+by their GitHub ID. The GitHub ID can be linked to further information via
+the ``all-contributorsrc`` file.	
+The tag can be inspected directly in the source code of the class,
+or via ``EstimatorName.get_class_tag("maintainers").``
+Inverse lookup such as "which algorithms does maintainer M maintain"
+can be carried out using ``registry.all_estimators``.
 
 When an algorithm maintainer resigns, they can appoint another contributor as the
-new algorithm maintainer. No vote is required. This change should be reflected in the ``CODEOWNERS`` file.
+new algorithm maintainer. No vote is required.
+This change should be reflected in the ``"maintainers"`` tag.
 
 Algorithm maintainers can be appointed by CC simple majority for any algorithm without maintainers.
 

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -162,7 +162,7 @@ as its first maintainer.
 
 Algorithm maintainers are listed in the ``"maintainers"`` tag of the estimator class,
 by their GitHub ID. The GitHub ID can be linked to further information via
-the ``all-contributorsrc`` file.	
+the ``all-contributorsrc`` file.
 The tag can be inspected directly in the source code of the class,
 or via ``EstimatorName.get_class_tag("maintainers").``
 Inverse lookup such as "which algorithms does maintainer M maintain"


### PR DESCRIPTION
This PR finishes the migration of algorithm author and maintainer information from `CODEOWNERS` to estimator tags.

As discussed in https://github.com/sktime/sktime/issues/5746, the information is also keyed more granularly, with `authors` tag keeping track of significant code contribution credits, while `maintainers` tracks the current active maintainer(s) according to the role specified in the governance doc.

The information previously present in `CODEOWNERS` has been moved completely to estimator tags, possibly reconciled with inconsistencies with `__authors__` attributes of the module, or commit history.

Barring accidental data entry error, the information should now be fully migrated via the following PR:

https://github.com/sktime/sktime/pull/5800
https://github.com/sktime/sktime/pull/5801
https://github.com/sktime/sktime/pull/5802
https://github.com/sktime/sktime/pull/5803
https://github.com/sktime/sktime/pull/5807

Minor note: the annotation module is not fully `scikit-base` compatible, so no migration was carried out there - information from `CODEOWNERS` is removed, but it is duplicative with `__authors__` information in the annontation module, so that information is not lost, and will be preserved once the module matures and migrates to `scikit-base` based classes.