### PR TITLE
[ENH] Add neuralforecast adapter and rnn forecaster

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -371,6 +371,14 @@ Deep learning based forecasters
 
     CINNForecaster
 
+.. currentmodule:: sktime.forecasting.neuralforecast
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    NeuralForecastRNN
+
 
 Intermittent time series forecasters
 ------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,6 +264,7 @@ cython_extras = [
 ]
 dl = [
   'FrEIA; python_version < "3.12"',
+  'neuralforecast<1.7.0,>=1.6.4; python_version < "3.11"',
   'tensorflow<=2.14,>=2; python_version < "3.12"',
   'torch; python_version < "3.12"',
 ]

--- a/sktime/forecasting/base/adapters/__init__.py
+++ b/sktime/forecasting/base/adapters/__init__.py
@@ -8,12 +8,14 @@ __all__ = [
     "_PmdArimaAdapter",
     "_StatsForecastAdapter",
     "_GeneralisedStatsForecastAdapter",
+    "_NeuralForecastAdapter",
 ]
 
 from sktime.forecasting.base.adapters._fbprophet import _ProphetAdapter
 from sktime.forecasting.base.adapters._generalised_statsforecast import (
     _GeneralisedStatsForecastAdapter,
 )
+from sktime.forecasting.base.adapters._neuralforecast import _NeuralForecastAdapter
 from sktime.forecasting.base.adapters._pmdarima import _PmdArimaAdapter
 from sktime.forecasting.base.adapters._statsforecast import _StatsForecastAdapter
 from sktime.forecasting.base.adapters._statsmodels import _StatsModelsAdapter

