### PR TITLE
Mse fast

### DIFF
--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1360,10 +1360,42 @@ class MedianAbsoluteError(BaseForecastingErrorMetricFunc):
 
 class MeanSquaredError(BaseForecastingErrorMetricFunc):
     """Mean squared error (MSE) or root mean squared error (RMSE).
+   
+    For a univariate, non-hierarchical sample
+    of true values :math:`y_1, \dots, y_n` and
+    predicted values :math:`\widehat{y}_1, \dots, \widehat{y}_n` (in :math:`mathbb{R}`),
+    at time indices :math:`t_1, \dots, t_n`,
+    ``evaluate`` or call returns:
 
-    If ``square_root`` is False then calculates MSE and if ``square_root`` is True
-    then RMSE is calculated.  Both MSE and RMSE are both non-negative floating
-    point. The best value is 0.0.
+    * if ``square_root`` is False, the Mean Squared Error,
+      :math:`\frac{1}{n}\sum_{i=1}^n \left(y_i - \widehat{y}_i\right)^2`
+    * if ``square_root`` is True, the Root Mean Squared Error,
+      :math:`\sqrt{\frac{1}{n}\sum_{i=1}^n \left(y_i - \widehat{y}_i\right)^2}`
+
+    Both MSE and RMSE are both non-negative floating point, lower values are better.
+    The lowest possible value is 0.0.
+
+    ``multioutput`` and ``multilevel`` control averaging across variables and
+    hierarchy indices, see below. If ``square_root`` is True, averages
+    are taken over square roots of squared errors.
+
+    ``evaluate_by_index`` returns, at a time index :math:`t_i`:
+
+    * if ``square_root`` is False, the squared error at that time index,
+      the absolute error at that time index, :math:`\left(y_i - \widehat{y}_i\right)^2`,
+      for all time indices :math:`t_1, \dots, t_n` in the input.
+    * if ``square_root`` is True, the jackknife pseudo-value of the RMSE
+      at that time index, :math:`n * \bar{\varepsilon} - (n-1) * \varepsilon_i`,
+      where :math:`\bar{\varepsilon}` is the RMSE over all time indices,
+      and :math:`\varepsilon_i` is the RMSE with the i-th time index removed,
+      i.e., using values :math:`y_1, \dots, y_{i-1}, y_{i+1}, \dots, y_n`,
+      and :math:`\widehat{y}_1, \dots, \widehat{y}_{i-1}, \widehat{y}_{i+1}, \dots, \widehat{y}_n`.  # noqa: E501
+
+    MAE output is non-negative floating point. The best value is 0.0.
+
+    MAE is on the same scale as the data. Because MAE takes the absolute value
+    of the forecast error rather than squaring it, MAE penalizes large errors
+    to a lesser degree than MSE or RMSE.
 
     MSE is measured in squared units of the input data, and RMSE is on the
     same scale as the data. Because MSE and RMSE square the forecast error
@@ -1427,8 +1459,6 @@ class MeanSquaredError(BaseForecastingErrorMetricFunc):
     0.8936491673103708
     """
 
-    func = mean_squared_error
-
     def __init__(
         self,
         multioutput="uniform_average",
@@ -1437,6 +1467,102 @@ class MeanSquaredError(BaseForecastingErrorMetricFunc):
     ):
         self.square_root = square_root
         super().__init__(multioutput=multioutput, multilevel=multilevel)
