### PR TITLE
[BUG] Resolve `LSTMFCNClassifier` and `LSTMFCNRegressor` changing `callback` parameter 

### DIFF
--- a/sktime/classification/deep_learning/lstmfcn.py
+++ b/sktime/classification/deep_learning/lstmfcn.py
@@ -132,8 +132,9 @@ class LSTMFCNClassifier(BaseDeepClassifier):
             optimizer="adam",
             metrics=["accuracy"],
         )
-
-        self.callbacks = self.callbacks or []
+        # .get_params() returns an empty list for callback.
+        # inconsistent with function initial run where callbacks was set to None
+        self.callbacks = self.callbacks or None
 
         return model
 
@@ -188,7 +189,7 @@ class LSTMFCNClassifier(BaseDeepClassifier):
             batch_size=self.batch_size,
             epochs=self.n_epochs,
             verbose=self.verbose,
-            callbacks=deepcopy(self.callbacks) if self.callbacks else [],
+            callbacks=deepcopy(self.callbacks) if self.callbacks else None,
         )
 
         self._is_fitted = True

--- a/sktime/classification/deep_learning/lstmfcn.py
+++ b/sktime/classification/deep_learning/lstmfcn.py
@@ -134,7 +134,7 @@ class LSTMFCNClassifier(BaseDeepClassifier):
         )
         # .get_params() returns an empty list for callback.
         # inconsistent with function initial run where callbacks was set to None
-        self.callbacks = self.callbacks or None
+        self._callbacks = self.callbacks or None
 
         return model
 
@@ -189,10 +189,8 @@ class LSTMFCNClassifier(BaseDeepClassifier):
             batch_size=self.batch_size,
             epochs=self.n_epochs,
             verbose=self.verbose,
-            callbacks=deepcopy(self.callbacks) if self.callbacks else None,
+            callbacks=deepcopy(self._callbacks) if self._callbacks else None,
         )
-
-        self._is_fitted = True
 
         return self
 

--- a/sktime/regression/deep_learning/lstmfcn.py
+++ b/sktime/regression/deep_learning/lstmfcn.py
@@ -144,7 +144,7 @@ class LSTMFCNRegressor(BaseDeepRegressor):
             metrics=["accuracy"],
         )
 
-        self.callbacks = self.callbacks or []
+        self.callbacks = self.callbacks or None
 
         return model
 
@@ -185,7 +185,7 @@ class LSTMFCNRegressor(BaseDeepRegressor):
             batch_size=self.batch_size,
             epochs=self.n_epochs,
             verbose=self.verbose,
-            callbacks=deepcopy(self.callbacks) if self.callbacks else [],
+            callbacks=deepcopy(self.callbacks) if self.callbacks else None,
         )
 
         self._is_fitted = True

--- a/sktime/regression/deep_learning/lstmfcn.py
+++ b/sktime/regression/deep_learning/lstmfcn.py
@@ -144,7 +144,7 @@ class LSTMFCNRegressor(BaseDeepRegressor):
             metrics=["accuracy"],
         )
 
-        self.callbacks = self.callbacks or None
+        self._callbacks = self.callbacks or None
 
         return model
 
@@ -185,10 +185,8 @@ class LSTMFCNRegressor(BaseDeepRegressor):
             batch_size=self.batch_size,
             epochs=self.n_epochs,
             verbose=self.verbose,
-            callbacks=deepcopy(self.callbacks) if self.callbacks else None,
+            callbacks=deepcopy(self._callbacks) if self._callbacks else None,
         )
