### PR TITLE
& albahhar [ENH] in `ForecastingPipeline`, allow `None` `X` to be passed to transformers

### DIFF
--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -149,10 +149,15 @@ class MyTransformer(BaseTransformer):
         # valid values: True = inner _fit, _transform receive only univariate series
         #   False = uni- and multivariate series are passed to inner methods
         #
+        # requires_X = does X need to be passed in fit?
+        "requires_X": True,
+        # valid values: False (no), True = exception is raised if no X is seen in _fit
+        #   requires_y setting is independent of requires_X
+        #
         # requires_y = does y need to be passed in fit?
         "requires_y": False,
         # valid values: False (no), True = exception is raised if no y is seen in _fit
-        #   y can be passed or not in _transform for either value of requires_y
+        #   requires_X setting is independent of requires_y
         #
         # remember_data = whether all data seen is remembered as self._X
         "remember_data": False,

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -486,8 +486,8 @@ class ForecastingPipeline(_Pipeline):
         -------
         self : returns an instance of self.
         """
-        # If X is not given or ignored, just passthrough the data without transformation
-        if self._X is not None and not self.get_tag("ignores-exogeneous-X"):
+        # If X is ignored, just passthrough the data without transformation
+        if not self.get_tag("ignores-exogeneous-X"):
             # transform X
             for step_idx, name, transformer in self._iter_transformers():
                 t = transformer.clone()
@@ -667,12 +667,10 @@ class ForecastingPipeline(_Pipeline):
         -------
         self : an instance of self
         """
-        # If X is not given, just passthrough the data without transformation
-        if X is not None:
-            for _, _, transformer in self._iter_transformers():
-                if hasattr(transformer, "update"):
-                    transformer.update(X=X, y=y, update_params=update_params)
-                    X = transformer.transform(X=X, y=y)
+        for _, _, transformer in self._iter_transformers():
+            if hasattr(transformer, "update"):
+                transformer.update(X=X, y=y, update_params=update_params)
+                X = transformer.transform(X=X, y=y)
 
         _, forecaster = self.steps_[-1]
         forecaster.update(y=y, X=X, update_params=update_params)
@@ -680,7 +678,7 @@ class ForecastingPipeline(_Pipeline):
 
     def _transform(self, X=None, y=None):
         # If X is not given or ignored, just passthrough the data without transformation
-        if self._X is not None and not self.get_tag("ignores-exogeneous-X"):
+        if not self.get_tag("ignores-exogeneous-X"):
             for _, _, transformer in self._iter_transformers():
                 # if y is required but not passed,
                 # we create a zero-column y from the forecasting horizon

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -32,7 +32,6 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
 
     def _get_pipeline_scitypes(self, estimators):
         """Get list of scityes (str) from names/estimator list."""
-
         return [scitype(x, raise_on_unknown=False) for x in estimators]
 
     def _get_forecaster_index(self, estimators):

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -483,7 +483,7 @@ class ForecastingPipeline(_Pipeline):
         first_trafo = self.steps_[0][1]
         cond1 = len(self.steps_) > 1 and first_trafo.get_tag("requires_X")
         cond1 = cond1 and X is None
-            
+
         # condition 2 for ignoring X: tag "ignores-exogeneous-X" is True
         # in this case the forecaster at the end ignores what comes out of the trafos
         cond2 = self.get_tag("ignores-exogeneous-X")

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -31,7 +31,7 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
 
     def _get_pipeline_scitypes(self, estimators):
         """Get list of scityes (str) from names/estimator list."""
