### PR TITLE
[DOC] author credits to `pycatch22` authors, fix missing documentation page

### DIFF
--- a/docs/source/api_reference/transformations.rst
+++ b/docs/source/api_reference/transformations.rst
@@ -224,6 +224,14 @@ These transformers extract larger collections of features.
 
     Catch22
 
+.. currentmodule:: sktime.transformations.panel.catch22wrapper
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    Catch22Wrapper
+
 Series-to-series transformers
 -----------------------------
 

--- a/sktime/transformations/panel/catch22wrapper.py
+++ b/sktime/transformations/panel/catch22wrapper.py
@@ -60,7 +60,8 @@ class Catch22Wrapper(BaseTransformer):
 
     See Also
     --------
-    Catch22 Catch22Classifier
+    Catch22
+    Catch22Classifier
 
     References
     ----------

--- a/sktime/transformations/panel/catch22wrapper.py
+++ b/sktime/transformations/panel/catch22wrapper.py
@@ -14,7 +14,7 @@ from sktime.transformations.panel import catch22
 
 
 class Catch22Wrapper(BaseTransformer):
-    """Canonical Time-series Characteristics (Catch22) C Wrapper.
+    """Canonical Time-series Characteristics (Catch22), using pycatch22 package.
 
     Wraps the pycatch22 implementation for sktime
     (https://github.com/DynamicsAndNeuralSystems/pycatch22).
@@ -74,8 +74,8 @@ class Catch22Wrapper(BaseTransformer):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["MatthewMiddlehurst", "fkiraly"],
-        "maintainers": "benfulcher",
+        "authors": ["benfulcher", "jmoo2800", "MatthewMiddlehurst", "fkiraly"],
+        "maintainers": ["benfulcher", "jmoo2800"],
         "python_dependencies": "pycatch22",
         # estimator type
         # --------------

--- a/sktime/transformations/panel/catch22wrapper.py
+++ b/sktime/transformations/panel/catch22wrapper.py
@@ -74,8 +74,8 @@ class Catch22Wrapper(BaseTransformer):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["benfulcher", "jmoo2800", "MatthewMiddlehurst", "fkiraly"],
-        "maintainers": ["benfulcher", "jmoo2800"],
+        "authors": ["benfulcher", "jmoo2880", "MatthewMiddlehurst", "fkiraly"],
+        "maintainers": ["benfulcher", "jmoo2880"],
         "python_dependencies": "pycatch22",
         # estimator type
         # --------------

--- a/sktime/transformations/panel/catch22wrapper.py
+++ b/sktime/transformations/panel/catch22wrapper.py
@@ -14,9 +14,10 @@ from sktime.transformations.panel import catch22
 
 
 class Catch22Wrapper(BaseTransformer):
-    """Canonical Time-series Characteristics (Catch22), using pycatch22 package.
+    """Canonical Time-series Characteristics (Catch22 and 24), using pycatch22 package.
 
-    Wraps the pycatch22 implementation for sktime
+    Direct interface to the ``pycatch22`` implementation of Catch-22 and Catch-24
+    feature sets
     (https://github.com/DynamicsAndNeuralSystems/pycatch22).
 
     Overview: Input n series with d dimensions of length m


### PR DESCRIPTION
With increased visibility of the authors field in the docs (e.g., in the reworked [estimator overview](https://www.sktime.net/en/latest/estimator_overview.html)), we should make sure it properly reflects contribution. Also see #5938.

This adds upstream authors to the author field of the `pycatch22` facing transformation, and gives clearer credit to `pycatch22` in the docstring by naming it.

It also appears that the estimator was never added to the public documentation page, and only the copy/reimplementation was visible there - I apologize for that, this dates back to old history of `sktime`, and was certainly not intentional on my part.

The author credits add @benfulcher and @jmoo2880. The maintainer tag had @benfulcher, so based on recent contribution activity I added @jmoo2880. Please correct me if this assumption of co-maintainership is wrong.