### PR TITLE
Fixed bug in ResNetRegressor

### DIFF
--- a/sktime/regression/deep_learning/resnetregressor.py
+++ b/sktime/regression/deep_learning/resnetregressor.py
@@ -1,0 +1,235 @@
+"""Residual Network (ResNet) for regression."""
+
+__author__ = ["James-Large", "Withington"]
+
+from copy import deepcopy
+
+from sklearn.utils import check_random_state
+import cloudpickle
+from sktime.networks.resnet import ResNetNetwork
+from sktime.regression.deep_learning.base import BaseDeepRegressor
+from sktime.utils.validation._dependencies import _check_dl_dependencies
+import joblib
+class ResNetRegressor(BaseDeepRegressor):
+    """Residual Neural Network Regressor adopted from [1].
+
+    Parameters
+    ----------
+    n_epochs       : int, default = 1500
+        the number of epochs to train the model
+    batch_size      : int, default = 16
+        the number of samples per gradient update.
+    random_state    : int or None, default=None
+        Seed for random number generation.
+    verbose         : boolean, default = False
+        whether to output extra information
+    loss            : string, default="mean_squared_error"
+        fit parameter for the keras model
+    optimizer       : keras.optimizer, default=keras.optimizers.Adam(),
+    metrics         : list of strings, default=["mean_squared_error"],
+    activation      : string or a tf callable, default="linear"
+        Activation function used in the output linear layer.
+        List of available activation functions:
+        https://keras.io/api/layers/activations/
+    use_bias        : boolean, default = True
+        whether the layer uses a bias vector.
+    optimizer       : keras.optimizers object, default = Adam(lr=0.01)
+        specify the optimizer and the learning rate to be used.
+
+    Notes
+        -----
+        Adapted from the implementation from source code
+        https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/resnet.py
+
+        References
+        ----------
+            .. [1] Wang et. al, Time series classification from
+        scratch with deep neural networks: A strong baseline,
+        International joint conference on neural networks (IJCNN), 2017.
+
+        Examples
+        --------
+        >>> from sktime.regression.deep_learning.resnet import ResNetRegressor
+        >>> from sktime.datasets import load_unit_test
+        >>> X_train, y_train = load_unit_test(split="train")
+        >>> clf = ResNetRegressor(n_epochs=20, batch_size=4) # doctest: +SKIP
+        >>> clf.fit(X_train, Y_train) # doctest: +SKIP
+        ResNetRegressor(...)
+        """
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": ["James-Large", "Withington"],
+        "maintainers": ["Withington"],
+        "python_dependencies": "tensorflow",
+        # estimator type handled by parent class
+    }
+    def __init__(
+        self,
+        n_epochs=1500,
+        callbacks=None,
+        verbose=False,
+        loss="mean_squared_error",
+        metrics=None,
+        batch_size=16,
+        random_state=None,
+        activation="linear",
+        use_bias=True,
+        optimizer=None,
+    ):
+        _check_dl_dependencies(severity="error")
+
+        self.n_epochs = n_epochs
+        self.callbacks = callbacks
+        self.verbose = verbose
+        self.loss = loss
+        self.metrics = metrics
+        self.batch_size = batch_size
+        self.random_state = random_state
+        self.activation = activation
+        self.use_bias = use_bias
+        self.optimizer = optimizer
+
+        super().__init__()
+
+        self.history = None
+        self._network = ResNetNetwork(random_state=random_state)
+        
+    def build_model(self, input_shape, **kwargs):
+        """Construct a compiled, un-trained, keras model that is ready for training.
+
+        In sktime, time series are stored in numpy arrays of shape (d,m), where d
+        is the number of dimensions, m is the series length. Keras/tensorflow assume
+        data is in shape (m,d). This method also assumes (m,d). Transpose should
+        happen in fit.
+
+        Parameters
+        ----------
+        input_shape : tuple
+            The shape of the data fed into the input layer, should be (m,d)
+
+        Returns
+        -------
+        output : a compiled Keras Model
+        """
+        import tensorflow as tf
+        from tensorflow import keras
+
+        tf.random.set_seed(self.random_state)
+
+        self.optimizer_ = (
+            keras.optimizers.Adam(learning_rate=0.01)
+            if self.optimizer is None
+            else self.optimizer
+        )
+        if self.metrics is None:
+            metrics = [
+                "mean_squared_error",
+            ]
+        else:
+            metrics = self.metrics
+
+        input_layer, output_layer = self._network.build_network(input_shape, **kwargs)
+
+        output_layer = keras.layers.Dense(
+            units=1, activation=self.activation, use_bias=self.use_bias
+        )(output_layer)
+
+        model = keras.models.Model(inputs=input_layer, outputs=output_layer)
+        model.compile(
+            loss=self.loss,
+            optimizer=self.optimizer_,
+            metrics=metrics,
+        )
+
+        return model
+    def _fit(self, X, y):
+        """Fit the regressor on the training set (X, y).
+
+        Parameters
+        ----------
+        X : np.ndarray of shape = (n_instances (n), n_dimensions (d), series_length (m))
+            The training input samples.
+        y : np.ndarray of shape n
+            The training data class labels.
+
+        Returns
+        -------
+        self : object
+        """
+        # Transpose to conform to Keras input style.
+        X = X.transpose(0, 2, 1)
+        check_random_state(self.random_state)
+        self.input_shape = X.shape[1:]
+        self.model_ = self.build_model(self.input_shape)
+        if self.verbose:
+            self.model_.summary()
+
+        self.callbacks_ = deepcopy(self.callbacks)
+        self.history = self.model_.fit(
+            X,
+            y,
+            batch_size=self.batch_size,
+            epochs=self.n_epochs,
+            verbose=self.verbose,
+            callbacks=self.callbacks_,
+        )
+        return self
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+            For classifiers, a "default" set of parameters should be provided for
+            general testing, and a "results_comparison" set for comparing against
+            previously recorded results if the general set does not produce suitable
+            probabilities to compare against.
+
+        Returns
+        -------
+        params : dict or list of dict, default={}
+            Parameters to create testing instances of the class.
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            ``MyClass(**params)`` or ``MyClass(**params[i])`` creates a valid test
+            instance.
+            ``create_test_instance`` uses the first (or only) dictionary in ``params``.
+        """
+        from sktime.utils.validation._dependencies import _check_soft_dependencies
+        param1 = {
+            "n_epochs": 6,
+            "batch_size": 4,
+            "use_bias": False,
+        }
+
+        param2 = {
+            "n_epochs": 4,
+            "batch_size": 6,
+            "use_bias": True,
+        }
+        test_params = [param1, param2]
+        if _check_soft_dependencies("keras", severity="none"):
+            from keras.callbacks import LambdaCallback
+
+            test_params.append(
+                {
+                    "n_epochs": 2,
+                    "callbacks": [LambdaCallback()],
+                }
+            )
+        return test_params
+    
+    # serializing lambda functions
+    def pickling(lambda_func):
+        lf = lambda_func
+        #  serialize(lf):
+        code = lf.__code__
+        env = lf.__globals__
+        # Return a picklable representation (e.g., a dictionary)
+        return {"code": code, "env": env}
+        # returns the constructed dictionary, representing the serialized lambda function
+        # joblib.parallel.PICKLE_FUNCTIONS[type(lambda x: x)] = serialize
+        # joblib.register(type(lambda x: x), pickler=serialize)


### PR DESCRIPTION
[<!--](url)
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #6153 .

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->


#### What does this implement/fix? Explain your changes.
<!--
The ResNetRegressor class had previously dependence on pickle package for serialization of lambda function. However it was giving error while testing with lambda function. So developed a function named pickling to manually serialize lambda function using its __code__and __globals__ attributes. It returns a dictionary representing a serialized lambda function. 
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintaners` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
