### PR TITLE
[MNT] create build tool to check invalid backticks

### DIFF
--- a/build_tools/check_backticks.py
+++ b/build_tools/check_backticks.py
@@ -100,13 +100,14 @@ def main():
             results[file] = results_on_file
 
     # print the lines along with the invalid backticks text
+    print(f'Results in "{folder_path}"')  # noqa: T201
     if len(results) > 0:
-        print(f"Total Files with invalid backticks: {len(results)}")  # noqa
+        print(f"Total Files with invalid backticks: {len(results)}")  # noqa: T201
         for filename, result in results.items():
             for lineno, errors in result.items():
-                print(f"{filename}:{lineno} {' '.join(errors)}")  # noqa
+                print(f"{filename}:{lineno} {' '.join(errors)}")  # noqa: T201
     else:
-        print("No invalid backticks found")  # noqa
+        print("No invalid backticks found")  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/build_tools/check_backticks.py
+++ b/build_tools/check_backticks.py
@@ -57,13 +57,11 @@ def find_invalid_backtick_text(docstring):
     valid_backtick_text = re.findall(r":.*?:(`.*?`)", docstring)
 
     # find all the invalid backtick code snippets
-    invalid_backtick_text = []
+    invalid_backtick_text = set()
     for text in all_backtick_text:
         if text in valid_backtick_text:
             continue
-        if text in invalid_backtick_text:
-            continue
-        invalid_backtick_text.append(text)
+        invalid_backtick_text.add(text)
 
     return invalid_backtick_text
 

--- a/build_tools/check_backticks.py
+++ b/build_tools/check_backticks.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3 -u
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+"""Test script to check for invalid use of single-backticks."""
+
+__author__ = ["geetu040"]
+
+import ast
+import os
+import re
+
+
+def find_py_files(folder_path):
+    """Find all Python files in a given folder path."""
+    py_files = []
+    for root, _, files in os.walk(folder_path):
+        for file in files:
+            if file.endswith(".py"):
+                py_files.append(os.path.join(root, file))
+    return py_files
+
+
+def extract_docstrings(filename):
+    """Extract docstrings from a Python file."""
+    with open(filename) as file:
+        tree = ast.parse(file.read(), filename=filename)
+
+    docstrings = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.ClassDef, ast.Module)):
+            if (
+                node.body
+                and isinstance(node.body[0], ast.Expr)
+                and isinstance(node.body[0].value, ast.Str)
+            ):
+                lineno = 0 if isinstance(node, ast.Module) else node.lineno
+                docstring = node.body[0].value.s
+                docstrings[lineno] = docstring
+    return docstrings
+
+
+def find_invalid_backtick_text(docstring):
+    """Find invalid backtick text in a docstring."""
+    # remove all the double-backticks
+    doc = docstring.replace("``", "")
+
+    all_backtick_text = re.findall(r"`.*?`", doc)
+    valid_backtick_text = re.findall(r":.*?:(`.*?`)", doc)
+
+    # find all the invalid backtick code snippets
+    invalid_backtick_text = []
+    for text in all_backtick_text:
+        if text in valid_backtick_text:
+            continue
+        if text in invalid_backtick_text:
+            continue
+        invalid_backtick_text.append(text)
+
+    return invalid_backtick_text
+
+
+def main():
+    """Execute the main function of the script."""
+    import sktime
+
+    results = {}
+
+    # list all the python files in the project
+    py_files = find_py_files(sktime.__path__[0])
+
+    for file in py_files:
+        docstrings = extract_docstrings(file)
+        results_on_file = {}
+
+        for lineno, docstring in docstrings.items():
+            invalid_backtick_text = find_invalid_backtick_text(docstring)
+
+            if len(invalid_backtick_text) > 0:
+                results_on_file[lineno] = invalid_backtick_text
+
+        if len(results_on_file) > 0:
+            results[file] = results_on_file
+
+    # print the lines along with the invalid backticks text
+    if len(results) > 0:
+        print(f"Total Files with invalid backticks: {len(results)}")  # noqa
+        for filename, result in results.items():
+            for lineno, errors in result.items():
+                print(f"{filename}:{lineno} {' '.join(errors)}")  # noqa
+    else:
+        print("No invalid backticks found")  # noqa
+
+
+if __name__ == "__main__":
+    main()

