### PR TITLE
[BUG] Fix backfill of custom function in window_feature

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2765,6 +2765,17 @@
         "code",
         "doc"
       ]
+    },
+    {
+      "login": "toandaominh1997",
+      "name": "Henry Dao",
+      "avatar_url": "https://avatars.githubusercontent.com/u/18400648?v=4",
+      "profile": "https://github.com/toandaominh1997",
+      "contributions": [
+        "bug",
+        "code",
+        "test"
+      ]
     }
   ]
 }

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -451,7 +451,7 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
     """
     lag = window[0]
     window_length = window[1]
-
+    feat = Z
     if summarizer in pd_rolling:
         if isinstance(Z, pd.core.groupby.generic.SeriesGroupBy):
             if bfill is False:
@@ -487,7 +487,7 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
                     .bfill()
                 )
     else:
-        feat = Z
+      
         if isinstance(Z, pd.core.groupby.generic.SeriesGroupBy) and callable(
             summarizer
         ):

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -500,9 +500,9 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
                 ).apply(summarizer, raw=True)
             )
         if bfill is False:
-            feat = Z.shift(lag)
+            feat = feat.shift(lag)
         else:
-            feat = Z.shift(lag).bfill()
+            feat = feat.shift(lag).bfill()
 
         feat = pd.DataFrame(feat)
     if bfill is True:

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -487,6 +487,7 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
                     .bfill()
                 )
     else:
+        feat = Z
         if isinstance(Z, pd.core.groupby.generic.SeriesGroupBy) and callable(
             summarizer
         ):
@@ -499,14 +500,15 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
                     window=window_length, min_periods=window_length
                 ).apply(summarizer, raw=True)
             )
-        if bfill is False:
-            feat = feat.shift(lag)
         else:
-            feat = feat.shift(lag).bfill()
+            ValueError("The provided summarizer is not callable. Ensure that the summarizer argument is a function or an object that implements the __call__ method.")
+        
+        if bfill == True:
+          feat = feat.shift(lag).bfill()
+        else:
+          feat = feat.shift(lag)
 
         feat = pd.DataFrame(feat)
-    if bfill is True:
-        feat = feat.bfill()
 
     if callable(summarizer):
         name = summarizer.__name__

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -451,7 +451,6 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
     """
     lag = window[0]
     window_length = window[1]
-    feat = Z
     if summarizer in pd_rolling:
         if isinstance(Z, pd.core.groupby.generic.SeriesGroupBy):
             if bfill is False:
@@ -487,7 +486,7 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
                     .bfill()
                 )
     else:
