### PR TITLE
[DOC] improved glossary and forecasting docstrings

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -6,27 +6,81 @@ Glossary of Common Terms
 The glossary below defines common terms and API elements used throughout
 sktime.
 
-.. note::
-
-    The glossary is under development. Important terms are still missing.
-    Please create a pull request if you want to add one.
-
-
 .. glossary::
     :sorted:
 
-    Scitype
-        See :term:`scientific type`.
+    mtype
+        ``sktime`` supports multiple in-memory specifications for time series data
+        and other objects. Such an in-memory specification is called ``mtype``
+        (short for "machine type").
+        Each ``mtype`` is represented by a string - e.g., ``pd-multiindex``,
+        which defines the data format and the data structure.
+        For example, a ``pd-multiindex`` mtype is a collection of time series,
+        represented as a 2-level ``MultiIndex``-ed ``pandas.DataFrame``, with
+        columns representing variables, rows indexed by ``(instance, timepoint)``,
+        where the ``timepoint`` level must be range-like or datetime-like.
+        Each mtype implements an abstract data type, a (data) :term:`scitype`,
+        for instance ``Panel`` which refers to the abstract type of a collection
+        of time series, with instance, timepoint and variable dimensions.
+        In this terminology, the ``pd-multiindex`` mtype implements the (abstract)
+        ``Panel`` scitype. Data containers can be checked for compliance with
+        a given mtype using the :func:`sktime.datatypes.check_is_mtype` function;
+        all mtypes can be listed in ``sktime.datatypes.MTYPE_REGISTER``.
+        For more details on the general concept, see
+        `the datatypes and datasets user guide <https://www.sktime.net/en/latest/examples/AA_datatypes_and_datasets.html>`_.
+
+    scitype
+        Short for scientific type, denotes the abstract type of an ``sktime`` object,
+        data container or estimator. One example of an estimator scitype is ``"forecaster"``,
+        which denotes the abstract concept of a forecaster with (abstract) ``fit``, ``predict``,
+        ``update`` methods. An example of a data scitype is ``Panel``, denoting
+        the abstract concept of an indexed collection of time series.
+        Scitypes are represented by strings, and are implemented by concrete types.
+        For data containers, concrete types are :term:`mtype`-s (see there), for
+        estimators, concrete types are python base interfaces, such as defined
+        by ``BaseForecaster`` or ``BaseClassifier``. Valid estimator scitypes,
+        with their corresponding base classes,
+        are listed in ``sktime.registry.BASE_CLASS_SCITYPE_LIST``.
+        All estimators of a given scitype can be listed using
+        ``sktime.registry.all_estimators``, and the scitype of a given estimator
+        can be inferred by the ``sktime.registry.scitype`` utility.
+        Compliance with concrete implementations of data scitypes can be checked using
+        the ``sktime.datatypes.check_is_scitype`` utility; for estimators, compliance
+        is checked using ``sktime.utils.check_estimator``.
+        For more details on data scitpyes, see :term:`mtype`.
+        For more details on estimator scitypes, see the user guides on individual
+        learning tasks.
 
     Scientific type
-        A class or object type to denote a category of objects defined by a
-        common python class interface and data scientific purpose.
-        For example, "forecaster" or "classifier", and the interface defined in
-        ``BaseForecaster`` or ``BaseClassifier``.
+        See :term:`scitype`.
+
+    Tag
+        Tags are string keyed value fields, used to identify properties of an object,
+        or set flags for internal boilerplate. An example of a tag is
+        ``capability:multivariate``, a boolean flag, which indicates whether the object
+        offers genuine support for multivariate time series.
+        Objects with a given capability - that is, objects filtering by
+        certain tag value - can be listed or filtered using
+        ``sktime.registry.all_estimators``.
+        In ``sktime``, most objects are ``scikit-base`` objects and implement
+        the tag interface via ``get_tag`` or ``get_tags``.
+        Some tags are for internal or extender use only, e.g., ``X_inner_mtype``,
+        which allows an extender to specify the mtype of the inner data container
+        they would like to work with.
+        A list of all tags and their meaning, optinally filtered by the :term:`scitype`
+        of object they apply to, can be obtained from
+        ``sktime.registry.all_tags``. Further details on tags, for developers,
+        can be found in the specification sheet that is part of the :ref:`extension templates`.
+
+    Extension templates
+
 
     Estimator
-        An algorithm of a specific :term:`scientific type`, implementing the python
-        class interface defined by it. For example, the ``ARIMA`` class.
+        An algorithm of a specific :term:`scitype`, implementing the python
+        class interface defined by the scitype.
+        Individual estimators correspond to concrete classes, implementing the
+        interface defined by the base class for the scitype.
+        For example, the ``ARIMA`` class is an estimator of :term:`scitype` ``"forecaster"``.
 
     Composite estimator
         An :term:`estimator` that consists of multiple other component estimators which

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -27,7 +27,7 @@ sktime.
         a given mtype using the :func:`sktime.datatypes.check_is_mtype` function;
         all mtypes can be listed in ``sktime.datatypes.MTYPE_REGISTER``.
         For more details on the general concept, see
-        `the datatypes and datasets user guide <https://www.sktime.net/en/latest/examples/AA_datatypes_and_datasets.html>`_.
+        `the datatypes and datasets user guide <https://www.sktime.net/en/stable/examples/AA_datatypes_and_datasets.html>`_.
 
     scitype
         Short for scientific type, denotes the abstract type of an ``sktime`` object,
@@ -116,7 +116,7 @@ sktime.
         An :term:`estimator` that consists of multiple other component estimators which
         can vary. An example is a pipeline consisting of a transformer and
         forecaster. The term can refer both to the class and its instance.
-        Composite estimators may have :term:`tag`s that depend on components, such as
+        For composite estimators, a :term:`tag` can depend on components, such as
         ``capability:missing_data``,
         and a :term:`scitype` that depends on the components' scitypes, e.g., the
         scitype of a pipeline being a forecaster or a classifier, depending on

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -70,10 +70,29 @@ sktime.
         A list of all tags and their meaning, optinally filtered by the :term:`scitype`
         of object they apply to, can be obtained from
         ``sktime.registry.all_tags``. Further details on tags, for developers,
-        can be found in the specification sheet that is part of the :ref:`extension templates`.
+        can be found in the specification sheet that is part of the :term:`extension templates`.
 
     Extension templates
-
+        ``sktime`` is designed to be easily extendable, with 3rd and 1st party
+        additions in the form of API compliant objects. To facilitate this, ``sktime``
+        provides a set of extension templates for power users to implement their own
+        objects, such as forecasters, transformers, classifiers.
+        The extension templates are found in the ``extension_templates`` folder,
+        these are fill-in-the-blank templates that can be used to create new
+        objects compliant with the ``sktime`` API.
+        Each template is specific to the :term:`scitype` of the object to be implemented,
+        and there are different templates for a given :term:`scitype`, depending on
+        simplicity vs feature richness.
+        The templates instruct a power user on setting of :term:`tags`,
+        and implementation of :term:`scitype`-specific methods. The methods are usually
+        private, e.g., ``_fit``, ``_predict``, while boilerplate is taken care of
+        by the base class.
+        For further details and a step-by-step tutorial on 1st and 3rd party
+        extensions, see the guide on :ref:`developer_guide_add_estimators`.
+        For power users familiar with software engineering
+        patterns: the extension templates make use of the template pattern for
+        the extension contract, ensuring compliance with the strategy pattern for
+        the user contract, defined by the :term:`scitype` specific interface.
 
     Estimator
         An algorithm of a specific :term:`scitype`, implementing the python