--- a/build_tools/check_backticks.py
+++ b/build_tools/check_backticks.py
@@ -57,6 +57,9 @@ def find_invalid_backtick_text(docstring):
     for text in all_backtick_text:
         if text in valid_backtick_text:
             continue
+        # rst hyperlinks are valid cases
+        if re.match(r"`.*?<http.*?>`", text, flags=re.DOTALL):
+            continue
         invalid_backtick_text.add(text)
 
     return invalid_backtick_text

--- a/build_tools/check_backticks.py
+++ b/build_tools/check_backticks.py
@@ -5,6 +5,7 @@
 
 __author__ = ["geetu040"]
 
+import argparse
 import ast
 import glob
 import re
@@ -69,12 +70,23 @@ def find_invalid_backtick_text(docstring):
 
 def main():
     """Execute the main function of the script."""
-    import sktime
+    # parse command line arguments
+    parser = argparse.ArgumentParser(
+        description="Test script to check for invalid use of single-backticks."
+    )
+    parser.add_argument(
+        "folder_path",
+        nargs="?",
+        default="./sktime",
+        help="Folder path to search for Python files",
+    )
+    args = parser.parse_args()
 
+    folder_path = args.folder_path
     results = {}
 
     # list all the python files in the project
-    py_files = find_py_files(sktime.__path__[0])
+    py_files = find_py_files(folder_path)
 
     for file in py_files:
         docstrings = extract_docstrings(file)
@@ -100,4 +112,11 @@ def main():
 
 
 if __name__ == "__main__":
+    """
+    Usage: defaults to "./sktime"
+    python build_tools/check_backticks.py
+
+    Usage: folder path as argument
+    python build_tools/check_backticks.py sktime/classification/distance_based
+    """
     main()

--- a/build_tools/check_backticks.py
+++ b/build_tools/check_backticks.py
@@ -44,17 +44,13 @@ def extract_docstrings(filename):
 
 def find_invalid_backtick_text(docstring):
     """Find invalid backtick text in a docstring."""
-    # remove all the code blocks to avoid interference
-    # they are allowed to use backticks in any way
-    docstring = re.sub(r"```.*?```", "", docstring, flags=re.DOTALL)
-
-    # remove all double-backticks to avoid interference
+    # remove all multiple backticks to avoid interference
     # we are looking only for invalid single-backtick
-    docstring = re.sub(r"``.*?``", "", docstring)
+    docstring = re.sub(r"`{2,}.*?`{2,}", "", docstring, flags=re.DOTALL)
 
-    all_backtick_text = re.findall(r"`.*?`", docstring)
+    all_backtick_text = re.findall(r"`.*?`", docstring, flags=re.DOTALL)
     # expressions like :math:`d(x, y):= (x-y)^2` are valid cases
-    valid_backtick_text = re.findall(r":.*?:(`.*?`)", docstring)
+    valid_backtick_text = re.findall(r":.*?:(`.*?`)", docstring, flags=re.DOTALL)
 
     # find all the invalid backtick code snippets
     invalid_backtick_text = set()

--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -112,7 +112,7 @@ class BOSSEnsemble(BaseClassifier):
     Notes
     -----
     For the Java version, see
-    - ``Original Publication <https://github.com/patrickzib/SFA>``_.
+    - `Original Publication <https://github.com/patrickzib/SFA>`_.
     - `TSML <https://github.com/uea-machine-learning/tsml/blob/master/src/main/java/
     tsml/classifiers/dictionary_based/BOSS.java>`_.
 

--- a/sktime/classification/dictionary_based/_muse.py
+++ b/sktime/classification/dictionary_based/_muse.py
@@ -101,7 +101,7 @@ class MUSE(BaseClassifier):
     Notes
     -----
     For the Java version, see
-    - ``Original Publication <https://github.com/patrickzib/SFA>``_.
+    - `Original Publication <https://github.com/patrickzib/SFA>`_.
     - `MUSE
         <https://github.com/uea-machine-learning/tsml/blob/master/src/main/java/tsml/
     classifiers/multivariate/WEASEL_MUSE.java>`_.

--- a/sktime/classification/dictionary_based/_weasel.py
+++ b/sktime/classification/dictionary_based/_weasel.py
@@ -103,7 +103,7 @@ class WEASEL(BaseClassifier):
     Notes
     -----
     For the Java version, see
