### PR TITLE
[MNT] update installation instructions on `conda` soft dependencies

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -77,9 +77,10 @@ To install ``sktime`` with maximum dependencies, including soft dependencies, in
 
     conda install -c conda-forge sktime-all-extras
 
-Note: currently this does not include the dependency ``catch-22``.
-As this package is not available on ``conda-forge``, it must be installed via ``pip`` if desired.
-Contributions to remedy this situation are appreciated.
+Note: not all soft dependencies of ``sktime`` are also available on ``conda-forge``,
+``sktime-all-extras`` includes only the soft dependencies that are available on ``conda-forge``.
+The other soft dependencies can be installed via ``pip``, after ``conda install pip``.
+
 
 Development versions
 --------------------


### PR DESCRIPTION
This PR updates the installation instructions on `conda` soft dependencies.

It changes the `catch22` specific instruction, which is also outdated (see #6227), to a more general reference to packages not available on `conda`. FYI @royiavital.