### PR TITLE
[DOC] update maintainer tag information in docs and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -53,7 +53,7 @@ Please go through the checklist below. Please feel free to remove points if they
 - [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
   How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
   See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
-- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
+- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintaners` tag - do this if you want to become the owner or maintainer of an estimator you added.
   See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
 - [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
 

--- a/docs/source/developer_guide/add_estimators.rst
+++ b/docs/source/developer_guide/add_estimators.rst
@@ -221,7 +221,7 @@ additional things need to be done:
 *   ensure that code also meets ``sktime's`` :ref:`documentation <developer_guide_documentation>` standards.
 *   add the estimator to the ``sktime`` API reference. This is done by adding a reference to the estimator in the
     correct ``rst`` file inside ``docs/source/api_reference``.
-*   authors of the estimator should add themselves to ``CODEOWNERS``, as owners of the contributed estimator.
+*   authors of the estimator should add themselves to the ``"authors"`` and ``"maintainers"`` tag of the estimator, as owners of the contributed estimator.
 *   if the estimator relies on soft dependencies, or adds new soft dependencies, the steps in the :ref:`"dependencies"
     developer guide <dependencies>` should be followed
 *   ensure that the estimator passes the entire local test suite of ``sktime``, with the estimator in its target location.

--- a/examples/01_forecasting.ipynb
+++ b/examples/01_forecasting.ipynb
@@ -6762,7 +6762,7 @@
     "6. To test your estimator automatically: call `sktime.utils.estimator_checks.check_estimator` on your estimator. You can call this on a class or object instance. Ensure you have specified test parameters in the `get_test_params` method, according to the extension template.\n",
     "\n",
     "In case of direct contribution to `sktime` or one of its affiliated packages, additionally:\n",
-    "* Add yourself as an author to the code, and to the `CODEOWNERS` for the new estimator file(s).\n",
+    "* Add yourself as an author and/or a maintainer for the new estimator file(s), via `\"authors\"` and `\"maintainers\"` tag.\n",
     "* Create a pull request that contains only the new estimators (and their inheritance tree, if it's not just one class), as well as the automated tests as described above.\n",
     "* In the pull request, describe the estimator and optimally provide a publication or other technical reference for the strategy it implements.\n",
     "* Before making the pull request, ensure that you have all necessary permissions to contribute the code to a permissive license (BSD-3) open source project."

--- a/examples/02_classification.ipynb
+++ b/examples/02_classification.ipynb
@@ -3030,7 +3030,7 @@
     "6. to test your estimator automatically: call `sktime.tests.test_all_estimators.check_estimator` on your estimator. You can call this on a class or object instance. Ensure you have specified test parameters in the `get_test_params` method, according to the extension template.\n",
     "\n",
     "In case of direct contribution to `sktime` or one of its affiliated packages, additionally:\n",
-    "* add yourself as an author to the code, and to the `CODEOWNERS` for the new estimator file(s).\n",
+    "* Add yourself as an author and/or a maintainer for the new estimator file(s), via `\"authors\"` and `\"maintainers\"` tag.\n",
     "* create a pull request that contains only the new estimators (and their inheritance tree, if it's not just one class), as well as the automated tests as described above.\n",
     "* in the pull request, describe the estimator and optimally provide a publication or other technical reference for the strategy it implements.\n",
     "* before making the pull request, ensure that you have all necessary permissions to contribute the code to a permissive license (BSD-3) open source project."

--- a/examples/03_transformers.ipynb
+++ b/examples/03_transformers.ipynb
@@ -4481,7 +4481,7 @@
     "6. to test your estimator automatically: call `sktime.tests.test_all_estimators.check_estimator` on your estimator. You can call this on a class or object instance. Ensure you have specified test parameters in the `get_test_params` method, according to the extension template.\n",
     "\n",
     "In case of direct contribution to `sktime` or one of its affiliated packages, additionally:\n",
-    "* add yourself as an author to the code, and to the `CODEOWNERS` for the new estimator file(s).\n",
+    "* Add yourself as an author and/or a maintainer for the new estimator file(s), via `\"authors\"` and `\"maintainers\"` tag.\n",
     "* create a pull request that contains only the new estimators (and their inheritance tree, if it's not just one class), as well as the automated tests as described above.\n",
     "* in the pull request, describe the estimator and optimally provide a publication or other technical reference for the strategy it implements.\n",
     "* before making the pull request, ensure that you have all necessary permissions to contribute the code to a permissive license (BSD-3) open source project."


### PR DESCRIPTION
Maintainers/owners of estimators are now tracked in the `maintainers` tag of the estimator, and no longer in `CODEOWNERS`.

This had been updated in various places, but a few locatoins had been missed:

* the PR template
* a few jupyter notebook tutorials
* the developer guide

This PR updates these locations with a updated pointers to the tags.