### PR TITLE
[MNT] temporary skip of estimators involved in timeouts #6344

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -53,7 +53,12 @@ EXCLUDE_ESTIMATORS = [
     "TestPlusTrainSplitter",
     "Repeat",
     "CutoffFhSplitter",
-    "VARMAX",  # sporadic timeouts, see #6344
+    # sporadic timeouts, see #6344
+    "VARMAX",
+    "BATS",
+    "TBATS",
+    "AutoARIMA",
+    "StatsForecastAutoARIMA",
 ]
 
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -59,6 +59,9 @@ EXCLUDE_ESTIMATORS = [
     "TBATS",
     "AutoARIMA",
     "StatsForecastAutoARIMA",
+    "SARIMAX",
+    "StatsModelsARIMA",
+    "ShapeletLearningClassifierTslearn",
 ]
 
 


### PR DESCRIPTION
This PR adds temporary skips for estimators involved in timeouts, see #6344, until the problem is fully diagnosed and addressed.