### PR TITLE
[MNT] temporary bounding `scikit-base<0.7.0` (status quo 0.25.0) for 0.25.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   "numpy<1.27,>=1.21",  # required for framework layer and base class logic
   "packaging",  # for estimator specific dependency parsing
   "pandas<2.2.0,>=1.1",  # pandas is the main in-memory data container
-  "scikit-base<0.8.0",  # base module for sklearn compatible base API
+  "scikit-base<0.7.0",  # base module for sklearn compatible base API
   "scikit-learn<1.4.0,>=0.24",  # required for estimators and framework layer
   "scipy<2.0.0,>=1.2",  # required for estimators and framework layer
 ]


### PR DESCRIPTION
This PR temorarily bounds `scikit-base<0.7.0` for the 0.25.1 release, to be reverted for 0.26.0.

This is in order to sync the MINOR bump of `scikit-base` with that of `sktime`.