### PR TITLE
[DOC] fix missing exports in time series regression API ref

### DIFF
--- a/docs/source/api_reference/regression.rst
+++ b/docs/source/api_reference/regression.rst
@@ -30,10 +30,10 @@ Deep learning
     :template: class.rst
 
     CNNRegressor
-    CNTCRRegressor
+    CNTCRegressor
     FCNRegressor
     InceptionTimeRegressor
-    LSTMRegressor
+    LSTMFCNRegressor
     MACNNRegressor
     MCDCNNRegressor
     MLPRegressor


### PR DESCRIPTION
This PR fixes some missing exports in the time series regression API reference, of deep learning regressors.