### PR TITLE
[MNT] address various deprecation and computation warnings

### DIFF
--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -270,7 +270,10 @@ def check_pdmultiindex_panel(obj, return_metadata=False, var_name="obj", panel=T
         "is_equally_spaced",
     ]
     if _req(requires_series_grps, return_metadata):
-        series_groups = obj.groupby(level=list(range(index.nlevels - 1)), sort=False)
+        levels = list(range(index.nlevels - 1))
+        if len(levels) == 1:
+            levels = levels[0]
+        series_groups = obj.groupby(level=levels, sort=False)
         n_series = series_groups.ngroups
 
         if _req("n_instances", return_metadata):

--- a/sktime/datatypes/tests/test_utils.py
+++ b/sktime/datatypes/tests/test_utils.py
@@ -410,7 +410,7 @@ def test_get_slice_expected_result():
 def test_retain_series_freq_on_update():
     """Tests that the frequency of a series is retained after updating it"""
     from sktime.datasets import load_airline
-    from sktime.forecasting.model_selection import temporal_train_test_split
+    from sktime.split import temporal_train_test_split
 
     y = load_airline()
 

--- a/sktime/performance_metrics/forecasting/probabilistic/_classes.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/_classes.py
@@ -406,7 +406,10 @@ def _groupby_dot(df, weights):
     out : pd.DataFrame
         dataframe with weighted groupby dot product
     """
-    out = df.groupby(axis=1, level=1).apply(lambda x: x.dot(weights))
+    out = df.T.groupby(level=1).apply(lambda x: x.T.dot(weights)).T
+    # formerly
+    # out = df.groupby(axis=1, level=1).apply(lambda x: x.dot(weights))
+    # but groupby(axis=1) is deprecated
     return out
 
 

--- a/sktime/proba/mixture.py
+++ b/sktime/proba/mixture.py
@@ -139,7 +139,7 @@ class Mixture(_HeterogenousMetaEstimator, BaseDistribution):
         n_df = len(df_list)
         df_weighted = [df * w for df, w in zip(df_list, weights)]
         df_concat = pd.concat(df_weighted, axis=1, keys=range(n_df))
-        df_res = df_concat.groupby(level=-1, axis=1).sum()
+        df_res = df_concat.T.groupby(level=-1).sum().T
         return df_res
 
     def pdf(self, x):

--- a/sktime/transformations/panel/channel_selection.py
+++ b/sktime/transformations/panel/channel_selection.py
@@ -33,7 +33,12 @@ def _detect_knee_point(values, indices):
     all_coords = np.vstack((range(n_points), values)).T
     first_point = all_coords[0]
     line_vec = all_coords[-1] - all_coords[0]
-    line_vec_norm = line_vec / np.sqrt(np.sum(line_vec**2))
+
+    line_vec_abs = np.sqrt(np.sum(line_vec**2))
+    if line_vec_abs == 0:  # ensuring normalization is correct in case of zero vector
+        line_vec_abs = 1
+    line_vec_norm = line_vec / line_vec_abs
+
     vec_from_first = all_coords - first_point
     scalar_prod = np.sum(vec_from_first * np.tile(line_vec_norm, (n_points, 1)), axis=1)
     vec_from_first_parallel = np.outer(scalar_prod, line_vec_norm)

--- a/sktime/transformations/panel/reduce.py
+++ b/sktime/transformations/panel/reduce.py
@@ -154,7 +154,7 @@ class TimeBinner(BaseTransformer):
         transformed version of X
         """
         idx = pd.cut(X.iloc[0, 0].index, bins=self.idx, include_lowest=True)
-        Xt = df_map(X)(lambda x: x.groupby(idx).apply(self._aggfunc))
+        Xt = df_map(X)(lambda x: x.groupby(idx, observed=False).apply(self._aggfunc))
         Xt = convert_to(Xt, to_type="numpyflat", as_scitype="Panel")
         return Xt
 

