### PR TITLE
[MNT] speed up test collection - cache differential testing switch utilities

### DIFF
--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -83,7 +83,7 @@ def run_test_for_class(cls, return_reason=False):
         return run
 
     if isinstance(cls, (list, tuple)):
-        runs = [run_test_for_class(x) for x in cls]
+        runs = [run_test_for_class(x, return_reason=True) for x in cls]
         reasons = [x[1] for x in runs]
 
         # if any of the classes are missing dependencies, return False

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -58,10 +58,12 @@ def run_test_for_class(cls):
     bool : True if class should be tested, False otherwise
         if cls was a list, is True iff True for at least one of the classes in the list
     """
-    if isinstance(cls, list):
+    if isinstance(cls, (list, tuple)):
         return all(_run_test_for_class(x) for x in cls)
-    else:
-        return _run_test_for_class(cls)
+    # if object is passed, obtain the class - objects are not hashable
+    if hasattr(cls, "get_class_tag") and not isclass(cls):
+        cls = cls.__class__
+    return _run_test_for_class(cls)
 
 
 @lru_cache

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -12,7 +12,7 @@ from inspect import getmro, isclass
 from sktime.tests._config import EXCLUDE_ESTIMATORS
 
 
-def run_test_for_class(cls):
+def run_test_for_class(cls, return_reason=False):
     """Check if test should run for a class or function.
 
     This checks the following conditions:
@@ -58,26 +58,84 @@ def run_test_for_class(cls):
     ----------
     cls : class, function or list of classes/functions
         class for which to determine whether it should be tested
+    return_reason: bool, optional, default=False
+        whether to return the reason for running or skipping the test
 
     Returns
     -------
     bool : True if class should be tested, False otherwise
         if cls was a list, is True iff True for at least one of the classes in the list
+    reason: str, reason to run or skip the test, returned only if ``return_reason=True``
+
+        * "False_required_deps_missing" - skip reason, required dependencies are missing
+        * "False_no_change" - skip reason, no change in class or dependencies
+        * "True_run_always" - run reason, run always
+        * "True_pyproject_change" - run reason, dep in ``pyproject.toml`` has changed
+        * "True_changed_tests" - run reason, tests covering class have changed
+        * "True_changed_class" - run reason, module containing class has changed
+
+        If multiple reasons are present, the first one in the above list is returned.
     """
+
+    def _return(run, reason):
+        if return_reason:
+            return run, reason
+        return run
+
     if isinstance(cls, (list, tuple)):
-        return all(run_test_for_class(x) for x in cls)
+        runs = [run_test_for_class(x) for x in cls]
+        reasons = [x[1] for x in runs]
+
+        # if any of the classes are missing dependencies, return False
+        if any(reason == "False_required_deps_missing" for reason in reasons):
+            return _return(False, "False_required_deps_missing")
+
+        # now check the "any of the classes should be tested" condition
+        POS_REASONS = [
+            "True_run_always",
+            "True_pyproject_change",
+            "True_changed_tests",
+            "True_changed_class",
+        ]
+        for pos_reason in POS_REASONS:
+            if any(reason == pos_reason for reason in reasons):
+                return _return(True, pos_reason)
+
+        # otherwise, we do not run, and the reason is "no change"
+        return False, "False_no_change"
+
     # if object is passed, obtain the class - objects are not hashable
     if hasattr(cls, "get_class_tag") and not isclass(cls):
         cls = cls.__class__
     # check whether estimator is on the exclude override list
     if cls.__name__ in EXCLUDE_ESTIMATORS:
         return False
-    return _run_test_for_class(cls)
+
+    # handle return reason or not
+    run, reason = _run_test_for_class(cls)
+    if return_reason:
+        return run, reason
+    return run
 
 
 @lru_cache
 def _run_test_for_class(cls):
-    """Check if test should run - cached with hashable cls."""
+    """Check if test should run - cached with hashable cls.
+
+    Returns
+    -------
+    bool : True if class should be tested, False otherwise
+    reason : str, reason to run or skip the test, one of:
+
+        * "False_required_deps_missing" - skip reason, required dependencies are missing
+        * "False_no_change" - skip reason, no change in class or dependencies
+        * "True_run_always" - run reason, run always
+        * "True_pyproject_change" - run reason, dep in ``pyproject.toml`` has changed
+        * "True_changed_tests" - run reason, tests covering class have changed
+        * "True_changed_class" - run reason, module containing class has changed
+
+        If multiple reasons are present, the first one in the above list is returned.
+    """
 
     from sktime.tests.test_all_estimators import ONLY_CHANGED_MODULES
     from sktime.utils.git_diff import get_packages_with_changed_specs, is_class_changed
@@ -131,27 +189,37 @@ def _run_test_for_class(cls):
     # Condition 1:
     # if any of the required soft dependencies are not present, do not run the test
     if not _required_deps_present(cls):
-        return False
+        return False, "False_required_deps_missing"
     # otherwise, continue
 
     # if ONLY_CHANGED_MODULES is off: always True
     # tests are always run if soft dependencies are present
     if not ONLY_CHANGED_MODULES:
-        return True
+        return True, "True_run_always"
 
-    # Condition 2:
-    # any of the modules containing any of the classes in the list have changed
-    # or any of the modules containing any parent classes in sktime have changed
-    cond2 = _is_class_changed_or_sktime_parents(cls)
+    # run the test if and only if at least one of the conditions 2-4 are met
+    # conditions are checked in order to minimize runtime due to git diff etc
+
+    # Condition 4:
+    # the package requirements for any dependency in pyproject.toml have changed
+    cond4 = _is_impacted_by_pyproject_change(cls)
+    if cond4:
+        return True, "True_pyproject_change"
 
     # Condition 3:
     # if the object is an sktime BaseObject, and one of the test classes
     # covering the class have changed, then run the test
     cond3 = _tests_covering_class_changed(cls)
+    if cond3:
+        return True, "True_changed_tests"
 
-    # Condition 4:
-    # the package requirements for any dependency in pyproject.toml have changed
-    cond4 = _is_impacted_by_pyproject_change(cls)
+    # Condition 2:
+    # any of the modules containing any of the classes in the list have changed
+    # or any of the modules containing any parent classes in sktime have changed
+    cond2 = _is_class_changed_or_sktime_parents(cls)
+    if cond2:
+        return True, "True_changed_class"
 
-    # run the test if and only if at least one of the conditions 2-4 are met
-    return cond2 or cond3 or cond4
+    # if none of the conditions are met, do not run the test
+    # reason is that there was no change
+    return False, "False_no_change"

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -9,6 +9,8 @@ __author__ = ["fkiraly"]
 from functools import lru_cache
 from inspect import getmro, isclass
 
+from sktime.tests._config import EXCLUDE_ESTIMATORS
+
 
 def run_test_for_class(cls):
     """Check if test should run for a class or function.
