### PR TITLE
[MNT] migrate `setup.cfg` options to GHA

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,13 +14,8 @@ addopts =
     --doctest-modules
     --durations 20
     --timeout 600
-    --cov sktime
-    --cov-report xml
-    --cov-report html
     --showlocals
-    --matrixdesign True
     --only_changed_modules True
-    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
Towards #6409 - moves the "slow" test options to the CI ymls or makefiles.

Work in progress.