### PR TITLE
[BUG] fixed indexing of return in `TSBootstrapAdapter`

### DIFF
--- a/sktime/transformations/bootstrap/_tsbootstrap.py
+++ b/sktime/transformations/bootstrap/_tsbootstrap.py
@@ -39,6 +39,12 @@ class TSBootstrapAdapter(BaseTransformer):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": "benheid",
+        "python_dependencies": ["tsbootstrap>=0.1.0"],
+        # estimator type
+        # --------------
         "scitype:transform-input": "Series",
         "scitype:transform-output": "Panel",
         "scitype:instancewise": True,  # is this an instance-wise transform?
@@ -51,8 +57,7 @@ class TSBootstrapAdapter(BaseTransformer):
         "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
         "enforce_index_type": None,  # index type that needs to be enforced in X/y
         "fit_is_empty": True,  # is fit empty and can be skipped? Yes = True
-        "transform-returns-same-time-index": False,
-        "python_dependencies": ["tsbootstrap>=0.1.0"],
+        "transform-returns-same-time-index": True,
     }
 
     def __init__(

--- a/sktime/transformations/bootstrap/_tsbootstrap.py
+++ b/sktime/transformations/bootstrap/_tsbootstrap.py
@@ -85,17 +85,21 @@ class TSBootstrapAdapter(BaseTransformer):
 
         bootstrapped_samples = [pd.DataFrame(sample) for sample in bootstrapped_samples]
 
-        boostrapped_df = pd.concat(
+        bootstrapped_df = pd.concat(
             bootstrapped_samples,
             keys=[f"synthetic_{i}" for i in range(len(bootstrapped_samples))],
         )
 
         _X = X.copy()
+        # Ensure that bootstrapped_df has the same index as X
+        _X.index = pd.MultiIndex.from_product([["actual"], range(len(X))])
+        bootstrapped_df.index = pd.MultiIndex.from_product(
+                    [bootstrapped_df.index.levels[0], range(len(X))]
+                )
         if self.include_actual:
-            _X.index = pd.MultiIndex.from_product([["actual"], range(len(X))])
-            return pd.concat([_X, boostrapped_df], axis=0)
+            return pd.concat([_X, bootstrapped_df], axis=0)
         else:
-            return boostrapped_df
+            return bootstrapped_df
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/transformations/bootstrap/_tsbootstrap.py
+++ b/sktime/transformations/bootstrap/_tsbootstrap.py
@@ -106,7 +106,6 @@ class TSBootstrapAdapter(BaseTransformer):
             Name of the set of test parameters to return, for use in tests. If no
             special parameters are defined for a value, will return `"default"` set.
 
-
         Returns
         -------
         params : dict or list of dict, default = {}


### PR DESCRIPTION
Fixes an unreported bug where `TSBootstrapAdapter` would always return `RangeIndex` for the bootstrapped time series.

This should default to the same index as `X` seen in `_transform`.