-
-        self._is_fitted = True
 
         return self
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -29,7 +29,7 @@ EXCLUDE_ESTIMATORS = [
     "TapNetRegressor",
     "TapNetClassifier",
     "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
-    "LSTMFCNClassifier",  # unknown cause, see bug report #4033
+    #"LSTMFCNClassifier",  # unknown cause, see bug report #4033
     "TimeSeriesLloyds",  # an abstract class, but does not follow naming convention
     # DL classifier suspected to cause hangs and memouts, see #4610
     "FCNClassifier",
@@ -38,13 +38,13 @@ EXCLUDE_ESTIMATORS = [
     "CNNClassifier",
     "FCNClassifier",
     "InceptionTimeClassifier",
-    "LSTMFCNClassifier",
+    #"LSTMFCNClassifier",
     "MLPClassifier",
     "MLPRegressor",
     "CNNRegressor",
     "ResNetRegressor",
     "FCNRegressor",
-    "LSTMFCNRegressor",
+    #"LSTMFCNRegressor",
     "MACNNRegressor",
     "CNTCClassifier",
     "CNTCRegressor",

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -29,7 +29,7 @@ EXCLUDE_ESTIMATORS = [
     "TapNetRegressor",
     "TapNetClassifier",
     "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
-    #"LSTMFCNClassifier",  # unknown cause, see bug report #4033
+    # "LSTMFCNClassifier",  # unknown cause, see bug report #4033
     "TimeSeriesLloyds",  # an abstract class, but does not follow naming convention
     # DL classifier suspected to cause hangs and memouts, see #4610
     "FCNClassifier",
@@ -38,13 +38,13 @@ EXCLUDE_ESTIMATORS = [
     "CNNClassifier",
     "FCNClassifier",
     "InceptionTimeClassifier",
-    #"LSTMFCNClassifier",
+    # "LSTMFCNClassifier",
     "MLPClassifier",
     "MLPRegressor",
     "CNNRegressor",
     "ResNetRegressor",
     "FCNRegressor",
-    #"LSTMFCNRegressor",
+    # "LSTMFCNRegressor",
     "MACNNRegressor",
     "CNTCClassifier",
     "CNTCRegressor",

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -29,7 +29,7 @@ EXCLUDE_ESTIMATORS = [
     "TapNetRegressor",
     "TapNetClassifier",
     "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
-    # "LSTMFCNClassifier",  # unknown cause, see bug report #4033
+    "LSTMFCNClassifier",  # unknown cause, see bug report #4033
     "TimeSeriesLloyds",  # an abstract class, but does not follow naming convention
     # DL classifier suspected to cause hangs and memouts, see #4610
     "FCNClassifier",
@@ -38,13 +38,13 @@ EXCLUDE_ESTIMATORS = [
     "CNNClassifier",
     "FCNClassifier",
     "InceptionTimeClassifier",
-    # "LSTMFCNClassifier",
+    "LSTMFCNClassifier",
     "MLPClassifier",
     "MLPRegressor",
     "CNNRegressor",
     "ResNetRegressor",
     "FCNRegressor",
-    # "LSTMFCNRegressor",
+    "LSTMFCNRegressor",
     "MACNNRegressor",
     "CNTCClassifier",
     "CNTCRegressor",

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -1233,8 +1233,8 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         new_params = fitted_est.get_params()
         # .get_params() returns an empty list for callback.
         # inconsistent with function initial run where callbacks was set to None
-        if new_params['callbacks'] == []:
-            new_params['callbacks'] = None
+        if new_params["callbacks"] == []:
+            new_params["callbacks"] = None
         for param_name, original_value in original_params.items():
             new_value = new_params[param_name]
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -1232,7 +1232,7 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         # Compare the state of the model parameters with the original parameters
         new_params = fitted_est.get_params()
         # .get_params() returns an empty list for callback.
-        # this is inconsistent with function initialisation where callbacks was set to None. 
+        # inconsistent with function initial run where callbacks was set to None
         if new_params['callbacks'] == []:
             new_params['callbacks'] = None
         for param_name, original_value in original_params.items():

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -1231,6 +1231,10 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
 
         # Compare the state of the model parameters with the original parameters
         new_params = fitted_est.get_params()
+        # .get_params() returns an empty list for callback.
+        # this is inconsistent with function initialisation where callbacks was set to None. 
+        if new_params['callbacks'] == []:
+            new_params['callbacks'] = None
         for param_name, original_value in original_params.items():
             new_value = new_params[param_name]
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -1231,10 +1231,6 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
 
         # Compare the state of the model parameters with the original parameters
         new_params = fitted_est.get_params()
-        # .get_params() returns an empty list for callback.
-        # inconsistent with function initial run where callbacks was set to None
-        if new_params["callbacks"] == []:
-            new_params["callbacks"] = None
         for param_name, original_value in original_params.items():
             new_value = new_params[param_name]
 


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
Fixes check_estimator for #6153 and partially solves it.
#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
It corrects the `test_fit_does_not_overwrite_hyper_params` by replacing the `callback = []` to `callback = None` as originally referenced.
![image](https://github.com/sktime/sktime/assets/38614120/ded77401-8e72-42f7-b058-6895bb71e618)

| Before Fix  | After Fix |
| ------------- | ------------- |
| ![image](https://github.com/sktime/sktime/assets/38614120/0318c7fe-26cb-49a4-8a10-10efcbe6e377)  |![image](https://github.com/sktime/sktime/assets/38614120/9a6fc3a8-09f0-448f-a736-6a3420eb4af6) |
| ![image](https://github.com/sktime/sktime/assets/38614120/0c1a2351-8486-4111-8d23-f1d624bf147f) | ![image](https://github.com/sktime/sktime/assets/38614120/8d30c67a-5a8e-451b-9e92-6347c2916c72)  |

Furthermore, to make sure that other code wasn't compromised I ran 2 more `check_estimator`
| Before Fix  | After Fix |
| ------------- | ------------- |
| ![image](https://github.com/sktime/sktime/assets/38614120/401367fa-998f-471b-b0a6-f8fc378e1f52) | ![image](https://github.com/sktime/sktime/assets/38614120/1321d38d-fa69-4379-9407-a953e2fd1fa6) |
|![image](https://github.com/sktime/sktime/assets/38614120/1688019e-c7d5-4d7c-98ff-8b14382c9913)| ![image](https://github.com/sktime/sktime/assets/38614120/ee220655-9dea-479a-ad03-9f5b89c73850)|


#### Does your contribution introduce a new dependency? If yes, which one?
NA
<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
