### PR TITLE
[ENH] mixture distribution

### DIFF
--- a/sktime/proba/mixture.py
+++ b/sktime/proba/mixture.py
@@ -81,8 +81,10 @@ class Mixture(_HeterogenousMetaEstimator, BaseDistribution):
 
     def mean(self):
         r"""Return expected value of the distribution.
+
         Let :math:`X` be a random variable with the distribution of `self`.
         Returns the expectation :math:`\mathbb{E}[X]`
+
         Returns
         -------
         pd.DataFrame with same rows, columns as `self`
@@ -92,8 +94,10 @@ class Mixture(_HeterogenousMetaEstimator, BaseDistribution):
 
     def var(self):
         r"""Return element/entry-wise variance of the distribution.
+
         Let :math:`X` be a random variable with the distribution of `self`.
         Returns :math:`\mathbb{V}[X] = \mathbb{E}\left(X - \mathbb{E}[X]\right)^2`
+
         Returns
         -------
         pd.DataFrame with same rows, columns as `self`
@@ -143,9 +147,11 @@ class Mixture(_HeterogenousMetaEstimator, BaseDistribution):
 
     def sample(self, n_samples=None):
         """Sample from the distribution.
+
         Parameters
         ----------
         n_samples : int, optional, default = None
+
         Returns
         -------
         if `n_samples` is `None`:

--- a/sktime/proba/mixture.py
+++ b/sktime/proba/mixture.py
@@ -38,8 +38,13 @@ class Mixture(_HeterogenousMetaEstimator, BaseDistribution):
         "capabilities:approx": ["pdfnorm", "energy", "ppf"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf"],
         "distr:measuretype": "mixed",
-        "named_object_parameters": "_distributions",
     }
+
+    # for default get_params/set_params from _HeterogenousMetaEstimator
+    # _steps_attr points to the attribute of self
+    # which contains the heterogeneous set of estimators
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
+    _steps_attr = "_distributions"
 
     def __init__(self, distributions, weights=None, index=None, columns=None):
         self.distributions = distributions

--- a/sktime/proba/mixture.py
+++ b/sktime/proba/mixture.py
@@ -5,13 +5,14 @@ __author__ = ["fkiraly"]
 
 import numpy as np
 import pandas as pd
-# from sktime.proba.base  import BaseMetaObject
 
+from sktime.base._meta import _HeterogenousMetaEstimator
 from sktime.proba.base import BaseDistribution
 
 
-class Mixture(BaseDistribution):
+class Mixture(_HeterogenousMetaEstimator, BaseDistribution):
     """Mixture of distributions.
+
     Parameters
     ----------
     distributions : list of tuples (str, BaseDistribution) or BaseDistribution
@@ -21,10 +22,12 @@ class Mixture(BaseDistribution):
         if not provided, uniform mixture is assumed
     index : pd.Index, optional, default = inferred from component distributions
     columns : pd.Index, optional, default = inferred from component distributions
+
     Example
     -------
     >>> from sktime.proba.mixture import Mixture
     >>> from sktime.proba.normal import Normal
+    >>>
     >>> n1 = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)
     >>> n2 = Normal(mu=3, sigma=2, index=n1.index, columns=n1.columns)
     >>> m = Mixture(distributions=[("n1", n1), ("n2", n2)], weights=[0.3, 0.7])
@@ -39,7 +42,6 @@ class Mixture(BaseDistribution):
     }
 
     def __init__(self, distributions, weights=None, index=None, columns=None):
-
         self.distributions = distributions
         self.weights = weights
         self.index = index
@@ -62,7 +64,6 @@ class Mixture(BaseDistribution):
         super().__init__(index=index, columns=columns)
 
     def _iloc(self, rowidx=None, colidx=None):
-
         dists = self._distributions
         weights = self.weights
 

