### PR TITLE
[BUG] fix `super` calls in deep learning classifiers and regressors

### DIFF
--- a/sktime/classification/deep_learning/base.py
+++ b/sktime/classification/deep_learning/base.py
@@ -40,13 +40,6 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         "python_dependencies": "tensorflow",
     }
 
-    def __init__(self, batch_size=40, random_state=None):
-        super().__init__()
-
-        self.batch_size = batch_size
-        self.random_state = random_state
-        self.model_ = None
-
     @abstractmethod
     def build_model(self, input_shape, n_classes, **kwargs):
         """Construct a compiled, un-trained, keras model that is ready for training.

--- a/sktime/classification/deep_learning/cnn.py
+++ b/sktime/classification/deep_learning/cnn.py
@@ -91,7 +91,8 @@ class CNNClassifier(BaseDeepClassifier):
         optimizer=None,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
+
+        self.batch_size = batch_size
         self.n_conv_layers = n_conv_layers
         self.avg_pool_size = avg_pool_size
         self.kernel_size = kernel_size
@@ -106,6 +107,9 @@ class CNNClassifier(BaseDeepClassifier):
         self.use_bias = use_bias
         self.optimizer = optimizer
         self.history = None
+
+        super().__init__()
+
         self._network = CNNNetwork(
             kernel_size=self.kernel_size,
             avg_pool_size=self.avg_pool_size,

--- a/sktime/classification/deep_learning/cntc.py
+++ b/sktime/classification/deep_learning/cntc.py
@@ -107,9 +107,10 @@ class CNTCClassifier(BaseDeepClassifier):
         self.loss = loss
         self.metrics = metrics
         self.random_state = random_state
-        self._network = CNTCNetwork()
 
-        super().__init__(batch_size=batch_size, random_state=random_state)
+        super().__init__()
+
+        self._network = CNTCNetwork()
 
     def build_model(self, input_shape, n_classes, **kwargs):
         """Construct a compiled, un-trained, keras model that is ready for training.

--- a/sktime/classification/deep_learning/fcn.py
+++ b/sktime/classification/deep_learning/fcn.py
@@ -82,7 +82,7 @@ class FCNClassifier(BaseDeepClassifier):
         optimizer=None,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
+
         self.callbacks = callbacks
         self.n_epochs = n_epochs
         self.batch_size = batch_size
@@ -94,9 +94,10 @@ class FCNClassifier(BaseDeepClassifier):
         self.use_bias = use_bias
         self.optimizer = optimizer
         self.history = None
-        self._network = FCNNetwork(
-            random_state=self.random_state,
-        )
+
+        super().__init__()
+
+        self._network = FCNNetwork(random_state=self.random_state)
 
     def build_model(self, input_shape, n_classes, **kwargs):
         """Construct a compiled, un-trained, keras model that is ready for training.

--- a/sktime/classification/deep_learning/inceptiontime.py
+++ b/sktime/classification/deep_learning/inceptiontime.py
@@ -68,9 +68,6 @@ class InceptionTimeClassifier(BaseDeepClassifier):
         metrics=None,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
-
-        self.verbose = verbose
 
         # predefined
         self.batch_size = batch_size
@@ -86,7 +83,8 @@ class InceptionTimeClassifier(BaseDeepClassifier):
         self.use_bottleneck = use_bottleneck
         self.use_residual = use_residual
         self.verbose = verbose
-        self._is_fitted = False
+
+        super().__init__()
 
         network_params = {
             "n_filters": n_filters,

--- a/sktime/classification/deep_learning/lstmfcn.py
+++ b/sktime/classification/deep_learning/lstmfcn.py
@@ -76,12 +76,6 @@ class LSTMFCNClassifier(BaseDeepClassifier):
         random_state=None,
         verbose=0,
     ):
-        super().__init__()
-
-        self.classes_ = None
-        self.input_shape = None
-        self.model_ = None
-        self.history = None
 
         # predefined
         self.n_epochs = n_epochs
@@ -96,6 +90,8 @@ class LSTMFCNClassifier(BaseDeepClassifier):
         self.random_state = random_state
         self.verbose = verbose
 
+        super().__init__()
+
         self._network = LSTMFCNNetwork(
             kernel_sizes=self.kernel_sizes,
             filter_sizes=self.filter_sizes,
@@ -104,7 +100,6 @@ class LSTMFCNClassifier(BaseDeepClassifier):
             dropout=self.dropout,
             attention=self.attention,
         )
-        self._is_fitted = False
 
     def build_model(self, input_shape, n_classes, **kwargs):
         """

--- a/sktime/classification/deep_learning/lstmfcn.py
+++ b/sktime/classification/deep_learning/lstmfcn.py
@@ -76,7 +76,6 @@ class LSTMFCNClassifier(BaseDeepClassifier):
         random_state=None,
         verbose=0,
     ):