--- a/sktime/forecasting/base/adapters/_neuralforecast.py
+++ b/sktime/forecasting/base/adapters/_neuralforecast.py
@@ -1,0 +1,290 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Implements adapter for NeuralForecast models."""
+import abc
+import functools
+import typing
+
+import pandas
+
+from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
+
+__all__ = ["_NeuralForecastAdapter"]
+__author__ = ["yarnabrina"]
+
+
+class _NeuralForecastAdapter(BaseForecaster):
+    """Base adapter class for NeuralForecast models.
+
+    Parameters
+    ----------
+    freq : str
+        frequency of the data, see available frequencies [1]_ from ``pandas``
+    local_scaler_type : str (default=None)
+        scaler to apply per-series to all features before fitting, which is inverted
+        after predicting
+
+        can be one of the following:
+
+        - 'standard'
+        - 'robust'
+        - 'robust-iqr'
+        - 'minmax'
+        - 'boxcox'
+    futr_exog_list : str list, (default=None)
+        future exogenous variables
+    verbose_fit : bool (default=False)
+        print processing steps during fit
+    verbose_predict : bool (default=False)
+        print processing steps during predict
+
+    Notes
+    -----
+    Only ``futr_exog_list`` will be considered as exogenous variables.
+
+    References
+    ----------
+    .. [1] https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
+    """  # noqa: E501
+
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": ["yarnabrina"],
+        "maintainers": ["yarnabrina"],
+        "python_version": ">=3.8",
+        "python_dependencies": ["neuralforecast"],
+        # estimator type
+        # --------------
+        "y_inner_mtype": "pd.Series",
+        "X_inner_mtype": "pd.DataFrame",
+        "scitype:y": "univariate",
+        "requires-fh-in-fit": True,
+        "X-y-must-have-same-index": True,
+        "handles-missing-data": False,
+        "capability:insample": False,
+    }
+
+    def __init__(
+        self: "_NeuralForecastAdapter",
+        freq: str,
+        local_scaler_type: typing.Optional[
+            typing.Literal["standard", "robust", "robust-iqr", "minmax"]
+        ] = None,
+        futr_exog_list: typing.Optional[typing.List[str]] = None,
+        verbose_fit: bool = False,
+        verbose_predict: bool = False,
+    ) -> None:
+        self.freq = freq
+        self.local_scaler_type = local_scaler_type
+
+        self.futr_exog_list = futr_exog_list
+
+        self.verbose_fit = verbose_fit
+        self.verbose_predict = verbose_predict
+
+        super().__init__()
+
+        self.id_col = "unique_id"
+        self.time_col = "ds"
+        self.target_col = "y"
+
+        self.needs_X = self.algorithm_exogenous_support and bool(self.futr_exog_list)
+
+        self.set_tags(**{"ignores-exogeneous-X": not self.needs_X})
+
+    @functools.cached_property
+    @abc.abstractmethod
+    def algorithm_exogenous_support(self: "_NeuralForecastAdapter") -> bool:
+        """Set support for exogenous features."""
+
+    @functools.cached_property
+    @abc.abstractmethod
+    def algorithm_name(self: "_NeuralForecastAdapter") -> str:
+        """Set custom model name."""
+
+    @functools.cached_property
+    @abc.abstractmethod
+    def algorithm_class(self: "_NeuralForecastAdapter"):
+        """Import underlying NeuralForecast algorithm class."""
+
+    @functools.cached_property
+    @abc.abstractmethod
+    def algorithm_parameters(self: "_NeuralForecastAdapter") -> dict:
+        """Get keyword parameters for the underlying NeuralForecast algorithm class.
+
+        Returns
+        -------
+        dict
+            keyword arguments for the underlying algorithm class
+
+        Notes
+        -----
+        This method should not include following parameters:
+
+        - future exogenous columns (``futr_exog_list``) - used from ``__init__``
+        - historical exogenous columns (``hist_exog_list``) - not supported
+        - statis exogenous columns (``stat_exog_list``) - not supported
+        - custom model name (``alias``) - used from ``algorithm_name``
+        """
+
+    def _instantiate_model(self: "_NeuralForecastAdapter", fh: ForecastingHorizon):
+        """Instantiate the model."""
+        exogenous_parameters = (
+            {"futr_exog_list": self.futr_exog_list} if self.needs_X else {}
+        )
+
+        algorithm_instance = self.algorithm_class(
+            fh,
+            alias=self.algorithm_name,
+            **self.algorithm_parameters,
+            **exogenous_parameters,
+        )
+
+        from neuralforecast import NeuralForecast
+
+        model = NeuralForecast(
+            [algorithm_instance], self.freq, local_scaler_type=self.local_scaler_type
+        )
+
+        return model
+
+    def _fit(
+        self: "_NeuralForecastAdapter",
+        y: pandas.Series,
+        X: typing.Optional[pandas.DataFrame],
+        fh: ForecastingHorizon,
+    ) -> "_NeuralForecastAdapter":
+        """Fit forecaster to training data.
+
+        private _fit containing the core logic, called from fit
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        y : sktime time series object
+            guaranteed to have a single column/variable
+        fh : guaranteed to be ForecastingHorizon
+            The forecasting horizon with the steps ahead to to predict.
+        X : sktime time series object, optional (default=None)
+            guaranteed to have at least one column/variable
+            Exogeneous time series to fit to.
+
+        Returns
+        -------
+        self : _NeuralForecastAdapter
+            reference to self
+        """
+        if not fh.is_all_out_of_sample(cutoff=self.cutoff):
+            raise NotImplementedError("in-sample prediction is currently not supported")
+
+        train_indices = y.index
+        if isinstance(train_indices, pandas.PeriodIndex):
+            train_indices = train_indices.to_timestamp(freq=self.freq)
+
+        train_data = {
+            self.id_col: 1,
+            self.time_col: train_indices.to_numpy(),
+            self.target_col: y.to_numpy(),
+        }
+
+        if self.futr_exog_list and X is None:
+            raise ValueError("Missing exogeneous data, 'futr_exog_list' is non-empty.")
+
+        if self.futr_exog_list:
+            for column in self.futr_exog_list:
+                train_data[column] = X[column].to_numpy()
+
+        train_dataset = pandas.DataFrame(data=train_data)
+
+        maximum_forecast_horizon = fh.to_relative(self.cutoff)[-1]
+        self._forecaster = self._instantiate_model(maximum_forecast_horizon)
+
+        self._forecaster.fit(df=train_dataset, verbose=self.verbose_fit)
+
+        return self
+
+    def _predict(
+        self: "_NeuralForecastAdapter",
+        fh: typing.Optional[ForecastingHorizon],
+        X: typing.Optional[pandas.DataFrame],
+    ) -> pandas.Series:
+        """Forecast time series at future horizon.
+
+        private _predict containing the core logic, called from predict
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+        X : sktime time series object, optional (default=None)
+            guaranteed to be of an mtype in self.get_tag("X_inner_mtype")
+            Exogeneous time series for the forecast
+
+        Returns
+        -------
+        y_pred : sktime time series object
+            guaranteed to have a single column/variable
+            Point predictions
+
+        Notes
+        -----
+        This method does not use ``fh``, the one passed during ``fit`` takes precedence.
+        """
+        del fh  # to avoid being detected as unused by ``vulture`` etc.
+
+        predict_parameters: dict = {"verbose": self.verbose_predict}
+
+        # this block is probably unnecessary, but kept to be safe
+        # the check in fit ensures X is passed if futr_exog_list is non-empty
+        # base framework should ensure X is passed in predict in that case
+        if self.futr_exog_list and X is None:
+            raise ValueError("Missing exogeneous data, 'futr_exog_list' is non-empty.")
+
+        if self.futr_exog_list:
+            predict_indices = X.index
+            if isinstance(predict_indices, pandas.PeriodIndex):
+                predict_indices = predict_indices.to_timestamp(freq=self.freq)
+
+            predict_data = {self.id_col: 1, self.time_col: predict_indices.to_numpy()}
+
+            for column in self.futr_exog_list:
+                predict_data[column] = X[column].to_numpy()
+
+            predict_dataset = pandas.DataFrame(data=predict_data)
+
+            predict_parameters["futr_df"] = predict_dataset
+
+        model_forecasts = self._forecaster.predict(**predict_parameters)
+
+        prediction_column_names = [
+            column
+            for column in model_forecasts.columns
+            if column.startswith(self.algorithm_name)
+        ]
+
+        # this block is necessary only for specific values of ``loss``
+        # for example, when using ``MQLoss`` for multiple quantiles
+        if len(prediction_column_names) > 1:
+            raise NotImplementedError("Multiple prediction columns are not supported.")
+
+        model_point_predictions = model_forecasts[prediction_column_names[0]].to_numpy()
+
+        absolute_horizons = self.fh.to_absolute_index(self.cutoff)
+        horizon_positions = self.fh.to_indexer(self.cutoff)
+
+        final_predictions = pandas.Series(
+            model_point_predictions[horizon_positions],
+            index=absolute_horizons,
+            name=self._y.name,
+        )
+
+        return final_predictions

--- a/sktime/forecasting/base/adapters/_neuralforecast.py
+++ b/sktime/forecasting/base/adapters/_neuralforecast.py
@@ -68,7 +68,7 @@ class _NeuralForecastAdapter(BaseForecaster):
         self: "_NeuralForecastAdapter",
         freq: str,
         local_scaler_type: typing.Optional[
-            typing.Literal["standard", "robust", "robust-iqr", "minmax"]
+            typing.Literal["standard", "robust", "robust-iqr", "minmax", "boxcox"]
         ] = None,
         futr_exog_list: typing.Optional[typing.List[str]] = None,
         verbose_fit: bool = False,

--- a/sktime/forecasting/neuralforecast.py
+++ b/sktime/forecasting/neuralforecast.py
@@ -4,6 +4,7 @@ import functools
 import typing
 
 from sktime.forecasting.base.adapters._neuralforecast import _NeuralForecastAdapter
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 __author__ = ["yarnabrina"]
 
@@ -313,29 +314,52 @@ class NeuralForecastRNN(_NeuralForecastAdapter):
         """
         del parameter_set  # to avoid being detected as unused by ``vulture`` etc.
 
