### PR TITLE
[ENH]: Fixes the `demoloading` with Classification Experiment Integration

### DIFF
--- a/sktime/_contrib/classification_experiments.py
+++ b/sktime/_contrib/classification_experiments.py
@@ -33,7 +33,7 @@ generated in java.
 
 
 def demo_loading():
-    """Test function to check dataset loading of univariate and multivaria problems."""
+    """Test function to check dataset loading of univariate and multivariate problems."""
     for i in range(0, len(dataset_lists.univariate)):
         data_dir = "../"
         dataset = dataset_lists.univariate[i]
@@ -63,6 +63,60 @@ def demo_loading():
         print(testX.shape)
         print("Test Y shape :")
         print(testY.shape)
+
+if __name__ == "__main__":
+    """Example simple usage, with arguments input via script or hard coded for
+    testing."""
+    if sys.argv.__len__() > 1:  # cluster run, this is fragile
+        print(sys.argv)
+        data_dir = sys.argv[1]
+        results_dir = sys.argv[2]
+        classifier = sys.argv[3]
+        dataset = sys.argv[4]
+        resample = int(sys.argv[5]) - 1
+
+        if len(sys.argv) > 6:
+            tf = sys.argv[6].lower() == "true"
+        else:
+            tf = False
+
+        if len(sys.argv) > 7:
+            predefined_resample = sys.argv[7].lower() == "true"
+        else:
+            predefined_resample = False
+
+        load_and_run_classification_experiment(
+            problem_path=data_dir,
+            results_path=results_dir,
+            classifier=set_classifier(classifier, resample, tf),
+            cls_name=classifier,
+            dataset=dataset,
+            resample_id=resample,
+            build_train=tf,
+            predefined_resample=predefined_resample,
+        )
+    else:  # Local run
+        print(" Local Run")
+        data_dir = "../datasets/data/"
+        results_dir = "./temp/"
+        cls_name = "FreshPRINCE"
+        classifier = FreshPRINCE()
+        dataset = "UnitTest"
+        resample = 0
+        tf = False
+        predefined_resample = False
+
+        load_and_run_classification_experiment(
+            overwrite=True,
+            problem_path=data_dir,
+            results_path=results_dir,
+            cls_name=cls_name,
+            classifier=classifier,
+            dataset=dataset,
+            resample_id=resample,
+            build_train=tf,
+            predefined_resample=predefined_resample,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
--> 

#### Reference Issues/PRs
<!--  #6176 


Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
--> Done


#### What does this implement/fix? Explain your changes.
<!-- The updated code includes logic to handle command-line arguments for a "cluster run" scenario, where specific arguments are expected and used to configure the experiment. If no arguments are provided, the script defaults to a "Local Run" scenario with predefined settings. The `load_and_run_classification_experiment` function is called with the appropriate arguments based on the scenario, allowing for flexibility in running classification experiments.

A clear and concise description of what you have implemented.
--> The `demo_loading` function serves as a test function to verify loading for both univariate and multivariate problems. It iterates over a list of datasets for univariate problems and sets the data directory accordingly. But the script is run with command-line arguments, it expects specific arguments for a "cluster run" scenario, such as the data directory, results directory, classifier, dataset, and other parameters. While arguments are then used to call `load_and_run_classification_experiment` to conduct a classification experiment. So can we intregate the command-line arguments are provided, the script defaults to a "Local Run" scenario, setting default values for the data directory, results directory, classifier, dataset, and other parameters, and then calls `load_and_run_classification_experiment` with these defaults. This approach makes the script flexible, allowing it to be used in different scenarios with varying sets of parameters.

#### Does your contribution introduce a new dependency? If yes, which one?

<!-- NO 
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
--> OKAY

#### What should a reviewer concentrate their feedback on?
Are there any specific sections or functions you'd like me to focus on

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
