### PR TITLE
[MNT] address some `pandas` deprecations

### DIFF
--- a/sktime/benchmarking/evaluation.py
+++ b/sktime/benchmarking/evaluation.py
@@ -452,15 +452,7 @@ class Evaluator:
             )
 
         # load all predictions
-        run_times = pd.DataFrame(
-            columns=[
-                "strategy_name",
-                "dataset_name",
-                "fit_estimator_start_time",
-                "fit_estimator_end_time",
-                "cv_fold",
-            ]
-        )
+        run_times_frames = []
         for cv_fold in cv_folds:
             for result in self.results.load_predictions(
                 cv_fold=cv_fold, train_or_test=train_or_test
@@ -483,7 +475,8 @@ class Evaluator:
                         "cv_fold": [cv_fold],
                     }
                 )
-                run_times = pd.concat([run_times, unwrapped], ignore_index=True)
+                run_times_frames.append(unwrapped)
+        run_times = pd.concat(run_times_frames, ignore_index=True)
 
         # calculate run time difference
         run_times["fit_runtime"] = (

--- a/sktime/transformations/panel/catch22wrapper.py
+++ b/sktime/transformations/panel/catch22wrapper.py
@@ -198,7 +198,7 @@ class Catch22Wrapper(BaseTransformer):
         f_count = -1
         for i in range(len(X)):
             dim = i * len(f_idx)
-            series = list(X[i])
+            series = list(X.iloc[i])
 
             if self.outlier_norm and (3 in f_idx or 4 in f_idx):
                 outlier_series = np.array(series)

--- a/sktime/transformations/panel/summarize/_extract.py
+++ b/sktime/transformations/panel/summarize/_extract.py
@@ -142,7 +142,10 @@ class DerivativeSlopeTransformer(BaseTransformer):
         def get_der(x):
             der = []
             for i in range(1, len(x) - 1):
-                der.append(((x[i] - x[i - 1]) + ((x[i + 1] - x[i - 1]) / 2)) / 2)
+                xi = x.iloc[i]
+                xim1 = x.iloc[i - 1]
+                xip1 = x.iloc[i + 1]
+                der.append(0.5 * ((xi - xim1) + 0.5 * (xip1 - xim1)))
             return pd.Series([der[0]] + der + [der[-1]])
 
         return [get_der(x) for x in X]

--- a/sktime/transformations/panel/tests/test_interpolate.py
+++ b/sktime/transformations/panel/tests/test_interpolate.py
@@ -46,5 +46,5 @@ def test_resizing():
 
     # 4) check that result time series have lengths equal to `target_len
     #       that we set above
-    ts_lens_after_resize = [len(Xt.iloc[0][i]) for i in range(len(Xt.iloc[0]))]
+    ts_lens_after_resize = [len(Xt.iloc[0].iloc[i]) for i in range(len(Xt.iloc[0]))]
     assert all([length == target_len for length in ts_lens_after_resize])


### PR DESCRIPTION
This PR addresses some warnings from `pandas` deprecations:

* change in behaviour of `__getitem__` with `int`, replaced by `iloc` - this fixes https://github.com/sktime/sktime/issues/5881 amongst others
* change in behaviour when `pd.concat` is called on empty `pd.DataFrame`