-        from neuralforecast.losses.pytorch import SMAPE, QuantileLoss
+        try:
+            _check_soft_dependencies("neuralforecast", severity="error")
+        except ModuleNotFoundError:
+            params = [
+                {
+                    "freq": "D",
+                    "inference_input_size": 2,
+                    "encoder_hidden_size": 2,
+                    "decoder_hidden_size": 3,
+                    "max_steps": 4,
+                    "trainer_kwargs": {"logger": False},
+                },
+                {
+                    "freq": "D",
+                    "inference_input_size": 2,
+                    "encoder_hidden_size": 2,
+                    "decoder_hidden_size": 3,
+                    "max_steps": 4,
+                    "val_check_steps": 2,
+                    "trainer_kwargs": {"logger": False},
+                },
+            ]
+        else:
+            from neuralforecast.losses.pytorch import SMAPE, QuantileLoss
 
-        params = [
-            {
-                "freq": "D",
-                "inference_input_size": 2,
-                "encoder_hidden_size": 2,
-                "decoder_hidden_size": 3,
-                "max_steps": 4,
-                "trainer_kwargs": {"logger": False},
-            },
-            {
-                "freq": "D",
-                "inference_input_size": 2,
-                "encoder_hidden_size": 2,
-                "decoder_hidden_size": 3,
-                "loss": QuantileLoss(0.5),
-                "valid_loss": SMAPE(),
-                "max_steps": 4,
-                "val_check_steps": 2,
-                "trainer_kwargs": {"logger": False},
-            },
-        ]
+            params = [
+                {
+                    "freq": "D",
+                    "inference_input_size": 2,
+                    "encoder_hidden_size": 2,
+                    "decoder_hidden_size": 3,
+                    "max_steps": 4,
+                    "trainer_kwargs": {"logger": False},
+                },
+                {
+                    "freq": "D",
+                    "inference_input_size": 2,
+                    "encoder_hidden_size": 2,
+                    "decoder_hidden_size": 3,
+                    "loss": QuantileLoss(0.5),
+                    "valid_loss": SMAPE(),
+                    "max_steps": 4,
+                    "val_check_steps": 2,
+                    "trainer_kwargs": {"logger": False},
+                },
+            ]
 
         return params
 

