### PR TITLE
[ENH] `FallbackForecaster` predict_interval

### DIFF
--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -33,7 +33,7 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
         These are "blueprint" transformers resp forecasters,
         forecaster states do not change when `fit` is called
 
-    verbose : bool, default=False
+    warn : bool, default=False
         If True, raises warnings when a forecaster fails to fit or predict.
 
     Attributes

--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -84,9 +84,7 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
         "y_inner_mtype": ALL_TIME_SERIES_MTYPES,
         "X_inner_mtype": ALL_TIME_SERIES_MTYPES,
         "fit_is_empty": False,
-        "capability:pred_int": True,
     }
-    _delegate_name = "estimator_"
     # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
@@ -103,7 +101,6 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
 
         self.forecasters = forecasters
         self.current_forecaster_ = None
-        self.estimator_ = None
         self.current_name_ = None
         self.verbose = verbose
 
@@ -170,7 +167,6 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
             try:
                 self.current_name_ = name
                 self.current_forecaster_ = forecaster.clone()
-                self.estimator_ = self.current_forecaster_
                 self.current_forecaster_.fit(y=y, X=X, fh=fh)
                 return self
             except Exception as e:

--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -113,38 +113,7 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
         self.forecasters_ = self._check_estimators(forecasters, "forecasters")
 
         self._anytagis_then_set("requires-fh-in-fit", True, False, self._forecasters)
-        self._do_all_estimators_have_pred_int(self.forecasters_)
-
-    def _do_all_estimators_have_pred_int(self, estimators):
-        pred_int_capability = True
-        nonvalid_estimators = []
-        for ix, (name, forecaster) in enumerate(estimators):
-            if not forecaster.get_tag("capability:pred_int"):
-                pred_int_capability = False
-                nonvalid_estimators.append(
-                    {
-                        "index": ix,
-                        "name": name,
-                        "estimator": forecaster.__class__.__name__,
-                    }
-                )
-        self._fallback_predict_int = {
-            "capability:pred_int": pred_int_capability,
-            "if.false": nonvalid_estimators,
-        }
-
-    def _predict_interval(self, fh, X, coverage):
-        pred_int_capability = self._fallback_predict_int["capability:pred_int"]
-        if pred_int_capability:
-            return self.current_forecaster_.predict_interval(fh, X, coverage)
-        else:
-            nonvalid_estimators = self._fallback_predict_int["if.false"]
-            raise AttributeError(
-                "All forecasters must have prediction capbility "
-                "enabled to call `predict_interval`, but at least one"
-                "forecaster is missing this capability, see: "
-                f"{nonvalid_estimators}"
-            )
+        self._anytagis_then_set("capability:pred_int", False, True, self._forecasters)
 
     def _get_delegate(self):
         return self.current_forecaster_

--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -13,11 +13,11 @@ __all__ = ["FallbackForecaster"]
 
 from sktime.base import _HeterogenousMetaEstimator
 from sktime.datatypes import ALL_TIME_SERIES_MTYPES
-from sktime.forecasting.base import BaseForecaster
+from sktime.forecasting.base._delegate import _DelegatedForecaster
 from sktime.utils.warnings import warn
 
 
