### PR TITLE
[BUG] fix tag handling in `IgnoreX`

### DIFF
--- a/sktime/forecasting/compose/_ignore_x.py
+++ b/sktime/forecasting/compose/_ignore_x.py
@@ -35,6 +35,7 @@ class IgnoreX(_DelegatedForecaster):
 
     _tags = {
         "ignores-exogeneous-X": True,
+        "requires-fh-in-fit": False,
     }
 
     def __init__(self, forecaster, ignore_x=True):

--- a/sktime/forecasting/compose/_ignore_x.py
+++ b/sktime/forecasting/compose/_ignore_x.py
@@ -3,6 +3,7 @@
 
 __author__ = ["fkiraly"]
 
+from sktime.datatypes import ALL_TIME_SERIES_MTYPES
 from sktime.forecasting.base._delegate import _DelegatedForecaster
 
 
@@ -34,8 +35,9 @@ class IgnoreX(_DelegatedForecaster):
     _delegate_name = "forecaster_"
 
     _tags = {
+        "authors": ["fkiraly", "tpvasconcelos"],
         "ignores-exogeneous-X": True,
-        "requires-fh-in-fit": False,
+        "scitype:y": "both",
     }
 
     def __init__(self, forecaster, ignore_x=True):
@@ -45,6 +47,22 @@ class IgnoreX(_DelegatedForecaster):
         super().__init__()
 
         self.forecaster_ = forecaster.clone()
+
+        TAGS_TO_CLONE = [
+            "capability:insample",
+            "capability:pred_int",
+            "capability:pred_int:insample",
+            "handles-missing-data",
+            "requires-fh-in-fit",
+            "X-y-must-have-same-index",
+            "enforce_index_type",
+        ]
+
+        self.clone_tags(forecaster, TAGS_TO_CLONE)
+
+        # this ensures that we convert in the inner estimator, not in the multiplexer
+        self.set_tags(**{"y_inner_mtype": ALL_TIME_SERIES_MTYPES})
+        self.set_tags(**{"X_inner_mtype": ALL_TIME_SERIES_MTYPES})
 
         if not ignore_x:
             self.set_tags(**{"ignores-exogeneous-X": ignore_x})


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.

`IgnoreX` breaks even when wrapping forecasters that do not require `fh` in `.fit()`

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

N/A

#### Did you add any tests for the change?

No.

#### Any other comments?

Why is this the default behaviour in `BaseForecaster`?

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

