### PR TITLE
[ENH] in transformer dunders, uniformize coercion of `sklearn` transformers

### DIFF
--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -8,8 +8,8 @@ from sktime.registry._base_classes import BASE_CLASS_REGISTER
 
 
 def scitype(
-        obj, force_single_scitype=True, coerce_to_list=False, raise_on_unknown=True
-    ):
+    obj, force_single_scitype=True, coerce_to_list=False, raise_on_unknown=True
+):
     """Determine scitype string of obj.
 
     Parameters

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -7,7 +7,9 @@ from inspect import isclass
 from sktime.registry._base_classes import BASE_CLASS_REGISTER
 
 
-def scitype(obj, force_single_scitype=True, coerce_to_list=False):
+def scitype(
+        obj, force_single_scitype=True, coerce_to_list=False, raise_on_unknown=True
+    ):
     """Determine scitype string of obj.
 
     Parameters
@@ -20,6 +22,9 @@ def scitype(obj, force_single_scitype=True, coerce_to_list=False):
     coerce_to_list : bool, optional, default = False
         determines the return type: if True, returns a single str,
         if False, returns a list of str
+    raise_on_unknown : bool, optional, default = True
+        if True, raises an error if no scitype can be determined for obj
+        if False, returns "object" scitype
 
     Returns
     -------
@@ -57,7 +62,10 @@ def scitype(obj, force_single_scitype=True, coerce_to_list=False):
         scitypes = [sci[0] for sci in BASE_CLASS_REGISTER if isinstance(obj, sci[1])]
 
     if len(scitypes) == 0:
-        raise TypeError("Error, no scitype could be determined for obj")
+        if raise_on_unknown:
+            raise TypeError("Error, no scitype could be determined for obj")
+        else:
+            scitypes = ["object"]
 
     if len(scitypes) > 1 and "object" in scitypes:
         scitypes = list(set(scitypes).difference(["object"]))

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -223,7 +223,8 @@ class BaseTransformer(BaseEstimator):
         """
         from sktime.registry import scitype
 
-        return is_sklearn_transformer(other) or scitype(other) == "transformer"
+        is_sktime_transformr = scitype(other, raise_on_unknown=False) == "transformer"
+        return is_sklearn_transformer(other) or is_sktime_transformr
 
     def __mul__(self, other):
         """Magic * method, return (right) concatenated TransformerPipeline.

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -223,9 +223,7 @@ class BaseTransformer(BaseEstimator):
         """
         from sktime.registry import scitype
 
-        is_sklearn_trafo = is_sklearn_transformer(other)
-        is_sktime_trafo = scitype(other) == "transformer"
-        return is_sklearn_trafo or is_sktime_trafo
+        return is_sklearn_transformer(other) or scitype(other) == "transformer"
 
     def __mul__(self, other):
         """Magic * method, return (right) concatenated TransformerPipeline.

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -208,6 +208,25 @@ class BaseTransformer(BaseEstimator):
         super().__init__()
         _check_estimator_deps(self)
 
+    def _is_transformer(self, other):
+        """Check whether other is a transformer - sklearn or sktime.
+
+        Returns True iff at least one of the following is True:
+
+        * ``is_sklearn_transformer(other)``
+        * ``scitype(other) == "transformer"``
+
+        Parameters
+        ----------
+        other : object
+            object to check
+        """
+        from sktime.registry import scitype
+
+        is_sklearn_transformer = is_sklearn_transformer(other)
+        is_sktime_transformer = scitype(other) == "transformer"
+        return is_sklearn_transformer or is_sktime_transformer
+
     def __mul__(self, other):
         """Magic * method, return (right) concatenated TransformerPipeline.
 
@@ -215,7 +234,7 @@ class BaseTransformer(BaseEstimator):
 
         Parameters
         ----------
-        other: `sktime` transformer, must inherit from BaseTransformer
+        other: ``sktime`` or ``sklearn`` compatible transformer
             otherwise, `NotImplemented` is returned
 
         Returns
@@ -228,11 +247,10 @@ class BaseTransformer(BaseEstimator):
         # we wrap self in a pipeline, and concatenate with the other
         #   the TransformerPipeline does the rest, e.g., case distinctions on other
         if (
-            isinstance(other, BaseTransformer)
+            self._is_transformer(other)
             or is_sklearn_classifier(other)
             or is_sklearn_clusterer(other)
             or is_sklearn_regressor(other)
-            or is_sklearn_transformer(other)
         ):
             self_as_pipeline = TransformerPipeline(steps=[self])
             return self_as_pipeline * other
@@ -246,7 +264,7 @@ class BaseTransformer(BaseEstimator):
 
         Parameters
         ----------
-        other: `sktime` transformer, must inherit from BaseTransformer
+        other: ``sktime`` or ``sklearn`` compatible transformer
             otherwise, `NotImplemented` is returned
 
         Returns
@@ -258,7 +276,7 @@ class BaseTransformer(BaseEstimator):
 
         # we wrap self in a pipeline, and concatenate with the other
         #   the TransformerPipeline does the rest, e.g., case distinctions on other
-        if isinstance(other, BaseTransformer) or is_sklearn_transformer(other):
+        if self._is_transformer(other):
             self_as_pipeline = TransformerPipeline(steps=[self])
             return other * self_as_pipeline
         else:
@@ -271,7 +289,8 @@ class BaseTransformer(BaseEstimator):
 
         Parameters
         ----------
-        other: `sktime` transformer or sktime MultiplexTransformer
+        other: ``sktime`` or ``sklearn`` compatible transformer
+            otherwise, `NotImplemented` is returned
 
         Returns
         -------
@@ -279,7 +298,7 @@ class BaseTransformer(BaseEstimator):
         """
         from sktime.transformations.compose import MultiplexTransformer
 
