### PR TITLE
[MNT] bound `moto<5.0.0` in `mlflow` tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,7 +270,7 @@ mlflow_tests = [
   "boto3",
   "botocore",
   "mlflow",
-  "moto",
+  "moto<5.0.0",
 ]
 pandas1 = [
   "pandas<2.0.0",


### PR DESCRIPTION
This PR bounds `moto<5.0.0` in `mlflow` tests to circumvent https://github.com/sktime/sktime/issues/5855