### PR TITLE
[ENH] make `numba` an optional backend for `DtwDist`, `EditDist`

### DIFF
--- a/sktime/distances/_ddtw.py
+++ b/sktime/distances/_ddtw.py
@@ -114,13 +114,6 @@ class _DdtwDistance(NumbaDistance):
             x, y, window, itakura_max_slope, bounding_matrix
         )
 
-        if not is_no_python_compiled_callable(compute_derivative):
-            raise TypeError(
-                f"The derivative callable must be no_python compiled. The name"
-                f"of the callable that must be compiled is "
-                f"{compute_derivative.__name__}"
-            )
-
         if return_cost_matrix is True:
 
             @njit(cache=True)
@@ -215,13 +208,6 @@ class _DdtwDistance(NumbaDistance):
         _bounding_matrix = resolve_bounding_matrix(
             x, y, window, itakura_max_slope, bounding_matrix
         )
-
-        if not is_no_python_compiled_callable(compute_derivative):
-            raise TypeError(
-                f"The derivative callable must be no_python compiled. The name"
-                f"of the callable that must be compiled is "
-                f"{compute_derivative.__name__}"
-            )
 
         @njit(cache=True)
         def numba_ddtw_distance(

--- a/sktime/distances/_wddtw.py
+++ b/sktime/distances/_wddtw.py
@@ -100,13 +100,6 @@ class _WddtwDistance(NumbaDistance):
                 f"The value of g must be a float. The current value is {g}"
             )
 
-        if not is_no_python_compiled_callable(compute_derivative):
-            raise ValueError(
-                f"The derivative callable must be no_python compiled. The name"
-                f"of the callable that must be compiled is "
-                f"{compute_derivative.__name__}"
-            )
-
         if return_cost_matrix is True:
 
             @njit(cache=True)
@@ -211,13 +204,6 @@ class _WddtwDistance(NumbaDistance):
         if not isinstance(g, float):
             raise ValueError(
                 f"The value of g must be a float. The current value is {g}"
-            )
-
-        if not is_no_python_compiled_callable(compute_derivative):
-            raise ValueError(
-                f"The derivative callable must be no_python compiled. The name"
-                f"of the callable that must be compiled is "
-                f"{compute_derivative.__name__}"
             )
 
         @njit(cache=True)

--- a/sktime/dists_kernels/dtw/_dtw_sktime.py
+++ b/sktime/dists_kernels/dtw/_dtw_sktime.py
@@ -126,7 +126,8 @@ class DtwDist(BasePairwiseTransformerPanel):
         # packaging info
         # --------------
         "authors": ["chrisholder", "TonyBagnall", "fkiraly"],
-        "python_dependencies": "numba",
+        # "python_dependencies": "numba",  optional backend
+        #
         # estimator type
         # --------------
         "symmetric": True,  # all the distances are symmetric
@@ -173,6 +174,10 @@ class DtwDist(BasePairwiseTransformerPanel):
         self.kwargs = kwargs
 
         super().__init__()
+
+        from sktime.utils.numba.warning import _check_numba_warning
+
+        _check_numba_warning(self, category=UserWarning)
 
     def _transform(self, X, X2=None):
         """Compute distance/kernel matrix.

--- a/sktime/dists_kernels/edit_dist.py
+++ b/sktime/dists_kernels/edit_dist.py
@@ -118,7 +118,8 @@ class EditDist(BasePairwiseTransformerPanel):
         # packaging info
         # --------------
         "authors": ["chrisholder", "TonyBagnall", "fkiraly"],
-        "python_dependencies": "numba",
+        # "python_dependencies": "numba",  optional backend
+        #
         # estimator type
         # --------------
         "symmetric": True,  # all the distances are symmetric
@@ -150,6 +151,10 @@ class EditDist(BasePairwiseTransformerPanel):
         self.p = p
 
         super().__init__()
+
+        from sktime.utils.numba.warning import _check_numba_warning
+
+        _check_numba_warning(self, category=UserWarning)
 
         kwargs = {
             "window": window,

--- a/sktime/utils/numba/njit.py
+++ b/sktime/utils/numba/njit.py
@@ -3,7 +3,7 @@
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 # exports numba.njit if numba is present, otherwise an identity njit
-if _check_soft_dependencies("numba", severity="warning"):
+if _check_soft_dependencies("numba", severity="none"):
     from numba import jit, njit  # noqa E402
 
 else:

--- a/sktime/utils/numba/warning.py
+++ b/sktime/utils/numba/warning.py
@@ -1,0 +1,29 @@
+"""Numba optional backend warning."""
+
+from inspect import isclass
+
+from sktime.utils.validation._dependencies import _check_soft_dependencies
+
+
+def _check_numba_warning(obj=None, category=None, stacklevel=1):
+    from sktime.utils.warnings import warn
+
+    if obj is None:
+        obj_name = "This feature"
+    elif isclass(obj):
+        obj_name = obj.__name__
+    elif isclass(type(obj)):
+        obj_name = type(obj).__name__
+    else:
+        obj_name = str(obj)
+
+    numba_available = _check_soft_dependencies("numba", severity="none")
+
+    if not numba_available:
+        warn(
+            f"{obj_name} uses numba as an optional backend, but numba was not found "
+            "in the python environment. Without numba, performance will be suboptimal.",
+            category=category,
+            stacklevel=stacklevel,
+            obj=obj,
+        )


### PR DESCRIPTION
This PR makes `numba` an optional - rather htan required - backend for `DtwDist`, `EditDist`.

Doing this relies on two observations:

* with some settings, `DtwDist` and `EditDist` would already allow to be run without `numba` - this is due to the isolation and compiler-free replacement of `njit` et al.
* Currently, dependencies were not checked on distances, so users could already build estimtaors with `DtwDist` for those settings without getting a "numba is missing" error or messate, see https://github.com/sktime/sktime/pull/5999

This puts us in a situation where it would be good to raise that message - or users may not be informed about the condition that degrades their performance - but not an exception, as that might break existing user code.

The solution I've come up with is raising a warning at construction, while removing the dependency tag from the header.

This PR also widens the range of applicability.

An alternative solution would be a parameter `use_numba` which gives the user explicit control - maybe that is better?
