### PR TITLE
[MNT] set GHA macos runner consistently to `macos-13`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,7 +182,7 @@ jobs:
 
   test-cython-estimators:
     needs: test-nosoftdeps
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
 
@@ -267,7 +267,7 @@ jobs:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -32,7 +32,7 @@ jobs:
           - "3.11"
           - "3.12"
         operating-system:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
           - windows-latest
     runs-on: ${{ matrix.operating-system }}
@@ -64,7 +64,7 @@ jobs:
           - "3.11"
           - "3.12"
         operating-system:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
           - windows-latest
         sktime-component:
@@ -107,7 +107,7 @@ jobs:
           - "3.11"
           - "3.12"
         operating-system:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
           - windows-latest
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/test_base.yml
+++ b/.github/workflows/test_base.yml
@@ -32,7 +32,7 @@ jobs:
           - "3.11"
           - "3.12"
         operating-system:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
           - windows-latest
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/test_datasets.yml
+++ b/.github/workflows/test_datasets.yml
@@ -17,7 +17,7 @@ jobs:
           - "3.11"
           - "3.12"
         operating-system:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
           - windows-latest
     runs-on: ${{ matrix.operating-system }}
@@ -57,7 +57,7 @@ jobs:
           - "3.11"
           - "3.12"
         operating-system:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
           - windows-latest
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/test_module.yml
+++ b/.github/workflows/test_module.yml
@@ -64,7 +64,7 @@ jobs:
           - "3.11"
           - "3.12"
         operating-system:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
           - windows-latest
         sktime-component: ${{ fromJSON(needs.detect.outputs.module_changes) }}

--- a/.github/workflows/test_other.yml
+++ b/.github/workflows/test_other.yml
@@ -45,7 +45,7 @@ jobs:
           - "3.11"
           - "3.12"
         operating-system:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
           - windows-latest
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:


### PR DESCRIPTION
This PR moves Mac based GHA runners consistently to `macos-13`.

`macos-latest` is failing with python 3.8 and 3.9 recently, and `macos-14` = `macos-latest` has half the memory of `macos-13`.