### PR TITLE
[DOC] Added an example to WhiteNoiseAugmenter #4264 

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2699,6 +2699,15 @@
       ]
     },
     {
+      "login": "SamruddhiNavale",
+      "name": "Samruddhi Navale",
+      "avatar_url": "https://avatars.githubusercontent.com/u/86359115?v=4",
+      "profile": "https://github.com/SamruddhiNavale",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
       "login": "vandit98",
       "name": "Vandit Tyagi",
       "avatar_url": "https://avatars.githubusercontent.com/u/91458535?v=4",

--- a/sktime/transformations/series/augmenter.py
+++ b/sktime/transformations/series/augmenter.py
@@ -65,9 +65,8 @@ class WhiteNoiseAugmenter(_AugmenterTags, BaseTransformer):
     >>> X = np.array([1, 2, 3, 4, 5])
     >>> augmenter = WhiteNoiseAugmenter(scale=0.5, random_state=42)
     >>> augmenter.fit(X)
+    WhiteNoiseAugmenter(...)
     >>> X_augmented = augmenter.transform(X)
-    >>> print("Original time series:", X)
-    >>> print("Augmented time series:", X_augmented)
 
     References and Footnotes
     ----------

--- a/sktime/transformations/series/augmenter.py
+++ b/sktime/transformations/series/augmenter.py
@@ -58,6 +58,17 @@ class WhiteNoiseAugmenter(_AugmenterTags, BaseTransformer):
             If None, rely on ``self.random_state``.
             Default is None." [3]
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.transformations.series.augmenter import WhiteNoiseAugmenter
+    >>> X = np.array([1, 2, 3, 4, 5])
+    >>> augmenter = WhiteNoiseAugmenter(scale=0.5, random_state=42)
+    >>> augmenter.fit(X)
+    >>> X_augmented = augmenter.transform(X)
+    >>> print("Original time series:", X)
+    >>> print("Augmented time series:", X_augmented)
+
     References and Footnotes
     ----------
 


### PR DESCRIPTION
#### Reference Issues/PRs
Adds to https://github.com/sktime/sktime/issues/4264

#### What does this implement/fix? Explain your changes.
Added examples to docstrings in `WhiteNoiseAugmenter`

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
No

#### Did you add any tests for the change?
 No


#### Any other comments?
No

#### PR checklist

##### For all contributions
* [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
* [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


