### PR TITLE
[ENH] refactor `Catch22Wrapper` transformer to use `pd.Series` type internally

### DIFF
--- a/sktime/transformations/panel/catch22wrapper.py
+++ b/sktime/transformations/panel/catch22wrapper.py
@@ -13,6 +13,7 @@ from joblib import Parallel, delayed
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.panel import catch22
 from sktime.utils.validation import check_n_jobs
+from sktime.utils.warnings import warn
 
 
 class Catch22Wrapper(BaseTransformer):
@@ -52,9 +53,6 @@ class Catch22Wrapper(BaseTransformer):
         while to process for large values.
     replace_nans : bool, optional, default=True
         Replace NaN or inf values from the Catch22 transform with 0.
-    n_jobs : int, optional, default=1
-        The number of jobs to run in parallel for transform. Requires multiple input
-        cases. ``-1`` means using all processors.
 
     See Also
     --------
@@ -86,13 +84,14 @@ class Catch22Wrapper(BaseTransformer):
         "fit_is_empty": True,
     }
 
+    # todo 0.29.0: remove n_jobs parameter
     def __init__(
         self,
         features="all",
         catch24=False,
         outlier_norm=False,
         replace_nans=False,
-        n_jobs=1,
+        n_jobs="deprecated",
     ):
         self.features = features
         self.catch24 = catch24
@@ -123,6 +122,19 @@ class Catch22Wrapper(BaseTransformer):
         self._transform_features = None
 
         super().__init__()
+
+        # todo 0.29.0: remove this warning and logic
+        if n_jobs != "deprecated":
+            warn(
+                "In Catch22Wrapper, the parameter "
+                "n_jobs is deprecated and will be removed in v0.29.0. "
+                "Instead, use set_config with the backend and backend:params "
+                "config fields, and set backend to 'joblib' and pass n_jobs "
+                "as a parameter of backend_params. ",
+                FutureWarning,
+                obj=self,
+            )
+            self.set_config(backend="joblib", backend_params={"n_jobs": n_jobs})
 
     def _transform(self, X, y=None):
         """Transform data into the Catch22 features.

--- a/sktime/transformations/panel/catch22wrapper.py
+++ b/sktime/transformations/panel/catch22wrapper.py
@@ -73,7 +73,7 @@ class Catch22Wrapper(BaseTransformer):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["MatthewMiddlehurst"],
+        "authors": ["MatthewMiddlehurst", "fkiraly"],
         "maintainers": "benfulcher",
         "python_dependencies": "pycatch22",
         # estimator type
@@ -81,7 +81,7 @@ class Catch22Wrapper(BaseTransformer):
         "scitype:transform-input": "Series",
         "scitype:transform-output": "Primitives",
         "scitype:instancewise": True,
-        "X_inner_mtype": "nested_univ",
+        "X_inner_mtype": "pd.Series",
         "y_inner_mtype": "None",
         "fit_is_empty": True,
     }
@@ -169,21 +169,12 @@ class Catch22Wrapper(BaseTransformer):
             pycatch22.PD_PeriodicityWang_th0_01,
         ]
 
-        threads_to_use = check_n_jobs(self.n_jobs)
-
-        c22_list = Parallel(n_jobs=threads_to_use)(
-            delayed(self._transform_case)(
-                X.iloc[i],
-                f_idx,
-                features,
-            )
-            for i in range(n_instances)
-        )
+        Xt =  self._transform_case(X, f_idx, features)
 
         if self.replace_nans:
-            c22_list = np.nan_to_num(c22_list, False, 0, 0, 0)
+            Xt = Xt.fillna(0)
 
-        return pd.DataFrame(c22_list)
+        return Xt
 
     def _transform_case(self, X, f_idx, features):
         c22 = np.zeros(len(f_idx) * len(X))


### PR DESCRIPTION
This refactors the `Catch22Wrapper` transformer to use `pd.Series` type internally, from the old `nested_univ` type.

This also means that parallelization is now supported via broadcasting and `set_config`, instead of being fused with the transformer.

For the deprecation period, if `n_jobs` is passed, the estimator uses `set_config` internally.