### PR TITLE
[MNT] temporary skip sporadically failing tests for `ShapeletTransformPyts`

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -216,6 +216,8 @@ EXCLUDED_TESTS = {
     "StatsForecastMSTL": ["test_pred_int_tag"],
     # KNeighborsTimeSeriesClassifierTslearn crashes in parallel mode
     "KNeighborsTimeSeriesClassifierTslearn": ["test_multiprocessing_idempotent"],
+    # ShapeletTransformPyts creates nested numpy shapelets sporadically, see #6171
+    "ShapeletTransformPyts": ["test_non_state_changing_method_contract"],
 }
 
 # We use estimator tags in addition to class hierarchies to further distinguish


### PR DESCRIPTION
This PR adds temporary skips to sporadically failing tests for `ShapeletTransformPyts` until the underlying bug is resolved, see #6171.