### PR TITLE
[BUG] Fixes not all notebooks are displayed in user-guide docs

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -27,3 +27,4 @@ The notebook files can be found `here <https://github.com/sktime/sktime/blob/mai
     :glob:
 
     examples/*
+    examples/*/*


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes not all notebooks are displayed in [user-guide](https://www.sktime.net/en/latest/user_guide.html), related to issue #3246. I think the merged PR wasn't the solution.  

#### Explain changes.

The wildcard `examples/*` could only match notebooks directly inside examples not notebooks inside the subdirs. 

#### Other comments

One of the straightforward bugs from the docs that I think could be fixed first. 

Worth noting that currently each notebook from docs/source/examples are linked **manually** to its source in examples. All links are more than 2 years old. If there are newly created examples they aren't included in the online docs. 

The local build attempts to rewrite the docs/source/examples with symbolic link from example, but the example folder does not categorize notebooks. So missing notebooks in Example page of locally built. 