@@ -81,11 +100,31 @@ sktime.
         Individual estimators correspond to concrete classes, implementing the
         interface defined by the base class for the scitype.
         For example, the ``ARIMA`` class is an estimator of :term:`scitype` ``"forecaster"``.
+        Users should distinguish the python class, which can be seen as a blueprint,
+        from an instance, which is a concrete object created from the blueprint,
+        with specific parameter settings, and which can be fitted or applied to data.
+        Somewhat confusingly, both the class (blueprint) and the instance (concrete object)
+        are often referred to as "estimator" in ``scikit-learn`` parlance.
+        Users should also take note of the distinction between "concrete class" in
+        software engineering terms, which is the ``ARIMA`` (python) class, as it implements
+        ``BaseForecaster`` (the "abstract class"), and the  "concrete object",
+        which is a python instance of a python class.
+        Estimators are objects with a ``fit`` method - not all :term:`scitype`-s
+        in ``sktime`` are estimators, e.g., performance metrics.
 
     Composite estimator
         An :term:`estimator` that consists of multiple other component estimators which
-        can vary. An example would be a pipeline consisting of a transformer and
-        forecaster.
+        can vary. An example is a pipeline consisting of a transformer and
+        forecaster. The term can refer both to the class and its instance.
+        Composite estimators may have :term:`tag`s that depend on components, such as
+        ``capability:missing_data``,
+        and a :term:`scitype` that depends on the components' scitypes, e.g., the
+        scitype of a pipeline being a forecaster or a classifier, depending on
+        whether its last element is a forecaster or a classifier.
+        Users familiar with software engineering patterns should note that this term
+        may be used in a different sense than "composite pattern":
+        in the context of ``scikit-learn``, the "composite estimator"
+        combines both the composite pattern and the strategy pattern.
 
     Hyperparameter:
         A parameter of a machine learning model that is set at construction.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -325,7 +325,7 @@ class BaseForecaster(BaseEstimator):
 
         Parameters
         ----------
-        y : time series in sktime compatible data container format
+        y : time series in ``sktime`` compatible data container format.
             Time series to which to fit the forecaster.
 
             Individual data formats in ``sktime`` are so-called :term:`mtype`
@@ -351,11 +351,12 @@ class BaseForecaster(BaseEstimator):
             If ``self.get_tag("requires-fh-in-fit")`` is ``True``,
             must be passed, in ``fit``, not optional
 
-        X : time series in sktime compatible format, optional (default=None)
+        X : time series in ``sktime`` compatible format, optional (default=None).
             Exogeneous time series to fit the model to.
-            Should be of same scitype (Series, Panel, or Hierarchical) as y
-            if self.get_tag("X-y-must-have-same-index"), X.index must contain y.index
-            there are no restrictions on number of columns (unlike for y)
+            Should be of same :term:`scitype` (``Series``, ``Panel``,
+            or ``Hierarchical``) as ``y``.
+            If ``self.get_tag("X-y-must-have-same-index")``,
+            ``X.index`` must contain ``y.index``.
 
         Returns
         -------
@@ -397,32 +398,37 @@ class BaseForecaster(BaseEstimator):
         """Forecast time series at future horizon.
 
         State required:
-            Requires state to be "fitted".
+            Requires state to be "fitted", i.e., ``self.is_fitted=True``.
 
         Accesses in self:
-            Fitted model attributes ending in "_".
-            self.cutoff, self._is_fitted
+
+            * Fitted model attributes ending in "_".
+            * ``self.cutoff``, ``self.is_fitted``
 
         Writes to self:
-            Stores fh to self.fh if fh is passed and has not been passed previously.
+            Stores ``fh`` to ``self.fh`` if ``fh`` is passed and has not been passed
+            previously.
 
         Parameters
         ----------
-        fh : int, list, np.array or ForecastingHorizon, optional (default=None)
+        fh : int, list, np.array or ``ForecastingHorizon``, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
-            if has not been passed in fit, must be passed, not optional
-        X : time series in sktime compatible format, optional (default=None)
-                Exogeneous time series to fit to
-            Should be of same scitype (Series, Panel, or Hierarchical) as y in fit
-            if self.get_tag("X-y-must-have-same-index"), X.index must contain fh.index
-            there are no restrictions on number of columns (unlike for y)
+            Need not be passed if has already been passed in ``fit``.
+            If has not been passed in fit, must be passed, not optional
+
+        X : time series in ``sktime`` compatible format, optional (default=None)
+            Exogeneous time series to use in prediction.
+            Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
+            as ``y`` in ``fit``.
+            If ``self.get_tag("X-y-must-have-same-index")``,
+            ``X.index`` must contain ``fh.index``.
 
         Returns
         -------
         y_pred : time series in sktime compatible data container format
-            Point forecasts at fh, with same index as fh
-            y_pred has same type as the y that has been passed most recently:
-                Series, Panel, Hierarchical scitype, same format (see above)
+            Point forecasts at ``fh``, with same index as ``fh``.
+            ``y_pred`` has same type as the ``y`` that has been passed most recently:
+            ``Series``, ``Panel``, ``Hierarchical`` scitype, same format (see above)
         """
         # handle inputs
 
@@ -459,55 +465,62 @@ class BaseForecaster(BaseEstimator):
         State change:
             Changes state to "fitted".
 
-        Writes to self:
-            Sets is_fitted flag to True.
-            Writes self._y and self._X with `y` and `X`, respectively.
-            Sets self.cutoff and self._cutoff to last index seen in `y`.
-            Sets fitted model attributes ending in "_".
-            Stores fh to self.fh.
+        Writes to self:                
+
+            * Sets fitted model attributes ending in "_", fitted attributes are
+              inspectable via ``get_fitted_params``.
+            * Sets ``self.is_fitted`` flag to ``True``.
+            * Sets ``self.cutoff`` to last index seen in `y`.
+            * Stores ``fh`` to ``self.fh``.
 
         Parameters
         ----------
         y : time series in sktime compatible data container format
             Time series to which to fit the forecaster.
