### PR TITLE
[ENH] `sklearn 1.4.0` compatibility patches

### DIFF
--- a/sktime/classification/deep_learning/base.py
+++ b/sktime/classification/deep_learning/base.py
@@ -116,7 +116,14 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         self.classes_ = self.label_encoder.classes_
         self.n_classes_ = len(self.classes_)
         y = y.reshape(len(y), 1)
-        self.onehot_encoder = OneHotEncoder(sparse=False, categories="auto")
+
+        # in sklearn 1.2, sparse was renamed to sparse_output
+        if _check_soft_dependencies("sklearn>=1.2", severity="none"):
+            sparse_kw = {"sparse_output": False}
+        else:
+            sparse_kw = {"sparse": False}
+
+        self.onehot_encoder = OneHotEncoder(categories="auto", **sparse_kw)
         # categories='auto' to get rid of FutureWarning
         y = self.onehot_encoder.fit_transform(y)
         return y

--- a/sktime/classification/interval_based/_tsf.py
+++ b/sktime/classification/interval_based/_tsf.py
@@ -114,6 +114,9 @@ class TimeSeriesForestClassifier(
         n_jobs=1,
         random_state=None,
     ):
+        self.criterion = "gini"  # needed for BaseForest in sklearn > 1.4.0,
+        # because sklearn tag logic looks at this attribute
+
         super().__init__(
             min_interval=min_interval,
             n_estimators=n_estimators,


### PR DESCRIPTION
`sklearn 1.4.0` compatibility patches:

* address rename of `sparse` to `sparse_output` in `OneHotEncoder`
* `TimeSeriesForestClassifier` fix of breakage due to `sklearn` parent inspecting non-existent `self.criterion`