### PR TITLE
[BUG] fix classifier default `_predict` returning integer labels always, even if `fit` `y` was not integer

### DIFF
--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -727,6 +727,9 @@ class BaseClassifier(BasePanelMixin):
         y_proba = self._predict_proba(X)
         y_pred = y_proba.argmax(axis=1)
 
+        # restore class labels if they were not originally integer
+        y_pred = self.classes_[y_pred]
+
         return y_pred
 
     def _predict_proba(self, X) -> np.ndarray:


### PR DESCRIPTION
This fixes one of the bugs reported in https://github.com/sktime/sktime/issues/6427, namely the default `_predict` in `BaseClassifier` always returning integer labels, even if the original labels were not integers.

This would cause all classifiers that did not have a custom `_predict` implemented - a few composites, among them `BaggingClassifier` - to always predict integers, even if the `y` seen in `fit` was of another type.

The fix is simple, adding a missing application of the memorized integer-to-class dictionary.

Test coverage is through https://github.com/sktime/sktime/pull/6428.