-            y can be in one of the following formats:
-            Series scitype: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
-            for vanilla forecasting, one time series
-            Panel scitype: pd.DataFrame with 2-level row MultiIndex,
-            3D np.ndarray, list of Series pd.DataFrame, or nested pd.DataFrame
-            for global or panel forecasting
-            Hierarchical scitype: pd.DataFrame with 3 or more level row MultiIndex
-            for hierarchical forecasting
-            Number of columns admissible depend on the "scitype:y" tag:
-            if self.get_tag("scitype:y")=="univariate":
-            y must have a single column/variable
-            if self.get_tag("scitype:y")=="multivariate":
-            y must have 2 or more columns
-            if self.get_tag("scitype:y")=="both": no restrictions on columns apply
-            For further details:
-            on usage, see forecasting tutorial examples/01_forecasting.ipynb
-            on specification of formats, examples/AA_datatypes_and_datasets.ipynb
-        fh : int, list, np.array or ForecastingHorizon (not optional)
+
+            Individual data formats in ``sktime`` are so-called :term:`mtype`
+            specifications, each mtype implements an abstract :term:`scitype`.
+
+            * ``Series`` scitype = individual time series, vanilla forecasting.
+              ``pd.DataFrame``, ``pd.Series``, or ``np.ndarray`` (1D or 2D)
+
+            * ``Panel`` scitype = collection of time series, global/panel forecasting.
+              ``pd.DataFrame`` with 2-level row ``MultiIndex`` ``(instance, time)``,
+              ``3D np.ndarray`` ``(instance, variable, time)``,
+              ``list`` of ``Series`` typed ``pd.DataFrame``
+
+            * ``Hierarchical`` scitype = hierarchical collection, for
+              hierarchical forecasting. ``pd.DataFrame`` with 3 or more level row
+              ``MultiIndex`` ``(hierarchy_1, ..., hierarchy_n, time)``
+
+            For further details on data format, see glossary on :term:`mtype`.
+            For usage, see forecasting tutorial ``examples/01_forecasting.ipynb``
+
+                    fh : int, list, np.array or ForecastingHorizon (not optional)
             The forecasting horizon encoding the time stamps to forecast at.
             if has not been passed in fit, must be passed, not optional
-        X : time series in sktime compatible format, optional (default=None)
-            Exogeneous time series to fit to
-            Should be of same scitype (Series, Panel, or Hierarchical) as y in fit
-            If ``self.get_tag("X-y-must-have-same-index")`` is True,
-            X.index must contain y.index.
-            If, in addition, X_pred is not passed, X must also contain fh.index.
+
+        X : time series in ``sktime`` compatible format, optional (default=None).
+            Exogeneous time series to fit the model to.
+            Should be of same :term:`scitype` (``Series``, ``Panel``,
+            or ``Hierarchical``) as ``y``.
+            If ``self.get_tag("X-y-must-have-same-index")``,
+            ``X.index`` must contain ``y.index``.
+
         X_pred : time series in sktime compatible format, optional (default=None)
-            Exogeneous time series to use in predict
+            Exogeneous time series to use in prediction.
             If passed, will be used in predict instead of X.
-            If ``self.get_tag("X-y-must-have-same-index")`` is True,
-            X_pred.index must contain fh.index.
+            Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
+            as ``y`` in ``fit``.
+            If ``self.get_tag("X-y-must-have-same-index")``,
+            ``X.index`` must contain ``fh.index``.
 
         Returns
         -------
         y_pred : time series in sktime compatible data container format
-            Point forecasts at fh, with same index as fh
-            y_pred has same type as the y that has been passed most recently:
-                Series, Panel, Hierarchical scitype, same format (see above)
+            Point forecasts at ``fh``, with same index as ``fh``.
+            ``y_pred`` has same type as the ``y`` that has been passed most recently:
+            ``Series``, ``Panel``, ``Hierarchical`` scitype, same format (see above)
         """
         # if X_pred is passed, run fit/predict with different X
         if X_pred is not None:
@@ -545,27 +558,34 @@ class BaseForecaster(BaseEstimator):
     def predict_quantiles(self, fh=None, X=None, alpha=None):
         """Compute/return quantile forecasts.
 
-        If alpha is iterable, multiple quantiles will be calculated.
+        If ``alpha`` is iterable, multiple quantiles will be calculated.
 
         State required:
-            Requires state to be "fitted".
+            Requires state to be "fitted", i.e., ``self.is_fitted=True``.
 
         Accesses in self:
-            Fitted model attributes ending in "_".
-            self.cutoff, self._is_fitted
+
+            * Fitted model attributes ending in "_".
+            * ``self.cutoff``, ``self.is_fitted``
 
         Writes to self:
-            Stores fh to self.fh if fh is passed and has not been passed previously.
+            Stores ``fh`` to ``self.fh`` if ``fh`` is passed and has not been passed
+            previously.
 
         Parameters
         ----------
-        fh : int, list, np.array or ForecastingHorizon (not optional)
+        fh : int, list, np.array or ``ForecastingHorizon``, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
-            if has not been passed in fit, must be passed, not optional
-        X : time series in sktime compatible format, optional (default=None)
-                Exogeneous time series to fit to
-            Should be of same scitype (Series, Panel, or Hierarchical) as y in fit
-            if self.get_tag("X-y-must-have-same-index"), must contain fh.index
+            Need not be passed if has already been passed in ``fit``.
+            If has not been passed in fit, must be passed, not optional
+
+        X : time series in ``sktime`` compatible format, optional (default=None)
+            Exogeneous time series to use in prediction.
+            Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
+            as ``y`` in ``fit``.
+            If ``self.get_tag("X-y-must-have-same-index")``,
+            ``X.index`` must contain ``fh.index``.
+
         alpha : float or list of float of unique values, optional (default=[0.05, 0.95])
             A probability or list of, at which quantile forecasts are computed.
 
@@ -619,27 +639,34 @@ class BaseForecaster(BaseEstimator):
     def predict_interval(self, fh=None, X=None, coverage=0.90):
         """Compute/return prediction interval forecasts.
 
-        If coverage is iterable, multiple intervals will be calculated.
+        If ``coverage`` is iterable, multiple intervals will be calculated.
 
         State required:
-            Requires state to be "fitted".
+            Requires state to be "fitted", i.e., ``self.is_fitted=True``.
 
         Accesses in self:
-            Fitted model attributes ending in "_".
-            self.cutoff, self._is_fitted
+
+            * Fitted model attributes ending in "_".
+            * ``self.cutoff``, ``self.is_fitted``
 
         Writes to self:
-            Stores fh to self.fh if fh is passed and has not been passed previously.
+            Stores ``fh`` to ``self.fh`` if ``fh`` is passed and has not been passed
+            previously.
 
         Parameters
         ----------
-        fh : int, list, np.array or ForecastingHorizon (not optional)
+        fh : int, list, np.array or ``ForecastingHorizon``, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
-            if has not been passed in fit, must be passed, not optional
-        X : time series in sktime compatible format, optional (default=None)
-                Exogeneous time series to fit to
-            Should be of same scitype (Series, Panel, or Hierarchical) as y in fit
-            if self.get_tag("X-y-must-have-same-index"), must contain fh.index
+            Need not be passed if has already been passed in ``fit``.
+            If has not been passed in fit, must be passed, not optional
+
+        X : time series in ``sktime`` compatible format, optional (default=None)
+            Exogeneous time series to use in prediction.
+            Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
+            as ``y`` in ``fit``.
+            If ``self.get_tag("X-y-must-have-same-index")``,
+            ``X.index`` must contain ``fh.index``.
+
         coverage : float or list of float of unique values, optional (default=0.90)
            nominal coverage(s) of predictive interval(s)
 
@@ -695,25 +722,31 @@ class BaseForecaster(BaseEstimator):
         """Compute/return variance forecasts.
 
         State required:
