### PR TITLE
[ENH] automatic inference of file ending in data loaders for single file types

### DIFF
--- a/sktime/datasets/_readers_writers/arff.py
+++ b/sktime/datasets/_readers_writers/arff.py
@@ -12,6 +12,8 @@ import pandas as pd
 
 from sktime.transformations.base import BaseTransformer
 
+from utils.py import file_has_extension
+
 # ==================================================================================================
 # Utils function to read  arff file
 # ==================================================================================================
@@ -59,6 +61,9 @@ def load_from_arff_to_dataframe(
     data_started = False
     is_multi_variate = False
     is_first_case = True
+
+    full_file_path_and_name = file_has_extension(full_file_path_and_name,".arff")
+    
     # Parse the file
     # print(full_file_path_and_name)
     with open(full_file_path_and_name, encoding="utf-8") as f:

--- a/sktime/datasets/_readers_writers/arff.py
+++ b/sktime/datasets/_readers_writers/arff.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from sktime.transformations.base import BaseTransformer
 
-from utils.py import file_has_extension
+from sktime.datasets._readers_writers.utils import file_has_extension
 
 # ==================================================================================================
 # Utils function to read  arff file

--- a/sktime/datasets/_readers_writers/arff.py
+++ b/sktime/datasets/_readers_writers/arff.py
@@ -10,9 +10,8 @@ import textwrap
 import numpy as np
 import pandas as pd
 
-from sktime.transformations.base import BaseTransformer
-
 from sktime.datasets._readers_writers.utils import get_path
+from sktime.transformations.base import BaseTransformer
 
 # ==================================================================================================
 # Utils function to read  arff file
@@ -62,8 +61,8 @@ def load_from_arff_to_dataframe(
     is_multi_variate = False
     is_first_case = True
 
-    full_file_path_and_name = get_path(full_file_path_and_name,".arff")
-    
+    full_file_path_and_name = get_path(full_file_path_and_name, ".arff")
+
     # Parse the file
     # print(full_file_path_and_name)
     with open(full_file_path_and_name, encoding="utf-8") as f:

--- a/sktime/datasets/_readers_writers/arff.py
+++ b/sktime/datasets/_readers_writers/arff.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from sktime.transformations.base import BaseTransformer
 
-from sktime.datasets._readers_writers.utils import file_has_extension
+from sktime.datasets._readers_writers.utils import get_path
 
 # ==================================================================================================
 # Utils function to read  arff file
@@ -62,7 +62,7 @@ def load_from_arff_to_dataframe(
     is_multi_variate = False
     is_first_case = True
 
-    full_file_path_and_name = file_has_extension(full_file_path_and_name,".arff")
+    full_file_path_and_name = get_path(full_file_path_and_name,".arff")
     
     # Parse the file
     # print(full_file_path_and_name)

--- a/sktime/datasets/_readers_writers/long.py
+++ b/sktime/datasets/_readers_writers/long.py
@@ -7,6 +7,8 @@ import pandas as pd
 
 from sktime.datatypes._panel._convert import from_long_to_nested
 
+from utils.py import file_has_extension
+
 
 # TODO: original author didn't add test for this function, for research purposes?
 def load_from_long_to_dataframe(full_file_path_and_name, separator=","):
@@ -24,6 +26,9 @@ def load_from_long_to_dataframe(full_file_path_and_name, separator=","):
     DataFrame
         A dataframe with sktime-formatted data
     """
+    
+    full_file_path_and_name = file_has_extension(full_file_path_and_name,".csv")
+
     data = pd.read_csv(full_file_path_and_name, sep=separator, header=0)
     # ensure there are 4 columns in the long_format table
     if len(data.columns) != 4:

--- a/sktime/datasets/_readers_writers/long.py
+++ b/sktime/datasets/_readers_writers/long.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from sktime.datatypes._panel._convert import from_long_to_nested
 
-from sktime.datasets._readers_writers.utils import file_has_extension
+from sktime.datasets._readers_writers.utils import get_path
 
 
 # TODO: original author didn't add test for this function, for research purposes?
@@ -27,7 +27,7 @@ def load_from_long_to_dataframe(full_file_path_and_name, separator=","):
         A dataframe with sktime-formatted data
     """
     
-    full_file_path_and_name = file_has_extension(full_file_path_and_name,".csv")
+    full_file_path_and_name = get_path(full_file_path_and_name,".csv")
 
     data = pd.read_csv(full_file_path_and_name, sep=separator, header=0)
     # ensure there are 4 columns in the long_format table

--- a/sktime/datasets/_readers_writers/long.py
+++ b/sktime/datasets/_readers_writers/long.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from sktime.datatypes._panel._convert import from_long_to_nested
 
-from utils.py import file_has_extension
+from sktime.datasets._readers_writers.utils import file_has_extension
 
 
 # TODO: original author didn't add test for this function, for research purposes?

--- a/sktime/datasets/_readers_writers/long.py
+++ b/sktime/datasets/_readers_writers/long.py
@@ -5,9 +5,8 @@ __all__ = ["load_from_long_to_dataframe"]
 
 import pandas as pd
 
-from sktime.datatypes._panel._convert import from_long_to_nested
-
 from sktime.datasets._readers_writers.utils import get_path
+from sktime.datatypes._panel._convert import from_long_to_nested
 
 
 # TODO: original author didn't add test for this function, for research purposes?
@@ -26,8 +25,7 @@ def load_from_long_to_dataframe(full_file_path_and_name, separator=","):
     DataFrame
         A dataframe with sktime-formatted data
     """
-    
-    full_file_path_and_name = get_path(full_file_path_and_name,".csv")
+    full_file_path_and_name = get_path(full_file_path_and_name, ".csv")
 
     data = pd.read_csv(full_file_path_and_name, sep=separator, header=0)
     # ensure there are 4 columns in the long_format table

--- a/sktime/datasets/_readers_writers/ts.py
+++ b/sktime/datasets/_readers_writers/ts.py
@@ -19,6 +19,8 @@ from sktime.datasets._readers_writers.utils import _alias_mtype_check, _write_he
 from sktime.datatypes import MTYPE_LIST_PANEL, check_is_scitype, convert, convert_to
 from sktime.utils.validation.panel import check_X, check_X_y
 
+from utils.py import file_has_extension
+
 # ==================================================================================================
 # Function to read  .ts file
 # ==================================================================================================
@@ -75,6 +77,9 @@ def load_from_tsfile_to_dataframe(
     instance_list = []
     class_val_list = []
     line_num = 0
+
+    full_file_path_and_name = file_has_extension(full_file_path_and_name,".ts")
+
     # Parse the file
     with open(full_file_path_and_name, encoding=encoding) as file:
         for line in file:

--- a/sktime/datasets/_readers_writers/ts.py
+++ b/sktime/datasets/_readers_writers/ts.py
@@ -19,7 +19,7 @@ from sktime.datasets._readers_writers.utils import _alias_mtype_check, _write_he
 from sktime.datatypes import MTYPE_LIST_PANEL, check_is_scitype, convert, convert_to
 from sktime.utils.validation.panel import check_X, check_X_y
 
-from sktime.datasets._readers_writers.utils import file_has_extension
+from sktime.datasets._readers_writers.utils import get_path
 
 # ==================================================================================================
 # Function to read  .ts file
@@ -78,7 +78,7 @@ def load_from_tsfile_to_dataframe(
     class_val_list = []
     line_num = 0
 
-    full_file_path_and_name = file_has_extension(full_file_path_and_name,".ts")
+    full_file_path_and_name = get_path(full_file_path_and_name,".ts")
 
     # Parse the file
     with open(full_file_path_and_name, encoding=encoding) as file:

--- a/sktime/datasets/_readers_writers/ts.py
+++ b/sktime/datasets/_readers_writers/ts.py
@@ -15,11 +15,13 @@ import itertools
 import numpy as np
 import pandas as pd
 
-from sktime.datasets._readers_writers.utils import _alias_mtype_check, _write_header
+from sktime.datasets._readers_writers.utils import (
+    _alias_mtype_check,
+    _write_header,
+    get_path,
+)
 from sktime.datatypes import MTYPE_LIST_PANEL, check_is_scitype, convert, convert_to
 from sktime.utils.validation.panel import check_X, check_X_y
-
-from sktime.datasets._readers_writers.utils import get_path
 
 # ==================================================================================================
 # Function to read  .ts file
@@ -78,7 +80,7 @@ def load_from_tsfile_to_dataframe(
     class_val_list = []
     line_num = 0
 
-    full_file_path_and_name = get_path(full_file_path_and_name,".ts")
+    full_file_path_and_name = get_path(full_file_path_and_name, ".ts")
 
     # Parse the file
     with open(full_file_path_and_name, encoding=encoding) as file:

--- a/sktime/datasets/_readers_writers/ts.py
+++ b/sktime/datasets/_readers_writers/ts.py
@@ -19,7 +19,7 @@ from sktime.datasets._readers_writers.utils import _alias_mtype_check, _write_he
 from sktime.datatypes import MTYPE_LIST_PANEL, check_is_scitype, convert, convert_to
 from sktime.utils.validation.panel import check_X, check_X_y
 
-from utils.py import file_has_extension
+from sktime.datasets._readers_writers.utils import file_has_extension
 
 # ==================================================================================================
 # Function to read  .ts file

--- a/sktime/datasets/_readers_writers/tsf.py
+++ b/sktime/datasets/_readers_writers/tsf.py
@@ -9,10 +9,10 @@ from typing import Dict
 
 import pandas as pd
 
+from sktime.datasets._readers_writers.utils import get_path
 from sktime.datatypes import MTYPE_LIST_HIERARCHICAL, convert
 from sktime.utils.strtobool import strtobool
 
-from sktime.datasets._readers_writers.utils import get_path
 
 def _convert_tsf_to_hierarchical(
     data: pd.DataFrame,
@@ -136,7 +136,7 @@ def load_tsf_to_dataframe(
     found_data_section = False
     started_reading_data_section = False
 
-    full_file_path_and_name = get_path(full_file_path_and_name,".tsf")
+    full_file_path_and_name = get_path(full_file_path_and_name, ".tsf")
 
     with open(full_file_path_and_name, encoding="cp1252") as file:
         for line in file:

--- a/sktime/datasets/_readers_writers/tsf.py
+++ b/sktime/datasets/_readers_writers/tsf.py
@@ -12,7 +12,7 @@ import pandas as pd
 from sktime.datatypes import MTYPE_LIST_HIERARCHICAL, convert
 from sktime.utils.strtobool import strtobool
 
-from sktime.datasets._readers_writers.utils import file_has_extension
+from sktime.datasets._readers_writers.utils import get_path
 
 def _convert_tsf_to_hierarchical(
     data: pd.DataFrame,
@@ -136,7 +136,7 @@ def load_tsf_to_dataframe(
     found_data_section = False
     started_reading_data_section = False
 
-    full_file_path_and_name = file_has_extension(full_file_path_and_name,".tsf")
+    full_file_path_and_name = get_path(full_file_path_and_name,".tsf")
 
     with open(full_file_path_and_name, encoding="cp1252") as file:
         for line in file:

--- a/sktime/datasets/_readers_writers/tsf.py
+++ b/sktime/datasets/_readers_writers/tsf.py
@@ -12,6 +12,7 @@ import pandas as pd
 from sktime.datatypes import MTYPE_LIST_HIERARCHICAL, convert
 from sktime.utils.strtobool import strtobool
 
+from utils.py import file_has_extension
 
 def _convert_tsf_to_hierarchical(
     data: pd.DataFrame,
@@ -134,6 +135,8 @@ def load_tsf_to_dataframe(
     found_data_tag = False
     found_data_section = False
     started_reading_data_section = False
+
+    full_file_path_and_name = file_has_extension(full_file_path_and_name,".tsf")
 
     with open(full_file_path_and_name, encoding="cp1252") as file:
         for line in file:

--- a/sktime/datasets/_readers_writers/tsf.py
+++ b/sktime/datasets/_readers_writers/tsf.py
@@ -12,7 +12,7 @@ import pandas as pd
 from sktime.datatypes import MTYPE_LIST_HIERARCHICAL, convert
 from sktime.utils.strtobool import strtobool
 
-from utils.py import file_has_extension
+from sktime.datasets._readers_writers.utils import file_has_extension
 
 def _convert_tsf_to_hierarchical(
     data: pd.DataFrame,

--- a/sktime/datasets/_readers_writers/tsv.py
+++ b/sktime/datasets/_readers_writers/tsv.py
@@ -5,6 +5,7 @@ __all__ = ["load_from_ucr_tsv_to_dataframe"]
 
 import pandas as pd
 
+from utils.py import file_has_extension
 
 # TODO: original author didn't add test for this function
 def load_from_ucr_tsv_to_dataframe(
@@ -32,6 +33,7 @@ def load_from_ucr_tsv_to_dataframe(
         all time-series and (if relevant) a column "class_vals" the
         associated class values.
     """
+    full_file_path_and_name = file_has_extension(full_file_path_and_name,".tsv")
     df = pd.read_csv(full_file_path_and_name, sep="\t", header=None)
     y = df.pop(0).values
     df.columns -= 1

--- a/sktime/datasets/_readers_writers/tsv.py
+++ b/sktime/datasets/_readers_writers/tsv.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from sktime.datasets._readers_writers.utils import get_path
 
+
 # TODO: original author didn't add test for this function
 def load_from_ucr_tsv_to_dataframe(
     full_file_path_and_name, return_separate_X_and_y=True
@@ -33,7 +34,7 @@ def load_from_ucr_tsv_to_dataframe(
         all time-series and (if relevant) a column "class_vals" the
         associated class values.
     """
-    full_file_path_and_name = get_path(full_file_path_and_name,".tsv")
+    full_file_path_and_name = get_path(full_file_path_and_name, ".tsv")
     df = pd.read_csv(full_file_path_and_name, sep="\t", header=None)
     y = df.pop(0).values
     df.columns -= 1

--- a/sktime/datasets/_readers_writers/tsv.py
+++ b/sktime/datasets/_readers_writers/tsv.py
@@ -5,7 +5,7 @@ __all__ = ["load_from_ucr_tsv_to_dataframe"]
 
 import pandas as pd
 
-from sktime.datasets._readers_writers.utils import file_has_extension
+from sktime.datasets._readers_writers.utils import get_path
 
 # TODO: original author didn't add test for this function
 def load_from_ucr_tsv_to_dataframe(
@@ -33,7 +33,7 @@ def load_from_ucr_tsv_to_dataframe(
         all time-series and (if relevant) a column "class_vals" the
         associated class values.
     """
-    full_file_path_and_name = file_has_extension(full_file_path_and_name,".tsv")
+    full_file_path_and_name = get_path(full_file_path_and_name,".tsv")
     df = pd.read_csv(full_file_path_and_name, sep="\t", header=None)
     y = df.pop(0).values
     df.columns -= 1

--- a/sktime/datasets/_readers_writers/tsv.py
+++ b/sktime/datasets/_readers_writers/tsv.py
@@ -5,7 +5,7 @@ __all__ = ["load_from_ucr_tsv_to_dataframe"]
 
 import pandas as pd
 
-from utils.py import file_has_extension
+from sktime.datasets._readers_writers.utils import file_has_extension
 
 # TODO: original author didn't add test for this function
 def load_from_ucr_tsv_to_dataframe(

--- a/sktime/datasets/_readers_writers/utils.py
+++ b/sktime/datasets/_readers_writers/utils.py
@@ -271,16 +271,16 @@ def write_results_to_uea_format(
     file.close()
 
 
-def file_has_extension(path, suffix):
+def file_has_extension(path:str, suffix:str) -> str:
     """
     Check if the filename contains the file extension
 
     Parameters
     ----------
-    path - str
+    path: str
         path or filename.
     
-    suffix - str
+    suffix: str
         the expected file extension.
 
     Returns

--- a/sktime/datasets/_readers_writers/utils.py
+++ b/sktime/datasets/_readers_writers/utils.py
@@ -12,6 +12,8 @@ __all__ = [
 import os
 import textwrap
 
+import pathlib
+
 
 def _alias_mtype_check(return_type):
     """Return appropriate return_type in case an alias was used."""
@@ -270,25 +272,31 @@ def write_results_to_uea_format(
             file.write("\n")
     file.close()
 
+def get_path(p:str or pathlib.Path, ext:str) -> str:
 
-def file_has_extension(path:str, suffix:str) -> str:
-    """
-    Check if the filename contains the file extension
+    """ Automatic inference of file ending in data loaders for single file types
 
     Parameters
     ----------
-    path: str
-        path or filename.
-    
+    path: str or pathlib.Path
+        The full pathname or filename.
     suffix: str
-        the expected file extension.
+        The expected file extension.
 
     Returns
     -------
-    Filename with required extension
-
+    path: str
+        The filename with required extension
     """
-    if not path.endswith(suffix):
-        path+=suffix
+    
+    p_ = pathlib.Path(p).expanduser().resolve()
+    
+    path = str(p_)
 
+    # Checks if the path has any extension
+    if not p_.suffix:
+        # Checks if a file with the same name exists
+        if not os.path.exists(path):
+            # adds the specified extention to the path
+            path += ext
     return path

--- a/sktime/datasets/_readers_writers/utils.py
+++ b/sktime/datasets/_readers_writers/utils.py
@@ -274,7 +274,7 @@ def write_results_to_uea_format(
 
 def get_path(p:str or pathlib.Path, ext:str) -> str:
 
-    """ Automatic inference of file ending in data loaders for single file types
+    """Automatic inference of file ending in data loaders for single file types
 
     Parameters
     ----------

--- a/sktime/datasets/_readers_writers/utils.py
+++ b/sktime/datasets/_readers_writers/utils.py
@@ -269,3 +269,26 @@ def write_results_to_uea_format(
                     file.write("," + str(j))
             file.write("\n")
     file.close()
+
+
+def file_has_extension(path, suffix):
+    """
+    Check if the filename contains the file extension
+
+    Parameters
+    ----------
+    path - str
+        path or filename.
+    
+    suffix - str
+        the expected file extension.
+
+    Returns
+    -------
+    Filename with required extension
+
+    """
+    if not path.endswith(suffix):
+        path+=suffix
+
+    return path

--- a/sktime/datasets/_readers_writers/utils.py
+++ b/sktime/datasets/_readers_writers/utils.py
@@ -10,9 +10,9 @@ __all__ = [
 ]
 
 import os
-import textwrap
-
 import pathlib
+import textwrap
+from typing import Union
 
 
 def _alias_mtype_check(return_type):
@@ -272,9 +272,13 @@ def write_results_to_uea_format(
             file.write("\n")
     file.close()
 
-def get_path(p:str or pathlib.Path, ext:str) -> str:
 
-    """Automatic inference of file ending in data loaders for single file types
+def get_path(path: Union[str, pathlib.Path], suffix: str) -> str:
+    """Automatic inference of file ending in data loaders for single file types.
+
+    This function checks if the provided path has a specified suffix. If not,
+    it checks if a file with the same name exists. If not, it adds the specified
+    suffix to the path.
 
     Parameters
     ----------
@@ -285,18 +289,16 @@ def get_path(p:str or pathlib.Path, ext:str) -> str:
 
     Returns
     -------
-    path: str
+    resolved_path: str
         The filename with required extension
     """
-    
-    p_ = pathlib.Path(p).expanduser().resolve()
-    
-    path = str(p_)
+    p_ = pathlib.Path(path).expanduser().resolve()
+    resolved_path = str(p_)
 
     # Checks if the path has any extension
     if not p_.suffix:
         # Checks if a file with the same name exists
-        if not os.path.exists(path):
+        if not os.path.exists(resolved_path):
             # adds the specified extention to the path
-            path += ext
-    return path
+            resolved_path += suffix
+    return resolved_path


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!-- 
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
--> Fixes #2576 


#### What does this implement/fix? Explain your changes.
<!--  data loaders for single file types will not require file ending specified. The data loaders will work the same even if the specified file extension is not given. 

A clear and concise description of what you have implemented.
--> I've created a function which takes two parameters (path, suffix). If the path does not have the specified file extension, the funciton appends it(suffix) to the path. (It basically eleminates the need of adding specified file ending for data loaders)

#### Does your contribution introduce a new dependency? If yes, which one?

<!--

Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
