### PR TITLE
[MNT] added joblib as core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ classifiers = [
 # core dependencies of sktime
 # this set should be kept minimal!
 dependencies = [
+  "joblib<1.5,>=1.2.0",  # required for parallel processing
   "numpy<1.27,>=1.21",  # required for framework layer and base class logic
   "packaging",  # for estimator specific dependency parsing
   "pandas<2.3.0,>=1.1",  # pandas is the main in-memory data container


### PR DESCRIPTION
There are multiple instances of direct imports by `joblib` without isolation, and it never causes problem as it is a dependency of `scikit-learn`. It has always been so and unlikely to change in future, so moving it to core dependencies to avoid conda linting warnings.