### PR TITLE
[DOC] add credit to @rikstarmans in `FallbackForecaster`

### DIFF
--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -8,7 +8,7 @@ If the active forecaster fails during prediction, it proceeds to the next. This 
 a robust forecasting mechanism by providing fallback options.
 """
 
-__author__ = ["ninedigits"]
+__author__ = ["ninedigits", "RikStarmans"]
 __all__ = ["FallbackForecaster"]
 
 from sktime.base import _HeterogenousMetaEstimator
@@ -107,7 +107,7 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     """
 
     _tags = {
-        "authors": ["ninedigits"],
+        "authors": ["ninedigits", "RikStarmans"],
         "maintainers": ["ninedigits"],
         "handles-missing-data": True,
         "scitype:y": "both",


### PR DESCRIPTION
By accident, I rediscovered an earlier discussion on what is now `FallbackForecaster` in https://github.com/sktime/sktime/issues/3838.

In it, @rikstarmans implemented and posted code of an almost functional prototype, but never made a pull request to `sktime`.

In consequence, I think @rikstarmans should be credited with (co-)authorship, but not listed as a maintainer of `FallbackForecaster` - this PR adds @rikstarmans as an author.

FYI @ninedigits