### PR TITLE
[MNT] addressing more `pandas` deprecations

### DIFF
--- a/sktime/transformations/panel/catch22.py
+++ b/sktime/transformations/panel/catch22.py
@@ -328,7 +328,7 @@ class Catch22(BaseTransformer):
 
         f_count = -1
         for i in range(len(X)):
-            series = np.array(X[i])
+            series = np.array(X.iloc[i])
             dim = i * len(f_idx)
             outlier_series = None
             smin = None

--- a/sktime/transformations/series/dilation_mapping.py
+++ b/sktime/transformations/series/dilation_mapping.py
@@ -105,9 +105,9 @@ class DilationMappingTransformer(BaseTransformer):
         return self._dilate_series(X, self.dilation)
 
     def _dilate_series(self, x, d):
-        x_dilated = pd.Series(name=x.name)
-        for i in range(0, d):
-            x_dilated = pd.concat((x_dilated, x[i::d]), axis=0)
+        x_dilations = [x[i::d] for i in range(0, d)]
+        x_dilated = pd.concat(x_dilations, axis=0)
+        x_dilated.name = x.name
         return x_dilated.reset_index(drop=True)
 
     @classmethod


### PR DESCRIPTION
Addresses further `pandas` deprecations:

* change of ambiguous `DataFrame.__getitem__` calls to `iloc`
* avoid empty series used in `pd.concat`