### PR TITLE
DIAGNOSTIC - failures if `pandas==2.2.0` is set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ classifiers = [
 dependencies = [
   "numpy<1.27,>=1.21",  # required for framework layer and base class logic
   "packaging",  # for estimator specific dependency parsing
-  "pandas<2.2.0,>=1.1",  # pandas is the main in-memory data container
+  "pandas==2.2.0",  # pandas is the main in-memory data container
   "scikit-base<0.8.0",  # base module for sklearn compatible base API
   "scikit-learn>=0.24,<1.5.0",  # required for estimators and framework layer
   "scipy<2.0.0,>=1.2",  # required for estimators and framework layer


### PR DESCRIPTION
Diagnostic PR to inspect failures if `pandas==2.2.0` is set.

From discussion with @yarnabrina, here: https://github.com/sktime/sktime/pull/6057#issuecomment-1977930595