### PR TITLE
[MNT] 0.28.0 deprecations and change actions

### DIFF
--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -445,7 +445,7 @@ Binning, sampling and segmentation
     :toctree: auto_generated/
     :template: class.rst
 
-    PAA2
+    PAA
 
 .. currentmodule:: sktime.transformations.series.sax
 
@@ -453,7 +453,7 @@ Binning, sampling and segmentation
     :toctree: auto_generated/
     :template: class.rst
 
-    SAX2
+    SAX
 
 .. currentmodule:: sktime.transformations.panel.dictionary_based
 
@@ -461,8 +461,8 @@ Binning, sampling and segmentation
     :toctree: auto_generated/
     :template: class.rst
 
-    PAA
-    SAX
+    PAAlegacy
+    SAXlegacy
 
 Missing value treatment
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -20,7 +20,7 @@ from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.utils.validation.panel import check_X
 
 
-# TODO: fix this in 0.28.0
+# TODO: fix this in 0.29.0
 # base class should have been changed to BaseEarlyClassifier
 class ProbabilityThresholdEarlyClassifier(BaseClassifier):
     """Probability Threshold Early Classifier.

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -816,7 +816,7 @@ def _to_relative(fh: ForecastingHorizon, cutoff=None) -> ForecastingHorizon:
             absolute = _coerce_to_period(absolute, freq=fh.freq)
             cutoff = _coerce_to_period(cutoff, freq=fh.freq)
 
-        # TODO: 0.28.0:
+        # TODO: 0.29.0:
         # Check at every minor release whether lower pandas bound >=0.15.0
         # if yes, can remove the workaround in the "else" condition and the check
         #

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -160,7 +160,7 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                         if len(levels) == 1:
                             levels = levels[0]
                         yt[ix] = y.xs(ix, level=levels, axis=1)
-                        # todo 0.28.0 - check why this cannot be easily removed
+                        # todo 0.29.0 - check why this cannot be easily removed
                         # in theory, we should get rid of the "Coverage" case treatment
                         # (the legacy naming convention was removed in 0.23.0)
                         # deal with the "Coverage" case, we need to get rid of this

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -18,7 +18,7 @@ from sktime.forecasting.model_selection._tune import (
 )
 
 
-# todo 0.28.0 - check whether we should remove, otherwise bump
+# todo 0.29.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def temporal_train_test_split(
     y, X=None, test_size=None, train_size=None, fh=None, anchor="start"
@@ -45,7 +45,7 @@ def temporal_train_test_split(
     )
 
 
-# todo 0.28.0 - check whether we should remove, otherwise bump
+# todo 0.29.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
     """Legacy export of Expanding window splitter.
@@ -68,7 +68,7 @@ def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
     return _EWSplitter(fh=fh, initial_window=initial_window, step_length=step_length)
 
 
-# todo 0.28.0 - check whether we should remove, otherwise bump
+# todo 0.29.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def SlidingWindowSplitter(
     fh=1, window_length=10, step_length=1, initial_window=None, start_with_window=True

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -84,7 +84,7 @@ class BaseGridSearch(_DelegatedForecaster):
         if tune_by_variable:
             self.set_tags(**{"scitype:y": "univariate"})
 