-            Requires state to be "fitted".
+            Requires state to be "fitted", i.e., ``self.is_fitted=True``.
 
         Accesses in self:
-            Fitted model attributes ending in "_".
-            self.cutoff, self._is_fitted
+
+            * Fitted model attributes ending in "_".
+            * ``self.cutoff``, ``self.is_fitted``
 
         Writes to self:
-            Stores fh to self.fh if fh is passed and has not been passed previously.
+            Stores ``fh`` to ``self.fh`` if ``fh`` is passed and has not been passed
+            previously.
 
         Parameters
         ----------
-        fh : int, list, np.array or ForecastingHorizon (not optional)
+        fh : int, list, np.array or ``ForecastingHorizon``, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
-            if has not been passed in fit, must be passed, not optional
-        X : time series in sktime compatible format, optional (default=None)
-                Exogeneous time series to fit to
-            Should be of same scitype (Series, Panel, or Hierarchical) as y in fit
-            if self.get_tag("X-y-must-have-same-index"),
-                X.index must contain fh.index and y.index both
+            Need not be passed if has already been passed in ``fit``.
+            If has not been passed in fit, must be passed, not optional
+
+        X : time series in ``sktime`` compatible format, optional (default=None)
+            Exogeneous time series to use in prediction.
+            Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
+            as ``y`` in ``fit``.
+            If ``self.get_tag("X-y-must-have-same-index")``,
+            ``X.index`` must contain ``fh.index``.
+
         cov : bool, optional (default=False)
             if True, computes covariance matrix forecast.
             if False, computes marginal variance forecasts.
@@ -767,24 +800,31 @@ class BaseForecaster(BaseEstimator):
         Note: currently only implemented for Series (non-panel, non-hierarchical) y.
 
         State required:
-            Requires state to be "fitted".
+            Requires state to be "fitted", i.e., ``self.is_fitted=True``.
 
         Accesses in self:
-            Fitted model attributes ending in "_".
-            self.cutoff, self._is_fitted
+
+            * Fitted model attributes ending in "_".
+            * ``self.cutoff``, ``self.is_fitted``
 
         Writes to self:
-            Stores fh to self.fh if fh is passed and has not been passed previously.
+            Stores ``fh`` to ``self.fh`` if ``fh`` is passed and has not been passed
+            previously.
 
         Parameters
         ----------
-        fh : int, list, np.array or ForecastingHorizon (not optional)
+        fh : int, list, np.array or ``ForecastingHorizon``, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
-            if has not been passed in fit, must be passed, not optional
-        X : time series in sktime compatible format, optional (default=None)
-                Exogeneous time series to fit to
-            Should be of same scitype (Series, Panel, or Hierarchical) as y in fit
-            if self.get_tag("X-y-must-have-same-index"), must contain fh.index
+            Need not be passed if has already been passed in ``fit``.
+            If has not been passed in fit, must be passed, not optional
+
+        X : time series in ``sktime`` compatible format, optional (default=None)
+            Exogeneous time series to use in prediction.
+            Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
+            as ``y`` in ``fit``.
+            If ``self.get_tag("X-y-must-have-same-index")``,
+            ``X.index`` must contain ``fh.index``.
+
         marginal : bool, optional (default=True)
             whether returned distribution is marginal by time index
 
@@ -824,52 +864,56 @@ class BaseForecaster(BaseEstimator):
 
         If no estimator-specific update method has been implemented,
         default fall-back is as follows:
-            update_params=True: fitting to all observed data so far
-            update_params=False: updates cutoff and remembers data only
+
+            * ``update_params=True``: fitting to all observed data so far
+            * ``update_params=False``: updates cutoff and remembers data only
 
         State required:
-            Requires state to be "fitted".
+            Requires state to be "fitted", i.e., ``self.is_fitted=True``.
 
         Accesses in self:
-            Fitted model attributes ending in "_".
-            Pointers to seen data, self._y and self.X
-            self.cutoff, self._is_fitted
-            If update_params=True, model attributes ending in "_".
+
+            * Fitted model attributes ending in "_".
+            * ``self.cutoff``, ``self.is_fitted``
 
         Writes to self:
-            Update self._y and self._X with `y` and `X`, by appending rows.
-            Updates self.cutoff and self._cutoff to last index seen in `y`.
-            If update_params=True,
-                updates fitted model attributes ending in "_".
+            * Updates ``self.cutoff`` to latest index seen in `y`.
+            * If ``update_params=True``, updates fitted model attributes ending in "_".
 
         Parameters
         ----------
-        y : time series in sktime compatible data container format
-                Time series to which to fit the forecaster in the update.
-            y can be in one of the following formats, must be same scitype as in fit:
-            Series scitype: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
-                for vanilla forecasting, one time series
-            Panel scitype: pd.DataFrame with 2-level row MultiIndex,
-                3D np.ndarray, list of Series pd.DataFrame, or nested pd.DataFrame
-                for global or panel forecasting
-            Hierarchical scitype: pd.DataFrame with 3 or more level row MultiIndex
-                for hierarchical forecasting
-            Number of columns admissible depend on the "scitype:y" tag:
-                if self.get_tag("scitype:y")=="univariate":
-                    y must have a single column/variable
-                if self.get_tag("scitype:y")=="multivariate":
-                    y must have 2 or more columns
-                if self.get_tag("scitype:y")=="both": no restrictions on columns apply
-            For further details:
-                on usage, see forecasting tutorial examples/01_forecasting.ipynb
-                on specification of formats, examples/AA_datatypes_and_datasets.ipynb
-        X : time series in sktime compatible format, optional (default=None)
-                Exogeneous time series to fit to
-            Should be of same scitype (Series, Panel, or Hierarchical) as y
-            if self.get_tag("X-y-must-have-same-index"), X.index must contain y.index
-            there are no restrictions on number of columns (unlike for y)
+        y : time series in ``sktime`` compatible data container format.
+            Time series with which to update the forecaster.
+
+            Individual data formats in ``sktime`` are so-called :term:`mtype`
+            specifications, each mtype implements an abstract :term:`scitype`.
+
+            * ``Series`` scitype = individual time series, vanilla forecasting.
+              ``pd.DataFrame``, ``pd.Series``, or ``np.ndarray`` (1D or 2D)
+
+            * ``Panel`` scitype = collection of time series, global/panel forecasting.
+              ``pd.DataFrame`` with 2-level row ``MultiIndex`` ``(instance, time)``,
+              ``3D np.ndarray`` ``(instance, variable, time)``,
+              ``list`` of ``Series`` typed ``pd.DataFrame``
+
+            * ``Hierarchical`` scitype = hierarchical collection, for
+              hierarchical forecasting. ``pd.DataFrame`` with 3 or more level row
+              ``MultiIndex`` ``(hierarchy_1, ..., hierarchy_n, time)``
+
+            For further details on data format, see glossary on :term:`mtype`.
+            For usage, see forecasting tutorial ``examples/01_forecasting.ipynb``
+
+        X : time series in ``sktime`` compatible format, optional (default=None).
+            Exogeneous time series to update the model fit with
+            Should be of same :term:`scitype` (``Series``, ``Panel``,
+            or ``Hierarchical``) as ``y``.
+            If ``self.get_tag("X-y-must-have-same-index")``,
+            ``X.index`` must contain ``y.index``.
+
         update_params : bool, optional (default=True)