@@ -48,6 +50,10 @@ def run_test_for_class(cls):
       at least one of criteria 2-4 above.
       If ``ONLY_CHANGED_MODULES`` is False, this condition is always True.
 
+    Also checks whether the class or function is on the exclude override list,
+    EXCLUDE_ESTIMATORS in sktime.tests._config (a list of strings, of names).
+    If so, the tests are always skipped, irrespective of the other conditions.
+
     Parameters
     ----------
     cls : class, function or list of classes/functions
@@ -63,6 +69,9 @@ def run_test_for_class(cls):
     # if object is passed, obtain the class - objects are not hashable
     if hasattr(cls, "get_class_tag") and not isclass(cls):
         cls = cls.__class__
+    # check whether estimator is on the exclude override list
+    if cls.__name__ in EXCLUDE_ESTIMATORS:
+        return False
     return _run_test_for_class(cls)
 
 

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -59,7 +59,7 @@ def run_test_for_class(cls):
         if cls was a list, is True iff True for at least one of the classes in the list
     """
     if isinstance(cls, (list, tuple)):
-        return all(_run_test_for_class(x) for x in cls)
+        return all(run_test_for_class(x) for x in cls)
     # if object is passed, obtain the class - objects are not hashable
     if hasattr(cls, "get_class_tag") and not isclass(cls):
         cls = cls.__class__

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -6,9 +6,11 @@ Module does not contain tests, only test utilities.
 
 __author__ = ["fkiraly"]
 
+from functools import lru_cache
 from inspect import getmro, isclass
 
 
+@lru_cache
 def run_test_for_class(cls):
     """Check if test should run for a class or function.
 