-class FallbackForecaster(_HeterogenousMetaEstimator, BaseForecaster):
+class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     """Forecaster that sequentially tries a list of forecasting models.
 
     Attempts to fit the provided forecasters in the order they are given. If a
@@ -84,8 +84,9 @@ class FallbackForecaster(_HeterogenousMetaEstimator, BaseForecaster):
         "y_inner_mtype": ALL_TIME_SERIES_MTYPES,
         "X_inner_mtype": ALL_TIME_SERIES_MTYPES,
         "fit_is_empty": False,
+        "capability:pred_int": True,
     }
-
+    _delegate_name = "estimator_"
     # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
@@ -102,6 +103,7 @@ class FallbackForecaster(_HeterogenousMetaEstimator, BaseForecaster):
 
         self.forecasters = forecasters
         self.current_forecaster_ = None
+        self.estimator_ = None
         self.current_name_ = None
         self.verbose = verbose
 
@@ -111,6 +113,29 @@ class FallbackForecaster(_HeterogenousMetaEstimator, BaseForecaster):
         self.forecasters_ = self._check_estimators(forecasters, "forecasters")
 
         self._anytagis_then_set("requires-fh-in-fit", True, False, self._forecasters)
+
+    def _predict_interval(self, fh, X, coverage):
+        pred_int_capability = True
+        nonvalid_estimators = []
+        for ix, (name, forecaster) in enumerate(self.forecasters):
+            if not forecaster.get_tag("capability:pred_int"):
+                pred_int_capability = False
+                nonvalid_estimators.append(
+                    {
+                        "index": ix,
+                        "name": name,
+                        "estimator": forecaster.__class__.__name__,
+                    }
+                )
+        if pred_int_capability:
+            return self.current_forecaster_.predict_interval(fh, X, coverage)
+        else:
+            raise AttributeError(
+                "All forecasters must have prediction capbility "
+                "enabled to call `predict_interval`, but at least one"
+                "forecaster is missing this capability, see: "
+                f"{nonvalid_estimators}"
+            )
 
     def _fit(self, y, X=None, fh=None):
         """Fit the forecasters in the given order until one succeeds.
@@ -164,6 +189,7 @@ class FallbackForecaster(_HeterogenousMetaEstimator, BaseForecaster):
             try:
                 self.current_name_ = name
                 self.current_forecaster_ = forecaster.clone()
+                self.estimator_ = self.current_forecaster_
                 self.current_forecaster_.fit(y=y, X=X, fh=fh)
                 return self
             except Exception as e:
@@ -209,7 +235,7 @@ class FallbackForecaster(_HeterogenousMetaEstimator, BaseForecaster):
             return self.current_forecaster_.predict(fh, X)
         except Exception as e:
             self.exceptions_raised_[self.first_nonfailing_forecaster_index_] = {
-                "failed_at_step": "predict",
+                "failed_at_step": "fit",
                 "exception": e,
                 "forecaster_name": self.current_name_,
             }

--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -33,7 +33,7 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
         These are "blueprint" transformers resp forecasters,
         forecaster states do not change when `fit` is called
 
-    warn : bool, default=False
+    verbose : bool, default=False
         If True, raises warnings when a forecaster fails to fit or predict.
 
     Attributes

--- a/sktime/forecasting/compose/tests/test_fallback.py
+++ b/sktime/forecasting/compose/tests/test_fallback.py
@@ -497,7 +497,9 @@ def test_fallbackforecaster_fails_many_simple():
 
 
 def test_fallbackforecaster_pred_int():
-    """First two FallbackForecasters fail, third succeeds"""
+    """Predict interval works bc all forecasters have them enabled, first forecaster
+    expected
+    """
     y = make_forecasting_problem(random_state=42)
     forecaster1 = NaiveForecaster("mean")
     forecaster2 = NaiveForecaster("last")
@@ -514,7 +516,7 @@ def test_fallbackforecaster_pred_int():
 
 
 def test_fallbackforecaster_pred_int_raises():
-    """First two FallbackForecasters fail, third succeeds"""
+    """Predict int raises because EnsembleForecaster does not have this capability"""
     y = make_forecasting_problem(random_state=42)
     forecaster1 = NaiveForecaster("mean")
     forecaster2 = EnsembleForecaster(

--- a/sktime/forecasting/compose/tests/test_fallback.py
+++ b/sktime/forecasting/compose/tests/test_fallback.py
@@ -525,10 +525,5 @@ def test_fallbackforecaster_pred_int_raises():
     )
     fh = [1, 2, 3]
     forecaster.fit(y, fh=fh)
-    with pytest.raises(AttributeError) as e:
+    with pytest.raises(NotImplementedError):
         forecaster.predict_interval()
-    msg_actual = e.value.args[0]
-    msg_expected = (
-        "[{'index': 1, 'name': 'ensemble', 'estimator': 'EnsembleForecaster'}]"
-    )
-    assert msg_expected in msg_actual


### PR DESCRIPTION
Addresses: https://github.com/sktime/sktime/issues/5835

<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Gives `FallbackForecaster` the option of using `forecaster.predict_interval()` when all forecasters have this capability. Raises and exception if at least one forecaster does not have `predict_interval` enabled.
#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?
Yes
<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
