### PR TITLE
[MNT] change cycle (0.29.0) for renaming `cINNForecaster` to `CINNForecaster`

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -369,7 +369,7 @@ Deep learning based forecasters
     :toctree: auto_generated/
     :template: class.rst
 
-    cINNForecaster
+    CINNForecaster
 
 .. currentmodule:: sktime.forecasting.neuralforecast
 

--- a/sktime/forecasting/conditional_invertible_neural_network.py
+++ b/sktime/forecasting/conditional_invertible_neural_network.py
@@ -1,4 +1,4 @@
-"""Conditional Invertible Neural Network (CINN) for forecasting."""
+"""Conditional Invertible Neural Network (cINN) for forecasting."""
 __author__ = ["benHeid"]
 
 from copy import deepcopy

--- a/sktime/forecasting/conditional_invertible_neural_network.py
+++ b/sktime/forecasting/conditional_invertible_neural_network.py
@@ -31,7 +31,7 @@ else:
 
 
 def default_sine(x, amplitude, phase, offset, amplitude2, amplitude3, phase2):
-    """Calculate a special sine for the CINN."""
+    """Calculate a special sine for the cINN."""
     sbase = np.sin(x * (1 / 365 / 24 * np.pi * 4) + phase) * amplitude + offset
     s1 = (
         amplitude2
@@ -44,12 +44,12 @@ def default_sine(x, amplitude, phase, offset, amplitude2, amplitude3, phase2):
 
 class CINNForecaster(BaseDeepNetworkPyTorch):
     """
-    Conditional Invertible Neural Network (CINN) Forecaster.
+    Conditional Invertible Neural Network (cINN) Forecaster.
 
-    This forecaster uses a CINN to forecast the time series. The CINN learns a
+    This forecaster uses a cINN to forecast the time series. The cINN learns a
     bijective mapping between the time series and a normal distributed latent
     space. The latent space is then sampled and transformed back to the time
-    series space. The CINN is conditioned on statistical and fourier term based
+    series space. The cINN is conditioned on statistical and fourier term based
     features of the time series and the provided exogenous features. This
     forecaster was applied in the BigDEAL challenge by the KIT-IAI team
     and is described in [1]_.
@@ -57,11 +57,11 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
     Parameters
     ----------
     n_coupling_layers : int, optional (default=15)
-        Number of coupling layers in the CINN.
+        Number of coupling layers in the cINN.
     hidden_dim_size : int, optional (default=64)
         Number of hidden units in the subnet.
     sample_dim : int, optional (default=24)
-        Dimension of the samples that the CINN is creating
+        Dimension of the samples that the cINN is creating
     batch_size : int, optional (default=64)
         Batch size for the training.
     encoded_cond_size : int, optional (default=64)
@@ -80,7 +80,7 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
     lag_feature: str, optional (default="mean")
         The rolling statistic that the WindowSummarizer should calculate.
     num_epochs : int, optional (default=50)
-        Number of epochs to train the CINN.
+        Number of epochs to train the cINN.
     verbose : bool, optional (default=False)
         Whether to print the training progress.
     f_statistic : function, optional (default=default_sine)
@@ -88,7 +88,7 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
     init_param_f_statistic : list of float, optional (default=[1, 0, 0, 10, 1, 1])
         Initial parameters for the f_statistic function.
     deterministic : bool, optional (default=False)
-        Whether to use a deterministic or stochastic CINN. Note, deterministic
+        Whether to use a deterministic or stochastic cINN. Note, deterministic
         should only used for testing.
     patience : int, optional (default=5)
         Number of epochs to wait before stopping the training.
@@ -259,7 +259,7 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
         self.optimizer = self._instantiate_optimizer()
         early_stopper = _EarlyStopper(patience=self.patience, min_delta=self.delta)
 
-        # Fit the CINN
+        # Fit the cINN
         for epoch in range(self.num_epochs):
             if not self._run_epoch(
                 epoch,
@@ -581,7 +581,7 @@ class PyTorchCinnTestDataset(Dataset):
 
 class _EarlyStopper:
     """
-    Early stopping for the CINN.
+    Early stopping for the cINN.
 
     Parameters
     ----------

--- a/sktime/networks/cinn.py
+++ b/sktime/networks/cinn.py
@@ -37,7 +37,7 @@ class CINNNetwork:
     encoded_cond_size : int
         Dimension of the encoded condition.
     num_coupling_layers : int
-        Number of coupling layers in the CINN.
+        Number of coupling layers in the cINN.
     hidden_dim_size : int
         Number of hidden units in the subnet.
     activation : torch.nn.modules.Module
@@ -77,7 +77,7 @@ class CINNNetwork:
             self, horizon, cond_features, encoded_cond_size, num_coupling_layers
         ):
             """
-            Build the CINN.
+            Build the cINN.
 
             Parameters
             ----------
@@ -88,7 +88,7 @@ class CINNNetwork:
             encoded_cond_size : int
                 Dimension of the encoded condition.
             num_coupling_layers : int
-                Number of coupling layers in the CINN.
+                Number of coupling layers in the cINN.
             """
             nodes = [Ff.InputNode(horizon)]
 
@@ -112,11 +112,11 @@ class CINNNetwork:
             return Ff.GraphINN(nodes + [cond, Ff.OutputNode(nodes[-1])], verbose=False)
 
         def parameters(self, recurse: bool = True):
-            """Return the trainable parameters of the CINN."""
+            """Return the trainable parameters of the cINN."""
             return self.trainable_parameters
 
         def create_subnet(self, hidden_dim_size, activation):
