### PR TITLE
[ENH] make `get_examples` side effect safe via `deepcopy`

### DIFF
--- a/sktime/datatypes/_examples.py
+++ b/sktime/datatypes/_examples.py
@@ -13,6 +13,8 @@ the representation is considered "lossy" if the representation is incomplete
     e.g., metadata such as column names are missing
 """
 
+from copy import deepcopy
+
 from sktime.datatypes._registry import mtype_to_scitype
 
 __author__ = ["fkiraly"]
@@ -124,4 +126,5 @@ def get_examples(
         else:
             fixtures[k[2]] = example_dict.get(k)
 
-    return fixtures
+    # deepcopy to avoid side effects
+    return deepcopy(fixtures)


### PR DESCRIPTION
This PR makes `get_examples` safer against side effects on the data fixtures, by adding a `deepcopy` at the end.

This should prevent issues like in https://github.com/sktime/sktime/pull/6253#pullrequestreview-1983193029 from occurring in the future.