### PR TITLE
[DOC] high-level explanation of deprecation policy principles

### DIFF
--- a/docs/source/developer_guide/deprecation.rst
+++ b/docs/source/developer_guide/deprecation.rst
@@ -27,8 +27,13 @@ then no release of ``sktime`` should change, without warning:
 
 * import location of ``BarForecaster``
 * argument signature of ``BarForecaster``, including name, order, and defaults of arguments
-* argument signature of ``fit``, ``predict``, including name, order, and defaults of arguments
-* the algorithm that ``BarForecaster`` carries out for the given arguments
+* the abstract algorithm that ``BarForecaster`` carries out for the given arguments
+
+Changes that can be carried out without warning:
+
+* adding more arguments at the end of the argument list, with a default value that retains prior behaviour
+* refactoring of internal code, as long as the public API remains the same
+* changing the implementation without changing the abstract algorithm, e.g., for performance reasons
 
 The deprecation policy outlined in this document provides details on how to carry out
 such changes in a user-friendly and reliable way.

--- a/docs/source/developer_guide/deprecation.rst
+++ b/docs/source/developer_guide/deprecation.rst
@@ -4,13 +4,38 @@
 Deprecation
 ===========
 
-Before we can make changes to sktime's user interface, we need to make sure that users have time to make the necessary adjustments in their code.
-For this reason, we first need to deprecate functionality and change it only in a next release.
+``sktime`` aims to be stable and reliable towards its users.
+Our high-level policy to ensure this is:
 
-.. note::
+"``sktime`` should never break user code without a clear and actionable warning
+given at least one (MINOR) release cycle in advance."
 
-    For upcoming changes and next releases, see our `Milestones <https://github.com/sktime/sktime/milestones?direction=asc&sort=due_date&state=open>`_.
-    For our long-term plan, see our :ref:`roadmap`.
+Here, "break" expressly includes a change to abstract logic, such as the algorithm
+being used, not just changes that lead to exceptions or performance degradation.
+
+For instance, if a user has code
+
+.. code:: python
+
+    from sktime.forecasting.foo import BarForecaster
+
+    bar = BarForecaster(42, x=43)
+    bar.fit(y_train, fh=[1, 2, 3])
+    y_pred = bar.predict()
+
+then no release of ``sktime`` should change, without warning:
+
+* import location of ``BarForecaster``
+* argument signature of ``BarForecaster``, including name, order, and defaults of arguments
+* argument signature of ``fit``, ``predict``, including name, order, and defaults of arguments
+* the algorithm that ``BarForecaster`` carries out for the given arguments
+
+The deprecation policy outlined in this document provides details on how to carry out
+such changes in a user-friendly and reliable way.
+
+It is accompanied by formulaic patterns for developers, with examples,
+and a process for release managers, to make the policy easy to follow.
+
 
 Deprecation policy
 ==================

--- a/docs/source/developer_guide/deprecation.rst
+++ b/docs/source/developer_guide/deprecation.rst
@@ -31,7 +31,8 @@ then no release of ``sktime`` should change, without warning:
 
 Changes that can be carried out without warning:
 
-* adding more arguments at the end of the argument list, with a default value that retains prior behaviour
+* adding more arguments at the end of the argument list, with a default value that retains prior behaviour,
+  as long as the new arguments are well-documented
 * refactoring of internal code, as long as the public API remains the same
 * changing the implementation without changing the abstract algorithm, e.g., for performance reasons
 

--- a/docs/source/developer_guide/deprecation.rst
+++ b/docs/source/developer_guide/deprecation.rst
@@ -37,7 +37,7 @@ Changes that can be carried out without warning:
 * changing the implementation without changing the abstract algorithm, e.g., for performance reasons
 
 The deprecation policy outlined in this document provides details on how to carry out
-such changes in a user-friendly and reliable way.
+changes that need change or deprecation handling, in a user-friendly and reliable way.
 
 It is accompanied by formulaic patterns for developers, with examples,
 and a process for release managers, to make the policy easy to follow.

--- a/docs/source/developer_guide/deprecation.rst
+++ b/docs/source/developer_guide/deprecation.rst
@@ -33,7 +33,7 @@ Changes that can be carried out without warning:
 
 * adding more arguments at the end of the argument list, with a default value that retains prior behaviour,
   as long as the new arguments are well-documented
-* refactoring of internal code, as long as the public API remains the same
+* pure refactoring of internal code, as long as the public API remains the same
 * changing the implementation without changing the abstract algorithm, e.g., for performance reasons
 
 The deprecation policy outlined in this document provides details on how to carry out


### PR DESCRIPTION
This PR adds a preamble to the "deprecation policy" document in the developer guide, explaining why we need a deprecation policy, and high-level principles from which the policy elements are derived.

This should hopefully provide a better degree of illustration and explanation to new developers that we onboard.

A review by new developers (e.g., summer mentees) is especially welcome, as this is written for you.