### PR TITLE
[ENH] fix `Empirical` index to be `pd.MultiIndex` for hierarchical data index

### DIFF
--- a/sktime/proba/empirical.py
+++ b/sktime/proba/empirical.py
@@ -63,7 +63,7 @@ class Empirical(BaseDistribution):
         self._N = len(_spl_instances)
 
         if index is None:
-            index = pd.Index(_timestamps)
+            index = _timestamps
 
         if columns is None:
             columns = spl.columns
@@ -127,6 +127,7 @@ class Empirical(BaseDistribution):
                 if x is None:
                     x_t = None
                 elif hasattr(x, "loc"):
+                    # x_t = x.at[ix, col]
                     x_t = x.loc[ix, col]
                 else:
                     x_t = x


### PR DESCRIPTION
The `Empirical` distribution would produce `pd.Index` of tuples instead of `pd.MultiIndex` in some methods, causing failures in https://github.com/sktime/sktime/pull/6052.

This PR fixes that.

In light of the current refactor in `skpro` which will see the `Empirical` reworked, I think it is sufficient to test indirectly via #6052 for onw.