### PR TITLE
[BUG] Update `_shapelet_transform_numba.py` to improve numerical stability

### DIFF
--- a/sktime/transformations/panel/_shapelet_transform_numba.py
+++ b/sktime/transformations/panel/_shapelet_transform_numba.py
@@ -56,7 +56,7 @@ def _online_shapelet_distance(series, shapelet, sorted_indices, position, length
             std = math.sqrt((sums2[n] - mean * mean * length) / length)
 
             dist = 0
-            use_std = std != 0
+            use_std = std > 1e-8 #Use a numerical tolerance to prevent division by values close to zero, enhancing numerical stability (i.e., avoid NaN in the computed transform)
             for j in range(length):
                 val = (series[pos + sorted_indices[j]] - mean) / std if use_std else 0
                 temp = shapelet[sorted_indices[j]] - val

--- a/sktime/transformations/panel/_shapelet_transform_numba.py
+++ b/sktime/transformations/panel/_shapelet_transform_numba.py
@@ -56,7 +56,7 @@ def _online_shapelet_distance(series, shapelet, sorted_indices, position, length
             std = math.sqrt((sums2[n] - mean * mean * length) / length)
 
             dist = 0
-            use_std = std > 1e-8 #Use a numerical tolerance to prevent division by values close to zero, enhancing numerical stability (i.e., avoid NaN in the computed transform)
+            use_std = std > 1e-8  # use a numerical tolerance to prevent NaN values
             for j in range(length):
                 val = (series[pos + sorted_indices[j]] - mean) / std if use_std else 0
                 temp = shapelet[sorted_indices[j]] - val

--- a/sktime/transformations/panel/_shapelet_transform_numba.py
+++ b/sktime/transformations/panel/_shapelet_transform_numba.py
@@ -56,7 +56,9 @@ def _online_shapelet_distance(series, shapelet, sorted_indices, position, length
             std = math.sqrt((sums2[n] - mean * mean * length) / length)
 
             dist = 0
-            use_std = std > 1e-8  # use a numerical tolerance to prevent NaN values
+
+            eps = 1e-8  # numerical eps, to avoid division by zero
+            use_std = std > eps  # use a numerical tolerance to prevent NaN values
             for j in range(length):
                 val = (series[pos + sorted_indices[j]] - mean) / std if use_std else 0
                 temp = shapelet[sorted_indices[j]] - val
@@ -70,7 +72,7 @@ def _online_shapelet_distance(series, shapelet, sorted_indices, position, length
 
         i += 1
 
-    return best_dist if best_dist == 0 else 1 / length * best_dist
+    return 1 / length * best_dist
 
 
 @njit(fastmath=True, cache=True)


### PR DESCRIPTION
Improved numerical stability by setting a tolerance threshold for standard deviation calculation in shapelet transform. This change from use_std = std != 0 to use_std = std > 1e-8 prevents potential NaN values by avoiding division by extremely small numbers, addressing issues related to the precision limits of floating-point arithmetic.


#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
This PR addresses the NaN issue discussed in [#4073](https://github.com/sktime/sktime/issues/4073). By introducing a tolerance threshold for the standard deviation calculation, it aims to resolve the NaN values encountered in certain cases.

#### What does this implement/fix? Explain your changes.
Enhances the `_online_shapelet_distance` function's robustness by introducing a tolerance threshold (`1e-8`) for the standard deviation (`std`) calculation, ensuring numerical stability and preventing NaN values in shapelet transform calculations.

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies introduced.

#### What should a reviewer concentrate their feedback on?
- The choice of the `1e-8` threshold for numerical stability.
- Potential impacts on the accuracy and performance of the shapelet transform function.


#### Did you add any tests for the change?
No new tests were added. Existing tests cover the functionality, but input on additional testing is welcome.

#### Any other comments?
I welcome any feedback or suggestions on this improvement.

#### PR checklist


##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

