### PR TITLE
[ENH] use `Index.unique` instead of `set` in conversion from `pd-multiindex` to `df-list` mtype

### DIFF
--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -988,7 +988,7 @@ convert_dict[("df-list", "pd-multiindex", "Panel")] = from_dflist_to_multiindex
 def from_multiindex_to_dflist(obj, store=None):
     obj = _coerce_df_dtypes(obj)
 
-    instance_index = set(obj.index.get_level_values(0))
+    instance_index = obj.index.get_level_values(0).unique()
 
     Xlist = [obj.loc[i].rename_axis(None) for i in instance_index]
 


### PR DESCRIPTION
This PR modifies the conversion from `pd-multiindex` to `df-list` mtype to use `Index.unique` instead of `set`.

As this is more idiomatic, it should be less error prone across `pandas` versions.

A possible fix for https://github.com/sktime/sktime/issues/5988, based on a guess what the issue could be.