### PR TITLE
Refactored test_base_regressor_fit tests with explicit error messages

### DIFF
--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -117,11 +117,6 @@ class _DummyConvertPandas(BaseClassifier):
         return self
 
 
-multivariate_message = r"multivariate series"
-missing_message = r"missing values"
-unequal_message = r"unequal length series"
-
-
 def test_base_classifier_fit():
     """Test function for the BaseClassifier class fit.
 
@@ -147,12 +142,12 @@ def test_base_classifier_fit():
     assert result is dummy
     result = dummy.fit(test_X3, test_y2)
     assert result is dummy
-    with pytest.raises(ValueError, match=multivariate_message):
+    with pytest.raises(ValueError, match=r"multivariate series"):
         result = dummy.fit(test_X2, test_y1)
     assert result is dummy
     result = dummy.fit(test_X3, test_y1)
     assert result is dummy
-    with pytest.raises(ValueError, match=multivariate_message):
+    with pytest.raises(ValueError, match=r"multivariate series"):
         result = dummy.fit(test_X4, test_y1)
     assert result is dummy
 
@@ -180,25 +175,25 @@ def test_check_capabilities(missing, multivariate, unequal):
 
     # checks that errors are raised
     if missing:
-        with pytest.raises(ValueError, match=missing_message):
+        with pytest.raises(ValueError, match=r"missing values"):
             handles_none._check_capabilities(X_metadata)
     if multivariate:
-        with pytest.raises(ValueError, match=multivariate_message):
+        with pytest.raises(ValueError, match=r"multivariate series"):
             handles_none._check_capabilities(X_metadata)
     if unequal:
-        with pytest.raises(ValueError, match=unequal_message):
+        with pytest.raises(ValueError, match=r"unequal length series"):
             handles_none._check_capabilities(X_metadata)
     if not missing and not multivariate and not unequal:
         handles_none._check_capabilities(X_metadata)
 
     if missing:
-        with pytest.warns(UserWarning, match=missing_message):
+        with pytest.warns(UserWarning, match=r"missing values"):
             handles_none_composite._check_capabilities(X_metadata)
     if multivariate:
-        with pytest.warns(UserWarning, match=multivariate_message):
+        with pytest.warns(UserWarning, match=r"multivariate series"):
             handles_none_composite._check_capabilities(X_metadata)
     if unequal:
-        with pytest.warns(UserWarning, match=unequal_message):
+        with pytest.warns(UserWarning, match=r"unequal length series"):
             handles_none_composite._check_capabilities(X_metadata)
     if not missing and not multivariate and not unequal:
         handles_none_composite._check_capabilities(X_metadata)

--- a/sktime/regression/tests/test_base.py
+++ b/sktime/regression/tests/test_base.py
@@ -103,11 +103,6 @@ class _DummyConvertPandas(BaseRegressor):
         return self
 
 
-multivariate_message = r"multivariate series"
-missing_message = r"missing values"
-unequal_message = r"unequal length series"
-
-
 def test_base_regressor_fit():
     """Test function for the BaseRegressor class fit.
 
@@ -133,12 +128,12 @@ def test_base_regressor_fit():
     assert result is dummy
     result = dummy.fit(test_X3, test_y2)
     assert result is dummy
-    with pytest.raises(ValueError, match=multivariate_message):
+    with pytest.raises(ValueError, match=r"multivariate series"):
         result = dummy.fit(test_X2, test_y1)
     assert result is dummy
     result = dummy.fit(test_X3, test_y1)
     assert result is dummy
-    with pytest.raises(ValueError, match=multivariate_message):
+    with pytest.raises(ValueError, match=r"multivariate series"):
         result = dummy.fit(test_X4, test_y1)
     assert result is dummy
 
@@ -166,25 +161,25 @@ def test_check_capabilities(missing, multivariate, unequal):
 
     # checks that errors are raised
     if missing:
-        with pytest.raises(ValueError, match=missing_message):
+        with pytest.raises(ValueError, match=r"missing values"):
             handles_none._check_capabilities(X_metadata)
     if multivariate:
-        with pytest.raises(ValueError, match=multivariate_message):
+        with pytest.raises(ValueError, match=r"multivariate series"):
             handles_none._check_capabilities(X_metadata)
     if unequal:
-        with pytest.raises(ValueError, match=unequal_message):
+        with pytest.raises(ValueError, match=r"unequal length series"):
             handles_none._check_capabilities(X_metadata)
     if not missing and not multivariate and not unequal:
         handles_none._check_capabilities(X_metadata)
 
     if missing:
-        with pytest.warns(UserWarning, match=missing_message):
+        with pytest.warns(UserWarning, match=r"missing values"):
             handles_none_composite._check_capabilities(X_metadata)
     if multivariate:
-        with pytest.warns(UserWarning, match=multivariate_message):
+        with pytest.warns(UserWarning, match=r"multivariate series"):
             handles_none_composite._check_capabilities(X_metadata)
     if unequal:
-        with pytest.warns(UserWarning, match=unequal_message):
+        with pytest.warns(UserWarning, match=r"unequal length series"):
             handles_none_composite._check_capabilities(X_metadata)
     if not missing and not multivariate and not unequal:
         handles_none_composite._check_capabilities(X_metadata)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes https://github.com/sktime/sktime/issues/6204 
See also: https://github.com/sktime/sktime/pull/6075

#### What does this implement/fix? Explain your changes.

Implements a rafactor of:
**`test_check_capabilities`**
Seperates `test_check_capabilities` into:
- `test_check_multivariate_capabilities`
- `test_check_unequal_capabilities`
- `test_check_unequal_capabilities`
- `test_check_none_capabilities`

**`test_base_regressor_fit`**
Uses literal strings for error messages instead of variable names

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?

Please look at how I seperated test_check_capabilities and if there is room for improvement. I moved X_metadata to be a global variable since the 4 new methods will each use it; Not entirely sure if this is best practice


#### Did you add any tests for the change?
No

#### Any other comments?
I'm still pretty green to testing, I would appreciate any and all feedback about this draft of a refactor.

