### PR TITLE
[BUG] search function for estimator overview not working

### DIFF
--- a/docs/source/_static/js/dynamic_table.js
+++ b/docs/source/_static/js/dynamic_table.js
@@ -1,9 +1,14 @@
-$(document).ready(function () {
-  $("#myInput").on("keyup", function () {
-	var value = $(this).val().toLowerCase();
-	$("tr").filter(function () {
-	  $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1);
-	});
+document.addEventListener("DOMContentLoaded", function () {
+  var myInput = document.getElementById("myInput");
+
+  myInput.addEventListener("keyup", function () {
+    var value = this.value.toLowerCase();
+    var rows = document.getElementsByTagName("tr");
+
+    for (var i = 0; i < rows.length; i++) {
+      var rowText = rows[i].textContent.toLowerCase();
+      rows[i].style.display = rowText.indexOf(value) > -1 ? "" : "none";
+    }
   });
 });
 


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
Fixes #5495

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

I identified the location of the Js search function. It was written with jQuery which I was not familiar with. I just rewrote it in vanilla Js and the problem was fixed. 
 
![search](https://github.com/sktime/sktime/assets/56506156/25f59113-e6cd-4d5f-a32e-5efac100eabe)

This is very basic so it may not but the most right or efficient. I am going to look further into the documentation and implement some other enhancements for the estimator overview in particular and the docs in general. Then I may find out why the jQuery didn't work or draw up some other solutions. 