### PR TITLE
[BUG] fixing broken link to `DropNA` in API reference

### DIFF
--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -479,8 +479,15 @@ Missing value treatment
     :toctree: auto_generated/
     :template: class.rst
 
-    DropNA
     Imputer
+
+.. currentmodule:: sktime.transformations.series.dropna
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    DropNA
 
 Seasonality and Date-Time Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes the dead link of DropNA in API reference (https://www.sktime.net/en/latest/api_reference/auto_generated/sktime.transformations.series.dropna.DropNA.html)