-        return [scitype(x, raise_on_unknown=False) for x in estimators]
+        return [scitype(x[1], raise_on_unknown=False) for x in estimators]
 
     def _get_forecaster_index(self, estimators):
         """Get the index of the first forecaster in the list."""

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -292,7 +292,7 @@ class ForecastingPipeline(_Pipeline):
         the pipeline behaves as follows:
 
     ``fit(y, X, fh)`` changes state by running ``t1.fit_transform`` with ``X=X`, ``y=y``
-        then ``t2.fit_transform`` on ``X=`` the output of ``t1.fit_transform``, ``y=y``, 
+        then ``t2.fit_transform`` on ``X=`` the output of ``t1.fit_transform``, ``y=y``,
         etc, sequentially, with ``t[i]`` receiving the output of ``t[i-1]`` as ``X``,
         then running ``f.fit`` with ``X`` being the output of ``t[N]``, and ``y=y``
 

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -676,10 +676,11 @@ class ForecastingPipeline(_Pipeline):
         -------
         self : an instance of self
         """
-        for _, _, transformer in self._iter_transformers():
-            if hasattr(transformer, "update"):
-                transformer.update(X=X, y=y, update_params=update_params)
-                X = transformer.transform(X=X, y=y)
+        if not self.skip_trafos_:
+            for _, _, transformer in self._iter_transformers():
+                if hasattr(transformer, "update"):
+                    transformer.update(X=X, y=y, update_params=update_params)
+                    X = transformer.transform(X=X, y=y)
 
         _, forecaster = self.steps_[-1]
         forecaster.update(y=y, X=X, update_params=update_params)

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -11,7 +11,6 @@ from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.base._delegate import _DelegatedForecaster
 from sktime.forecasting.base._fh import ForecastingHorizon
 from sktime.registry import scitype
-from sktime.transformations.base import BaseTransformer
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 from sktime.utils.validation.series import check_series
 
@@ -288,56 +287,60 @@ class ForecastingPipeline(_Pipeline):
     to X. The forecaster can also be a TransformedTargetForecaster containing
     transformers to transform y.
 
-    For a list `t1`, `t2`, ..., `tN`, `f`
-        where `t[i]` are transformers, and `f` is an sktime forecaster,
+    For a list ``t1``, ``t2``, ..., ``tN``, ``f``
+        where ``t[i]`` are transformers, and ``f`` is an ``sktime`` forecaster,
         the pipeline behaves as follows:
 
-    `fit(y, X, fh)` - changes state by running `t1.fit_transform` with `X=X`, `y=y`
-        then `t2.fit_transform` on `X=` the output of `t1.fit_transform`, `y=y`, etc
-        sequentially, with `t[i]` receiving the output of `t[i-1]` as `X`,
-        then running `f.fit` with `X` being the output of `t[N]`, and `y=y`
-    `predict(X, fh)` - result is of executing `f.predict`, with `fh=fh`, and `X`
+    ``fit(y, X, fh)`` changes state by running ``t1.fit_transform`` with ``X=X`, ``y=y``
+        then ``t2.fit_transform`` on ``X=`` the output of ``t1.fit_transform``, ``y=y``, 
+        etc, sequentially, with ``t[i]`` receiving the output of ``t[i-1]`` as ``X``,
+        then running ``f.fit`` with ``X`` being the output of ``t[N]``, and ``y=y``
+
+    ``predict(X, fh)`` - result is of executing ``f.predict``, with ``fh=fh``, and ``X``
         being the result of the following process:
-        running `t1.fit_transform` with `X=X`,
-        then `t2.fit_transform` on `X=` the output of `t1.fit_transform`, etc
-        sequentially, with `t[i]` receiving the output of `t[i-1]` as `X`,
-        and returning th output of `tN` to pass to `f.predict` as `X`.
-    `predict_interval(X, fh)`, `predict_quantiles(X, fh)` - as `predict(X, fh)`,
-        with `predict_interval` or `predict_quantiles` substituted for `predict`
-    `predict_var`, `predict_proba` - uses base class default to obtain
-        crude estimates from `predict_quantiles`.
+        running ``t1.fit_transform`` with ``X=X``,
+        then ``t2.fit_transform`` on ``X=`` the output of ``t1.fit_transform``, etc
+        sequentially, with ``t[i]`` receiving the output of ``t[i-1]`` as ``X``,
+        and returning th output of ``tN`` to pass to ``f.predict`` as ``X``.
 
-    `get_params`, `set_params` uses `sklearn` compatible nesting interface
-        if list is unnamed, names are generated as names of classes
-        if names are non-unique, `f"_{str(i)}"` is appended to each name string
-            where `i` is the total count of occurrence of a non-unique string
-            inside the list of names leading up to it (inclusive)
+    ``predict_interval(X, fh)``, ``predict_quantiles(X, fh)`` - as ``predict(X, fh)``,
+        with ``predict_interval`` or ``predict_quantiles`` substituted for ``predict``
 
