### PR TITLE
[DOC] 2024 summer programme links on `sktime.net` landing page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,15 @@ Welcome to sktime
 
 A unified framework for machine learning with time series.
 
+.. topic:: Join the sktime summer programme 2024 with Google Summer of Code!
+
+    Apply for paid internships and/or mentoring:
+    `GSoC and internships <https://github.com/sktime/mentoring>`_
+
+    Sponsor a project, or join coordinated workstreams:
+    `Register here <https://forms.gle/98XBxgxN6XfQYMBB6>`_
+
+
 .. topic:: Register as a user, or voter for sktime committees!
 
     Prioritized bugfixes, shape the tech roadmap and governance policy.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,11 +8,11 @@ A unified framework for machine learning with time series.
 
 .. topic:: Join the sktime summer programme 2024 with Google Summer of Code!
 
-    Apply for paid internships and/or mentoring:
+    Apply for paid internships and/or mentoring (by April 2):
     `GSoC and internships <https://github.com/sktime/mentoring>`_
 
-    Sponsor a project, or join coordinated workstreams:
-    `Register here <https://forms.gle/98XBxgxN6XfQYMBB6>`_
+    Sponsor a project, or join coordinated workstreams (by April 15):
+    `Fill out the planning form <https://forms.gle/98XBxgxN6XfQYMBB6>`_
 
 
 .. topic:: Register as a user, or voter for sktime committees!


### PR DESCRIPTION
This PR puts a box with key links to 2024 summer programme participation on the `sktime.net` landing page:

* application to internhsips and mentoring
* contribution to managed workstreams (sponsoring and time commitments)