--- a/sktime/proba/mixture.py
+++ b/sktime/proba/mixture.py
@@ -1,0 +1,187 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Mixture distribution."""
+
+__author__ = ["fkiraly"]
+
+import numpy as np
+import pandas as pd
+# from sktime.proba.base  import BaseMetaObject
+
+from sktime.proba.base import BaseDistribution
+
+
+class Mixture(BaseDistribution):
+    """Mixture of distributions.
+    Parameters
+    ----------
+    distributions : list of tuples (str, BaseDistribution) or BaseDistribution
+        list of mixture components
+    weights : list of float, optional, default = None
+        list of mixture weights, will be normalized to sum to 1
+        if not provided, uniform mixture is assumed
+    index : pd.Index, optional, default = inferred from component distributions
+    columns : pd.Index, optional, default = inferred from component distributions
+    Example
+    -------
+    >>> from sktime.proba.mixture import Mixture
+    >>> from sktime.proba.normal import Normal
+    >>> n1 = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)
+    >>> n2 = Normal(mu=3, sigma=2, index=n1.index, columns=n1.columns)
+    >>> m = Mixture(distributions=[("n1", n1), ("n2", n2)], weights=[0.3, 0.7])
+    >>> mixture_sample = m.sample(n_samples=10)
+    """
+
+    _tags = {
+        "capabilities:approx": ["pdfnorm", "energy", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf"],
+        "distr:measuretype": "mixed",
+        "named_object_parameters": "_distributions",
+    }
+
+    def __init__(self, distributions, weights=None, index=None, columns=None):
+
+        self.distributions = distributions
+        self.weights = weights
+        self.index = index
+        self.columns = columns
+
+        self._distributions = distributions
+        n_dists = len(self._distributions)
+
+        if weights is None:
+            self._weights = np.ones(n_dists) / n_dists
+        else:
+            self._weights = np.array(weights) / np.sum(weights)
+
+        if index is None:
+            index = self._distributions[0][1].index
+
+        if columns is None:
+            columns = self._distributions[0][1].columns
+
+        super().__init__(index=index, columns=columns)
+
+    def _iloc(self, rowidx=None, colidx=None):
+
+        dists = self._distributions
+        weights = self.weights
+
+        dists_subset = [(x[0], x[1].iloc[rowidx, colidx]) for x in dists]
+
+        index_subset = dists_subset[0][1].index
+        columns_subset = dists_subset[0][1].columns
+
+        return Mixture(
+            distributions=dists_subset,
+            weights=weights,
+            index=index_subset,
+            columns=columns_subset,
+        )
+
+    def mean(self):
+        r"""Return expected value of the distribution.
+        Let :math:`X` be a random variable with the distribution of `self`.
+        Returns the expectation :math:`\mathbb{E}[X]`
+        Returns
+        -------
+        pd.DataFrame with same rows, columns as `self`
+        expected value of distribution (entry-wise)
+        """
+        return self._average("mean")
+
+    def var(self):
+        r"""Return element/entry-wise variance of the distribution.
+        Let :math:`X` be a random variable with the distribution of `self`.
+        Returns :math:`\mathbb{V}[X] = \mathbb{E}\left(X - \mathbb{E}[X]\right)^2`
+        Returns
+        -------
+        pd.DataFrame with same rows, columns as `self`
+        variance of distribution (entry-wise)
+        """
+        weights = self._weights
+        var_mean = self._average("var")
+        mixture_mean = self._average("mean")
+
+        means = [d.mean() for _, d in self._distributions]
+        mean_var = [(m - mixture_mean) ** 2 for m in means]
+        var_mean_var = self._average_df(mean_var, weights=weights)
+
+        return var_mean + var_mean_var
+
+    def _average(self, method, x=None, weights=None):
+        """Average a method over the mixture components."""
+        if x is None:
+            args = ()
+        else:
+            args = (x,)
+
+        vals = [getattr(d, method)(*args) for _, d in self._distributions]
+
+        return self._average_df(vals, weights=weights)
+
+    def _average_df(self, df_list, weights=None):
+        """Average a list of `pd.DataFrame` objects, with weights."""
+        if weights is None and hasattr(self, "_weights"):
+            weights = self._weights
+        elif weights is None:
+            weights = np.ones(len(df_list)) / len(df_list)
+
+        n_df = len(df_list)
+        df_weighted = [df * w for df, w in zip(df_list, weights)]
+        df_concat = pd.concat(df_weighted, axis=1, keys=range(n_df))
+        df_res = df_concat.groupby(level=-1, axis=1).sum()
+        return df_res
+
+    def pdf(self, x):
+        """Probability density function."""
+        return self._average("pdf", x)
+
+    def cdf(self, x):
+        """Cumulative distribution function."""
+        return self._average("cdf", x)
+
+    def sample(self, n_samples=None):
+        """Sample from the distribution.
+        Parameters
+        ----------
+        n_samples : int, optional, default = None
+        Returns
+        -------
+        if `n_samples` is `None`:
+        returns a sample that contains a single sample from `self`,
+        in `pd.DataFrame` mtype format convention, with `index` and `columns` as `self`
+        if n_samples is `int`:
+        returns a `pd.DataFrame` that contains `n_samples` i.i.d. samples from `self`,
+        in `pd-multiindex` mtype format convention, with same `columns` as `self`,
+        and `MultiIndex` that is product of `RangeIndex(n_samples)` and `self.index`
+        """
+        if n_samples is None:
+            N = 1
+        else:
+            N = n_samples
+
+        n_dist = len(self._distributions)
+        selector = np.random.choice(n_dist, size=N, p=self._weights)
+
+        samples = [self._distributions[i][1].sample() for i in selector]
+
+        if n_samples is None:
+            return samples[0]
+        else:
+            return pd.concat(samples, axis=0, keys=range(N))
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        from sktime.proba.normal import Normal
+
+        index = pd.RangeIndex(3)
+        columns = pd.Index(["a", "b"])
+        normal1 = Normal(mu=0, sigma=1, index=index, columns=columns)
+        normal2 = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1, columns=columns)
+
+        dists = [("normal1", normal1), ("normal2", normal2)]
+
+        params1 = {"distributions": dists}
+        params2 = {"distributions": dists, "weights": [0.3, 0.7]}
+        return [params1, params2]


### PR DESCRIPTION
#### Reference Issues/PRs

Related to issue #4518


#### What does this implement/fix? Explain your changes.
Moves mixture distribution from `skpro` into `sktime`.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

Facing a issue while testing, I have tested the distribution in my own terminal.
![image](https://github.com/sktime/sktime/assets/91458535/481d7949-ec86-4eab-9999-a65b2958946f)
when i tried **pytest ./sktime**  , i got this issue.
Does installing TensorRT is a solution but i see it tries to install different version of tensorflow. Any recommendation here is much appreciated.
![image](https://github.com/sktime/sktime/assets/91458535/fda2c5c7-5b05-4fa9-a1fa-e176e50ac24e)

#### Did you add any tests for the change?

No

#### Any other comments?
No

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
