### PR TITLE
[MNT] bound `transformers<4.41.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,7 +273,7 @@ dl = [
   'neuralforecast<1.8.0,>=1.6.4; python_version < "3.11"',
   'tensorflow<2.17,>=2; python_version < "3.12"',
   'torch; python_version < "3.12"',
-  'transformers[torch]; python_version < "3.12"',
+  'transformers[torch]<4.41.0; python_version < "3.12"',
 ]
 mlflow = [
   "mlflow",


### PR DESCRIPTION
Carries out @benheid's suggestion to fix #6445 