### PR TITLE
[BUG] fix `BaseForecaster.predict_var` default if `predict_proba` is implemented

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -2293,16 +2293,8 @@ class BaseForecaster(BaseEstimator):
 
         if implements_proba:
             # todo: this works only univariate now, need to implement multivariate
-            pred_var = self._predict_proba(fh=fh, X=X)
-            pred_var = pd.DataFrame(pred_var)
-
-            # ensure index and columns are as expected
-            if fh.is_relative:
-                fh = fh.to_absolute(self.cutoff)
-            pred_var.index = fh.to_pandas()
-
-            if isinstance(pred_var, pd.DataFrame):
-                pred_var.columns = self._get_columns(method="predict_var")
+            pred_dist = self.predict_proba(fh=fh, X=X)
+            pred_var = pred_dist.var()
 
             return pred_var
 


### PR DESCRIPTION
The default for `BaseForecaster.predict_var` in a case where `predict_proba` was implemented was erroneous - this is fixed.

Discovered - and covered - via the upgrade of `BaggingForecaster` in #6052 