-            """Create a subnet for the CINN.
+            """Create a subnet for the cINN.
 
             Parameters
             ----------
@@ -136,7 +136,7 @@ class CINNNetwork:
             return get_subnet
 
         def forward(self, x, c, rev=False):
-            """Forward pass through the CINN.
+            """Forward pass through the cINN.
 
             Parameters
             ----------
@@ -167,7 +167,7 @@ class CINNNetwork:
 
         def reverse_sample(self, z, c):
             """
-            Reverse sample from the CINN.
+            Reverse sample from the cINN.
 
             Parameters
             ----------
@@ -208,7 +208,7 @@ class CINNNetwork:
         )
 
     def build(self):
-        """Build the CINN."""
+        """Build the cINN."""
         return self._CINNNetwork(
             self.horizon,
             self.cond_features,

--- a/sktime/networks/cinn.py
+++ b/sktime/networks/cinn.py
@@ -1,4 +1,4 @@
-"""Conditional Invertible Neural Network (CINN) for forecasting."""
+"""Conditional Invertible Neural Network (cINN) for forecasting."""
 __author__ = ["benHeid"]
 
 import numpy as np

--- a/sktime/networks/cinn.py
+++ b/sktime/networks/cinn.py
@@ -1,4 +1,4 @@
-"""Conditional Invertible Neural Network (cINN) for forecasting."""
+"""Conditional Invertible Neural Network (CINN) for forecasting."""
 __author__ = ["benHeid"]
 
 import numpy as np
@@ -24,8 +24,7 @@ if _check_soft_dependencies("FrEIA", severity="none"):
     import FrEIA.modules as Fm
 
 
-# TODO 0.29.0: rename the class cINNNetwork to CINNNetwork
-class cINNNetwork:
+class CINNNetwork:
     """
     Conditional Invertible Neural Network.
 
@@ -38,14 +37,14 @@ class cINNNetwork:
     encoded_cond_size : int
         Dimension of the encoded condition.
     num_coupling_layers : int
-        Number of coupling layers in the cINN.
+        Number of coupling layers in the CINN.
     hidden_dim_size : int
         Number of hidden units in the subnet.
     activation : torch.nn.modules.Module
         Activation function to use in the subnet.
     """
 
-    class _cINNNetwork(NNModule):
+    class _CINNNetwork(NNModule):
         def __init__(
             self,
             horizon,
@@ -78,7 +77,7 @@ class cINNNetwork:
             self, horizon, cond_features, encoded_cond_size, num_coupling_layers
         ):
             """
-            Build the cINN.
+            Build the CINN.
 
             Parameters
             ----------
@@ -89,7 +88,7 @@ class cINNNetwork:
             encoded_cond_size : int
                 Dimension of the encoded condition.
             num_coupling_layers : int
-                Number of coupling layers in the cINN.
+                Number of coupling layers in the CINN.
             """
             nodes = [Ff.InputNode(horizon)]
 
@@ -113,11 +112,11 @@ class cINNNetwork:
             return Ff.GraphINN(nodes + [cond, Ff.OutputNode(nodes[-1])], verbose=False)
 
         def parameters(self, recurse: bool = True):
-            """Return the trainable parameters of the cINN."""
+            """Return the trainable parameters of the CINN."""
             return self.trainable_parameters
 
         def create_subnet(self, hidden_dim_size, activation):
-            """Create a subnet for the cINN.
+            """Create a subnet for the CINN.
 
             Parameters
             ----------
@@ -137,7 +136,7 @@ class cINNNetwork:
             return get_subnet
 
         def forward(self, x, c, rev=False):
-            """Forward pass through the cINN.
+            """Forward pass through the CINN.
 
             Parameters
             ----------
@@ -168,7 +167,7 @@ class cINNNetwork:
 
         def reverse_sample(self, z, c):
             """
-            Reverse sample from the cINN.
+            Reverse sample from the CINN.
 
             Parameters
             ----------
@@ -196,8 +195,9 @@ class cINNNetwork:
         self.hidden_dim_size = hidden_dim_size
         self.activation = activation if activation is not None else nn.ReLU
 
+        # TODO 0.30.0: remove this warning
         warn(
-            "cINNNetwork will be renamed to CINNNetwork in sktime 0.29.0, "
+            "cINNNetwork has been renamed to CINNNetwork in sktime 0.29.0, "
             "The estimator is available under the future name at its "
             "current location, and will be available under its deprecated name "
             "until 0.30.0. "
@@ -208,8 +208,8 @@ class cINNNetwork:
         )
 
     def build(self):
-        """Build the cINN."""
-        return self._cINNNetwork(
+        """Build the CINN."""
+        return self._CINNNetwork(
             self.horizon,
             self.cond_features,
             self.encoded_cond_size,
@@ -219,6 +219,5 @@ class cINNNetwork:
         )
 
 
-# TODO 0.29.0: switch the line to cINNNetwork = CINNNetwork
 # TODO 0.30.0: remove this alias altogether
-CINNNetwork = cINNNetwork
+cINNNetwork = CINNNetwork


### PR DESCRIPTION
#### Reference Issues/PRs
This PR completes step 2 of change cycle for renaming cINNForecaster to CINNForecaster completing the steps for release v0.29.0 in https://github.com/sktime/sktime/issues/6120

#### What does this implement/fix? Explain your changes.
- renames the classes
- updates deprecation warning