### PR TITLE
[ENH] interface to `ARIMA` from `statsmodels` library

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -232,6 +232,14 @@ All "ARIMA" and "Auto-ARIMA" models below include SARIMAX capability.
 
     ARIMA
 
+.. currentmodule:: sktime.forecasting.statsmodels_arima
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    StatsModelsARIMA
+
 .. currentmodule:: sktime.forecasting.sarimax
 
 .. autosummary::

--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -231,13 +231,6 @@ All "ARIMA" and "Auto-ARIMA" models below include SARIMAX capability.
     :template: class.rst
 
     ARIMA
-
-.. currentmodule:: sktime.forecasting.statsmodels_arima
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
     StatsModelsARIMA
 
 .. currentmodule:: sktime.forecasting.sarimax

--- a/sktime/forecasting/arima/__init__.py
+++ b/sktime/forecasting/arima/__init__.py
@@ -3,11 +3,8 @@
 __all__ = [
     "AutoARIMA",
     "ARIMA",
-    "StatsModelsARIMA"
+    "StatsModelsARIMA",
 ]
 
-from sktime.forecasting.arima._pmdarima import (
-    ARIMA,
-    AutoARIMA,
-)
+from sktime.forecasting.arima._pmdarima import ARIMA, AutoARIMA
 from sktime.forecasting.arima._statsmodels import StatsModelsARIMA

--- a/sktime/forecasting/arima/__init__.py
+++ b/sktime/forecasting/arima/__init__.py
@@ -1,0 +1,13 @@
+"""Time series forecasting with ARIMA models."""
+
+__all__ = [
+    "AutoARIMA",
+    "ARIMA",
+    "StatsModelsARIMA"
+]
+
+from sktime.forecasting.arima._pmdarima import (
+    ARIMA,
+    AutoARIMA,
+)
+from sktime.forecasting.arima._statsmodels import StatsModelsARIMA

--- a/sktime/forecasting/arima/_pmdarima.py
+++ b/sktime/forecasting/arima/_pmdarima.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3 -u
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Implements autoregressive integrated moving average (ARIMA) models."""
+"""Interface to ARIMA and AutoARIMA models from pmdarima package."""
 
 __author__ = ["mloning", "hyang1996", "fkiraly", "ilkersigirci"]
 __all__ = ["AutoARIMA", "ARIMA"]

--- a/sktime/forecasting/arima/_pmdarima.py
+++ b/sktime/forecasting/arima/_pmdarima.py
@@ -9,7 +9,7 @@ from sktime.forecasting.base.adapters._pmdarima import _PmdArimaAdapter
 
 
 class AutoARIMA(_PmdArimaAdapter):
-    """Wrapper of the pmdarima implementation of fitting Auto-(S)ARIMA(X) models.
+    """Auto-(S)ARIMA(X) forecaster, from pmdarima package.
 
     Includes automated fitting of (S)ARIMA(X) hyper-parameters (p, d, q, P, D, Q).
 
@@ -487,7 +487,7 @@ class AutoARIMA(_PmdArimaAdapter):
 
 
 class ARIMA(_PmdArimaAdapter):
-    """Wrapper of the pmdarima implementation of fitting (S)ARIMA(X) models.
+    """(S)ARIMA(X) forecaster, from pmdarima package.
 
     Exposes `pmdarima.arima.ARIMA` [1]_ under the `sktime` interface.
     Seasonal ARIMA models and exogeneous input is supported, hence this estimator is

--- a/sktime/forecasting/arima/_pmdarima.py
+++ b/sktime/forecasting/arima/_pmdarima.py
@@ -248,6 +248,7 @@ class AutoARIMA(_PmdArimaAdapter):
     See Also
     --------
     ARIMA
+    StatsForecastAutoARIMA
 
     References
     ----------

--- a/sktime/forecasting/arima/_statsmodels.py
+++ b/sktime/forecasting/arima/_statsmodels.py
@@ -14,7 +14,7 @@ from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
 
 class StatsModelsARIMA(_StatsModelsAdapter):
-    """ARIMA forecaster.
+    """ARIMA forecaster, from statsmodels package.
 
     Direct interface for `statsmodels.tsa.arima.model.ARIMA`.
 

--- a/sktime/forecasting/arima/_statsmodels.py
+++ b/sktime/forecasting/arima/_statsmodels.py
@@ -1,6 +1,6 @@
 # !/usr/bin/env python3 -u
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Implements ARIMA."""
+"""Interface to ARIMA from statsmodels package."""
 
 __all__ = ["StatsModelsARIMA"]
 __author__ = ["arnaujc91"]

--- a/sktime/forecasting/arima/_statsmodels.py
+++ b/sktime/forecasting/arima/_statsmodels.py
@@ -137,13 +137,14 @@ class StatsModelsARIMA(_StatsModelsAdapter):
     See Also
     --------
     ARIMA
+    SARIMAX
     AutoARIMA
     StatsForecastAutoARIMA
 
     Examples
     --------
     >>> from sktime.datasets import load_airline