-            whether model parameters should be updated
+            whether model parameters should be updated.
+            If ``False``, only the cutoff is updated, model parameters
+            (e.g., coefficients) are not updated.
 
         Returns
         -------
@@ -909,79 +953,105 @@ class BaseForecaster(BaseEstimator):
     ):
         """Make predictions and update model iteratively over the test set.
 
+        Shorthand to carry out chain of multiple ``update`` / ``predict``
+        executions, with data playback based on temporal splitter ``cv``.
+
+        Same as the following (if only ``y``, ``cv`` are non-default):
+
+        1. ``self.update(y=cv.split_series(y)[0][0])``
+        2. remember ``self.predict()`` (return later in single batch)
+        3. ``self.update(y=cv.split_series(y)[1][0])``
+        4. remember ``self.predict()`` (return later in single batch)
+        5. etc
+        6. return all remembered predictions
+
+        If no estimator-specific update method has been implemented,
+        default fall-back is as follows:
+
+            * ``update_params=True``: fitting to all observed data so far
+            * ``update_params=False``: updates cutoff and remembers data only
+
         State required:
-            Requires state to be "fitted".
+            Requires state to be "fitted", i.e., ``self.is_fitted=True``.
 
         Accesses in self:
-            Fitted model attributes ending in "_".
-            Pointers to seen data, self._y and self.X
-            self.cutoff, self._is_fitted
-            If update_params=True, model attributes ending in "_".
 
-        Writes to self, if reset_forecaster=False:
-            Update self._y and self._X with `y` and `X`, by appending rows.
-            Updates self.cutoff and self._cutoff to last index seen in `y`.
-            If update_params=True,
-                updates fitted model attributes ending in "_".
+            * Fitted model attributes ending in "_".
+            * ``self.cutoff``, ``self.is_fitted``
 
-        Does not update state if reset_forecaster=True.
+        Writes to self (unless ``reset_forecaster=True``):
+            * Updates ``self.cutoff`` to latest index seen in `y`.
+            * If ``update_params=True``, updates fitted model attributes ending in "_".
+
+        Does not update state if ``reset_forecaster=True``.
 
         Parameters
         ----------
-        y : time series in sktime compatible data container format
-                Time series to which to fit the forecaster in the update.
-            y can be in one of the following formats, must be same scitype as in fit:
-            Series scitype: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
-                for vanilla forecasting, one time series
-            Panel scitype: pd.DataFrame with 2-level row MultiIndex,
-                3D np.ndarray, list of Series pd.DataFrame, or nested pd.DataFrame
-                for global or panel forecasting
-            Hierarchical scitype: pd.DataFrame with 3 or more level row MultiIndex
-                for hierarchical forecasting
-            Number of columns admissible depend on the "scitype:y" tag:
-                if self.get_tag("scitype:y")=="univariate":
-                    y must have a single column/variable
-                if self.get_tag("scitype:y")=="multivariate":
-                    y must have 2 or more columns
-                if self.get_tag("scitype:y")=="both": no restrictions on columns apply
-            For further details:
-                on usage, see forecasting tutorial examples/01_forecasting.ipynb
-                on specification of formats, examples/AA_datatypes_and_datasets.ipynb
+        y : time series in ``sktime`` compatible data container format.
+            Time series with which to update the forecaster.
+
+            Individual data formats in ``sktime`` are so-called :term:`mtype`
+            specifications, each mtype implements an abstract :term:`scitype`.
+
+            * ``Series`` scitype = individual time series, vanilla forecasting.
+              ``pd.DataFrame``, ``pd.Series``, or ``np.ndarray`` (1D or 2D)
+
+            * ``Panel`` scitype = collection of time series, global/panel forecasting.
+              ``pd.DataFrame`` with 2-level row ``MultiIndex`` ``(instance, time)``,
+              ``3D np.ndarray`` ``(instance, variable, time)``,
+              ``list`` of ``Series`` typed ``pd.DataFrame``
+
+            * ``Hierarchical`` scitype = hierarchical collection, for
+              hierarchical forecasting. ``pd.DataFrame`` with 3 or more level row
+              ``MultiIndex`` ``(hierarchy_1, ..., hierarchy_n, time)``
+
+            For further details on data format, see glossary on :term:`mtype`.
+            For usage, see forecasting tutorial ``examples/01_forecasting.ipynb``
+
         cv : temporal cross-validation generator inheriting from BaseSplitter, optional
-            for example, SlidingWindowSplitter or ExpandingWindowSplitter
+            for example, ``SlidingWindowSplitter`` or ``ExpandingWindowSplitter``;
             default = ExpandingWindowSplitter with `initial_window=1` and defaults
-                = individual data points in y/X are added and forecast one-by-one,
-                `initial_window = 1`, `step_length = 1` and `fh = 1`
+            = individual data points in y/X are added and forecast one-by-one,
+            ``initial_window = 1``, ``step_length = 1`` and ``fh = 1``
+
         X : time series in sktime compatible format, optional (default=None)
             Exogeneous time series for updating and forecasting
-            Should be of same scitype (Series, Panel, or Hierarchical) as y
-            if self.get_tag("X-y-must-have-same-index"),
-                X.index must contain y.index and fh.index both
-            there are no restrictions on number of columns (unlike for y)
+            Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
+            as ``y`` in ``fit``.
+            If ``self.get_tag("X-y-must-have-same-index")``,
+            ``X.index`` must contain ``fh.index``.
+
         update_params : bool, optional (default=True)
-            whether model parameters should be updated in each update step
+            whether model parameters should be updated.
+            If ``False``, only the cutoff is updated, model parameters
+            (e.g., coefficients) are not updated.
+
         reset_forecaster : bool, optional (default=True)
-            if True, will not change the state of the forecaster,
-                i.e., update/predict sequence is run with a copy,
-                and cutoff, model parameters, data memory of self do not change
-            if False, will update self when the update/predict sequence is run
-                as if update/predict were called directly
+
+            * if True, will not change the state of the forecaster,
+              i.e., update/predict sequence is run with a copy,
+              and cutoff, model parameters, data memory of self do not change
+
+            * if False, will update self when the update/predict sequence is run
+              as if update/predict were called directly
 
         Returns
         -------
         y_pred : object that tabulates point forecasts from multiple split batches
             format depends on pairs (cutoff, absolute horizon) forecast overall
-            if collection of absolute horizon points is unique:
-                type is time series in sktime compatible data container format
-                cutoff is suppressed in output
-                has same type as the y that has been passed most recently:
-                Series, Panel, Hierarchical scitype, same format (see above)
-            if collection of absolute horizon points is not unique:
-                type is a pandas DataFrame, with row and col index being time stamps
-                row index corresponds to cutoffs that are predicted from
-                column index corresponds to absolute horizons that are predicted
-                entry is the point prediction of col index predicted from row index
-                entry is nan if no prediction is made at that (cutoff, horizon) pair
+
+            * if collection of absolute horizon points is unique:
+              type is time series in sktime compatible data container format
+              cutoff is suppressed in output
+              has same type as the y that has been passed most recently:
+              Series, Panel, Hierarchical scitype, same format (see above)
+
+            * if collection of absolute horizon points is not unique:
+              type is a pandas DataFrame, with row and col index being time stamps
+              row index corresponds to cutoffs that are predicted from
+              column index corresponds to absolute horizons that are predicted
+              entry is the point prediction of col index predicted from row index
+              entry is nan if no prediction is made at that (cutoff, horizon) pair
         """
         from sktime.split import ExpandingWindowSplitter
 
