### PR TITLE
[BUG] fix network construction in `InceptionTimeRegressor`

### DIFF
--- a/sktime/regression/deep_learning/inceptiontime.py
+++ b/sktime/regression/deep_learning/inceptiontime.py
@@ -153,7 +153,7 @@ class InceptionTimeRegressor(BaseDeepRegressor):
 
         check_random_state(self.random_state)
         self.input_shape = X.shape[1:]
-        self.model_ = self.build_model(self.input_shape, self.n_classes_)
+        self.model_ = self.build_model(self.input_shape)
         if self.verbose:
             self.model_.summary()
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -48,7 +48,6 @@ EXCLUDE_ESTIMATORS = [
     "FCNRegressor",
     "LSTMFCNRegressor",
     "MACNNRegressor",
-    "InceptionTimeRegressor",
     "CNTCClassifier",
     "CNTCRegressor",
 ]


### PR DESCRIPTION
Fixes an unreported network construction bug in `InceptionTimeRegressor`.

A `self.n_classes_` attribute was used internally, which neither the estimator nor the network had.

Previously undetedted since the estimator was excepted from testing, see https://github.com/sktime/sktime/pull/6138