-    >>> from sktime.forecasting.statsmodels_arima import StatsModelsARIMA
+    >>> from sktime.forecasting.arima import StatsModelsARIMA
     >>> y = load_airline()
     >>> forecaster = StatsModelsARIMA(order=(0, 0, 12))  # doctest: +SKIP
     >>> forecaster.fit(y)  # doctest: +SKIP

--- a/sktime/forecasting/statsmodels_arima.py
+++ b/sktime/forecasting/statsmodels_arima.py
@@ -1,0 +1,315 @@
+# !/usr/bin/env python3 -u
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Implements ARIMA."""
+
+__all__ = ["StatsModelsARIMA"]
+__author__ = ["arnaujc91"]
+
+from typing import Iterable, Optional, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+from sktime.forecasting.base.adapters import _StatsModelsAdapter
+
+
+class StatsModelsARIMA(_StatsModelsAdapter):
+    """ARIMA forecaster.
+
+    Direct interface for `statsmodels.tsa.arima.model.ARIMA`.
+
+    Parameters
+    ----------
+    order : tuple, optional The (p, d, q) order of the model for the autoregressive,
+    differences, and moving average components. `d` is always an integer, while `p`
+    and `q` may either be integers or lists of integers.
+
+    seasonal_order : tuple, optional The (P, D, Q, s) order of the seasonal component
+    of the model for the AR parameters, differences, MA parameters, and periodicity.
+    Default is (0, 0, 0, 0). `D` and `s` are always integers, while `P` and `Q` may
+    either be integers or lists of positive integers.
+
+    trend : str{'n', 'c', 't', 'ct'} or iterable, optional Parameter controlling the
+    deterministic trend. Can be specified as a string where 'c' indicates a constant
+    term, 't' indicates a linear trend in time, and 'ct' includes both. Can also be
+    specified as an iterable defining a polynomial, as in numpy.poly1d, where [1,1,0,
+    1] would denote ... Default is 'c' for models without integration, and no trend
+    for models with integration. Note that all trend terms are included in the model
+    as exogenous regressors, which differs from how trends are included in SARIMAX
+    models. See the Notes section for a precise definition of the treatment of trend
+    terms.
+
+    enforce_stationarity : bool, optional Whether to require the autoregressive
+    parameters to correspond to a stationarity process.
+
+    enforce_invertibility : bool, optional Whether to require the moving average
+    parameters to correspond to an invertible process.
+
+    concentrate_scale : bool, optional Whether to concentrate the scale (variance of
+    the error term) out of the likelihood. This reduces the number of parameters by
+    one. This is only applicable when considering estimation by numerical maximum
+    likelihood.
+
+    trend_offset : int, optional The offset at which to start time trend values.
+    Default is 1, so that if `trend='t'` the trend is equal to 1, 2, …,
+    nobs. Typically, is only set when the model created by extending a previous dataset.
+
+    dates : array_like of datetime, optional If no index is given by `endog` or
+    `exog`, an array-like object of datetime objects can be provided.
+
+    freq : str, optional If no index is given by `endog` or `exog`, the frequency of
+    the time-series may be specified here as a Pandas offset or offset string.
+
+    missing : str, optional Available options are 'none', 'drop', and 'raise'. If
+    'none', no nan checking is done. If 'drop', any observations with nans are
+    dropped. If 'raise', an error is raised. Default is 'none'.
+
+    validate_specification : bool, optional
+        Whether to validate the model specification. Default is True.
+
+    start_params : array_like, optional
+        Initial guess of the solution for the loglikelihood maximization.
+        If None, the default is given by Model.start_params.
+
+    transformed : bool, optional
+        Whether start_params is already transformed. Default is True.
+
+    includes_fixed : bool, optional If parameters were previously fixed with the
+    fix_params method, this argument describes whether start_params also includes the
+    fixed parameters, in addition to the free parameters. Default is False.
+
+    method : str, optional The method used for estimating the parameters of the
+    model. Valid options include 'statespace', 'innovations_mle', 'hannan_rissanen',
+    'burg', 'innovations', and 'yule_walker'. Not all options are available for every
+    specification (for example 'yule_walker' can only be used with AR(p) models).
+
+    method_kwargs : dict, optional Arguments to pass to the fit function for the
+    parameter estimator described by the method argument.
+
+    gls : bool, optional
+        Whether to use generalized least squares (GLS) to estimate regression effects.
+        The default is False if method='statespace' and is True otherwise.
+
+    gls_kwargs : dict, optional Arguments to pass to the GLS estimation fit method.
+    Only applicable if GLS estimation is used (see gls argument for details).
+
+    cov_type : str, optional The cov_type keyword governs the method for calculating
+    the covariance matrix of parameter estimates. Can be one of 'opg' for the outer
+    product of gradient estimator, 'oim' for the observed information matrix
+    estimator, calculated using the method of Harvey (1989), 'approx' for the
+    observed information matrix estimator, calculated using a numerical approximation
+    of the Hessian matrix, 'robust' for an approximate (quasi-maximum likelihood)
+    covariance matrix that may be valid even in the presence of some
+    misspecifications. Intermediate calculations use the 'oim' method.
+    'robust_approx' is the same as 'robust' except that the intermediate calculations
+    use the 'approx' method. 'none' for no covariance matrix calculation. Default is
+    'opg' unless memory conservation is used to avoid computing the loglikelihood
+    values for each observation, in which case the default is 'oim'.
+
+    cov_kwds : dict or None, optional
+        A dictionary of arguments affecting covariance matrix computation.
+
+    return_params : bool, optional
+        Whether to return only the array of maximizing parameters. Default is False.
+
+    low_memory : bool, optional If set to True, techniques are applied to
+    substantially reduce memory usage. If used, some features of the results object
+    will not be available (including smoothed results and in-sample prediction),
+    although out-of-sample forecasting is possible. Default is False.
+
+    See Also
+    --------
+    ARIMA
+    AutoARIMA
+    StatsForecastAutoARIMA
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.statsmodels_arima import StatsModelsARIMA
+    >>> y = load_airline()
+    >>> forecaster = StatsModelsARIMA(
+    ...     order=(0, 0, 12))  # doctest: +SKIP
+    ... )
+    >>> forecaster.fit(y)  # doctest: +SKIP
+    SARIMAX(...)
+    >>> y_pred = forecaster.predict(fh=y.index)  # doctest: +SKIP
+    """
+
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": ["arnaujc91"],
+        "maintainers": ["arnaujc91"],
+        "ignores-exogeneous-X": False,
+        "capability:pred_int": True,
+        "capability:pred_int:insample": True,
+    }
+
+    def __init__(
+        self,
+        order: Tuple[int, int, int] = (0, 0, 0),
+        seasonal_order: Tuple[int, int, int, int] = (0, 0, 0, 0),
+        trend: Optional[Union[str, Iterable]] = None,
+        enforce_stationarity: bool = True,
+        enforce_invertibility: bool = True,
+        concentrate_scale: bool = False,
+        trend_offset: int = 1,
+        dates: Optional[np.ndarray] = None,
+        freq: Optional[str] = None,
+        missing: Optional[str] = None,
+        validate_specification: bool = True,
+        start_params: Optional[np.ndarray] = None,
+        transformed: bool = True,
+        includes_fixed: bool = False,
+        method: Optional[str] = None,
+        method_kwargs: Optional[dict] = None,
+        gls: Optional[bool] = False,
+        gls_kwargs: Optional[dict] = None,
+        cov_type: Optional[str] = "opg",
+        cov_kwds: Optional[dict] = None,
+        return_params: Optional[bool] = False,
+        low_memory: Optional[bool] = False,
+    ):
+        self.order = order
+        self.seasonal_order = seasonal_order
+        self.trend = trend
+        self.enforce_stationarity = enforce_stationarity
+        self.enforce_invertibility = enforce_invertibility
+        self.concentrate_scale = concentrate_scale
+        self.trend_offset = trend_offset
+        self.dates = dates
+        self.freq = freq
+        self.missing = missing
+        self.validate_specification = validate_specification
+
+        # Fit params
+        self.start_params = start_params
+        self.transformed = transformed
+        self.includes_fixed = includes_fixed
+        self.method = method
+        self.method_kwargs = method_kwargs
+        self.gls = gls
+        self.gls_kwargs = gls_kwargs
+        self.cov_type = cov_type
+        self.cov_kwds = cov_kwds
+        self.return_params = return_params
+        self.low_memory = low_memory
+
+        super().__init__()
+
+    def _fit_forecaster(self, y, X=None):
+        from statsmodels.tsa.arima.model import ARIMA as _ARIMA
+
+        self._forecaster = _ARIMA(
+            endog=y,
+            exog=X,
+            order=self.order,
+            seasonal_order=self.seasonal_order,
+            trend=self.trend,
+            enforce_stationarity=self.enforce_stationarity,
+            enforce_invertibility=self.enforce_invertibility,
+            concentrate_scale=self.concentrate_scale,
+            trend_offset=self.trend_offset,
+            dates=self.dates,
+            freq=self.freq,
+            missing=self.missing,
+            validate_specification=self.validate_specification,
+        )
+        self._fitted_forecaster = self._forecaster.fit(
+            start_params=self.start_params,
+            transformed=self.transformed,
+            includes_fixed=self.includes_fixed,
+            method=self.method,
+            method_kwargs=self.method_kwargs,
+            gls=self.gls,
+            gls_kwargs=self.gls_kwargs,
+            cov_type=self.cov_type,
+            cov_kwds=self.cov_kwds,
+            return_params=self.return_params,
+            low_memory=self.low_memory,
+        )
+
+    def summary(self):
+        """Get a summary of the fitted forecaster.
+
+        This is the same as the implementation in statsmodels:
+        https://www.statsmodels.org/dev/examples/notebooks/generated/statespace_structural_harvey_jaeger.html
+        """
+        return self._fitted_forecaster.summary()
+
+    @staticmethod
+    def _extract_conf_int(prediction_results, alpha) -> pd.DataFrame:
+        """Construct confidence interval at specified `alpha` for each timestep.
+
+        Parameters
+        ----------
+        prediction_results : PredictionResults
+            results class, as returned by ``self._fitted_forecaster.get_prediction``
+        alpha : float
+            one minus nominal coverage
+
+        Returns
+        -------
+        pd.DataFrame
+            confidence intervals at each timestep
+
+            The dataframe must have at least two columns ``lower`` and ``upper``, and
+            the row indices must be integers relative to ``self.cutoff``. Order of
+            columns do not matter, and row indices must be a superset of relative
+            integer horizon of ``fh``.
+        """
+        conf_int = prediction_results.conf_int(alpha=alpha)
+        conf_int.columns = ["lower", "upper"]
+
+        return conf_int
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for forecasters.
+
+        Returns
+        -------
+        params : list of dict, default = []
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        return [
+            {
+                "order": (0, 1, 2),
+                "trend": "t",
+                "enforce_stationarity": False,
+                "enforce_invertibility": False,
+                "concentrate_scale": True,
+                "method": "statespace",  # Example value, adjust as needed
+            },
+            {
+                "order": (
+                    1,
+                    1,
+                    2,
+                ),  # Adjust the order based on your requirements
+                "trend": "t",
+                "enforce_stationarity": False,
+                "enforce_invertibility": False,
+                "method": "statespace",  # Example value, adjust as needed
+            },
+            {
+                "order": (0, 0, 1),
+                "trend": "ct",
+                "seasonal_order": (1, 0, 1, 2),
+                "cov_type": "opg",
+                "gls": True,
+                "method": "statespace",  # Example value, adjust as needed
+            },
+            {"cov_type": "robust", "gls": True, "method": "burg"},
+        ]

--- a/sktime/forecasting/statsmodels_arima.py
+++ b/sktime/forecasting/statsmodels_arima.py
@@ -133,7 +133,7 @@ class StatsModelsARIMA(_StatsModelsAdapter):
     >>> y = load_airline()
     >>> forecaster = StatsModelsARIMA(order=(0, 0, 12))  # doctest: +SKIP
     >>> forecaster.fit(y)  # doctest: +SKIP
-    >>> y_pred = forecaster.predict(fh=y.index)  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
     """
 
     _tags = {

--- a/sktime/forecasting/statsmodels_arima.py
+++ b/sktime/forecasting/statsmodels_arima.py
@@ -301,18 +301,14 @@ class StatsModelsARIMA(_StatsModelsAdapter):
         return [
             {
                 "order": (0, 1, 2),
-                "trend": "t",
+                "trend": "n",
                 "enforce_stationarity": False,
                 "enforce_invertibility": False,
                 "concentrate_scale": True,
                 "method": "statespace",
             },
             {
-                "order": (
-                    1,
-                    1,
-                    2,
-                ),
+                "order": (1, 1, 2),
                 "trend": "t",
                 "enforce_stationarity": False,
                 "enforce_invertibility": False,

--- a/sktime/forecasting/statsmodels_arima.py
+++ b/sktime/forecasting/statsmodels_arima.py
@@ -144,6 +144,7 @@ class StatsModelsARIMA(_StatsModelsAdapter):
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
+        "python_dependencies": ["statsmodels"],
     }
 
     def __init__(

--- a/sktime/forecasting/statsmodels_arima.py
+++ b/sktime/forecasting/statsmodels_arima.py
@@ -20,105 +20,119 @@ class StatsModelsARIMA(_StatsModelsAdapter):
 
     Parameters
     ----------
-    order : tuple, optional The (p, d, q) order of the model for the autoregressive,
-        differences, and moving average components. `d` is always an integer, while `p`
-        and `q` may either be integers or lists of integers.
-
-    seasonal_order : tuple, optional The (P, D, Q, s) order of the seasonal component
-        of the model for the AR parameters, differences, MA parameters, and periodicity.
-        Default is (0, 0, 0, 0). `D` and `s` are always integers, while `P` and `Q` may
-        either be integers or lists of positive integers.
-
-    trend : str{'n', 'c', 't', 'ct'} or iterable, optional Parameter controlling the
-        deterministic trend. Can be specified as a string where 'c' indicates a constant
-        term, 't' indicates a linear trend in time, and 'ct' includes both. Can also be
-        specified as an iterable defining a polynomial, as in numpy.poly1d, where
-        [1,1,0,1] would denote :math:`a + bt + ct^3`. Default is 'c' for models without
-        integration, and no trend for models with integration. Note that all trend terms
-        are included in the model as exogenous regressors, which differs from how trends
-        are included in SARIMAX models. See the Notes section for a precise definition
-        of the treatment of trend terms.
-
-    enforce_stationarity : bool, optional Whether to require the autoregressive
-        parameters to correspond to a stationarity process.
-
-    enforce_invertibility : bool, optional Whether to require the moving average
-        parameters to correspond to an invertible process.
-
-    concentrate_scale : bool, optional Whether to concentrate the scale (variance of
-        the error term) out of the likelihood. This reduces the number of parameters by
-        one. This is only applicable when considering estimation by numerical maximum
-        likelihood.
-
-    trend_offset : int, optional The offset at which to start time trend values.
-        Default is 1, so that if `trend='t'` the trend is equal to 1, 2, …,
-        nobs. Typically, is only set when the model created by extending a previous
-         dataset.
-
-    dates : array_like of datetime, optional If no index is given by `endog` or
-        `exog`, an array-like object of datetime objects can be provided.
-
-    freq : str, optional If no index is given by `endog` or `exog`, the frequency of
-        the time-series may be specified here as a Pandas offset or offset string.
-
-    missing : str, optional Available options are 'none', 'drop', and 'raise'. If
-        'none', no nan checking is done. If 'drop', any observations with nans are
-        dropped. If 'raise', an error is raised. Default is 'none'.
-
-    validate_specification : bool, optional
-        Whether to validate the model specification. Default is True.
-
+    order : tuple, optional
+        The (p,d,q) order of the model for the autoregressive, differences, and
+        moving average components. d is always an integer, while p and q may
+        either be integers or lists of integers.
+    seasonal_order : tuple, optional
+        The (P,D,Q,s) order of the seasonal component of the model for the
+        AR parameters, differences, MA parameters, and periodicity. Default
+        is (0, 0, 0, 0). D and s are always integers, while P and Q
+        may either be integers or lists of positive integers.
+    trend : str{'n','c','t','ct'} or iterable, optional
+        Parameter controlling the deterministic trend. Can be specified as a
+        string where 'c' indicates a constant term, 't' indicates a
+        linear trend in time, and 'ct' includes both. Can also be specified as
+        an iterable defining a polynomial, as in `numpy.poly1d`, where
+        `[1,1,0,1]` would denote :math:`a + bt + ct^3`. Default is 'c' for
+        models without integration, and no trend for models with integration.
+        Note that all trend terms are included in the model as exogenous
+        regressors, which differs from how trends are included in ``SARIMAX``
+        models.  See the Notes section for a precise definition of the
+        treatment of trend terms.
+    enforce_stationarity : bool, optional
+        Whether or not to require the autoregressive parameters to correspond
+        to a stationarity process.
+    enforce_invertibility : bool, optional
+        Whether or not to require the moving average parameters to correspond
+        to an invertible process.
+    concentrate_scale : bool, optional
+        Whether or not to concentrate the scale (variance of the error term)
+        out of the likelihood. This reduces the number of parameters by one.
+        This is only applicable when considering estimation by numerical
+        maximum likelihood.
+    trend_offset : int, optional
+        The offset at which to start time trend values. Default is 1, so that
+        if `trend='t'` the trend is equal to 1, 2, ..., nobs. Typically is only
+        set when the model created by extending a previous dataset.
+    dates : array_like of datetime, optional
+        If no index is given by `endog` or `exog`, an array-like object of
+        datetime objects can be provided.
+    freq : str, optional
+        If no index is given by `endog` or `exog`, the frequency of the
+        time-series may be specified here as a Pandas offset or offset string.
+    missing : str
+        Available options are 'none', 'drop', and 'raise'. If 'none', no nan
+        checking is done. If 'drop', any observations with nans are dropped.
+        If 'raise', an error is raised. Default is 'none'.
     start_params : array_like, optional
         Initial guess of the solution for the loglikelihood maximization.
         If None, the default is given by Model.start_params.
-
     transformed : bool, optional
-        Whether start_params is already transformed. Default is True.
-
-    includes_fixed : bool, optional If parameters were previously fixed with the
-        fix_params method, this argument describes whether start_params also includes
-        the fixed parameters, in addition to the free parameters. Default is False.
-
-    method : str, optional The method used for estimating the parameters of the
-        model. Valid options include 'statespace', 'innovations_mle', 'hannan_rissanen',
-        'burg', 'innovations', and 'yule_walker'. Not all options are available for
-        every specification (for example 'yule_walker' can only be used with
-        AR(p) models).
-
-    method_kwargs : dict, optional Arguments to pass to the fit function for the
-        parameter estimator described by the method argument.
-
+        Whether or not `start_params` is already transformed. Default is
+        True.
+    includes_fixed : bool, optional
+        If parameters were previously fixed with the `fix_params` method,
+        this argument describes whether or not `start_params` also includes
+        the fixed parameters, in addition to the free parameters. Default
+        is False.
+    method : str, optional
+        The method used for estimating the parameters of the model. Valid
+        options include 'statespace', 'innovations_mle', 'hannan_rissanen',
+        'burg', 'innovations', and 'yule_walker'. Not all options are
+        available for every specification (for example 'yule_walker' can
+        only be used with AR(p) models).
+    method_kwargs : dict, optional
+        Arguments to pass to the fit function for the parameter estimator
+        described by the `method` argument.
     gls : bool, optional
-        Whether to use generalized least squares (GLS) to estimate regression effects.
-        The default is False if method='statespace' and is True otherwise.
+        Whether or not to use generalized least squares (GLS) to estimate
+        regression effects. The default is False if `method='statespace'`
+        and is True otherwise.
+    gls_kwargs : dict, optional
+        Arguments to pass to the GLS estimation fit method. Only applicable
+        if GLS estimation is used (see `gls` argument for details).
+    cov_type : str, optional
+        The `cov_type` keyword governs the method for calculating the
+        covariance matrix of parameter estimates. Can be one of:
 
-    gls_kwargs : dict, optional Arguments to pass to the GLS estimation fit method.
-        Only applicable if GLS estimation is used (see gls argument for details).
+        - 'opg' for the outer product of gradient estimator
+        - 'oim' for the observed information matrix estimator, calculated
+          using the method of Harvey (1989)
+        - 'approx' for the observed information matrix estimator,
+          calculated using a numerical approximation of the Hessian matrix.
+        - 'robust' for an approximate (quasi-maximum likelihood) covariance
+          matrix that may be valid even in the presence of some
+          misspecifications. Intermediate calculations use the 'oim'
+          method.
+        - 'robust_approx' is the same as 'robust' except that the
+          intermediate calculations use the 'approx' method.
+        - 'none' for no covariance matrix calculation.
 
-    cov_type : str, optional The cov_type keyword governs the method for calculating
-        the covariance matrix of parameter estimates. Can be one of 'opg' for the outer
-        product of gradient estimator, 'oim' for the observed information matrix
-        estimator, calculated using the method of Harvey (1989), 'approx' for the
-        observed information matrix estimator, calculated using a numerical
-        approximation of the Hessian matrix, 'robust' for an approximate
-        (quasi-maximum likelihood) covariance matrix that may be valid even in the
-         presence of some misspecifications. Intermediate calculations use the 'oim'
-         method. 'robust_approx' is the same as 'robust' except that the intermediate
-         calculations use the 'approx' method. 'none' for no covariance matrix
-         calculation. Default is 'opg' unless memory conservation is used to avoid
-         computing the loglikelihood values for each observation,
-         in which case the default is 'oim'.
-
+        Default is 'opg' unless memory conservation is used to avoid
+        computing the loglikelihood values for each observation, in which
+        case the default is 'oim'.
     cov_kwds : dict or None, optional
         A dictionary of arguments affecting covariance matrix computation.
 
-    return_params : bool, optional
-        Whether to return only the array of maximizing parameters. Default is False.
+        **opg, oim, approx, robust, robust_approx**
 
-    low_memory : bool, optional If set to True, techniques are applied to
-        substantially reduce memory usage. If used, some features of the results object
-        will not be available (including smoothed results and in-sample prediction),
-        although out-of-sample forecasting is possible. Default is False.
+        - 'approx_complex_step' : bool, optional - If True, numerical
+          approximations are computed using complex-step methods. If False,
+          numerical approximations are computed using finite difference
+          methods. Default is True.
+        - 'approx_centered' : bool, optional - If True, numerical
+          approximations computed using finite difference methods use a
+          centered approximation. Default is False.
+    return_params : bool, optional
+        Whether or not to return only the array of maximizing parameters.
+        Default is False.
+    low_memory : bool, optional
+        If set to True, techniques are applied to substantially reduce
+        memory usage. If used, some features of the results object will
+        not be available (including smoothed results and in-sample
+        prediction), although out-of-sample forecasting is possible.
+        Default is False.
 
     See Also
     --------
@@ -165,12 +179,12 @@ class StatsModelsARIMA(_StatsModelsAdapter):
         includes_fixed: bool = False,
         method: Optional[str] = None,
         method_kwargs: Optional[dict] = None,
-        gls: Optional[bool] = False,
+        gls: bool = False,
         gls_kwargs: Optional[dict] = None,
-        cov_type: Optional[str] = "opg",
+        cov_type: str = "opg",
         cov_kwds: Optional[dict] = None,
-        return_params: Optional[bool] = False,
-        low_memory: Optional[bool] = False,
+        return_params: bool = False,
+        low_memory: bool = False,
     ):
         self.order = order
         self.seasonal_order = seasonal_order

--- a/sktime/forecasting/statsmodels_arima.py
+++ b/sktime/forecasting/statsmodels_arima.py
@@ -131,11 +131,8 @@ class StatsModelsARIMA(_StatsModelsAdapter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.statsmodels_arima import StatsModelsARIMA
     >>> y = load_airline()
-    >>> forecaster = StatsModelsARIMA(
-    ...     order=(0, 0, 12))  # doctest: +SKIP
-    ... )
+    >>> forecaster = StatsModelsARIMA(order=(0, 0, 12))  # doctest: +SKIP
     >>> forecaster.fit(y)  # doctest: +SKIP
-    SARIMAX(...)
     >>> y_pred = forecaster.predict(fh=y.index)  # doctest: +SKIP
     """
 

--- a/sktime/forecasting/statsmodels_arima.py
+++ b/sktime/forecasting/statsmodels_arima.py
@@ -21,48 +21,49 @@ class StatsModelsARIMA(_StatsModelsAdapter):
     Parameters
     ----------
     order : tuple, optional The (p, d, q) order of the model for the autoregressive,
-    differences, and moving average components. `d` is always an integer, while `p`
-    and `q` may either be integers or lists of integers.
+        differences, and moving average components. `d` is always an integer, while `p`
+        and `q` may either be integers or lists of integers.
 
     seasonal_order : tuple, optional The (P, D, Q, s) order of the seasonal component
-    of the model for the AR parameters, differences, MA parameters, and periodicity.
-    Default is (0, 0, 0, 0). `D` and `s` are always integers, while `P` and `Q` may
-    either be integers or lists of positive integers.
+        of the model for the AR parameters, differences, MA parameters, and periodicity.
+        Default is (0, 0, 0, 0). `D` and `s` are always integers, while `P` and `Q` may
+        either be integers or lists of positive integers.
 
     trend : str{'n', 'c', 't', 'ct'} or iterable, optional Parameter controlling the
-    deterministic trend. Can be specified as a string where 'c' indicates a constant
-    term, 't' indicates a linear trend in time, and 'ct' includes both. Can also be
-    specified as an iterable defining a polynomial, as in numpy.poly1d, where [1,1,0,
-    1] would denote ... Default is 'c' for models without integration, and no trend
-    for models with integration. Note that all trend terms are included in the model
-    as exogenous regressors, which differs from how trends are included in SARIMAX
-    models. See the Notes section for a precise definition of the treatment of trend
-    terms.
+        deterministic trend. Can be specified as a string where 'c' indicates a constant
+        term, 't' indicates a linear trend in time, and 'ct' includes both. Can also be
+        specified as an iterable defining a polynomial, as in numpy.poly1d, where
+        [1,1,0,1] would denote :math:`a + bt + ct^3`. Default is 'c' for models without
+        integration, and no trend for models with integration. Note that all trend terms
+        are included in the model as exogenous regressors, which differs from how trends
+        are included in SARIMAX models. See the Notes section for a precise definition
+        of the treatment of trend terms.
 
     enforce_stationarity : bool, optional Whether to require the autoregressive
-    parameters to correspond to a stationarity process.
+        parameters to correspond to a stationarity process.
 
     enforce_invertibility : bool, optional Whether to require the moving average
-    parameters to correspond to an invertible process.
+        parameters to correspond to an invertible process.
 
     concentrate_scale : bool, optional Whether to concentrate the scale (variance of
-    the error term) out of the likelihood. This reduces the number of parameters by
-    one. This is only applicable when considering estimation by numerical maximum
-    likelihood.
+        the error term) out of the likelihood. This reduces the number of parameters by
+        one. This is only applicable when considering estimation by numerical maximum
+        likelihood.
 
     trend_offset : int, optional The offset at which to start time trend values.
-    Default is 1, so that if `trend='t'` the trend is equal to 1, 2, …,
-    nobs. Typically, is only set when the model created by extending a previous dataset.
+        Default is 1, so that if `trend='t'` the trend is equal to 1, 2, …,
+        nobs. Typically, is only set when the model created by extending a previous
+         dataset.
 
     dates : array_like of datetime, optional If no index is given by `endog` or
-    `exog`, an array-like object of datetime objects can be provided.
+        `exog`, an array-like object of datetime objects can be provided.
 
     freq : str, optional If no index is given by `endog` or `exog`, the frequency of
-    the time-series may be specified here as a Pandas offset or offset string.
+        the time-series may be specified here as a Pandas offset or offset string.
 
     missing : str, optional Available options are 'none', 'drop', and 'raise'. If
-    'none', no nan checking is done. If 'drop', any observations with nans are
-    dropped. If 'raise', an error is raised. Default is 'none'.
+        'none', no nan checking is done. If 'drop', any observations with nans are
+        dropped. If 'raise', an error is raised. Default is 'none'.
 
     validate_specification : bool, optional
         Whether to validate the model specification. Default is True.
@@ -75,36 +76,38 @@ class StatsModelsARIMA(_StatsModelsAdapter):
         Whether start_params is already transformed. Default is True.
 
     includes_fixed : bool, optional If parameters were previously fixed with the
-    fix_params method, this argument describes whether start_params also includes the
-    fixed parameters, in addition to the free parameters. Default is False.
+        fix_params method, this argument describes whether start_params also includes
+        the fixed parameters, in addition to the free parameters. Default is False.
 
     method : str, optional The method used for estimating the parameters of the
-    model. Valid options include 'statespace', 'innovations_mle', 'hannan_rissanen',
-    'burg', 'innovations', and 'yule_walker'. Not all options are available for every
-    specification (for example 'yule_walker' can only be used with AR(p) models).
+        model. Valid options include 'statespace', 'innovations_mle', 'hannan_rissanen',
+        'burg', 'innovations', and 'yule_walker'. Not all options are available for
+        every specification (for example 'yule_walker' can only be used with
+        AR(p) models).
 
     method_kwargs : dict, optional Arguments to pass to the fit function for the
-    parameter estimator described by the method argument.
+        parameter estimator described by the method argument.
 
     gls : bool, optional
         Whether to use generalized least squares (GLS) to estimate regression effects.
         The default is False if method='statespace' and is True otherwise.
 
     gls_kwargs : dict, optional Arguments to pass to the GLS estimation fit method.
-    Only applicable if GLS estimation is used (see gls argument for details).
+        Only applicable if GLS estimation is used (see gls argument for details).
 
     cov_type : str, optional The cov_type keyword governs the method for calculating
-    the covariance matrix of parameter estimates. Can be one of 'opg' for the outer
-    product of gradient estimator, 'oim' for the observed information matrix
-    estimator, calculated using the method of Harvey (1989), 'approx' for the
-    observed information matrix estimator, calculated using a numerical approximation
-    of the Hessian matrix, 'robust' for an approximate (quasi-maximum likelihood)
-    covariance matrix that may be valid even in the presence of some
-    misspecifications. Intermediate calculations use the 'oim' method.
-    'robust_approx' is the same as 'robust' except that the intermediate calculations
-    use the 'approx' method. 'none' for no covariance matrix calculation. Default is
-    'opg' unless memory conservation is used to avoid computing the loglikelihood
-    values for each observation, in which case the default is 'oim'.
+        the covariance matrix of parameter estimates. Can be one of 'opg' for the outer
+        product of gradient estimator, 'oim' for the observed information matrix
+        estimator, calculated using the method of Harvey (1989), 'approx' for the
+        observed information matrix estimator, calculated using a numerical
+        approximation of the Hessian matrix, 'robust' for an approximate
+        (quasi-maximum likelihood) covariance matrix that may be valid even in the
+         presence of some misspecifications. Intermediate calculations use the 'oim'
+         method. 'robust_approx' is the same as 'robust' except that the intermediate
+         calculations use the 'approx' method. 'none' for no covariance matrix
+         calculation. Default is 'opg' unless memory conservation is used to avoid
+         computing the loglikelihood values for each observation,
+         in which case the default is 'oim'.
 
     cov_kwds : dict or None, optional
         A dictionary of arguments affecting covariance matrix computation.
@@ -113,9 +116,9 @@ class StatsModelsARIMA(_StatsModelsAdapter):
         Whether to return only the array of maximizing parameters. Default is False.
 
     low_memory : bool, optional If set to True, techniques are applied to
-    substantially reduce memory usage. If used, some features of the results object
-    will not be available (including smoothed results and in-sample prediction),
-    although out-of-sample forecasting is possible. Default is False.
+        substantially reduce memory usage. If used, some features of the results object
+        will not be available (including smoothed results and in-sample prediction),
+        although out-of-sample forecasting is possible. Default is False.
 
     See Also
     --------
@@ -290,18 +293,18 @@ class StatsModelsARIMA(_StatsModelsAdapter):
                 "enforce_stationarity": False,
                 "enforce_invertibility": False,
                 "concentrate_scale": True,
-                "method": "statespace",  # Example value, adjust as needed
+                "method": "statespace",
             },
             {
                 "order": (
                     1,
                     1,
                     2,
-                ),  # Adjust the order based on your requirements
+                ),
                 "trend": "t",
                 "enforce_stationarity": False,
                 "enforce_invertibility": False,
-                "method": "statespace",  # Example value, adjust as needed
+                "method": "statespace",
             },
             {
                 "order": (0, 0, 1),
@@ -309,7 +312,7 @@ class StatsModelsARIMA(_StatsModelsAdapter):
                 "seasonal_order": (1, 0, 1, 2),
                 "cov_type": "opg",
                 "gls": True,
-                "method": "statespace",  # Example value, adjust as needed
+                "method": "statespace",
             },
             {"cov_type": "robust", "gls": True, "method": "burg"},
         ]


### PR DESCRIPTION
#### Reference Issues/PRs

No issue created for this PR so far. We wanted to implement the `ARIMA` forecast from `statsmodels` library.



#### What does this implement/fix? Explain your changes.

Implement `ARIMA` forecast from `statsmodels` library



#### What should a reviewer concentrate their feedback on?


- [x] Check test params in `get_test_params`
- [x] Check methods implemented, is there anything missing or anything that would be useful to add?
- [x] Check tags
- [x] Check python docstrings and compare to original docu from statsmodels
- [x] Check documentation in the .rst files

#### Did you add any tests for the change?
 
No tests added besides the tests run for ALL forecasters.




##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [x] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

