### PR TITLE
[DOC] format docstrings in `feature_selection.py` correctly

### DIFF
--- a/sktime/transformations/series/feature_selection.py
+++ b/sktime/transformations/series/feature_selection.py
@@ -25,6 +25,7 @@ class FeatureSelection(BaseTransformer):
     ----------
     method : str, required
         The method of how to select the features. Implemented methods are:
+        
         * "feature-importances": Use feature_importances_ of the regressor (meta-model)
           to select n_columns with highest importance values.
           Requires parameter n_columns.
@@ -32,6 +33,7 @@ class FeatureSelection(BaseTransformer):
         * "columns": Select features by given names.
         * "none": Remove all columns, transform returns None.
         * "all": Select all given features.
+        
     regressor : sklearn-like regressor, optional, default=None.
         Used as meta-model for the method "feature-importances". The given
         regressor must have an attribute "feature_importances_". If None,

--- a/sktime/transformations/series/feature_selection.py
+++ b/sktime/transformations/series/feature_selection.py
@@ -25,6 +25,7 @@ class FeatureSelection(BaseTransformer):
     ----------
     method : str, required
         The method of how to select the features. Implemented methods are:
+
         * "feature-importances": Use feature_importances_ of the regressor (meta-model)
           to select n_columns with highest importance values.
           Requires parameter n_columns.
@@ -32,6 +33,7 @@ class FeatureSelection(BaseTransformer):
         * "columns": Select features by given names.
         * "none": Remove all columns, transform returns None.
         * "all": Select all given features.
+
     regressor : sklearn-like regressor, optional, default=None.
         Used as meta-model for the method "feature-importances". The given
         regressor must have an attribute "feature_importances_". If None,

--- a/sktime/transformations/series/feature_selection.py
+++ b/sktime/transformations/series/feature_selection.py
@@ -32,7 +32,6 @@ class FeatureSelection(BaseTransformer):
         * "columns": Select features by given names.
         * "none": Remove all columns, transform returns None.
         * "all": Select all given features.
-        
     regressor : sklearn-like regressor, optional, default=None.
         Used as meta-model for the method "feature-importances". The given
         regressor must have an attribute "feature_importances_". If None,

--- a/sktime/transformations/series/feature_selection.py
+++ b/sktime/transformations/series/feature_selection.py
@@ -25,7 +25,6 @@ class FeatureSelection(BaseTransformer):
     ----------
     method : str, required
         The method of how to select the features. Implemented methods are:
-        
         * "feature-importances": Use feature_importances_ of the regressor (meta-model)
           to select n_columns with highest importance values.
           Requires parameter n_columns.


### PR DESCRIPTION
The bullet point for the " feature-importance" is not properly rendered. I have added blank line before and after the bullet point list.

<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes #5993


#### What does this implement/fix? Explain your changes.
The bullet point for the " feature-importance" in feature_selection.py is not properly rendered. I have added blank line before and after the bullet point list.

#### Does your contribution introduce a new dependency? If yes, which one?

No


#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
No


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
