### PR TITLE
[ENH ] `FourierFeatures` featurizer to use `y.index` if `X.index` is not available

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -486,8 +486,8 @@ class ForecastingPipeline(_Pipeline):
         -------
         self : returns an instance of self.
         """
-        # If X is not given or ignored, just passthrough the data without transformation
-        if self._X is not None and not self.get_tag("ignores-exogeneous-X"):
+        # If X is ignored, just passthrough the data without transformation
+        if not self.get_tag("ignores-exogeneous-X"):
             # transform X
             for step_idx, name, transformer in self._iter_transformers():
                 t = transformer.clone()
@@ -667,12 +667,10 @@ class ForecastingPipeline(_Pipeline):
         -------
         self : an instance of self
         """
-        # If X is not given, just passthrough the data without transformation
-        if X is not None:
-            for _, _, transformer in self._iter_transformers():
-                if hasattr(transformer, "update"):
-                    transformer.update(X=X, y=y, update_params=update_params)
-                    X = transformer.transform(X=X, y=y)
+        for _, _, transformer in self._iter_transformers():
+            if hasattr(transformer, "update"):
+                transformer.update(X=X, y=y, update_params=update_params)
+                X = transformer.transform(X=X, y=y)
 
         _, forecaster = self.steps_[-1]
         forecaster.update(y=y, X=X, update_params=update_params)
@@ -680,7 +678,7 @@ class ForecastingPipeline(_Pipeline):
 
     def _transform(self, X=None, y=None):
         # If X is not given or ignored, just passthrough the data without transformation
-        if self._X is not None and not self.get_tag("ignores-exogeneous-X"):
+        if not self.get_tag("ignores-exogeneous-X"):
             for _, _, transformer in self._iter_transformers():
                 # if y is required but not passed,
                 # we create a zero-column y from the forecasting horizon

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -682,8 +682,7 @@ class ForecastingPipeline(_Pipeline):
             for _, _, transformer in self._iter_transformers():
                 # if y is required but not passed,
                 # we create a zero-column y from the forecasting horizon
-                requires_y = transformer.get_tag("requires_y", False)
-                if isinstance(y, ForecastingHorizon) and requires_y:
+                if isinstance(y, ForecastingHorizon):
                     y = y.to_absolute_index(self.cutoff)
                     y = pd.DataFrame(index=y)
                 else:

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -583,8 +583,6 @@ class BaseTransformer(BaseEstimator):
         # check whether is fitted
         self.check_is_fitted()
 
-        print(X)
-
         # input check and conversion for X/y
         X_inner, y_inner, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
 
@@ -606,8 +604,6 @@ class BaseTransformer(BaseEstimator):
             X_out = self._convert_output(Xt, metadata=metadata)
         else:
             X_out = Xt
-
-        print(X_out)
 
         return X_out
 

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -583,6 +583,8 @@ class BaseTransformer(BaseEstimator):
         # check whether is fitted
         self.check_is_fitted()
 
+        print(X)
+
         # input check and conversion for X/y
         X_inner, y_inner, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
 
@@ -604,6 +606,8 @@ class BaseTransformer(BaseEstimator):
             X_out = self._convert_output(Xt, metadata=metadata)
         else:
             X_out = Xt
+
+        print(X_out)
 
         return X_out
 


### PR DESCRIPTION
This PR aims at making the following code work in a non-invasive way, i.e., using featurizers without `YtoX` in a `ForecastingPipeline`.

The strategy used is (a) allowing featurizers to access `y`, and (b) using `y.index` if `X.index` is not available. For this, in `transform` we always need to pass `fh.index`, not just in the `requires_y` case.

Code example that should work with this PR:


```python
import pandas as pd
import numpy as np

from sktime.forecasting.compose import ForecastingPipeline
from sktime.transformations.compose import YtoX
from sktime.transformations.series.fourier import FourierFeatures

calls_per_minute_low = 100 * 60
calls_per_minute_high = 500 * 60
calls = pd.Series(
    data=np.random.randint(low=calls_per_minute_low, high=calls_per_minute_high, size=100)
)

fh = range(1, 10)

fcst = YfromX.create_test_instance()

pipe = ForecastingPipeline([
    FourierFeatures(sp_list=[24, 24*7], fourier_terms_list=[10, 5]),
    fcst,
])

y_pred = pipe.fit_predict(y=calls, fh=fh)
```

Related: https://github.com/sktime/sktime/issues/5967