### PR TITLE
[MNT] Skip `mlflow` tests when soft-dependencies are absent

### DIFF
--- a/sktime/utils/tests/test_mlflow_sktime_model_export.py
+++ b/sktime/utils/tests/test_mlflow_sktime_model_export.py
@@ -15,6 +15,7 @@ from sktime.datasets import load_airline, load_arrow_head, load_longley
 from sktime.forecasting.arima import AutoARIMA
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.split import temporal_train_test_split
+from sktime.tests.test_switch import run_test_for_class
 from sktime.utils.multiindex import flatten_multiindex
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
@@ -90,6 +91,10 @@ def test_data_arrow_head():
     return y_train.astype(int), y_test.astype(int), X_train, X_test
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(AutoARIMA),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
+)
 @pytest.fixture(scope="module")
 def auto_arima_model(test_data_airline):
     """Create instance of fitted auto arima model."""
@@ -123,8 +128,11 @@ def naive_forecaster_model_with_regressor(test_data_longley):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 @pytest.mark.parametrize("serialization_format", ["pickle", "cloudpickle"])
 def test_auto_arima_model_save_and_load(
@@ -146,8 +154,11 @@ def test_auto_arima_model_save_and_load(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 @pytest.mark.parametrize("serialization_format", ["pickle", "cloudpickle"])
 def test_auto_arima_model_pyfunc_output(
@@ -198,8 +209,8 @@ def test_auto_arima_model_pyfunc_output(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not _check_soft_dependencies(["mlflow", "tensorflow"], severity="none"),
+    reason="skip mlflow tests on CNN if required soft dependency not available",
 )
 @pytest.mark.parametrize("serialization_format", ["pickle", "cloudpickle"])
 def test_cnn_model_save_and_load(
@@ -223,8 +234,11 @@ def test_cnn_model_save_and_load(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 def test_auto_arima_model_pyfunc_with_params_output(auto_arima_model, model_path):
     """Test auto arima prediction of loaded pyfunc model with parameters."""
@@ -277,8 +291,11 @@ def test_auto_arima_model_pyfunc_with_params_output(auto_arima_model, model_path
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 def test_auto_arima_model_pyfunc_without_params_output(auto_arima_model, model_path):
     """Test auto arima prediction of loaded pyfunc model without parameters."""
@@ -331,8 +348,11 @@ def test_auto_arima_model_pyfunc_without_params_output(auto_arima_model, model_p
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 def test_auto_arima_model_pyfunc_without_conf_output(auto_arima_model, model_path):
     """Test auto arima prediction of loaded pyfunc model without config."""
@@ -409,8 +429,11 @@ def test_naive_forecaster_model_with_regressor_pyfunc_output(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 @pytest.mark.parametrize("use_signature", [True, False])
 @pytest.mark.parametrize("use_example", [True, False])
@@ -444,8 +467,11 @@ def test_signature_and_examples_saved_correctly(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 @pytest.mark.parametrize("use_signature", [True, False])
 def test_predict_var_signature_saved_correctly(
@@ -467,8 +493,11 @@ def test_predict_var_signature_saved_correctly(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 @pytest.mark.parametrize("use_signature", [True, False])
 @pytest.mark.parametrize("use_example", [True, False])
@@ -515,8 +544,11 @@ def test_signature_and_example_for_pyfunc_predict(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 def test_load_from_remote_uri_succeeds(auto_arima_model, model_path, mock_s3_bucket):
     """Test loading native sktime model from mock S3 bucket."""
@@ -541,8 +573,11 @@ def test_load_from_remote_uri_succeeds(auto_arima_model, model_path, mock_s3_buc
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 @pytest.mark.parametrize("should_start_run", [True, False])
 @pytest.mark.parametrize("serialization_format", ["pickle", "cloudpickle"])
@@ -585,8 +620,11 @@ def test_log_model(auto_arima_model, tmp_path, should_start_run, serialization_f
 
 @pytest.mark.xfail(reason="known failure to be debugged, see #4904")
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 def test_log_model_calls_register_model(auto_arima_model, tmp_path):
     """Test log model calls register model."""
@@ -616,8 +654,11 @@ def test_log_model_calls_register_model(auto_arima_model, tmp_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 def test_log_model_no_registered_model_name(auto_arima_model, tmp_path):
     """Test log model calls register model without registered model name."""
@@ -640,8 +681,11 @@ def test_log_model_no_registered_model_name(auto_arima_model, tmp_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 def test_pyfunc_raises_invalid_attribute_type(auto_arima_model, model_path):
     """Test pyfunc raises exception with invalid attribute type."""
@@ -661,8 +705,11 @@ def test_pyfunc_raises_invalid_attribute_type(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 def test_pyfunc_raises_invalid_dict_key(auto_arima_model, model_path):
     """Test pyfunc raises exception with invalid dict key."""
@@ -682,8 +729,11 @@ def test_pyfunc_raises_invalid_dict_key(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 def test_pyfunc_raises_invalid_dict_value_type(auto_arima_model, model_path):
     """Test pyfunc raises exception with invalid dict value type."""
@@ -702,8 +752,11 @@ def test_pyfunc_raises_invalid_dict_value_type(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 def test_pyfunc_raises_invalid_dict_value(auto_arima_model, model_path):
     """Test pyfunc raises exception with invalid dict value."""
@@ -723,8 +776,11 @@ def test_pyfunc_raises_invalid_dict_value(auto_arima_model, model_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 def test_pyfunc_predict_proba_raises_invalid_attribute_type(
     auto_arima_model, model_path
@@ -747,8 +803,11 @@ def test_pyfunc_predict_proba_raises_invalid_attribute_type(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mlflow", severity="none"),
-    reason="skip test if required soft dependency not available",
+    not (
+        _check_soft_dependencies("mlflow", severity="none")
+        and run_test_for_class(AutoARIMA)
+    ),
+    reason="Skip AutoARIMA to test mlflow functionalities since soft deps are missing.",
 )
 def test_pyfunc_predict_proba_raises_invalid_dict_value(auto_arima_model, model_path):
     """Test pyfunc predict_proba raises exception with invalid dict value."""


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
Fixes #5859

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
`mlflow` tests were missing the skip markers despite using estimators like `AutoARIMA` and `CNNClassifier` that have soft dependencies. I've added `pytest.mark.skipif` decorators on top of each fixture/test that make use of either of these estimators.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->
None

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
I'm not particularly fond of cases where I find myself copy-pasting any amount of code. I can appreciate the modularity such unit tests provide but I was wondering if we could instead use classes (one for mlflow-only test, mlflow-arima tests and mlflow-tensorflow tests).

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
