### PR TITLE
Add a `test_mstl` module checking if `transform` returns desired components

### DIFF
--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -4,7 +4,7 @@
 __author__ = ["krishna-t"]
 
 import pytest
-import statsmodels as statsmodels
+import statsmodels
 
 from sktime.datasets import load_airline
 from sktime.transformations.series.detrend.mstl import MSTL
@@ -32,29 +32,24 @@ def test_transform_returns_correct_components():
     # Check if the transformed data has the expected components
     assert "transformed" in transformed.columns, (
         "Test of MSTL.transform failed with return_components=True, "
-        "returned DataFrame columns"
-        " are missing 'transformed"
-        " variable."
+        "returned DataFrame columns are missing 'transformed' "
+        "variable."
     )
     assert "trend" in transformed.columns, (
         "Test of MSTL.transform failed with return_components=True, "
-        "returned DataFrame columns are "
-        "missing 'trend' variable."
+        "returned DataFrame columns are missing 'trend' variable."
     )
     assert "resid" in transformed.columns, (
         "Test of MSTL.transform failed with return_components=True, "
-        "returned DataFrame columns are "
-        "missing 'resid' variable."
+        "returned DataFrame columns are missing 'resid' variable."
     )
     assert "seasonal_3" in transformed.columns, (
         "Test of MSTL.transform failed with return_components=True, "
-        "returned DataFrame columns"
-        " are missing 'seasonal_3 "
+        "returned DataFrame columns are missing 'seasonal_3 "
         "variable."
     )
     assert "seasonal_12" in transformed.columns, (
         "Test of MSTL.transform failed with return_components=True, "
-        "returned DataFrame "
-        "columns are missing "
-        "'seasonal_12' variable."
+        "returned DataFrame columns are missing 'seasonal_12' "
+        "variable."
     )

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -15,8 +15,8 @@ from sktime.transformations.series.detrend.mstl import MSTL
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_transform_returns_correct_components():
-    """Tests whether expected components are returned when
-    *return_components* parameter is switched on."""
+    """Tests if expected components are returned when return_components=True.
+    """
     # Load our default test dataset
     series = load_airline()
     series.index = series.index.to_timestamp()

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -1,7 +1,6 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Tests MSTL functionality."""
 
-__all__ = ["test-MSTL"]
 __authors__ = ["krishna-t"]
 
 import numpy as np

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from sktime.datasets import load_airline
-from sktime.transformations.series.detrend import MSTL
+from sktime.transformations.series.detrend.mstl import MSTL
 
 def test_transform_returns_correct_components():
     # TODO: See if we need to create a fresh time series dataset?

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -12,9 +12,7 @@ from sktime.transformations.series.detrend.mstl import MSTL
 
 @pytest.mark.skipif(
     not run_test_for_class([MSTL]),
-    reason="run test only if softdeps are present and "
-    "incrementally"
-    " (if requested)",
+    reason="run test only if softdeps are present " "and incrementally (if requested)",
 )
 def test_transform_returns_correct_components():
     """Tests whether expected components are returned when

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pandas as pd
+from sktime.transformations.series.detrend import MSTL
+
+def test_mstl_returns_correct_components():
+    # Create a time series dataset
+    np.random.seed(42)
+    data = np.random.randn(100)
+    index = pd.date_range(start="2020-01-01", periods=100, freq="D")
+    series = pd.Series(data, index=index)
+
+    # Initialize the MSTL transformer with specific parameters
+    transformer = MSTL(periods=7, return_components=True)
+
+    # Fit the transformer to the data
+    transformer.fit(series)
+
+    # Transform the data
+    transformed = transformer.transform(series)
+
+    # Check if the transformed data has the expected components
+    assert 'seasonal' in transformed.columns, "Seasonal component missing"
+    assert 'trend' in transformed.columns, "Trend component missing"
+    assert 'resid' in transformed.columns, "Residual component missing"
+
+    # Optionally, check the inverse transform
+    inverse_transformed = transformer.inverse_transform(transformed)
+    assert np.allclose(series, inverse_transformed), "Inverse transform failed"
+
+# Above tests MUST be modified because it's just a "template" kind of thing right now.
+#  Also additional tests can be written to check for edge cases, incorrect parameters, etc.

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -4,14 +4,16 @@
 __author__ = ["krishna-t"]
 
 import pytest
-import statsmodels
 
 from sktime.datasets import load_airline
