### PR TITLE
[ENH] compatibility of `ForecastingHorizon` with `pandas` `freq` `2Y` on `pandas 2.2.0` and above

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -898,7 +898,7 @@ def _to_absolute(fh: ForecastingHorizon, cutoff) -> ForecastingHorizon:
 
         if is_timestamp:
             # coerce back to DatetimeIndex after operation
-            absolute = absolute.to_timestamp(fh.freq)
+            absolute = absolute.to_timestamp()
 
         if old_tz is not None:
             absolute = absolute.tz_localize(old_tz)
@@ -955,19 +955,10 @@ def _coerce_to_period(x, freq=None):
         raise ValueError(
             "_coerce_to_period requires freq argument to be passed if x is pd.Timestamp"
         )
-    try:
+    elif x.freq is None:
         return x.to_period(freq)
-    except (ValueError, AttributeError) as e:
-        msg = str(e)
-        if "Invalid frequency" in msg or "_period_dtype_code" in msg:
-            raise ValueError(
-                "Invalid frequency. Please select a frequency that can "
-                "be converted to a regular `pd.PeriodIndex`. For other "
-                "frequencies, basic arithmetic operation to compute "
-                "durations currently do not work reliably."
-            )
-        else:
-            raise
+    else:
+        return x.to_period()
 
 
 def _index_range(relative, cutoff):

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -840,7 +840,6 @@ def _to_relative(fh: ForecastingHorizon, cutoff=None) -> ForecastingHorizon:
             "pandas>=1.5.0", severity="none"
         )
         if pandas_version_with_bugfix:
-            print(absolute, cutoff)
             relative = absolute - cutoff
         else:
             relative = pd.Index([date - cutoff[0] for date in absolute])


### PR DESCRIPTION
`pandas` has once more changed their interfaces and `ForecastingHorizon` breaks with `2Y` and other frequencies, see https://github.com/sktime/sktime/issues/6499.

This fix moves internal use of `freq` to objects, from strings, which fixes the issue in a backwards compatible manner without changing any of the public interfaces.