### PR TITLE
Revert "[MNT] run `update-contributors` workflow only on PR"

### DIFF
--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -1,9 +1,7 @@
 name: Update Contributors
 
 on:
-  pull_request:
-    branches:
-      - main
+  push:
     paths:
       - '.all-contributorsrc'
 


### PR DESCRIPTION
Reverts sktime/sktime#6133

I think this does not work - not sure why the job fails on PR.