### PR TITLE
[DOC] add missing documentation on PEP 440 format specification for `python_dependencies` tag in extension templates

### DIFF
--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -183,7 +183,7 @@ class MyForecaster(BaseForecaster):
         #
         # soft dependency requirement
         "python_dependencies": None,
-        # valid values: str or list of str
+        # valid values: str or list of str, PEP 440 valid package version specifiers
         # raises exception at construction if modules at strings cannot be imported
     }
     #  in case of inheritance, concrete class should typically set tags

--- a/extension_templates/param_est.py
+++ b/extension_templates/param_est.py
@@ -133,7 +133,7 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
         #
         # soft dependency requirement
         "python_dependencies": None,
-        # valid values: str or list of str
+        # valid values: str or list of str, PEP 440 valid package version specifiers
         # raises exception at construction if modules at strings cannot be imported
     }
     #  in case of inheritance, concrete class should typically set tags

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -119,7 +119,7 @@ class MySplitter(BaseSplitter):
         #
         # soft dependency requirement
         "python_dependencies": None,
-        # valid values: str or list of str
+        # valid values: str or list of str, PEP 440 valid package version specifiers
         # raises exception at construction if modules at strings cannot be imported
     }
 

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -270,7 +270,7 @@ class MyTransformer(BaseTransformer):
         #
         # soft dependency requirement
         "python_dependencies": None,
-        # valid values: str or list of str
+        # valid values: str or list of str, PEP 440 valid package version specifiers
         # raises exception at construction if modules at strings cannot be imported
     }
     # in case of inheritance, concrete class should typically set tags


### PR DESCRIPTION
This PR adds missing documentation on PEP 440 format specification for the `python_dependencies` tag in some extension templates.