-        if isinstance(other, BaseTransformer):
+        if self._is_transformer(other):
             multiplex_self = MultiplexTransformer([self])
             return multiplex_self | other
         else:
@@ -292,7 +311,7 @@ class BaseTransformer(BaseEstimator):
 
         Parameters
         ----------
-        other: `sktime` transformer, must inherit from BaseTransformer
+        other: ``sktime`` or ``sklearn`` compatible transformer
             otherwise, `NotImplemented` is returned
 
         Returns
@@ -304,7 +323,7 @@ class BaseTransformer(BaseEstimator):
 
         # we wrap self in a pipeline, and concatenate with the other
         #   the FeatureUnion does the rest, e.g., case distinctions on other
-        if isinstance(other, BaseTransformer):
+        if self._is_transformer(other):
             self_as_pipeline = FeatureUnion(transformer_list=[self])
             return self_as_pipeline + other
         else:
@@ -317,7 +336,7 @@ class BaseTransformer(BaseEstimator):
 
         Parameters
         ----------
-        other: `sktime` transformer, must inherit from BaseTransformer
+        other: ``sktime`` or ``sklearn`` compatible transformer
             otherwise, `NotImplemented` is returned
 
         Returns
@@ -329,7 +348,7 @@ class BaseTransformer(BaseEstimator):
 
         # we wrap self in a pipeline, and concatenate with the other
         #   the TransformerPipeline does the rest, e.g., case distinctions on other
-        if isinstance(other, BaseTransformer):
+        if self._is_transformer(other):
             self_as_pipeline = FeatureUnion(transformer_list=[self])
             return other + self_as_pipeline
         else:

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -223,9 +223,9 @@ class BaseTransformer(BaseEstimator):
         """
         from sktime.registry import scitype
 
-        is_sklearn_transformer = is_sklearn_transformer(other)
-        is_sktime_transformer = scitype(other) == "transformer"
-        return is_sklearn_transformer or is_sktime_transformer
+        is_sklearn_trafo = is_sklearn_transformer(other)
+        is_sktime_trafo = scitype(other) == "transformer"
+        return is_sklearn_trafo or is_sktime_trafo
 
     def __mul__(self, other):
         """Magic * method, return (right) concatenated TransformerPipeline.

--- a/sktime/transformations/bootstrap/_mbb.py
+++ b/sktime/transformations/bootstrap/_mbb.py
@@ -165,7 +165,12 @@ class STLBootstrapTransformer(BaseTransformer):
     """
 
     _tags = {
+        # packaging info
+        # --------------
         "authors": "ltsaprounis",
+        "python_dependencies": "statsmodels",
+        # estimator type
+        # --------------
         # todo: what is the scitype of X: Series, or Panel
         "scitype:transform-input": "Series",
         # todo: what scitype is returned: Primitives, Series, Panel
@@ -184,7 +189,6 @@ class STLBootstrapTransformer(BaseTransformer):
         "enforce_index_type": None,  # index type that needs to be enforced in X/y
         "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
         "transform-returns-same-time-index": False,
-        "python_dependencies": "statsmodels",
     }
 
     def __init__(

--- a/sktime/transformations/compose/_featureunion.py
+++ b/sktime/transformations/compose/_featureunion.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from sktime.base._meta import _HeterogenousMetaEstimator
 from sktime.transformations.base import BaseTransformer
+from sktime.transformations.compose._common import _coerce_to_sktime
 from sktime.utils.multiindex import flatten_multiindex
 
 
@@ -133,6 +134,7 @@ class FeatureUnion(_HeterogenousMetaEstimator, BaseTransformer):
         TransformerPipeline object, concatenation of `self` (first) with `other` (last).
             not nested, contains only non-FeatureUnion `sktime` transformers
         """