--- a/sktime/forecasting/neuralforecast.py
+++ b/sktime/forecasting/neuralforecast.py
@@ -158,7 +158,7 @@ class NeuralForecastRNN(_NeuralForecastAdapter):
         self: "NeuralForecastRNN",
         freq: str,
         local_scaler_type: typing.Optional[
-            typing.Literal["standard", "robust", "robust-iqr", "minmax"]
+            typing.Literal["standard", "robust", "robust-iqr", "minmax", "boxcox"]
         ] = None,
         futr_exog_list: typing.Optional[typing.List[str]] = None,
         verbose_fit: bool = False,

--- a/sktime/forecasting/neuralforecast.py
+++ b/sktime/forecasting/neuralforecast.py
@@ -1,0 +1,343 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Interfaces to estimators from neuralforecast by Nixtla."""
+import functools
+import typing
+
+from sktime.forecasting.base.adapters._neuralforecast import _NeuralForecastAdapter
+
+__author__ = ["yarnabrina"]
+
+
+class NeuralForecastRNN(_NeuralForecastAdapter):
+    """StatsForecast RNN model.
+
+    Interface to ``neuralforecast.models.RNN`` [1]_
+    through ``neuralforecast.NeuralForecast`` [2]_,
+    from ``neuralforecast`` [3]_ by Nixtla.
+
+    Multi Layer Elman RNN (RNN), with MLP decoder.
+    The network has `tanh` or `relu` non-linearities, it is trained using
+    ADAM stochastic gradient descent.
+
+    Parameters
+    ----------
+    freq : str
+        frequency of the data, see available frequencies [4]_ from ``pandas``
+    local_scaler_type : str (default=None)
+        scaler to apply per-series to all features before fitting, which is inverted
+        after predicting
+
+        can be one of the following:
+
+        - 'standard'
+        - 'robust'
+        - 'robust-iqr'
+        - 'minmax'
+        - 'boxcox'
+    futr_exog_list : str list, (default=None)
+        future exogenous variables
+    verbose_fit : bool (default=False)
+        print processing steps during fit
+    verbose_predict : bool (default=False)
+        print processing steps during predict
+    input_size : int (default=-1)
+        maximum sequence length for truncated train backpropagation
+
+        default (-1) uses all history
+    inference_input_size : int (default=-1)
+        maximum sequence length for truncated inference
+
+        default (-1) uses all history
+    encoder_n_layers : int (default=2)
+        number of layers for the RNN
+    encoder_hidden_size : int (default=200)
+        units for the RNN's hidden state size
+    encoder_activation : str (default="tanh")
+        type of RNN activation from `tanh` or `relu`
+    encoder_bias : bool (default=True)
+        whether or not to use biases b_ih, b_hh within RNN units
+    encoder_dropout : float (default=0.0)
+        dropout regularization applied to RNN outputs
+    context_size : int (default=10)
+        size of context vector for each timestamp on the forecasting window
+    decoder_hidden_size : int (default=200)
+        size of hidden layer for the MLP decoder
+    decoder_layers : int (default=2)
+        number of layers for the MLP decoder
+    loss : pytorch module (default=None)
+        instantiated train loss class from losses collection [5]_
+    valid_loss : pytorch module (default=None)
+        instantiated validation loss class from losses collection [5]_
+    max_steps : int (default=1000)
+        maximum number of training steps
+    learning_rate : float (default=1e-3)
+        learning rate between (0, 1)
+    num_lr_decays : int (default=-1)
+        number of learning rate decays, evenly distributed across max_steps
+    early_stop_patience_steps : int (default=-1)
+        number of validation iterations before early stopping
+    val_check_steps : int (default=100)
+        number of training steps between every validation loss check
+    batch_size : int (default=32)
+        number of different series in each batch
+    valid_batch_size : typing.Optional[int] (default=None)
+        number of different series in each validation and test batch
+    scaler_type : str (default="robust")
+        type of scaler for temporal inputs normalization
+    random_seed : int (default=1)
+        random_seed for pytorch initializer and numpy generators
+    num_workers_loader : int (default=0)
+        workers to be used by `TimeSeriesDataLoader`
+    drop_last_loader : bool (default=False)
+        whether `TimeSeriesDataLoader` drops last non-full batch
+    trainer_kwargs : dict (default=None)
+        keyword trainer arguments inherited from PyTorch Lighning's trainer [6]_
+
+    Notes
+    -----
+    * If ``loss`` is unspecified, MAE is used as the loss function for training.
+    * Only ``futr_exog_list`` will be considered as exogenous variables.
+
+    Examples
+    --------
+    >>>
+    >>> # importing necessary libraries
+    >>> from sktime.datasets import load_longley
+    >>> from sktime.forecasting.neuralforecast import NeuralForecastRNN
+    >>> from sktime.split import temporal_train_test_split
+    >>>
+    >>> # loading the Longley dataset and splitting it into train and test subsets
+    >>> y, X = load_longley()
+    >>> y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, test_size=4)
+    >>>
+    >>> # creating model instance configuring the hyperparameters
+    >>> model = NeuralForecastRNN(  # doctest: +SKIP
+    ...     "A-DEC", futr_exog_list=["ARMED", "POP"], max_steps=5
+    ... )
+    >>>
+    >>> # fitting the model
+    >>> model.fit(y_train, X=X_train, fh=[1, 2, 3, 4])  # doctest: +SKIP
+    Seed set to 1
+    Epoch 4: 100%|█| 1/1 [00:00<00:00, 42.85it/s, v_num=870, train_loss_step=0.589, train_loss_epoc
+    NeuralForecastRNN(freq='A-DEC', futr_exog_list=['ARMED', 'POP'], max_steps=5)
+    >>>
+    >>> # getting point predictions
+    >>> model.predict(X=X_test)  # doctest: +SKIP
+    Predicting DataLoader 0: 100%|██████████████████████████████████| 1/1 [00:00<00:00, 198.64it/s]
+    1959    66241.984375
+    1960    66700.125000
+    1961    66550.195312
+    1962    67310.007812
+    Freq: A-DEC, Name: TOTEMP, dtype: float64
+    >>>
+
+    References
+    ----------
+    .. [1] https://nixtlaverse.nixtla.io/neuralforecast/models.rnn.html#rnn
+    .. [2] https://nixtlaverse.nixtla.io/neuralforecast/core.html#neuralforecast
+    .. [3] https://github.com/Nixtla/neuralforecast/
+    .. [4] https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
+    .. [5] https://nixtlaverse.nixtla.io/neuralforecast/losses.pytorch.html
+    .. [6] https://lightning.ai/docs/pytorch/stable/api/pytorch_lightning.trainer.trainer.Trainer.html#lightning.pytorch.trainer.trainer.Trainer
+    """  # noqa: E501
+
+    _tags = {
+        # packaging info
+        # --------------
+        # "authors": ["yarnabrina"],
+        # "maintainers": ["yarnabrina"],
+        # "python_dependencies": "neuralforecast"
+        # inherited from _NeuralForecastAdapter
+        # estimator type
+        # --------------
+        "python_dependencies": ["neuralforecast>=1.6.4"],
+    }
+
+    def __init__(
+        self: "NeuralForecastRNN",
+        freq: str,
+        local_scaler_type: typing.Optional[
+            typing.Literal["standard", "robust", "robust-iqr", "minmax"]
+        ] = None,
+        futr_exog_list: typing.Optional[typing.List[str]] = None,
+        verbose_fit: bool = False,
+        verbose_predict: bool = False,
+        input_size: int = -1,
+        inference_input_size: int = -1,
+        encoder_n_layers: int = 2,
+        encoder_hidden_size: int = 200,
+        encoder_activation: str = "tanh",
+        encoder_bias: bool = True,
+        encoder_dropout: float = 0.0,
+        context_size: int = 10,
+        decoder_hidden_size: int = 200,
+        decoder_layers: int = 2,
+        loss=None,
+        valid_loss=None,
+        max_steps: int = 1000,
+        learning_rate: float = 1e-3,
+        num_lr_decays: int = -1,
+        early_stop_patience_steps: int = -1,
+        val_check_steps: int = 100,
+        batch_size=32,
+        valid_batch_size: typing.Optional[int] = None,
+        scaler_type: str = "robust",
+        random_seed=1,
+        num_workers_loader=0,
+        drop_last_loader=False,
+        trainer_kwargs: typing.Optional[dict] = None,
+    ):
+        self.input_size = input_size
+        self.inference_input_size = inference_input_size
+        self.encoder_n_layers = encoder_n_layers
+        self.encoder_hidden_size = encoder_hidden_size
+        self.encoder_activation = encoder_activation
+        self.encoder_bias = encoder_bias
+        self.encoder_dropout = encoder_dropout
+        self.context_size = context_size
+        self.decoder_hidden_size = decoder_hidden_size
+        self.decoder_layers = decoder_layers
+        self.loss = loss
+        self.valid_loss = valid_loss
+        self.max_steps = max_steps
+        self.learning_rate = learning_rate
+        self.num_lr_decays = num_lr_decays
+        self.early_stop_patience_steps = early_stop_patience_steps
+        self.val_check_steps = val_check_steps
+        self.batch_size = batch_size
+        self.valid_batch_size = valid_batch_size
+        self.scaler_type = scaler_type
+        self.random_seed = random_seed
+        self.num_workers_loader = num_workers_loader
+        self.drop_last_loader = drop_last_loader
+        self.trainer_kwargs = trainer_kwargs
+
+        super().__init__(
+            freq,
+            local_scaler_type=local_scaler_type,
+            futr_exog_list=futr_exog_list,
+            verbose_fit=verbose_fit,
+            verbose_predict=verbose_predict,
+        )
+
+        # initiate internal variables to avoid AttributeError in future
+        self._trainer_kwargs = None
+        self._loss = None
+        self._valid_loss = None
+
+    @functools.cached_property
+    def algorithm_exogenous_support(self: "NeuralForecastRNN") -> bool:
+        """Set support for exogenous features."""
+        return True
+
+    @functools.cached_property
+    def algorithm_name(self: "NeuralForecastRNN") -> str:
+        """Set custom model name."""
+        return "RNN"
+
+    @functools.cached_property
+    def algorithm_class(self: "NeuralForecastRNN"):
+        """Import underlying NeuralForecast algorithm class."""
+        from neuralforecast.models import RNN
+
+        return RNN
+
+    @functools.cached_property
+    def algorithm_parameters(self: "NeuralForecastRNN") -> dict:
+        """Get keyword parameters for the underlying NeuralForecast algorithm class.
+
+        Returns
+        -------
+        dict
+            keyword arguments for the underlying algorithm class
+        """
+        self._trainer_kwargs = (
+            {} if self.trainer_kwargs is None else self.trainer_kwargs
+        )
+
+        if self.loss:
+            self._loss = self.loss
+        else:
+            from neuralforecast.losses.pytorch import MAE
+
+            self._loss = MAE()
+
+        if self.valid_loss:
+            self._valid_loss = self.valid_loss
+
+        return {
+            "input_size": self.input_size,
+            "inference_input_size": self.inference_input_size,
+            "encoder_n_layers": self.encoder_n_layers,
+            "encoder_hidden_size": self.encoder_hidden_size,
+            "encoder_activation": self.encoder_activation,
+            "encoder_bias": self.encoder_bias,
+            "encoder_dropout": self.encoder_dropout,
+            "context_size": self.context_size,
+            "decoder_hidden_size": self.decoder_hidden_size,
+            "decoder_layers": self.decoder_layers,
+            "loss": self._loss,
+            "valid_loss": self._valid_loss,
+            "max_steps": self.max_steps,
+            "learning_rate": self.learning_rate,
+            "num_lr_decays": self.num_lr_decays,
+            "early_stop_patience_steps": self.early_stop_patience_steps,
+            "val_check_steps": self.val_check_steps,
+            "batch_size": self.batch_size,
+            "valid_batch_size": self.valid_batch_size,
+            "scaler_type": self.scaler_type,
+            "random_seed": self.random_seed,
+            "num_workers_loader": self.num_workers_loader,
+            "drop_last_loader": self.drop_last_loader,
+            **self._trainer_kwargs,
+        }
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for forecasters.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        del parameter_set  # to avoid being detected as unused by ``vulture`` etc.
+
+        from neuralforecast.losses.pytorch import SMAPE, QuantileLoss
+
+        params = [
+            {
+                "freq": "D",
+                "inference_input_size": 2,
+                "encoder_hidden_size": 2,
+                "decoder_hidden_size": 3,
+                "max_steps": 4,
+                "trainer_kwargs": {"logger": False},
+            },
+            {
+                "freq": "D",
+                "inference_input_size": 2,
+                "encoder_hidden_size": 2,
+                "decoder_hidden_size": 3,
+                "loss": QuantileLoss(0.5),
+                "valid_loss": SMAPE(),
+                "max_steps": 4,
+                "val_check_steps": 2,
+                "trainer_kwargs": {"logger": False},
+            },
+        ]
+
+        return params
+
+
+__all__ = ["NeuralForecastRNN"]

--- a/sktime/forecasting/tests/test_neuralforecast.py
+++ b/sktime/forecasting/tests/test_neuralforecast.py
@@ -1,0 +1,150 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for NeuralForecastRNN."""
+import pandas
+import pytest
+
+from sktime.datasets import load_longley
+from sktime.forecasting.neuralforecast import NeuralForecastRNN
+from sktime.split import temporal_train_test_split
+from sktime.tests.test_switch import run_test_for_class
+
+__author__ = ["yarnabrina"]
+
+y, X = load_longley()
+y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, test_size=4)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(NeuralForecastRNN),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_neural_forecast_rnn_univariate_y_without_X() -> None:
+    """Test NeuralForecastRNN with single endogenous without exogenous."""
+    # define model
+    model = NeuralForecastRNN("A-DEC", max_steps=5, trainer_kwargs={"logger": False})
+
+    # attempt fit with negative fh
+    with pytest.raises(
+        NotImplementedError, match="in-sample prediction is currently not supported"
+    ):
+        model.fit(y_train, fh=[-2, -1, 0, 1, 2])
+
+    # train model
+    model.fit(y_train, fh=[1, 2, 3, 4])
+
+    # predict with trained model
+    y_pred = model.predict()
+
+    # check prediction index
+    pandas.testing.assert_index_equal(y_pred.index, y_test.index, check_names=False)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(NeuralForecastRNN),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_neural_forecast_rnn_univariate_y_with_X() -> None:
+    """Test NeuralForecastRNN with single endogenous with exogenous."""
+    # select feature columns
+    exog_list = ["GNPDEFL", "GNP", "UNEMP"]
+
+    # define model
+    model = NeuralForecastRNN(
+        "A-DEC", futr_exog_list=exog_list, max_steps=5, trainer_kwargs={"logger": False}
+    )
+
+    # attempt fit without X
+    with pytest.raises(
+        ValueError, match="Missing exogeneous data, 'futr_exog_list' is non-empty."
+    ):
+        model.fit(y_train, fh=[1, 2, 3, 4])
+
+    # train model with all X columns
+    model.fit(y_train, X=X_train, fh=[1, 2, 3, 4])
+
+    # attempt predict without X
+    with pytest.raises(
+        ValueError, match="Missing exogeneous data, 'futr_exog_list' is non-empty."
+    ):
+        model.predict()
+
+    # predict with only selected columns
+    # checking that rest are not used
+    y_pred = model.predict(X=X_test[exog_list])
+
+    # check prediction index
+    pandas.testing.assert_index_equal(y_pred.index, y_test.index, check_names=False)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(NeuralForecastRNN),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_neural_forecast_rnn_multivariate_y_without_X() -> None:
+    """Test NeuralForecastRNN with multiple endogenous without exogenous."""
+    # define model
+    model = NeuralForecastRNN("A-DEC", max_steps=5, trainer_kwargs={"logger": False})
+
+    # train model
+    model.fit(X_train, fh=[1, 2, 3, 4])
+
+    # predict with trained model
+    X_pred = model.predict()
+
+    # check prediction index
+    pandas.testing.assert_index_equal(X_pred.index, X_test.index, check_names=False)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(NeuralForecastRNN),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_neural_forecast_rnn_with_non_default_loss() -> None:
+    """Test NeuralForecastRNN with multiple endogenous without exogenous."""
+    # import non-default pytorch losses
+    from neuralforecast.losses.pytorch import MASE, HuberQLoss
+
+    # define model
+    model = NeuralForecastRNN(
+        "A-DEC",
+        loss=HuberQLoss(0.5),
+        valid_loss=MASE(1),
+        max_steps=5,
+        trainer_kwargs={"logger": False},
+    )
+
+    # train model
+    model.fit(X_train, fh=[1, 2, 3, 4])
+
+    # predict with trained model
+    X_pred = model.predict()
+
+    # check prediction index
+    pandas.testing.assert_index_equal(X_pred.index, X_test.index, check_names=False)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(NeuralForecastRNN),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_neural_forecast_rnn_fail_with_multiple_predictions() -> None:
+    """Check NeuralForecastRNN fail when multiple prediction columns are used."""
+    # import pytorch losses with multiple predictions capability
+    from neuralforecast.losses.pytorch import MQLoss
+
+    # define model
+    model = NeuralForecastRNN(
+        "A-DEC",
+        loss=MQLoss(quantiles=[0.25, 0.5, 0.75]),
+        max_steps=5,
+        trainer_kwargs={"logger": False},
+    )
+
+    # train model
+    model.fit(X_train, fh=[1, 2, 3, 4])
+
+    # attempt predict
+    with pytest.raises(
+        NotImplementedError, match="Multiple prediction columns are not supported."
+    ):
+        model.predict()


