### PR TITLE
Feature/amazon chronos interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dependencies = [
 all_extras = [
   "arch>=5.6,<6.4.0",
   "cloudpickle",
+  "chronos @ git+https://github.com/amazon-science/chronos-forecasting.git",
   "dash!=2.9.0",
   "dask<2024.2.2",
   "dtw-python",
@@ -185,6 +186,7 @@ clustering = [
 ]
 forecasting = [
   "arch>=5.6,<6.4",
+  "chronos @ git+https://github.com/amazon-science/chronos-forecasting.git",
   'pmdarima!=1.8.1,<2.1,>=1.8; python_version < "3.12"',
   "prophet<1.2,>=1.1",
   "skpro<2.3.0,>=2",

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -1,0 +1,327 @@
+import torch
+import numpy as np
+import pandas as pd
+
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Extension template for forecasters, SIMPLE version.
+
+Contains only bare minimum of implementation requirements for a functional forecaster.
+Also assumes *no composition*, i.e., no forecaster or other estimator components.
+For advanced cases (probabilistic, composition, etc),
+    see full extension template in forecasting.py
+
+Purpose of this implementation template:
+    quick implementation of new estimators following the template
+    NOT a concrete class to import! This is NOT a base class or concrete class!
+    This is to be used as a "fill-in" coding template.
+
+How to use this implementation template to implement a new estimator:
+- make a copy of the template in a suitable location, give it a descriptive name.
+- work through all the "todo" comments below
+- fill in code for mandatory methods, and optionally for optional methods
+- do not write to reserved variables: is_fitted, _is_fitted, _X, _y, cutoff, _fh,
+    _cutoff, _converter_store_y, forecasters_, _tags, _tags_dynamic, _is_vectorized
+- you can add more private methods, but do not override BaseEstimator's private methods
+    an easy way to be safe is to prefix your methods with "_custom"
+- change docstrings for functions and the file
+- ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
+- once complete: use as a local library, or contribute to sktime via PR
+- more details:
+  https://www.sktime.net/en/stable/developer_guide/add_estimators.html
+
+Mandatory implements:
+    fitting         - _fit(self, y, X=None, fh=None)
+    forecasting     - _predict(self, fh=None, X=None)
+
+Testing - required for sktime test framework and check_estimator usage:
+    get default parameters for test instance(s) - get_test_params()
+"""
+# todo: write an informative docstring for the file or module, remove the above
+# todo: add an appropriate copyright notice for your estimator
+#       estimators contributed to sktime should have the copyright notice at the top
+#       estimators of your own do not need to have permissive or BSD-3 copyright
+
+# todo: uncomment the following line, enter authors' GitHub IDs
+# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+
+
+from sktime.forecasting.base import BaseForecaster
+
+
+# todo: add any necessary imports here
+
+
+class Chronos(BaseForecaster):
+    """Custom forecaster. todo: write docstring.
+
+    todo: describe your custom forecaster here
+
+    Parameters
+    ----------
+    parama : int
+        descriptive explanation of parama
+    paramb : string, optional (default='default')
+        descriptive explanation of paramb
+    paramc : boolean, optional (default= whether paramb is not the default)
+        descriptive explanation of paramc
+    and so on
+    """
+
+    # todo: fill out estimator tags here
+    #  tags are inherited from parent class if they are not set
+    # todo: define the forecaster scitype by setting the tags
+    #  the "forecaster scitype" is determined by the tags
+    #   scitype:y - the expected input scitype of y - univariate or multivariate or both
+    # tag values are "safe defaults" which can usually be left as-is
+    _tags = {
+        # to list all valid tags with description, use sktime.registry.all_tags
+        #   all_tags(estimator_types="forecaster", as_dataframe=True)
+        #
+        # behavioural tags: internal type
+        # -------------------------------
+        #
+        # y_inner_mtype, X_inner_mtype control which format X/y appears in
+        # in the inner functions _fit, _predict, etc
+        "y_inner_mtype": "pd.Series",
+        "X_inner_mtype": "pd.DataFrame",
+        # valid values: str and list of str
+        # if str, must be a valid mtype str, in sktime.datatypes.MTYPE_REGISTER
+        #   of scitype Series, Panel (panel data) or Hierarchical (hierarchical series)
+        #   in that case, all inputs are converted to that one type
+        # if list of str, must be a list of valid str specifiers
+        #   in that case, X/y are passed through without conversion if on the list
+        #   if not on the list, converted to the first entry of the same scitype
+        #
+        # scitype:y controls whether internal y can be univariate/multivariate
+        # if multivariate is not valid, applies vectorization over variables
+        "scitype:y": "univariate",
+        # valid values: "univariate", "multivariate", "both"
+        #   "univariate": inner _fit, _predict, etc, receive only univariate series
+        #   "multivariate": inner methods receive only series with 2 or more variables
+        #   "both": inner methods can see series with any number of variables
+        #
+        # capability tags: properties of the estimator
+        # --------------------------------------------
+        #
+        # ignores-exogeneous-X = does estimator ignore the exogeneous X?
+        "ignores-exogeneous-X": False,
+        # valid values: boolean True (ignores X), False (uses X in non-trivial manner)
+        # CAVEAT: if tag is set to True, inner methods always see X=None
+        #
+        # requires-fh-in-fit = is forecasting horizon always required in fit?
+        "requires-fh-in-fit": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, raises exception in fit if fh has not been passed
+        #
+        # ownership and contribution tags
+        # -------------------------------
+        #
+        # author = author(s) of th estimator
+        # an author is anyone with significant contribution to the code at some point
+        "authors": ["author1", "author2"],
+        # valid values: str or list of str, should be GitHub handles
+        # this should follow best scientific contribution practices
+        # scope is the code, not the methodology (method is per paper citation)
+        #
+        # maintainer = current maintainer(s) of the estimator
+        # per algorithm maintainer role, see governance document
+        # this is an "owner" type role, with rights and maintenance duties
+        "maintainers": ["maintainer1", "maintainer2"],
+        # valid values: str or list of str, should be GitHub handles
+        # remove tag if maintained by sktime core team
+    }
+
+    # todo: add any hyper-parameters and components to constructor
+    def __init__(self, args_list, kwargs_dict=None):
+        # todo: write any hyper-parameters to self
+        self.context = None
+        self.top_p = None
+        self.top_k = None
+        self.temperature = None
+        self.num_samples = None
+        self.args_list = args_list
+        self.kwargs_dict = kwargs_dict
+        from chronos import ChronosPipeline
+        if self.kwargs_dict is None:
+            self.model = ChronosPipeline.from_pretrained(*self.args_list)
+        else:
+            self.model = ChronosPipeline.from_pretrained(*self.args_list, **self.kwargs_dict)
+        # IMPORTANT: the self.params should never be overwritten or mutated from now on
+        # for handling defaults etc, write to other attributes, e.g., self._parama
+
+        # leave this as is
+        super().__init__()
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
+
+    # todo: implement this, mandatory
+    def _fit(self, y, X, fh, num_samples=20, temperature=1.0, top_k=50, top_p=1.0):
+        """Fit forecaster to training data.
+
+        private _fit containing the core logic, called from fit
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
+            Time series to which to fit the forecaster.
+            if self.get_tag("scitype:y")=="univariate":
+                guaranteed to have a single column/variable
+            if self.get_tag("scitype:y")=="multivariate":
+                guaranteed to have 2 or more columns
+            if self.get_tag("scitype:y")=="both": no restrictions apply
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            Required (non-optional) here if self.get_tag("requires-fh-in-fit")==True
+            Otherwise, if not passed in _fit, guaranteed to be passed in _predict
+        X : optional (default=None)
+            guaranteed to be of a type in self.get_tag("X_inner_mtype")
+            Exogeneous time series to fit to.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        # any model parameters should be written to attributes ending in "_"
+        #  attributes set by the constructor must not be overwritten
+        #
+        # todo:
+        # insert logic here
+        # self.fitted_model_param_ = sthsth
+        #
+        self.context = torch.tensor(y.values)
+        self.num_samples = num_samples
+        self.temperature = temperature
+        self.top_k = top_k
+        self.top_p = top_p
+        return self
+
+        # implement here
+        # IMPORTANT: avoid side effects to y, X, fh
+        #
+        # any model parameters should be written to attributes ending in "_"
+        #  attributes set by the constructor must not be overwritten
+        #
+        # Note: when interfacing a model that has fit, with parameters
+        #   that are not data (y, X) or forecasting-horizon-like,
+        #   but model parameters, *don't* add as arguments to fit, but treat as follows:
+        #   1. pass to constructor,  2. write to self in constructor,
+        #   3. read from self in _fit,  4. pass to interfaced_model.fit in _fit
+
+    # todo: implement this, mandatory
+    def _predict(self, fh=None, X=None):
+        """Forecast time series at future horizon.
+
+        private _predict containing the core logic, called from predict
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+            self.cutoff
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
+            The forecasting horizon with the steps ahead to to predict.
+            If not passed in _fit, guaranteed to be passed here
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
+
+        Returns
+        -------
+        y_pred : sktime time series object
+            should be of the same type as seen in _fit, as in "y_inner_mtype" tag
+            Point predictions
+        """
+        # todo
+        prediction_length = len(fh)
+        forecast = self.model.predict(
+            self.context,
+            prediction_length,
+            num_samples=self.num_samples,
+            temperature=self.temperature,
+            top_k=self.top_k,
+            top_p=self.top_p,
+        )
+        # return np.median(forecast[0].numpy(), axis=0)
+        # to get fitted model params set in fit, do this:
+        #
+        # fitted_model_param = self.fitted_model_param_
+
+        # todo: add logic to compute values
+        values = np.median(forecast[0].numpy(), axis=0)
+
+        # then return as pd.DataFrame
+        # below code guarantees the right row and column index
+        #
+        '''
+        row_idx = fh.to_absolute_index(self.cutoff)
+        col_idx = self._y.index
+        '''
+        #
+        y_pred = pd.DataFrame(values)
+        return y_pred
+
+        # IMPORTANT: avoid side effects to X, fh
+
+    # todo: implement this if this is an estimator contributed to sktime
+    #   or to run local automated unit and integration testing of estimator
+    #   method should return default parameters, so that a test instance can be created
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for forecasters.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+
+        # todo: set the testing parameters for the estimators
+        # Testing parameters can be dictionary or list of dictionaries.
+        # Testing parameter choice should cover internal cases well.
+        #   for "simple" extension, ignore the parameter_set argument.
+        #
+        # this method can, if required, use:
+        #   class properties (e.g., inherited); parent class test case
+        #   imported objects such as estimators from sktime or sklearn
+        # important: all such imports should be *inside get_test_params*, not at the top
+        #            since imports are used only at testing time
+        #
+        # A good parameter set should primarily satisfy two criteria,
+        #   1. Chosen set of parameters should have a low testing time,
+        #      ideally in the magnitude of few seconds for the entire test suite.
+        #       This is vital for the cases where default values result in
+        #       "big" models which not only increases test time but also
+        #       run into the risk of test workers crashing.
+        #   2. There should be a minimum two such parameter sets with different
+        #      sets of values to ensure a wide range of code coverage is provided.
+        #
+        # example 1: specify params as dictionary
+        # any number of params can be specified
+        # params = {"est": value0, "parama": value1, "paramb": value2}
+        #
+        # example 2: specify params as list of dictionary
+        # note: Only first dictionary will be used by create_test_instance
+        # params = [{"est": value1, "parama": value2},
+        #           {"est": value3, "parama": value4}]
+        #
+        # return params
+        params = {"args_list": ["amazon/chronos-t5-small"], "kwargs_dict": {"torch_dtype": torch.bfloat16}}
+        return params

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -2,17 +2,14 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements Chronos forecaster by wrapping amazon's chronos."""
 
-import numpy as np
-import pandas as pd
-
 __author__ = ["RigvedManoj"]
 __all__ = ["Chronos"]
 
 
+import numpy as np
+import pandas as pd
+
 from sktime.forecasting.base import BaseForecaster
-
-
-# todo: add any necessary imports here
 
 
 class Chronos(BaseForecaster):
@@ -23,7 +20,7 @@ class Chronos(BaseForecaster):
 
     Parameters
     ----------
-    modelName: str, required
+    model_name: str, required
     top_p: float, default=1.0
     top_k: int, default=50
     temperature: float, default=1.0
@@ -40,23 +37,23 @@ class Chronos(BaseForecaster):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.chronos import Chronos
     >>> from sktime.split import temporal_train_test_split
-    >>> from sktime.performance_metrics.forecasting import mean_absolute_percentage_error
     >>> from sktime.forecasting.base import ForecastingHorizon
     >>> import torch
     >>> y = load_airline()
     >>> y_train, y_test = temporal_train_test_split(y)
     >>> fh = ForecastingHorizon(y_test.index, is_relative=False)
-    >>> forecaster = Chronos("amazon/chronos-t5-small", kwargs_dict={"torch_dtype": torch.bfloat16})
-    >>> forecaster.fit(y_train)
-    >>> y_pred = forecaster.predict(fh)
-    >>> mean_absolute_percentage_error(y_test, y_pred)
+    >>> forecaster = Chronos(
+    ...        "amazon/chronos-t5-small",
+    ...        kwargs_dict={"torch_dtype": torch.bfloat16}
+        )  # doctest: +SKIP
+    >>> forecaster.fit(y_train)  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh) # doctest: +SKIP
     """
 
     # tag values are "safe defaults" which can usually be left as-is
     _tags = {
         "python_dependencies": ["torch"],
         "y_inner_mtype": "pd.Series",
-        "X_inner_mtype": "pd.DataFrame",
         "scitype:y": "univariate",
         "ignores-exogeneous-X": True,
         "requires-fh-in-fit": False,
@@ -64,8 +61,17 @@ class Chronos(BaseForecaster):
         "maintainers": ["RigvedManoj"],
     }
 
-    def __init__(self, modelName, num_samples=20, temperature=1.0, top_k=50, top_p=1.0, args_list=None, kwargs_dict=None):
-        self.modelName = modelName
+    def __init__(
+        self,
+        model_name,
+        num_samples=20,
+        temperature=1.0,
+        top_k=50,
+        top_p=1.0,
+        args_list=None,
+        kwargs_dict=None,
+    ):
+        self.model_name = model_name
         self.num_samples = num_samples
         self.temperature = temperature
         self.top_k = top_k
@@ -98,14 +104,17 @@ class Chronos(BaseForecaster):
         """
         import torch
         from chronos import ChronosPipeline
+
         if self.args_list is not None:
-            args_list = [self.modelName] + self.args_list
+            args_list = [self.model_name] + self.args_list
         else:
-            args_list = [self.modelName]
+            args_list = [self.model_name]
         if self.kwargs_dict is None:
             self._model = ChronosPipeline.from_pretrained(*args_list)
         else:
-            self._model = ChronosPipeline.from_pretrained(*args_list, **self.kwargs_dict)
+            self._model = ChronosPipeline.from_pretrained(
+                *args_list, **self.kwargs_dict
+            )
         self._context = torch.tensor(y.values)
         return self
 
@@ -136,10 +145,10 @@ class Chronos(BaseForecaster):
             top_p=self.top_p,
         )
         values = np.median(forecast[0].numpy(), axis=0)
-        '''
+        """
         row_idx = fh.to_absolute_index(self.cutoff)
         col_idx = self._y.index
-        '''
+        """
         y_pred = pd.DataFrame(values)
         return y_pred
 
@@ -157,5 +166,5 @@ class Chronos(BaseForecaster):
         -------
         params : dict or list of dict
         """
-        params = {"modelName": "amazon/chronos-t5-small"}
+        params = {"model_name": "amazon/chronos-t5-small"}
         return params

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -1,48 +1,13 @@
+# !/usr/bin/env python3 -u
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Implements Chronos forecaster by wrapping amazon's chronos."""
+
 import torch
 import numpy as np
 import pandas as pd
 
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Extension template for forecasters, SIMPLE version.
-
-Contains only bare minimum of implementation requirements for a functional forecaster.
-Also assumes *no composition*, i.e., no forecaster or other estimator components.
-For advanced cases (probabilistic, composition, etc),
-    see full extension template in forecasting.py
-
-Purpose of this implementation template:
-    quick implementation of new estimators following the template
-    NOT a concrete class to import! This is NOT a base class or concrete class!
-    This is to be used as a "fill-in" coding template.
-
-How to use this implementation template to implement a new estimator:
-- make a copy of the template in a suitable location, give it a descriptive name.
-- work through all the "todo" comments below
-- fill in code for mandatory methods, and optionally for optional methods
-- do not write to reserved variables: is_fitted, _is_fitted, _X, _y, cutoff, _fh,
-    _cutoff, _converter_store_y, forecasters_, _tags, _tags_dynamic, _is_vectorized
-- you can add more private methods, but do not override BaseEstimator's private methods
-    an easy way to be safe is to prefix your methods with "_custom"
-- change docstrings for functions and the file
-- ensure interface compatibility by sktime.utils.estimator_checks.check_estimator
-- once complete: use as a local library, or contribute to sktime via PR
-- more details:
-  https://www.sktime.net/en/stable/developer_guide/add_estimators.html
-
-Mandatory implements:
-    fitting         - _fit(self, y, X=None, fh=None)
-    forecasting     - _predict(self, fh=None, X=None)
-
-Testing - required for sktime test framework and check_estimator usage:
-    get default parameters for test instance(s) - get_test_params()
-"""
-# todo: write an informative docstring for the file or module, remove the above
-# todo: add an appropriate copyright notice for your estimator
-#       estimators contributed to sktime should have the copyright notice at the top
-#       estimators of your own do not need to have permissive or BSD-3 copyright
-
-# todo: uncomment the following line, enter authors' GitHub IDs
-# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+__author__ = ["RigvedManoj"]
+__all__ = ["Chronos"]
 
 
 from sktime.forecasting.base import BaseForecaster
@@ -52,112 +17,65 @@ from sktime.forecasting.base import BaseForecaster
 
 
 class Chronos(BaseForecaster):
-    """Custom forecaster. todo: write docstring.
+    """Chronos forecaster by wrapping Amazon's Chronos model [1]_.
 
-    todo: describe your custom forecaster here
+    Direct interface to Amazon Chronos, using the sktime interface.
+    All hyperparameters are exposed via the constructor.
 
     Parameters
     ----------
-    parama : int
-        descriptive explanation of parama
-    paramb : string, optional (default='default')
-        descriptive explanation of paramb
-    paramc : boolean, optional (default= whether paramb is not the default)
-        descriptive explanation of paramc
-    and so on
+    modelName: str, required
+    top_p: float, default=1.0
+    top_k: int, default=50
+    temperature: float, default=1.0
+    num_samples: int, default=20
+    args_list: list, default=None
+    kwargs_dict: dict, default=None
+
+    References
+    ----------
+    . [1] https://github.com/amazon-science/chronos-forecasting
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.chronos import Chronos
+    >>> from sktime.split import temporal_train_test_split
+    >>> from sktime.performance_metrics.forecasting import mean_absolute_percentage_error
+    >>> from sktime.forecasting.base import ForecastingHorizon
+    >>> import torch
+    >>> y = load_airline()
+    >>> y_train, y_test = temporal_train_test_split(y)
+    >>> fh = ForecastingHorizon(y_test.index, is_relative=False)
+    >>> forecaster = Chronos("amazon/chronos-t5-small", kwargs_dict={"torch_dtype": torch.bfloat16})
+    >>> forecaster.fit(y_train)
+    >>> y_pred = forecaster.predict(fh)
+    >>> mean_absolute_percentage_error(y_test, y_pred)
     """
 
-    # todo: fill out estimator tags here
-    #  tags are inherited from parent class if they are not set
-    # todo: define the forecaster scitype by setting the tags
-    #  the "forecaster scitype" is determined by the tags
-    #   scitype:y - the expected input scitype of y - univariate or multivariate or both
     # tag values are "safe defaults" which can usually be left as-is
     _tags = {
-        # to list all valid tags with description, use sktime.registry.all_tags
-        #   all_tags(estimator_types="forecaster", as_dataframe=True)
-        #
-        # behavioural tags: internal type
-        # -------------------------------
-        #
-        # y_inner_mtype, X_inner_mtype control which format X/y appears in
-        # in the inner functions _fit, _predict, etc
         "y_inner_mtype": "pd.Series",
         "X_inner_mtype": "pd.DataFrame",
-        # valid values: str and list of str
-        # if str, must be a valid mtype str, in sktime.datatypes.MTYPE_REGISTER
-        #   of scitype Series, Panel (panel data) or Hierarchical (hierarchical series)
-        #   in that case, all inputs are converted to that one type
-        # if list of str, must be a list of valid str specifiers
-        #   in that case, X/y are passed through without conversion if on the list
-        #   if not on the list, converted to the first entry of the same scitype
-        #
-        # scitype:y controls whether internal y can be univariate/multivariate
-        # if multivariate is not valid, applies vectorization over variables
         "scitype:y": "univariate",
-        # valid values: "univariate", "multivariate", "both"
-        #   "univariate": inner _fit, _predict, etc, receive only univariate series
-        #   "multivariate": inner methods receive only series with 2 or more variables
-        #   "both": inner methods can see series with any number of variables
-        #
-        # capability tags: properties of the estimator
-        # --------------------------------------------
-        #
-        # ignores-exogeneous-X = does estimator ignore the exogeneous X?
-        "ignores-exogeneous-X": False,
-        # valid values: boolean True (ignores X), False (uses X in non-trivial manner)
-        # CAVEAT: if tag is set to True, inner methods always see X=None
-        #
-        # requires-fh-in-fit = is forecasting horizon always required in fit?
+        "ignores-exogeneous-X": True,
         "requires-fh-in-fit": False,
-        # valid values: boolean True (yes), False (no)
-        # if True, raises exception in fit if fh has not been passed
-        #
-        # ownership and contribution tags
-        # -------------------------------
-        #
-        # author = author(s) of th estimator
-        # an author is anyone with significant contribution to the code at some point
-        "authors": ["author1", "author2"],
-        # valid values: str or list of str, should be GitHub handles
-        # this should follow best scientific contribution practices
-        # scope is the code, not the methodology (method is per paper citation)
-        #
-        # maintainer = current maintainer(s) of the estimator
-        # per algorithm maintainer role, see governance document
-        # this is an "owner" type role, with rights and maintenance duties
-        "maintainers": ["maintainer1", "maintainer2"],
-        # valid values: str or list of str, should be GitHub handles
-        # remove tag if maintained by sktime core team
+        "authors": ["RigvedManoj"],
+        "maintainers": ["RigvedManoj"],
     }
 
-    # todo: add any hyper-parameters and components to constructor
-    def __init__(self, args_list, kwargs_dict=None):
-        # todo: write any hyper-parameters to self
-        self.context = None
-        self.top_p = None
-        self.top_k = None
-        self.temperature = None
-        self.num_samples = None
+    def __init__(self, modelName, num_samples=20, temperature=1.0, top_k=50, top_p=1.0, args_list=None, kwargs_dict=None):
+        self.modelName = modelName
+        self.num_samples = num_samples
+        self.temperature = temperature
+        self.top_k = top_k
+        self.top_p = top_p
         self.args_list = args_list
         self.kwargs_dict = kwargs_dict
-        from chronos import ChronosPipeline
-        if self.kwargs_dict is None:
-            self.model = ChronosPipeline.from_pretrained(*self.args_list)
-        else:
-            self.model = ChronosPipeline.from_pretrained(*self.args_list, **self.kwargs_dict)
-        # IMPORTANT: the self.params should never be overwritten or mutated from now on
-        # for handling defaults etc, write to other attributes, e.g., self._parama
 
-        # leave this as is
         super().__init__()
 
-        # todo: optional, parameter checking logic (if applicable) should happen here
-        # if writes derived values to self, should *not* overwrite self.parama etc
-        # instead, write to self._parama, self._newparam (starting with _)
-
-    # todo: implement this, mandatory
-    def _fit(self, y, X, fh, num_samples=20, temperature=1.0, top_k=50, top_p=1.0):
+    def _fit(self, y, X=None, fh=None):
         """Fit forecaster to training data.
 
         private _fit containing the core logic, called from fit
@@ -167,112 +85,63 @@ class Chronos(BaseForecaster):
 
         Parameters
         ----------
-        y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
-            Time series to which to fit the forecaster.
-            if self.get_tag("scitype:y")=="univariate":
-                guaranteed to have a single column/variable
-            if self.get_tag("scitype:y")=="multivariate":
-                guaranteed to have 2 or more columns
-            if self.get_tag("scitype:y")=="both": no restrictions apply
+        y : pd.Series
+            Target time series to which to fit the forecaster.
         fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
-            The forecasting horizon with the steps ahead to to predict.
-            Required (non-optional) here if self.get_tag("requires-fh-in-fit")==True
-            Otherwise, if not passed in _fit, guaranteed to be passed in _predict
-        X : optional (default=None)
-            guaranteed to be of a type in self.get_tag("X_inner_mtype")
-            Exogeneous time series to fit to.
+            The forecasting horizon with the steps ahead to predict.
+        X : pd.DataFrame, optional (default=None)
+            Exogenous variables are ignored.
 
         Returns
         -------
         self : reference to self
         """
-        # any model parameters should be written to attributes ending in "_"
-        #  attributes set by the constructor must not be overwritten
-        #
-        # todo:
-        # insert logic here
-        # self.fitted_model_param_ = sthsth
-        #
-        self.context = torch.tensor(y.values)
-        self.num_samples = num_samples
-        self.temperature = temperature
-        self.top_k = top_k
-        self.top_p = top_p
+        from chronos import ChronosPipeline
+        if self.args_list is not None:
+            args_list = [self.modelName] + self.args_list
+        else:
+            args_list = [self.modelName]
+        if self.kwargs_dict is None:
+            self._model = ChronosPipeline.from_pretrained(*args_list)
+        else:
+            self._model = ChronosPipeline.from_pretrained(*args_list, **self.kwargs_dict)
+        self._context = torch.tensor(y.values)
         return self
 
-        # implement here
-        # IMPORTANT: avoid side effects to y, X, fh
-        #
-        # any model parameters should be written to attributes ending in "_"
-        #  attributes set by the constructor must not be overwritten
-        #
-        # Note: when interfacing a model that has fit, with parameters
-        #   that are not data (y, X) or forecasting-horizon-like,
-        #   but model parameters, *don't* add as arguments to fit, but treat as follows:
-        #   1. pass to constructor,  2. write to self in constructor,
-        #   3. read from self in _fit,  4. pass to interfaced_model.fit in _fit
-
-    # todo: implement this, mandatory
     def _predict(self, fh=None, X=None):
         """Forecast time series at future horizon.
 
         private _predict containing the core logic, called from predict
 
-        State required:
-            Requires state to be "fitted".
-
-        Accesses in self:
-            Fitted model attributes ending in "_"
-            self.cutoff
-
         Parameters
         ----------
         fh : guaranteed to be ForecastingHorizon or None, optional (default=None)
-            The forecasting horizon with the steps ahead to to predict.
-            If not passed in _fit, guaranteed to be passed here
+            The forecasting horizon with the steps ahead to predict.
         X : pd.DataFrame, optional (default=None)
-            Exogenous time series
+            Exogenous variables are ignored.
 
         Returns
         -------
-        y_pred : sktime time series object
-            should be of the same type as seen in _fit, as in "y_inner_mtype" tag
-            Point predictions
+        y_pred : pd.DataFrame
+            Predicted forecasts.
         """
-        # todo
         prediction_length = len(fh)
-        forecast = self.model.predict(
-            self.context,
+        forecast = self._model.predict(
+            self._context,
             prediction_length,
             num_samples=self.num_samples,
             temperature=self.temperature,
             top_k=self.top_k,
             top_p=self.top_p,
         )
-        # return np.median(forecast[0].numpy(), axis=0)
-        # to get fitted model params set in fit, do this:
-        #
-        # fitted_model_param = self.fitted_model_param_
-
-        # todo: add logic to compute values
         values = np.median(forecast[0].numpy(), axis=0)
-
-        # then return as pd.DataFrame
-        # below code guarantees the right row and column index
-        #
         '''
         row_idx = fh.to_absolute_index(self.cutoff)
         col_idx = self._y.index
         '''
-        #
         y_pred = pd.DataFrame(values)
         return y_pred
 
-        # IMPORTANT: avoid side effects to X, fh
-
-    # todo: implement this if this is an estimator contributed to sktime
-    #   or to run local automated unit and integration testing of estimator
-    #   method should return default parameters, so that a test instance can be created
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
@@ -281,47 +150,11 @@ class Chronos(BaseForecaster):
         ----------
         parameter_set : str, default="default"
             Name of the set of test parameters to return, for use in tests. If no
-            special parameters are defined for a value, will return `"default"` set.
-            There are currently no reserved values for forecasters.
+            special parameters are defined for a value, will return ``"default"`` set.
 
         Returns
         -------
-        params : dict or list of dict, default = {}
-            Parameters to create testing instances of the class
-            Each dict are parameters to construct an "interesting" test instance, i.e.,
-            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
-            `create_test_instance` uses the first (or only) dictionary in `params`
+        params : dict or list of dict
         """
-
-        # todo: set the testing parameters for the estimators
-        # Testing parameters can be dictionary or list of dictionaries.
-        # Testing parameter choice should cover internal cases well.
-        #   for "simple" extension, ignore the parameter_set argument.
-        #
-        # this method can, if required, use:
-        #   class properties (e.g., inherited); parent class test case
-        #   imported objects such as estimators from sktime or sklearn
-        # important: all such imports should be *inside get_test_params*, not at the top
-        #            since imports are used only at testing time
-        #
-        # A good parameter set should primarily satisfy two criteria,
-        #   1. Chosen set of parameters should have a low testing time,
-        #      ideally in the magnitude of few seconds for the entire test suite.
-        #       This is vital for the cases where default values result in
-        #       "big" models which not only increases test time but also
-        #       run into the risk of test workers crashing.
-        #   2. There should be a minimum two such parameter sets with different
-        #      sets of values to ensure a wide range of code coverage is provided.
-        #
-        # example 1: specify params as dictionary
-        # any number of params can be specified
-        # params = {"est": value0, "parama": value1, "paramb": value2}
-        #
-        # example 2: specify params as list of dictionary
-        # note: Only first dictionary will be used by create_test_instance
-        # params = [{"est": value1, "parama": value2},
-        #           {"est": value3, "parama": value4}]
-        #
-        # return params
-        params = {"args_list": ["amazon/chronos-t5-small"], "kwargs_dict": {"torch_dtype": torch.bfloat16}}
+        params = {"modelName": "amazon/chronos-t5-small", "kwargs_dict": {"torch_dtype": torch.bfloat16}}
         return params

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -2,7 +2,6 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements Chronos forecaster by wrapping amazon's chronos."""
 
-import torch
 import numpy as np
 import pandas as pd
 
@@ -55,6 +54,7 @@ class Chronos(BaseForecaster):
 
     # tag values are "safe defaults" which can usually be left as-is
     _tags = {
+        "python_dependencies": ["torch"],
         "y_inner_mtype": "pd.Series",
         "X_inner_mtype": "pd.DataFrame",
         "scitype:y": "univariate",
@@ -96,6 +96,7 @@ class Chronos(BaseForecaster):
         -------
         self : reference to self
         """
+        import torch
         from chronos import ChronosPipeline
         if self.args_list is not None:
             args_list = [self.modelName] + self.args_list
@@ -156,5 +157,5 @@ class Chronos(BaseForecaster):
         -------
         params : dict or list of dict
         """
-        params = {"modelName": "amazon/chronos-t5-small", "kwargs_dict": {"torch_dtype": torch.bfloat16}}
+        params = {"modelName": "amazon/chronos-t5-small"}
         return params

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -114,7 +114,7 @@ class Chronos(BaseForecaster):
             self._model = ChronosPipeline.from_pretrained(
                 *args_list, **self.kwargs_dict
             )
-        self._context = torch.tensor(y.values)
+        self._context = torch.tensor(self._y.values)
         return self
 
     def _predict(self, fh=None, X=None):
@@ -144,8 +144,8 @@ class Chronos(BaseForecaster):
             top_p=self.top_p,
         )
         values = np.median(forecast[0].numpy(), axis=0)
-        row_idx = fh.to_absolute_index(self.cutoff)
-        y_pred = pd.DataFrame(values, index=row_idx)
+        row_idx = self.fh.to_absolute_index(self.cutoff)
+        y_pred = pd.Series(values, index=row_idx, name=self._y.name)
         return y_pred
 
     @classmethod

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -5,7 +5,6 @@
 __author__ = ["RigvedManoj"]
 __all__ = ["Chronos"]
 
-
 import numpy as np
 import pandas as pd
 
@@ -38,14 +37,14 @@ class Chronos(BaseForecaster):
     >>> from sktime.forecasting.chronos import Chronos
     >>> from sktime.split import temporal_train_test_split
     >>> from sktime.forecasting.base import ForecastingHorizon
-    >>> import torch
+    >>> import torch # doctest: +SKIP
     >>> y = load_airline()
     >>> y_train, y_test = temporal_train_test_split(y)
     >>> fh = ForecastingHorizon(y_test.index, is_relative=False)
     >>> forecaster = Chronos(
     ...        "amazon/chronos-t5-small",
     ...        kwargs_dict={"torch_dtype": torch.bfloat16}
-        )  # doctest: +SKIP
+    ... )  # doctest: +SKIP
     >>> forecaster.fit(y_train)  # doctest: +SKIP
     >>> y_pred = forecaster.predict(fh) # doctest: +SKIP
     """
@@ -145,11 +144,8 @@ class Chronos(BaseForecaster):
             top_p=self.top_p,
         )
         values = np.median(forecast[0].numpy(), axis=0)
-        """
         row_idx = fh.to_absolute_index(self.cutoff)
-        col_idx = self._y.index
-        """
-        y_pred = pd.DataFrame(values)
+        y_pred = pd.DataFrame(values, index=row_idx)
         return y_pred
 
     @classmethod

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -52,7 +52,7 @@ class Chronos(BaseForecaster):
 
     # tag values are "safe defaults" which can usually be left as-is
     _tags = {
-        "python_dependencies": ["torch"],
+        "python_dependencies": ["torch", "chronos"],
         "y_inner_mtype": "pd.Series",
         "scitype:y": "univariate",
         "ignores-exogeneous-X": True,


### PR DESCRIPTION
Implements Chronos Forecaster from https://github.com/sktime/sktime/issues/6119

What does this implement/fix? Explain your changes.
This impementation adds a new forecaster (Amazon's Chronos).

Does your contribution introduce a new dependency? If yes, which one?
Amazon Chronos (https://github.com/amazon-science/chronos-forecasting)

What should a reviewer concentrate their feedback on?
Class names and API layout
Design
CheckEstimator 

Did you add any tests for the change?
Not yet

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintaners` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

