### PR TITLE
[MNT] skip `VARMAX` until sporadic failures are resolved

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -53,6 +53,7 @@ EXCLUDE_ESTIMATORS = [
     "TestPlusTrainSplitter",
     "Repeat",
     "CutoffFhSplitter",
+    "VARMAX",  # sporadic timeouts, see #6344
 ]
 
 


### PR DESCRIPTION
Skips tests for the `VARMAX` forecaster until #6344 is resolved.