### PR TITLE
[MNT] temporary skip for some sporadic failures on `main`

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -93,6 +93,7 @@ EXCLUDED_TESTS = {
         "test_persistence_via_pickle",
         "test_fit_does_not_overwrite_hyper_params",
         "test_save_estimators_to_file",
+        "test_fit_idempotent",  # see 6201
     ],
     # TapNet fails due to Lambda layer, see #3539 and #3616
     "TapNetClassifier": [
@@ -145,6 +146,7 @@ EXCLUDED_TESTS = {
         "test_fit_idempotent",
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
+        "test_multioutput",  # see 6201
     ],
     "SimpleRNNRegressor": [
         "test_fit_idempotent",


### PR DESCRIPTION
This PR skips some of the sporadic failures on main, see https://github.com/sktime/sktime/issues/6201