### PR TITLE
[MNT] 0.26.0 deprecations and change actions

### DIFF
--- a/sktime/classification/deep_learning/rnn.py
+++ b/sktime/classification/deep_learning/rnn.py
@@ -14,10 +14,6 @@ from sktime.utils.validation._dependencies import _check_dl_dependencies
 from sktime.utils.warnings import warn
 
 
-# todo: 0.26.0 - please remove num_epochs parameter and related logic,
-# because parameter num_epochs usage is deprecated and will be renamed
-# to n_epochs.  Also n_epochs should be moved to become the first
-# argument in the __init__ and super().__init__.
 class SimpleRNNClassifier(BaseDeepClassifier):
     """Simple recurrent neural network.
 
@@ -63,7 +59,7 @@ class SimpleRNNClassifier(BaseDeepClassifier):
 
     def __init__(
         self,
-        num_epochs=None,
+        n_epochs=100,
         batch_size=1,
         units=6,
         callbacks=None,
@@ -75,26 +71,11 @@ class SimpleRNNClassifier(BaseDeepClassifier):
         activation="sigmoid",
         use_bias=True,
         optimizer=None,
-        n_epochs=100,
     ):
         _check_dl_dependencies(severity="error")
+
         super().__init__()
-        # todo: 0.26.0 - remove this, replace by
-        # self._n_epochs = n_epochs
-        # Deprecated Parameter Handling
-        if num_epochs is not None:
-            warn(
-                "In SimpleRNNClassifier, the parameter 'num_epochs' is deprecated "
-                "and will be removed in v0.26.0. It will be renamed to n_epochs. "
-                "To avoid this warning, update your code to use 'n_epochs'. ",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self._n_epochs = num_epochs
-        else:
-            self._n_epochs = n_epochs
-        self.num_epochs = num_epochs
-        # end remove
+
         self.batch_size = batch_size
         self.verbose = verbose
         self.units = units
@@ -218,7 +199,7 @@ class SimpleRNNClassifier(BaseDeepClassifier):
             X,
             y_onehot,
             batch_size=self.batch_size,
-            epochs=self._n_epochs,
+            epochs=self.n_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks_,
         )

--- a/sktime/classification/deep_learning/rnn.py
+++ b/sktime/classification/deep_learning/rnn.py
@@ -11,7 +11,6 @@ from sklearn.utils import check_random_state
 from sktime.classification.deep_learning.base import BaseDeepClassifier
 from sktime.networks.rnn import RNNNetwork
 from sktime.utils.validation._dependencies import _check_dl_dependencies
-from sktime.utils.warnings import warn
 
 
 class SimpleRNNClassifier(BaseDeepClassifier):

--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -20,7 +20,7 @@ from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.utils.validation.panel import check_X
 
 
-# TODO: fix this in 0.26.0
+# TODO: fix this in 0.27.0
 # base class should have been changed to BaseEarlyClassifier
 class ProbabilityThresholdEarlyClassifier(BaseClassifier):
     """Probability Threshold Early Classifier.

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -87,14 +87,13 @@ def _coerce_list_of_str(obj, var_name="obj"):
     return obj
 
 
