### PR TITLE
[ENH] Add nan policy handler for FallbackForecaster #5897

### DIFF
--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -51,9 +51,11 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     nan_predict_policy: str, default='ignore'
         Determines the action to take if NaN values are found in the predictions.
         Available options:
+
         * "ignore"
         * "raise"
         * "warn"
+
         When set to 'raise', this policy treats NaN predictions as errors, prompting the
         FallbackForecaster to sequentially try the next forecaster in the queue. This
         process continues until a NaN-free prediction is obtained or all forecasters

--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -17,6 +17,17 @@ from sktime.forecasting.base._delegate import _DelegatedForecaster
 from sktime.utils.warnings import warn
 
 
+def _check_nan_policy_option(nan_predict_policy):
+    """Ensure user selects correct `nan_predict_policy` option."""
+    nan_predict_policy_options = ["ignore", "raise", "warn"]
+    if nan_predict_policy not in nan_predict_policy_options:
+        raise AttributeError(
+            f"`nan_predict_policy` must choose from "
+            f"{nan_predict_policy_options} but instead got "
+            f"{nan_predict_policy}"
+        )
+
+
 class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     """Forecaster that sequentially tries a list of forecasting models.
 
@@ -35,6 +46,13 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
 
     verbose : bool, default=False
         If True, raises warnings when a forecaster fails to fit or predict.
+
+    nan_predict_policy: str, default='ignore'
+        Determines the action to take if NaN values are found in the predictions. If set
+         to 'raise', the method raises a ValueError when NaN values are detected in the
+         predictions. If set to 'warn', a warning is issued instead of raising an
+         exception. The default value 'ignore' means that the presence of NaN values in
+         predictions will not trigger any warning or error.
 
     Attributes
     ----------
@@ -96,13 +114,16 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_fitted_attr = "forecasters_"
 
-    def __init__(self, forecasters, verbose=False):
+    def __init__(self, forecasters, verbose=False, nan_predict_policy="ignore"):
         super().__init__()
 
         self.forecasters = forecasters
         self.current_forecaster_ = None
         self.current_name_ = None
         self.verbose = verbose
+
+        _check_nan_policy_option(nan_predict_policy)
+        self.nan_predict_policy = nan_predict_policy
 
         self._forecasters = self._check_estimators(
             forecasters, "forecasters", clone_ests=False
@@ -111,6 +132,20 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
 
         self._anytagis_then_set("requires-fh-in-fit", True, False, self._forecasters)
         self._anytagis_then_set("capability:pred_int", False, True, self._forecasters)
+
+    def _validate_y_pred(self, y_pred):
+        if self.nan_predict_policy in ("warn", "raise"):
+            num_nans = y_pred.isna().sum()
+            if num_nans > 0:
+                msg = f"Null value presents in predict: {y_pred}"
+                if self.nan_predict_policy == "raise":
+                    raise ValueError(msg)
+                else:
+                    warn(
+                        msg,
+                        stacklevel=2,
+                        obj=self,
+                    )
 
     def _get_delegate(self):
         return self.current_forecaster_
@@ -209,7 +244,9 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
             raise RuntimeError("No forecaster has been successfully fitted yet.")
 
         try:
-            return self.current_forecaster_.predict(fh, X)
+            y_pred = self.current_forecaster_.predict(fh, X)
+            self._validate_y_pred(y_pred)
+            return y_pred
         except Exception as e:
             self.exceptions_raised_[self.first_nonfailing_forecaster_index_] = {
                 "failed_at_step": "predict",
@@ -227,7 +264,9 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
             # Fit the next forecaster and retry prediction
             self.current_forecaster_ = None
             self._try_fit_forecasters(self._y, self._X, self._fh)
-            return self.predict(fh, X)
+            y_pred = self.predict(fh, X)
+            self._validate_y_pred(y_pred)
+            return y_pred
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/forecasting/compose/tests/test_fallback.py
+++ b/sktime/forecasting/compose/tests/test_fallback.py
@@ -625,3 +625,20 @@ def test_fallbackforecaster_warns():
     forecaster.fit(y=y, fh=[1, 2, 3])
     with pytest.warns(UserWarning):
         forecaster.predict()
+
+
+def test_fallbackforecaster_raises():
+    """All forecasters fail when last forecaster predicts nan, raises RuntimeError."""
+    y = make_forecasting_problem(random_state=42)
+    forecaster1 = DummyForecaster(raise_at="fit")
+    forecaster2 = DummyForecaster(raise_at=None, predict_nans=True)
+    forecaster = FallbackForecaster(
+        [
+            ("forecaster1_fails_fit", forecaster1),
+            ("forecaster2_pred_nans", forecaster2),
+        ],
+        nan_predict_policy="raise",
+    )
+    forecaster.fit(y=y, fh=[1, 2, 3])
+    with pytest.raises(RuntimeError):
+        forecaster.predict()

--- a/sktime/forecasting/compose/tests/test_fallback.py
+++ b/sktime/forecasting/compose/tests/test_fallback.py
@@ -47,9 +47,11 @@ class DummyForecaster(_HeterogenousMetaEstimator, BaseForecaster):
 
     Parameters
     ----------
-    raise_at : str
+    raise_at : str or NoneType
         Stage at which the forecaster should fail. Options are "fit", "predict",
-        "update".
+        "update", and None.
+    predict_nans : bool
+        Replaces the first prediction with a null value when true.
 
     Raises
     ------
@@ -57,13 +59,14 @@ class DummyForecaster(_HeterogenousMetaEstimator, BaseForecaster):
         If `raise_at` is not one of the valid options.
     """
 
