### PR TITLE
[BUG] fix `test_run_test_for_class` test logic

### DIFF
--- a/sktime/tests/tests/test_test_utils.py
+++ b/sktime/tests/tests/test_test_utils.py
@@ -75,12 +75,12 @@ def test_run_test_for_class():
         assert reason_nodep == "False_no_change"
 
     # now check estimator with soft deps
-    run_nodep = run_test_for_class(f_with_deps)
+    run_wdep = run_test_for_class(f_with_deps)
     assert isinstance(run, bool)
 
     dep_present = _check_estimator_deps(f_with_deps, severity="none")
     if not dep_present:
-        assert not run_nodep
+        assert not run_wdep
 
     res = run_test_for_class(f_with_deps, return_reason=True)
     assert isinstance(res, tuple)


### PR DESCRIPTION
The `test_run_test_for_class` test logic was erroneous in case the class with dependency was changed.

This is due to an accidental variable overwrite, `run_no_dep` being overwritten with the value from the test class with dependencies.

Spotted through failure in https://github.com/sktime/skpro/pull/343, which changed the "class with dependencies" example used in `skpro`.