### PR TITLE
[MNT] address some upcoming deprecations

### DIFF
--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -15,14 +15,24 @@ from joblib import Parallel, effective_n_jobs
 from sklearn.metrics import pairwise
 from sklearn.utils import check_random_state, gen_even_slices
 from sklearn.utils.extmath import safe_sparse_dot
-from sklearn.utils.fixes import delayed
 from sklearn.utils.sparsefuncs_fast import csr_row_norms
 from sklearn.utils.validation import _num_samples
 
 from sktime.classification.base import BaseClassifier
 from sktime.transformations.panel.dictionary_based import SFAFast
+from sktime.utils.validation._dependencies import _check_soft_dependencies
 from sktime.utils.validation.panel import check_X_y
 
+# delayed was moved from utils.fixes to utils.parallel in scikit-learn 1.3
+if _check_soft_dependencies(
+    "scikit-learn>=1.3",
+    package_import_alias={"scikit-learn": "sklearn"},
+    severity="none",
+):
+    from sklearn.utils.parallel import delayed
+else:
+    from sklearn.utils.fixes import delayed
+    
 
 class BOSSEnsemble(BaseClassifier):
     """Ensemble of Bag of Symbolic Fourier Approximation Symbols (BOSS).

--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -32,7 +32,7 @@ if _check_soft_dependencies(
     from sklearn.utils.parallel import delayed
 else:
     from sklearn.utils.fixes import delayed
-    
+
 
 class BOSSEnsemble(BaseClassifier):
     """Ensemble of Bag of Symbolic Fourier Approximation Symbols (BOSS).

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -120,13 +120,13 @@ def test_make_scorer():
     """Test make_forecasting_scorer and the failure case in #4827."""
     import functools
 
-    from sklearn.metrics import mean_squared_log_error
+    from sklearn.metrics import mean_tweedie_deviance
 
     from sktime.performance_metrics.forecasting import make_forecasting_scorer
 
-    rmsle = functools.partial(mean_squared_log_error, squared=False)
+    rmsle = functools.partial(mean_tweedie_deviance, power=1.5)
 
-    scorer = make_forecasting_scorer(rmsle, name="RMSLE")
+    scorer = make_forecasting_scorer(rmsle, name="MTD")
 
     scorer.evaluate(pd.Series([1, 2, 3]), pd.Series([1, 2, 4]))
 
@@ -141,6 +141,6 @@ def test_make_scorer_sklearn():
 
     from sktime.performance_metrics.forecasting import make_forecasting_scorer
 
-    scorer = make_forecasting_scorer(mean_absolute_error, name="RMSLE")
+    scorer = make_forecasting_scorer(mean_absolute_error, name="MAE")
 
     scorer.evaluate(pd.Series([1, 2, 3]), pd.Series([1, 2, 4]))

--- a/sktime/transformations/bootstrap/_mbb.py
+++ b/sktime/transformations/bootstrap/_mbb.py
@@ -148,7 +148,7 @@ class STLBootstrapTransformer(BaseTransformer):
     >>> y_hat = transformer.fit_transform(y)  # doctest: +SKIP
     >>> series_list = []  # doctest: +SKIP
     >>> names = []  # doctest: +SKIP
-    >>> for group, series in y_hat.groupby(level=[0], as_index=False):
+    >>> for group, series in y_hat.groupby(level=0, as_index=False):
     ...     series.index = series.index.droplevel(0)
     ...     series_list.append(series)
     ...     names.append(group)  # doctest: +SKIP


### PR DESCRIPTION
This PR addresess some minor deprecations:

* move of `delayed` from `sklearn.utils.fixes` to `sklearn.utils.parallel`
* change in behaviour of `pandas.DataFrame.groupby` with length 1 `level`
* deprecation of `squared` arg in `sklearn` metrics