### PR TITLE
[ENH] forecasting test scenarios for categorical variables

### DIFF
--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -190,6 +190,14 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj", panel=T
         msg = f"{var_name} must have a MultiIndex, found {type(obj.index)}"
         return _ret(False, msg, None, return_metadata)
 
+    # check to delineate from nested_univ mtype (Hierarchical)
+    # pd.DataFrame mtype allows object dtype,
+    # but if we allow object dtype with Panel entries,
+    # the mtype becomes ambiguous, i.e., non-delineable from nested_univ
+    if np.prod(obj.shape) > 0 and isinstance(obj.iloc[0, 0], (pd.Series, pd.DataFrame)):
+        msg = f"{var_name} cannot contain nested pd.Series or pd.DataFrame"
+        return _ret(False, msg, None, return_metadata)
+
     index = obj.index
 
     # check that columns are unique

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -198,11 +198,6 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj", panel=T
         msg = f"{var_name} must have unique column indices, but found {col_names}"
         return _ret(False, msg, None, return_metadata)
 
-    # check that no dtype is object
-    if "object" in obj.dtypes.values:
-        msg = f"{var_name} should not have column of 'object' dtype"
-        return _ret(False, msg, None, return_metadata)
-
     # check that there are precisely two index levels
     nlevels = index.nlevels
     if panel is True and not nlevels == 2:

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -87,11 +87,6 @@ def check_pddataframe_series(obj, return_metadata=False, var_name="obj"):
         )
         return ret(False, msg, None, return_metadata)
 
-    # check that no dtype is object
-    if "object" in obj.dtypes.values:
-        msg = f"{var_name} should not have column of 'object' dtype"
-        return ret(False, msg, None, return_metadata)
-
     # Check time index is ordered in time
     if not index.is_monotonic_increasing:
         msg = (
@@ -138,11 +133,6 @@ def check_pdseries_series(obj, return_metadata=False, var_name="obj"):
             metadata["feature_names"] = [0]
         else:
             metadata["feature_names"] = [obj.name]
-
-    # check that dtype is not object
-    if "object" == obj.dtypes:
-        msg = f"{var_name} should not be of 'object' dtype"
-        return ret(False, msg, None, return_metadata)
 
     # check whether the time index is of valid type
     if not is_in_valid_index_types(index):
@@ -314,11 +304,6 @@ if _check_soft_dependencies("xarray", severity="none"):
                 f"{type(index)} is not supported for {var_name}, use "
                 f"one of {VALID_INDEX_TYPES} or integer index instead."
             )
-            return ret(False, msg, None, return_metadata)
-
-        # check that the dtype is not object
-        if "object" == obj.dtype:
-            msg = f"{var_name} should not have column of 'object' dtype"
             return ret(False, msg, None, return_metadata)
 
         # Check time index is ordered in time

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -63,6 +63,14 @@ def check_pddataframe_series(obj, return_metadata=False, var_name="obj"):
         msg = f"{var_name} must be a pandas.DataFrame, found {type(obj)}"
         return ret(False, msg, None, return_metadata)
 
+    # check to delineate from nested_univ mtype (Panel)
+    # pd.DataFrame mtype allows object dtype,
+    # but if we allow object dtype with pd.Series entries,
+    # the mtype becomes ambiguous, i.e., non-delineable from nested_univ
+    if np.prod(obj.shape) > 0 and isinstance(obj.iloc[0, 0], (pd.Series, pd.DataFrame)):
+        msg = f"{var_name} cannot contain nested pd.Series or pd.DataFrame"
+        return ret(False, msg, None, return_metadata)
+
     # we now know obj is a pd.DataFrame
     index = obj.index
     if _req("is_empty", return_metadata):

--- a/sktime/datatypes/tests/test_check.py
+++ b/sktime/datatypes/tests/test_check.py
@@ -3,12 +3,14 @@
 __author__ = ["fkiraly"]
 
 import numpy as np
+import pandas
 
 from sktime.datatypes._check import (
     AMBIGUOUS_MTYPES,
     check_dict,
     check_is_mtype,
     check_is_scitype,
+    check_raise,
 )
 from sktime.datatypes._check import mtype as infer_mtype
 from sktime.datatypes._check import scitype as infer_scitype
@@ -441,3 +443,14 @@ def test_scitype_infer(scitype, mtype, fixture_index):
         assert scitype == infer_scitype(
             fixture, candidate_scitypes=SCITYPES_FOR_INFER_TEST
         ), f"scitype {scitype} not correctly identified for fixture {fixture_index}"
+
+
+def test_object_support_for_series_scitype() -> None:
+    """Test that passing object dtype does not fail series scitype check."""
+
+    sample_dataset = pandas.Series(
+        np.random.default_rng().choice(["A", "B"], size=(31 + 29 + 31), replace=True),
+        index=pandas.date_range(start="2000-01-01", end="2000-03-31", freq="D"),
+    )
+
+    assert check_raise(sample_dataset, "pd.Series")

--- a/sktime/utils/_testing/scenarios_forecasting.py
+++ b/sktime/utils/_testing/scenarios_forecasting.py
@@ -272,6 +272,49 @@ class ForecasterFitPredictHierarchicalSimple(ForecasterTestScenario):
     default_method_sequence = ["fit", "predict"]
 
 
+y_cat = s = pd.Series(["a", "b", "c", "a", "b", "c", "a", "b", "c"], dtype="category")
+
+
+class ForecasterFitPredictCategorical(ForecasterTestScenario):
+    """Fit/predict only, categorical y."""
+
+    _tags = {"univariate_y": True, "fh_passed_in_fit": True, "is_enabled": True}
+
+    args = {"fit": {"y": y_cat, "fh": [1, 2, 3]}, "predict": {}}
+    default_method_sequence = ["fit", "predict"]
+
+
+X_cat = pd.DataFrame(	
+    {
+        "a": ["a", "b", "c", "a", "b", "c", "a", "b", "c", "c"],
+        "b": [1, 2, 3, 4, 5, 6, 7, 7, 8, 9],
+    },
+).astype({"a": "category", "b": "float64"})
+
+X_cat_test = pd.DataFrame(
+    {
+        "a": ["a", "b", "c"],
+        "b": [10, 11, 12],
+    },
+).astype({"a": "category", "b": "float64"})
+
+
+class ForecasterFitPredictCategoricalExog(ForecasterTestScenario):
+    """Fit/predict only, numerical y categorical X."""
+
+    _tags = {"univariate_y": True, "fh_passed_in_fit": True, "is_enabled": True}
+
+    args = {
+        "fit": {
+            "y": _make_series(n_timepoints=10, n_columns=1, random_state=RAND_SEED),
+            "X": X_cat.copy(),
+            "fh": [1, 2, 3],
+        },
+        "predict": {"X": X_cat_test.copy()},
+    }
+    default_method_sequence = ["fit", "predict"]
+
+
 forecasting_scenarios_simple = [
     ForecasterFitPredictUnivariateNoX,
     ForecasterFitPredictMultivariateWithX,


### PR DESCRIPTION
This PR adds two test scenarios for use of categorical variables in forecasting:

* `ForecasterFitPredictCategorical`, with a categorical univariate `y` and no exogeneous data
* `ForecasterFitPredictCategoricalExog`, with a mixed categorical/float exogeneous `X`, and float univariate `y`

Depends on https://github.com/sktime/sktime/pull/5962 which relaxes the `pandas` based types to allow categorical and object data.

FYI @yarnabrina - this test should systematically run all forecaster test parameter settings with the given input.