### PR TITLE
[ENH] add missing `PluginParamsTransformer` to API reference

### DIFF
--- a/docs/source/api_reference/param_est.rst
+++ b/docs/source/api_reference/param_est.rst
@@ -41,6 +41,7 @@ Composition
     :template: class.rst
 
     PluginParamsForecaster
+    PluginParamsTransformer
 
 Naive
 ~~~~~


### PR DESCRIPTION
This PR adds the missing `PluginParamsTransformer` to the API reference