-    - ``Original Publication <https://github.com/patrickzib/SFA>``_.
+    - `Original Publication <https://github.com/patrickzib/SFA>`_.
     - `TSML <https://github.com/uea-machine-learning/tsml/blob/master/src/main/java
     /tsml/classifiers/dictionary_based/WEASEL.java>`_.
 

--- a/sktime/classification/feature_based/_catch22_classifier.py
+++ b/sktime/classification/feature_based/_catch22_classifier.py
@@ -53,7 +53,7 @@ class Catch22Classifier(_DelegatedClassifier):
 
     Notes
     -----
-    Authors ``catch22ForestClassifier <https://github.com/chlubba/sktime-catch22>``_.
+    Authors `catch22ForestClassifier <https://github.com/chlubba/sktime-catch22>`_.
 
     For the Java version, see `tsml <https://github.com/uea-machine-learning/tsml/blob
     /master/src/main/java/tsml/classifiers/hybrids/Catch22Classifier.java>`_.

--- a/sktime/clustering/k_means/_k_means_tslearn.py
+++ b/sktime/clustering/k_means/_k_means_tslearn.py
@@ -51,7 +51,7 @@ class TimeSeriesKMeansTslearn(_TslearnAdapter, BaseClusterer):
         parallelization.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See scikit-learns'
-        ``Glossary <https://scikit-learn.org/stable/glossary.html#term-n-jobs>``_
+        `Glossary <https://scikit-learn.org/stable/glossary.html#term-n-jobs>`_
         for more details.
 
     dtw_inertia: bool (default: False)

--- a/sktime/clustering/kernel_k_means.py
+++ b/sktime/clustering/kernel_k_means.py
@@ -48,7 +48,7 @@ class TimeSeriesKernelKMeans(_TslearnAdapter, BaseClusterer):
         computations.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See scikit-learns'
-        ``Glossary <https://scikit-learn.org/stable/glossary.html#term-n-jobs>``_
+        `Glossary <https://scikit-learn.org/stable/glossary.html#term-n-jobs>`_
         for more details.
     random_state: int or np.random.RandomState instance or None, defaults = None
         Determines random number generation for centroid initialization.

--- a/sktime/dists_kernels/gak.py
+++ b/sktime/dists_kernels/gak.py
@@ -21,7 +21,7 @@ class GAKernel(_TslearnPwTrafoAdapter, BasePairwiseTransformerPanel):
         The number of jobs to run in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See scikit-learns'
-        ``Glossary <https://scikit-learn.org/stable/glossary.html#term-n-jobs>``__
+        `Glossary <https://scikit-learn.org/stable/glossary.html#term-n-jobs>`_
         for more details.
     verbose : int, optional, default=0
         The verbosity level: if non zero, progress messages are printed.

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -50,7 +50,7 @@ class Deseasonalizer(BaseTransformer):
     -----
     For further explanation on seasonal components and additive vs.
     multiplicative models see
-    ``Forecasting: Principles and Practice <https://otexts.com/fpp3/components.html>``_.
+    `Forecasting: Principles and Practice <https://otexts.com/fpp3/components.html>`_.
     Seasonal decomposition is computed using `statsmodels
 
     <https://www.statsmodels.org/stable/generated/statsmodels.tsa.seasonal.seasonal_decompose.html>`_.
@@ -286,7 +286,7 @@ class ConditionalDeseasonalizer(Deseasonalizer):
     -----
     For further explanation on seasonal components and additive vs.
     multiplicative models see
-    ``Forecasting: Principles and Practice <https://otexts.com/fpp3/components.html>``_.
+    `Forecasting: Principles and Practice <https://otexts.com/fpp3/components.html>`_.
     Seasonal decomposition is computed using `statsmodels
 
     <https://www.statsmodels.org/stable/generated/statsmodels.tsa.seasonal.seasonal_decompose.html>`_.


### PR DESCRIPTION
#### Reference Issues/PRs

This PR is related to this work here: https://github.com/sktime/sktime/pull/6023

#### What does this implement/fix? Explain your changes.

It creates a python script in `build_tools` that can be run to list out all the files and incorrect uses of `backticks` in the docstrings.

#### What should a reviewer concentrate their feedback on?

- checkout the regex expressions used in function: `find_invalid_backtick_text`
- I am not sure how the output should look like, I have attached a snapshot below in comments.

#### Any other comments?

If this tool is accepted we can use this to fix all the remaining invalid `backtick` uses and can later be converted to a pre-commit tool.

#### PR checklist

##### For all contributions
- [x] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.