### PR TITLE
[MNT] run `update-contributors` workflow only on PR

### DIFF
--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -1,7 +1,9 @@
 name: Update Contributors
 
 on:
-  push:
+  pull_request:
+    branches:
+      - main
     paths:
       - '.all-contributorsrc'
 


### PR DESCRIPTION
Currently, the `update-contributors` workflow - which updates `CONTRIBUTORS.md` if `.all-contributorsrc` is updated - triggers a job targeting any branch where that is the case.

This happens for PR branches, where this is intended behaviour, but also for `main`, where the update job fails due to branch protection.

This PR means to remove the second condition, which triggers unintended behaviour, and only leave the first one that triggers the intended behaviour.