@@ -1034,42 +1104,50 @@ class BaseForecaster(BaseEstimator):
 
         Parameters
         ----------
-        y : time series in sktime compatible data container format
-                Time series to which to fit the forecaster in the update.
-            y can be in one of the following formats, must be same scitype as in fit:
-            Series scitype: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
-                for vanilla forecasting, one time series
-            Panel scitype: pd.DataFrame with 2-level row MultiIndex,
-                3D np.ndarray, list of Series pd.DataFrame, or nested pd.DataFrame
-                for global or panel forecasting
-            Hierarchical scitype: pd.DataFrame with 3 or more level row MultiIndex
-                for hierarchical forecasting
-            Number of columns admissible depend on the "scitype:y" tag:
-                if self.get_tag("scitype:y")=="univariate":
-                    y must have a single column/variable
-                if self.get_tag("scitype:y")=="multivariate":
-                    y must have 2 or more columns
-                if self.get_tag("scitype:y")=="both": no restrictions on columns apply
-            For further details:
-                on usage, see forecasting tutorial examples/01_forecasting.ipynb
-                on specification of formats, examples/AA_datatypes_and_datasets.ipynb
-        fh : int, list, np.array or ForecastingHorizon, optional (default=None)
+        y : time series in ``sktime`` compatible data container format.
+            Time series with which to update the forecaster.
+
+            Individual data formats in ``sktime`` are so-called :term:`mtype`
+            specifications, each mtype implements an abstract :term:`scitype`.
+
+            * ``Series`` scitype = individual time series, vanilla forecasting.
+              ``pd.DataFrame``, ``pd.Series``, or ``np.ndarray`` (1D or 2D)
+
+            * ``Panel`` scitype = collection of time series, global/panel forecasting.
+              ``pd.DataFrame`` with 2-level row ``MultiIndex`` ``(instance, time)``,
+              ``3D np.ndarray`` ``(instance, variable, time)``,
+              ``list`` of ``Series`` typed ``pd.DataFrame``
+
+            * ``Hierarchical`` scitype = hierarchical collection, for
+              hierarchical forecasting. ``pd.DataFrame`` with 3 or more level row
+              ``MultiIndex`` ``(hierarchy_1, ..., hierarchy_n, time)``
+
+            For further details on data format, see glossary on :term:`mtype`.
+            For usage, see forecasting tutorial ``examples/01_forecasting.ipynb``
+
+        fh : int, list, np.array or ``ForecastingHorizon``, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
-            if has not been passed in fit, must be passed, not optional
+            Need not be passed if has already been passed in ``fit``.
+            If has not been passed in fit, must be passed, not optional
+
         X : time series in sktime compatible format, optional (default=None)
-                Exogeneous time series for updating and forecasting
-            Should be of same scitype (Series, Panel, or Hierarchical) as y
-            if self.get_tag("X-y-must-have-same-index"),
-                X.index must contain y.index and fh.index both
-        update_params : bool, optional (default=False)
+            Exogeneous time series for updating and forecasting
+            Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
+            as ``y`` in ``fit``.
+            If ``self.get_tag("X-y-must-have-same-index")``,
+            ``X.index`` must contain ``fh.index``.
+
+        update_params : bool, optional (default=True)
+            whether model parameters should be updated.
+            If ``False``, only the cutoff is updated, model parameters
+            (e.g., coefficients) are not updated.
 
         Returns
         -------
         y_pred : time series in sktime compatible data container format
-            Point forecasts at fh, with same index as fh
-            if fh was relative, index is relative to cutoff after update with y
-            y_pred has same type as the y that has been passed most recently:
-                Series, Panel, Hierarchical scitype, same format (see above)
+            Point forecasts at ``fh``, with same index as ``fh``.
+            ``y_pred`` has same type as the ``y`` that has been passed most recently:
+            ``Series``, ``Panel``, ``Hierarchical`` scitype, same format (see above)
         """
         if y is None or (hasattr(y, "__len__") and len(y) == 0):
             warn(
@@ -1138,20 +1216,25 @@ class BaseForecaster(BaseEstimator):
         y : time series in sktime compatible data container format
             Time series with ground truth observations, to compute residuals to.
             Must have same type, dimension, and indices as expected return of predict.
-            if None, the y seen so far (self._y) are used, in particular:
-                if preceded by a single fit call, then in-sample residuals are produced
-                if fit requires fh, it must have pointed to index of y in fit
-        X : pd.DataFrame, or 2D np.ndarray, optional (default=None)
-            Exogeneous time series to predict from
-            if self.get_tag("X-y-must-have-same-index"),
-                X.index must contain fh.index and y.index both
+
+            If None, the y seen so far (self._y) are used, in particular:
+
+            * if preceded by a single fit call, then in-sample residuals are produced
+            * if fit requires ``fh``, it must have pointed to index of y in fit
+
+        X : time series in sktime compatible format, optional (default=None)
+            Exogeneous time series for updating and forecasting
+            Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
+            as ``y`` in ``fit``.
+            If ``self.get_tag("X-y-must-have-same-index")``,
+            ``X.index`` must contain both ``fh.index`` and ``y.index``.
 
         Returns
         -------
-        y_res : time series in sktime compatible data container format
-            Forecast residuals at fh, with same index as fh
-            y_res has same type as the y that has been passed most recently:
-                Series, Panel, Hierarchical scitype, same format (see above)
+        y_res : time series in ``sktime`` compatible data container format
+            Forecast residuals at ``fh`, with same index as ``fh``.
+            ``y_res`` has same type as the ``y`` that has been passed most recently:
+            ``Series``, ``Panel``, ``Hierarchical`` scitype, same format (see above)
         """
         self.check_is_fitted()
 
@@ -1204,11 +1287,7 @@ class BaseForecaster(BaseEstimator):
         ----------
         y : pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
             Time series to score
