### PR TITLE
[MNT] revert temporary bounding of `scikit-base<0.7.0` to `scikit-base<0.8.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   "numpy<1.27,>=1.21",  # required for framework layer and base class logic
   "packaging",  # for estimator specific dependency parsing
   "pandas<2.2.0,>=1.1",  # pandas is the main in-memory data container
-  "scikit-base<0.7.0",  # base module for sklearn compatible base API
+  "scikit-base<0.8.0",  # base module for sklearn compatible base API
   "scikit-learn<1.4.0,>=0.24",  # required for estimators and framework layer
   "scipy<2.0.0,>=1.2",  # required for estimators and framework layer
 ]


### PR DESCRIPTION
Update: I think the bugfixes in 0.7.0 are very localized but important, so I'll bump the bound for 0.25.1 after all.

---

Reverts sktime/sktime#5824, to be released with the 0.26.0 release, to ensure core dependencies bump minor version bounds in sync with `sktime` (to avoid downstream instability).