### PR TITLE
[MNT] Fix typos in changelog

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 # specified directly in the estimator,
 # in the "maintainers" tag of the respective scikit-base object.
 #
-# Algorithm maintainers are programmatically queriable
+# Algorithm maintainers are programmatically queryable
 # via Estimator.get_class_tag("maintainers").
 # Further lookup such as "which algorithms does M maintain"
 # can be carried out using registry.all_estimators

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,7 +18,7 @@ available on GitHub.
 For upcoming changes and next releases, see our `milestones <https://github.com/sktime/sktime/milestones?direction=asc&sort=due_date&state=open>`_.
 For our long-term plan, see our :ref:`roadmap`.
 
-Version 0.27.0 - 2023-02-28
+Version 0.27.0 - 2024-02-28
 ---------------------------
 
 Maintenance release:
@@ -27,7 +27,7 @@ Maintenance release:
 * support for soft dependency ``numba 0.59`` and ``numba`` under ``python 3.12``
 * minor documentation updates, website updates for GSoC 2024
 
-For last non-maintenance content updates, see 0.25.1.
+For last non-maintenance content updates, see 0.26.1.
 
 Dependency changes
 ~~~~~~~~~~~~~~~~~~
@@ -103,7 +103,7 @@ Maintenance
 
 Contributors
 
-Version 0.26.1 - 2023-02-26
+Version 0.26.1 - 2024-02-26
 ---------------------------
 
 Highlights
@@ -309,7 +309,7 @@ Contributors
 :user:`yarnabrina`
 
 
-Version 0.26.0 - 2023-01-27
+Version 0.26.0 - 2024-01-27
 ---------------------------
 
 Maintenance release:
@@ -375,7 +375,7 @@ Contents
 * [BUG] fix tag handling in ``IgnoreX`` (:pr:`5843`) :user:`tpvasconcelos`, :user:`fkiraly`
 
 
-Version 0.25.1 - 2023-01-24
+Version 0.25.1 - 2024-01-24
 ---------------------------
 
 Highlights

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -433,7 +433,7 @@ Parameter estimation and hypothesis testing
 
 * Parameter plugin or estimation based parameter tuning estimators can now be quickly constructed
   with the ``*`` dunder, which will construct a ``PluginParamsForecaster`` or ``PluginParamsTransformer``
-  with all fitted paramters (``get_fitted_params``) of the left element plugged in into the right element
+  with all fitted parameters (``get_fitted_params``) of the left element plugged in into the right element
   (``set_params``), where parameter names match.
   For instance, ``SeasonalityACF() * Deseasonalizer()`` will construct
   a ``Deseasonalizer`` whose ``sp`` (seasonality period) parameter is tuned
@@ -831,7 +831,7 @@ Forecasting
   are now supported. To use a custom ``joblib`` backend, use ``set_config`` to
   set the ``backend:parallel`` configuration flag to ``"joblib"``,
   and set the ``backend`` parameter in the ``dict`` set via ``backend:parallel:params``
-  to the name of the custom ``joblib`` backend. Further bakcend parameters
+  to the name of the custom ``joblib`` backend. Further backend parameters
   can be passed in the same ``dict``. See docstring of ``set_config`` for details.
 
 Time series classification
@@ -857,7 +857,7 @@ Transformations
   are now supported. To use a custom ``joblib`` backend, use ``set_config`` to
   set the ``backend:parallel`` configuration flag to ``"joblib"``,
   and set the ``backend`` parameter in the ``dict`` set via ``backend:parallel:params``
-  to the name of the custom ``joblib`` backend. Further bakcend parameters
+  to the name of the custom ``joblib`` backend. Further backend parameters
   can be passed in the same ``dict``. See docstring of ``set_config`` for details.
 
 Enhancements
@@ -2307,7 +2307,7 @@ Maintenance
 * [MNT] [Dependabot](deps): Bump actions/upload-artifact from 2 to 3 (:pr:`4856`) :user:`dependabot[bot]`
 * [MNT] fix remaining ``sklearn 1.3.0`` compatibility issues (:pr:`4860`) :user:`fkiraly`, :user:`hazrulakmal`
 * [MNT] remove forgotten ``deprecated`` import from 0.13.0 (:pr:`4824`) :user:`fkiraly`
-* [MNT] Extend softdep error message tests support for packages with version speciefier and alias (:pr:`4867`) :user:`hazrulakmal`, :user:`fkiraly`
+* [MNT] Extend softdep error message tests support for packages with version specifier and alias (:pr:`4867`) :user:`hazrulakmal`, :user:`fkiraly`
 
 Documentation
 ~~~~~~~~~~~~~
