### PR TITLE
[ENH] centralize logic for safe clone of delegator tags - forecasting

### DIFF
--- a/sktime/forecasting/base/_delegate.py
+++ b/sktime/forecasting/base/_delegate.py
@@ -38,6 +38,57 @@ class _DelegatedForecaster(BaseForecaster):
     def _get_delegate(self):
         return getattr(self, self._delegate_name)
 
+    def _set_delegated_tags(self, delegate=None):
+        """Sets delegated tags, only tags for boilerplate control.
+
+        Writes tags to self.
+        Can be used by descendant classes to set dependent tags.
+        Makes safe baseline assumptions about tags, which can be overwritten.
+
+        * data mtype tags are set to the most general value.
+          This is to ensure that conversion is left to the inner estimator.
+        * packaging tags such as "author" or "python_depedencies" are not cloned.
+        * other boilerplate tags are cloned.
+
+        Parameters
+        ----------
+        delegate : object, optional (default=None)
+            object to get tags from, if None, uses self._get_delegate()
+
+        Returns
+        -------
+        self : reference to self
+        """
+        from sktime.datatypes import ALL_TIME_SERIES_MTYPES
+
+        if delegate is None:
+            delegate = self._get_delegate()
+
+        TAGS_TO_DELEGATE = [
+            "requires-fh-in-fit",
+            "handles-missing-data",
+            "ignores-exogeneous-X",
+            "capability:insample",
+            "capability:pred_int",
+            "capability:pred_int:insample",
+            "handles-missing-data",
+            "requires-fh-in-fit",
+            "X-y-must-have-same-index",
+            "enforce_index_type",
+            "fit_is_empty",
+        ]
+
+        TAGS_TO_SET = {
+            "scitype:y": "both",
+            "y_inner_mtype": ALL_TIME_SERIES_MTYPES,
+            "X_inner_mtype": ALL_TIME_SERIES_MTYPES,
+        }
+
+        self.clone_tags(delegate, tags_to_clone=TAGS_TO_DELEGATE)
+        self.set_tags(**TAGS_TO_SET)
+
+        return self
+
     def _fit(self, y, X, fh):
         """Fit forecaster to training data.
 

--- a/sktime/forecasting/base/_delegate.py
+++ b/sktime/forecasting/base/_delegate.py
@@ -39,7 +39,7 @@ class _DelegatedForecaster(BaseForecaster):
         return getattr(self, self._delegate_name)
 
     def _set_delegated_tags(self, delegate=None):
-        """Sets delegated tags, only tags for boilerplate control.
+        """Set delegated tags, only tags for boilerplate control.
 
         Writes tags to self.
         Can be used by descendant classes to set dependent tags.

--- a/sktime/forecasting/base/_delegate.py
+++ b/sktime/forecasting/base/_delegate.py
@@ -84,7 +84,7 @@ class _DelegatedForecaster(BaseForecaster):
             "X_inner_mtype": ALL_TIME_SERIES_MTYPES,
         }
 
-        self.clone_tags(delegate, tags_to_clone=TAGS_TO_DELEGATE)
+        self.clone_tags(delegate, tag_names=TAGS_TO_DELEGATE)
         self.set_tags(**TAGS_TO_SET)
 
         return self

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -75,7 +75,7 @@ class ForecastByLevel(_DelegatedForecaster):
 
         super().__init__()
 
-        self.clone_tags(self.forecaster_)
+        self._set_delegated_tags(self.forecaster_)
         self.set_tags(**{"fit_is_empty": False})
 
         if groupby == "local":

--- a/sktime/forecasting/compose/_ignore_x.py
+++ b/sktime/forecasting/compose/_ignore_x.py
@@ -45,6 +45,9 @@ class IgnoreX(_DelegatedForecaster):
 
         self.forecaster_ = forecaster.clone()
 
+        self._set_delegated_tags(self.forecaster_)
+        self.set_tags(**{"ignores-exogeneous-X": True})
+
         if not ignore_x:
             self.set_tags(**{"ignores-exogeneous-X": ignore_x})
 

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -119,7 +119,7 @@ class MultiplexForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
         )
         self._set_forecaster()
 
-        self.clone_tags(self.forecaster_)
+        self._set_delegated_tags()
         self.set_tags(**{"fit_is_empty": False})
         # this ensures that we convert in the inner estimator, not in the multiplexer
         self.set_tags(**{"y_inner_mtype": ALL_TIME_SERIES_MTYPES})

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -1730,17 +1730,8 @@ class Permute(_DelegatedForecaster, BaseForecaster, _HeterogenousMetaEstimator):
         self.steps_arg = steps_arg
 
         super().__init__()
-        tags_to_clone = [
-            "ignores-exogeneous-X",  # does estimator ignore the exogeneous X?
-            "capability:insample",
-            "capability:pred_int",  # can the estimator produce prediction intervals?
-            "capability:pred_int:insample",
-            "requires-fh-in-fit",  # is forecasting horizon already required in fit?
-            "enforce_index_type",  # index type that needs to be enforced in X/y
-            "fit_is_empty",
-        ]
 
-        self.clone_tags(self.estimator, tags_to_clone)
+        self._set_delegated_tags(estimator)
 
         self._set_permuted_estimator()
 

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -76,18 +76,9 @@ class BaseGridSearch(_DelegatedForecaster):
 
         super().__init__()
 
-        tags_to_clone = [
-            "requires-fh-in-fit",
-            "capability:pred_int",
-            "capability:pred_int:insample",
-            "capability:insample",
-            "ignores-exogeneous-X",
-            "handles-missing-data",
-            "y_inner_mtype",
-            "X_inner_mtype",
-            "X-y-must-have-same-index",
-            "enforce_index_type",
-        ]
+        self._set_delegated_tags(forecaster)
+
+        tags_to_clone = ["y_inner_mtype", "X_inner_mtype"]
         self.clone_tags(forecaster, tags_to_clone)
         self._extend_to_all_scitypes("y_inner_mtype")
         self._extend_to_all_scitypes("X_inner_mtype")

--- a/sktime/forecasting/stream/_update.py
+++ b/sktime/forecasting/stream/_update.py
@@ -9,13 +9,6 @@ from sktime.datatypes import ALL_TIME_SERIES_MTYPES
 from sktime.datatypes._utilities import get_window
 from sktime.forecasting.base._delegate import _DelegatedForecaster
 
-# prepare tags to clone - exceptions are TAGS_TO_KEEP
-TAGS_TO_KEEP = ["fit_is_empty", "X_inner_mtype", "y_inner_mtype"]
-# fit must be executed to fit the wrapped estimator and remember the cutoff
-# mtype tags are set so X/y is passed through, conversions happen in wrapped estimator
-TAGS_TO_CLONE = _DelegatedForecaster().get_tags().keys()
-TAGS_TO_CLONE = list(set(TAGS_TO_CLONE).difference(TAGS_TO_KEEP))
-
 
 class UpdateRefitsEvery(_DelegatedForecaster):
     """Refits periodically when update is called.