+from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.series.detrend.mstl import MSTL
 
 
 @pytest.mark.skipif(
-    statsmodels.tsa.seasonal.MSTL is None, reason="MSTL is not installed"
+    not run_test_for_class([MSTL]),
+    reason="run test only if softdeps are present and incrementally"
+           " (if requested)",
 )
 def test_transform_returns_correct_components():
     """Tests whether expected components are returned when

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -12,8 +12,9 @@ from sktime.transformations.series.detrend.mstl import MSTL
 
 @pytest.mark.skipif(
     not run_test_for_class([MSTL]),
-    reason="run test only if softdeps are present and incrementally"
-           " (if requested)",
+    reason="run test only if softdeps are present and "
+    "incrementally"
+    " (if requested)",
 )
 def test_transform_returns_correct_components():
     """Tests whether expected components are returned when

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -1,22 +1,27 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Tests MSTL functionality."""
 
-__authors__ = ["krishna-t"]
+__author__ = ["krishna-t"]
 
-import numpy as np
-import pandas as pd
+import pytest
+import statsmodels as statsmodels
+
 from sktime.datasets import load_airline
 from sktime.transformations.series.detrend.mstl import MSTL
 
+
+@pytest.mark.skipif(
+    statsmodels.tsa.seasonal.MSTL is None, reason="MSTL is not installed"
+)
 def test_transform_returns_correct_components():
-    """Tests whether expected components are returned when 
+    """Tests whether expected components are returned when
     *return_components* parameter is switched on."""
     # Load our default test dataset
     series = load_airline()
     series.index = series.index.to_timestamp()
-    
+
     # Initialize the MSTL transformer with specific parameters
-    transformer = MSTL(periods=[3,12], return_components=True)
+    transformer = MSTL(periods=[3, 12], return_components=True)
 
     # Fit the transformer to the data
     transformer.fit(series)
@@ -25,8 +30,31 @@ def test_transform_returns_correct_components():
     transformed = transformer.transform(series)
 
     # Check if the transformed data has the expected components
