### PR TITLE
[MNT] final change cycle (0.30.0) for renaming `cINNForecaster` to `CINNForecaster`

### DIFF
--- a/sktime/forecasting/conditional_invertible_neural_network.py
+++ b/sktime/forecasting/conditional_invertible_neural_network.py
@@ -17,7 +17,6 @@ from sktime.networks.cinn import CINNNetwork
 from sktime.transformations.merger import Merger
 from sktime.transformations.series.fourier import FourierFeatures
 from sktime.transformations.series.summarize import WindowSummarizer
-from sktime.utils.warnings import warn
 
 if _check_soft_dependencies("torch", severity="none"):
     import torch
@@ -177,18 +176,6 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
         self.delta = delta
         self.val_split = val_split
         super().__init__(num_epochs, batch_size, lr=lr)
-
-        # TODO 0.30.0: remove this warning
-        warn(
-            "cINNForecaster has been renamed to CINNForecaster in sktime 0.29.0, "
-            "The estimator is available under the future name at its "
-            "current location, and will be available under its deprecated name "
-            "until 0.30.0. "
-            "To prepare for the name change, "
-            "replace cINNForecaster with CINNForecaster",
-            DeprecationWarning,
-            obj=self,
-        )
 
     def _fit(self, y, fh, X=None):
         """Fit forecaster to training data.
@@ -620,7 +607,3 @@ class _EarlyStopper:
             if self.counter >= self.patience:
                 return True
         return False
-
-
-# TODO 0.30.0: remove this alias altogether
-cINNForecaster = CINNForecaster

--- a/sktime/networks/cinn.py
+++ b/sktime/networks/cinn.py
@@ -4,8 +4,6 @@ __author__ = ["benHeid"]
 import numpy as np
 from skbase.utils.dependencies import _check_soft_dependencies
 
-from sktime.utils.warnings import warn
-
 if _check_soft_dependencies("torch", severity="none"):
     import torch
     import torch.nn as nn
@@ -195,18 +193,6 @@ class CINNNetwork:
         self.hidden_dim_size = hidden_dim_size
         self.activation = activation if activation is not None else nn.ReLU
 
-        # TODO 0.30.0: remove this warning
-        warn(
-            "cINNNetwork has been renamed to CINNNetwork in sktime 0.29.0, "
-            "The estimator is available under the future name at its "
-            "current location, and will be available under its deprecated name "
-            "until 0.30.0. "
-            "To prepare for the name change, "
-            "replace cINNNetwork with CINNNetwork",
-            DeprecationWarning,
-            obj=self,
-        )
-
     def build(self):
         """Build the cINN."""
         return self._CINNNetwork(
@@ -217,7 +203,3 @@ class CINNNetwork:
             self.hidden_dim_size,
             self.activation,
         )
-
-
-# TODO 0.30.0: remove this alias altogether
-cINNNetwork = CINNNetwork


### PR DESCRIPTION

#### Reference Issues/PRs

This completes step 3 of change cycle for renaming cINNForecaster to CINNForecaster, completing the steps for release v0.30.0 in #6120

#### What does this implement/fix? Explain your changes.

* remove aliases altogether
* remove deprecation warning
