### PR TITLE
Add new test parameter sets for ``TimeSeriesKMeansTslearn``

### DIFF
--- a/sktime/clustering/k_means/_k_means_tslearn.py
+++ b/sktime/clustering/k_means/_k_means_tslearn.py
@@ -177,22 +177,17 @@ class TimeSeriesKMeansTslearn(_TslearnAdapter, BaseClusterer):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
-        # commented since k-means++ does not properly work
-        # errors out with
-        # TypeError:
-        # _kmeans_plusplus() missing 1 required positional argument: 'sample_weight'
-        #
-        # params1 = {
-        #     "n_clusters": 3,
-        #     "max_iter": 3,
-        #     "tol": 0.001,
-        #     "n_init": 2,
-        #     "metric": "euclidean",
-        #     "max_iter_barycenter": 7,
-        #     "verbose": 0,
-        #     "random_state": 42,
-        #     "init": "k-means++",
-        # }
+        params1 = {
+            "n_clusters": 3,
+            "max_iter": 3,
+            "tol": 0.001,
+            "n_init": 2,
+            "metric": "euclidean",
+            "max_iter_barycenter": 7,
+            "verbose": 0,
+            "random_state": 42,
+            "init": "k-means++",
+        }
         params2 = {
             "n_clusters": 2,
             "max_iter": 5,
@@ -204,20 +199,7 @@ class TimeSeriesKMeansTslearn(_TslearnAdapter, BaseClusterer):
             "random_state": None,
             "init": "random",
         }
-        params3 = {
-            "n_clusters": 5,
-            "max_iter": 100,
-            "tol": 1e-5,
-            "n_init": 5,
-            "metric": "euclidean",
-            "max_iter_barycenter": 20,
-            "verbose": 1,
-            "random_state": 42,
-            "init": "random",
-        }
-        return [params2, params3]
-        # return [params1, params2]
-        # return [params2]
+        return [params1, params2]
 
     def _score(self, X, y=None) -> float:
         return np.abs(self.inertia_)

--- a/sktime/clustering/k_means/_k_means_tslearn.py
+++ b/sktime/clustering/k_means/_k_means_tslearn.py
@@ -205,15 +205,15 @@ class TimeSeriesKMeansTslearn(_TslearnAdapter, BaseClusterer):
             "init": "random",
         }
         params3 = {
-        "n_clusters": 5,
-        "max_iter": 100,
-        "tol": 1e-5,
-        "n_init": 5,
-        "metric": "euclidean",
-        "max_iter_barycenter": 20,
-        "verbose": 1,
-        "random_state": 42,
-        "init": "random",
+            "n_clusters": 5,
+            "max_iter": 100,
+            "tol": 1e-5,
+            "n_init": 5,
+            "metric": "euclidean",
+            "max_iter_barycenter": 20,
+            "verbose": 1,
+            "random_state": 42,
+            "init": "random",
         }
         return [params2, params3]
         # return [params1, params2]

--- a/sktime/clustering/k_means/_k_means_tslearn.py
+++ b/sktime/clustering/k_means/_k_means_tslearn.py
@@ -204,8 +204,20 @@ class TimeSeriesKMeansTslearn(_TslearnAdapter, BaseClusterer):
             "random_state": None,
             "init": "random",
         }
+        params3 = {
+        "n_clusters": 5,
+        "max_iter": 100,
+        "tol": 1e-5,
+        "n_init": 5,
+        "metric": "euclidean",
+        "max_iter_barycenter": 20,
+        "verbose": 1,
+        "random_state": 42,
+        "init": "random",
+        }
+        return [params2, params3]
         # return [params1, params2]
-        return [params2]
+        # return [params2]
 
     def _score(self, X, y=None) -> float:
         return np.abs(self.inertia_)


### PR DESCRIPTION
- Introduce two test parameter sets for ``TimeSeriesKMeansTslearn`` in the ``get_test_params`` function.

- Reference Issues
  Towards : #3429 

- Tests passed: pytest sktime\clustering\tests\test_k_means.py

