### PR TITLE
[MNT] skip doctest for `all_estimators`

### DIFF
--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -140,12 +140,12 @@ def all_estimators(
     >>> # return all forecasters by filtering for estimator type
     >>> all_estimators("forecaster")  # doctest: +SKIP
     >>> # return all forecasters which handle missing data in the input by tag filtering
-    >>> all_estimators("forecaster", filter_tags={"handles-missing-data": True})  # doctest: +SKIP  # noqa: E501
+    >>> all_estimators("forecaster", filter_tags={"handles-missing-data": True})  # doctest: +SKIP
 
     References
     ----------
     Modified version from scikit-learn's ``all_estimators()``.
-    """
+    """  # noqa: E501
     MODULES_TO_IGNORE = (
         "tests",
         "setup",

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -136,11 +136,11 @@ def all_estimators(
     --------
     >>> from sktime.registry import all_estimators
     >>> # return a complete list of estimators as pd.Dataframe
-    >>> all_estimators(as_dataframe=True)
+    >>> all_estimators(as_dataframe=True)  # doctest: +SKIP
     >>> # return all forecasters by filtering for estimator type
-    >>> all_estimators("forecaster")
+    >>> all_estimators("forecaster")  # doctest: +SKIP
     >>> # return all forecasters which handle missing data in the input by tag filtering
-    >>> all_estimators("forecaster", filter_tags={"handles-missing-data": True})
+    >>> all_estimators("forecaster", filter_tags={"handles-missing-data": True})  # doctest: +SKIP  # noqa: E501
 
     References
     ----------


### PR DESCRIPTION
Adds a doctest skip for the `all_estimators` example.

This is to avoid running the retrieval method three times, the same functionality is already covered in `test_lookup`.

Also, the test should fail, because the printout is not tested against, so it is odd that it does not fail on `main` currently.