### PR TITLE
[MNT] initialize change cycle (0.28.0) for renaming `cINNForecaster` to `CINNForecaster`

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -369,7 +369,7 @@ Deep learning based forecasters
     :toctree: auto_generated/
     :template: class.rst
 
-    CINNForecaster
+    cINNForecaster
 
 .. currentmodule:: sktime.forecasting.neuralforecast
 

--- a/sktime/forecasting/conditional_invertible_neural_network.py
+++ b/sktime/forecasting/conditional_invertible_neural_network.py
@@ -17,6 +17,7 @@ from sktime.networks.cinn import cINNNetwork
 from sktime.transformations.merger import Merger
 from sktime.transformations.series.fourier import FourierFeatures
 from sktime.transformations.series.summarize import WindowSummarizer
+from sktime.utils.warnings import warn
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch
@@ -41,6 +42,7 @@ def default_sine(x, amplitude, phase, offset, amplitude2, amplitude3, phase2):
     return sbase + s1 + s2
 
 
+# TODO 0.29.0: rename the class cINNForecaster to CINNForecaster
 class cINNForecaster(BaseDeepNetworkPyTorch):
     """
     Conditional Invertible Neural Network (cINN) Forecaster.
@@ -176,6 +178,17 @@ class cINNForecaster(BaseDeepNetworkPyTorch):
         self.delta = delta
         self.val_split = val_split
         super().__init__(num_epochs, batch_size, lr=lr)
+
+        warn(
+            "cINNForecaster will be renamed to CINNForecaster in sktime 0.29.0, "
+            "The estimator is available under the future name at its "
+            "current location, and will be available under its deprecated name "
+            "until 0.30.0. "
+            "To prepare for the name change, "
+            "replace cINNForecaster with CINNForecaster",
+            DeprecationWarning,
+            obj=self,
+        )
 
     def _fit(self, y, fh, X=None):
         """Fit forecaster to training data.
@@ -607,3 +620,8 @@ class _EarlyStopper:
             if self.counter >= self.patience:
                 return True
         return False
+
+
+# TODO 0.29.0: switch the line to cINNForecaster = CINNForecaster
+# TODO 0.30.0: remove this alias altogether
+CINNForecaster = cINNForecaster

--- a/sktime/networks/cinn.py
+++ b/sktime/networks/cinn.py
@@ -219,6 +219,6 @@ class cINNNetwork:
         )
 
 
-# TODO 0.29.0: switch the line to cINNForecaster = CINNForecaster
+# TODO 0.29.0: switch the line to cINNNetwork = CINNNetwork
 # TODO 0.30.0: remove this alias altogether
 CINNNetwork = cINNNetwork

--- a/sktime/networks/cinn.py
+++ b/sktime/networks/cinn.py
@@ -4,6 +4,8 @@ __author__ = ["benHeid"]
 import numpy as np
 from skbase.utils.dependencies import _check_soft_dependencies
 
+from sktime.utils.warnings import warn
+
 if _check_soft_dependencies("torch", severity="none"):
     import torch
     import torch.nn as nn
@@ -22,6 +24,7 @@ if _check_soft_dependencies("FrEIA", severity="none"):
     import FrEIA.modules as Fm
 
 
+# TODO 0.29.0: rename the class cINNNetwork to CINNNetwork
 class cINNNetwork:
     """
     Conditional Invertible Neural Network.
@@ -193,6 +196,17 @@ class cINNNetwork:
         self.hidden_dim_size = hidden_dim_size
         self.activation = activation if activation is not None else nn.ReLU
 
+        warn(
+            "cINNNetwork will be renamed to CINNNetwork in sktime 0.29.0, "
+            "The estimator is available under the future name at its "
+            "current location, and will be available under its deprecated name "
+            "until 0.30.0. "
+            "To prepare for the name change, "
+            "replace cINNNetwork with CINNNetwork",
+            DeprecationWarning,
+            obj=self,
+        )
+
     def build(self):
         """Build the cINN."""
         return self._cINNNetwork(
@@ -203,3 +217,8 @@ class cINNNetwork:
             self.hidden_dim_size,
             self.activation,
         )
+
+
+# TODO 0.29.0: switch the line to cINNForecaster = CINNForecaster
+# TODO 0.30.0: remove this alias altogether
+CINNNetwork = cINNNetwork


### PR DESCRIPTION
#### Reference Issues/PRs
This PR prepares the change cycle for renaming `cINNForecaster` to `CINNForecaster` completing the steps for release v0.28.0 in #6120

#### What does this implement/fix? Explain your changes.
- todos on top of class definition
- warning message in class initialization
- alias line added with a todo in the bottom of the file

#### What should a reviewer concentrate their feedback on?
I have tried to mimic this implementation https://github.com/sktime/sktime/pull/5799
The todos lines with release versions and warning message should be considered.