-    assert 'transformed' in transformed.columns, "Transformed component missing!"
-    assert 'trend' in transformed.columns, "Trend component missing!"
-    assert 'resid' in transformed.columns, "Residual component missing!"
-    assert 'seasonal_3' in transformed.columns, "Seasonal component missing!" 
-    assert 'seasonal_12' in transformed.columns, "Seasonal component missing!"
+    assert "transformed" in transformed.columns, (
+        "Test of MSTL.transform failed with return_components=True, "
+        "returned DataFrame columns"
+        " are missing 'transformed"
+        " variable."
+    )
+    assert "trend" in transformed.columns, (
+        "Test of MSTL.transform failed with return_components=True, "
+        "returned DataFrame columns are "
+        "missing 'trend' variable."
+    )
+    assert "resid" in transformed.columns, (
+        "Test of MSTL.transform failed with return_components=True, "
+        "returned DataFrame columns are "
+        "missing 'resid' variable."
+    )
+    assert "seasonal_3" in transformed.columns, (
+        "Test of MSTL.transform failed with return_components=True, "
+        "returned DataFrame columns"
+        " are missing 'seasonal_3 "
+        "variable."
+    )
+    assert "seasonal_12" in transformed.columns, (
+        "Test of MSTL.transform failed with return_components=True, "
+        "returned DataFrame "
+        "columns are missing "
+        "'seasonal_12' variable."
+    )

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -12,7 +12,7 @@ from sktime.transformations.series.detrend.mstl import MSTL
 
 @pytest.mark.skipif(
     not run_test_for_class([MSTL]),
-    reason="run test only if softdeps are present " "and incrementally (if requested)",
+    reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_transform_returns_correct_components():
     """Tests whether expected components are returned when

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -1,16 +1,21 @@
 import numpy as np
 import pandas as pd
+from sktime.datasets import load_airline
 from sktime.transformations.series.detrend import MSTL
 
-def test_mstl_returns_correct_components():
-    # Create a time series dataset
-    np.random.seed(42)
-    data = np.random.randn(100)
-    index = pd.date_range(start="2020-01-01", periods=100, freq="D")
-    series = pd.Series(data, index=index)
+def test_transform_returns_correct_components():
+    # TODO: See if we need to create a fresh time series dataset?
+    # np.random.seed(42)
+    # data = np.random.randn(100)
+    # index = pd.date_range(start="2020-01-01", periods=100, freq="D")
+    # series = pd.Series(data, index=index)
 
+    # Load our default test dataset
+    series = load_airline()
+    series.index = y.index.to_timestamp()
+    
     # Initialize the MSTL transformer with specific parameters
-    transformer = MSTL(periods=7, return_components=True)
+    transformer = MSTL(periods=[3,12], return_components=True)
 
     # Fit the transformer to the data
     transformer.fit(series)
@@ -19,13 +24,9 @@ def test_mstl_returns_correct_components():
     transformed = transformer.transform(series)
 
     # Check if the transformed data has the expected components
-    assert 'seasonal' in transformed.columns, "Seasonal component missing"
+    assert 'transformed' in transformed.columns, "Transformed component missing"
     assert 'trend' in transformed.columns, "Trend component missing"
     assert 'resid' in transformed.columns, "Residual component missing"
-
-    # Optionally, check the inverse transform
-    inverse_transformed = transformer.inverse_transform(transformed)
-    assert np.allclose(series, inverse_transformed), "Inverse transform failed"
-
-# Above tests MUST be modified because it's just a "template" kind of thing right now.
-#  Also additional tests can be written to check for edge cases, incorrect parameters, etc.
+    # TODO: Specify "Seasonal_3" and "Seasonal_12" missing for our specific data or not?
+    assert 'seasonal_3' in transformed.columns, "Seasonal component missing" 
+    assert 'seasonal_12' in transformed.columns, "Seasonal component missing"

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -15,8 +15,7 @@ from sktime.transformations.series.detrend.mstl import MSTL
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_transform_returns_correct_components():
-    """Tests if expected components are returned when return_components=True.
-    """
+    """Tests if expected components are returned when return_components=True."""
     # Load our default test dataset
     series = load_airline()
     series.index = series.index.to_timestamp()

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -10,8 +10,8 @@ from sktime.datasets import load_airline
 from sktime.transformations.series.detrend.mstl import MSTL
 
 def test_transform_returns_correct_components():
-    """Tests whether expected components are returned when *return_components* 
-    parameter is switched on."""
+    """Tests whether expected components are returned when 
+    *return_components* parameter is switched on."""
     # Load our default test dataset
     series = load_airline()
     series.index = series.index.to_timestamp()

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -1,18 +1,20 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests MSTL functionality."""
+
+__all__ = ["test-MSTL"]
+__authors__ = ["krishna-t"]
+
 import numpy as np
 import pandas as pd
 from sktime.datasets import load_airline
 from sktime.transformations.series.detrend.mstl import MSTL
 
 def test_transform_returns_correct_components():
-    # TODO: See if we need to create a fresh time series dataset?
-    # np.random.seed(42)
-    # data = np.random.randn(100)
-    # index = pd.date_range(start="2020-01-01", periods=100, freq="D")
-    # series = pd.Series(data, index=index)
-
+    """Tests whether expected components are returned when *return_components* 
+    parameter is switched on."""
     # Load our default test dataset
     series = load_airline()
-    series.index = y.index.to_timestamp()
+    series.index = series.index.to_timestamp()
     
     # Initialize the MSTL transformer with specific parameters
     transformer = MSTL(periods=[3,12], return_components=True)
@@ -24,9 +26,8 @@ def test_transform_returns_correct_components():
     transformed = transformer.transform(series)
 
     # Check if the transformed data has the expected components
-    assert 'transformed' in transformed.columns, "Transformed component missing"
-    assert 'trend' in transformed.columns, "Trend component missing"
-    assert 'resid' in transformed.columns, "Residual component missing"
-    # TODO: Specify "Seasonal_3" and "Seasonal_12" missing for our specific data or not?
-    assert 'seasonal_3' in transformed.columns, "Seasonal component missing" 
-    assert 'seasonal_12' in transformed.columns, "Seasonal component missing"
+    assert 'transformed' in transformed.columns, "Transformed component missing!"
+    assert 'trend' in transformed.columns, "Trend component missing!"
+    assert 'resid' in transformed.columns, "Residual component missing!"
+    assert 'seasonal_3' in transformed.columns, "Seasonal component missing!" 
+    assert 'seasonal_12' in transformed.columns, "Seasonal component missing!"


### PR DESCRIPTION
Closes #6083, resolves #5458.

This PR adds a test file for the [MSTL](https://github.com/sktime/sktime/blob/main/sktime/transformations/series/detrend/mstl.py) class. Currently, all it intends to do is test whether [MSTL](https://github.com/sktime/sktime/blob/main/sktime/transformations/series/detrend/mstl.py)'s `transform` returns the correct components when `return_components` is set to True during initialization.

If it would be beneficial, I could probably expand the testing script to test MSTL in other scenarios (like we do for `_detrender` and `_deseasonalizer`). From @fkiraly's last comment in #5458, I thought this would be the most immediately helpful and nice-to-have test.

There's just one method in my code right now so it should be quick to review. This is my first PR here and I'm still familiarizing myself with the codebase, so any feedback would help.

Couple quick questions (mentioned as a TODO in the code, though they're just notes):

1.) I wonder whether I should test `mstl` using our own `load_airline` or create a fresh small numpy dataset within the script itself? 

2.) For the `assert` statements, should we specify "`Seasonal_3` not returned" for eg, or is it enough to say `Seasonal component not returned"?

Lastly, would it be beneficial to add further tests for other MSTL functionalities (which functionalities)?

Thanks everyone! 😊 🚀 