-      
+        feat = Z
         if isinstance(Z, pd.core.groupby.generic.SeriesGroupBy) and callable(
             summarizer
         ):

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -451,62 +451,28 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
     """
     lag = window[0]
     window_length = window[1]
+    feat: pd.DataFrame = pd.DataFrame()
     if summarizer in pd_rolling:
-        if isinstance(Z, pd.core.groupby.generic.SeriesGroupBy):
-            if bfill is False:
-                feat = getattr(
-                    Z.shift(lag).rolling(
-                        window=window_length, min_periods=window_length
-                    ),
-                    summarizer,
-                )()
-            else:
-                feat = getattr(
-                    Z.shift(lag)
-                    .bfill()
-                    .rolling(window=window_length, min_periods=window_length),
-                    summarizer,
-                )()
-            feat = pd.DataFrame(feat)
-        else:
-            if bfill is False:
-                feat = Z.apply(
-                    lambda x: getattr(
-                        x.rolling(window=window_length, min_periods=window_length),
-                        summarizer,
-                    )().shift(lag)
-                )
-            else:
-                feat = Z.apply(
-                    lambda x: getattr(
-                        x.rolling(window=window_length, min_periods=window_length),
-                        summarizer,
-                    )()
-                    .shift(lag)
-                    .bfill()
-                )
+        feat = Z.transform(
+            lambda x: getattr(
+                x.rolling(window=window_length, min_periods=window_length), summarizer
+            )().shift(lag)
+        )
+    elif summarizer == "lag":
+        feat = Z.transform(lambda x: x.shift(lag))
+    elif callable(summarizer):
+        feat = Z.transform(
+            lambda x: x.rolling(window=window_length, min_periods=window_length)
+            .apply(summarizer, raw=True)
+            .shift(lag)
+        )
     else:
-        feat = Z
-        if isinstance(Z, pd.core.groupby.generic.SeriesGroupBy) and callable(
-            summarizer
-        ):
-            feat = Z.rolling(window_length).apply(summarizer, raw=True)
-        elif not isinstance(Z, pd.core.groupby.generic.SeriesGroupBy) and callable(
-            summarizer
-        ):
-            feat = Z.apply(
-                lambda x: x.rolling(
-                    window=window_length, min_periods=window_length
-                ).apply(summarizer, raw=True)
-            )
-        else:
-            ValueError("The provided summarizer is not callable.")
-        if bfill is True:
-            feat = feat.shift(lag).bfill()
-        else:
-            feat = feat.shift(lag)
+        raise ValueError("The provided summarizer is not callable.")
+    feat = pd.DataFrame(feat)
 
-        feat = pd.DataFrame(feat)
+    # Handle backfill
+    if bfill is True:
+        feat = feat.bfill()
 
     if callable(summarizer):
         name = summarizer.__name__

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -500,12 +500,11 @@ def _window_feature(Z, summarizer=None, window=None, bfill=False):
                 ).apply(summarizer, raw=True)
             )
         else:
-            ValueError("The provided summarizer is not callable. Ensure that the summarizer argument is a function or an object that implements the __call__ method.")
-        
-        if bfill == True:
-          feat = feat.shift(lag).bfill()
+            ValueError("The provided summarizer is not callable.")
+        if bfill is True:
+            feat = feat.shift(lag).bfill()
         else:
-          feat = feat.shift(lag)
+            feat = feat.shift(lag)
 
         feat = pd.DataFrame(feat)
 

--- a/sktime/transformations/series/tests/test_window_summarizer.py
+++ b/sktime/transformations/series/tests/test_window_summarizer.py
@@ -198,12 +198,22 @@ def test_wrong_column():
 
 def count_unique(x):
     return len(np.unique(x))
-
+def count_greater_zero(x):
+    return np.sum((x>0)[::-1])
 
 kwargs_custom_function = {
     "lag_feature": {
         count_unique: [[1, 2]],
     }
+}
+
+kwargs_lag_custom_function = {
+    "lag_feature": {
+        count_unique: [[1, 2]],
+        count_greater_zero: [[1, 3]],
+        "lag": [1],
+        "sum": [[1, 2]],
+    },
 }
 
 
@@ -215,6 +225,20 @@ kwargs_custom_function = {
             ["a_count_unique_1_2"],
             y_pd,
             pd.DataFrame({"a_count_unique_1_2": [np.NAN, np.NAN, 2.0, 2.0]}),
+            None,
+            None,
+        ),
+        (
+            kwargs_lag_custom_function,
+            ["a_count_unique_1_2", "a_count_greater_zero_1_3", "a_lag_1", "a_sum_1_2"],
+            y_pd,
+            pd.DataFrame({
+                "a_count_unique_1_2": [np.NAN, np.NAN, 2.0, 2.0],
+                "a_count_greater_zero_1_3": [np.NAN, np.NAN, np.NAN, 3.0],
+                "a_lag_1": [np.NAN, 1.0, 4.0, 0.5],
+                "a_sum_1_2": [np.NAN, np.NAN, 5.0, 4.5]
+                }
+            ),
             None,
             None,
         ),

--- a/sktime/transformations/series/tests/test_window_summarizer.py
+++ b/sktime/transformations/series/tests/test_window_summarizer.py
@@ -195,21 +195,34 @@ def test_wrong_column():
     Xt = transformer.fit_transform(X_ll_train)
     return Xt
 
+
 def count_unique(x):
     return len(np.unique(x))
+
+
 kwargs_custom_function = {
     "lag_feature": {
         count_unique: [[1, 2]],
     }
-
 }
+
+
 @pytest.mark.parametrize(
     "kwargs, column_names, y, x_transform, target_cols, truncate",
     [
-        (kwargs_custom_function, ["a_count_unique_1_2"], y_pd, pd.DataFrame({"a_count_unique_1_2": [np.NAN, np.NAN, 2.0, 2.0]}), None, None),
-    ]
+        (
+            kwargs_custom_function,
+            ["a_count_unique_1_2"],
+            y_pd,
+            pd.DataFrame({"a_count_unique_1_2": [np.NAN, np.NAN, 2.0, 2.0]}),
+            None,
+            None,
+        ),
+    ],
 )
-def test_windowsummarizer_with_output(kwargs, column_names, y, x_transform, target_cols, truncate):
+def test_windowsummarizer_with_output(
+    kwargs, column_names, y, x_transform, target_cols, truncate
+):
     """Test x_transform match kwargs arguments."""
     if kwargs is not None:
         transformer = WindowSummarizer(
@@ -219,5 +232,3 @@ def test_windowsummarizer_with_output(kwargs, column_names, y, x_transform, targ
         transformer = WindowSummarizer(target_cols=target_cols, truncate=truncate)
     Xt = transformer.fit_transform(y)
     pd.testing.assert_frame_equal(Xt, x_transform)
-   
-

--- a/sktime/transformations/series/tests/test_window_summarizer.py
+++ b/sktime/transformations/series/tests/test_window_summarizer.py
@@ -194,3 +194,30 @@ def test_wrong_column():
     transformer = WindowSummarizer(target_cols=["dummy"])
     Xt = transformer.fit_transform(X_ll_train)
     return Xt
+
+def count_unique(x):
+  return len(np.unique(x))
+kwargs_custom_function = {
+    "lag_feature": {
+        count_unique: [[1, 2]],
+    }
+
+}
+@pytest.mark.parametrize(
+    "kwargs, column_names, y, x_transform, target_cols, truncate",
+    [
+        (kwargs_custom_function, ["a_count_unique_1_2"], y_pd, pd.DataFrame({"a_count_unique_1_2": [np.NAN, np.NAN, 2.0, 2.0]}), None, None),
+    ]
+)
+def test_windowsummarizer_with_output(kwargs, column_names, y, x_transform, target_cols, truncate):
+    """Test x_transform match kwargs arguments."""
+    if kwargs is not None:
+        transformer = WindowSummarizer(
+            **kwargs, target_cols=target_cols, truncate=truncate
+        )
+    else:
+        transformer = WindowSummarizer(target_cols=target_cols, truncate=truncate)
+    Xt = transformer.fit_transform(y)
+    pd.testing.assert_frame_equal(Xt, x_transform)
+   
+

--- a/sktime/transformations/series/tests/test_window_summarizer.py
+++ b/sktime/transformations/series/tests/test_window_summarizer.py
@@ -196,7 +196,7 @@ def test_wrong_column():
     return Xt
 
 def count_unique(x):
-  return len(np.unique(x))
+    return len(np.unique(x))
 kwargs_custom_function = {
     "lag_feature": {
         count_unique: [[1, 2]],

--- a/sktime/transformations/series/tests/test_window_summarizer.py
+++ b/sktime/transformations/series/tests/test_window_summarizer.py
@@ -198,8 +198,11 @@ def test_wrong_column():
 
 def count_unique(x):
     return len(np.unique(x))
+
+
 def count_greater_zero(x):
-    return np.sum((x>0)[::-1])
+    return np.sum((x > 0)[::-1])
+
 
 kwargs_custom_function = {
     "lag_feature": {
@@ -218,7 +221,7 @@ kwargs_lag_custom_function = {
 
 
 @pytest.mark.parametrize(
-    "kwargs, column_names, y, x_transform, target_cols, truncate",
+    "kwargs, column_names, y, X, target_cols, truncate",
     [
         (
             kwargs_custom_function,
@@ -232,22 +235,80 @@ kwargs_lag_custom_function = {
             kwargs_lag_custom_function,
             ["a_count_unique_1_2", "a_count_greater_zero_1_3", "a_lag_1", "a_sum_1_2"],
             y_pd,
-            pd.DataFrame({
-                "a_count_unique_1_2": [np.NAN, np.NAN, 2.0, 2.0],
-                "a_count_greater_zero_1_3": [np.NAN, np.NAN, np.NAN, 3.0],
-                "a_lag_1": [np.NAN, 1.0, 4.0, 0.5],
-                "a_sum_1_2": [np.NAN, np.NAN, 5.0, 4.5]
-                }
+            pd.DataFrame(
+                {
+                    "a_count_unique_1_2": [np.NAN, np.NAN, 2.0, 2.0],
+                    "a_count_greater_zero_1_3": [np.NAN, np.NAN, np.NAN, 3.0],
+                    "a_lag_1": [np.NAN, 1.0, 4.0, 0.5],
+                    "a_sum_1_2": [np.NAN, np.NAN, 5.0, 4.5],
+                },
             ),
             None,
+            None,
+        ),
+        (
+            kwargs_lag_custom_function,
+            ["a_count_unique_1_2", "a_count_greater_zero_1_3", "a_lag_1", "a_sum_1_2"],
+            y_multi,
+            pd.DataFrame(
+                {
+                    "var_0_count_unique_1_2": [
+                        np.NAN,
+                        np.NAN,
+                        2.0,
+                        np.NAN,
+                        np.NAN,
+                        2.0,
+                        np.NAN,
+                        np.NAN,
+                        2.0,
+                    ],
+                    "var_0_count_greater_zero_1_3": [
+                        np.NAN,
+                        np.NAN,
+                        np.NAN,
+                        np.NAN,
+                        np.NAN,
+                        np.NAN,
+                        np.NAN,
+                        np.NAN,
+                        np.NAN,
+                    ],
+                    "var_0_lag_1": [
+                        np.NAN,
+                        1.0,
+                        2.0,
+                        np.NAN,
+                        1.0,
+                        2.0,
+                        np.NAN,
+                        1.0,
+                        2.0,
+                    ],
+                    "var_0_sum_1_2": [
+                        np.NAN,
+                        np.NAN,
+                        3.0,
+                        np.NAN,
+                        np.NAN,
+                        3.0,
+                        np.NAN,
+                        np.NAN,
+                        3.0,
+                    ],
+                    "var_1": y_multi["var_1"],
+                },
+                index=y_multi.index,
+            ),
+            ["var_0"],
             None,
         ),
     ],
 )
 def test_windowsummarizer_with_output(
-    kwargs, column_names, y, x_transform, target_cols, truncate
+    kwargs, column_names, y, X, target_cols, truncate
 ):
-    """Test x_transform match kwargs arguments."""
+    """Test X match kwargs arguments."""
     if kwargs is not None:
         transformer = WindowSummarizer(
             **kwargs, target_cols=target_cols, truncate=truncate
@@ -255,4 +316,7 @@ def test_windowsummarizer_with_output(
     else:
         transformer = WindowSummarizer(target_cols=target_cols, truncate=truncate)
     Xt = transformer.fit_transform(y)
-    pd.testing.assert_frame_equal(Xt, x_transform)
+    pd.testing.assert_frame_equal(Xt, X)
+
+    # Checking for duplicate index names
+    assert len(set(Xt.index.names)) == len(X.index.names)


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
"In this implementation, within the _window_feature function, if the summarizer is a callable function, it will perform a rolling operation and apply the custom function. However, in the backfill stage, which the previous author set up to use 'Z' for backfilling, the custom function is not applied.
#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
