### PR TITLE
[BUG] Fix `STLTransformer.inverse_transform` for univariate case

### DIFF
--- a/sktime/transformations/bootstrap/tests/__init__.py
+++ b/sktime/transformations/bootstrap/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Tests bor bootstrap Transformers."""
+"""Tests bootstrap Transformers."""

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -593,7 +593,7 @@ class STLTransformer(BaseTransformer):
         # for inverse transform, we sum up the columns
         # this will be close if return_components=True
         row_sums = X.sum(axis=1)
-        row_sums.columns = self.fit_column_names
+        row_sums.columns = self._X.columns
         return row_sums
 
     def _make_return_object(self, X, stl):

--- a/sktime/transformations/series/detrend/tests/test_deseasonalise.py
+++ b/sktime/transformations/series/detrend/tests/test_deseasonalise.py
@@ -15,9 +15,6 @@ from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 MODELS = ["additive", "multiplicative"]
 
-y = make_forecasting_problem()
-y_train, y_test = temporal_train_test_split(y, train_size=0.75)
-
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("statsmodels", severity="none"),
@@ -26,6 +23,9 @@ y_train, y_test = temporal_train_test_split(y, train_size=0.75)
 @pytest.mark.parametrize("sp", TEST_SPS)
 def test_deseasonalised_values(sp):
     from statsmodels.tsa.seasonal import seasonal_decompose
+
+    y = make_forecasting_problem()
+    y_train, _ = temporal_train_test_split(y, train_size=0.75)
 
     transformer = Deseasonalizer(sp=sp)
     transformer.fit(y_train)
@@ -43,6 +43,9 @@ def test_deseasonalised_values(sp):
 @pytest.mark.parametrize("sp", TEST_SPS)
 @pytest.mark.parametrize("model", MODELS)
 def test_transform_time_index(sp, model):
+    y = make_forecasting_problem()
+    y_train, y_test = temporal_train_test_split(y, train_size=0.75)
+
     transformer = Deseasonalizer(sp=sp, model=model)
     transformer.fit(y_train)
     yt = transformer.transform(y_test)
@@ -56,6 +59,9 @@ def test_transform_time_index(sp, model):
 @pytest.mark.parametrize("sp", TEST_SPS)
 @pytest.mark.parametrize("model", MODELS)
 def test_inverse_transform_time_index(sp, model):
+    y = make_forecasting_problem()
+    y_train, y_test = temporal_train_test_split(y, train_size=0.75)
+
     transformer = Deseasonalizer(sp=sp, model=model)
     transformer.fit(y_train)
     yit = transformer.inverse_transform(y_test)
@@ -69,6 +75,9 @@ def test_inverse_transform_time_index(sp, model):
 @pytest.mark.parametrize("sp", TEST_SPS)
 @pytest.mark.parametrize("model", MODELS)
 def test_transform_inverse_transform_equivalence(sp, model):
+    y = make_forecasting_problem()
+    y_train, y_test = temporal_train_test_split(y, train_size=0.75)
+
     transformer = Deseasonalizer(sp=sp, model=model)
     transformer.fit(y_train)
     yit = transformer.inverse_transform(transformer.transform(y_train))
@@ -98,3 +107,24 @@ def test_deseasonalizer_in_pipeline():
     train_df = all_df["1949":"1950"]
     model.fit(train_df)
     model.update(y=all_df["1951":"1951"])
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+@pytest.mark.parametrize("return_components", [True, False])
+def test_stl_inverse(return_components):
+    """Test STLtransformer inverse_transform."""
+    from sktime.datasets import load_airline
+    from sktime.transformations.series.detrend import STLTransformer
+
+    X = load_airline()
+    transformer = STLTransformer(sp=12, return_components=return_components)
+    transformer.fit_transform(X)
+    Xit = transformer.inverse_transform(X)
+    # this currently fails, bug #6337
+    # Xit = transformer.inverse_transform(Xt)
+
+    # check that the index is preserved
+    assert X.index.equals(Xit.index)


### PR DESCRIPTION
This PR fixes `STLTransformer.inverse_transform` for the univariate case.
An attribute was accessed that did not exist.

Related to https://github.com/sktime/sktime/issues/6337 but not identical, unreported.

It needs to be investigated why suite tests did not catch this, for now I have added a manual test.

Makes minor improvements to files touched:

* fixes minor typo
* moves fixture generation inside test functions to avoid data generation on module load