### PR TITLE
[MNT] isolate `utils` module init and `sktime` init from external imports

### DIFF
--- a/sktime/utils/plotting.py
+++ b/sktime/utils/plotting.py
@@ -72,7 +72,6 @@ def plot_series(
     >>> y = load_airline()
     >>> fig, ax = plot_series(y)  # doctest: +SKIP
     """
-
     from sktime.utils.dependencies import _check_soft_dependencies
 
     _check_soft_dependencies("matplotlib", "seaborn")

--- a/sktime/utils/plotting.py
+++ b/sktime/utils/plotting.py
@@ -5,16 +5,8 @@
 __all__ = ["plot_series", "plot_correlations", "plot_windows", "plot_calibration"]
 __author__ = ["mloning", "RNKuhns", "Dbhasin1", "chillerobscuro", "benheid"]
 
-import copy
 import math
 from warnings import simplefilter, warn
-
-import numpy as np
-import pandas as pd
-
-from sktime.datatypes import convert_to
-from sktime.utils.validation.forecasting import check_interval_df, check_y
-from sktime.utils.validation.series import check_consistent_index_type
 
 
 def plot_series(
@@ -80,11 +72,17 @@ def plot_series(
     >>> y = load_airline()
     >>> fig, ax = plot_series(y)  # doctest: +SKIP
     """
+
     from sktime.utils.dependencies import _check_soft_dependencies
 
     _check_soft_dependencies("matplotlib", "seaborn")
     import matplotlib.pyplot as plt
+    import pandas as pd
     import seaborn as sns
+
+    from sktime.datatypes import convert_to
+    from sktime.utils.validation.forecasting import check_interval_df, check_y
+    from sktime.utils.validation.series import check_consistent_index_type
 
     for y in series:
         check_y(y)
@@ -128,7 +126,9 @@ def plot_series(
         check_consistent_index_type(l_series[0].index, y.index)
 
     if isinstance(l_series[0].index, pd.core.indexes.period.PeriodIndex):
-        tmp = copy.deepcopy(l_series)  # local copy
+        from copy import deepcopy
+
+        tmp = deepcopy(l_series)  # local copy
         l_series = tmp
 
     for y in l_series:
@@ -239,6 +239,10 @@ def plot_lags(series, lags=1, suptitle=None):
 
     _check_soft_dependencies("matplotlib")
     import matplotlib.pyplot as plt
+    import numpy as np
+    import pandas as pd
+
+    from sktime.utils.validation.forecasting import check_y
 
     check_y(series)
 
@@ -351,7 +355,11 @@ def plot_correlations(
 
     _check_soft_dependencies("matplotlib", "statsmodels")
     import matplotlib.pyplot as plt
+    import numpy as np
     from statsmodels.graphics.tsaplots import plot_acf, plot_pacf
+
+    from sktime.datatypes import convert_to
+    from sktime.utils.validation.forecasting import check_y
 
     series = check_y(series)
     series = convert_to(series, "pd.Series", "Series")
@@ -448,6 +456,7 @@ def plot_windows(cv, y, title="", ax=None):
 
     _check_soft_dependencies("matplotlib", "seaborn")
     import matplotlib.pyplot as plt
+    import numpy as np
     import seaborn as sns
     from matplotlib.ticker import MaxNLocator
 
@@ -563,7 +572,13 @@ def plot_calibration(y_true, y_pred, ax=None):
     ax : matplotlib.axes.Axes
         matplotlib axes object with the figure
     """
+    from sktime.utils.dependencies import _check_soft_dependencies
+
+    _check_soft_dependencies("matplotlib")
     import matplotlib.pyplot as plt
+    import pandas as pd
+
+    from sktime.datatypes import convert_to
 
     series = convert_to(y_true, "pd.Series", "Series")
 


### PR DESCRIPTION
This PR prevents external imports upon import of `sktime.utils`.

This has an impact on initialization performance of `sktime` and test collection, as otherwise external dependencies such as `numpy`, `pandas`, are imported whenever `utils.estimator_checks` or `utils.dependencies` is loaded. This happens repeatedly upon `pytest` call, making the tests less performant than they could be.

Imports were caused by imports from the `plotting` module` directly in `__init__`, which are now isolate inside the methods to prevent imports upon use of test functionality.

The same issue was also present for `sktime` init, i.e., the package proper, as it imports `show_versions` which in turn imported `utils` (as its root location).