### PR TITLE
[DOC] author credits to `tslearn` authors

### DIFF
--- a/sktime/classification/distance_based/_time_series_neighbors_tslearn.py
+++ b/sktime/classification/distance_based/_time_series_neighbors_tslearn.py
@@ -4,7 +4,7 @@ from sktime.classification.base import BaseClassifier
 
 
 class KNeighborsTimeSeriesClassifierTslearn(_TslearnAdapter, BaseClassifier):
-    """K-nearest neighbors Time Series Classifier.
+    """K-nearest neighbors Time Series Classifier, from tslearn.
 
     Direct interface to ``tslearn.neighbors.KNeighborsTimeSeriesClassifier``.
 
@@ -60,7 +60,7 @@ class KNeighborsTimeSeriesClassifierTslearn(_TslearnAdapter, BaseClassifier):
     _tags = {
         # packaging info
         # --------------
-        "authors": "fkiraly",
+        "authors": ["rtavenar", "fkiraly"],  # rtavenar credit for interfaced code
         "python_dependencies": "tslearn",
         # estimator type
         # --------------

--- a/sktime/clustering/k_means/_k_means_tslearn.py
+++ b/sktime/clustering/k_means/_k_means_tslearn.py
@@ -6,7 +6,7 @@ from sktime.clustering.base import BaseClusterer
 
 
 class TimeSeriesKMeansTslearn(_TslearnAdapter, BaseClusterer):
-    """K-means clustering for time-series data.
+    """K-means clustering for time-series data, from tslearn.
 
     Direct interface to ``tslearn.clustering.TimeSeriesKMeans``.
 
@@ -102,7 +102,7 @@ class TimeSeriesKMeansTslearn(_TslearnAdapter, BaseClusterer):
     _tags = {
         # packaging info
         # --------------
-        "authors": "fkiraly",
+        "authors": ["rtavenar", "fkiraly"],  # rtavenar credit for interfaced code
         "python_dependencies": "tslearn",
         # estimator type
         # --------------

--- a/sktime/clustering/k_shapes.py
+++ b/sktime/clustering/k_shapes.py
@@ -9,7 +9,7 @@ from sktime.clustering.base import BaseClusterer
 
 
 class TimeSeriesKShapes(_TslearnAdapter, BaseClusterer):
-    """Kshape clustering for time series.
+    """K-shape clustering for time series, from tslearn.
 
     Direct interface to ``tslearn.clustering.KShape``.
 
@@ -52,7 +52,7 @@ class TimeSeriesKShapes(_TslearnAdapter, BaseClusterer):
     _tags = {
         # packaging info
         # --------------
-        "authors": "fkiraly",
+        "authors": ["rtavenar", "fkiraly"],  # rtavenar credit for interfaced code
         "python_dependencies": "tslearn",
         # estimator type
         # --------------

--- a/sktime/clustering/kernel_k_means.py
+++ b/sktime/clustering/kernel_k_means.py
@@ -9,7 +9,9 @@ from sktime.clustering.base import BaseClusterer
 
 
 class TimeSeriesKernelKMeans(_TslearnAdapter, BaseClusterer):
-    """Kernel algorithm wrapper tslearns implementation.
+    """Kernel k-means clustering, from tslearn.
+
+    Direct interface to ``tslearn.clustering.KernelKMeans``.
 
     Parameters
     ----------
@@ -67,7 +69,7 @@ class TimeSeriesKernelKMeans(_TslearnAdapter, BaseClusterer):
     _tags = {
         # packaging info
         # --------------
-        "authors": "fkiraly",
+        "authors": ["rtavenar", "fkiraly"],  # rtavenar credit for interfaced code
         "python_dependencies": "tslearn",
         # estimator type
         # --------------

--- a/sktime/dists_kernels/ctw.py
+++ b/sktime/dists_kernels/ctw.py
@@ -53,7 +53,8 @@ class CtwDistTslearn(_TslearnPwTrafoAdapter, BasePairwiseTransformerPanel):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["fkiraly"],
+        "authors": ["rtavenar", "ysoullard", "chusloj", "fkiraly"],
+        # rtavenar, ysoullard, chusloj credit for interfaced code
         "python_dependencies": ["tslearn"],
         # estimator type
         # --------------

--- a/sktime/dists_kernels/dtw/_dtw_tslearn.py
+++ b/sktime/dists_kernels/dtw/_dtw_tslearn.py
@@ -53,7 +53,7 @@ class DtwDistTslearn(_TslearnPwTrafoAdapter, BasePairwiseTransformerPanel):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["rtavenar", "yanncabanees", "fkiraly"],
+        "authors": ["rtavenar", "yanncabanes", "fkiraly"],
         # rtavenar, yanncabanes credit for interfaced code
         "python_dependencies": ["tslearn"],
         # estimator type

--- a/sktime/dists_kernels/dtw/_dtw_tslearn.py
+++ b/sktime/dists_kernels/dtw/_dtw_tslearn.py
@@ -53,7 +53,8 @@ class DtwDistTslearn(_TslearnPwTrafoAdapter, BasePairwiseTransformerPanel):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["fkiraly"],
+        "authors": ["rtavenar", "yanncabanees", "fkiraly"],
+        # rtavenar, yanncabanes credit for interfaced code
         "python_dependencies": ["tslearn"],
         # estimator type
         # --------------

--- a/sktime/dists_kernels/gak.py
+++ b/sktime/dists_kernels/gak.py
@@ -37,7 +37,8 @@ class GAKernel(_TslearnPwTrafoAdapter, BasePairwiseTransformerPanel):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["fkiraly"],
+        "authors": ["rtavenar", "yanncabanes", "fkiraly"],
+        # rtavenar, yanncabanes credit for interfaced code
         "python_dependencies": ["tslearn"],
         # estimator type
         # --------------

--- a/sktime/dists_kernels/lcss.py
+++ b/sktime/dists_kernels/lcss.py
@@ -47,7 +47,7 @@ class LcssTslearn(_TslearnPwTrafoAdapter, BasePairwiseTransformerPanel):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["fkiraly"],
+        "authors": ["danisodu", "rtavenar", "fkiraly"],
         "python_dependencies": ["tslearn"],
         # estimator type
         # --------------


### PR DESCRIPTION
With increased visibility of the authors field in the docs (e.g., in the reworked [estimator overview](https://www.sktime.net/en/latest/estimator_overview.html)), we should make sure it properly reflects contribution. Also see #5938.

This adds upstream authors to the author fields of interfaced estimators from `tslearn` - based on best guesses inferred from author strings and commit history.

FYI @rtavenar, @yanncabanes, @chusloj, @danisodu. Please let us know if we are missing anything or anyone.
Please feel free to claim maintainer role for any of the algorithms if you want.