-# todo 0.26.0: change default for msg_return_dict to "dict", update docstring
 def check_is_mtype(
     obj,
     mtype: Union[str, List[str]],
     scitype: str = None,
     return_metadata=False,
     var_name="obj",
-    msg_return_dict=None,
+    msg_return_dict="dict",
 ):
     """Check object for compliance with mtype specification, return metadata.
 
@@ -112,10 +111,10 @@ def check_is_mtype(
         if str, list of str, metadata return dict is subset to keys in return_metadata
     var_name: str, optional, default="obj"
         name of input in error messages
-    msg_return_dict: str, "list" or "dict", optional, default="list"
+    msg_return_dict: str, "list" or "dict", optional, default="dict"
         whether returned msg, if returned is a str, dict or list
         if "list", msg is str if mtype is str, list of str if mtype is list
-        if "dict", msg is dict if mtype is str, list of str if mtype is list,
+        if "dict", msg is str if mtype is str, dict of str if mtype is list,
         if dict, has with mtype as key and error message for mtype as value
 
     Returns
@@ -168,16 +167,8 @@ def check_is_mtype(
 
     # initialize loop variables
     if msg_return_dict is None:
-        # todo 0.26.0: remove this warning, and change default to "dict"
-        warn(
-            "From sktime 0.26.0 onwards, msg return of check_is_mtype "
-            "will default to dict if mtype is a list. "
-            "To retain the old behaviour, set msg_return_dict='list' explicitly. "
-            "To move to the new behaviour, set msg_return_dict='dict' explicitly. "
-            "Setting msg_return_dict explicitly will silence the warning."
-        )
-        msg = []
-        msg_return_dict = "list"
+        msg_return_dict = "dict"
+        msg = dict()
     elif msg_return_dict == "list":
         msg = []
     elif msg_return_dict == "dict":
@@ -232,7 +223,10 @@ def check_is_mtype(
     # c. no mtype is found - then return False and all error messages if requested
     else:
         if len(msg) == 1:
-            msg = msg[0]
+            if msg_return_dict == "list":
+                msg = msg[0]
+            else:
+                msg = list(msg.values())[0]
 
         return _ret(False, msg, None, return_metadata)
 

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -35,7 +35,6 @@ from sktime.datatypes._proba import check_dict_Proba
 from sktime.datatypes._registry import AMBIGUOUS_MTYPES, SCITYPE_LIST, mtype_to_scitype
 from sktime.datatypes._series import check_dict_Series
 from sktime.datatypes._table import check_dict_Table
-from sktime.utils.warnings import warn
 
 # pool convert_dict-s
 check_dict = dict()

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -809,7 +809,7 @@ def _to_relative(fh: ForecastingHorizon, cutoff=None) -> ForecastingHorizon:
             absolute = _coerce_to_period(absolute, freq=fh.freq)
             cutoff = _coerce_to_period(cutoff, freq=fh.freq)
 
-        # TODO: 0.26.0:
+        # TODO: 0.27.0:
         # Check at every minor release whether lower pandas bound >=0.15.0
         # if yes, can remove the workaround in the "else" condition and the check
         #

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -170,7 +170,7 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                         if len(levels) == 1:
                             levels = levels[0]
                         yt[ix] = y.xs(ix, level=levels, axis=1)
-                        # todo 0.26.0 - check why this cannot be easily removed
+                        # todo 0.27.0 - check why this cannot be easily removed
                         # in theory, we should get rid of the "Coverage" case treatment
                         # (the legacy naming convention was removed in 0.23.0)
                         # deal with the "Coverage" case, we need to get rid of this

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -330,7 +330,6 @@ def evaluate(
     backend: Optional[str] = None,
     cv_X=None,
     backend_params: Optional[dict] = None,
-    **kwargs,
 ):
     r"""Evaluate forecaster using timeseries cross-validation.
 
@@ -518,18 +517,6 @@ def evaluate(
                 "running evaluate with backend='dask' requires the dask package "
                 "installed, but dask is not present in the python environment"
             )
