### PR TITLE
[BUG] fix `BaseClassifier.fit_predict` and `fit_predict_proba` for `pd-multiindex` mtype

### DIFF
--- a/sktime/base/_base_panel.py
+++ b/sktime/base/_base_panel.py
@@ -102,7 +102,15 @@ class BasePanelMixin(BaseEstimator):
 
             return y_pred
 
-    def _fit_predict_boilerplate(self, X, y, cv, change_state, method):
+    def _fit_predict_boilerplate(
+        self,
+        X,
+        y,
+        cv,
+        change_state,
+        method,
+        return_type="single_y_pred",
+    ):
         """Boilerplate logic for fit_predict and fit_predict_proba."""
         from sklearn.model_selection import KFold
 
@@ -147,31 +155,86 @@ class BasePanelMixin(BaseEstimator):
             X = convert(
                 X,
                 from_type=X_mtype,
-                to_type="nested_univ",
+                to_type=["pd-multiindex", "nested_univ"],
                 as_scitype="Panel",
                 store_behaviour="freeze",
             )
 
-        if method == "predict_proba":
-            y_pred = np.empty([len(y), len(np.unique(y))])
-        else:
-            y_pred = np.empty_like(y)
-        y_pred[:] = -1
-        if isinstance(X, np.ndarray):
-            for tr_idx, tt_idx in cv.split(X):
-                X_train = X[tr_idx]
-                X_test = X[tt_idx]
-                y_train = y[tr_idx]
-                fitted_est = self.clone().fit(X_train, y_train)
-                y_pred[tt_idx] = getattr(fitted_est, method)(X_test)
-        else:
-            for tr_idx, tt_idx in cv.split(X):
-                X_train = X.iloc[tr_idx]
-                X_test = X.iloc[tt_idx]
-                y_train = y[tr_idx]
-                fitted_est = self.clone().fit(X_train, y_train)
-                y_pred[tt_idx] = getattr(fitted_est, method)(X_test)
+        y_preds = []
+        tt_ixx = []
 
