### PR TITLE
[MNT] add `pip` cache to `setup-python` actions

### DIFF
--- a/.github/actions/test-base/action.yml
+++ b/.github/actions/test-base/action.yml
@@ -28,6 +28,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version-identifier }}
+        cache: 'pip'
 
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"

--- a/.github/actions/test-component/action.yml
+++ b/.github/actions/test-component/action.yml
@@ -31,6 +31,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version-identifier }}
+        cache: 'pip'
 
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,17 +19,23 @@ jobs:
     steps:
       - name: repository checkout step
         uses: actions/checkout@v4
+
       - name: python environment step
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
+
       - name: install pre-commit
         run: python3 -m pip install pre-commit
+
       - id: changed-files
         name: identify modified files
         uses: tj-actions/changed-files@v44
+
       - name: run pre-commit hooks on modified files
         run: pre-commit run --color always --files ${{ steps.changed-files.outputs.all_changed_files }} --show-diff-on-failure
+
       - name: check missing __init__ files
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash
@@ -39,14 +45,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+          cache: 'pip'
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install .[all_extras,binder,dev,mlflow]
+
       - name: Run example notebooks
         run: build_tools/run_examples.sh
         shell: bash
@@ -56,14 +66,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+          cache: 'pip'
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install .[all_extras,binder,dev,mlflow]
+
       - name: Run example notebooks
         run: build_tools/run_blogposts.sh
         shell: bash
@@ -92,10 +106,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+          cache: 'pip'
+
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
@@ -113,10 +130,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+          cache: 'pip'
+
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
@@ -144,6 +164,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+          cache: 'pip'
 
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
@@ -163,10 +184,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+          cache: 'pip'
+
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
@@ -194,6 +218,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+          cache: 'pip'
+
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
@@ -280,6 +306,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
@@ -320,6 +347,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -11,10 +11,13 @@ jobs:
     steps:
       - name: repository checkout step
         uses: actions/checkout@v4
+
       - name: python environment step
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
+
       - name: check missing __init__ files
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash
@@ -34,16 +37,19 @@ jobs:
           - macos-13
           - ubuntu-latest
           - windows-latest
+
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: checkout pull request branch
         uses: actions/checkout@v4
+
       - name: run tests on python ${{ matrix.python-version }}
         uses: ./.github/actions/test-base
         with:
           python-version-identifier: ${{ matrix.python-version }}
           sub-sample-estimators: "False"
           test-affected-estimators: "False"
+
       - name: upload coverage
         uses: codecov/codecov-action@v4
         with:
@@ -75,10 +81,12 @@ jobs:
           - param_est
           - regression
           - transformations
+
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: checkout pull request branch
         uses: actions/checkout@v4
+
       - name: run tests for component ${{ matrix.sktime-component }} on python ${{ matrix.python-version }}
         uses: ./.github/actions/test-component
         with:
@@ -86,6 +94,7 @@ jobs:
           python-version-identifier: ${{ matrix.python-version }}
           sub-sample-estimators: "False"
           test-affected-estimators: "False"
+
       - name: upload coverage
         uses: codecov/codecov-action@v4
         with:
@@ -107,20 +116,30 @@ jobs:
           - macos-13
           - ubuntu-latest
           - windows-latest
+
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: checkout pull request branch
         uses: actions/checkout@v4
+
       - name: update local git tracking reference
         run: git remote set-branches origin main
+
       - name: update local shallow clone
         run: git fetch --depth 1
+
       - name: create python virtual environment
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
       - name: install core, test and all soft dependencies
         run: python3 -m pip install .[all_extras_pandas2,tests]
+
+      - name: Show dependencies
+        run: python -m pip list
+
       - name: run unit tests
         run: >-
           python3
@@ -139,6 +158,7 @@ jobs:
           --ignore sktime/transformations
           --matrixdesign False
           --only_changed_modules False
+
       - name: upload coverage
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/test_datasets.yml
+++ b/.github/workflows/test_datasets.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: dependencies installation step
         run: python3 -m pip install .[tests]
         shell: bash
@@ -72,6 +73,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: dependencies installation step
         run: python3 -m pip install .[tests,datasets]
         shell: bash

--- a/.github/workflows/test_other.yml
+++ b/.github/workflows/test_other.yml
@@ -51,16 +51,25 @@ jobs:
     steps:
       - name: checkout pull request branch
         uses: actions/checkout@v4
+
       - name: update local git tracking reference
         run: git remote set-branches origin main
+
       - name: update local shallow clone
         run: git fetch --depth 1
+
       - name: create python virtual environment
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
       - name: install core, test and all soft dependencies
         run: python3 -m pip install .[all_extras_pandas2,tests]
+
+      - name: Show dependencies
+        run: python -m pip list
+
       - name: run unit tests
         run: >-
           python3
@@ -79,6 +88,7 @@ jobs:
           --ignore sktime/transformations
           --matrixdesign True
           --only_changed_modules True
+
       - name: upload coverage
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+          cache: 'pip'
 
       - name: Build wheel
         run: |
@@ -42,6 +43,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - uses: actions/download-artifact@v4
         with:
@@ -75,6 +77,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
There is an ongoing discussion with GitHub support around inconsistent package hashes in CI, see https://github.com/sktime/sktime/issues/6406.

Their claim is this is not malicious, and they suggest we try to enable `pip` cache on the CI, which would also speed up the CI and contribute to cutting down test time.

This PR adds `pip` cache settings to all `setup-python` actions in the repository.