-    def __init__(self, raise_at="fit"):
+    def __init__(self, raise_at="fit", predict_nans=False):
         super().__init__()
-        __valid__ = ["fit", "predict", "update"]
+        __valid__ = ["fit", "predict", "update", None]
         if raise_at not in __valid__:
             raise AttributeError(f"`raise_at` must choose from {__valid__}")
         self.forecaster = NaiveForecaster()
         self.raise_at = raise_at
+        self.predict_nans = predict_nans
         self._is_fitted = False
 
     def _fit(self, y, X=None, fh=None):
@@ -80,7 +83,10 @@ class DummyForecaster(_HeterogenousMetaEstimator, BaseForecaster):
             raise ForecastingError("The forecaster is not fitted yet.")
         if self.raise_at == "predict":
             raise ForecastingError("Intentional failure in predict.")
-        return self.forecaster.predict(fh, X)
+        y_pred = self.forecaster.predict(fh, X)
+        if self.predict_nans:
+            y_pred.iloc[0] = pd.NA
+        return y_pred
 
     def _update(self, y, X=None, update_params=True):
         """Update the forecaster. Optionally fail here."""
@@ -118,6 +124,15 @@ def test_raises_at_update():
     forecaster.predict()
     with pytest.raises(ForecastingError):
         forecaster.update(y)
+
+
+def test_predicts_nans():
+    """Test dummy forecaster predict nans"""
+    y = make_forecasting_problem(random_state=42)
+    forecaster = DummyForecaster(raise_at=None, predict_nans=True)
+    forecaster.fit(y=y, fh=[1, 2, 3])
+    y_pred = forecaster.predict()
+    assert y_pred.isna().sum() > 0
 
 
 def test_fallbackforecaster_fails_at_fit():
@@ -529,3 +544,84 @@ def test_fallbackforecaster_pred_int_raises():
     forecaster.fit(y, fh=fh)
     with pytest.raises(NotImplementedError):
         forecaster.predict_interval()
