### PR TITLE
[DOC] Typo in documentation, fixed monotonous to monotonic 

### DIFF
--- a/examples/AA_datatypes_and_datasets.ipynb
+++ b/examples/AA_datatypes_and_datasets.ipynb
@@ -105,18 +105,18 @@
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Section 1.1.1: Time series - the `\"pd.DataFrame\"` mtype\n",
-    "\n",
-    "In the `\"pd.DataFrame\"` mtype, time series are represented by an in-memory container `obj: pandas.DataFrame` as follows.\n",
-    "\n",
-    "* structure convention: `obj.index` must be monotonous, and one of `Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex`.\n",
-    "* variables: columns of `obj` correspond to different variables\n",
-    "* variable names: column names `obj.columns`\n",
-    "* time points: rows of `obj` correspond to different, distinct time points\n",
-    "* time index: `obj.index` is interpreted as a time index.\n",
-    "* capabilities: can represent multivariate series; can represent unequally spaced series"
-   ]
+    "source": [
+      "### Section 1.1.1: Time series - the `\"pd.DataFrame\"` mtype\n",
+      "\n",
+      "In the `\"pd.DataFrame\"` mtype, time series are represented by an in-memory container `obj: pandas.DataFrame` as follows.\n",
+      "\n",
+      "* structure convention: `obj.index` must be monotonic, and one of `Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex`.\n",
+      "* variables: columns of `obj` correspond to different variables\n",
+      "* variable names: column names `obj.columns`\n",
+      "* time points: rows of `obj` correspond to different, distinct time points\n",
+      "* time index: `obj.index` is interpreted as a time index.\n",
+      "* capabilities: can represent multivariate series; can represent unequally spaced series"
+    ]
   },
   {
    "attachments": {},
@@ -279,18 +279,18 @@
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Section 1.1.2: Time series - the `\"pd.Series\"` mtype\n",
-    "\n",
-    "In the `\"pd.Series\"` mtype, time series are represented by an in-memory container `obj: pandas.Series` as follows.\n",
-    "\n",
-    "* structure convention: `obj.index` must be monotonous, and one of `Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex`.\n",
-    "* variables: there is a single variable, corresponding to the values of `obj`. Only univariate series can be represented.\n",
-    "* variable names: by default, there is no column name. If needed, a variable name can be provided as `obj.name`.\n",
-    "* time points: entries of `obj` correspond to different, distinct time points\n",
-    "* time index: `obj.index` is interpreted as a time index.\n",
-    "* capabilities: cannot represent multivariate series; can represent unequally spaced series"
-   ]
+    "source": [
+      "### Section 1.1.2: Time series - the `\"pd.Series\"` mtype\n",
+      "\n",
+      "In the `\"pd.Series\"` mtype, time series are represented by an in-memory container `obj: pandas.Series` as follows.\n",
+      "\n",
+      "* structure convention: `obj.index` must be monotonic, and one of `Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex`.\n",
+      "* variables: there is a single variable, corresponding to the values of `obj`. Only univariate series can be represented.\n",
+      "* variable names: by default, there is no column name. If needed, a variable name can be provided as `obj.name`.\n",
+      "* time points: entries of `obj` correspond to different, distinct time points\n",
+      "* time index: `obj.index` is interpreted as a time index.\n",
+      "* capabilities: cannot represent multivariate series; can represent unequally spaced series"
+    ]
   },
   {
    "attachments": {},
@@ -435,20 +435,20 @@
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Section 1.2.1: Time series panels - the `\"pd-multiindex\"` mtype\n",
-    "\n",
-    "In the `\"pd-multiindex\"` mtype, time series panels are represented by an in-memory container `obj: pandas.DataFrame` as follows.\n",
-    "\n",
-    "* structure convention: `obj.index` must be a pair multi-index of type `(Index, t)`, where `t` is one of `Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex` and monotonous. `obj.index` must have two levels (can be named or not).\n",
-    "* instance index: the first element of pairs in `obj.index` (0-th level value) is interpreted as an instance index, we call it \"instance index\" below.\n",
-    "* instances: rows with the same \"instance index\" index value correspond to the same instance; rows with different \"instance index\" values correspond to different instances. \n",
-    "* time index: the second element of pairs in `obj.index` (1-st level value) is interpreted as a time index, we call it \"time index\" below. \n",
-    "* time points: rows of `obj` with the same \"time index\" value correspond correspond to the same time point; rows of `obj` with different \"time index\" index correspond correspond to the different time points.\n",
-    "* variables: columns of `obj` correspond to different variables\n",
-    "* variable names: column names `obj.columns`\n",
-    "* capabilities: can represent panels of multivariate series; can represent unequally spaced series; can represent panels of unequally supported series; cannot represent panels of series with different sets of variables."
-   ]
+    "source": [
+      "### Section 1.2.1: Time series panels - the `\"pd-multiindex\"` mtype\n",
+      "\n",
+      "In the `\"pd-multiindex\"` mtype, time series panels are represented by an in-memory container `obj: pandas.DataFrame` as follows.\n",
+      "\n",
+      "* structure convention: `obj.index` must be a pair multi-index of type `(Index, t)`, where `t` is one of `Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex` and monotonic. `obj.index` must have two levels (can be named or not).\n",
+      "* instance index: the first element of pairs in `obj.index` (0-th level value) is interpreted as an instance index, we call it \"instance index\" below.\n",
+      "* instances: rows with the same \"instance index\" index value correspond to the same instance; rows with different \"instance index\" values correspond to different instances. \n",
+      "* time index: the second element of pairs in `obj.index` (1-st level value) is interpreted as a time index, we call it \"time index\" below. \n",
+      "* time points: rows of `obj` with the same \"time index\" value correspond correspond to the same time point; rows of `obj` with different \"time index\" index correspond correspond to the different time points.\n",
+      "* variables: columns of `obj` correspond to different variables\n",
+      "* variable names: column names `obj.columns`\n",
+      "* capabilities: can represent panels of multivariate series; can represent unequally spaced series; can represent panels of unequally supported series; cannot represent panels of series with different sets of variables."
+    ]
   },
   {
    "attachments": {},
@@ -702,18 +702,18 @@
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "#### Hierarchical time series - the `\"pd_multiindex_hier\"` mtype\n",
-    "\n",
-    "* structure convention: `obj.index` must be a 3 or more level multi-index of type `(Index, ..., Index, t)`, where `t` is one of `Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex` and monotonous. We call the last index the \"time-like\" index.\n",
-    "* hierarchy level: rows with the same non-time-like index values correspond to the same hierarchy unit; rows with different non-time-like index combination correspond to different hierarchy unit.\n",
-    "* hierarchy: the non-time-like indices in `obj.index` are interpreted as a hierarchy identifying index. \n",
-    "* time index: the last element of tuples in `obj.index` is interpreted as a time index. \n",
-    "* time points: rows of `obj` with the same `\"timepoints\"` index correspond correspond to the same time point; rows of `obj` with different `\"timepoints\"` index correspond correspond to the different time points.\n",
-    "* variables: columns of `obj` correspond to different variables\n",
-    "* variable names: column names `obj.columns`\n",
-    "* capabilities: can represent hierarchical series; can represent unequally spaced series; can represent unequally supported hierarchical series; cannot represent hierarchical series with different sets of variables."
-   ]
+    "source": [
+      "#### Hierarchical time series - the `\"pd_multiindex_hier\"` mtype\n",
+      "\n",
+      "* structure convention: `obj.index` must be a 3 or more level multi-index of type `(Index, ..., Index, t)`, where `t` is one of `Int64Index`, `RangeIndex`, `DatetimeIndex`, `PeriodIndex` and monotonic. We call the last index the \"time-like\" index.\n",
+      "* hierarchy level: rows with the same non-time-like index values correspond to the same hierarchy unit; rows with different non-time-like index combination correspond to different hierarchy unit.\n",
+      "* hierarchy: the non-time-like indices in `obj.index` are interpreted as a hierarchy identifying index. \n",
+      "* time index: the last element of tuples in `obj.index` is interpreted as a time index. \n",
+      "* time points: rows of `obj` with the same `\"timepoints\"` index correspond correspond to the same time point; rows of `obj` with different `\"timepoints\"` index correspond correspond to the different time points.\n",
+      "* variables: columns of `obj` correspond to different variables\n",
+      "* variable names: column names `obj.columns`\n",
+      "* capabilities: can represent hierarchical series; can represent unequally spaced series; can represent unequally supported hierarchical series; cannot represent hierarchical series with different sets of variables."
+    ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Reference Issues/PRs

Fixes issues #5878 

What does this implement/fix? Explain your changes.
I have addressed the typo in the structure convention. Instead of 'monotonous,' it now correctly states 'monotonic.' I made this adjustment in the section detailing the structure convention for time series objects, specifically in the line: 'obj.index must be monotonous, and one of... I have push just the correct file this time.

Does your contribution introduce a new dependency? If yes, which one?

No

What should a reviewer concentrate their feedback on?

Did you add any tests for the change?

no

Any other comments?

no

PR checklist

- [ ]  I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)

- [ ]  Optionally, I've added myself and possibly others to the [CODEOWNERS]

- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

For new estimators

 

- [ ] I've added the estimator to the API reference - in docs/source/api_reference/taskname.rst, follow the pattern.

- [ ]  I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant Examples section.

- [ ] If the estimator relies on a soft dependency, I've set the python_dependencies tag and ensured

dependency isolation, see the [estimator dependencies guide]