### PR TITLE
[BUG] allow metric classes to be called with `multilevel` arg if series is not hierarchical

### DIFF
--- a/sktime/performance_metrics/forecasting/_coerce.py
+++ b/sktime/performance_metrics/forecasting/_coerce.py
@@ -18,6 +18,8 @@ def _coerce_to_scalar(obj):
 
 def _coerce_to_df(obj):
     """Coerce to pd.DataFrame, from polymorphic input scalar or pandas."""
+    if isinstance(obj, (float, int))
+        return pd.DataFrame([obj])
     return pd.DataFrame(obj)
 
 

--- a/sktime/performance_metrics/forecasting/_coerce.py
+++ b/sktime/performance_metrics/forecasting/_coerce.py
@@ -18,7 +18,7 @@ def _coerce_to_scalar(obj):
 
 def _coerce_to_df(obj):
     """Coerce to pd.DataFrame, from polymorphic input scalar or pandas."""
-    if isinstance(obj, (float, int))
+    if isinstance(obj, (float, int)):
         return pd.DataFrame([obj])
     return pd.DataFrame(obj)
 

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -159,4 +159,4 @@ def test_metric_coercion_bug():
     metric = mae(y_true, y_pred)
 
     assert isinstance(metric, pd.DataFrame)
-    assert metric.shape = (1, 1)
+    assert metric.shape == (1, 1)

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -144,3 +144,19 @@ def test_make_scorer_sklearn():
     scorer = make_forecasting_scorer(mean_absolute_error, name="MAE")
 
     scorer.evaluate(pd.Series([1, 2, 3]), pd.Series([1, 2, 4]))
+
+
+def test_metric_coercion_bug():
+    """Tests for sensible output when using hierarchical arg with non-hierarchical data.
+
+    Failure case in bug #6413.
+    """
+    from sktime.performance_metrics.forecasting import MeanAbsoluteError
+
+    y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
+    mae = MeanAbsoluteError(multilevel="raw_values", multioutput=[0.4, 0.6])
+    metric = mae(y_true, y_pred)
+
+    assert isinstance(metric, pd.DataFrame)
+    assert metric.shape = (1, 1)


### PR DESCRIPTION
This PR allows metric classes to be called with `multilevel` arg in all cases, if the series is not hierarchical. Previously, this would crash the metric.

This PR changes behaviour in this degenerate case so a single-entry `pd.DataFrame` is returned.

Fixes https://github.com/sktime/sktime/issues/6413