### PR TITLE
[MNT] update versions of several actions

### DIFF
--- a/.github/actions/test-base/action.yml
+++ b/.github/actions/test-base/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
 
     - name: python environment step
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version-identifier }}
 

--- a/.github/actions/test-component/action.yml
+++ b/.github/actions/test-component/action.yml
@@ -28,7 +28,7 @@ runs:
       shell: bash
 
     - name: python environment step
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version-identifier }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         run: python3 -m pip install pre-commit
       - id: changed-files
         name: identify modified files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v42
       - name: run pre-commit hooks on modified files
         run: pre-commit run --color always --files ${{ steps.changed-files.outputs.all_changed_files }} --show-diff-on-failure
       - name: check missing __init__ files
@@ -199,7 +199,7 @@ jobs:
       datasets: ${{ steps.filter.outputs.datasets }}
       pyproject: ${{ steps.filter.outputs.pyproject }}
     steps:
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |


### PR DESCRIPTION
Currently quite a few of our actions are outdated, and they are throwing lots of deprecation warnings.

![image](https://github.com/sktime/sktime/assets/39331844/a20e2c8f-a901-4af8-b7e7-f6074fe91de7)

These should have been updated by Dependabot, but they may have been overridden by merge changes. This PR updates them to latest versions.