+
+
+def test_fallbackforecaster_predict_nan_allow():
+    """Test FallbackForecaster allow nans in predict"""
+    y = make_forecasting_problem(random_state=42)
+    forecaster1 = DummyForecaster(raise_at="fit")
+    forecaster2 = DummyForecaster(raise_at=None, predict_nans=True)
+    forecaster = FallbackForecaster(
+        [
+            ("forecaster1_fails_fit", forecaster1),
+            ("forecaster2_pred_nans", forecaster2),
+        ],
+        nan_predict_policy="ignore",
+    )
+    forecaster.fit(y=y, fh=[1, 2, 3])
+    y_pred_actual = forecaster.predict()
+
+    forecaster2.fit(y=y, fh=[1, 2, 3])
+    y_pred_expected = forecaster2.predict()
+
+    assert y_pred_actual.isna().sum() > 0
+
+    pd.testing.assert_series_equal(y_pred_expected, y_pred_actual)
+
+
+def test_fallbackforecaster_predict_nan():
+    """Test FallbackForecaster raise if nans in predict"""
+    y = make_forecasting_problem(random_state=42)
+    forecaster1 = DummyForecaster(raise_at="fit")
+    forecaster2 = DummyForecaster(raise_at=None, predict_nans=True)
+    forecaster3 = PolynomialTrendForecaster()
+    forecaster4 = NaiveForecaster()
+
+    forecaster = FallbackForecaster(
+        [
+            ("forecaster1_fails_fit", forecaster1),
+            ("forecaster2_pred_nans", forecaster2),
+            ("forecaster3_succeeded", forecaster3),
+            ("forecaster4_notcalled", forecaster4),
+        ],
+        nan_predict_policy="raise",
+    )
+    forecaster.fit(y=y, fh=[1, 2, 3])
+    y_pred_actual = forecaster.predict()
+
+    forecaster3.fit(y=y, fh=[1, 2, 3])
+    y_pred_expected = forecaster3.predict()
+
+    # Assert correct forecaster name
+    name = forecaster.current_name_
+    assert name == "forecaster3_succeeded"
+
+    # Assert correct y_pred
+    pd.testing.assert_series_equal(y_pred_expected, y_pred_actual)
+
+    # Assert correct number of expected exceptions
+    exceptions_raised = forecaster.exceptions_raised_
+    assert len(exceptions_raised) == 2
+
+    # Assert the correct forecasters failed
+    names_raised_actual = [
+        vals["forecaster_name"] for vals in exceptions_raised.values()
+    ]
+    names_raised_expected = ["forecaster1_fails_fit", "forecaster2_pred_nans"]
+    assert names_raised_actual == names_raised_expected
+
+
+def test_fallbackforecaster_warns():
+    y = make_forecasting_problem(random_state=42)
+    forecaster1 = DummyForecaster(raise_at="fit")
+    forecaster2 = DummyForecaster(raise_at=None, predict_nans=True)
+    forecaster = FallbackForecaster(
+        [
+            ("forecaster1_fails_fit", forecaster1),
+            ("forecaster2_pred_nans", forecaster2),
+        ],
+        nan_predict_policy="warn",
+    )
+    forecaster.fit(y=y, fh=[1, 2, 3])
+    with pytest.warns(UserWarning):
+        forecaster.predict()


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
-Issue: https://github.com/sktime/sktime/issues/5897
-Additional discussion: https://github.com/sktime/sktime/pull/5847


#### What does this implement/fix? Explain your changes.

We've introduced a `nan_predict_policy` within the `FallbackForecaster` class to handle NaN values in forecaster predictions. This policy defaults to "ignore" and can be set to "raise", which will actively check for NaN values in the prediction output and raise an exception if any are detected, or "warn", which will warn the user if any values are detected. This enhancement is aimed at improving the robustness and reliability of the forecasting process, especially when integrating transformations like BoxCox with ARIMA forecasters.


#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies.

#### What should a reviewer concentrate their feedback on?

- Correctness of the NaN detection and exception raising mechanism.
- Adhering to existing `sktime` design standards.
- Adequacy of tests covering the new functionality.

#### Did you add any tests for the change?

Yes, tests have been added to ensure the `nan_predict_policy` behaves as expected in scenarios where NaN values are predicted. These tests cover both the "raise" and "warn" policies to verify their correct implementation.

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
