### PR TITLE
[DOC] fix various typos

### DIFF
--- a/sktime/classification/model_selection/_tune.py
+++ b/sktime/classification/model_selection/_tune.py
@@ -53,7 +53,7 @@ class TSCGridSearchCV(_DelegatedClassifier):
 
     refit : bool, str, or callable, default=True
         Refit an estimator using the best found parameters on the whole
-        dataset. If ``False``, the ``predict`` and ``predict_probab`` will not work.
+        dataset. If ``False``, the ``predict`` and ``predict_proba`` will not work.
 
         For multiple metric evaluation, this needs to be a `str` denoting the
         scorer that would be used to find the best parameters for refitting

--- a/sktime/forecasting/compose/tests/test_multiplex.py
+++ b/sktime/forecasting/compose/tests/test_multiplex.py
@@ -104,7 +104,7 @@ def test_multiplex_with_grid_search():
     reason="skip test if required soft dependency for AutoARIMA not available",
 )
 def test_multiplex_or_dunder():
-    """Test that the MultiplexForecaster magic "|" dunder methodbahves as expected.
+    """Test that the MultiplexForecaster magic "|" dunder method behaves as expected.
 
     A MultiplexForecaster can be created by using the "|" dunder method on either
     forecaster or MultiplexForecaster objects. Here we test that it performs as expected

--- a/sktime/forecasting/model_evaluation/__init__.py
+++ b/sktime/forecasting/model_evaluation/__init__.py
@@ -2,7 +2,6 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements functionality to evaluate forecasting models."""
 
-__author__ = ["Martin Walter"]
 __all__ = ["evaluate"]
 
 from sktime.forecasting.model_evaluation._functions import evaluate

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -2,7 +2,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements functions to be used in evaluating forecasting models."""
 
-__author__ = ["aiwalter", "mloning", "fkiraly", "topher-lo"]
+__author__ = ["aiwalter", "mloning", "fkiraly", "topher-lo", "hazrulakmal"]
 __all__ = ["evaluate"]
 
 import time


### PR DESCRIPTION
Fixes various minor typos:

* docstring typos
* author credits: `model_evaluation` was missing credits of @hazrulakmal; module `__init__` should have no authors variable