### PR DESCRIPTION
Adapter class to `neuralforecast` from `Nixtla` and concrete estimator for `RNN`.

Notes for reviewers (not in any particular order)

1. `neuralforecast` supports 3 types of exogenous features: static (constant over time), historical (unknown for prediction horizon) and future (known for prediction horizon). I felt the static type has no predictive capability if models are trained per series, and as far as I know, sktime will not be able to support historical type for framework compatibilities. Hence in this first draft of adaptation, I have added support for only future type.

2. `neuralforecast` has the capability of directly supporting panel/hierarchical datasets directly. I am not sure how to take benefit of that in sktime, so have not used it in this first draft. If it's easy enough to support, I can update if some references are shared, otherwise this can definitely be a extension.

3. ~`RNN` in `neuralforecast` supports specification of loss and validation loss, but they needs to be instances of [pytorch loss functions](https://nixtlaverse.nixtla.io/neuralforecast/losses.pytorch.html). I am not sure how set these defaults in instance, as soft dependencies can not be checked there. I have hence not exposed these parameters and rely on the defaults, but this is both important and common parameter. With some suggestions and references, I will like to enhance this in this draft itself.~ Added some support using internal attributes.

4. `neuralforecast` does support probablistic forecasts, but it seems that depends on choice of loss function (and may be something more, not sure). In this first draft, I have not added that support so far and this can be part of an extension.

5. `neuralforecast` has a public `NeuralForecast` class which accepts `pandas.DataFrame` objects of special schema directly, and has the ability to train multiple models and find best one. The underlying models do not support `pandas.DataFrame` directly and relies of `TimeSeriesDataset`, a sub-class of `torch.utils.data.Dataset`. For simplification with most other forecasters, I opted for the higher level class.

6. `neuralforecast` supports in-sample predictions, but warns that those may be inaccurate. Since the library itself is marked as `Alpha`, I have disabled entire support of in-sample predictions for now.

7. `neuralforecast` takes a lot of dependencies, and adding it in `forecasting` extra may cause too much installation for users who won't use it. But adding it in `dl` extra means new CI is not going to test it, so we need to decide what to do.

8. ~`neuralforecast` supports a lot of models, and (hopefully) all of them can be used with the adapter in this PR. However that is a lot of models, and it leads to the question of how should we organise them, by model or by dependency or by both or by something else.~ Modified only `dl` dependency similar to other recent PR's that affect torch/tensorflow etc.