### PR TITLE
[ENH] Adds `MSTL` import statement in `detrend`

### DIFF
--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -304,13 +304,6 @@ Detrending and Decomposition
     Deseasonalizer
     ConditionalDeseasonalizer
     STLTransformer
-
-.. currentmodule:: sktime.transformations.series.detrend.mstl
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
     MSTL
 
 .. currentmodule:: sktime.transformations.series.vmd

--- a/sktime/transformations/series/detrend/__init__.py
+++ b/sktime/transformations/series/detrend/__init__.py
@@ -2,7 +2,13 @@
 """Transformer module for detrending and deseasonalization."""
 
 __author__ = ["mloning", "eyalshafran", "SveaMeyer13"]
-__all__ = ["Detrender", "Deseasonalizer", "ConditionalDeseasonalizer", "STLTransformer"]
+__all__ = [
+    "Detrender",
+    "Deseasonalizer",
+    "ConditionalDeseasonalizer",
+    "STLTransformer",
+    "MSTL",
+]
 
 from sktime.transformations.series.detrend._deseasonalize import (
     ConditionalDeseasonalizer,
@@ -10,3 +16,4 @@ from sktime.transformations.series.detrend._deseasonalize import (
     STLTransformer,
 )
 from sktime.transformations.series.detrend._detrend import Detrender
+from sktime.transformations.series.detrend.mstl import MSTL

--- a/sktime/transformations/series/detrend/mstl.py
+++ b/sktime/transformations/series/detrend/mstl.py
@@ -88,7 +88,7 @@ class MSTL(BaseTransformer):
     --------
     >>> import matplotlib.pyplot as plt  # doctest: +SKIP
     >>> from sktime.datasets import load_airline
-    >>> from sktime.transformations.series.detrend.mstl import MSTL
+    >>> from sktime.transformations.series.detrend import MSTL
     >>> y = load_airline()
     >>> y.index = y.index.to_timestamp()
     >>> mstl = MSTL(return_components=True)  # doctest: +SKIP


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #6085.

#### What does this implement/fix? Explain your changes.
`MSTL` import has been added to `sktime/transformations/series/detrend/__init__.py`.

```py
# previous import
from sktime.transformations.series.detrend.mstl import MSTL
# after changes: MSTL can also be imported like this
from sktime.transformations.series.detrend import MSTL
```

#### What should a reviewer concentrate their feedback on?
This change does not require a deprecation message as it is supported downwards and "don't break user code without forewarning".

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