-        # todo 0.28.0: check if this is still necessary
+        # todo 0.29.0: check if this is still necessary
         # n_jobs is deprecated, left due to use in tutorials, books, blog posts
         if n_jobs != "deprecated":
             warn(

--- a/sktime/forecasting/trend/_pwl_trend_forecaster.py
+++ b/sktime/forecasting/trend/_pwl_trend_forecaster.py
@@ -130,7 +130,7 @@ class ProphetPiecewiseLinearTrendForecaster(_ProphetAdapter):
         self.verbose = verbose
 
         super().__init__()
- 
+
         # import inside method to avoid hard dependency
         from prophet.forecaster import Prophet as _Prophet
 

--- a/sktime/forecasting/trend/_pwl_trend_forecaster.py
+++ b/sktime/forecasting/trend/_pwl_trend_forecaster.py
@@ -8,7 +8,6 @@ import pandas as pd
 
 from sktime.forecasting.base._base import DEFAULT_ALPHA
 from sktime.forecasting.base.adapters import _ProphetAdapter
-from sktime.utils.warnings import warn
 
 
 class ProphetPiecewiseLinearTrendForecaster(_ProphetAdapter):

--- a/sktime/forecasting/trend/_pwl_trend_forecaster.py
+++ b/sktime/forecasting/trend/_pwl_trend_forecaster.py
@@ -52,15 +52,15 @@ class ProphetPiecewiseLinearTrendForecaster(_ProphetAdapter):
         automatic changepoint selection. Large values will allow many
         changepoints, small values will allow few changepoints.
         Recommended to take values within [0.001,0.5].
-    yearly_seasonality: str or bool or int, default="auto"
+    yearly_seasonality: str or bool or int, default=False
         Include yearly seasonality in the model. "auto" for automatic determination,
         True to enable, False to disable, or an integer specifying the number of terms
         to include in the Fourier series.
-    weekly_seasonality: str or bool or int, default="auto"
+    weekly_seasonality: str or bool or int, default=False
         Include weekly seasonality in the model. "auto" for automatic determination,
         True to enable, False to disable, or an integer specifying the number of terms
         to include in the Fourier series.
-    daily_seasonality: str or bool or int, default="auto"
+    daily_seasonality: str or bool or int, default=False
         Include weekly seasonality in the model. "auto" for automatic determination,
         True to enable, False to disable, or an integer specifying the number of terms
         to include in the Fourier series.
@@ -95,10 +95,6 @@ class ProphetPiecewiseLinearTrendForecaster(_ProphetAdapter):
         "python_dependencies": "prophet",
     }
 
-    # TODO (release 0.28.0) - change defaults to False
-    # set yearly_seasonality = False in __init__
-    # set weekly_seasonality = False in __init__
-    # set daily_seasonality = False in __init__
     def __init__(
         self,
         changepoints=None,
@@ -106,9 +102,9 @@ class ProphetPiecewiseLinearTrendForecaster(_ProphetAdapter):
         changepoint_range=0.8,
         changepoint_prior_scale=0.05,
         verbose=0,
-        yearly_seasonality="changing_value",
-        weekly_seasonality="changing_value",
-        daily_seasonality="changing_value",
+        yearly_seasonality=False,
+        weekly_seasonality=False,
+        daily_seasonality=False,
     ):
         self.freq = None
         self.add_seasonality = None
@@ -134,44 +130,7 @@ class ProphetPiecewiseLinearTrendForecaster(_ProphetAdapter):
         self.verbose = verbose
 
         super().__init__()
-        # TODO (release 0.28.0)
-        # remove the following 4 'if' checks
-        # set yearly_seasonality=self.yearly_seasonality in def _instantiate_model
-        # set weekly_seasonality=self.weekly_seasonality in def _instantiate_model
-        # set daily_seasonality=self.daily_seasonality in def _instantiate_model
-        if any(
-            setting == "changing_value"
-            for setting in [
-                yearly_seasonality,
-                weekly_seasonality,
-                daily_seasonality,
-            ]
-        ):
-            warn(
-                "Warning: In sktime 0.28.0, the default value for all seasonality "
-                "parameters in ProphetPiecewiseLinearTrendForecaster will change from "
-                "'auto' to 'False'. To retain the prior behavior, set all seasonality "
-                "parameters to 'auto' explicitly.",
-                category=DeprecationWarning,
-                stacklevel=3,
-            )
-
-        if yearly_seasonality == "changing_value":
-            self._yearly_seasonality = "auto"
-        else:
-            self._yearly_seasonality = yearly_seasonality
-
-        if weekly_seasonality == "changing_value":
-            self._weekly_seasonality = "auto"
-        else:
-            self._weekly_seasonality = weekly_seasonality
-
-        if daily_seasonality == "changing_value":
-            self._daily_seasonality = "auto"
-        else:
-            self._daily_seasonality = daily_seasonality
-        # end of TODO (release 0.28.0)
-
+ 
         # import inside method to avoid hard dependency
         from prophet.forecaster import Prophet as _Prophet
 
@@ -183,9 +142,9 @@ class ProphetPiecewiseLinearTrendForecaster(_ProphetAdapter):
             changepoints=self.changepoints,
             n_changepoints=self.n_changepoints,
             changepoint_range=self.changepoint_range,
