### PR TITLE
[DOC] remove superfluous request for contribution (pytho 3.10 compatibility) in install docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,8 +10,6 @@ Installation
 
 See here for a `full list of precompiled wheels available on PyPI <https://pypi.org/simple/sktime/>`_.
 
-We appreciate community contributions towards compatibility with python 3.10, or other operating systems.
-
 .. contents::
    :local:
 


### PR DESCRIPTION
This PR removes a superfluous request for contribution in install docs, to contribute to making `sktime` compatible with python 3.10.

This is obsolet, as `sktime` is already compatible with the full range of 3.8-3.12, and 3.10 since long ago.