### PR TITLE
[ENH] Addresses #6012

### DIFF
--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -420,7 +420,7 @@ def _fit_and_score(params, meta):
     return out
 
 
-class ForecastingGridSearch(BaseGridSearch):
+class ForecastingGridSearchCV(BaseGridSearch):
     """Perform grid-search cross-validation to find optimal model parameters.
 
     The forecaster is fit on the initial window and then temporal


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #6012

#### What does this implement/fix? Explain your changes.
Added an optional param scoring_list which modifies the output of cv_results_ in accordance with #6012, allowing for multiple metrics to be displayed. This will affect ForecastingGridSearchCV and ForecastingRandomisedSearchCV (I have avoided touching Skopt due to it being an experimental feature currently).

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
Just see if any changes other than this are to be incorporated

#### Did you add any tests for the change?
No, I tested on the samples mentioned in ForecastingGridSearchCV and used a modified version of the same to incorporate scoring_list

#### Any other comments?
Please guide accordingly if there are any issues as I was unable to run make tests locally

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [No] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [Yes] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.