### PR TITLE
[MNT] fix isolation of `mlflow` soft dependencies

### DIFF
--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -55,8 +55,8 @@ from sktime.utils.multiindex import flatten_multiindex
 from sktime.utils.validation._dependencies import _check_mlflow_dependencies
 
 if _check_mlflow_dependencies(severity="warning"):
-    from mlflow import pyfunc
     import yaml
+    from mlflow import pyfunc
 
 FLAVOR_NAME = "mlflow_sktime"
 

--- a/sktime/utils/mlflow_sktime.py
+++ b/sktime/utils/mlflow_sktime.py
@@ -47,7 +47,6 @@ import logging
 import os
 
 import pandas as pd
-import yaml
 
 import sktime
 from sktime import utils
@@ -57,6 +56,7 @@ from sktime.utils.validation._dependencies import _check_mlflow_dependencies
 
 if _check_mlflow_dependencies(severity="warning"):
     from mlflow import pyfunc
+    import yaml
 
 FLAVOR_NAME = "mlflow_sktime"
 


### PR DESCRIPTION
It seems the fix #6282 caused another issue - I believe the reason is that `dask` removed `pyyaml` as a dependency.

Consequently, the `import yaml` statement in the mlflow module now fails, post #6282. Unclear why the tests did not recognize this.

The fix should be this: import `yaml` only if `mlflow` is present.