### PR TITLE
[ENH] `neuralforecast` based LSTM model

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -378,6 +378,7 @@ Deep learning based forecasters
     :template: class.rst
 
     NeuralForecastRNN
+    NeuralForecastLSTM
 
 
 Intermittent time series forecasters

--- a/sktime/forecasting/neuralforecast.py
+++ b/sktime/forecasting/neuralforecast.py
@@ -15,7 +15,7 @@ __all__ = [
 
 
 class NeuralForecastRNN(_NeuralForecastAdapter):
-    """StatsForecast RNN model.
+    """NeuralForecast RNN model.
 
     Interface to ``neuralforecast.models.RNN`` [1]_
     through ``neuralforecast.NeuralForecast`` [2]_,
@@ -370,6 +370,147 @@ class NeuralForecastRNN(_NeuralForecastAdapter):
 
 
 class NeuralForecastLSTM(_NeuralForecastAdapter):
+    """NeuralForecast LSTM model.
+
+     Interface to ``neuralforecast.models.LSMT`` [1]_
+     through ``neuralforecast.NeuralForecast`` [2]_,
+     from ``neuralforecast`` [3]_ by Nixtla.
+
+    The Long Short-Term Memory Recurrent Neural Network (LSTM), uses a
+    multilayer LSTM encoder and an MLP decoder
+
+     Parameters
+     ----------
+     freq : str
+         frequency of the data, see available frequencies [4]_ from ``pandas``
+     local_scaler_type : str (default=None)
+         scaler to apply per-series to all features before fitting, which is inverted
+         after predicting
+
+         can be one of the following:
+
+         - 'standard'
+         - 'robust'
+         - 'robust-iqr'
+         - 'minmax'
+         - 'boxcox'
+     futr_exog_list : str list, (default=None)
+         future exogenous variables
+     verbose_fit : bool (default=False)
+         print processing steps during fit
+     verbose_predict : bool (default=False)
+         print processing steps during predict
+     input_size : int (default=-1)
+         maximum sequence length for truncated train backpropagation
+
+         default (-1) uses all history
+     inference_input_size : int (default=-1)
+         maximum sequence length for truncated inference
+
+         default (-1) uses all history
+     encoder_n_layers : int (default=2)
+         number of layers for the LSTM
+     encoder_hidden_size : int (default=200)
+         units for the LSTM hidden state size
+     encoder_bias : bool (default=True)
+         whether or not to use biases b_ih, b_hh within LSTM units
+     encoder_dropout : float (default=0.0)
+         dropout regularization applied to LSTM outputs
+     context_size : int (default=10)
+         size of context vector for each timestamp on the forecasting window
+     decoder_hidden_size : int (default=200)
+         size of hidden layer for the MLP decoder
+     decoder_layers : int (default=2)
+         number of layers for the MLP decoder
+     loss : pytorch module (default=None)
+         instantiated train loss class from losses collection [5]_
+     valid_loss : pytorch module (default=None)
+         instantiated validation loss class from losses collection [5]_
+     max_steps : int (default=1000)
+         maximum number of training steps
+     learning_rate : float (default=1e-3)
+         learning rate between (0, 1)
+     num_lr_decays : int (default=-1)
+         number of learning rate decays, evenly distributed across max_steps
+     early_stop_patience_steps : int (default=-1)
+         number of validation iterations before early stopping
+     val_check_steps : int (default=100)
+         number of training steps between every validation loss check
+     batch_size : int (default=32)
+         number of different series in each batch
+     valid_batch_size : typing.Optional[int] (default=None)
+         number of different series in each validation and test batch
+     scaler_type : str (default="robust")
+         type of scaler for temporal inputs normalization
+     random_seed : int (default=1)
+         random_seed for pytorch initializer and numpy generators
+     num_workers_loader : int (default=0)
+         workers to be used by `TimeSeriesDataLoader`
+     drop_last_loader : bool (default=False)
+         whether `TimeSeriesDataLoader` drops last non-full batch
+     trainer_kwargs : dict (default=None)
+         keyword trainer arguments inherited from PyTorch Lighning's trainer [6]_
+
+     Notes
+     -----
+     * If ``loss`` is unspecified, MAE is used as the loss function for training.
+     * Only ``futr_exog_list`` will be considered as exogenous variables.
+
+     Examples
+     --------
+     >>>
+     >>> # importing necessary libraries
+     >>> from sktime.datasets import load_longley
+     >>> from sktime.forecasting.neuralforecast import NeuralForecastLSTM
+     >>> from sktime.split import temporal_train_test_split
+     >>>
+     >>> # loading the Longley dataset and splitting it into train and test subsets
+     >>> y, X = load_longley()
+     >>> y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, test_size=4)
+     >>>
+     >>> # creating model instance configuring the hyperparameters
+     >>> model = NeuralForecastLSTM(  # doctest: +SKIP
+     ...     "A-DEC", futr_exog_list=["ARMED", "POP"], max_steps=5
+     ... )
+     >>>
+     >>> # fitting the model
+     >>> model.fit(y_train, X=X_train, fh=[1, 2, 3, 4])  # doctest: +SKIP
+     Seed set to 1
+     Epoch 4: 100%|█| 1/1 [00:00<00:00, 42.85it/s, v_num=870, train_loss_step=0.589, train_loss_epoc
+     NeuralForecastLSTM(freq='A-DEC', futr_exog_list=['ARMED', 'POP'], max_steps=5)
+     >>>
+     >>> # getting point predictions
+     >>> model.predict(X=X_test)  # doctest: +SKIP
+     Predicting DataLoader 0: 100%|██████████████████████████████████| 1/1 [00:00<00:00, 198.64it/s]
+     1959    64083.226562
+     1960    64426.304688
+     1961    64754.886719
+     1962    64889.496094
+     Freq: A-DEC, Name: TOTEMP, dtype: float64
+     >>>
+
+     References
+     ----------
+     .. [1] https://nixtlaverse.nixtla.io/neuralforecast/models.lstm.html#lstm
+     .. [2] https://nixtlaverse.nixtla.io/neuralforecast/core.html#neuralforecast
+     .. [3] https://github.com/Nixtla/neuralforecast/
+     .. [4] https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
+     .. [5] https://nixtlaverse.nixtla.io/neuralforecast/losses.pytorch.html
+     .. [6] https://lightning.ai/docs/pytorch/stable/api/pytorch_lightning.trainer.trainer.Trainer.html#lightning.pytorch.trainer.trainer.Trainer
+    """  # noqa: E501
+
+    _tags = {
+        # packaging info
+        # --------------
+        # "authors": ["pranavvp16"],
+        # "maintainers": ["yarnabrina", "pranavvp16"],
+        # "python_dependencies": "neuralforecast"
+        # inherited from _NeuralForecastAdapter
+        # estimator type
+        # --------------
+        "python_dependencies": ["neuralforecast>=1.6.4"],
+    }
+
     def __init__(
         self: "NeuralForecastLSTM",
         freq: str,
@@ -573,7 +714,3 @@ class NeuralForecastLSTM(_NeuralForecastAdapter):
             ]
 
         return params
-
-
-
-

--- a/sktime/forecasting/neuralforecast.py
+++ b/sktime/forecasting/neuralforecast.py
@@ -8,11 +8,6 @@ from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 __author__ = ["yarnabrina"]
 
-__all__ = [
-    "NeuralForecastRNN",
-    "NeuralForecastLSTM",
-]
-
 
 class NeuralForecastRNN(_NeuralForecastAdapter):
     """NeuralForecast RNN model.
@@ -382,18 +377,18 @@ class NeuralForecastLSTM(_NeuralForecastAdapter):
     Parameters
     ----------
     freq : str
-    frequency of the data, see available frequencies [4]_ from ``pandas``
+        frequency of the data, see available frequencies [4]_ from ``pandas``
     local_scaler_type : str (default=None)
-    scaler to apply per-series to all features before fitting, which is inverted
-    after predicting
+        scaler to apply per-series to all features before fitting, which is inverted
+        after predicting
 
-    can be one of the following:
+        can be one of the following:
 
-    - 'standard'
-    - 'robust'
-    - 'robust-iqr'
-    - 'minmax'
-    - 'boxcox'
+        - 'standard'
+        - 'robust'
+        - 'robust-iqr'
+        - 'minmax'
+        - 'boxcox'
     futr_exog_list : str list, (default=None)
         future exogenous variables
     verbose_fit : bool (default=False)
@@ -712,3 +707,9 @@ class NeuralForecastLSTM(_NeuralForecastAdapter):
             ]
 
         return params
+
+
+__all__ = [
+    "NeuralForecastRNN",
+    "NeuralForecastLSTM",
+]

--- a/sktime/forecasting/neuralforecast.py
+++ b/sktime/forecasting/neuralforecast.py
@@ -367,12 +367,12 @@ class NeuralForecastRNN(_NeuralForecastAdapter):
 class NeuralForecastLSTM(_NeuralForecastAdapter):
     """NeuralForecast LSTM model.
 
-    Interface to ``neuralforecast.models.LSMT`` [1]_
+    Interface to ``neuralforecast.models.LSTM`` [1]_
     through ``neuralforecast.NeuralForecast`` [2]_,
     from ``neuralforecast`` [3]_ by Nixtla.
 
     The Long Short-Term Memory Recurrent Neural Network (LSTM), uses a
-    multilayer LSTM encoder and an MLP decoder
+    multilayer LSTM encoder and an MLP decoder.
 
     Parameters
     ----------
@@ -497,8 +497,8 @@ class NeuralForecastLSTM(_NeuralForecastAdapter):
     _tags = {
         # packaging info
         # --------------
-        # "authors": ["pranavvp16"],
-        # "maintainers": ["yarnabrina", "pranavvp16"],
+        "authors": ["pranavvp16"],
+        "maintainers": ["pranavvp16"],
         # "python_dependencies": "neuralforecast"
         # inherited from _NeuralForecastAdapter
         # estimator type

--- a/sktime/forecasting/neuralforecast.py
+++ b/sktime/forecasting/neuralforecast.py
@@ -372,131 +372,131 @@ class NeuralForecastRNN(_NeuralForecastAdapter):
 class NeuralForecastLSTM(_NeuralForecastAdapter):
     """NeuralForecast LSTM model.
 
-     Interface to ``neuralforecast.models.LSMT`` [1]_
-     through ``neuralforecast.NeuralForecast`` [2]_,
-     from ``neuralforecast`` [3]_ by Nixtla.
+    Interface to ``neuralforecast.models.LSMT`` [1]_
+    through ``neuralforecast.NeuralForecast`` [2]_,
+    from ``neuralforecast`` [3]_ by Nixtla.
 
     The Long Short-Term Memory Recurrent Neural Network (LSTM), uses a
     multilayer LSTM encoder and an MLP decoder
 
-     Parameters
-     ----------
-     freq : str
-         frequency of the data, see available frequencies [4]_ from ``pandas``
-     local_scaler_type : str (default=None)
-         scaler to apply per-series to all features before fitting, which is inverted
-         after predicting
+    Parameters
+    ----------
+    freq : str
+    frequency of the data, see available frequencies [4]_ from ``pandas``
+    local_scaler_type : str (default=None)
+    scaler to apply per-series to all features before fitting, which is inverted
+    after predicting
 
-         can be one of the following:
+    can be one of the following:
 
-         - 'standard'
-         - 'robust'
-         - 'robust-iqr'
-         - 'minmax'
-         - 'boxcox'
-     futr_exog_list : str list, (default=None)
-         future exogenous variables
-     verbose_fit : bool (default=False)
-         print processing steps during fit
-     verbose_predict : bool (default=False)
-         print processing steps during predict
-     input_size : int (default=-1)
-         maximum sequence length for truncated train backpropagation
+    - 'standard'
+    - 'robust'
+    - 'robust-iqr'
+    - 'minmax'
+    - 'boxcox'
+    futr_exog_list : str list, (default=None)
+        future exogenous variables
+    verbose_fit : bool (default=False)
+        print processing steps during fit
+    verbose_predict : bool (default=False)
+        print processing steps during predict
+    input_size : int (default=-1)
+        maximum sequence length for truncated train backpropagation
 
-         default (-1) uses all history
-     inference_input_size : int (default=-1)
-         maximum sequence length for truncated inference
+        default (-1) uses all history
+    inference_input_size : int (default=-1)
+        maximum sequence length for truncated inference
 
-         default (-1) uses all history
-     encoder_n_layers : int (default=2)
-         number of layers for the LSTM
-     encoder_hidden_size : int (default=200)
-         units for the LSTM hidden state size
-     encoder_bias : bool (default=True)
-         whether or not to use biases b_ih, b_hh within LSTM units
-     encoder_dropout : float (default=0.0)
-         dropout regularization applied to LSTM outputs
-     context_size : int (default=10)
-         size of context vector for each timestamp on the forecasting window
-     decoder_hidden_size : int (default=200)
-         size of hidden layer for the MLP decoder
-     decoder_layers : int (default=2)
-         number of layers for the MLP decoder
-     loss : pytorch module (default=None)
-         instantiated train loss class from losses collection [5]_
-     valid_loss : pytorch module (default=None)
-         instantiated validation loss class from losses collection [5]_
-     max_steps : int (default=1000)
-         maximum number of training steps
-     learning_rate : float (default=1e-3)
-         learning rate between (0, 1)
-     num_lr_decays : int (default=-1)
-         number of learning rate decays, evenly distributed across max_steps
-     early_stop_patience_steps : int (default=-1)
-         number of validation iterations before early stopping
-     val_check_steps : int (default=100)
-         number of training steps between every validation loss check
-     batch_size : int (default=32)
-         number of different series in each batch
-     valid_batch_size : typing.Optional[int] (default=None)
-         number of different series in each validation and test batch
-     scaler_type : str (default="robust")
-         type of scaler for temporal inputs normalization
-     random_seed : int (default=1)
-         random_seed for pytorch initializer and numpy generators
-     num_workers_loader : int (default=0)
-         workers to be used by `TimeSeriesDataLoader`
-     drop_last_loader : bool (default=False)
-         whether `TimeSeriesDataLoader` drops last non-full batch
-     trainer_kwargs : dict (default=None)
-         keyword trainer arguments inherited from PyTorch Lighning's trainer [6]_
+        default (-1) uses all history
+    encoder_n_layers : int (default=2)
+        number of layers for the LSTM
+    encoder_hidden_size : int (default=200)
+        units for the LSTM hidden state size
+    encoder_bias : bool (default=True)
+        whether or not to use biases b_ih, b_hh within LSTM units
+    encoder_dropout : float (default=0.0)
+        dropout regularization applied to LSTM outputs
+    context_size : int (default=10)
+        size of context vector for each timestamp on the forecasting window
+    decoder_hidden_size : int (default=200)
+        size of hidden layer for the MLP decoder
+    decoder_layers : int (default=2)
+        number of layers for the MLP decoder
+    loss : pytorch module (default=None)
+        instantiated train loss class from losses collection [5]_
+    valid_loss : pytorch module (default=None)
+        instantiated validation loss class from losses collection [5]_
+    max_steps : int (default=1000)
+        maximum number of training steps
+    learning_rate : float (default=1e-3)
+        learning rate between (0, 1)
+    num_lr_decays : int (default=-1)
+        number of learning rate decays, evenly distributed across max_steps
+    early_stop_patience_steps : int (default=-1)
+        number of validation iterations before early stopping
+    val_check_steps : int (default=100)
+        number of training steps between every validation loss check
+    batch_size : int (default=32)
+        number of different series in each batch
+    valid_batch_size : typing.Optional[int] (default=None)
+        number of different series in each validation and test batch
+    scaler_type : str (default="robust")
+        type of scaler for temporal inputs normalization
+    random_seed : int (default=1)
+        random_seed for pytorch initializer and numpy generators
+    num_workers_loader : int (default=0)
+        workers to be used by `TimeSeriesDataLoader`
+    drop_last_loader : bool (default=False)
+        whether `TimeSeriesDataLoader` drops last non-full batch
+    trainer_kwargs : dict (default=None)
+        keyword trainer arguments inherited from PyTorch Lighning's trainer [6]_
 
-     Notes
-     -----
-     * If ``loss`` is unspecified, MAE is used as the loss function for training.
-     * Only ``futr_exog_list`` will be considered as exogenous variables.
+    Notes
+    -----
+    * If ``loss`` is unspecified, MAE is used as the loss function for training.
+    * Only ``futr_exog_list`` will be considered as exogenous variables.
 
-     Examples
-     --------
-     >>>
-     >>> # importing necessary libraries
-     >>> from sktime.datasets import load_longley
-     >>> from sktime.forecasting.neuralforecast import NeuralForecastLSTM
-     >>> from sktime.split import temporal_train_test_split
-     >>>
-     >>> # loading the Longley dataset and splitting it into train and test subsets
-     >>> y, X = load_longley()
-     >>> y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, test_size=4)
-     >>>
-     >>> # creating model instance configuring the hyperparameters
-     >>> model = NeuralForecastLSTM(  # doctest: +SKIP
-     ...     "A-DEC", futr_exog_list=["ARMED", "POP"], max_steps=5
-     ... )
-     >>>
-     >>> # fitting the model
-     >>> model.fit(y_train, X=X_train, fh=[1, 2, 3, 4])  # doctest: +SKIP
-     Seed set to 1
-     Epoch 4: 100%|█| 1/1 [00:00<00:00, 42.85it/s, v_num=870, train_loss_step=0.589, train_loss_epoc
-     NeuralForecastLSTM(freq='A-DEC', futr_exog_list=['ARMED', 'POP'], max_steps=5)
-     >>>
-     >>> # getting point predictions
-     >>> model.predict(X=X_test)  # doctest: +SKIP
-     Predicting DataLoader 0: 100%|██████████████████████████████████| 1/1 [00:00<00:00, 198.64it/s]
-     1959    64083.226562
-     1960    64426.304688
-     1961    64754.886719
-     1962    64889.496094
-     Freq: A-DEC, Name: TOTEMP, dtype: float64
-     >>>
+    Examples
+    --------
+    >>>
+    >>> # importing necessary libraries
+    >>> from sktime.datasets import load_longley
+    >>> from sktime.forecasting.neuralforecast import NeuralForecastLSTM
+    >>> from sktime.split import temporal_train_test_split
+    >>>
+    >>> # loading the Longley dataset and splitting it into train and test subsets
+    >>> y, X = load_longley()
+    >>> y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, test_size=4)
+    >>>
+    >>> # creating model instance configuring the hyperparameters
+    >>> model = NeuralForecastLSTM(  # doctest: +SKIP
+    ...     "A-DEC", futr_exog_list=["ARMED", "POP"], max_steps=5
+    ... )
+    >>>
+    >>> # fitting the model
+    >>> model.fit(y_train, X=X_train, fh=[1, 2, 3, 4])  # doctest: +SKIP
+    Seed set to 1
+    Epoch 4: 100%|█| 1/1 [00:00<00:00, 42.85it/s, v_num=870, train_loss_step=0.589, train_loss_epoc
+    NeuralForecastLSTM(freq='A-DEC', futr_exog_list=['ARMED', 'POP'], max_steps=5)
+    >>>
+    >>> # getting point predictions
+    >>> model.predict(X=X_test)  # doctest: +SKIP
+    Predicting DataLoader 0: 100%|██████████████████████████████████| 1/1 [00:00<00:00, 198.64it/s]
+    1959    64083.226562
+    1960    64426.304688
+    1961    64754.886719
+    1962    64889.496094
+    Freq: A-DEC, Name: TOTEMP, dtype: float64
+    >>>
 
-     References
-     ----------
-     .. [1] https://nixtlaverse.nixtla.io/neuralforecast/models.lstm.html#lstm
-     .. [2] https://nixtlaverse.nixtla.io/neuralforecast/core.html#neuralforecast
-     .. [3] https://github.com/Nixtla/neuralforecast/
-     .. [4] https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
-     .. [5] https://nixtlaverse.nixtla.io/neuralforecast/losses.pytorch.html
-     .. [6] https://lightning.ai/docs/pytorch/stable/api/pytorch_lightning.trainer.trainer.Trainer.html#lightning.pytorch.trainer.trainer.Trainer
+    References
+    ----------
+    .. [1] https://nixtlaverse.nixtla.io/neuralforecast/models.lstm.html#lstm
+    .. [2] https://nixtlaverse.nixtla.io/neuralforecast/core.html#neuralforecast
+    .. [3] https://github.com/Nixtla/neuralforecast/
+    .. [4] https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
+    .. [5] https://nixtlaverse.nixtla.io/neuralforecast/losses.pytorch.html
+    .. [6] https://lightning.ai/docs/pytorch/stable/api/pytorch_lightning.trainer.trainer.Trainer.html#lightning.pytorch.trainer.trainer.Trainer
     """  # noqa: E501
 
     _tags = {
@@ -544,7 +544,6 @@ class NeuralForecastLSTM(_NeuralForecastAdapter):
         drop_last_loader=False,
         trainer_kwargs: typing.Optional[dict] = None,
     ):
-
         self.input_size = input_size
         self.inference_input_size = inference_input_size
         self.encoder_n_layers = encoder_n_layers
@@ -668,7 +667,6 @@ class NeuralForecastLSTM(_NeuralForecastAdapter):
         try:
             _check_soft_dependencies("neuralforecast", severity="error")
         except ModuleNotFoundError:
-
             params = [
                 {
                     "freq": "D",

--- a/sktime/forecasting/tests/test_neuralforecast.py
+++ b/sktime/forecasting/tests/test_neuralforecast.py
@@ -1,5 +1,5 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Tests for NeuralForecastRNN."""
+"""Tests for NeuralForecastRNN, NeuralForecastLSTM."""
 import pandas
 import pytest
 
@@ -8,20 +8,21 @@ from sktime.forecasting.neuralforecast import NeuralForecastLSTM, NeuralForecast
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
 
-__author__ = ["yarnabrina"]
+__author__ = ["yarnabrina", "pranavvp16"]
 
 y, X = load_longley()
 y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, test_size=4)
 
 
+@pytest.mark.parametrize("model_class", [NeuralForecastLSTM, NeuralForecastRNN])
 @pytest.mark.skipif(
-    not run_test_for_class(NeuralForecastRNN),
+    not run_test_for_class([NeuralForecastLSTM, NeuralForecastRNN]),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-def test_neural_forecast_rnn_univariate_y_without_X() -> None:
-    """Test NeuralForecastRNN with single endogenous without exogenous."""
+def test_neural_forecast_univariate_y_without_X(model_class) -> None:
+    """Test NeuralForecast with single endogenous without exogenous."""
     # define model
-    model = NeuralForecastRNN("A-DEC", max_steps=5, trainer_kwargs={"logger": False})
+    model = model_class("A-DEC", max_steps=5, trainer_kwargs={"logger": False})
 
     # attempt fit with negative fh
     with pytest.raises(
@@ -39,17 +40,18 @@ def test_neural_forecast_rnn_univariate_y_without_X() -> None:
     pandas.testing.assert_index_equal(y_pred.index, y_test.index, check_names=False)
 
 
+@pytest.mark.parametrize("model_class", [NeuralForecastLSTM, NeuralForecastRNN])
 @pytest.mark.skipif(
-    not run_test_for_class(NeuralForecastRNN),
+    not run_test_for_class([NeuralForecastLSTM, NeuralForecastRNN]),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-def test_neural_forecast_rnn_univariate_y_with_X() -> None:
-    """Test NeuralForecastRNN with single endogenous with exogenous."""
+def test_neural_forecast_univariate_y_with_X(model_class) -> None:
+    """Test NeuralForecast with single endogenous with exogenous."""
     # select feature columns
     exog_list = ["GNPDEFL", "GNP", "UNEMP"]
 
     # define model
-    model = NeuralForecastRNN(
+    model = model_class(
         "A-DEC", futr_exog_list=exog_list, max_steps=5, trainer_kwargs={"logger": False}
     )
 
@@ -76,14 +78,15 @@ def test_neural_forecast_rnn_univariate_y_with_X() -> None:
     pandas.testing.assert_index_equal(y_pred.index, y_test.index, check_names=False)
 
 
+@pytest.mark.parametrize("model_class", [NeuralForecastLSTM, NeuralForecastRNN])
 @pytest.mark.skipif(
-    not run_test_for_class(NeuralForecastRNN),
+    not run_test_for_class([NeuralForecastLSTM, NeuralForecastRNN]),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-def test_neural_forecast_rnn_multivariate_y_without_X() -> None:
-    """Test NeuralForecastRNN with multiple endogenous without exogenous."""
+def test_neural_forecast_multivariate_y_without_X(model_class) -> None:
+    """Test NeuralForecast with multiple endogenous without exogenous."""
     # define model
-    model = NeuralForecastRNN("A-DEC", max_steps=5, trainer_kwargs={"logger": False})
+    model = model_class("A-DEC", max_steps=5, trainer_kwargs={"logger": False})
 
     # train model
     model.fit(X_train, fh=[1, 2, 3, 4])
@@ -95,17 +98,18 @@ def test_neural_forecast_rnn_multivariate_y_without_X() -> None:
     pandas.testing.assert_index_equal(X_pred.index, X_test.index, check_names=False)
 
 
+@pytest.mark.parametrize("model_class", [NeuralForecastLSTM, NeuralForecastRNN])
 @pytest.mark.skipif(
-    not run_test_for_class(NeuralForecastRNN),
+    not run_test_for_class([NeuralForecastLSTM, NeuralForecastRNN]),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-def test_neural_forecast_rnn_with_non_default_loss() -> None:
-    """Test NeuralForecastRNN with multiple endogenous without exogenous."""
+def test_neural_forecast_with_non_default_loss(model_class) -> None:
+    """Test NeuralForecast models with multiple endogenous without exogenous."""
     # import non-default pytorch losses
     from neuralforecast.losses.pytorch import MASE, HuberQLoss
 
     # define model
-    model = NeuralForecastRNN(
+    model = model_class(
         "A-DEC",
         loss=HuberQLoss(0.5),
         valid_loss=MASE(1),
@@ -123,17 +127,18 @@ def test_neural_forecast_rnn_with_non_default_loss() -> None:
     pandas.testing.assert_index_equal(X_pred.index, X_test.index, check_names=False)
 
 
+@pytest.mark.parametrize("model_class", [NeuralForecastLSTM, NeuralForecastRNN])
 @pytest.mark.skipif(
-    not run_test_for_class(NeuralForecastRNN),
+    not run_test_for_class([NeuralForecastLSTM, NeuralForecastRNN]),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-def test_neural_forecast_rnn_fail_with_multiple_predictions() -> None:
-    """Check NeuralForecastRNN fail when multiple prediction columns are used."""
+def test_neural_forecast_fail_with_multiple_predictions(model_class) -> None:
+    """Check NeuralForecast fail when multiple prediction columns are used."""
     # import pytorch losses with multiple predictions capability
     from neuralforecast.losses.pytorch import MQLoss
 
     # define model
-    model = NeuralForecastRNN(
+    model = model_class(
         "A-DEC",
         loss=MQLoss(quantiles=[0.25, 0.5, 0.75]),
         max_steps=5,
@@ -148,93 +153,3 @@ def test_neural_forecast_rnn_fail_with_multiple_predictions() -> None:
         NotImplementedError, match="Multiple prediction columns are not supported."
     ):
         model.predict()
-
-
-@pytest.mark.skipif(
-    not run_test_for_class(NeuralForecastLSTM),
-    reason="run test only if softdeps are present and incrementally (if requested)",
-)
-def test_neural_forecast_lstm_univariate_y_without_X() -> None:
-    """Test NeuralForecastLSTM with single endogenous without exogenous."""
-    # define model
-    model = NeuralForecastLSTM("A-DEC", max_steps=5, trainer_kwargs={"logger": False})
-
-    # attempt fit with negative fh
-    with pytest.raises(
-        NotImplementedError, match="in-sample prediction is currently not supported"
-    ):
-        model.fit(y_train, fh=[-2, -1, 0, 1, 2])
-
-    # train model
-    model.fit(y_train, fh=[1, 2, 3, 4])
-
-    # predict with trained model
-    y_pred = model.predict()
-
-    # check prediction index
-    pandas.testing.assert_index_equal(y_pred.index, y_test.index, check_names=False)
-
-
-@pytest.mark.skipif(
-    not run_test_for_class(NeuralForecastLSTM),
-    reason="run test only if softdeps are present and incrementally (if requested)",
-)
-def test_neural_forecast_lstm_univariate_y_with_X() -> None:
-    """Test NeuralForecastLSTM with single endogenous with exogenous."""
-    # select feature columns
-    exog_list = ["GNPDEFL", "GNP", "UNEMP"]
-
-    # define model
-    model = NeuralForecastLSTM(
-        "A-DEC", futr_exog_list=exog_list, max_steps=5, trainer_kwargs={"logger": False}
-    )
-
-    # attempt fit without X
-    with pytest.raises(
-        ValueError, match="Missing exogeneous data, 'futr_exog_list' is non-empty."
-    ):
-        model.fit(y_train, fh=[1, 2, 3, 4])
-
-    # train model with all X columns
-    model.fit(y_train, X=X_train, fh=[1, 2, 3, 4])
-
-    # attempt predict without X
-    with pytest.raises(
-        ValueError, match="Missing exogeneous data, 'futr_exog_list' is non-empty."
-    ):
-        model.predict()
-
-    # predict with only selected columns
-    # checking that rest are not used
-    y_pred = model.predict(X=X_test[exog_list])
-
-    # check prediction index
-    pandas.testing.assert_index_equal(y_pred.index, y_test.index, check_names=False)
-
-
-@pytest.mark.skipif(
-    not run_test_for_class(NeuralForecastLSTM),
-    reason="run test only if softdeps are present and incrementally (if requested)",
-)
-def test_neural_forecast_lstm_with_non_default_loss() -> None:
-    """Test NeuralForecastLSTM with multiple endogenous without exogenous."""
-    # import non-default pytorch losses
-    from neuralforecast.losses.pytorch import MASE, HuberQLoss
-
-    # define model
-    model = NeuralForecastLSTM(
-        "A-DEC",
-        loss=HuberQLoss(0.5),
-        valid_loss=MASE(1),
-        max_steps=5,
-        trainer_kwargs={"logger": False},
-    )
-
-    # train model
-    model.fit(X_train, fh=[1, 2, 3, 4])
-
-    # predict with trained model
-    X_pred = model.predict()
-
-    # check prediction index
-    pandas.testing.assert_index_equal(X_pred.index, X_test.index, check_names=False)

--- a/sktime/forecasting/tests/test_neuralforecast.py
+++ b/sktime/forecasting/tests/test_neuralforecast.py
@@ -1,5 +1,5 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Tests for NeuralForecastRNN, NeuralForecastLSTM."""
+"""Tests for interfacing estimators from neuralforecast."""
 import pandas
 import pytest
 
@@ -20,7 +20,7 @@ y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, test_size=4)
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_neural_forecast_univariate_y_without_X(model_class) -> None:
-    """Test NeuralForecast with single endogenous without exogenous."""
+    """Test with single endogenous without exogenous."""
     # define model
     model = model_class("A-DEC", max_steps=5, trainer_kwargs={"logger": False})
 
@@ -46,7 +46,7 @@ def test_neural_forecast_univariate_y_without_X(model_class) -> None:
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_neural_forecast_univariate_y_with_X(model_class) -> None:
-    """Test NeuralForecast with single endogenous with exogenous."""
+    """Test with single endogenous with exogenous."""
     # select feature columns
     exog_list = ["GNPDEFL", "GNP", "UNEMP"]
 
@@ -84,7 +84,7 @@ def test_neural_forecast_univariate_y_with_X(model_class) -> None:
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_neural_forecast_multivariate_y_without_X(model_class) -> None:
-    """Test NeuralForecast with multiple endogenous without exogenous."""
+    """Test with multiple endogenous without exogenous."""
     # define model
     model = model_class("A-DEC", max_steps=5, trainer_kwargs={"logger": False})
 
@@ -104,7 +104,7 @@ def test_neural_forecast_multivariate_y_without_X(model_class) -> None:
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_neural_forecast_with_non_default_loss(model_class) -> None:
-    """Test NeuralForecast models with multiple endogenous without exogenous."""
+    """Test with multiple endogenous without exogenous."""
     # import non-default pytorch losses
     from neuralforecast.losses.pytorch import MASE, HuberQLoss
 
@@ -133,7 +133,7 @@ def test_neural_forecast_with_non_default_loss(model_class) -> None:
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_neural_forecast_fail_with_multiple_predictions(model_class) -> None:
-    """Check NeuralForecast fail when multiple prediction columns are used."""
+    """Check fail when multiple prediction columns are used."""
     # import pytorch losses with multiple predictions capability
     from neuralforecast.losses.pytorch import MQLoss
 

--- a/sktime/forecasting/tests/test_neuralforecast.py
+++ b/sktime/forecasting/tests/test_neuralforecast.py
@@ -4,7 +4,7 @@ import pandas
 import pytest
 
 from sktime.datasets import load_longley
-from sktime.forecasting.neuralforecast import NeuralForecastRNN, NeuralForecastLSTM
+from sktime.forecasting.neuralforecast import NeuralForecastLSTM, NeuralForecastRNN
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
 


### PR DESCRIPTION
Sktime already has an adapter for `neuralforecast` which only implements `RNN` model. RNN's suffer from problems like gradient vanishing while training, So I it's good to have LSTM model implemented that works better than RNN for time-series forecasting. 

Here is a demo of LSTM implemented in sktime using neuralforecast [notebook](https://colab.research.google.com/drive/1R9z5HS4uRpzVuVYKMHoB-q3-osWgHyD_?usp=sharing)