### PR TITLE
[DOC] Added blank lines to properly render `FourierFeatures` docstring, `sp_list` (#5932)

### DIFF
--- a/sktime/transformations/series/fourier.py
+++ b/sktime/transformations/series/fourier.py
@@ -45,12 +45,16 @@ class FourierFeatures(BaseTransformer):
     ----------
     sp_list : List[float and/or str]
         List of seasonal periods. Can be defined with the following options:
-        * float : Periodicity defined as number of timesteps since the beginning of the
-        data seen in `fit`.
-        * string : Periodicity defined as a column name in X that contains the
-        :math:`t/sp` values
-        * string : Periodicity defined as a pandas period alias:
-        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#period-aliases
+
+        * | float : Periodicity defined as number of timesteps since the beginning of
+            the data seen in ``fit``.
+
+        * | string : Periodicity defined as a column name in X that contains the
+            :math:`t/sp` values.
+
+        * | string : Periodicity defined as a pandas period alias:
+            https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#period-aliases
+
     fourier_terms_list : List[int]
         List of number of fourier terms (:math:`K`) per corresponding (:math:`sp`); each
         :math:`K` matches to one :math:`sp` of the sp_list. For example, if sp_list =
@@ -63,7 +67,7 @@ class FourierFeatures(BaseTransformer):
         match a pandas offset alias:
         https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
     keep_original_columns : boolean, optional, default=False
-        Keep original columns in X passed to `.transform()`
+        Keep original columns in X passed to ``.transform()``
 
     References
     ----------


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
Fixes #5932

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
I added blank lines and line blocks to properly create the sp_list description, as required by the reStructuredText syntax.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->
No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
No

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->
No

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

<!--
Thanks for contributing!
-->
