### PR TITLE
[DOC] author credits to `pyts` authors

### DIFF
--- a/sktime/classification/distance_based/_time_series_neighbors_pyts.py
+++ b/sktime/classification/distance_based/_time_series_neighbors_pyts.py
@@ -76,7 +76,7 @@ class KNeighborsTimeSeriesClassifierPyts(_PytsAdapter, BaseClassifier):
     _tags = {
         # packaging info
         # --------------
-        "authors": "fkiraly",
+        "authors": ["johannfaouzi", "fkiraly"],  # johannfaouzi is author of upstream
         "python_dependencies": "pyts",
         # estimator type
         # --------------

--- a/sktime/transformations/panel/rocket/_rocket_pyts.py
+++ b/sktime/transformations/panel/rocket/_rocket_pyts.py
@@ -87,7 +87,7 @@ class RocketPyts(_PytsAdapter, BaseTransformer):
     _tags = {
         # packaging info
         # --------------
-        "authors": "fkiraly",
+        "authors": ["johannfaouzi", "fkiraly"],  # johannfaouzi is author of upstream
         "python_dependencies": "pyts",
         # estimator type
         # --------------

--- a/sktime/transformations/panel/shapelet_transform/_shapelet_transform_pyts.py
+++ b/sktime/transformations/panel/shapelet_transform/_shapelet_transform_pyts.py
@@ -123,7 +123,8 @@ class ShapeletTransformPyts(_PytsAdapter, BaseTransformer):
     _tags = {
         # packaging info
         # --------------
-        "authors": "Abhay-Lejith",
+        "authors": ["johannfaouzi", "Abhay-Lejith"],
+        # johannfaouzi is author of upstream pyts code
         "python_dependencies": "pyts",
         # univariate-only controls whether internal X can be univariate/multivariate
         # if True (only univariate), always applies vectorization over variables


### PR DESCRIPTION
With increased visibility of the authors field in the docs (e.g., in the reworked [estimator overview](https://www.sktime.net/en/latest/estimator_overview.html)), we should make sure it properly reflects contribution. Also see #5938.

This adds upstream authors to the author fields of interfaced estimators from `pyts` - based on best guesses inferred from author strings and commit history.

FYI @johannfaouzi. Please let us know if we are missing anything or anyone.
Please feel free to claim maintainer role for any of the algorithms if you want.