-            if self.get_tag("scitype:y")=="univariate":
-                must have a single column/variable
-            if self.get_tag("scitype:y")=="multivariate":
-                must have 2 or more columns
-            if self.get_tag("scitype:y")=="both": no restrictions apply
+
         fh : int, list, array-like or ForecastingHorizon, optional (default=None)
             The forecasters horizon with the steps ahead to to predict.
         X : pd.DataFrame, or 2D np.array, optional (default=None)

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -349,7 +349,7 @@ class BaseForecaster(BaseEstimator):
         fh : int, list, np.array or ForecastingHorizon, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
             If ``self.get_tag("requires-fh-in-fit")`` is ``True``,
-            must be passed, in ``fit``, not optional
+            must be passed in ``fit``, not optional
 
         X : time series in ``sktime`` compatible format, optional (default=None).
             Exogeneous time series to fit the model to.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -316,7 +316,7 @@ class BaseForecaster(BaseEstimator):
             Changes state to "fitted".
 
         Writes to self:
-    
+
             * Sets fitted model attributes ending in "_", fitted attributes are
               inspectable via ``get_fitted_params``.
             * Sets ``self.is_fitted`` flag to ``True``.
@@ -876,6 +876,7 @@ class BaseForecaster(BaseEstimator):
             * ``self.cutoff``, ``self.is_fitted``
 
         Writes to self:
+
             * Updates ``self.cutoff`` to latest index seen in `y`.
             * If ``update_params=True``, updates fitted model attributes ending in "_".
 

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -496,9 +496,8 @@ class BaseForecaster(BaseEstimator):
             For further details on data format, see glossary on :term:`mtype`.
             For usage, see forecasting tutorial ``examples/01_forecasting.ipynb``
 
-                    fh : int, list, np.array or ForecastingHorizon (not optional)
+        fh : int, list, np.array or ``ForecastingHorizon`` (not optional)
             The forecasting horizon encoding the time stamps to forecast at.
-            if has not been passed in fit, must be passed, not optional
 
         X : time series in ``sktime`` compatible format, optional (default=None).
             Exogeneous time series to fit the model to.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -465,7 +465,7 @@ class BaseForecaster(BaseEstimator):
         State change:
             Changes state to "fitted".
 
-        Writes to self:                
+        Writes to self:
 
             * Sets fitted model attributes ending in "_", fitted attributes are
               inspectable via ``get_fitted_params``.

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -316,38 +316,43 @@ class BaseForecaster(BaseEstimator):
             Changes state to "fitted".
 
         Writes to self:
-            Sets self._is_fitted flag to True.
-            Writes self._y and self._X with `y` and `X`, respectively.
-            Sets self.cutoff and self._cutoff to last index seen in `y`.
-            Sets fitted model attributes ending in "_".
-            Stores fh to self.fh if fh is passed.
+    
+            * Sets fitted model attributes ending in "_", fitted attributes are
+              inspectable via ``get_fitted_params``.
+            * Sets ``self.is_fitted`` flag to ``True``.
+            * Sets ``self.cutoff`` to last index seen in `y`.
+            * Stores ``fh`` to ``self.fh`` if ``fh`` is passed.
 
         Parameters
         ----------
         y : time series in sktime compatible data container format
-                Time series to which to fit the forecaster.
-            y can be in one of the following formats:
-            Series scitype: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
-                for vanilla forecasting, one time series
-            Panel scitype: pd.DataFrame with 2-level row MultiIndex,
-                3D np.ndarray, list of Series pd.DataFrame, or nested pd.DataFrame
-                for global or panel forecasting
-            Hierarchical scitype: pd.DataFrame with 3 or more level row MultiIndex
-                for hierarchical forecasting
-            Number of columns admissible depend on the "scitype:y" tag:
-                if self.get_tag("scitype:y")=="univariate":
-                    y must have a single column/variable
-                if self.get_tag("scitype:y")=="multivariate":
-                    y must have 2 or more columns
-                if self.get_tag("scitype:y")=="both": no restrictions on columns apply
-            For further details:
-                on usage, see forecasting tutorial examples/01_forecasting.ipynb
-                on specification of formats, examples/AA_datatypes_and_datasets.ipynb
+            Time series to which to fit the forecaster.
+
+            Individual data formats in ``sktime`` are so-called :term:`mtype`
+            specifications, each mtype implements an abstract :term:`scitype`.
+
+            * ``Series`` scitype = individual time series, vanilla forecasting.
+              ``pd.DataFrame``, ``pd.Series``, or ``np.ndarray`` (1D or 2D)
+
+            * ``Panel`` scitype = collection of time series, global/panel forecasting.
+              ``pd.DataFrame`` with 2-level row ``MultiIndex`` ``(instance, time)``,
+              ``3D np.ndarray`` ``(instance, variable, time)``,
+              ``list`` of ``Series`` typed ``pd.DataFrame``
+
+            * ``Hierarchical`` scitype = hierarchical collection, for
+              hierarchical forecasting. ``pd.DataFrame`` with 3 or more level row
+              ``MultiIndex`` ``(hierarchy_1, ..., hierarchy_n, time)``
+
+            For further details on data format, see glossary on :term:`mtype`.
+            For usage, see forecasting tutorial ``examples/01_forecasting.ipynb``
+
         fh : int, list, np.array or ForecastingHorizon, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
-            if self.get_tag("requires-fh-in-fit"), must be passed, not optional
+            If ``self.get_tag("requires-fh-in-fit")`` is ``True``,
+            must be passed, in ``fit``, not optional
+
         X : time series in sktime compatible format, optional (default=None)
-                Exogeneous time series to fit to
+            Exogeneous time series to fit the model to.
             Should be of same scitype (Series, Panel, or Hierarchical) as y
             if self.get_tag("X-y-must-have-same-index"), X.index must contain y.index
             there are no restrictions on number of columns (unlike for y)

--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -413,7 +413,7 @@ class BaseForecaster(BaseEstimator):
         ----------
         fh : int, list, np.array or ``ForecastingHorizon``, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
-            Need not be passed if has already been passed in ``fit``.
+            Should not be passed if has already been passed in ``fit``.
             If has not been passed in fit, must be passed, not optional
 
         X : time series in ``sktime`` compatible format, optional (default=None)
@@ -421,7 +421,7 @@ class BaseForecaster(BaseEstimator):
             Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
             as ``y`` in ``fit``.
             If ``self.get_tag("X-y-must-have-same-index")``,
-            ``X.index`` must contain ``fh.index``.
+            ``X.index`` must contain ``fh`` index reference.
 
         Returns
         -------
@@ -512,7 +512,7 @@ class BaseForecaster(BaseEstimator):
             Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
             as ``y`` in ``fit``.
             If ``self.get_tag("X-y-must-have-same-index")``,
-            ``X.index`` must contain ``fh.index``.
+            ``X.index`` must contain ``fh`` index reference.
 
         Returns
         -------
@@ -575,7 +575,7 @@ class BaseForecaster(BaseEstimator):
         ----------
         fh : int, list, np.array or ``ForecastingHorizon``, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
