### PR TITLE
[DOC] clarification regarding immutability of `self`-params in extension templates

### DIFF
--- a/extension_templates/alignment.py
+++ b/extension_templates/alignment.py
@@ -108,6 +108,8 @@ class MyAligner(BaseAligner):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
 
         # leave this as is
         super().__init__()

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -117,6 +117,9 @@ class MyTimeSeriesClassifier(BaseClassifier):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
+        # for estimators, initialize a clone, e.g., self.est_ = clone(est)
 
         # leave this as is
         super().__init__()

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -119,7 +119,7 @@ class MyTimeSeriesClassifier(BaseClassifier):
         self.paramc = paramc
         # IMPORTANT: the self.params should never be overwritten or mutated from now on
         # for handling defaults etc, write to other attributes, e.g., self._parama
-        # for estimators, initialize a clone, e.g., self.est_ = clone(est)
+        # for estimators, initialize a clone, e.g., self.est_ = est.clone()
 
         # leave this as is
         super().__init__()

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -107,6 +107,8 @@ class MyClusterer(BaseClusterer):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
 
         # leave this as is
         super().__init__()

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -78,6 +78,8 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
 
         # leave this as is
         super().__init__()

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -78,6 +78,8 @@ class MyTrafoPw(BasePairwiseTransformer):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
 
         # leave this as is
         super().__init__()

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -97,6 +97,8 @@ class MyEarlyTimeSeriesClassifier(BaseEarlyClassifier):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
 
         # leave this as is
         super().__init__()

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -201,7 +201,7 @@ class MyForecaster(BaseForecaster):
         self.paramc = paramc
         # IMPORTANT: the self.params should never be overwritten or mutated from now on
         # for handling defaults etc, write to other attributes, e.g., self._parama
-        # for estimators, initialize a clone, e.g., self.est_ = clone(est)
+        # for estimators, initialize a clone, e.g., self.est_ = est.clone()
 
         # leave this as is
         super().__init__()

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -199,6 +199,9 @@ class MyForecaster(BaseForecaster):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
+        # for estimators, initialize a clone, e.g., self.est_ = clone(est)
 
         # leave this as is
         super().__init__()

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -132,6 +132,8 @@ class MyForecaster(BaseForecaster):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
 
         # leave this as is
         super().__init__()

--- a/extension_templates/forecasting_supersimple.py
+++ b/extension_templates/forecasting_supersimple.py
@@ -93,6 +93,8 @@ class MyForecaster(BaseForecaster):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
 
         # leave this as is
         super().__init__()

--- a/extension_templates/param_est.py
+++ b/extension_templates/param_est.py
@@ -149,6 +149,8 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
 
         # leave this as is
         super().__init__()

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -133,6 +133,8 @@ class MySplitter(BaseSplitter):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
 
         # leave this as is
         super().__init__()

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -292,6 +292,9 @@ class MyTransformer(BaseTransformer):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
+        # for estimators, initialize a clone, e.g., self.est_ = clone(est)
 
         # leave this as is
         super().__init__()

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -294,7 +294,7 @@ class MyTransformer(BaseTransformer):
         self.paramc = paramc
         # IMPORTANT: the self.params should never be overwritten or mutated from now on
         # for handling defaults etc, write to other attributes, e.g., self._parama
-        # for estimators, initialize a clone, e.g., self.est_ = clone(est)
+        # for estimators, initialize a clone, e.g., self.est_ = est.clone()
 
         # leave this as is
         super().__init__()

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -197,6 +197,8 @@ class MyTransformer(BaseTransformer):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
 
         # leave this as is
         super().__init__()

--- a/extension_templates/transformer_supersimple.py
+++ b/extension_templates/transformer_supersimple.py
@@ -101,6 +101,8 @@ class MyTransformer(BaseTransformer):
         self.parama = parama
         self.paramb = paramb
         self.paramc = paramc
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
 
         # leave this as is
         super().__init__()


### PR DESCRIPTION
This PR adds further clarification regarding immutability of `self`-params in the extension templates, including recipes on handling defaults and estimators (the latter only in "non-simple" extension templates).