### PR TITLE
&duydl [MNT] Ensure Update Contributors does not run on main

### DIFF
--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -1,6 +1,8 @@
 name: Update Contributors
 
 on:
+  release:
+    types: [published]
   push:
     branches-ignore:
       - main

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -2,9 +2,11 @@ name: Update Contributors
 
 on:
   push:
+    branches-ignore:
+      - main
     paths:
       - '.all-contributorsrc'
-
+      
 jobs:
   generate-markdown-and-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - '.all-contributorsrc'
-      
+
 jobs:
   generate-markdown-and-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -1,8 +1,6 @@
 name: Update Contributors
 
 on:
-  release:
-    types: [published]
   push:
     branches-ignore:
       - main

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,10 +3,6 @@ name: Build wheels and publish to PyPI
 on:
   release:
     types: [published]
-  workflow_run:
-    workflows: [Update Contributors]
-    types: 
-      - completed
 
 jobs:
   build_wheels:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,6 +3,10 @@ name: Build wheels and publish to PyPI
 on:
   release:
     types: [published]
+  workflow_run:
+    workflows: [Update Contributors]
+    types: 
+      - completed
 
 jobs:
   build_wheels:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #6181.
<!--
Fixes #6181.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->


#### What does this implement/fix? Explain your changes.
This implement ensures that `Update Contributors` does not run on `main`. It also makes sure `build wheels` only triggers when `release` is triggered and and `Update Contributors` is completed.
<!--
A clear and concise description of what you have implemented.
-->

#### Did you add any tests for the change?
Not yet, but I am considering to add based on feedback and possible merge

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
I think the workflow is too tightly woven together, and can be broken down further to ensure seamlessness.