### PR TITLE
[MNT] 0.29.0 deprecations and change actions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   "numpy<1.27,>=1.21",  # required for framework layer and base class logic
   "packaging",  # for estimator specific dependency parsing
   "pandas<2.3.0,>=1.1",  # pandas is the main in-memory data container
-  "scikit-base<0.8.0",  # base module for sklearn compatible base API
+  "scikit-base<0.8.0,>=0.6.1",  # base module for sklearn compatible base API
   "scikit-learn>=0.24,<1.5.0",  # required for estimators and framework layer
   "scipy<2.0.0,>=1.2",  # required for estimators and framework layer
 ]

--- a/sktime/classification/deep_learning/base.py
+++ b/sktime/classification/deep_learning/base.py
@@ -205,7 +205,7 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         if hasattr(self, "history"):
             self.__dict__["history"] = self.history
 
-    def save(self, path=None, serialization_format="pickle", legacy_save=True):
+    def save(self, path=None, serialization_format="pickle", legacy_save=False):
         """Save serialized self to bytes-like object or to (.zip) file.
 
         Behaviour:
@@ -233,11 +233,10 @@ class BaseDeepClassifier(BaseClassifier, ABC):
             ``sktime.base._base.SERIALIZATION_FORMATS``. Note that non-default formats
             might require installation of other soft dependencies.
 
-        legacy_save : bool, default = True
+        legacy_save : bool, default = False
             whether to use the legacy saving method for the model. If
             tensorflow >= 2.16.0 is installed, this is ignored.
-            The default will switch to False in sktime 0.29.0, and the
-            legacy saving method will be removed in sktime 0.30.0.
+            The legacy saving method will be removed in sktime 0.30.0.
 
         Returns
         -------
@@ -245,7 +244,6 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         if ``path`` is file location - ZipFile with reference to the file
         """
         # TODO - remove the legacy_save parameter in sktime 0.30.0
-        # TODO - change the default value of legacy_save to False in sktime 0.29.0
         import pickle
         from pathlib import Path
 

--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -20,7 +20,7 @@ from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.utils.validation.panel import check_X
 
 
-# TODO: fix this in 0.29.0
+# TODO: fix this in 0.30.0
 # base class should have been changed to BaseEarlyClassifier
 class ProbabilityThresholdEarlyClassifier(BaseClassifier):
     """Probability Threshold Early Classifier.

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -816,7 +816,7 @@ def _to_relative(fh: ForecastingHorizon, cutoff=None) -> ForecastingHorizon:
             absolute = _coerce_to_period(absolute, freq=fh.freq)
             cutoff = _coerce_to_period(cutoff, freq=fh.freq)
 
-        # TODO: 0.29.0:
+        # TODO: 0.30.0:
         # Check at every minor release whether lower pandas bound >=0.15.0
         # if yes, can remove the workaround in the "else" condition and the check
         #

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -163,7 +163,7 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                         if len(levels) == 1:
                             levels = levels[0]
                         yt[ix] = y.xs(ix, level=levels, axis=1)
-                        # todo 0.29.0 - check why this cannot be easily removed
+                        # todo 0.30.0 - check why this cannot be easily removed
                         # in theory, we should get rid of the "Coverage" case treatment
                         # (the legacy naming convention was removed in 0.23.0)
                         # deal with the "Coverage" case, we need to get rid of this

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -18,7 +18,7 @@ from sktime.forecasting.model_selection._tune import (
 )
 
 
-# todo 0.29.0 - check whether we should remove, otherwise bump
+# todo 0.30.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def temporal_train_test_split(
     y, X=None, test_size=None, train_size=None, fh=None, anchor="start"
@@ -45,7 +45,7 @@ def temporal_train_test_split(
     )
 
 
-# todo 0.29.0 - check whether we should remove, otherwise bump
+# todo 0.30.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
     """Legacy export of Expanding window splitter.
@@ -68,7 +68,7 @@ def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
     return _EWSplitter(fh=fh, initial_window=initial_window, step_length=step_length)
 
 
-# todo 0.29.0 - check whether we should remove, otherwise bump
+# todo 0.30.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def SlidingWindowSplitter(
     fh=1, window_length=10, step_length=1, initial_window=None, start_with_window=True

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -84,7 +84,7 @@ class BaseGridSearch(_DelegatedForecaster):
         if tune_by_variable:
             self.set_tags(**{"scitype:y": "univariate"})
 