+        if isinstance(X.index, pd.MultiIndex):
+            X_ix = X.index.get_level_values(0).unique()
+        else:
+            X_ix = np.arange(len(X))
+
+        for tr_idx, tt_idx in cv.split(X_ix):
+            X_train = self._subset(X, tr_idx)
+            X_test = self._subset(X, tt_idx)
+            y_train = self._subset(y, tr_idx)
+            fitted_est = self.clone().fit(X_train, y_train)
+            y_preds.append(getattr(fitted_est, method)(X_test))
+            tt_ixx.append(tt_idx)
+
+        if return_type == "single_y_pred":
+            return self._pool(y_preds, tt_ixx, y)
+        else:
+            return y_preds
+
+    def _subset(self, obj, ix):
+        """Subset input data by ix, for use in fit_predict_boilerplate.
+
+        Parameters
+        ----------
+        obj : pd.DataFrame or np.ndarray
+            if pd.DataFrame, instance index = first level of pd.MultiIndex
+            if np.ndarray, instance index = 0-th axis
+        ix : sklearn splitter index, e.g., ix, _ from KFold.split(X)
+
+        Returns
+        -------
+        obj_ix : obj subset by ix
+        """
+        if isinstance(obj, np.ndarray):
+            return obj[ix]
+        if not isinstance(obj, (pd.DataFrame, pd.Series)):
+            raise ValueError("obj must be a pd.DataFrame, pd.Series, or np.ndarray")
+        if not isinstance(obj.index, pd.MultiIndex):
+            return obj.iloc[ix]
+        else:
+            ix_loc = obj.index.get_level_values(0).unique()[ix]
+            return obj.loc[ix_loc]
+
+    def _pool(self, y_preds, tt_ixx, y):
+        """Pool predictions from cv splits, for use in fit_predict_boilerplate.
+
+        Parameters
+        ----------
+        y_preds : list of np.ndarray or pd.DataFrame
+            list of predictions from cv splits
+        tt_ixx : list of np.ndarray or pd.DataFrame
+            list of test indices from cv splits
+
+        Returns
+        -------
+        y_pred : np.ndarray, pooled predictions
+        """
+        y_pred = y_preds[0]
+        if isinstance(y_pred, (pd.DataFrame, pd.Series)):
+            for i in range(1, len(y_preds)):
+                y_pred = y_pred.combine_first(y_preds[i])
+            y_pred = y_pred.reindex(y.index).fillna(-1)
+        else:
+            if y_pred.ndim == 1:
+                sh = y.shape
+            else:
+                sh = (y.shape[0], y_pred.shape[1])
+            y_pred = -np.ones(sh, dtype=y.dtype)
+            for i, ix in enumerate(tt_ixx):
+                y_preds_i = y_preds[i]
+                if y_pred.ndim == 1:
+                    y_preds_i = y_preds_i.reshape(-1)
+                y_pred[ix] = y_preds_i
         return y_pred
 
     def _check_convert_X_for_predict(self, X):

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -25,10 +25,9 @@ __author__ = ["mloning", "fkiraly", "TonyBagnall", "MatthewMiddlehurst", "ksharm
 import time
 
 import numpy as np
-import pandas as pd
 
 from sktime.base import BasePanelMixin
-from sktime.datatypes import VectorizedDF, check_is_scitype, convert
+from sktime.datatypes import VectorizedDF, check_is_scitype
 from sktime.utils.sklearn import is_sklearn_transformer
 from sktime.utils.validation import check_n_jobs
 from sktime.utils.validation._dependencies import _check_estimator_deps

--- a/sktime/classification/base.py
+++ b/sktime/classification/base.py
@@ -374,6 +374,7 @@ class BaseClassifier(BasePanelMixin):
             or of any other supported Panel mtype
             for list of mtypes, see datatypes.SCITYPE_REGISTER
             for specifications, see examples/AA_datatypes_and_datasets.ipynb
+
         y : sktime compatible tabular data container, Table scitype
             1D iterable, of shape [n_instances]
             or 2D iterable, of shape [n_instances, n_dimensions]
@@ -381,20 +382,26 @@ class BaseClassifier(BasePanelMixin):
             0-th indices correspond to instance indices in X
             1-st indices (if applicable) correspond to multioutput vector indices in X
             supported sktime types: np.ndarray (1D, 2D), pd.Series, pd.DataFrame
+
         cv : None, int, or sklearn cross-validation object, optional, default=None
-            None : predictions are in-sample, equivalent to fit(X, y).predict(X)
-            cv : predictions are equivalent to fit(X_train, y_train).predict(X_test)
-                where multiple X_train, y_train, X_test are obtained from cv folds
-                returned y is union over all test fold predictions
-                cv test folds must be non-intersecting
-            int : equivalent to cv=KFold(cv, shuffle=True, random_state=x),
-                i.e., k-fold cross-validation predictions out-of-sample
-                random_state x is taken from self if exists, otherwise x=None
+
+            * None : predictions are in-sample, equivalent to ``fit(X, y).predict(X)``
+            * cv : predictions are equivalent to
+              ``fit(X_train, y_train).predict(X_test)``, where multiple
+              ``X_train``, ``y_train``, ``X_test`` are obtained from ``cv`` folds.
+              returned ``y`` is union over all test fold predictions,
+              ``cv`` test folds must be non-intersecting
+            * int : equivalent to ``cv=KFold(cv, shuffle=True, random_state=x)``,
+              i.e., k-fold cross-validation predictions out-of-sample, and where
+              ``random_state`` ``x`` is taken from ``self`` if exists,
+              otherwise ``x=None``
+
         change_state : bool, optional (default=True)
-            if False, will not change the state of the classifier,
-                i.e., fit/predict sequence is run with a copy, self does not change
-            if True, will fit self to the full X and y,
-                end state will be equivalent to running fit(X, y)
+
+            * if False, will not change the state of the classifier,
+              i.e., fit/predict sequence is run with a copy, self does not change
+            * if True, will fit self to the full X and y,
+              end state will be equivalent to running fit(X, y)
 
         Returns
         -------
@@ -410,136 +417,6 @@ class BaseClassifier(BasePanelMixin):
         return self._fit_predict_boilerplate(
             X=X, y=y, cv=cv, change_state=change_state, method="predict"
         )
-
-    def _fit_predict_boilerplate(
-        self,
-        X,
-        y,
-        cv,
-        change_state,
-        method,
-        return_type="single_y_pred",
-    ):
-        """Boilerplate logic for fit_predict and fit_predict_proba."""
-        from sklearn.model_selection import KFold
-
-        if isinstance(cv, int):
-            random_state = getattr(self, "random_state", None)
-            cv = KFold(cv, random_state=random_state, shuffle=True)
-
-        if change_state:
-            self.reset()
-            est = self
-        else:
-            est = self.clone()
-
-        if cv is None:
-            return getattr(est.fit(X, y), method)(X)
-        elif change_state:
-            self.fit(X, y)
-
-        # we now know that cv is an sklearn splitter
-        X, y = self._internal_convert(X, y)
-        X_metadata = self._check_input(
-            X, y, return_metadata=self.METADATA_REQ_IN_CHECKS
-        )
-        X_mtype = X_metadata["mtype"]
-        # Check this classifier can handle characteristics
-        self._check_capabilities(X_metadata)
-
-        # handle single class case
-        if len(self._class_dictionary) == 1:
-            return self._single_class_y_pred(X)
-
-        # Convert data to format easily usable for applying cv
-        if isinstance(X, np.ndarray):
-            X = convert(
-                X,
-                from_type=X_mtype,
-                to_type="numpy3D",
-                as_scitype="Panel",
-                store_behaviour="freeze",
-            )
-        else:
-            X = convert(
-                X,
-                from_type=X_mtype,
-                to_type=["pd-multiindex", "nested_univ"],
-                as_scitype="Panel",
-                store_behaviour="freeze",
-            )
-
-        y_preds = []
-        tt_ixx = []
-
-        for tr_idx, tt_idx in cv.split(X):
-            X_train = self._subset(X, tr_idx)
-            X_test = self._subset(X, tt_idx)
-            y_train = self._subset(y, tr_idx)
-            fitted_est = self.clone().fit(X_train, y_train)
-            y_preds.append(getattr(fitted_est, method)(X_test))
-            tt_ixx.append(tt_idx)
-
-        if return_type == "single_y_pred":
-            return self._pool(y_preds, tt_ixx, y)
-        else:
-            return y_preds
-
-    def _subset(self, obj, ix):
-        """Subset input data by ix, for use in fit_predict_boilerplate.
-
-        Parameters
-        ----------
-        obj : pd.DataFrame or np.ndarray
-            if pd.DataFrame, instance index = first level of pd.MultiIndex
-            if np.ndarray, instance index = 0-th axis
-        ix : sklearn splitter index, e.g., ix, _ from KFold.split(X)
-
-        Returns
-        -------
-        obj_ix : obj subset by ix
-        """
-        if isinstance(obj, np.ndarray):
-            return obj[ix]
-        if not isinstance(obj, (pd.DataFrame, pd.Series)):
-            raise ValueError("obj must be a pd.DataFrame, pd.Series, or np.ndarray")
-        if not isinstance(obj.index, pd.MultiIndex):
-            return obj.iloc[ix]
-        else:
-            ix_loc = obj.index.get_level_values(0).unique()[ix]
-            return obj.loc[ix_loc]
-
-    def _pool(self, y_preds, tt_ixx, y):
-        """Pool predictions from cv splits, for use in fit_predict_boilerplate.
-
-        Parameters
-        ----------
-        y_preds : list of np.ndarray or pd.DataFrame
-            list of predictions from cv splits
-        tt_ixx : list of np.ndarray or pd.DataFrame
-            list of test indices from cv splits
-
-        Returns
-        -------
-        y_pred : np.ndarray, pooled predictions
-        """
-        y_pred = y_preds[0]
-        if isinstance(y_pred, (pd.DataFrame, pd.Series)):
-            for i in range(1, len(y_preds)):
-                y_pred = y_pred.combine_first(y_preds[i])
-            y_pred = y_pred.reindex(y.index).fillna(-1)
-        else:
-            if y_pred.ndim == 1:
-                sh = y.shape
-            else:
-                sh = (y.shape[0], y_pred.shape[1])
-            y_pred = -np.ones(sh, dtype=y.dtype)
-            for i, ix in enumerate(tt_ixx):
-                y_preds_i = y_preds[i]
-                if y_pred.ndim == 1:
-                    y_preds_i = y_preds_i.reshape(-1)
-                y_pred[ix] = y_preds_i
-        return y_pred
 
     def fit_predict_proba(self, X, y, cv=None, change_state=True):
         """Fit and predict labels probabilities for sequences in X.
@@ -564,6 +441,7 @@ class BaseClassifier(BasePanelMixin):
             or of any other supported Panel mtype
             for list of mtypes, see datatypes.SCITYPE_REGISTER
             for specifications, see examples/AA_datatypes_and_datasets.ipynb
+
         y : sktime compatible tabular data container, Table scitype
             1D iterable, of shape [n_instances]
             or 2D iterable, of shape [n_instances, n_dimensions]
@@ -571,18 +449,26 @@ class BaseClassifier(BasePanelMixin):
             0-th indices correspond to instance indices in X
             1-st indices (if applicable) correspond to multioutput vector indices in X
             supported sktime types: np.ndarray (1D, 2D), pd.Series, pd.DataFrame
+
         cv : None, int, or sklearn cross-validation object, optional, default=None
-            None : predictions are in-sample, equivalent to fit(X, y).predict(X)
-            cv : predictions are equivalent to fit(X_train, y_train).predict(X_test)
-                where multiple X_train, y_train, X_test are obtained from cv folds
-                returned y is union over all test fold predictions
-                cv test folds must be non-intersecting
-            int : equivalent to cv=Kfold(int), i.e., k-fold cross-validation predictions
+
+            * None : predictions are in-sample, equivalent to ``fit(X, y).predict(X)``
+            * cv : predictions are equivalent to
+              ``fit(X_train, y_train).predict(X_test)``, where multiple
+              ``X_train``, ``y_train``, ``X_test`` are obtained from ``cv`` folds.
+              returned ``y`` is union over all test fold predictions,
+              ``cv`` test folds must be non-intersecting
+            * int : equivalent to ``cv=KFold(cv, shuffle=True, random_state=x)``,
+              i.e., k-fold cross-validation predictions out-of-sample, and where
+              ``random_state`` ``x`` is taken from ``self`` if exists,
+              otherwise ``x=None``
+
         change_state : bool, optional (default=True)
-            if False, will not change the state of the classifier,
-                i.e., fit/predict sequence is run with a copy, self does not change
-            if True, will fit self to the full X and y,
-                end state will be equivalent to running fit(X, y)
+
+            * if False, will not change the state of the classifier,
+              i.e., fit/predict sequence is run with a copy, self does not change
+            * if True, will fit self to the full X and y,
+              end state will be equivalent to running fit(X, y)
 
         Returns
         -------


### PR DESCRIPTION
This fixes an unreported bug where `BaseClassifier.fit_predict` and `fit_predict_proba` would not work for `pd-multiindex` mtype.

The failure is due to `cv.split` being called on a multi-index, which applies to `iloc` range index instead of the first `loc` index component of the multi-index.

Test coverage is added through the scenario in PR https://github.com/sktime/sktime/pull/6374 which covers both `pd-multiindex` as well as the three-class case.

This PR also de-duplicates the `_fit_predict_boilerplate` method of `BaseClassifier` with `BasePanelMixin`.