-
         # predefined
         self.n_epochs = n_epochs
         self.batch_size = batch_size

--- a/sktime/classification/deep_learning/macnn.py
+++ b/sktime/classification/deep_learning/macnn.py
@@ -107,7 +107,6 @@ class MACNNClassifier(BaseDeepClassifier):
         verbose=False,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
 
         self.n_epochs = n_epochs
         self.batch_size = batch_size
@@ -126,6 +125,9 @@ class MACNNClassifier(BaseDeepClassifier):
         self.callbacks = callbacks
         self.random_state = random_state
         self.verbose = verbose
+
+        super().__init__()
+
         self.history = None
         self._network = MACNNNetwork(
             padding=self.padding,

--- a/sktime/classification/deep_learning/mcdcnn.py
+++ b/sktime/classification/deep_learning/mcdcnn.py
@@ -107,7 +107,6 @@ class MCDCNNClassifier(BaseDeepClassifier):
         random_state=0,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
 
         self.n_epochs = n_epochs
         self.batch_size = batch_size
@@ -125,6 +124,9 @@ class MCDCNNClassifier(BaseDeepClassifier):
         self.optimizer = optimizer
         self.verbose = verbose
         self.random_state = random_state
+
+        super().__init__()
+
         self.history = None
         self._network = MCDCNNNetwork(
             kernel_size=self.kernel_size,

--- a/sktime/classification/deep_learning/mlp.py
+++ b/sktime/classification/deep_learning/mlp.py
@@ -82,7 +82,7 @@ class MLPClassifier(BaseDeepClassifier):
         optimizer=None,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
+
         self.callbacks = callbacks
         self.n_epochs = n_epochs
         self.batch_size = batch_size
@@ -93,6 +93,9 @@ class MLPClassifier(BaseDeepClassifier):
         self.activation = activation
         self.use_bias = use_bias
         self.optimizer = optimizer
+
+        super().__init__()
+
         self.history = None
         self._network = MLPNetwork(
             random_state=self.random_state,

--- a/sktime/classification/deep_learning/resnet.py
+++ b/sktime/classification/deep_learning/resnet.py
@@ -83,7 +83,7 @@ class ResNetClassifier(BaseDeepClassifier):
         optimizer=None,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
+
         self.n_epochs = n_epochs
         self.callbacks = callbacks
         self.verbose = verbose
@@ -94,6 +94,9 @@ class ResNetClassifier(BaseDeepClassifier):
         self.activation = activation
         self.use_bias = use_bias
         self.optimizer = optimizer
+
+        super().__init__()
+
         self.history = None
         self._network = ResNetNetwork(random_state=random_state)
 

--- a/sktime/classification/deep_learning/rnn.py
+++ b/sktime/classification/deep_learning/rnn.py
@@ -73,9 +73,8 @@ class SimpleRNNClassifier(BaseDeepClassifier):
     ):
         _check_dl_dependencies(severity="error")
 
-        super().__init__()
-
         self.batch_size = batch_size
+        self.n_epochs = n_epochs
         self.verbose = verbose
         self.units = units
         self.callbacks = callbacks
@@ -86,9 +85,11 @@ class SimpleRNNClassifier(BaseDeepClassifier):
         self.activation = activation
         self.use_bias = use_bias
         self.optimizer = optimizer
+
+        super().__init__()
+
         self.history = None
         self._network = RNNNetwork(random_state=random_state, units=units)
-        self.n_epochs = n_epochs
 
     def build_model(self, input_shape, n_classes, **kwargs):
         """Construct a compiled, un-trained, keras model that is ready for training.

--- a/sktime/classification/deep_learning/tapnet.py
+++ b/sktime/classification/deep_learning/tapnet.py
@@ -119,7 +119,6 @@ class TapNetClassifier(BaseDeepClassifier):
         verbose=False,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
 
         self.batch_size = batch_size
         self.random_state = random_state
@@ -147,6 +146,8 @@ class TapNetClassifier(BaseDeepClassifier):
         # parameters for random projection
         self.use_rp = use_rp
         self.rp_params = rp_params
+
+        super().__init__()
 
         self._network = TapNetNetwork(
             dropout=self.dropout,

--- a/sktime/regression/deep_learning/base.py
+++ b/sktime/regression/deep_learning/base.py
@@ -38,12 +38,6 @@ class BaseDeepRegressor(BaseRegressor, ABC):
         "python_dependencies": "tensorflow",
     }
 
-    def __init__(self, batch_size=40):
-        super().__init__()
-
-        self.batch_size = batch_size
-        self.model_ = None
-
     @abstractmethod
     def build_model(self, input_shape, **kwargs):
         """Construct a compiled, un-trained, keras model that is ready for training.

--- a/sktime/regression/deep_learning/cnn.py
+++ b/sktime/regression/deep_learning/cnn.py
@@ -92,9 +92,7 @@ class CNNRegressor(BaseDeepRegressor):
         optimizer=None,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__(
-            batch_size=batch_size,
-        )
+        super().__init__()
         self.n_conv_layers = n_conv_layers
         self.avg_pool_size = avg_pool_size
         self.kernel_size = kernel_size

--- a/sktime/regression/deep_learning/cntc.py
+++ b/sktime/regression/deep_learning/cntc.py
@@ -97,9 +97,11 @@ class CNTCRegressor(BaseDeepRegressor):
         self.loss = loss
         self.metrics = metrics
         self.random_state = random_state
+
+        super().__init__()
+
         self._network = CNTCNetwork()
 
-        super().__init__(batch_size=batch_size, random_state=random_state)
 
     def build_model(self, input_shape, **kwargs):
         """Construct a compiled, un-trained, keras model that is ready for training.

--- a/sktime/regression/deep_learning/cntc.py
+++ b/sktime/regression/deep_learning/cntc.py
@@ -102,7 +102,6 @@ class CNTCRegressor(BaseDeepRegressor):
 
         self._network = CNTCNetwork()
 
-
     def build_model(self, input_shape, **kwargs):
         """Construct a compiled, un-trained, keras model that is ready for training.
 

--- a/sktime/regression/deep_learning/fcn.py
+++ b/sktime/regression/deep_learning/fcn.py
@@ -71,7 +71,7 @@ class FCNRegressor(BaseDeepRegressor):
         optimizer=None,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
+
         self.n_epochs = n_epochs
         self.batch_size = batch_size
         self.callbacks = callbacks
@@ -83,6 +83,9 @@ class FCNRegressor(BaseDeepRegressor):
         self.use_bias = use_bias
         self.optimizer = optimizer
         self.history = None
+
+        super().__init__()
+
         self._network = FCNNetwork(
             random_state=self.random_state,
         )

--- a/sktime/regression/deep_learning/inceptiontime.py
+++ b/sktime/regression/deep_learning/inceptiontime.py
@@ -68,7 +68,6 @@ class InceptionTimeRegressor(BaseDeepRegressor):
         metrics=None,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
 
         self.verbose = verbose
 
@@ -86,7 +85,8 @@ class InceptionTimeRegressor(BaseDeepRegressor):
         self.use_bottleneck = use_bottleneck
         self.use_residual = use_residual
         self.verbose = verbose
-        self._is_fitted = False
+
+        super().__init__()
 
         network_params = {
             "n_filters": n_filters,

--- a/sktime/regression/deep_learning/lstmfcn.py
+++ b/sktime/regression/deep_learning/lstmfcn.py
@@ -76,11 +76,6 @@ class LSTMFCNRegressor(BaseDeepRegressor):
         random_state=None,
         verbose=0,
     ):
-        super().__init__()
-
-        self.input_shape = None
-        self.model_ = None
-        self.history = None
 
         # predefined
         self.n_epochs = n_epochs
@@ -95,6 +90,12 @@ class LSTMFCNRegressor(BaseDeepRegressor):
         self.random_state = random_state
         self.verbose = verbose
 
+        super().__init__()
+
+        self.input_shape = None
+        self.model_ = None
+        self.history = None
+
         self._network = LSTMFCNNetwork(
             kernel_sizes=self.kernel_sizes,
             filter_sizes=self.filter_sizes,
@@ -103,7 +104,6 @@ class LSTMFCNRegressor(BaseDeepRegressor):
             dropout=self.dropout,
             attention=self.attention,
         )
-        self._is_fitted = False
 
     def build_model(self, input_shape, **kwargs):
         """

--- a/sktime/regression/deep_learning/lstmfcn.py
+++ b/sktime/regression/deep_learning/lstmfcn.py
@@ -76,7 +76,6 @@ class LSTMFCNRegressor(BaseDeepRegressor):
         random_state=None,
         verbose=0,
     ):
-
         # predefined
         self.n_epochs = n_epochs
         self.batch_size = batch_size

--- a/sktime/regression/deep_learning/macnn.py
+++ b/sktime/regression/deep_learning/macnn.py
@@ -94,7 +94,6 @@ class MACNNRegressor(BaseDeepRegressor):
         verbose=False,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
 
         self.n_epochs = n_epochs
         self.batch_size = batch_size
@@ -113,6 +112,9 @@ class MACNNRegressor(BaseDeepRegressor):
         self.callbacks = callbacks
         self.random_state = random_state
         self.verbose = verbose
+
+        super().__init__()
+
         self.history = None
         self._network = MACNNNetwork(
             padding=self.padding,

--- a/sktime/regression/deep_learning/mcdcnn.py
+++ b/sktime/regression/deep_learning/mcdcnn.py
@@ -105,7 +105,6 @@ class MCDCNNRegressor(BaseDeepRegressor):
         random_state=0,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
 
         self.n_epochs = n_epochs
         self.batch_size = batch_size
@@ -123,6 +122,9 @@ class MCDCNNRegressor(BaseDeepRegressor):
         self.optimizer = optimizer
         self.verbose = verbose
         self.random_state = random_state
+
+        super().__init__()
+
         self.history = None
         self._network = MCDCNNNetwork(
             kernel_size=self.kernel_size,

--- a/sktime/regression/deep_learning/mlp.py
+++ b/sktime/regression/deep_learning/mlp.py
@@ -72,7 +72,7 @@ class MLPRegressor(BaseDeepRegressor):
         optimizer=None,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
+
         self.callbacks = callbacks
         self.n_epochs = n_epochs
         self.batch_size = batch_size
@@ -83,6 +83,9 @@ class MLPRegressor(BaseDeepRegressor):
         self.activation = activation
         self.use_bias = use_bias
         self.optimizer = optimizer
+
+        super().__init__()
+
         self.history = None
         self._network = MLPNetwork(
             random_state=self.random_state,

--- a/sktime/regression/deep_learning/resnet.py
+++ b/sktime/regression/deep_learning/resnet.py
@@ -82,7 +82,6 @@ class ResNetRegressor(BaseDeepRegressor):
         optimizer=None,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
 
         self.n_epochs = n_epochs
         self.callbacks = callbacks
@@ -94,6 +93,9 @@ class ResNetRegressor(BaseDeepRegressor):
         self.activation = activation
         self.use_bias = use_bias
         self.optimizer = optimizer
+
+        super().__init__()
+
         self.history = None
         self._network = ResNetNetwork(random_state=random_state)
 

--- a/sktime/regression/deep_learning/rnn.py
+++ b/sktime/regression/deep_learning/rnn.py
@@ -74,8 +74,7 @@ class SimpleRNNRegressor(BaseDeepRegressor):
     ):
         _check_dl_dependencies(severity="error")
 
-        super().__init__()
-
+        self.n_epochs = n_epochs
         self.batch_size = batch_size
         self.verbose = verbose
         self.units = units
@@ -87,9 +86,11 @@ class SimpleRNNRegressor(BaseDeepRegressor):
         self.activation = activation
         self.use_bias = use_bias
         self.optimizer = optimizer
+
+        super().__init__()
+
         self.history = None
         self._network = RNNNetwork(random_state=random_state, units=units)
-        self.n_epochs = n_epochs
 
     def build_model(self, input_shape, **kwargs):
         """Construct a compiled, un-trained, keras model that is ready for training.

--- a/sktime/regression/deep_learning/tapnet.py
+++ b/sktime/regression/deep_learning/tapnet.py
@@ -107,7 +107,6 @@ class TapNetRegressor(BaseDeepRegressor):
         verbose=False,
     ):
         _check_dl_dependencies(severity="error")
-        super().__init__()
 
         self.batch_size = batch_size
         self.random_state = random_state
@@ -135,6 +134,8 @@ class TapNetRegressor(BaseDeepRegressor):
         # parameters for random projection
         self.use_rp = use_rp
         self.rp_params = rp_params
+
+        super().__init__()
 
         self._network = TapNetNetwork(
             dropout=self.dropout,


### PR DESCRIPTION
Some of the current deep learning classifiers on `main` had unreported bugs in their `__init__` logic and were not tested.

This was due to `BaseDeepClassifier` and `BaseDeepRegressor` having `__init__` args and defaults, for `batch_size` (both) and `random_state` (only `BaseDeepClassifer`).

If `super().__init__()` was called from the child class without passing these parameters, they would be overwritten by the defaults. Most existing classes did not pass these on, so were getting their defaults overwritten, unless they overwrote them again after that in their own `__init__`.

Further, some regressors were passing parameters that the super's `__init__` did not actually have, crashing upon construction - which was not noticed, as someone had added these classes to the `tests._config` exceptions.

This PR fixes this state by:

* removing `__init__` from `BaseDeepRegressor` and `BaseDeepClassifier` altogether - nothing useful was happening there, and only confusion was added due to the default overwrite
* `__init__`-s of all deep learning classifiers and regressores were cleaned up, to have parameter write to self and simple `super().__init__` calls without args, then any other logic

Testing is for now conducted via merge to PR https://github.com/sktime/sktime/pull/6138