### PR TITLE
`resolves #5781` 1st row 2nd column returns correct value after switching rolling and …

### DIFF
--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -454,16 +454,12 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
         if isinstance(Z, pd.core.groupby.generic.SeriesGroupBy):
             if bfill is False:
                 feat = getattr(
-                    Z.shift(lag).rolling(
-                        window=window_length, min_periods=window_length
-                    ),
+                    Z.rolling(window=window_length, min_periods=1),
                     summarizer,
-                )()
+                )().shift(lag)
             else:
                 feat = getattr(
-                    Z.shift(lag)
-                    .bfill()
-                    .rolling(window=window_length, min_periods=window_length),
+                    Z.rolling(window=window_length, min_periods=1).shift(lag).bfill(),
                     summarizer,
                 )()
             feat = pd.DataFrame(feat)
@@ -471,41 +467,32 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
             if bfill is False:
                 feat = Z.apply(
                     lambda x: getattr(
-                        x.shift(lag).rolling(
-                            window=window_length, min_periods=window_length
-                        ),
+                        x.rolling(window=window_length, min_periods=1),
                         summarizer,
-                    )()
+                    )().shift(lag)
                 )
             else:
                 feat = Z.apply(
                     lambda x: getattr(
-                        x.shift(lag)
-                        .bfill()
-                        .rolling(window=window_length, min_periods=window_length),
+                        x.rolling(window=window_length, min_periods=1).shift(lag).bfill(),
                         summarizer,
                     )()
                 )
     else:
-        if bfill is False:
-            feat = Z.shift(lag)
-        else:
-            feat = Z.shift(lag).bfill()
         if isinstance(Z, pd.core.groupby.generic.SeriesGroupBy) and callable(
             summarizer
         ):
-            feat = feat.rolling(window_length).apply(summarizer, raw=True)
+            feat = Z.rolling(window=window_length,min_periods=1).apply(summarizer, raw=True).shift(lag)
         elif not isinstance(Z, pd.core.groupby.generic.SeriesGroupBy) and callable(
             summarizer
         ):
-            feat = feat.apply(
+            feat = Z.apply(
                 lambda x: x.rolling(
-                    window=window_length, min_periods=window_length
-                ).apply(summarizer, raw=True)
+                    window=window_length, min_periods=1
+                ).apply(summarizer, raw=True).shift(lag)
             )
-        feat = pd.DataFrame(feat)
-    if bfill is True:
-        feat = feat.bfill()
+        if bfill is True:
+            feat = feat.bfill()
 
     if callable(summarizer):
         name = summarizer.__name__


### PR DESCRIPTION
On switching the rolling and shift and making the min_periods=1 to  ensure that the rolling window operation computes the statistic for any window size, even if it has only one observation. Thereby preventing the NaN values at the beginning .
But I am still not able to fix the NaN values that are there for the last row. Could you guide me through this.