### PR TITLE
[BUG] `BaseForecaster` - move `check_fh` to inner loop if vectorized

### DIFF
--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -392,9 +392,10 @@ def update_data(X, X_new=None):
             return np.concatenate([X, X_new], axis=2)
     #  if y is pandas, we use combine_first to update
     elif isinstance(X_new, (pd.Series, pd.DataFrame)) and len(X_new) > 0:
-        # using .combine_first() can mess with df frequencies, e.g. change 24H to 1D,
-        # which can cause issues when converting fh.to_absolute() at the predict stage
-        # because to_absolute(self.cutoff) converts timestamps to period internally
+        # using .combine_first() can mess with pd.Series frequencies, e.g. change 24H
+        # to 1D, which can cause issues when converting fh.to_absolute() at the
+        # predict stage because to_absolute(self.cutoff) converts timestamps to
+        # period internally
         X_new = X_new.combine_first(X)
         if hasattr(X.index, "freq") and hasattr(X_new.index, "freq"):
             if X.index.freq == X_new.index.freq:

--- a/sktime/datatypes/_utilities.py
+++ b/sktime/datatypes/_utilities.py
@@ -392,7 +392,15 @@ def update_data(X, X_new=None):
             return np.concatenate([X, X_new], axis=2)
     #  if y is pandas, we use combine_first to update
     elif isinstance(X_new, (pd.Series, pd.DataFrame)) and len(X_new) > 0:
-        return X_new.combine_first(X)
+        # using .combine_first() can mess with df frequencies, e.g. change 24H to 1D,
+        # which can cause issues when converting fh.to_absolute() at the predict stage
+        # because to_absolute(self.cutoff) converts timestamps to period internally
+        X_new = X_new.combine_first(X)
+        if hasattr(X.index, "freq") and hasattr(X_new.index, "freq"):
+            if X.index.freq == X_new.index.freq:
+                if X.index.freqstr != X_new.index.freqstr:
+                    X_new.index.freq = X.index.freq
+        return X_new
 
 
 GET_WINDOW_SUPPORTED_MTYPES = [

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -587,14 +587,14 @@ class BaseForecaster(BaseEstimator):
 
         # input checks and conversions
 
+        # check fh and coerce to ForecastingHorizon, if not already passed in fit
+        fh = self._check_fh(fh)
+
         # default alpha
         if alpha is None:
             alpha = [0.05, 0.95]
         # check alpha and coerce to list
         alpha = check_alpha(alpha, name="alpha")
-
-        # check fh and coerce to ForecastingHorizon, if not already passed in fit
-        fh = self._check_fh(fh)
 
         # input check and conversion for X
         X_inner = self._check_X(X=X)
@@ -603,6 +603,7 @@ class BaseForecaster(BaseEstimator):
         if not self._is_vectorized:
             quantiles = self._predict_quantiles(fh=fh, X=X_inner, alpha=alpha)
         else:
+            # otherwise we call the vectorized version of predict_quantiles
             quantiles = self._vectorize(
                 "predict_quantiles",
                 fh=fh,
@@ -663,12 +664,12 @@ class BaseForecaster(BaseEstimator):
             )
         self.check_is_fitted()
 
+        # check fh and coerce to ForecastingHorizon, if not already passed in fit
+        fh = self._check_fh(fh)
+
         # input checks and conversions
         # check alpha and coerce to list
         coverage = check_alpha(coverage, name="coverage")
-
-        # check fh and coerce to ForecastingHorizon, if not already passed in fit
-        fh = self._check_fh(fh)
 
         # check and convert X
         X_inner = self._check_X(X=X)

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1685,6 +1685,11 @@ class BaseForecaster(BaseEstimator):
             fit, predict-like, update-like
 
         Reads and writes to self._fh.
+        Reads self._cutoff, self._is_fitted, self._is_vectorized.
+
+        Therefore, requires self._check_X_y(X=X, y=y) and
+        self._update_y_X(y_inner, X_inner) to have been run at least once.
+
         Writes fh to self._fh if does not exist.
         Checks equality of fh with self._fh if exists, raises error if not equal.
         Assigns the frequency inferred from self._y

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -664,10 +664,11 @@ class BaseForecaster(BaseEstimator):
             )
         self.check_is_fitted()
 