-        # todo 0.29.0: check if this is still necessary
+        # todo 0.30.0: check if this is still necessary
         # n_jobs is deprecated, left due to use in tutorials, books, blog posts
         if n_jobs != "deprecated":
             warn(

--- a/sktime/regression/deep_learning/base.py
+++ b/sktime/regression/deep_learning/base.py
@@ -155,7 +155,7 @@ class BaseDeepRegressor(BaseRegressor, ABC):
         if hasattr(self, "history"):
             self.__dict__["history"] = self.history
 
-    def save(self, path=None, legacy_save=True):
+    def save(self, path=None, legacy_save=False):
         """Save serialized self to bytes-like object or to (.zip) file.
 
         Behaviour:
@@ -177,11 +177,10 @@ class BaseDeepRegressor(BaseRegressor, ABC):
                 path="/home/stored/estimator" then a zip file ``estimator.zip`` will be
                 stored in ``/home/stored/``.
 
-        legacy_save : bool, default = True
+        legacy_save : bool, default = False
             whether to use the legacy saving method for the model. If
             tensorflow >= 2.16.0 is installed, this is ignored.
-            The default will switch to False in sktime 0.28.0, and the
-            legacy saving method will be removed in sktime 0.29.0.
+            The legacy saving method will be removed in sktime 0.30.0.
 
         Returns
         -------
@@ -189,7 +188,6 @@ class BaseDeepRegressor(BaseRegressor, ABC):
         if ``path`` is file location - ZipFile with reference to the file
         """
         # TODO 0.30.0 - remove the legacy_save parameter in sktime 0.30.0
-        # TODO 0.29.0 - change the default value of legacy_save to False
         import pickle
         import shutil
         from pathlib import Path

--- a/sktime/transformations/panel/catch22.py
+++ b/sktime/transformations/panel/catch22.py
@@ -10,7 +10,6 @@ from typing import List, Union
 
 import numpy as np
 import pandas as pd
-from joblib import Parallel, delayed
 
 from sktime.datatypes import convert_to
 from sktime.transformations.base import BaseTransformer

--- a/sktime/transformations/panel/catch22.py
+++ b/sktime/transformations/panel/catch22.py
@@ -259,14 +259,12 @@ class Catch22(BaseTransformer):
         "fit_is_empty": True,
     }
 
-    # todo 0.29.0: remove n_jobs parameter
     def __init__(
         self,
         features: Union[int, str, List[Union[int, str]]] = "all",
         catch24: bool = False,
         outlier_norm: bool = False,
         replace_nans: bool = False,
-        n_jobs="deprecated",
         col_names: str = "range",
     ):
         self.features = features
@@ -278,19 +276,6 @@ class Catch22(BaseTransformer):
 
         # todo: remove this unimplemented logic
         self._transform_features = None
-        # todo 0.29.0: remove this warning and logic
-        self.n_jobs = n_jobs
-        if n_jobs != "deprecated":
-            warn(
-                "In Catch22, the parameter "
-                "n_jobs is deprecated and will be removed in v0.29.0. "
-                "Instead, use set_config with the backend and backend:params "
-                "config fields, and set backend to 'joblib' and pass n_jobs "
-                "as a parameter of backend_params. ",
-                FutureWarning,
-                obj=self,
-            )
-            self.set_config(backend="joblib", backend_params={"n_jobs": n_jobs})
 
         super().__init__()
 
@@ -375,10 +360,7 @@ class Catch22(BaseTransformer):
 
         # todo: remove Parallel in future versions, left for
         # compatibility with `CanonicalIntervalForest`
-        n_jobs = self.n_jobs if isinstance(self.n_jobs, int) else 1
-        c22_list = Parallel(n_jobs=n_jobs)(
-            delayed(self._transform_case)(X[i], [feature]) for i in range(n_instances)
-        )
+        c22_list = [self._transform_case(X[i], [feature]) for i in range(n_instances)]
 
         if self.replace_nans:
             c22_list = np.nan_to_num(c22_list, False, 0, 0, 0)

--- a/sktime/utils/_testing/deep_equals.py
+++ b/sktime/utils/_testing/deep_equals.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 
 
-# todo 0.29.0: check whether scikit-base>=0.6.1 lower bound is 0.6.1 or higher
+# todo 0.30.0: check whether scikit-base>=0.6.1 lower bound is 0.6.1 or higher
 # if yes, remove this legacy function and use the new one from sktime.utils.deep_equals
 def deep_equals(x, y, return_msg=False):
     """Test two objects for equality in value.
@@ -68,8 +68,7 @@ def deep_equals(x, y, return_msg=False):
     )
 
     removal_schedule = (
-        "The legacy deep_equals is not scheduled for removal yet, this "
-        "warning will change to specify a removal date when it is scheduled."
+        "The legacy deep_equals is scheduled for removal in sktime 0.30.0. "
     )
 
     if _check_soft_dependencies(

--- a/sktime/utils/deep_equals/__init__.py
+++ b/sktime/utils/deep_equals/__init__.py
@@ -2,7 +2,7 @@
 """Module for nested equality checking."""
 from sktime.utils.validation._dependencies import _check_soft_dependencies
 
-# todo 0.29.0: check whether scikit-base>=0.6.1 lower bound is 0.6.1 or higher
+# todo 0.30.0: check whether scikit-base>=0.6.1 lower bound is 0.6.1 or higher
 # if yes, remove legacy handling and only use the new deep_equals
 if _check_soft_dependencies(
     "scikit-base<0.6.1",


### PR DESCRIPTION
Carries out deprecations and change actions scheduled for 0.29.0:

* removed `n_jobs` parameter in `Catch22`
* in deep learning based classifiers and regressors, change default for `legacy_method` in `save` to `False`
* intermediate stage rename cycle for `cINNForecaster` to `CINNForecaster`
* added lower bound `scikit-base>=0.6.1`, schedule removal of legacy `deep_equals` for 0.30.0
* bump deprecation/change checks scheduled for 0.29.0 to 0.30.0