### PR TITLE
[ENH] TBATS test parameters to cover doc example

### DIFF
--- a/sktime/forecasting/tbats.py
+++ b/sktime/forecasting/tbats.py
@@ -153,4 +153,12 @@ class TBATS(_TbatsAdapter):
             "use_arma_errors": True,
             "n_jobs": 2,
         }
-        return [params1, params2]
+        params3 = {
+            "use_box_cox": False,
+            "use_trend": False,
+            "use_damped_trend": False,
+            "sp": 3,
+            "use_arma_errors": False,
+            "n_jobs": 1,
+        }
+        return [params1, params2, params3]


### PR DESCRIPTION
This adds one test parameter set to the `TBATS` forecaster to cover the doc example.