--- a/sktime/tests/tests/__init__.py
+++ b/sktime/tests/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the test utilities."""

--- a/sktime/tests/tests/test_test_utils.py
+++ b/sktime/tests/tests/test_test_utils.py
@@ -15,10 +15,12 @@ def test_run_test_for_class():
     """Test that run_test_for_class runs tests for various cases."""
     # estimator on the exception list
     from sktime.classification.hybrid import HIVECOTEV2
-    # estimator without soft deps
-    from sktime.forecasting.naive import NaiveForecaster
+
     # estimator with soft deps
     from sktime.forecasting.fbprophet import Prophet
+
+    # estimator without soft deps
+    from sktime.forecasting.naive import NaiveForecaster
 
     # boolean flag for whether to run tests for all estimators
     from sktime.tests.test_all_estimators import ONLY_CHANGED_MODULES

--- a/sktime/tests/tests/test_test_utils.py
+++ b/sktime/tests/tests/test_test_utils.py
@@ -1,0 +1,137 @@
+"""Tests for the test utilities."""
+
+from sktime.tests._config import EXCLUDE_ESTIMATORS
+from sktime.tests.test_switch import run_test_for_class
+from sktime.utils.validation._dependencies import _check_estimator_deps
+
+
+def test_exclude_estimators():
+    """Test that EXCLUDE_ESTIMATORS is a list of strings."""
+    assert isinstance(EXCLUDE_ESTIMATORS, list)
+    assert all(isinstance(estimator, str) for estimator in EXCLUDE_ESTIMATORS)
+
+
+def test_run_test_for_class():
+    """Test that run_test_for_class runs tests for various cases."""
+    # estimator on the exception list
+    from sktime.classification.hybrid import HIVECOTEV2
+    # estimator without soft deps
+    from sktime.forecasting.naive import NaiveForecaster
+    # estimator with soft deps
+    from sktime.forecasting.fbprophet import Prophet
+
+    # boolean flag for whether to run tests for all estimators
+    from sktime.tests.test_all_estimators import ONLY_CHANGED_MODULES
+
+    # test that assumptions on being on exception list are correct
+    assert "HIVECOTEV2" in EXCLUDE_ESTIMATORS  # if this fails, switch the example
+    assert "NaiveForecaster" not in EXCLUDE_ESTIMATORS  # same here
+    assert "Prophet" not in EXCLUDE_ESTIMATORS  # same here
+
+    f_on_excl_list = HIVECOTEV2
+    f_no_deps = NaiveForecaster
+    f_with_deps = Prophet
+
+    # check result for skipped estimator
+    run = run_test_for_class(f_on_excl_list)
+    # run should be False, as the estimator is on the exception list
+    assert isinstance(run, bool)
+    assert not run
+    # same with reason returned
+    res = run_test_for_class(f_on_excl_list, return_reason=True)
+    assert isinstance(res, tuple)
+    assert len(res) == 2
+    run, reason = res
+    assert isinstance(run, bool)
+    assert not run
+    assert isinstance(reason, str)
+    assert reason == "False_exclude_list"
+
+    # check result for estimator without soft deps
+    run = run_test_for_class(f_no_deps)
+    assert isinstance(run, bool)
+    if not ONLY_CHANGED_MODULES:  # if we run all tests, we should run this one
+        assert run
+
+    # result depends now on whether there is a change in the classes
+    res = run_test_for_class(f_no_deps, return_reason=True)
+    assert isinstance(res, tuple)
+    assert len(res) == 2
+    run_nodep, reason_nodep = res
+    assert isinstance(run_nodep, bool)
+    assert isinstance(reason_nodep, str)
+
+    POS_REASONS = ["True_pyproject_change", "True_changed_class", "True_changed_tests"]
+
+    if not ONLY_CHANGED_MODULES:
+        assert run_nodep
+        assert reason_nodep == "True_run_always"
+    elif run_nodep:
+        # otherwise, if we run, it must be due to changes in class or pyproject
+        assert reason_nodep in POS_REASONS
+    else:  # not run and only changed modules
+        assert reason_nodep == "False_no_change"
+
+    # now check estimator with soft deps
+    run_nodep = run_test_for_class(f_with_deps)
+    assert isinstance(run, bool)
+
+    dep_present = _check_estimator_deps(f_with_deps, severity="none")
+    if not dep_present:
+        assert not run_nodep
+
+    res = run_test_for_class(f_with_deps, return_reason=True)
+    assert isinstance(res, tuple)
+    assert len(res) == 2
+    run_wdep, reason_wdep = res
+
+    if not dep_present:
+        assert not run_wdep
+        assert reason_wdep == "False_required_deps_missing"
+    elif not ONLY_CHANGED_MODULES:
+        assert run_wdep
+        assert reason_wdep == "True_run_always"
+    elif run_wdep:
+        assert reason_wdep in POS_REASONS
+    else:  # not run and only changed modules
+        assert reason_wdep == "False_no_change"
+
+    # now a list of estimator with exception plus one estimator
+    run = run_test_for_class([f_on_excl_list, f_no_deps])
+    assert isinstance(run, bool)
+    assert not run
+
+    res = run_test_for_class([f_on_excl_list, f_no_deps], return_reason=True)
+    assert isinstance(res, tuple)
+    assert len(res) == 2
+    run, reason = res
+    assert isinstance(run, bool)
+    assert not run
+    assert reason == "False_exclude_list"
+
+    # now a list of the estimator with and without soft deps
+    run = run_test_for_class([f_no_deps, f_with_deps])
+    assert isinstance(run, bool)
+
+    # if deps are not present, we do not run the test
+    # otherwise we run the test iff we run one of the two
+    if not dep_present:
+        assert not run
+    else:
+        assert run == run_nodep or run_wdep
+
+    res = run_test_for_class([f_no_deps, f_with_deps], return_reason=True)
+    assert isinstance(res, tuple)
+    assert len(res) == 2
+    run, reason = res
+
+    if not dep_present:
+        assert not run
+        assert reason == "False_required_deps_missing"
+    elif run:
+        assert reason in POS_REASONS
+        assert reason_wdep == reason or reason_nodep == reason
+    else:
+        assert reason == "False_no_change"
+        assert reason_wdep == "False_no_change"
+        assert reason_nodep == "False_no_change"

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -3,11 +3,11 @@
 __author__ = ["fkiraly"]
 __all__ = []
 
-from functools import lru_cache
-
 import importlib.util
 import inspect
 import subprocess
+from functools import lru_cache
+
 
 
 @lru_cache

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -4,6 +4,7 @@ __author__ = ["fkiraly"]
 __all__ = []
 
 from functools import lru_cache
+
 import importlib.util
 import inspect
 import subprocess

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -9,7 +9,6 @@ import subprocess
 from functools import lru_cache
 
 
-
 @lru_cache
 def get_module_from_class(cls):
     """Get full parent module string from class.

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -3,11 +3,13 @@
 __author__ = ["fkiraly"]
 __all__ = []
 
