### PR TITLE
[BUG] fix `var` of `Laplace` distribution

### DIFF
--- a/sktime/proba/laplace.py
+++ b/sktime/proba/laplace.py
@@ -111,7 +111,7 @@ class Laplace(BaseDistribution):
         pd.DataFrame with same rows, columns as `self`
         variance of distribution (entry-wise)
         """
-        sd_arr = self._scale / np.sqrt(2)
+        sd_arr = self._scale * np.sqrt(2)
         return pd.DataFrame(sd_arr, index=self.index, columns=self.columns) ** 2
 
     def pdf(self, x):


### PR DESCRIPTION
Fixes an unreported bug: the variance method `var` of the `Laplace` distribution was returning scale parameter divided by $\sqrt{2}$. However, instead, the scale parameter should be multiplied by $\sqrt{2}$.