### PR TITLE
[ENH] remove unnecessary line in `all_estimators`

### DIFF
--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -158,7 +158,6 @@ def all_estimators(
         "test_split",
     )
 
-    result = []
     ROOT = str(Path(__file__).parent.parent)  # sktime package root directory
 
     if estimator_types:


### PR DESCRIPTION
This PR removes a spurious line from `all_estimators` - the line had no effect.