### PR TITLE
[BUG] in `CNNClassifier` and `CNNRegressor`, ensure `filter_sizes` and `padding` is passed on

### DIFF
--- a/sktime/classification/deep_learning/cnn.py
+++ b/sktime/classification/deep_learning/cnn.py
@@ -43,6 +43,12 @@ class CNNClassifier(BaseDeepClassifier):
         whether the layer uses a bias vector.
     optimizer       : keras.optimizers object, default = Adam(lr=0.01)
         specify the optimizer and the learning rate to be used.
+    padding : string, default = "auto"
+        Controls padding logic for the convolutional layers,
+        i.e. whether ``'valid'`` and ``'same'`` are passed to the ``Conv1D`` layer.
+        - "auto": as per original implementation, ``"same"`` is passed if
+          ``input_shape[0] < 60`` in the input layer, and ``"valid"`` otherwise.
+        - "valid", "same", and other values are passed directly to ``Conv1D``
 
     Notes
     -----
@@ -89,6 +95,8 @@ class CNNClassifier(BaseDeepClassifier):
         activation="softmax",
         use_bias=True,
         optimizer=None,
+        filter_sizes=None,
+        padding="auto",
     ):
         _check_dl_dependencies(severity="error")
 
@@ -107,6 +115,8 @@ class CNNClassifier(BaseDeepClassifier):
         self.use_bias = use_bias
         self.optimizer = optimizer
         self.history = None
+        self.filter_sizes = filter_sizes
+        self.padding = padding
 
         super().__init__()
 
@@ -114,7 +124,9 @@ class CNNClassifier(BaseDeepClassifier):
             kernel_size=self.kernel_size,
             avg_pool_size=self.avg_pool_size,
             n_conv_layers=self.n_conv_layers,
+            filter_sizes=self.filter_sizes,
             activation=self.activation,
+            padding=self.padding,
             random_state=self.random_state,
         )
 

--- a/sktime/classification/deep_learning/cnn.py
+++ b/sktime/classification/deep_learning/cnn.py
@@ -27,14 +27,14 @@ class CNNClassifier(BaseDeepClassifier):
         size of the average pooling windows
     n_conv_layers   : int, default = 2
         the number of convolutional plus average pooling layers
-    filter_sizes    : array of shape (n_conv_layers) default = [6, 12]
-    random_state    : int or None, default=None
-        Seed for random number generation.
+    callbacks       : list of keras.callbacks, default = None
     verbose         : boolean, default = False
         whether to output extra information
     loss            : string, default="categorical_crossentropy"
         fit parameter for the keras model
     metrics         : list of strings, default=["accuracy"],
+    random_state    : int or None, default=None
+        Seed for random number generation.
     activation      : string or a tf callable, default="softmax"
         Activation function used in the output linear layer.
         List of available activation functions:
@@ -43,6 +43,7 @@ class CNNClassifier(BaseDeepClassifier):
         whether the layer uses a bias vector.
     optimizer       : keras.optimizers object, default = Adam(lr=0.01)
         specify the optimizer and the learning rate to be used.
+    filter_sizes    : array of shape (n_conv_layers) default = [6, 12]
     padding : string, default = "auto"
         Controls padding logic for the convolutional layers,
         i.e. whether ``'valid'`` and ``'same'`` are passed to the ``Conv1D`` layer.

--- a/sktime/regression/deep_learning/cnn.py
+++ b/sktime/regression/deep_learning/cnn.py
@@ -42,6 +42,12 @@ class CNNRegressor(BaseDeepRegressor):
     use_bias        : bool, default=True
         whether to use bias in the output layer.
     metrics         : list of strings, default=["accuracy"],
+    padding : string, default = "auto"
+        Controls padding logic for the convolutional layers,
+        i.e. whether ``'valid'`` and ``'same'`` are passed to the ``Conv1D`` layer.
+        - "auto": as per original implementation, ``"same"`` is passed if
+          ``input_shape[0] < 60`` in the input layer, and ``"valid"`` otherwise.
+        - "valid", "same", and other values are passed directly to ``Conv1D``
 
     References
     ----------
@@ -90,6 +96,8 @@ class CNNRegressor(BaseDeepRegressor):
         activation="linear",
         use_bias=True,
         optimizer=None,
+        filter_sizes=None,
+        padding="auto",
     ):
         _check_dl_dependencies(severity="error")
         super().__init__()
@@ -107,11 +115,16 @@ class CNNRegressor(BaseDeepRegressor):
         self.use_bias = use_bias
         self.optimizer = optimizer
         self.history = None
+        self.filter_sizes = filter_sizes
+        self.padding = padding
+
         self._network = CNNNetwork(
             kernel_size=self.kernel_size,
             avg_pool_size=self.avg_pool_size,
             n_conv_layers=self.n_conv_layers,
+            filter_sizes=self.filter_sizes,
             activation=self.activation,
+            padding=self.padding,
             random_state=self.random_state,
         )
 

--- a/sktime/regression/deep_learning/cnn.py
+++ b/sktime/regression/deep_learning/cnn.py
@@ -17,7 +17,6 @@ class CNNRegressor(BaseDeepRegressor):
 
     Parameters
     ----------
-    should inherited fields be listed here?
     n_epochs       : int, default = 2000
         the number of epochs to train the model
     batch_size      : int, default = 16
@@ -28,20 +27,23 @@ class CNNRegressor(BaseDeepRegressor):
         size of the average pooling windows
     n_conv_layers   : int, default = 2
         the number of convolutional plus average pooling layers
-    filter_sizes    : array of shape (n_conv_layers) default = [6, 12]
-    random_state    : int or None, default=None
-        Seed for random number generation.
+    callbacks       : list of keras.callbacks, default = None
     verbose         : boolean, default = False
         whether to output extra information
     loss            : string, default="mean_squared_error"
         fit parameter for the keras model
-    activation      : keras.activations or string, default ``linear``
-        function to use in the output layer.
-    optimizer       : keras.optimizers or string, default ``None``.
-        when ``None``, internally uses ``keras.optimizers.Adam(0.01)``
-    use_bias        : bool, default=True
-        whether to use bias in the output layer.
     metrics         : list of strings, default=["accuracy"],
+    random_state    : int or None, default=None
+        Seed for random number generation.
+    activation      : string or a tf callable, default="softmax"
+        Activation function used in the output linear layer.
+        List of available activation functions:
+        https://keras.io/api/layers/activations/
+    use_bias        : boolean, default = True
+        whether the layer uses a bias vector.
+    optimizer       : keras.optimizers object, default = Adam(lr=0.01)
+        specify the optimizer and the learning rate to be used.
+    filter_sizes    : array of shape (n_conv_layers) default = [6, 12]
     padding : string, default = "auto"
         Controls padding logic for the convolutional layers,
         i.e. whether ``'valid'`` and ``'same'`` are passed to the ``Conv1D`` layer.


### PR DESCRIPTION
This PR adds `filter_sizes` and `padding` parameters to `CNNClassifier` and `CNNRegressor`, and ensures these are passed on to `CNNNetwork`.

Fixes https://github.com/sktime/sktime/issues/6436.