--- a/sktime/transformations/series/binning.py
+++ b/sktime/transformations/series/binning.py
@@ -117,7 +117,7 @@ class TimeBinAggregate(BaseTransformer):
         """
         bins = self.bins
         idx_cut = pd.cut(X.index, bins=self._bins, include_lowest=True)
-        Xt = X.groupby(idx_cut).apply(self._aggfunc)
+        Xt = X.groupby(idx_cut, observed=False).apply(self._aggfunc)
 
         if self.return_index == "range":
             Xt = Xt.reset_index(drop=True)

--- a/sktime/transformations/series/peak.py
+++ b/sktime/transformations/series/peak.py
@@ -294,7 +294,9 @@ class PeakTimeFeature(BaseTransformer):
         df = self._extract_peaktime_features(calendar_features, datetime_freq)
 
         if self.keep_original_columns:
-            Xt = pd.concat([X, df], axis=1, copy=True)
+            to_concat = [X, df]
+            to_concat = [df for df in to_concat if not df.empty]
+            Xt = pd.concat(to_concat, axis=1, copy=True)
         else:
             Xt = df
 

--- a/sktime/transformations/series/vmd/_vmdpy.py
+++ b/sktime/transformations/series/vmd/_vmdpy.py
@@ -148,7 +148,7 @@ def VMD(f, alpha, tau, K, DC, init, tol):
         # update first omega if not held at 0
         if not DC:
             wts = abs(u_hat_plus[n + 1, T // 2 : T, k]) ** 2
-            omega_plus[n + 1, k] = np.average(freqs[T // 2 : T], weights=wts)
+            omega_plus[n + 1, k] = _safe_average(freqs[T // 2 : T], weights=wts)
 
         # update of any other mode
         for k in np.arange(1, K):
@@ -160,7 +160,7 @@ def VMD(f, alpha, tau, K, DC, init, tol):
             u_hat_plus[n + 1, :, k] = u_hat_plus_enumerator / u_hat_plus_denominator
             # center frequencies
             wts = abs(u_hat_plus[n + 1, T // 2 : T, k]) ** 2
-            omega_plus[n + 1, k] = np.average(freqs[T // 2 : T], weights=wts)
+            omega_plus[n + 1, k] = _safe_average(freqs[T // 2 : T], weights=wts)
 
         # Dual ascent
         lambda_update = tau * (np.sum(u_hat_plus[n + 1, :, :], axis=1) - f_hat_plus)
@@ -205,3 +205,29 @@ def VMD(f, alpha, tau, K, DC, init, tol):
         u_hat[:, k] = np.fft.fftshift(np.fft.fft(u[k, :]))
 
     return u, u_hat, omega
+
+
+def _safe_average(x, weights):
+    """Compute the weighted average of x, with safe handling of zero weights.
+
+    If not all weights are zero, the function returns the weighted arithmetic mean of x,
+    equivalent to ``np.average(x, weights=weights)``.
+    If all weights are zero, the function returns the unweighted arithmetic mean of x.
+
+    Parameters
+    ----------
+    x : 1D array_like
+        the data to be averaged
+    weights : 1D array_like
+        the weights for the average
+
+    Returns
+    -------
+    average : float
+        the weighted average of x
+    """
+    wtsum = np.sum(weights)
+    if wtsum == 0:
+        return np.mean(x)
+    else:
+        return np.dot(x, weights) / wtsum

--- a/sktime/transformations/series/vmd/_vmdpy.py
+++ b/sktime/transformations/series/vmd/_vmdpy.py
@@ -147,11 +147,8 @@ def VMD(f, alpha, tau, K, DC, init, tol):
 
         # update first omega if not held at 0
         if not DC:
-            o_pl_enum = np.dot(
-                freqs[T // 2 : T], abs(u_hat_plus[n + 1, T // 2 : T, k]) ** 2
-            )
-            o_pl_denom = np.sum(abs(u_hat_plus[n + 1, T // 2 : T, k]) ** 2)
-            omega_plus[n + 1, k] = o_pl_enum / o_pl_denom
+            wts = abs(u_hat_plus[n + 1, T // 2 : T, k]) ** 2
+            omega_plus[n + 1, k] = np.average(freqs[T // 2 : T], weights=wts)
 
         # update of any other mode
         for k in np.arange(1, K):
@@ -162,11 +159,8 @@ def VMD(f, alpha, tau, K, DC, init, tol):
             u_hat_plus_denominator = 1.0 + Alpha[k] * (freqs - omega_plus[n, k]) ** 2
             u_hat_plus[n + 1, :, k] = u_hat_plus_enumerator / u_hat_plus_denominator
             # center frequencies
-            o_pl_enum = np.dot(
-                freqs[T // 2 : T], abs(u_hat_plus[n + 1, T // 2 : T, k]) ** 2
-            )
-            o_pl_denom = np.sum(abs(u_hat_plus[n + 1, T // 2 : T, k]) ** 2)
-            omega_plus[n + 1, k] = o_pl_enum / o_pl_denom
+            wts = abs(u_hat_plus[n + 1, T // 2 : T, k]) ** 2
+            omega_plus[n + 1, k] = np.average(freqs[T // 2 : T], weights=wts)
 
         # Dual ascent
         lambda_update = tau * (np.sum(u_hat_plus[n + 1, :, :], axis=1) - f_hat_plus)


### PR DESCRIPTION
This PR addresses various warnings in the code, related to deprecated features or mathematical computations.

Deprecations:

* addressed deprecation of `pd.DataFrame.groupby(axis=1)` in multiple locations
* address changed signature of `groupby` for length 1 `level` parameter
* address changed default of `observed` in `groupby`
* fixed import of `sktime` `train_test_split` from deprecated location
* addressed change in behaviour of `pd.concat` on empty `DataFrame`

Computations:

* fixed unsafe division in `channel_selection.py`
* fixed unsafe weighted average in `vmdpy`