### PR TITLE
[DOC] in extension templates, clarify handling of soft dependencies

### DIFF
--- a/extension_templates/alignment.py
+++ b/extension_templates/alignment.py
@@ -46,10 +46,12 @@ from sktime.alignment.base import BaseAligner
 
 # todo: add any necessary imports here
 
-# todo: if any imports are sktime soft dependencies:
+# todo: for imports of sktime soft dependencies:
 # make sure to fill in the "python_dependencies" tag with the package import name
+# import soft dependencies only inside methods of the class, not at the top of the file
 
 
+# todo: change class name and write docstring
 class MyAligner(BaseAligner):
     """Custom time series aligner. todo: write docstring.
 

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -46,10 +46,12 @@ from sktime.classification.base import BaseClassifier
 
 # todo: add any necessary imports here
 
-# todo: if any imports are sktime soft dependencies:
+# todo: for imports of sktime soft dependencies:
 # make sure to fill in the "python_dependencies" tag with the package import name
+# import soft dependencies only inside methods of the class, not at the top of the file
 
 
+# todo: change class name and write docstring
 class MyTimeSeriesClassifier(BaseClassifier):
     """Custom time series classifier. todo: write docstring.
 

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -44,7 +44,12 @@ from sktime.clustering import BaseClusterer
 
 # todo: add any necessary imports here
 
+# todo: for imports of sktime soft dependencies:
+# make sure to fill in the "python_dependencies" tag with the package import name
+# import soft dependencies only inside methods of the class, not at the top of the file
 
+
+# todo: change class name and write docstring
 class MyClusterer(BaseClusterer):
     """Custom clusterer. todo: write docstring.
 

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -27,10 +27,12 @@ from sktime.dists_kernels import BasePairwiseTransformerPanel
 
 # todo: add any necessary imports here
 
-# todo: if any imports are sktime soft dependencies:
+# todo: for imports of sktime soft dependencies:
 # make sure to fill in the "python_dependencies" tag with the package import name
+# import soft dependencies only inside methods of the class, not at the top of the file
 
 
+# todo: change class name and write docstring
 class MyTrafoPwPanel(BasePairwiseTransformerPanel):
     """Custom time series distance/kernel. todo: write docstring.
 

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -27,10 +27,12 @@ from sktime.dists_kernels import BasePairwiseTransformer
 
 # todo: add any necessary imports here
 
-# todo: if any imports are sktime soft dependencies:
+# todo: for imports of sktime soft dependencies:
 # make sure to fill in the "python_dependencies" tag with the package import name
+# import soft dependencies only inside methods of the class, not at the top of the file
 
 
+# todo: change class name and write docstring
 class MyTrafoPw(BasePairwiseTransformer):
     """Custom distance/kernel (on data frame rows). todo: write docstring.
 

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -48,10 +48,12 @@ from sktime.forecasting.base import BaseForecaster
 
 # todo: add any necessary imports here
 
-# todo: if any imports are sktime soft dependencies:
+# todo: for imports of sktime soft dependencies:
 # make sure to fill in the "python_dependencies" tag with the package import name
+# import soft dependencies only inside methods of the class, not at the top of the file
 
 
+# todo: change class name and write docstring
 class MyForecaster(BaseForecaster):
     """Custom forecaster. todo: write docstring.
 

--- a/extension_templates/param_est.py
+++ b/extension_templates/param_est.py
@@ -35,10 +35,12 @@ from sktime.param_est.base import BaseParamFitter
 
 # todo: add any necessary imports here
 
-# todo: if any imports are sktime soft dependencies:
+# todo: for imports of sktime soft dependencies:
 # make sure to fill in the "python_dependencies" tag with the package import name
+# import soft dependencies only inside methods of the class, not at the top of the file
 
 
+# todo: change class name and write docstring
 class MyTimeSeriesParamFitter(BaseParamFitter):
     """Custom time series parameter fitter. todo: write docstring.
 

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -43,10 +43,12 @@ from sktime.split.base import BaseSplitter
 
 # todo: add any necessary imports here
 
-# todo: if any imports are sktime soft dependencies:
+# todo: for imports of sktime soft dependencies:
 # make sure to fill in the "python_dependencies" tag with the package import name
+# import soft dependencies only inside methods of the class, not at the top of the file
 
 
+# todo: change class name and write docstring
 class MySplitter(BaseSplitter):
     """Custom splitter. todo: write docstring.
 

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -46,10 +46,12 @@ from sktime.transformations.base import BaseTransformer
 
 # todo: add any necessary sktime internal imports here
 
-# todo: if any imports are sktime soft dependencies:
+# todo: for imports of sktime soft dependencies:
 # make sure to fill in the "python_dependencies" tag with the package import name
+# import soft dependencies only inside methods of the class, not at the top of the file
 
 
+# todo: change class name and write docstring
 class MyTransformer(BaseTransformer):
     """Custom transformer. todo: write docstring.
 


### PR DESCRIPTION
Clarifies handling of soft dependencies in extension templates.

This concerns all extension templates except the "simple" templates, where no soft dependencies of the estimator are assumed.