@@ -3495,7 +3495,7 @@ Highlights
 
 * ``HierarchyEnsembleForecaster`` for level- or node-wise application of forecasters on panel/hierarchical data (:pr:`3905`) :user:`VyomkeshVyas`
 * new transformer: ``BKFilter``, Baxter-King filter, interfaced from ``statsmodels`` (:pr:`4127`) :user:`klam-data`, :user:`pyyim``
-* ``get_fitted_params`` of pipelines and other heterogenous meta-estimators now supports parameter nesting (:pr:`4110`) :user:`fkiraly`
+* ``get_fitted_params`` of pipelines and other heterogeneous meta-estimators now supports parameter nesting (:pr:`4110`) :user:`fkiraly`
 
 Dependency changes
 ~~~~~~~~~~~~~~~~~~
@@ -3561,7 +3561,7 @@ Enhancements
 BaseEstimator
 ^^^^^^^^^^^^^
 
-* [ENH] ``get_fitted_params`` for pipelines and other heterogenous meta-estimators (:pr:`4110`) :user:`fkiraly`
+* [ENH] ``get_fitted_params`` for pipelines and other heterogeneous meta-estimators (:pr:`4110`) :user:`fkiraly`
 * [ENH] ``deep`` argument for ``get_fitted_params`` (:pr:`4113`) :user:`fkiraly`
 
 Data types, checks, conversions
@@ -7214,7 +7214,7 @@ Fixed
 
 * [MNT] Fix appveyor failure (:pr:`1541`) :user:`freddyaboulton`
 * [MNT] Fix macOS CI (:pr:`1511`) :user:`mloning`
-* [MNT] Depcrecate manylinux2010 (:pr:`1379`) :user:`mloning`
+* [MNT] Deprecate manylinux2010 (:pr:`1379`) :user:`mloning`
 * [MNT] Added pre-commit hook to sort imports (:pr:`1465`) :user:`aiwalter`
 * [MNT] add :code:`max_requirements`, bound statsmodels (:pr:`1479`) :user:`fkiraly`
 * [MNT] Hotfix tag scitype:y typo (:pr:`1449`) :user:`aiwalter`

--- a/docs/source/developer_guide/deprecation.rst
+++ b/docs/source/developer_guide/deprecation.rst
@@ -230,7 +230,7 @@ and ensure to use ``self._<param_name>`` in the rest of the code instead of
 ``self.<param_name>``.
 
 3. add a warning, using ``sktime.utils.warnings.warn``, if any of the position changing
-paramters are called with a non-default. This warning should always include
+parameters are called with a non-default. This warning should always include
 the name of the estimator/function, the version of change, and a clear instruction
 on how to change the code to retain prior behaviour. The instruction
 should direct the user to use ``kwargs`` calls instead of positional calls, for

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -673,7 +673,7 @@ We have the following guidelines:
 Note that an algorithm need not be in sktime to be fully compatible with
 sktime interfaces. You can implement your favorite algorithm in a sktime
 compatible way in a third party codebase - open or closed - following
-the guide for implmenting compatible estimators (see :ref:`developer_guide_add_estimators:`).
+the guide for implementing compatible estimators (see :ref:`developer_guide_add_estimators:`).
 
 We are happy to list any compatible open source project under `related
 software <https://github.com/sktime/sktime/wiki/related-software>`__.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -67,7 +67,7 @@ sktime.
         Some tags are for internal or extender use only, e.g., ``X_inner_mtype``,
         which allows an extender to specify the mtype of the inner data container
         they would like to work with.
-        A list of all tags and their meaning, optinally filtered by the :term:`scitype`
+        A list of all tags and their meaning, optionally filtered by the :term:`scitype`
         of object they apply to, can be obtained from
         ``sktime.registry.all_tags``. Further details on tags, for developers,
         can be found in the specification sheet that is part of the :term:`extension templates`.

--- a/sktime/classification/interval_based/_tsf.py
+++ b/sktime/classification/interval_based/_tsf.py
@@ -47,7 +47,7 @@ class TimeSeriesForestClassifier(
       which also allows switching the base estimator.
     * to build a a time series forest with configurable ensembling, base estimator,
       and/or feature extraction, fully from composable blocks,
-      combine ``sktime.classication.ensemble.BaggingClassifier`` with
+      combine ``sktime.classification.ensemble.BaggingClassifier`` with
       any classifier pipeline, e.g., pipelining any ``sklearn`` classifier
       with any time series feature extraction, e.g., ``Summarizer``
 

--- a/sktime/forecasting/base/_delegate.py
+++ b/sktime/forecasting/base/_delegate.py
@@ -47,7 +47,7 @@ class _DelegatedForecaster(BaseForecaster):
 
         * data mtype tags are set to the most general value.
           This is to ensure that conversion is left to the inner estimator.
-        * packaging tags such as "author" or "python_depedencies" are not cloned.
+        * packaging tags such as "author" or "python_dependencies" are not cloned.
         * other boilerplate tags are cloned.
 
         Parameters

--- a/sktime/forecasting/ltsf.py
+++ b/sktime/forecasting/ltsf.py
@@ -69,7 +69,7 @@ class LTSFLinearForecaster(BaseDeepNetworkPyTorch):
         # --------------
         "authors": ["luca-miniati"],
         "maintainers": ["luca-miniati"],
-        # "python_dependencis": "pytorch" - inherited from BaseDeepNetworkPyTorch
+        # "python_dependencies": "pytorch" - inherited from BaseDeepNetworkPyTorch
         # estimator type vars inherited from BaseDeepNetworkPyTorch
     }
 

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -94,7 +94,7 @@ def run_test_for_class(cls):
         return any(is_class_changed(x) for x in test_classes)
 
     def _is_impacted_by_pyproject_change(cls):
-        """Check if the dep specifcations of cls have changed, return bool."""
+        """Check if the dep specifications of cls have changed, return bool."""
         from packaging.requirements import Requirement
 
         if not isclass(cls) or not hasattr(cls, "get_class_tags"):

--- a/sktime/utils/deep_equals/_deep_equals.py
+++ b/sktime/utils/deep_equals/_deep_equals.py
@@ -80,8 +80,8 @@ def _fh_equals_plugin(x, y, return_msg=False, deep_equals=None):
 
     Parameters
     ----------
-    x: ForcastingHorizon
-    y: ForcastingHorizon
+    x: ForecastingHorizon
+    y: ForecastingHorizon
     return_msg : bool, optional, default=False
         whether to return informative message about what is not equal
 


### PR DESCRIPTION
The 4 releases in 2024 had wrong dates in changelog. This PR fixes those, and also run codespell and typos for some other spelling mistakes.