### PR TITLE
[ENH] remove `Prophet` from `test_differencer_cutoff`

### DIFF
--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -12,7 +12,6 @@ import pytest
 from sktime.datasets import load_airline
 from sktime.transformations.series.difference import Differencer
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
-from sktime.utils.validation._dependencies import _check_soft_dependencies
 
 y_airline = load_airline()
 y_airline_df = pd.concat([y_airline, y_airline], axis=1)
@@ -107,10 +106,6 @@ def test_differencer_prediction(y, lags, index_type):
     _assert_array_almost_equal(y_true, y_pred_inv)
 
 
-@pytest.mark.skipif(
-    not _check_soft_dependencies("prophet", severity="none"),
-    reason="requires Prophet forecaster in the example",
-)
 def test_differencer_cutoff():
     """Tests a special case that triggers freq inference.
 
@@ -119,8 +114,7 @@ def test_differencer_cutoff():
     on line "fh = ForecastingHorizon(etc" in Differencer._check_inverse_transform_index
     """
     from sktime.datasets import load_longley
-    from sktime.forecasting.compose import TransformedTargetForecaster
-    from sktime.forecasting.fbprophet import Prophet
+    from sktime.forecasting.compose import TransformedTargetForecaster, YfromX
     from sktime.forecasting.model_selection import ForecastingGridSearchCV
     from sktime.split import ExpandingWindowSplitter, temporal_train_test_split
     from sktime.transformations.series.difference import Differencer
@@ -138,7 +132,7 @@ def test_differencer_cutoff():
     pipe = TransformedTargetForecaster(
         steps=[
             ("differencer", Differencer(na_handling="fill_zero")),
-            ("myforecaster", Prophet()),
+            ("myforecaster", YfromX.create_test_instance()),
         ]
     )
 


### PR DESCRIPTION
Removes `Prophet` as an example of an exogeneous forecaster from `test_differencer_cutoff`.

This has multiple advantages, runtime, and removal of an unnecessary dependency in the test.

It also allows to diagnose https://github.com/sktime/sktime/issues/6487 - if this still fails, then `Prophet` is not the culprit, and we have found a simpler example for the bug #6487.
If it no longer fails, we know there´s something specific about `Prophet`, possibly an interaction.