### PR TITLE
[DOC] remove type annotations in extension templates

### DIFF
--- a/extension_templates/alignment.py
+++ b/extension_templates/alignment.py
@@ -33,6 +33,14 @@ Testing - required for sktime test framework and check_estimator usage:
 
 copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """
+# todo: write an informative docstring for the file or module, remove the above
+# todo: add an appropriate copyright notice for your estimator
+#       estimators contributed to sktime should have the copyright notice at the top
+#       estimators of your own do not need to have permissive or BSD-3 copyright
+
+# todo: uncomment the following line, enter authors' GitHub IDs
+# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+
 
 from sktime.alignment.base import BaseAligner
 

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -33,7 +33,14 @@ Testing - required for sktime test framework and check_estimator usage:
 
 copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """
-import numpy as np
+# todo: write an informative docstring for the file or module, remove the above
+# todo: add an appropriate copyright notice for your estimator
+#       estimators contributed to sktime should have the copyright notice at the top
+#       estimators of your own do not need to have permissive or BSD-3 copyright
+
+# todo: uncomment the following line, enter authors' GitHub IDs
+# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+
 
 from sktime.classification.base import BaseClassifier
 
@@ -209,7 +216,7 @@ class MyTimeSeriesClassifier(BaseClassifier):
     # todo: consider implementing this, optional
     # if you do not implement it, then the default _predict_proba will be called.
     # the default simply calls predict and sets probas to 0 or 1.
-    def _predict_proba(self, X) -> np.ndarray:
+    def _predict_proba(self, X):
         """Predicts labels probabilities for sequences in X.
 
         private _predict_proba containing the core logic, called from predict_proba

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -31,7 +31,14 @@ Testing - required for sktime test framework and check_estimator usage:
 
 copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """
-import numpy as np
+# todo: write an informative docstring for the file or module, remove the above
+# todo: add an appropriate copyright notice for your estimator
+#       estimators contributed to sktime should have the copyright notice at the top
+#       estimators of your own do not need to have permissive or BSD-3 copyright
+
+# todo: uncomment the following line, enter authors' GitHub IDs
+# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+
 
 from sktime.clustering import BaseClusterer
 
@@ -132,7 +139,7 @@ class MyClusterer(BaseClusterer):
 
     # todo: implement this, mandatory
     # at least one of _predict and _get_fitted_params should be implemented
-    def _predict(self, X) -> np.ndarray:
+    def _predict(self, X):
         """Predict the closest cluster each sample in X belongs to.
 
         Parameters

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -34,9 +34,14 @@ Testing - required for sktime test framework and check_estimator usage:
 
 copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """
-from typing import Tuple
+# todo: write an informative docstring for the file or module, remove the above
+# todo: add an appropriate copyright notice for your estimator
+#       estimators contributed to sktime should have the copyright notice at the top
+#       estimators of your own do not need to have permissive or BSD-3 copyright
 
-import numpy as np
+# todo: uncomment the following line, enter authors' GitHub IDs
+# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+
 
 from sktime.classification.early_classification import BaseEarlyClassifier
 
@@ -145,7 +150,7 @@ class MyEarlyTimeSeriesClassifier(BaseEarlyClassifier):
         #   3. read from self in _fit,  4. pass to interfaced_model.fit in _fit
 
     # todo: implement this, mandatory
-    def _predict(self, X) -> Tuple[np.ndarray, np.ndarray]:
+    def _predict(self, X):
         """Predict labels for sequences in X.
 
         core logic
@@ -175,7 +180,7 @@ class MyEarlyTimeSeriesClassifier(BaseEarlyClassifier):
         # decision to use the returned predictions.
 
     # todo: implement this, mandatory
-    def _update_predict(self, X) -> Tuple[np.ndarray, np.ndarray]:
+    def _update_predict(self, X):
         """Update labels for sequences in X using a larger series length.
 
         core logic
@@ -210,7 +215,7 @@ class MyEarlyTimeSeriesClassifier(BaseEarlyClassifier):
     # todo: consider implementing this, optional
     # if you do not implement it, then the default _predict_proba will be  called.
     # the default simply calls predict and sets probas to 0 or 1.
-    def _predict_proba(self, X) -> Tuple[np.ndarray, np.ndarray]:
+    def _predict_proba(self, X):
         """Predicts labels probabilities for sequences in X.
 
         This method should update state_info with any values necessary to make future
@@ -244,7 +249,7 @@ class MyEarlyTimeSeriesClassifier(BaseEarlyClassifier):
     # todo: consider implementing this, optional
     # if you do not implement it, then the default _update_predict_proba will be called.
     # the default simply calls predict and sets probas to 0 or 1.
-    def _update_predict_proba(self, X) -> Tuple[np.ndarray, np.ndarray]:
+    def _update_predict_proba(self, X):
         """Update labels probabilities for sequences in X using a larger series length.
 
         Uses information from previous decisions stored in state_info. This method
@@ -279,7 +284,7 @@ class MyEarlyTimeSeriesClassifier(BaseEarlyClassifier):
         # decision to use the returned predictions.
 
     # todo: implement this, mandatory
-    def _score(self, X, y) -> Tuple[float, float, float]:
+    def _score(self, X, y):
         """Scores predicted labels against ground truth labels on X.
 
         Parameters


### PR DESCRIPTION
Minor PR updating extension templates:

* remove type annotations, some of these were not compatible with lower python versions in the support range
* add the preamble on docstring and authors variable on top in those templates where these were missing