-            yearly_seasonality=self._yearly_seasonality,  # TODO (release 0.28.0)
-            weekly_seasonality=self._weekly_seasonality,  # TODO (release 0.28.0)
-            daily_seasonality=self._daily_seasonality,  # TODO (release 0.28.0)
+            yearly_seasonality=self.yearly_seasonality,
+            weekly_seasonality=self.weekly_seasonality,
+            daily_seasonality=self.daily_seasonality,
             holidays=self.holidays,
             seasonality_mode=self.seasonality_mode,
             seasonality_prior_scale=float(self.seasonality_prior_scale),

--- a/sktime/forecasting/trend/tests/test_pwl_trend.py
+++ b/sktime/forecasting/trend/tests/test_pwl_trend.py
@@ -97,8 +97,15 @@ def test_pred_with_explicit_changepoints():
     y_train, y_test = temporal_train_test_split(y)
 
     fh = ForecastingHorizon(y_test.index, is_relative=False)
-    a = ProphetPiecewiseLinearTrendForecaster(changepoints=["1953-05-31"])
-    b = ProphetPiecewiseLinearTrendForecaster()
+    seasonality_params = {
+        "yearly_seasonality": True,
+        "weekly_seasonality": True,
+        "daily_seasonality": True,
+    }
+    a = ProphetPiecewiseLinearTrendForecaster(
+        changepoints=["1953-05-31"], **seasonality_params
+    )
+    b = ProphetPiecewiseLinearTrendForecaster(**seasonality_params)
 
     slope_a = a.fit(y_train).predict(fh).diff().mean()
     slope_b = b.fit(y_train).predict(fh).diff().mean()

--- a/sktime/transformations/panel/catch22wrapper.py
+++ b/sktime/transformations/panel/catch22wrapper.py
@@ -89,21 +89,18 @@ class Catch22Wrapper(BaseTransformer):
         "fit_is_empty": True,
     }
 
-    # todo 0.28.0: remove n_jobs parameter
     def __init__(
         self,
         features="all",
         catch24=False,
         outlier_norm=False,
         replace_nans=False,
-        n_jobs="deprecated",
         col_names="range",
     ):
         self.features = features
         self.catch24 = catch24
         self.outlier_norm = outlier_norm
         self.replace_nans = replace_nans
