### PR TITLE
[ENH] k-nearest neighbors classifier: support for non-brute algorithms and non-precomputed mode to improve memory efficiency

### DIFF
--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -25,7 +25,7 @@ import pandas as pd
 from sklearn.neighbors import KNeighborsClassifier
 
 from sktime.classification.base import BaseClassifier
-from sktime.datatypes import check_is_mtype, convert
+from sktime.datatypes import convert
 from sktime.distances import pairwise_distance
 
 # add new distance string codes here

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -414,18 +414,16 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
             return self._predict_dist(X)
 
     def _predict_dist(self, X):
-
+        """Predict using adapted distance metric."""
         X = self._convert_X_to_sklearn(X)
         y_pred = self.knn_estimator_.predict(X)
         return y_pred
 
-
     def _predict_precomp(self, X):
+        """Predict using precomputed distance matrix."""
         # self._X should be the stored _X
         dist_mat = self._distance(X, self._X)
-
         y_pred = self.knn_estimator_.predict(dist_mat)
-
         return y_pred
 
     def _predict_proba(self, X):
@@ -449,16 +447,16 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
             return self._predict_proba_dist(X)
 
     def _predict_proba_dist(self, X):
+        """Predict (proba) using adapted distance metric."""
         X = self._convert_X_to_sklearn(X)
         y_pred = self.knn_estimator_.predict_proba(X)
         return y_pred
 
     def _predict_proba_precomp(self, X):
+        """Predict (proba) using precomputed distance matrix."""
         # self._X should be the stored _X
         dist_mat = self._distance(X, self._X)
-
         y_pred = self.knn_estimator_.predict_proba(dist_mat)
-
         return y_pred
 
     @classmethod

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -307,18 +307,6 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         else:
             return self._fit_dist(X=X, y=y)
 
-    def _n_instances(self, X):
-        """Get number of instances from X."""
-        X_inner_mtype = self.get_tag("X_inner_mtype")
-        _, _, X_meta = check_is_mtype(
-            X,
-            X_inner_mtype,
-            return_metadata=["n_instances"],
-            msg_return_dict="list"
-        )
-        n = X_meta["n_instances"]
-        return n
-
     def _fit_dist(self, X, y):
         """Fit the model using adapted distance metric."""
         # sklearn wants distance callabel element-wise,
@@ -358,7 +346,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         if self.pass_train_distances:
             dist_mat = self._distance(X)
         else:
-            n = self._n_instances(X)
+            n = self._X_metadata["n_instances"]
             # if we do not want/need to pass train-train distances,
             #   we still need to pass a zeros matrix, this means "do not consider"
             # citing the sklearn KNeighborsClassifier docs on distance matrix input:

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -240,22 +240,52 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         if n_vars == 1:
             x = np.reshape(x, (1, n_vars, -1))
             y = np.reshape(y, (1, n_vars, -1))
-        else:
+        elif self._X_metadata["is_equal_length"]:
             x = np.reshape(x, (-1, n_vars))
             y = np.reshape(y, (-1, n_vars))
             x_ix = pd.MultiIndex.from_product([[0], range(len(x))])
             y_ix = pd.MultiIndex.from_product([[0], range(len(y))])
             x = pd.DataFrame(x, index=x_ix)
             y = pd.DataFrame(y, index=y_ix)
+        else:  # multivariate, unequal length
+            # in _convert_X_to_sklearn, we have encoded the length as the first column
+            # this was coerced to float, so we round to avoid rounding errors
+            x_len = round(x[0])
+            y_len = round(y[0])
+            # pd.pivot switches the axes, compared to numpy
+            x = np.reshape(x[1:], (n_vars, -1)).T
+            y = np.reshape(y[1:], (n_vars, -1)).T
+            # cut to length
+            x = x[:x_len]
+            y = y[:y_len]
+            x_ix = pd.MultiIndex.from_product([[0], range(x_len)])
+            y_ix = pd.MultiIndex.from_product([[0], range(y_len)])
+            x = pd.DataFrame(x, index=x_ix)
+            y = pd.DataFrame(y, index=y_ix)
         return self._distance(x, y)[0, 0]
 
     def _convert_X_to_sklearn(self, X):
         """Convert X to 2D numpy for sklearn."""
+        # special treatment for unequal length series
+        if not self._X_metadata["is_equal_length"]:
+            # then we know we are dealing with pd-multiindex
+            # as a trick to deal with unequal length data,
+            # we flatten encode the length as the first column
+            X_w_ix = X.reset_index(-1)
+            X_pivot = X_w_ix.pivot(columns=[X_w_ix.columns[0]])
+            # fillna since this creates nan but sklearn does not accept these
+            # the fill value does not matter as the distance ignores it
+            X_pivot = X_pivot.fillna(0).to_numpy()
+            X_lens = X.groupby(X_w_ix.index).size().to_numpy()
+            # add the first column, encoding length of individual series
+            X_w_lens = np.concatenate([X_lens[:, None], X_pivot], axis=1)
+            return X_w_lens
+
+        # equal length series case
         if isinstance(X, np.ndarray):
             X_mtype = "numpy3D"
         else:
             X_mtype = "pd-multiindex"
-            print(X)
         return convert(X, from_type=X_mtype, to_type="numpyflat")
 
     def _fit(self, X, y):

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -75,12 +75,15 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         * 'brute' precomputes the distance matrix and applies
           ``sklearn`` ``KNeighborsClassifier`` directly.
           This algorithm is not memory efficient as it scales with the size
-          of the distance matrix.
+          of the distance matrix, but may be more runtime efficient.
         * 'brute_incr' passes the distance to ``sklearn`` ``KNeighborsClassifier``,
           with ``algorithm='brute'``. This is useful for large datasets,
-          as the distance is used incrementally, without precomputation
+          for memory efficiency, as the distance is used incrementally,
+          without precomputation. However, this may be less runtime efficient.
         * 'ball_tree' uses a ball tree to find the nearest neighbors,
           using ``KNeighborsClassifier`` from ``sklearn``.
+          May be more runtime and memory efficient on mid-to-large datasets,
+          however, the distance computation may be slower.
 
     distance : str or callable, optional. default ='dtw'
         distance measure between time series

--- a/sktime/utils/profiling.py
+++ b/sktime/utils/profiling.py
@@ -25,7 +25,6 @@ def profile_classifier(
 
     Of each experiment, time spent in fit and time spent in predict is measured.
 
-
     Parameters
     ----------
     est : sktime classifier, BaseClassifier descendant, object or class


### PR DESCRIPTION
This PR adds code to `KNeighborsTimeSeriesClassifier` that passes a callable to the internal sklearn estimator to avoid oom errors when precomputing the distance matrix, trading off memory efficiency with compute efficiency.

Adds the following algorithms - with test coverage - to `KNeighborsTimeSeriesClassifier`:

* `ball_tree`
* `brute_incr` - brute force, but distances are not all precomputed

These strategies also allow for unequal length time series given internal adapter encoding.

Removes `kd_tree` from the docstring which did not work previously, and cannot be interfaced, as `sklearn` does not allow this to be called together with a custom distance.

Potentially fixes https://github.com/sktime/sktime/issues/5914, and fixes #2774