### PR TITLE
[DOC] ExponentialSmoothing default method change from L-BFGS-B to SLSQP

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2695,6 +2695,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "manuel-munoz-aguirre",
+      "name": "Manuel Muñoz Aguirre",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5576458?v=4",
+      "profile": "https://github.com/manuel-munoz-aguirre",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -70,7 +70,7 @@ class ExponentialSmoothing(_StatsModelsAdapter):
         starting values are determined using a combination of grid search
         and reasonable values based on the initial values of the data. See
         the notes for the structure of the model parameters.
-    method : str, default "L-BFGS-B"
+    method : str, default "SLSQP"
         The minimizer used. Valid options are "L-BFGS-B" , "TNC",
         "SLSQP" (default), "Powell", "trust-constr", "basinhopping" (also
         "bh") and "least_squares" (also "ls"). basinhopping tries multiple


### PR DESCRIPTION
#### Reference Issues/PRs
While exploring #6175, realized that the default parameter for `method` in Exponential Smoothing should be `SLSQP`. This also affects statsmodels documentation and there is already an [open PR](https://github.com/statsmodels/statsmodels/pull/9129) in their repo to fix this.

#### What does this implement/fix? Explain your changes.
Changes `method='L-BFGS-B'` to `method='SLSQP'`.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
See [statsmodels default](https://github.com/statsmodels/statsmodels/blob/192670b31c9069b247b0901d66013853e2ca47b7/statsmodels/tsa/holtwinters/model.py#L1142C1-L1142C55)

#### Did you add any tests for the change?
N/A

#### Any other comments?
N/A

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
