### PR TITLE
[ENH] Add `neuralforecast` auto adapter and an example with `AutoTFT`

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -377,6 +377,7 @@ Deep learning based forecasters
     :toctree: auto_generated/
     :template: class.rst
 
+    NeuralForecastAutoTFT
     NeuralForecastRNN
     NeuralForecastLSTM
 

--- a/sktime/forecasting/base/adapters/_neuralforecast.py
+++ b/sktime/forecasting/base/adapters/_neuralforecast.py
@@ -12,7 +12,7 @@ import pandas
 from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
 from sktime.utils.warnings import warn
 
-__all__ = ["_NeuralForecastAdapter"]
+__all__ = ["_SUPPORTED_LOCAL_SCALAR_TYPES", "_NeuralForecastAdapter"]
 __author__ = ["yarnabrina", "geetu040", "pranavvp16"]
 
 _SUPPORTED_LOCAL_SCALAR_TYPES = Literal[


### PR DESCRIPTION
This PR adds an interface to the `AutoTFT` model provided in `neuralforecast`, and expose to users as `NeuralForecastAutoTFT`. For that, it uses the adapter class `_NeuralForecastAutoAdapter` which can be used by other `Auto*` models as well.