-    `ForecastingPipeline` can also be created by using the magic multiplication
-        on any forecaster, i.e., if `my_forecaster` inherits from `BaseForecaster`,
-            and `my_t1`, `my_t2`, inherit from `BaseTransformer`,
-            then, for instance, `my_t1 ** my_t2 ** my_forecaster`
-            will result in the same object as  obtained from the constructor
-            `ForecastingPipeline([my_t1, my_t2, my_forecaster])`
-        magic multiplication can also be used with (str, transformer) pairs,
-            as long as one element in the chain is a transformer
+    ``predict_var``, ``predict_proba`` - uses base class default to obtain
+        crude normal estimates from ``predict_quantiles``.
+
+    ``get_params``, ``set_params`` uses ``sklearn`` compatible nesting interface:
+
+        * if list is unnamed, names are generated as names of classes
+        * if names are non-unique, ``f"_{str(i)}"`` is appended to each name string
+          where ``i`` is the total count of occurrence of a non-unique string
+          inside the list of names leading up to it (inclusive)
+
+    ``ForecastingPipeline`` can also be created by using the magic multiplication
+        on any forecaster, i.e., if ``my_forecaster`` inherits from ``BaseForecaster``,
+        and ``my_t1``, ``my_t2``, inherit from ``BaseTransformer``,
+        then, for instance, ``my_t1 ** my_t2 ** my_forecaster``
+        will result in the same object as  obtained from the constructor
+        ``ForecastingPipeline([my_t1, my_t2, my_forecaster])``.
+        Magic multiplication can also be used with (str, transformer) pairs,
+        as long as one element in the chain is a transformer.
 
     Parameters
     ----------
     steps : list of sktime transformers and forecasters, or
-        list of tuples (str, estimator) of sktime transformers or forecasters
-            the list must contain exactly one forecaster
-        these are "blueprint" transformers resp forecasters,
-            forecaster/transformer states do not change when `fit` is called
+        list of tuples (str, estimator) of ``sktime`` transformers or forecasters.
+        The list must contain exactly one forecaster.
+        These are "blueprint" transformers resp forecasters,
+        forecaster/transformer states do not change when ``fit`` is called.
 
     Attributes
     ----------
-    steps_ : list of tuples (str, estimator) of sktime transformers or forecasters
+    steps_ : list of tuples (str, estimator) of ``sktime`` transformers or forecasters
         clones of estimators in `steps` which are fitted in the pipeline
-        is always in (str, estimator) format, even if `steps` is just a list
-        strings not passed in `steps` are replaced by unique generated strings
-        i-th transformer in `steps_` is clone of i-th in `steps`
-    forecaster_ : estimator, reference to the unique forecaster in steps_
+        is always in (str, estimator) format, even if ``steps`` is just a list
+        strings not passed in ``steps`` are replaced by unique generated strings
+        i-th transformer in ``steps_`` is clone of i-th in ``steps``
+    forecaster_ : estimator, reference to the unique forecaster in ``steps_``
 
     Examples
     --------
@@ -421,17 +424,18 @@ class ForecastingPipeline(_Pipeline):
     def __rpow__(self, other):
         """Magic ** method, return (left) concatenated ForecastingPipeline.
 
-        Implemented for `other` being a transformer, otherwise returns `NotImplemented`.
+        Implemented for ``other`` being a transformer,
+        otherwise returns ``NotImplemented``.
 
         Parameters
         ----------
-        other: `sktime` transformer, must inherit from BaseTransformer
-            otherwise, `NotImplemented` is returned
+        other: ``sktime`` transformer, must inherit from ``BaseTransformer``
+            otherwise, ``NotImplemented`` is returned
 
         Returns
         -------
         ForecastingPipeline object,
-            concatenation of `other` (first) with `self` (last).
+            concatenation of ``other`` (first) with ``self`` (last).
             not nested, contains only non-TransformerPipeline `sktime` steps
         """
         from sktime.transformations.base import BaseTransformer