@@ -69,7 +62,8 @@ class UpdateRefitsEvery(_DelegatedForecaster):
 
         super().__init__()
 
-        self.clone_tags(forecaster, TAGS_TO_CLONE)
+        self._set_delegated_tags(self.forecaster_)
+        self.set_tags(**{"fit_is_empty": False})
 
     def _fit(self, y, X, fh):
         """Fit forecaster to training data.
@@ -251,7 +245,8 @@ class UpdateEvery(_DelegatedForecaster):
 
         super().__init__()
 
-        self.clone_tags(forecaster, TAGS_TO_KEEP)
+        self._set_delegated_tags(self.forecaster_)
+        self.set_tags(**{"fit_is_empty": False})
 
     def _fit(self, y, X, fh):
         """Fit forecaster to training data.
@@ -415,7 +410,8 @@ class DontUpdate(_DelegatedForecaster):
 
         super().__init__()
 
-        self.clone_tags(forecaster, TAGS_TO_CLONE)
+        self._set_delegated_tags(self.forecaster_)
+        self.set_tags(**{"fit_is_empty": False})
 
     def _update(self, y, X=None, update_params=True):
         """Update time series to incremental training data.

--- a/sktime/param_est/plugin/_forecaster.py
+++ b/sktime/param_est/plugin/_forecaster.py
@@ -131,9 +131,10 @@ class PluginParamsForecaster(_DelegatedForecaster):
 
         self._set_delegated_tags(self.forecaster_)
 
-        self.set_tags(**{"fit_is_empty": False})
+        self.set_tags(**{"fit_is_empty": False, "scitype:y": "univariate"})
         # todo: only works for single series now
         #   think about how to deal with vectorization later
+        self.set_tags(**{"X_inner_mtype": ["pd.DataFrame", "pd.Series", "np.ndarray"]})
         self.set_tags(**{"y_inner_mtype": ["pd.DataFrame", "pd.Series", "np.ndarray"]})
 
     def _fit(self, y, X, fh):

--- a/sktime/param_est/plugin/_forecaster.py
+++ b/sktime/param_est/plugin/_forecaster.py
@@ -131,7 +131,7 @@ class PluginParamsForecaster(_DelegatedForecaster):
 
         self._set_delegated_tags(self.forecaster_)
 
-        if not param_est.get_tags("capability:multivariate"):
+        if not param_est.get_tags()["capability:multivariate"]:
             self.set_tags(**{"scitype:y": "univariate"})
 
         self.set_tags(**{"fit_is_empty": False})

--- a/sktime/param_est/plugin/_forecaster.py
+++ b/sktime/param_est/plugin/_forecaster.py
@@ -131,8 +131,11 @@ class PluginParamsForecaster(_DelegatedForecaster):
 
         self._set_delegated_tags(self.forecaster_)
 
-        if not param_est.get_tags()["capability:multivariate"]:
-            self.set_tags(**{"scitype:y": "univariate"})
+        # parameter estimators that are univariate do not broadcast,
+        # so broadcasting needs to be done by the composite (i.e., self)
+        if param_est.get_tags()["object_type"] == "param_est":
+            if not param_est.get_tags()["capability:multivariate"]:
+                self.set_tags(**{"scitype:y": "univariate"})
 
         self.set_tags(**{"fit_is_empty": False})
         # todo: only works for single series now

--- a/sktime/param_est/plugin/_forecaster.py
+++ b/sktime/param_est/plugin/_forecaster.py
@@ -131,7 +131,7 @@ class PluginParamsForecaster(_DelegatedForecaster):
 
         self._set_delegated_tags(self.forecaster_)
 
-        self.set_tags(**{"fit_is_empty": False, "scitype:y": "univariate"})
+        self.set_tags(**{"fit_is_empty": False})
         # todo: only works for single series now
         #   think about how to deal with vectorization later
         self.set_tags(**{"X_inner_mtype": ["pd.DataFrame", "pd.Series", "np.ndarray"]})

--- a/sktime/param_est/plugin/_forecaster.py
+++ b/sktime/param_est/plugin/_forecaster.py
@@ -131,6 +131,9 @@ class PluginParamsForecaster(_DelegatedForecaster):
 
         self._set_delegated_tags(self.forecaster_)
 
+        if not param_est.get_tags("capability:multivariate"):
+            self.set_tags(**{"scitype:y": "univariate"})
+
         self.set_tags(**{"fit_is_empty": False})
         # todo: only works for single series now
         #   think about how to deal with vectorization later

--- a/sktime/param_est/plugin/_forecaster.py
+++ b/sktime/param_est/plugin/_forecaster.py
@@ -128,7 +128,9 @@ class PluginParamsForecaster(_DelegatedForecaster):
         self.update_params = update_params
 
         super().__init__()
-        self.clone_tags(self.forecaster_)
+
+        self._set_delegated_tags(self.forecaster_)
+
         self.set_tags(**{"fit_is_empty": False})
         # todo: only works for single series now
         #   think about how to deal with vectorization later


### PR DESCRIPTION
This PR:

* cetralizes logic for safe cloning of delegator tags in `_DelegatedForecaster`, previously in a array of individual descendants
* excepts packaging tags such as `"authors"` and `"python_depedencies"` from cloning (this type of tag did not exist in its current form when most descendant logic was implemented originally)

The refactor ensures that the logic has to be updated only in one location.

From a design perspective, one might consider localizing `set_delegated_tags` in `_DelegatedForecaster.__init__` and call `super().__init__` after, however that has the danger of not being downwards compatible, since `_DelegatedForecaster` currently has no `__init__`.

Related discussion https://github.com/sktime/sktime/pull/5843 as brought up by @tpvasconcelos in the context of `IgnoreX` which was not properly cloning the wrapped estimator's tags.