### PR TITLE
[BUG] fix dependent tags of `TimeSeriesDBSCAN`

### DIFF
--- a/sktime/clustering/dbscan.py
+++ b/sktime/clustering/dbscan.py
@@ -104,6 +104,15 @@ class TimeSeriesDBSCAN(BaseClusterer):
             ]
             self.clone_tags(distance, tags_to_clone)
 
+        # numba distance in sktime (indexed by string)
+        # cannot support unequal length data, and require numpy3D input
+        if isinstance(distance, str):
+            tags_to_set = {
+                "X_inner_mtype": "numpy3D",
+                "capability:unequal_length": False,
+            }
+            self.set_tags(**tags_to_set)
+
         self.dbscan_ = None
 
     def _fit(self, X, y=None):

--- a/sktime/dists_kernels/dtw/_dtw_sktime.py
+++ b/sktime/dists_kernels/dtw/_dtw_sktime.py
@@ -131,6 +131,7 @@ class DtwDist(BasePairwiseTransformerPanel):
         # --------------
         "symmetric": True,  # all the distances are symmetric
         "X_inner_mtype": "numpy3D",
+        "capability:unequal_length": False,  # can dist handle unequal length panels?
     }
 
     def __init__(

--- a/sktime/dists_kernels/edit_dist.py
+++ b/sktime/dists_kernels/edit_dist.py
@@ -123,6 +123,7 @@ class EditDist(BasePairwiseTransformerPanel):
         # --------------
         "symmetric": True,  # all the distances are symmetric
         "X_inner_mtype": "numpy3D",
+        "capability:unequal_length": False,  # can dist handle unequal length panels?
     }
 
     ALLOWED_DISTANCE_STR = ["lcss", "edr", "erp", "twe"]


### PR DESCRIPTION
`TimeSeriesDBSCAN` does not set its tags correctly if one of the `numba` based distance in `sktime` is used. In this case, it cannot support unequal length time series, and the corresponding tag needs to be set.

Similarly, the tags for some of the `numba` distances were set incorrectly, which is now corrected as well.