-        self.n_jobs = n_jobs
         self.col_names = col_names
 
         self.features_arguments = (
@@ -129,19 +126,6 @@ class Catch22Wrapper(BaseTransformer):
         self._transform_features = None
 
         super().__init__()
-
-        # todo 0.28.0: remove this warning and logic
-        if n_jobs != "deprecated":
-            warn(
-                "In Catch22Wrapper, the parameter "
-                "n_jobs is deprecated and will be removed in v0.28.0. "
-                "Instead, use set_config with the backend and backend:params "
-                "config fields, and set backend to 'joblib' and pass n_jobs "
-                "as a parameter of backend_params. ",
-                FutureWarning,
-                obj=self,
-            )
-            self.set_config(backend="joblib", backend_params={"n_jobs": n_jobs})
 
     def _transform(self, X, y=None):
         """Transform data into the Catch22 features.

--- a/sktime/transformations/panel/catch22wrapper.py
+++ b/sktime/transformations/panel/catch22wrapper.py
@@ -11,7 +11,6 @@ import pandas as pd
 
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.panel import catch22
-from sktime.utils.warnings import warn
 
 
 class Catch22Wrapper(BaseTransformer):

--- a/sktime/transformations/panel/dictionary_based/__init__.py
+++ b/sktime/transformations/panel/dictionary_based/__init__.py
@@ -1,10 +1,8 @@
 """Transformers."""
 
-# TODO 0.28.0 - remove exports of PAA, SAX
-__all__ = ["PAA", "SFA", "SFAFast", "SAX", "PAAlegacy", "SAXlegacy"]
+__all__ = ["SFA", "SFAFast", "PAAlegacy", "SAXlegacy"]
 
-# TODO 0.28.0 - remove exports of PAA, SAX
-from sktime.transformations.panel.dictionary_based._paa import PAA, PAAlegacy
-from sktime.transformations.panel.dictionary_based._sax import SAX, SAXlegacy
+from sktime.transformations.panel.dictionary_based._paa import PAAlegacy
+from sktime.transformations.panel.dictionary_based._sax import SAXlegacy
 from sktime.transformations.panel.dictionary_based._sfa import SFA
 from sktime.transformations.panel.dictionary_based._sfa_fast import SFAFast

--- a/sktime/transformations/panel/dictionary_based/_paa.py
+++ b/sktime/transformations/panel/dictionary_based/_paa.py
@@ -44,24 +44,6 @@ class PAAlegacy(BaseTransformer):
         self.num_intervals = num_intervals
         super().__init__()
 
-        # todo 0.28.0: remove this warning
-        warn(
-            "panel.dictionary_based.PAA has been renamed to PAAlegacy in sktime 0.27.0,"
-            " while sktime.transformations.series.PAA2 was renamed to PAA. "
-            "PAA2 will become the primary PAA implementation in sktime, "
-            "while the former PAA will continue to be available as PAAlegacy. "
-            "Both estimators are also available under their future name at their "
-            "current location, and will be available under their deprecated name "
-            "until 0.28.0. "
-            "To prepare for the name change, do one of the following: "
-            "1. replace use of PAA2 from sktime.transformations.panel.dictionary_based "
-            "by use of PAA from sktime.transformations.series.paa, or "
-            "2. replace use of PAA from sktime.transformations.panel.dictionary_based "
-            "by use of PAAlegacy from sktime.transformations.panel.dictionary_based. ",
-            DeprecationWarning,
-            obj=self,
-        )
-
     def set_num_intervals(self, n):
         """Set self.num_intervals to n."""
         self.num_intervals = n
@@ -171,7 +153,3 @@ class PAAlegacy(BaseTransformer):
                 + type(self.num_intervals).__name__
                 + "' instead."
             )
-
-
-# TODO 0.28.0: remove this alias altogether
-PAA = PAAlegacy

--- a/sktime/transformations/panel/dictionary_based/_paa.py
+++ b/sktime/transformations/panel/dictionary_based/_paa.py
@@ -3,7 +3,6 @@ import pandas as pd
 
 from sktime.datatypes._panel._convert import from_nested_to_2d_array
 from sktime.transformations.base import BaseTransformer
-from sktime.utils.warnings import warn
 
 __author__ = ["MatthewMiddlehurst"]
 

--- a/sktime/transformations/panel/dictionary_based/_sax.py
+++ b/sktime/transformations/panel/dictionary_based/_sax.py
@@ -8,7 +8,6 @@ import scipy.stats
 
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.panel.dictionary_based import PAAlegacy as PAA
-from sktime.utils.warnings import warn
 
 __author__ = ["MatthewMiddlehurst"]
 

--- a/sktime/transformations/panel/dictionary_based/_sax.py
+++ b/sktime/transformations/panel/dictionary_based/_sax.py
@@ -86,24 +86,6 @@ class SAXlegacy(BaseTransformer):
 
         super().__init__()
 
-        # todo 0.28.0: remove this warning
-        warn(
-            "panel.dictionary_based.SAX has been renamed to SAXlegacy in sktime 0.27.0,"
-            " while sktime.transformations.series.SAX2 was renamed to SAX. "
-            "SAX2 will become the primary SAX implementation in sktime, "
-            "while the former SAX will continue to be available as SAXlegacy. "
-            "Both estimators are also available under their future name at their "
-            "current location, and will be available under their deprecated name "
-            "until 0.28.0. "
-            "To prepare for the name change, do one of the following: "
-            "1. replace use of SAX2 from sktime.transformations.panel.dictionary_based "
-            "by use of SAX from sktime.transformations.series.sax, or "
-            "2. replace use of SAX from sktime.transformations.panel.dictionary_based "
-            "by use of SAXlegacy from sktime.transformations.panel.dictionary_based. ",
-            DeprecationWarning,
-            obj=self,
-        )
-
         self.set_config(**{"output_conversion": "off"})
 
     # todo: looks like this just loops over series instances
@@ -235,7 +217,3 @@ class SAXlegacy(BaseTransformer):
         # small word length, window size for testing
         params = {"word_length": 2, "window_size": 4}
         return params
-
-
-# TODO 0.28.0: remove this alias altogether
-SAX = SAXlegacy

--- a/sktime/transformations/series/paa.py
+++ b/sktime/transformations/series/paa.py
@@ -5,7 +5,6 @@ __author__ = ["steenrotsman"]
 import numpy as np
 
 from sktime.transformations.base import BaseTransformer
-from sktime.utils.warnings import warn
 
 
 class PAA(BaseTransformer):

--- a/sktime/transformations/series/paa.py
+++ b/sktime/transformations/series/paa.py
@@ -70,20 +70,6 @@ class PAA(BaseTransformer):
 
         super().__init__()
 
-        # TODO 0.28.0: remove the deprecation warning
-        warn(
-            "Since sktime 0.27.0, PAA2 is the primary PAA implementation in "
-            "sktime, and has been renamed to PAA. "
-            "PAA2 is available under both its current and future name at its "
-            "current location, imports under the deprecated name PAA2 will be possible"
-            "until 0.28.0. "
-            "To prepare for the name change, replace imports of PAA2 from "
-            "sktime.transformations.series.paa by imports of PAA from the same "
-            "module.",
-            DeprecationWarning,
-            obj=self,
-        )
-
         self._check_params()
 
     def _transform(self, X, y=None):
@@ -167,7 +153,3 @@ class PAA(BaseTransformer):
 
         if self.frames < 1 and not self.frame_size:
             raise ValueError("frames must be at least 1.")
-
-
-# TODO 0.28.0: remove the alias line altogether
-PAA2 = PAA

--- a/sktime/transformations/series/paa.py
+++ b/sktime/transformations/series/paa.py
@@ -37,13 +37,13 @@ class PAA(BaseTransformer):
     Examples
     --------
     >>> from numpy import arange
-    >>> from sktime.transformations.series.paa import PAA2
+    >>> from sktime.transformations.series.paa import PAA
 
     >>> X = arange(10)
-    >>> paa = PAA2(frames=3)
+    >>> paa = PAA(frames=3)
     >>> paa.fit_transform(X)  # doctest: +SKIP
     array([1.2, 4.5, 7.8])
-    >>> paa = PAA2(frame_size=3)  # doctest: +SKIP
+    >>> paa = PAA(frame_size=3)  # doctest: +SKIP
     array([1, 4, 7, 9])
     """
 

--- a/sktime/transformations/series/sax.py
+++ b/sktime/transformations/series/sax.py
@@ -5,7 +5,6 @@ from scipy.stats import norm, zscore
 
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.series.paa import PAA
-from sktime.utils.warnings import warn
 
 
 class SAX(BaseTransformer):

--- a/sktime/transformations/series/sax.py
+++ b/sktime/transformations/series/sax.py
@@ -80,19 +80,6 @@ class SAX(BaseTransformer):
 
         super().__init__()
 
-        warn(
-            "Since sktime 0.27.0, SAX2 is the primary SAX implementation in "
-            "sktime, and has been renamed to SAX. "
-            "SAX2 is available under both its current and future name at its "
-            "current location, imports under the deprecated name SAX2 will be possible"
-            "until 0.28.0. "
-            "To prepare for the name change, replace imports of SAX2 from "
-            "sktime.transformations.series.sax by imports of SAX from the same "
-            "module.",
-            DeprecationWarning,
-            obj=self,
-        )
-
         self._check_params()
 
     def _transform(self, X, y=None):
@@ -156,7 +143,3 @@ class SAX(BaseTransformer):
             raise ValueError("alphabet_size must be at least 2.")
         if self.frame_size < 0:
             raise ValueError("frame_size must be at least 0.")
-
-
-# TODO 0.28.0: remove the alias line altogether
-SAX2 = SAX

--- a/sktime/transformations/series/sax.py
+++ b/sktime/transformations/series/sax.py
@@ -46,13 +46,13 @@ class SAX(BaseTransformer):
     Examples
     --------
     >>> from numpy import arange
-    >>> from sktime.transformations.series.sax import SAX2
+    >>> from sktime.transformations.series.sax import SAX
 
     >>> X = arange(10)
-    >>> sax = SAX2(word_size=3, alphabet_size=5)
+    >>> sax = SAX(word_size=3, alphabet_size=5)
     >>> sax.fit_transform(X)  # doctest: +SKIP
     array([0, 2, 4])
-    >>> sax = SAX2(frame_size=2, alphabet_size=5)  # doctest: +SKIP
+    >>> sax = SAX(frame_size=2, alphabet_size=5)  # doctest: +SKIP
     array([0, 1, 2, 3, 4])
     """
 

--- a/sktime/transformations/series/tests/test_paa.py
+++ b/sktime/transformations/series/tests/test_paa.py
@@ -2,7 +2,7 @@
 import numpy as np
 import pytest
 
-from sktime.transformations.series.paa import PAA2
+from sktime.transformations.series.paa import PAA
 
 
 # Check that exception is raised for bad frames values.
@@ -16,10 +16,10 @@ def test_bad_input_args(bad_frames):
     if not isinstance(bad_frames, int):
         for attribute in ["frames", "frame_size"]:
             with pytest.raises(TypeError):
-                PAA2(**{attribute: bad_frames}).fit(X).transform(X)
+                PAA(**{attribute: bad_frames}).fit(X).transform(X)
     else:
         with pytest.raises(ValueError):
-            PAA2(bad_frames).fit(X).transform(X)
+            PAA(bad_frames).fit(X).transform(X)
 
 
 @pytest.mark.parametrize(
@@ -38,7 +38,7 @@ def test_bad_input_args(bad_frames):
 def test_output_of_transformer(frames, frame_size, expected):
     """Test that the transformer has changed the data correctly."""
     X = np.arange(10).T
-    paa = PAA2(frames, frame_size)
+    paa = PAA(frames, frame_size)
     res = paa.fit_transform(X)
     want = np.array(expected, dtype=np.float64).T
     np.testing.assert_array_equal(res, want)

--- a/sktime/transformations/series/tests/test_sax.py
+++ b/sktime/transformations/series/tests/test_sax.py
@@ -2,7 +2,7 @@
 import numpy as np
 import pytest
 
-from sktime.transformations.series.sax import SAX2
+from sktime.transformations.series.sax import SAX
 
 
 # Check that exception is raised for bad size values.
@@ -13,7 +13,7 @@ def test_bad_input_types(bad_size):
     """Test that exception is raised for bad sizes."""
     for attribute in ["word_size", "alphabet_size", "frame_size"]:
         with pytest.raises(TypeError):
-            SAX2(**{attribute: bad_size})
+            SAX(**{attribute: bad_size})
 
 
 @pytest.mark.parametrize(
@@ -27,7 +27,7 @@ def test_bad_input_types(bad_size):
 def test_bad_input_values(attribute, bad_size):
     """Test that word_size is at least 1 (if frame_size is not set)."""
     with pytest.raises(ValueError):
-        SAX2(**{attribute: bad_size})
+        SAX(**{attribute: bad_size})
 
 
 @pytest.mark.parametrize(
@@ -42,7 +42,7 @@ def test_bad_input_values(attribute, bad_size):
 def test_output_of_transformer(word_size, alphabet_size, frame_size, expected):
     """Test that the transformer has changed the data correctly."""
     X = np.arange(10).T
-    sax = SAX2(word_size, alphabet_size, frame_size)
+    sax = SAX(word_size, alphabet_size, frame_size)
     res = sax.fit_transform(X)
     want = np.array(expected, dtype=np.float64).T
     np.testing.assert_array_equal(res, want)

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 
 
-# todo 0.28.0: check whether scikit-base>=0.6.1 lower bound is 0.6.1 or higher
+# todo 0.29.0: check whether scikit-base>=0.6.1 lower bound is 0.6.1 or higher
 # if yes, remove this legacy function and use the new one from sktime.utils.deep_equals
 def deep_equals(x, y, return_msg=False):
     """Test two objects for equality in value.

--- a/sktime/utils/deep_equals/__init__.py
+++ b/sktime/utils/deep_equals/__init__.py
@@ -2,7 +2,7 @@
 """Module for nested equality checking."""
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-# todo 0.28.0: check whether scikit-base>=0.6.1 lower bound is 0.6.1 or higher
+# todo 0.29.0: check whether scikit-base>=0.6.1 lower bound is 0.6.1 or higher
 # if yes, remove legacy handling and only use the new deep_equals
 if _check_soft_dependencies(
     "scikit-base<0.6.1",


### PR DESCRIPTION
Carries out deprecations and change actions scheduled for 0.28.0:

* removed `n_jobs` parameter in `Catch22Wrapper`
* in `ProphetPiecewiseLinearTrendForecaster`, switch seasonality defaults to False
* finalize rename cycle for `PAA`, `SAX`
* bump deprecation/change checks scheduled for 0.28.0 to 0.29.0