+from functools import lru_cache
 import importlib.util
 import inspect
 import subprocess
 
 
+@lru_cache
 def get_module_from_class(cls):
     """Get full parent module string from class.
 
@@ -24,6 +26,7 @@ def get_module_from_class(cls):
     return module.__name__ if module else None
 
 
+@lru_cache
 def get_path_from_module(module_str):
     r"""Get local path string from module string.
 
@@ -47,6 +50,7 @@ def get_path_from_module(module_str):
         raise ImportError(f"Error finding module '{module_str}'") from e
 
 
+@lru_cache
 def is_module_changed(module_str):
     """Check if a module has changed compared to the main branch.
 
@@ -64,6 +68,7 @@ def is_module_changed(module_str):
         return True
 
 
+@lru_cache
 def is_class_changed(cls):
     """Check if a class' parent module has changed compared to the main branch.
 
@@ -121,6 +126,7 @@ def get_changed_lines(file_path, only_indented=True):
         return []
 
 
+@lru_cache
 def get_packages_with_changed_specs():
     """Get packages with changed or added specs.
 


### PR DESCRIPTION
Towards https://github.com/sktime/sktime/issues/6344.

Speeds up test collection by `lru_cache`-ing all test switch utilities called from `run_test_for_class`.

This gets test collection time for the classification module to 5 seconds, compared to historical test times:

* 0.22.0 - 12 sec for 301 tests
* 0.24.0 - 11 sec for 294 tests
    * in 0.24.2, parent classes were included in diff check
* 0.25.0 - 38 sec for 355 tests
* 0.26.0 - 38 sec for 355 tests
    * in 0.26.1, the condition on dep change in `pyproject` was added
* 0.27.0 - 56 sec for 363 tests
* 0.28.1 - 72 sec for 246 tests
* this PR: 5 sec for 246 tests

(timings from `python -m pytest sktime/classification -n0 --collect-only`)

For all of `sktime`, the test collection time is down to 40sec for me locally, from >20 minutes.