### PR TITLE
[MNT] avoid running unit tests in CI for documentation/template/etc. changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,9 +64,9 @@ jobs:
         run: build_tools/run_blogposts.sh
         shell: bash
 
-  detect-code-change:
+  detect-package-change:
     needs: code-quality
-    name: detect changes in sktime folder
+    name: detect package changes
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -80,10 +80,11 @@ jobs:
           filters: |
             sktime:
               - sktime/**
+              - pyproject.toml
 
   test-nodevdeps:
-    needs: detect-code-change
-    if: ${{ needs.detect-code-change.outputs.sktime == 'true' }}
+    needs: detect-package-change
+    if: ${{ needs.detect-package-change.outputs.sktime == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -103,8 +104,8 @@ jobs:
           python sktime/_nopytest_tests.py
 
   test-nosoftdeps:
-    needs: detect-code-change
-    if: ${{ needs.detect-code-change.outputs.sktime == 'true' }}
+    needs: detect-package-change
+    if: ${{ needs.detect-package-change.outputs.sktime == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,23 @@ jobs:
         run: build_tools/run_blogposts.sh
         shell: bash
 
+  detect-code-change:
+    needs: code-quality
+    name: detect changes in sktime folder
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      sktime: ${{ steps.filter.outputs.sktime }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            sktime:
+              - sktime/**
+
   test-nodevdeps:
     needs: code-quality
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,8 @@ jobs:
               - sktime/**
 
   test-nodevdeps:
-    needs: code-quality
+    needs: detect-code-change
+    if: ${{ needs.detect-code-change.outputs.sktime == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -102,7 +103,8 @@ jobs:
           python sktime/_nopytest_tests.py
 
   test-nosoftdeps:
-    needs: code-quality
+    needs: detect-code-change
+    if: ${{ needs.detect-code-change.outputs.sktime == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds a job so that changes outside `sktime` folder, e.g. changes in docs/templates/examples do not trigger unit tests.