+        other = _coerce_to_sktime(other)
         return self._dunder_concat(
             other=other,
             base_class=BaseTransformer,
@@ -156,6 +158,7 @@ class FeatureUnion(_HeterogenousMetaEstimator, BaseTransformer):
         TransformerPipeline object, concatenation of `self` (last) with `other` (first).
             not nested, contains only non-FeatureUnion `sktime` transformers
         """
+        other = _coerce_to_sktime(other)
         return self._dunder_concat(
             other=other,
             base_class=BaseTransformer,

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -84,6 +84,24 @@ def test_dunder_add():
 
     _assert_array_almost_equal(t123r.fit_transform(X), t123.fit_transform(X))
 
+def test_dunder_add_sklearn():
+    """Test the add dunder method, with sklearn coercion."""
+    X = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+
+    t1 = ExponentTransformer(power=2)
+    t2 = StandardScaler()
+    t3 = ExponentTransformer(power=3)
+
+    t123 = t1 + t2 + t3
+    t123r = t1 + (t2 + t3)
+    t123l = (t1 + t2) + t3
+
+    assert isinstance(t123, FeatureUnion)
+    assert isinstance(t123r, FeatureUnion)
+    assert isinstance(t123l, FeatureUnion)
+
+    _assert_array_almost_equal(t123.fit_transform(X), t123l.fit_transform(X))
+    _assert_array_almost_equal(t123r.fit_transform(X), t123l.fit_transform(X))
 
 def test_mul_sklearn_autoadapt():
     """Test auto-adapter for sklearn in mul."""

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -10,6 +10,7 @@ from sklearn.preprocessing import StandardScaler
 
 from sktime.datasets import load_airline
 from sktime.datatypes import get_examples
+from sktime.transformations.bootstrap import STLBootstrapTransformer
 from sktime.transformations.compose import (
     FeatureUnion,
     InvertTransform,
@@ -25,7 +26,7 @@ from sktime.transformations.series.summarize import SummaryTransformer
 from sktime.transformations.series.theta import ThetaLinesTransformer
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 from sktime.utils.deep_equals import deep_equals
-from sktime.utils.validation._dependencies import _check_soft_dependencies
+from sktime.utils.validation._dependencies import _check_estimator_deps
 
 
 def test_dunder_mul():
@@ -285,7 +286,7 @@ def test_dunder_neg():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("statsmodel", severity="none"),
+    not _check_estimator_deps(STLBootstrapTransformer, severity="none"),
     reason="skip test if required soft dependency for statsmodels not available",
 )
 def test_input_output_series_panel_chain():
@@ -294,7 +295,6 @@ def test_input_output_series_panel_chain():
     Failure case of #5624.
     """
     from sktime.datasets import load_airline
-    from sktime.transformations.bootstrap import STLBootstrapTransformer
     from sktime.transformations.series.impute import Imputer
 
     X = load_airline()

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -85,6 +85,7 @@ def test_dunder_add():
 
     _assert_array_almost_equal(t123r.fit_transform(X), t123.fit_transform(X))
 
+
 def test_dunder_add_sklearn():
     """Test the add dunder method, with sklearn coercion."""
     X = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
@@ -103,6 +104,7 @@ def test_dunder_add_sklearn():
 
     _assert_array_almost_equal(t123.fit_transform(X), t123l.fit_transform(X))
     _assert_array_almost_equal(t123r.fit_transform(X), t123l.fit_transform(X))
+
 
 def test_mul_sklearn_autoadapt():
     """Test auto-adapter for sklearn in mul."""

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -86,7 +86,7 @@ def test_dunder_add():
     _assert_array_almost_equal(t123r.fit_transform(X), t123.fit_transform(X))
 
 
-def test_dunder_add_sklearn():
+def test_add_sklearn_autoadapt():
     """Test the add dunder method, with sklearn coercion."""
     X = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
 
@@ -107,7 +107,7 @@ def test_dunder_add_sklearn():
 
 
 def test_mul_sklearn_autoadapt():
-    """Test auto-adapter for sklearn in mul."""
+    """Test the mul dunder method, with sklearn coercion."""
     X = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
 
     t1 = ExponentTransformer(power=2)


### PR DESCRIPTION
This PR uniformizes coercion of `sklearn` transformers in transformation dunders across the codebase, syntactically and architecturally.

* coercion to `sktime` was missing in the `+` (`FeatureUnion`) dunder, while present in all others
* checks were too restrictive in some cases where the downstream code would have been able to coerce, dunder checks were relaxed to let `sklearn` estimators pass.
* `sktime` type checks were using inheritance rather than tags, which may be problematic for polymorphic estimators. This has been addressed by using the `scitype` utility rather than inheritance check.

A test has been added for coercion in the `+` (`FeatureUnion`) dunder, the remainder should be covered by current tests.

Also contains a minor fix in the test file: the test `test_input_output_series_panel_chain` was by accident deactivated as the name of the required dependency was misspelled (`"statsmodel"`, not `"statsmodels"`). This has been replaced by a more robust class based dependency check.