### PR TITLE
&fspinna [BUG] fix `FeatureUnion` for primitive outputs

### DIFF
--- a/sktime/transformations/compose/_featureunion.py
+++ b/sktime/transformations/compose/_featureunion.py
@@ -80,9 +80,10 @@ class FeatureUnion(_HeterogenousMetaEstimator, BaseTransformer):
         flatten_transform_index=True,
     ):
         self.transformer_list = transformer_list
-        self.transformer_list_ = self._check_estimators(
+        transformer_list_ = self._check_estimators(
             transformer_list, cls_type=BaseTransformer
         )
+        self.transformer_list_ = transformer_list_
 
         self.n_jobs = n_jobs
         self.transformer_weights = transformer_weights
@@ -90,9 +91,11 @@ class FeatureUnion(_HeterogenousMetaEstimator, BaseTransformer):
 
         super().__init__()
 
-        # todo: check for transform-input, transform-output
-        #   for now, we assume it's always Series/Series or Series/Panel
-        #   but no error is currently raised
+        t_outs = [t.get_tag("scitype:transform-output") for _, t in transformer_list_]
+        t_ins = [t.get_tag("scitype:transform-input") for _, t in transformer_list_]
+        # todo: error or special case handling if these are not all the same
+        self.set_tags(**{"scitype:transform-output": t_outs[0]})
+        self.set_tags(**{"scitype:transform-input": t_ins[0]})
 
         # abbreviate for readability
         ests = self.transformer_list_

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 from sklearn.preprocessing import StandardScaler
 
-from sktime.datasets import load_airline
+from sktime.datasets import load_airline, load_unit_test
 from sktime.datatypes import get_examples
 from sktime.transformations.bootstrap import STLBootstrapTransformer
 from sktime.transformations.compose import (
@@ -172,6 +172,21 @@ def test_featureunion_transform_cols():
 
     assert deep_equals(Xt.columns, expected_cols), msg
 
+
+def test_featureunion_primitives():
+    """Test that FeatureUnion is correctly applied to primitives.
+
+    Failure case of bug #6077.
+    """
+    X, _ = load_unit_test(split="train", return_X_y=True)
+
+    fu = SummaryTransformer() + SummaryTransformer()
+    Xt = fu.fit_transform(X)
+
+    assert isinstance(Xt, pd.DataFrame)
+    assert len(Xt) == len(X)
+    assert Xt.shape[1] == 2 * 9  # 9-feature summary statistics
+    assert Xt.columns[0] == "SummaryTransformer_1__mean"  # unique naming
 
 def test_sklearn_after_primitives():
     """Test that sklearn transformer after primitives is correctly applied."""

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -188,6 +188,7 @@ def test_featureunion_primitives():
     assert Xt.shape[1] == 2 * 9  # 9-feature summary statistics
     assert Xt.columns[0] == "SummaryTransformer_1__mean"  # unique naming
 
+
 def test_sklearn_after_primitives():
     """Test that sklearn transformer after primitives is correctly applied."""
     t = SummaryTransformer() * StandardScaler()


### PR DESCRIPTION
This PR fixes #6077, by correcting the output type tag inference as suggested by @fspinna.

Also adds the MRE from #6077 as a test.

Currently, the tags are copied from the first component instance in the feature union - I'm unsure what should happen in case the tags are unequal for the members of the feature union.