### PR TITLE
[BUG] Empty dummy step's buffer only if new data arrive

### DIFF
--- a/sktime/pipeline/pipeline.py
+++ b/sktime/pipeline/pipeline.py
@@ -598,10 +598,15 @@ class Pipeline(BaseEstimator):
     def _initiate_call(self, X, y, kwargs):
         if not self._assembled:
             self._assemble_steps()
-        for step in self.assembled_steps.values():
-            step.reset()
-        self.assembled_steps["X"].buffer = X
-        self.assembled_steps["y"].buffer = y
+        for key, step in self.assembled_steps.items():
+            if key in ["X", "y"]:
+                step.reset(reset_buffer=False)
+            else:
+                step.reset()
+        if X is not None:
+            self.assembled_steps["X"].buffer = X
+        if y is not None:
+            self.assembled_steps["y"].buffer = y
         self.kwargs.update(kwargs)
 
     def _method_allowed(self, method):

--- a/sktime/pipeline/pipeline.py
+++ b/sktime/pipeline/pipeline.py
@@ -599,10 +599,13 @@ class Pipeline(BaseEstimator):
         if not self._assembled:
             self._assemble_steps()
         for key, step in self.assembled_steps.items():
+            # Empty the buffer of all steps except for the dummy
+            # steps X and y (input steps)
             if key in ["X", "y"]:
                 step.reset(reset_buffer=False)
             else:
                 step.reset()
+        # Overwrite the buffer of X and y if data are provided
         if X is not None:
             self.assembled_steps["X"].buffer = X
         if y is not None:

--- a/sktime/pipeline/step.py
+++ b/sktime/pipeline/step.py
@@ -73,9 +73,10 @@ class Step:
         self.input_edges = input_edges
         self.params = params
 
-    def reset(self):
+    def reset(self, reset_buffer=True):
         """Reset the step."""
-        self.buffer = None
+        if reset_buffer:
+            self.buffer = None
         self.mode = ""
 
     def get_allowed_method(self):

--- a/sktime/pipeline/tests/regression_tests/test_pipeline_regression.py
+++ b/sktime/pipeline/tests/regression_tests/test_pipeline_regression.py
@@ -2,10 +2,11 @@ import numpy as np
 import pandas as pd
 import pytest
 from skbase.utils.dependencies import _check_soft_dependencies
+from sklearn.linear_model import Ridge
 
 from sktime.classification.dummy import DummyClassifier
-from sktime.datasets import load_arrow_head, load_longley, load_airline
-from sktime.forecasting.compose import ForecastX
+from sktime.datasets import load_airline, load_arrow_head, load_longley
+from sktime.forecasting.compose import ForecastX, make_reduction
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.forecasting.sarimax import SARIMAX
 from sktime.pipeline.pipeline import Pipeline
@@ -17,8 +18,6 @@ from sktime.transformations.series.difference import Differencer
 from sktime.transformations.series.exponent import ExponentTransformer
 from sktime.transformations.series.lag import Lag
 from sktime.utils._testing.hierarchical import _bottom_hier_datagen, _make_hierarchical
-from sktime.forecasting.compose import make_reduction
-from sklearn.linear_model import Ridge
 
 
 def test_transformer_regression():

--- a/sktime/pipeline/tests/regression_tests/test_pipeline_regression.py
+++ b/sktime/pipeline/tests/regression_tests/test_pipeline_regression.py
@@ -333,5 +333,5 @@ def test_lagged_y_prediction():
         forecaster, name="forecaster", edges={"X": "differencer", "y": "y"}
     )
     pipe.fit(y=y_train)
-    y_pred = pipe.predict(fh=[1, 2, 3])
+    y_pred = pipe.predict(fh=y_test.index)
     assert y_pred.shape == y_test.shape


### PR DESCRIPTION
Fix pipeline.predict if inner X are derrived by y by not emptying the buffer of the y dummy step.

<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes #5830 


#### What does this implement/fix? Explain your changes.
Avoid to empty the buffer if no new data is arriving during `predict` call. 

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?

#### Did you add any tests for the change?

* [x] TODO
#### Any other comments?

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

<!--
Thanks for contributing!
-->