+        # input checks and conversions
+
         # check fh and coerce to ForecastingHorizon, if not already passed in fit
         fh = self._check_fh(fh)
 
-        # input checks and conversions
         # check alpha and coerce to list
         coverage = check_alpha(coverage, name="coverage")
 
@@ -744,6 +745,8 @@ class BaseForecaster(BaseEstimator):
             )
         self.check_is_fitted()
 
+        # input checks and conversions
+
         # check fh and coerce to ForecastingHorizon, if not already passed in fit
         fh = self._check_fh(fh)
 
@@ -806,6 +809,8 @@ class BaseForecaster(BaseEstimator):
                 "automated vectorization for predict_proba is not implemented"
             )
         self.check_is_fitted()
+
+        # input checks and conversions
 
         # check fh and coerce to ForecastingHorizon, if not already passed in fit
         fh = self._check_fh(fh)

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -32,7 +32,7 @@ State:
     fitted state inspection - check_is_fitted()
 """
 
-__author__ = ["mloning", "big-o", "fkiraly", "sveameyer13", "miraep8"]
+__author__ = ["mloning", "big-o", "fkiraly", "sveameyer13", "miraep8", "ciaran-g"]
 
 __all__ = ["BaseForecaster"]
 

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -424,6 +424,8 @@ class BaseForecaster(BaseEstimator):
 
         # input check and conversion for X
         X_inner = self._check_X(X=X)
+
+        # check fh and coerce to ForecastingHorizon, if not already passed in fit
         fh = self._check_fh(fh)
 
         # we call the ordinary _predict if no looping/vectorization needed
@@ -518,6 +520,8 @@ class BaseForecaster(BaseEstimator):
         # set internal X/y to the new X/y
         # this also updates cutoff from y
         self._update_y_X(y_inner, X_inner)
+
+        # check fh and coerce to ForecastingHorizon
         fh = self._check_fh(fh)
 
         # apply fit and then predict
@@ -589,9 +593,11 @@ class BaseForecaster(BaseEstimator):
         # check alpha and coerce to list
         alpha = check_alpha(alpha, name="alpha")
 
+        # check fh and coerce to ForecastingHorizon, if not already passed in fit
+        fh = self._check_fh(fh)
+
         # input check and conversion for X
         X_inner = self._check_X(X=X)
-        fh = self._check_fh(fh)
 
         # we call the ordinary _predict_quantiles if no looping/vectorization needed
         if not self._is_vectorized:
@@ -661,9 +667,11 @@ class BaseForecaster(BaseEstimator):
         # check alpha and coerce to list
         coverage = check_alpha(coverage, name="coverage")
 
+        # check fh and coerce to ForecastingHorizon, if not already passed in fit
+        fh = self._check_fh(fh)
+
         # check and convert X
         X_inner = self._check_X(X=X)
-        fh = self._check_fh(fh)
 
         # we call the ordinary _predict_interval if no looping/vectorization needed
         if not self._is_vectorized:
@@ -735,9 +743,11 @@ class BaseForecaster(BaseEstimator):
             )
         self.check_is_fitted()
 
+        # check fh and coerce to ForecastingHorizon, if not already passed in fit
+        fh = self._check_fh(fh)
+
         # check and convert X
         X_inner = self._check_X(X=X)
-        fh = self._check_fh(fh)
 
         # we call the ordinary _predict_interval if no looping/vectorization needed
         if not self._is_vectorized:
@@ -795,7 +805,8 @@ class BaseForecaster(BaseEstimator):
                 "automated vectorization for predict_proba is not implemented"
             )
         self.check_is_fitted()
-        # input checks
+
+        # check fh and coerce to ForecastingHorizon, if not already passed in fit
         fh = self._check_fh(fh)
 
         # check and convert X
@@ -1068,9 +1079,11 @@ class BaseForecaster(BaseEstimator):
 
         self.check_is_fitted()
 
+        # check fh and coerce to ForecastingHorizon, if not already passed in fit
+        fh = self._check_fh(fh)
+
         # input checks and minor coercions on X, y
         X_inner, y_inner = self._check_X_y(X=X, y=y)
-        fh = self._check_fh(fh)
 
         # update internal _X/_y with the new X/y
         # this also updates cutoff from y

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -493,7 +493,7 @@ def test_panel_with_inner_freq():
     y = pd.DataFrame(y.values, index=ind, columns=["passengers"])
 
     y_pan = y.set_index([y.index.hour.rename("hour"), y.index]).sort_index()
-    assert y_pan.loc[0].index.freq == pd.Timedelta("1D"), "Expected daily frequency"
+    assert y_pan.loc[0].index.freq == pd.Timedelta("24H"), "Expected 24H frequency"
 
     fh = [1, 2]
     y_train, y_test = temporal_train_test_split(y_pan, test_size=len(fh))

--- a/sktime/forecasting/squaring_residuals.py
+++ b/sktime/forecasting/squaring_residuals.py
@@ -363,7 +363,7 @@ class SquaringResiduals(BaseForecaster):
         fh_rel_index = fh_rel.to_pandas()
         pred_var = pd.Series(index=fh_rel_index, dtype="float64")
         for el in fh_rel:
-            pred_var.at[el] = self._res_forecasters[el].predict(fh=el)[0]
+            pred_var.at[el] = self._res_forecasters[el].predict(fh=el)
         if self.strategy == "square":
             pred_var = pred_var**0.5
         pred_var.index = fh_abs.to_pandas()

--- a/sktime/forecasting/tests/test_exp_smoothing.py
+++ b/sktime/forecasting/tests/test_exp_smoothing.py
@@ -88,13 +88,3 @@ def check_panel_with_freq():
     y_pred = forecaster.predict(fh=fh)
 
     assert y_pred.equals(y_pred_update), "Expected same predictions after update"
-
-    y.index.names = ["datetime"]
-    y.name = "passengers"
-    y = y.to_frame()
-    y["hour_of_day"] = y.index.hour
-    y = y.reset_index().set_index(["hour_of_day", "datetime"]).sort_index()
-
-    forecaster = ExponentialSmoothing(trend="add", sp=1)
-    forecaster.fit(y)
-    forecaster.predict(fh=[1, 3])

--- a/sktime/forecasting/tests/test_exp_smoothing.py
+++ b/sktime/forecasting/tests/test_exp_smoothing.py
@@ -72,7 +72,7 @@ def check_panel_with_freq():
     )
     y = pd.DataFrame(y.values, index=ind, columns=["passengers"])
     y = y.set_index([y.index.hour.rename("hour"), y.index]).sort_index()
-    assert y.loc[0].index.freq == pd.Timedelta("1D"), "Expected daily frequency"
+    assert y.loc[0].index.freq == pd.Timedelta("24H"), "Expected 24H frequency"
 
     fh = [1, 2]
     y_train, y_test = temporal_train_test_split(y, test_size=len(fh))


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->

N/A


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Found a bug when fitting panel-style models where the panels have a frequency attribute.

Changed the base (:/) to check fh only on the inner, non-vectorized, loop. Also, added a check, with the freq check turned off, when it is vectorized since when fh is supplied only in predict it seems to be written to self and expects something there in other tests

```python
from sktime.datasets import load_airline
from sktime.forecasting.exp_smoothing import ExponentialSmoothing
import pandas as pd


y = load_airline()
ind = pd.date_range(
    start="1960-01-01", periods=len(y.index), freq="H", name="datetime"
)
y = pd.DataFrame(y.values, index=ind, columns=["passengers"])
y = y.set_index([y.index.hour.rename("hour"), y.index]).sort_index()
assert y.loc[0].index.freq == pd.Timedelta("1D"), "Expected daily frequency"

fh = [1, 2]
forecaster = ExponentialSmoothing(trend="add", sp=1)
forecaster.fit(y)
forecaster.predict(fh=fh)

```

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

I was hesitant to change the base forecaster and it seems like a band-aid fix, but was struggling for other ideas

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

Aye, but only with the exponential smoothing estimator

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

<!--
Thanks for contributing!
-->