@@ -717,68 +721,76 @@ class ForecastingPipeline(_Pipeline):
 class TransformedTargetForecaster(_Pipeline):
     """Meta-estimator for forecasting transformed time series.
 
-    Pipeline functionality to apply transformers to the target series. The
-    X data is not transformed. If you want to transform X, please use the
-    ForecastingPipeline.
+    Pipeline functionality to apply transformers to endogeneous time series, ``y``.
+    The exogeneous data, ``X``, is not transformed.
+    To transform ``X``, the ``ForecastingPipeline`` can be used.
 
-    For a list `t1`, `t2`, ..., `tN`, `f`, `tp1`, `tp2`, ..., `tpM`
-        where `t[i]` and `tp[i]` are transformers (`t` to pre-, `tp` to post-process),
-        and `f` is an sktime forecaster,
+    For a list ``t1``, ``t2``, ..., ``tN``, ``f``, ``tp1``, ``tp2``, ..., ``tpM``,
+        where ``t[i]`` and ``tp[i]`` are transformers
+        (``t`` to pre-, ``tp`` to post-process),
+        and ``f`` is an sktime forecaster,
         the pipeline behaves as follows:
-    `fit(y, X, fh)` - changes state by running `t1.fit_transform` with `X=y`, `y=X`
-        then `t2.fit_transform` on `X=` the output of `t1.fit_transform`, `y=X`, etc
-        sequentially, with `t[i]` receiving the output of `t[i-1]` as `X`,
-        then running `f.fit` with `y` being the output of `t[N]`, and `X=X`,
-        then running `tp1.fit_transform`  with `X=y`, `y=X`,
-        then `tp2.fit_transform` on `X=` the output of `tp1.fit_transform`, etc
-        sequentially, with `tp[i]` receiving the output of `tp[i-1]`,
-    `predict(X, fh)` - result is of executing `f.predict`, with `X=X`, `fh=fh`,
-        then running `tp1.inverse_transform` with `X=` the output of `f`, `y=X`,
-        then `t2.inverse_transform` on `X=` the output of `t1.inverse_transform`, etc
-        sequentially, with `t[i]` receiving the output of `t[i-1]` as `X`,
-        then running `tp1.fit_transform` with `X=` the output of `t[N]s`, `y=X`,
-        then `tp2.fit_transform` on `X=` the output of `tp1.fit_transform`, etc
-        sequentially, with `tp[i]` receiving the output of `tp[i-1]`,
-    `predict_interval(X, fh)`, `predict_quantiles(X, fh)` - as `predict(X, fh)`,
-        with `predict_interval` or `predict_quantiles` substituted for `predict`
-    `predict_var`, `predict_proba` - uses base class default to obtain
-        crude estimates from `predict_quantiles`.
 
-    `get_params`, `set_params` uses `sklearn` compatible nesting interface
-        if list is unnamed, names are generated as names of classes
-        if names are non-unique, `f"_{str(i)}"` is appended to each name string
-            where `i` is the total count of occurrence of a non-unique string
-            inside the list of names leading up to it (inclusive)
+    ``fit(y, X, fh)`` - changes state by running ``t1.fit_transform``
+        with ``X=y``, ``y=X``,
+        then ``t2.fit_transform`` on ``X=`` the output of ``t1.fit_transform``, ``y=X``,
+        etc, sequentially, with ``t[i]`` receiving the output of ``t[i-1]`` as ``X``,
+        then running ``f.fit`` with ``y`` being the output of ``t[N]``, and ``X=X``,
+        then running ``tp1.fit_transform``  with ``X=y``, ``y=X``,
+        then ``tp2.fit_transform`` on ``X=`` the output of ``tp1.fit_transform``, etc
+        sequentially, with ``tp[i]`` receiving the output of ``tp[i-1]``,
 
-    `TransformedTargetForecaster` can also be created by using the magic multiplication
-        on any forecaster, i.e., if `my_forecaster` inherits from `BaseForecaster`,
-            and `my_t1`, `my_t2`, `my_tp` inherit from `BaseTransformer`,
-            then, for instance, `my_t1 * my_t2 * my_forecaster * my_tp`
-            will result in the same object as  obtained from the constructor
-            `TransformedTargetForecaster([my_t1, my_t2, my_forecaster, my_tp])`
-        magic multiplication can also be used with (str, transformer) pairs,
-            as long as one element in the chain is a transformer
+    ``predict(X, fh)`` - result is of executing ``f.predict``, with ``X=X``, ``fh=fh``,
+        then running ``tp1.inverse_transform`` with ``X=`` the output of ``f``, ``y=X``,
+        then ``t2.inverse_transform`` on ``X=`` the output of ``t1.inverse_transform``,
+        etc, sequentially, with ``t[i]`` receiving the output of ``t[i-1]`` as ``X``,
+        then running ``tp1.fit_transform`` with ``X=`` the output of ``t[N]s``, ``y=X``,
+        then ``tp2.fit_transform`` on ``X=`` the output of ``tp1.fit_transform``, etc,
+        sequentially, with ``tp[i]`` receiving the output of ``tp[i-1]``,
+
+    ``predict_interval(X, fh)``, ``predict_quantiles(X, fh)`` - as ``predict(X, fh)``,
+        with ``predict_interval`` or ``predict_quantiles`` substituted for ``predict``
+
+    ``predict_var``, ``predict_proba`` - uses base class default to obtain
+        crude normal estimates from ``predict_quantiles``.
+
+    ``get_params``, ``set_params`` uses ``sklearn`` compatible nesting interface:
+
+        * if list is unnamed, names are generated as names of classes
+        * if names are non-unique, ``f"_{str(i)}"`` is appended to each name string
+          where ``i`` is the total count of occurrence of a non-unique string
+          inside the list of names leading up to it (inclusive)
+
+    ``TransformedTargetForecaster`` can also be created by using the magic
+        multiplication
+        on any forecaster, i.e., if ``my_forecaster`` inherits from ``BaseForecaster``,
+        and ``my_t1``, ``my_t2``, ``my_tp`` inherit from ``BaseTransformer``,
+        then, for instance, ``my_t1 * my_t2 * my_forecaster * my_tp``
+        will result in the same object as  obtained from the constructor
+        ``TransformedTargetForecaster([my_t1, my_t2, my_forecaster, my_tp])``.
+        Magic multiplication can also be used with (str, transformer) pairs,
+        as long as one element in the chain is a transformer.
 
     Parameters
     ----------
-    steps : list of sktime transformers and forecasters, or
-        list of tuples (str, estimator) of sktime transformers or forecasters
-            the list must contain exactly one forecaster
-        these are "blueprint" transformers resp forecasters,
-            forecaster/transformer states do not change when `fit` is called
+    steps : list of ``sktime`` transformers and forecasters, or
+        list of tuples (str, estimator) of ``sktime`` transformers or forecasters.
+        The list must contain exactly one forecaster.
+        These are "blueprint" transformers resp forecasters,
+        forecaster/transformer states do not change when ``fit`` is called.
 
     Attributes
     ----------
-    steps_ : list of tuples (str, estimator) of sktime transformers or forecasters
-        clones of estimators in `steps` which are fitted in the pipeline
-        is always in (str, estimator) format, even if `steps` is just a list
-        strings not passed in `steps` are replaced by unique generated strings
-        i-th transformer in `steps_` is clone of i-th in `steps`
-    forecaster_ : estimator, reference to the unique forecaster in steps_
+    steps_ : list of tuples (str, estimator) of ``sktime`` transformers or forecasters
+        clones of estimators in ``steps`` which are fitted in the pipeline
+        is always in (str, estimator) format, even if ``steps`` is just a list
+        strings not passed in ``steps`` are replaced by unique generated strings
+        i-th transformer in ``steps_`` is clone of i-th in ``steps``
+    forecaster_ : estimator, reference to the unique forecaster in ``steps_``
     transformers_pre_ : list of tuples (str, transformer) of sktime transformers
-        reference to pairs in steps_ that precede forecaster_
+        reference to pairs in ``steps_`` that precede ``forecaster_``
     transformers_ost_ : list of tuples (str, transformer) of sktime transformers
-        reference to pairs in steps_ that succeed forecaster_
+        reference to pairs in ``steps_`` that succeed ``forecaster_``
 
     Examples
     --------

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -543,11 +543,13 @@ def test_pipeline_featurizer_noexog():
 
     fcst = YfromX.create_test_instance()
 
-    pipe = ForecastingPipeline([
-        YtoX(),
-        FourierFeatures(sp_list=[24, 24*7], fourier_terms_list=[10, 5]),
-        fcst,
-    ])
+    pipe = ForecastingPipeline(
+        [
+            YtoX(),
+            FourierFeatures(sp_list=[24, 24 * 7], fourier_terms_list=[10, 5]),
+            fcst,
+        ]
+    )
 
     y_pred = pipe.fit_predict(y=calls, fh=fh)
 

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -192,6 +192,12 @@ ESTIMATOR_TAG_REGISTER = [
         "what is the scitype of y: None (not needed), Primitives, Series, Panel?",
     ),
     (
+        "requires_X",
+        "transformer",
+        "bool",
+        "does this transformer require X to be passed in fit and transform?",
+    ),
+    (
         "requires_y",
         "transformer",
         "bool",

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -118,6 +118,7 @@ class BaseTransformer(BaseEstimator):
         "X_inner_mtype": "pd.DataFrame",  # which mtypes do _fit/_predict support for X?
         # this can be a Panel mtype even if transform-input is Series, vectorized
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
+        "requires_X": True,  # does X need to be passed in fit?
         "requires_y": False,  # does y need to be passed in fit?
         "enforce_index_type": None,  # index type that needs to be enforced in X/y
         "fit_is_empty": True,  # is fit empty and can be skipped? Yes = True
@@ -467,6 +468,10 @@ class BaseTransformer(BaseEstimator):
         if self.get_tag("fit_is_empty") and not self.get_tag("remember_data", False):
             self._is_fitted = True
             return self
+
+        # if requires_y is set, y is required in fit and update
+        if self.get_tag("requires_X") and X is None:
+            raise ValueError(f"{self.__class__.__name__} requires `X` in `fit`.")
 
         # if requires_y is set, y is required in fit and update
         if self.get_tag("requires_y") and y is None:

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -583,8 +583,6 @@ class BaseTransformer(BaseEstimator):
         # check whether is fitted
         self.check_is_fitted()
 
-        print(X)
-
         # input check and conversion for X/y
         X_inner, y_inner, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
 
@@ -606,8 +604,6 @@ class BaseTransformer(BaseEstimator):
             X_out = self._convert_output(Xt, metadata=metadata)
         else:
             X_out = Xt
-
-        print(X_out)
 
         return X_out
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -583,6 +583,8 @@ class BaseTransformer(BaseEstimator):
         # check whether is fitted
         self.check_is_fitted()
 
+        print(X)
+
         # input check and conversion for X/y
         X_inner, y_inner, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
 
@@ -604,6 +606,8 @@ class BaseTransformer(BaseEstimator):
             X_out = self._convert_output(Xt, metadata=metadata)
         else:
             X_out = Xt
+
+        print(X_out)
 
         return X_out
 

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -158,6 +158,7 @@ class ColumnEnsembleTransformer(
         if isinstance(transformers, BaseTransformer):
             tags_to_clone = [
                 "fit_is_empty",
+                "requires_X",
                 "requires_y",
                 "X-y-must-have-same-index",
                 "transform-returns-same-time-index",
@@ -172,6 +173,7 @@ class ColumnEnsembleTransformer(
         else:
             l_transformers = [(x[0], x[1]) for x in transformers]
             # self._anytagis_then_set("fit_is_empty", False, True, l_transformers)
+            self._anytagis_then_set("requires_X", True, False, l_transformers)
             self._anytagis_then_set("requires_y", True, False, l_transformers)
             self._anytagis_then_set(
                 "X-y-must-have-same-index", True, False, l_transformers

--- a/sktime/transformations/compose/_ytox.py
+++ b/sktime/transformations/compose/_ytox.py
@@ -30,6 +30,7 @@ class YtoX(BaseTransformer):
         "y_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         "scitype:y": "both",
         "fit_is_empty": True,
+        "requires_X": False,
         "requires_y": True,
     }
 


### PR DESCRIPTION
Fixes #5975, see there for description of the edge case bug where `X` is `None`, but passing to transformers is valid.

Changes included:

* added tag `requires_X` for transformers, because passing `X` always causes problems with other examples. This is turned off for, e.g., `YfromX`.
* replaced custom scitype inference utility in `_pipeline.py` module with the central entry point in `registry` (that was created later)
* better docstring formatting in `TransformedTargetForecaster` and `ForecastingPipeline`