### PR TITLE
[ENH] `sklearn 1.5.0` compatibility patch

### DIFF
--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -608,7 +608,7 @@ class BaseClassifier(BasePanelMixin):
         else:  # method == "predict_proba"
             return np.repeat([[1]], n_instances, axis=0)
 
-    def score(self, X, y, multioutput="uniform_average") -> float:
+    def score(self, X, y) -> float:
         """Scores predicted labels against ground truth labels on X.
 
         Parameters
@@ -632,7 +632,7 @@ class BaseClassifier(BasePanelMixin):
 
         Returns
         -------
-        float, accuracy score of predict(X) vs y.
+        float, accuracy score of predict(X) vs y
         """
         from sklearn.metrics import accuracy_score
 

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -608,7 +608,7 @@ class BaseClassifier(BasePanelMixin):
         else:  # method == "predict_proba"
             return np.repeat([[1]], n_instances, axis=0)
 
-    def score(self, X, y) -> float:
+    def score(self, X, y, multioutput="uniform_average") -> float:
         """Scores predicted labels against ground truth labels on X.
 
         Parameters
@@ -629,16 +629,26 @@ class BaseClassifier(BasePanelMixin):
             0-th indices correspond to instance indices in X
             1-st indices (if applicable) correspond to multioutput vector indices in X
             supported sktime types: np.ndarray (1D, 2D), pd.Series, pd.DataFrame
+        multioutput : str, optional (default="uniform_average")
+            {"raw_values", "uniform_average"}, array-like of shape
+            (n_outputs,) or None, default="uniform_average".
+            Defines aggregating of multiple output scores. Array-like value defines
+            weights used to average scores.
 
         Returns
         -------
-        float, accuracy score of predict(X) vs y
+        float (default) or 1D np.array of float
+            accuracy score of predict(X) vs y.
+            float if multioutput="uniform_average" or y is univariate,
+            1D np.array if multioutput="raw_values" and y is multivariate
         """
         from sklearn.metrics import accuracy_score
 
         self.check_is_fitted()
 
-        return accuracy_score(y, self.predict(X), normalize=True)
+        return accuracy_score(
+            y, self.predict(X), normalize=True, multioutput=multioutput
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -629,26 +629,16 @@ class BaseClassifier(BasePanelMixin):
             0-th indices correspond to instance indices in X
             1-st indices (if applicable) correspond to multioutput vector indices in X
             supported sktime types: np.ndarray (1D, 2D), pd.Series, pd.DataFrame
-        multioutput : str, optional (default="uniform_average")
-            {"raw_values", "uniform_average"}, array-like of shape
-            (n_outputs,) or None, default="uniform_average".
-            Defines aggregating of multiple output scores. Array-like value defines
-            weights used to average scores.
 
         Returns
         -------
-        float (default) or 1D np.array of float
-            accuracy score of predict(X) vs y.
-            float if multioutput="uniform_average" or y is univariate,
-            1D np.array if multioutput="raw_values" and y is multivariate
+        float, accuracy score of predict(X) vs y.
         """
         from sklearn.metrics import accuracy_score
 
         self.check_is_fitted()
 
-        return accuracy_score(
-            y, self.predict(X), normalize=True, multioutput=multioutput
-        )
+        return accuracy_score(y, self.predict(X), normalize=True)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/regression/base.py
+++ b/sktime/regression/base.py
@@ -315,7 +315,11 @@ class BaseRegressor(BasePanelMixin):
 
         Returns
         -------
-        float, R-squared score of predict(X) vs y
+        float (default) or 1D np.array of float
+            R-squared score of predict(X) vs y
+            float if multioutput="uniform_average" or "variance_weighted,
+            or y is univariate;
+            1D np.array if multioutput="raw_values" and y is multivariate
         """
         from sklearn.metrics import r2_score
 

--- a/sktime/regression/tests/test_all_regressors.py
+++ b/sktime/regression/tests/test_all_regressors.py
@@ -13,6 +13,7 @@ from sktime.utils._testing.panel import make_regression_problem
 from sktime.utils._testing.scenarios_classification import (
     ClassifierFitPredictMultivariate,
 )
+from sktime.utils.validation import is_float
 
 
 class RegressorFixtureGenerator(BaseFixtureGenerator):
@@ -79,12 +80,12 @@ class TestAllRegressors(RegressorFixtureGenerator, QuickTester):
         y_pred = scenario.run(estimator_instance, method_sequence=["fit", "predict"])
         # check score
         score = estimator_instance.score(X_new, y_pred)
-        assert np.issubdtype(score.dtype, np.floating)
+        assert is_float(score)
 
         # check predict
         assert isinstance(y_pred, np.ndarray)
         assert y_pred.shape == (X_new_instances,)
-        assert np.issubdtype(y_pred.dtype, np.floating)
+        assert is_float(y_pred)
 
     def test_multioutput(self, estimator_instance):
         """Test multioutput regression for all classifiers.
@@ -100,7 +101,7 @@ class TestAllRegressors(RegressorFixtureGenerator, QuickTester):
         y_pred = estimator_instance.predict(X)
         # check score
         score = estimator_instance.score(X, y_mult)
-        assert np.issubdtype(score.dtype, np.floating)
+        assert is_float(score)
 
         assert isinstance(y_pred, pd.DataFrame)
         assert y_pred.shape == y_mult.shape

--- a/sktime/regression/tests/test_all_regressors.py
+++ b/sktime/regression/tests/test_all_regressors.py
@@ -85,7 +85,7 @@ class TestAllRegressors(RegressorFixtureGenerator, QuickTester):
         # check predict
         assert isinstance(y_pred, np.ndarray)
         assert y_pred.shape == (X_new_instances,)
-        assert is_float(y_pred)
+        assert np.issubdtype(y_pred.dtype, np.floating)
 
     def test_multioutput(self, estimator_instance):
         """Test multioutput regression for all classifiers.


### PR DESCRIPTION
Makes some minor changes to ensure `sklearn 1.5.0` compatibility.

* relaxes tests for return of `BaseRegressor.score`, which uses `sklearn` metrics internally. `sklearn` regression metrics now seem to return `float` instead of `np.floating`. To ensure this is can be in line with `sklearn` type on all versions, the test is relaxed to allow for both. I do not think stricter tests are needed, as `np.floating` behaves like `float` for all practical purposes.
* fixes an unreported bug where `BaseClassifier.score`, in some instances, returned an 1D `np.ndarray` and not a float by default