### PR TITLE
[BUG] fix `BaseRegressor.score` method failing with `sklearn.metrics r2_score got an unexpected keyword argument 'normalize'`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2590,6 +2590,7 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/69190238?v=4",
       "profile": "https://cyrilmeyer.eu/",
       "contributions": [
+        "bug",
         "code"
       ]
     },

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2591,7 +2591,8 @@
       "profile": "https://cyrilmeyer.eu/",
       "contributions": [
         "bug",
-        "code"
+        "code",
+        "test"
       ]
     },
     {

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -299,7 +299,7 @@ class BaseRegressor(BasePanelMixin):
 
         self.check_is_fitted()
 
-        return r2_score(y, self.predict(X), normalize=True, multioutput=multioutput)
+        return r2_score(y, self.predict(X), multioutput=multioutput)
 
     def _fit(self, X, y):
         """Fit time series regressor to training data.

--- a/sktime/regression/tests/test_all_regressors.py
+++ b/sktime/regression/tests/test_all_regressors.py
@@ -95,6 +95,9 @@ class TestAllRegressors(RegressorFixtureGenerator, QuickTester):
 
         estimator_instance.fit(X, y_mult)
         y_pred = estimator_instance.predict(X)
+        # check score
+        score = estimator_instance.score(X, y_mult)
+        assert np.issubdtype(score.dtype, np.floating)
 
         assert isinstance(y_pred, pd.DataFrame)
         assert y_pred.shape == y_mult.shape

--- a/sktime/regression/tests/test_all_regressors.py
+++ b/sktime/regression/tests/test_all_regressors.py
@@ -77,6 +77,9 @@ class TestAllRegressors(RegressorFixtureGenerator, QuickTester):
 
         # run fit and predict
         y_pred = scenario.run(estimator_instance, method_sequence=["fit", "predict"])
+        # check score
+        score = estimator_instance.score(X_new, y_pred)
+        assert np.issubdtype(score.dtype, np.floating)
 
         # check predict
         assert isinstance(y_pred, np.ndarray)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #6018

#### What does this implement/fix? Explain your changes.
Remove non-existing `normalize` parameter for `r2_score` in `sktime.regression.base` class : `BaseRegressor` method : `score`.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
This PR does not solve another issue which is not directly linked, but should be noted.

With `test_x,  test_y  = load_UCR_UEA_dataset(name=data, split="test")`
```
model.score(test_x, test_y)
```
Will throw error :
<details>

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[6], line 1
----> 1 model.score(test_x, test_y)

File [~/Development/sktime-dev/sktime/sktime/regression/base.py:302](http://localhost:18888/lab/tree/sktime/sktime/sktime/regression/base.py#line=301), in BaseRegressor.score(self, X, y, multioutput)
    298 from sklearn.metrics import r2_score
    300 self.check_is_fitted()
--> 302 return r2_score(y, self.predict(X), multioutput=multioutput)

File [~/Development/sktime-dev/venv/lib/python3.10/site-packages/sklearn/utils/_param_validation.py:213](http://localhost:18888/lab/tree/sktime/venv/lib/python3.10/site-packages/sklearn/utils/_param_validation.py#line=212), in validate_params.<locals>.decorator.<locals>.wrapper(*args, **kwargs)
    207 try:
    208     with config_context(
    209         skip_parameter_validation=(
    210             prefer_skip_nested_validation or global_skip_validation
    211         )
    212     ):
--> 213         return func(*args, **kwargs)
    214 except InvalidParameterError as e:
    215     # When the function is just a wrapper around an estimator, we allow
    216     # the function to delegate validation to the estimator, but we replace
    217     # the name of the estimator by the name of the function in the error
    218     # message to avoid confusion.
    219     msg = re.sub(
    220         r"parameter of \w+ must be",
    221         f"parameter of {func.__qualname__} must be",
    222         str(e),
    223     )

File [~/Development/sktime-dev/venv/lib/python3.10/site-packages/sklearn/metrics/_regression.py:1180](http://localhost:18888/lab/tree/sktime/venv/lib/python3.10/site-packages/sklearn/metrics/_regression.py#line=1179), in r2_score(y_true, y_pred, sample_weight, multioutput, force_finite)
   1039 @validate_params(
   1040     {
   1041         "y_true": ["array-like"],
   (...)
   1059     force_finite=True,
   1060 ):
   1061     """:math:`R^2` (coefficient of determination) regression score function.
   1062 
   1063     Best possible score is 1.0 and it can be negative (because the
   (...)
   1178     -inf
   1179     """
-> 1180     y_type, y_true, y_pred, multioutput = _check_reg_targets(
   1181         y_true, y_pred, multioutput
   1182     )
   1183     check_consistent_length(y_true, y_pred, sample_weight)
   1185     if _num_samples(y_pred) < 2:

File [~/Development/sktime-dev/venv/lib/python3.10/site-packages/sklearn/metrics/_regression.py:103](http://localhost:18888/lab/tree/sktime/venv/lib/python3.10/site-packages/sklearn/metrics/_regression.py#line=102), in _check_reg_targets(y_true, y_pred, multioutput, dtype)
     69 """Check that y_true and y_pred belong to the same regression task.
     70 
     71 Parameters
   (...)
    100     correct keyword.
    101 """
    102 check_consistent_length(y_true, y_pred)
--> 103 y_true = check_array(y_true, ensure_2d=False, dtype=dtype)
    104 y_pred = check_array(y_pred, ensure_2d=False, dtype=dtype)
    106 if y_true.ndim == 1:

File [~/Development/sktime-dev/venv/lib/python3.10/site-packages/sklearn/utils/validation.py:1038](http://localhost:18888/lab/tree/sktime/venv/lib/python3.10/site-packages/sklearn/utils/validation.py#line=1037), in check_array(array, accept_sparse, accept_large_sparse, dtype, order, copy, force_all_finite, ensure_2d, allow_nd, ensure_min_samples, ensure_min_features, estimator, input_name)
   1035         raise ValueError(msg)
   1037 if dtype_numeric and hasattr(array.dtype, "kind") and array.dtype.kind in "USV":
-> 1038     raise ValueError(
   1039         "dtype='numeric' is not compatible with arrays of bytes/strings."
   1040         "Convert your data to numeric values explicitly instead."
   1041     )
   1042 if not allow_nd and array.ndim >= 3:
   1043     raise ValueError(
   1044         "Found array with dim %d. %s expected <= 2."
   1045         % (array.ndim, estimator_name)
   1046     )

ValueError: dtype='numeric' is not compatible with arrays of bytes/strings.Convert your data to numeric values explicitly instead.
```
</details>

The solution is to do something like : 
```
model.score(test_x, test_y.astype(np.float64))
```

#### Did you add any tests for the change?
Change is straightforward and working on dev setup, but I didn't run coverrage test.

```
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
check for broken symlinks............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
debug statements (python)................................................Passed
fix end of files.........................................................Passed
fix python encoding pragma...............................................Passed
fix requirements.txt.................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
pyupgrade................................................................Passed
isort....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
nbqa-black...........................................(no files to check)Skipped
nbqa-isort...........................................(no files to check)Skipped
nbqa-flake8..........................................(no files to check)Skipped
pydocstyle...............................................................Passed
shellcheck...........................................(no files to check)Skipped
```

#### Any other comments?
1. This error can probably be detected in tests.
2. `r2_score` choice is debatable, `mean_squared_error` can also be an option.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
