### PR TITLE
[DOC] add GitHub ID hyperlinks in estimator table

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -324,6 +324,9 @@ def _make_estimator_overview(app):
         Multiple author names will be separated by a comma,
         with the final name always preceded by "&".
         """
+        if isinstance(author_info, str) and author_info.lower() == "sktime developers":
+            return "sktime developers"
+
         if not isinstance(author_info, list):
             author_info = [author_info]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -327,7 +327,7 @@ def _make_estimator_overview(app):
         if isinstance(author_info, str) and author_info.lower() == "sktime developers":
             link = (
                 '<a href="https://www.sktime.net/en/stable/about/team.html">'
-                'sktime developers</a>'
+                "sktime developers</a>"
             )
             return link
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -325,7 +325,11 @@ def _make_estimator_overview(app):
         with the final name always preceded by "&".
         """
         if isinstance(author_info, str) and author_info.lower() == "sktime developers":
-            return "sktime developers"
+            link = (
+                '<a href="https://www.sktime.net/en/stable/about/team.html">'
+                'sktime developers</a>'
+            )
+            return link
 
         if not isinstance(author_info, list):
             author_info = [author_info]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -324,13 +324,19 @@ def _make_estimator_overview(app):
         Multiple author names will be separated by a comma,
         with the final name always preceded by "&".
         """
-        if isinstance(author_info, list):
-            if len(author_info) > 1:
-                return ", ".join(author_info[:-1]) + " & " + author_info[-1]
-            else:
-                return author_info[0]
+        if not isinstance(author_info, list):
+            author_info = [author_info]
+
+        def _add_link(github_id_str):
+            link = '<a href="https://www.github.com/{0}">{0}</a>'.format(github_id_str)
+            return link
+
+        author_info = [_add_link(author) for author in author_info]
+
+        if len(author_info) > 1:
+            return ", ".join(author_info[:-1]) + " & " + author_info[-1]
         else:
-            return author_info
+            return author_info[0]
 
     def _does_not_start_with_underscore(input_string):
         return not input_string.startswith("_")


### PR DESCRIPTION
This PR adds hyperlinks to the GitHub IDs in author and maintainer fields in the estimator table.