+
+    def _evaluate(self, y_true, y_pred, **kwargs):
+        """Evaluate the desired metric on given inputs.
+
+        private _evaluate containing core logic, called from evaluate
+
+        By default this uses evaluate_by_index, taking arithmetic mean over time points.
+
+        Parameters
+        ----------
+        y_true : time series in sktime compatible data container format
+            Ground truth (correct) target values
+            y can be in one of the following formats:
+            Series scitype: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
+            Panel scitype: pd.DataFrame with 2-level row MultiIndex,
+                3D np.ndarray, list of Series pd.DataFrame, or nested pd.DataFrame
+            Hierarchical scitype: pd.DataFrame with 3 or more level row MultiIndex
+        y_pred :time series in sktime compatible data container format
+            Forecasted values to evaluate
+            must be of same format as y_true, same indices and columns if indexed
+
+        Returns
+        -------
+        loss : float or np.ndarray
+            Calculated metric, averaged or by variable.
+            float if self.multioutput="uniform_average" or array-like
+                value is metric averaged over variables (see class docstring)
+            np.ndarray of shape (y_true.columns,) if self.multioutput="raw_values"
+                i-th entry is metric calculated for i-th variable
+        """
+        multioutput = self.multioutput
+
+        raw_values = (y_true - y_pred)^2
+        msqe = raw_values.mean()
+
+        if self.square_root:
+            msqe = msqe.pow(0.5)
+
+        if isinstance(multioutput, str):
+            if multioutput == "raw_values":
+                return msqe
+
+            if multioutput == "uniform_average":
+                return msqe.mean()
+
+        # else, we expect multioutput to be array-like
+        return msqe.dot(multioutput)
+
+    def _evaluate_by_index(self, y_true, y_pred, **kwargs):
+        """Return the metric evaluated at each time point.
+
+        private _evaluate_by_index containing core logic, called from evaluate_by_index
+
+        Parameters
+        ----------
+        y_true : time series in sktime compatible pandas based data container format
+            Ground truth (correct) target values
+            y can be in one of the following formats:
+            Series scitype: pd.DataFrame
+            Panel scitype: pd.DataFrame with 2-level row MultiIndex
+            Hierarchical scitype: pd.DataFrame with 3 or more level row MultiIndex
+        y_pred :time series in sktime compatible data container format
+            Forecasted values to evaluate
+            must be of same format as y_true, same indices and columns if indexed
+
+        Returns
+        -------
+        loss : pd.Series or pd.DataFrame
+            Calculated metric, by time point (default=jackknife pseudo-values).
+            pd.Series if self.multioutput="uniform_average" or array-like
+                index is equal to index of y_true
+                entry at index i is metric at time i, averaged over variables
+            pd.DataFrame if self.multioutput="raw_values"
+                index and columns equal to those of y_true
+                i,j-th entry is metric at time i, at variable j
+        """
+        multioutput = self.multioutput
+
+        raw_values = (y_true - y_pred)^2
+
+        if self.square_root:
+            n = raw_values.shape[0]
+            rmse = raw_values.mean(axis=0)
+            pseudo_values = n * rmse - (n - 1) * raw_values
+        else:
+            pseudo_values = raw_values
+
+        if isinstance(multioutput, str):
+            if multioutput == "raw_values":
+                return pseudo_values
+
+            if multioutput == "uniform_average":
+                return pseudo_values.mean(axis=1)
+
+        # else, we expect multioutput to be array-like
+        return pseudo_values.dot(multioutput)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1358,7 +1358,7 @@ class MedianAbsoluteError(BaseForecastingErrorMetricFunc):
     func = median_absolute_error
 
 
-class MeanSquaredError(BaseForecastingErrorMetricFunc):
+class MeanSquaredError(BaseForecastingErrorMetric):
     """Mean squared error (MSE) or root mean squared error (RMSE).
    
     For a univariate, non-hierarchical sample

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1499,7 +1499,7 @@ class MeanSquaredError(BaseForecastingErrorMetricFunc):
         """
         multioutput = self.multioutput
 
-        raw_values = (y_true - y_pred)^2
+        raw_values = (y_true - y_pred)**2
         msqe = raw_values.mean()
 
         if self.square_root:
@@ -1545,7 +1545,7 @@ class MeanSquaredError(BaseForecastingErrorMetricFunc):
         """
         multioutput = self.multioutput
 
-        raw_values = (y_true - y_pred)^2
+        raw_values = (y_true - y_pred)**2
 
         if self.square_root:
             n = raw_values.shape[0]


### PR DESCRIPTION
Towards https://github.com/sktime/sktime/issues/4304

Efficient `_evaluate_by_index` for MSE and RMSE.

This PR is also meant to be a template for implementing `_evaluate_by_index` in cases where the metric is not the same as the mean of pseudo-values (i.e., the metric is not a mean loss) - this is the case for RMSE, which is not a mean due ot the root.