-
-    # todo 0.26.0: remove kwargs and this warning
-    if kwargs != {}:
-        warnings.warn(
-            "in evaluate, kwargs are no longer supported. "
-            "to pass configuration arguments to the parallelization backend, "
-            "use backend_params instead. "
-            f"The following kwargs were found: {kwargs.keys()}, pass these as "
-            "dict elements to backend_params instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     _check_strategy(strategy)
     cv = check_cv(cv, enforce_start_with_window=True)

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -18,7 +18,7 @@ from sktime.forecasting.model_selection._tune import (
 )
 
 
-# todo 0.26.0 - check whether we should remove, otherwise bump
+# todo 0.27.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def temporal_train_test_split(
     y, X=None, test_size=None, train_size=None, fh=None, anchor="start"
@@ -45,7 +45,7 @@ def temporal_train_test_split(
     )
 
 
-# todo 0.26.0 - check whether we should remove, otherwise bump
+# todo 0.27.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
     """Legacy export of Expanding window splitter.
@@ -68,7 +68,7 @@ def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
     return _EWSplitter(fh=fh, initial_window=initial_window, step_length=step_length)
 
 
-# todo 0.26.0 - check whether we should remove, otherwise bump
+# todo 0.27.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def SlidingWindowSplitter(
     fh=1, window_length=10, step_length=1, initial_window=None, start_with_window=True

--- a/sktime/regression/deep_learning/rnn.py
+++ b/sktime/regression/deep_learning/rnn.py
@@ -11,7 +11,6 @@ from sklearn.utils import check_random_state
 from sktime.networks.rnn import RNNNetwork
 from sktime.regression.deep_learning.base import BaseDeepRegressor
 from sktime.utils.validation._dependencies import _check_dl_dependencies
-from sktime.utils.warnings import warn
 
 
 class SimpleRNNRegressor(BaseDeepRegressor):

--- a/sktime/regression/deep_learning/rnn.py
+++ b/sktime/regression/deep_learning/rnn.py
@@ -14,10 +14,6 @@ from sktime.utils.validation._dependencies import _check_dl_dependencies
 from sktime.utils.warnings import warn
 
 
-# todo: 0.26.0 - please remove num_epochs parameter and related logic,
-# because parameter num_epochs usage is deprecated and will be renamed
-# to n_epochs.  Also n_epochs should be moved to become the first
-# argument in the __init__ and super().__init__.
 class SimpleRNNRegressor(BaseDeepRegressor):
     """Simple recurrent neural network.
 
@@ -64,7 +60,7 @@ class SimpleRNNRegressor(BaseDeepRegressor):
 
     def __init__(
         self,
-        num_epochs=None,
+        n_epochs=100,
         batch_size=1,
         units=6,
         callbacks=None,
@@ -76,26 +72,11 @@ class SimpleRNNRegressor(BaseDeepRegressor):
         activation="linear",
         use_bias=True,
         optimizer=None,
-        n_epochs=100,
     ):
         _check_dl_dependencies(severity="error")
+
         super().__init__()
-        # todo: 0.26.0 - remove this, replace by
-        # self._n_epochs = n_epochs
-        # Deprecated Parameter Handling
-        if num_epochs is not None:
-            warn(
-                "In SimpleRNNRegressor, the parameter 'num_epochs' is deprecated "
-                "and will be removed in v0.26.0. It will be renamed to n_epochs. "
-                "To avoid this warning, update your code to use 'n_epochs'. ",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self._n_epochs = num_epochs
-        else:
-            self._n_epochs = n_epochs
-        self.num_epochs = num_epochs
-        # end remove
+
         self.batch_size = batch_size
         self.verbose = verbose
         self.units = units
@@ -213,7 +194,7 @@ class SimpleRNNRegressor(BaseDeepRegressor):
             X,
             y,
             batch_size=self.batch_size,
-            epochs=self._n_epochs,
+            epochs=self.n_epochs,
             verbose=self.verbose,
             callbacks=self.callbacks_,
         )

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 
 
-# todo 0.26.0: check whether scikit-base>=0.6.1 lower bound is 0.6.1 or higher
+# todo 0.27.0: check whether scikit-base>=0.6.1 lower bound is 0.6.1 or higher
 # if yes, remove this legacy function and use the new one from sktime.utils.deep_equals
 def deep_equals(x, y, return_msg=False):
     """Test two objects for equality in value.

--- a/sktime/utils/deep_equals/__init__.py
+++ b/sktime/utils/deep_equals/__init__.py
@@ -2,7 +2,7 @@
 """Module for nested equality checking."""
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-# todo 0.26.0: check whether scikit-base>=0.6.1 lower bound is 0.6.1 or higher
+# todo 0.27.0: check whether scikit-base>=0.6.1 lower bound is 0.6.1 or higher
 # if yes, remove legacy handling and only use the new deep_equals
 if _check_soft_dependencies(
     "scikit-base<0.6.1",


### PR DESCRIPTION
Carries out deprecations and change actions scheduled for 0.26.0:

* finish deprecation of num_epochs inn RNN classifier and regressor
* in `check_is_mtype`, change default of `msg_return_dict` to `"dict"`
* in forecast benchmark `evaluate`, remove `kwargs`
* bump deprecation/change checks scheduled for 0.26.0 to 0.27.0