-            Need not be passed if has already been passed in ``fit``.
+            Should not be passed if has already been passed in ``fit``.
             If has not been passed in fit, must be passed, not optional
 
         X : time series in ``sktime`` compatible format, optional (default=None)
@@ -583,7 +583,7 @@ class BaseForecaster(BaseEstimator):
             Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
             as ``y`` in ``fit``.
             If ``self.get_tag("X-y-must-have-same-index")``,
-            ``X.index`` must contain ``fh.index``.
+            ``X.index`` must contain ``fh`` index reference.
 
         alpha : float or list of float of unique values, optional (default=[0.05, 0.95])
             A probability or list of, at which quantile forecasts are computed.
@@ -656,7 +656,7 @@ class BaseForecaster(BaseEstimator):
         ----------
         fh : int, list, np.array or ``ForecastingHorizon``, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
-            Need not be passed if has already been passed in ``fit``.
+            Should not be passed if has already been passed in ``fit``.
             If has not been passed in fit, must be passed, not optional
 
         X : time series in ``sktime`` compatible format, optional (default=None)
@@ -664,7 +664,7 @@ class BaseForecaster(BaseEstimator):
             Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
             as ``y`` in ``fit``.
             If ``self.get_tag("X-y-must-have-same-index")``,
-            ``X.index`` must contain ``fh.index``.
+            ``X.index`` must contain ``fh`` index reference.
 
         coverage : float or list of float of unique values, optional (default=0.90)
            nominal coverage(s) of predictive interval(s)
@@ -736,7 +736,7 @@ class BaseForecaster(BaseEstimator):
         ----------
         fh : int, list, np.array or ``ForecastingHorizon``, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
-            Need not be passed if has already been passed in ``fit``.
+            Should not be passed if has already been passed in ``fit``.
             If has not been passed in fit, must be passed, not optional
 
         X : time series in ``sktime`` compatible format, optional (default=None)
@@ -744,7 +744,7 @@ class BaseForecaster(BaseEstimator):
             Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
             as ``y`` in ``fit``.
             If ``self.get_tag("X-y-must-have-same-index")``,
-            ``X.index`` must contain ``fh.index``.
+            ``X.index`` must contain ``fh`` index reference.
 
         cov : bool, optional (default=False)
             if True, computes covariance matrix forecast.
@@ -814,7 +814,7 @@ class BaseForecaster(BaseEstimator):
         ----------
         fh : int, list, np.array or ``ForecastingHorizon``, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
-            Need not be passed if has already been passed in ``fit``.
+            Should not be passed if has already been passed in ``fit``.
             If has not been passed in fit, must be passed, not optional
 
         X : time series in ``sktime`` compatible format, optional (default=None)
@@ -822,7 +822,7 @@ class BaseForecaster(BaseEstimator):
             Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
             as ``y`` in ``fit``.
             If ``self.get_tag("X-y-must-have-same-index")``,
-            ``X.index`` must contain ``fh.index``.
+            ``X.index`` must contain ``fh`` index reference.
 
         marginal : bool, optional (default=True)
             whether returned distribution is marginal by time index
@@ -1019,7 +1019,7 @@ class BaseForecaster(BaseEstimator):
             Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
             as ``y`` in ``fit``.
             If ``self.get_tag("X-y-must-have-same-index")``,
-            ``X.index`` must contain ``fh.index``.
+            ``X.index`` must contain ``fh`` index reference.
 
         update_params : bool, optional (default=True)
             whether model parameters should be updated.
@@ -1127,7 +1127,7 @@ class BaseForecaster(BaseEstimator):
 
         fh : int, list, np.array or ``ForecastingHorizon``, optional (default=None)
             The forecasting horizon encoding the time stamps to forecast at.
-            Need not be passed if has already been passed in ``fit``.
+            Should not be passed if has already been passed in ``fit``.
             If has not been passed in fit, must be passed, not optional
 
         X : time series in sktime compatible format, optional (default=None)
@@ -1135,7 +1135,7 @@ class BaseForecaster(BaseEstimator):
             Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
             as ``y`` in ``fit``.
             If ``self.get_tag("X-y-must-have-same-index")``,
-            ``X.index`` must contain ``fh.index``.
+            ``X.index`` must contain ``fh`` index reference.
 
         update_params : bool, optional (default=True)
             whether model parameters should be updated.
@@ -1227,7 +1227,7 @@ class BaseForecaster(BaseEstimator):
             Should be of same scitype (``Series``, ``Panel``, or ``Hierarchical``)
             as ``y`` in ``fit``.
             If ``self.get_tag("X-y-must-have-same-index")``,
-            ``X.index`` must contain both ``fh.index`` and ``y.index``.
+            ``X.index`` must contain both ``fh`` index reference and ``y.index``.
 
         Returns
         -------

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -277,17 +277,21 @@ def all_tags(
 ):
     """Get a list of all tags from sktime.
 
-    Retrieves tags directly from `_tags`, offers filtering functionality.
+    All objects in ``sktime`` are tagged with a set of :term`tag`s.
+    This function allows to list all tags, optionally filtered by
+    the object :term:`scitype` they apply to.
 
     Parameters
     ----------
     estimator_types: string, list of string, optional (default=None)
-        Ta gs for hich kind of estimators should be returned.
+        The object type (:term:`scitype`) for which applicable tags should be listed.
 
         - If None, no filter is applied and tags for all estimators are returned.
-        - Possible values are 'classifier', 'regressor', 'transformer' and
-        'forecaster' to get estimator tags only fo these specific types, or a list of
-        these to get tags for estimators that fit at least one of the types.
+        - Possible values are identifier strings for object scitypes, such as
+          ``"forecaster"``, ``"classifier", ``"transformer"``, or lists thereof.
+          If list, finds tags applicable to at least one of the listed types.
+          Valid scitype strings are in ``sktime.registry.BASE_CLASS_SCITYPE_LIST``.
+
 
     as_dataframe: bool, optional (default=False)
         if False, return is as described below;
@@ -297,11 +301,13 @@ def all_tags(
     -------
     tags: list of tuples (a, b, c, d),
         in alphabetical order by a
+
         a : string - name of the tag as used in the _tags dictionary
-        b : string - name of the scitype this tag applies to
-        must be in _base_classes.BASE_CLASS_SCITYPE_LIST
-        c : string - expected type of the tag value
-        should be one of:
+
+        b : string - name of the scitype this tag applies to,
+        as in .BASE_CLASS_SCITYPE.LIST
+
+        c : string - expected type of the tag value, one of:
 
             * ``"bool"`` - valid values are True/False
             * ``"int"`` - valid values are all integers


### PR DESCRIPTION
This PR makes improvements around the documentation of data container types and forecasting docstrings:

* glossary items for mtype, scitype, pointers to lookup, extension templates
* forecasting docstrings have been reworked: clarified requirements, cleaned up docstrings, consistency
* removed the obsolete restriction arising from univariate/multivariate in forecasting docstrings, simplifying these quite a bit (this is no longer a restriction since quite a while, since we introduced broadcasting across variables)

Critical review would be appreciated, e.g., whether this makes things easier to understand for newcomers and current users.