### PR TITLE
 [DOC] minor clarifications in mtype descriptions

### DIFF
--- a/sktime/datatypes/_table/_registry.py
+++ b/sktime/datatypes/_table/_registry.py
@@ -11,9 +11,9 @@ __all__ = [
 
 MTYPE_REGISTER_TABLE = [
     ("pd_DataFrame_Table", "Table", "pd.DataFrame representation of a data table"),
-    ("numpy1D", "Table", "1D np.narray representation of a univariate table"),
-    ("numpy2D", "Table", "2D np.narray representation of a univariate table"),
-    ("pd_Series_Table", "Table", "pd.Series representation of a data table"),
+    ("numpy1D", "Table", "1D np.narray representation of a univariate data table"),
+    ("numpy2D", "Table", "2D np.narray representation of a multivariate data table"),
+    ("pd_Series_Table", "Table", "pd.Series representation of a univariate data table"),
     ("list_of_dict", "Table", "list of dictionaries with primitive entries"),
     ("polars_eager_table", "Table", "polars.DataFrame representation of a data table"),
     ("polars_lazy_table", "Table", "polars.LazyFrame representation of a data table"),


### PR DESCRIPTION
While refactoring `datatypes`, noticed some minor inconsistencies in the registry short descriptions of mtypes. Fixed in this PR.