### PR TITLE
[MNT] run tests in `distances` module only if it has changed

### DIFF
--- a/sktime/distances/_distance.py
+++ b/sktime/distances/_distance.py
@@ -2110,10 +2110,10 @@ def pairwise_distance(
     Examples
     --------
     >>> import numpy as np
-    >>> from sktime.distances import pairwise_distance
+    >>> from sktime.distances import pairwise_distance  # doctest: +SKIP
     >>> x_1d = np.array([1, 2, 3, 4])  # 1d array
     >>> y_1d = np.array([5, 6, 7, 8])  # 1d array
-    >>> pairwise_distance(x_1d, y_1d, metric='dtw')
+    >>> pairwise_distance(x_1d, y_1d, metric='dtw')  # doctest: +SKIP
     array([[16., 25., 36., 49.],
            [ 9., 16., 25., 36.],
            [ 4.,  9., 16., 25.],
@@ -2121,19 +2121,19 @@ def pairwise_distance(
 
     >>> x_2d = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])  # 2d array
     >>> y_2d = np.array([[9, 10, 11, 12], [13, 14, 15, 16]])  # 2d array
-    >>> pairwise_distance(x_2d, y_2d, metric='dtw')
+    >>> pairwise_distance(x_2d, y_2d, metric='dtw')  # doctest: +SKIP
     array([[256., 576.],
            [ 58., 256.]])
 
     >>> x_3d = np.array([[[1], [2], [3], [4]], [[5], [6], [7], [8]]])  # 3d array
     >>> y_3d = np.array([[[9], [10], [11], [12]], [[13], [14], [15], [16]]])  # 3d array
-    >>> pairwise_distance(x_3d, y_3d, metric='dtw')
+    >>> pairwise_distance(x_3d, y_3d, metric='dtw')  # doctest: +SKIP
     array([[256., 576.],
            [ 64., 256.]])
 
     >>> x_2d = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])  # 2d array
     >>> y_2d = np.array([[9, 10, 11, 12], [13, 14, 15, 16]])  # 2d array
-    >>> pairwise_distance(x_2d, y_2d, metric='dtw', window=0.5)
+    >>> pairwise_distance(x_2d, y_2d, metric='dtw', window=0.5)  # doctest: +SKIP
     array([[256., 576.],
            [ 58., 256.]])
     """

--- a/sktime/distances/tests/test_distance_alignment_path.py
+++ b/sktime/distances/tests/test_distance_alignment_path.py
@@ -71,7 +71,8 @@ def _validate_distance_alignment_path_result(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
+    not _check_soft_dependencies("numba", severity="none")
+    or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("dist", _METRIC_INFOS)

--- a/sktime/distances/tests/test_distance_alignment_path.py
+++ b/sktime/distances/tests/test_distance_alignment_path.py
@@ -4,8 +4,8 @@ import pytest
 
 from sktime.distances._distance import _METRIC_INFOS, distance, distance_alignment_path
 from sktime.distances.tests._utils import create_test_distance_numpy
+from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils.dependencies import _check_soft_dependencies
-from sktime.utils.git_diff import is_module_changed
 
 
 def _validate_distance_alignment_path_result(
@@ -72,7 +72,7 @@ def _validate_distance_alignment_path_result(
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("numba", severity="none")
-    or not is_module_changed("sktime.distances"),  # noqa: E501
+    or not run_test_module_changed("sktime.distances"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("dist", _METRIC_INFOS)

--- a/sktime/distances/tests/test_distance_alignment_path.py
+++ b/sktime/distances/tests/test_distance_alignment_path.py
@@ -5,6 +5,7 @@ import pytest
 from sktime.distances._distance import _METRIC_INFOS, distance, distance_alignment_path
 from sktime.distances.tests._utils import create_test_distance_numpy
 from sktime.utils.dependencies import _check_soft_dependencies
+from sktime.utils.git_diff import is_module_changed
 
 
 def _validate_distance_alignment_path_result(
@@ -70,7 +71,7 @@ def _validate_distance_alignment_path_result(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
+    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("dist", _METRIC_INFOS)

--- a/sktime/distances/tests/test_distance_correctness.py
+++ b/sktime/distances/tests/test_distance_correctness.py
@@ -65,7 +65,8 @@ basic_motions_distances = {
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
+    not _check_soft_dependencies("numba", severity="none")
+    or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("uni_multi", ["uni", "multi"])

--- a/sktime/distances/tests/test_distance_correctness.py
+++ b/sktime/distances/tests/test_distance_correctness.py
@@ -12,6 +12,7 @@ from sktime.datasets import load_basic_motions, load_unit_test
 from sktime.distances._distance import _METRIC_INFOS
 from sktime.tests.test_switch import run_test_for_class
 from sktime.utils.dependencies import _check_soft_dependencies
+from sktime.utils.git_diff import is_module_changed
 
 distance_parameters = {
     "dtw": [0.0, 0.1, 1.0],  # window
@@ -64,7 +65,7 @@ basic_motions_distances = {
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
+    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("uni_multi", ["uni", "multi"])

--- a/sktime/distances/tests/test_distance_correctness.py
+++ b/sktime/distances/tests/test_distance_correctness.py
@@ -10,9 +10,8 @@ from numpy.testing import assert_almost_equal
 
 from sktime.datasets import load_basic_motions, load_unit_test
 from sktime.distances._distance import _METRIC_INFOS
-from sktime.tests.test_switch import run_test_for_class
+from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
 from sktime.utils.dependencies import _check_soft_dependencies
-from sktime.utils.git_diff import is_module_changed
 
 distance_parameters = {
     "dtw": [0.0, 0.1, 1.0],  # window
@@ -66,7 +65,7 @@ basic_motions_distances = {
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("numba", severity="none")
-    or not is_module_changed("sktime.distances"),  # noqa: E501
+    or not run_test_module_changed("sktime.distances"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("uni_multi", ["uni", "multi"])

--- a/sktime/distances/tests/test_lower_bounding.py
+++ b/sktime/distances/tests/test_lower_bounding.py
@@ -5,6 +5,7 @@ import pytest
 
 from sktime.distances.lower_bounding import LowerBounding
 from sktime.distances.tests._utils import create_test_distance_numpy
+from sktime.utils.git_diff import is_module_changed
 
 
 def _validate_bounding_result(
@@ -145,6 +146,10 @@ def _validate_bounding(
     )
 
 
+@pytest.mark.skipif(
+    not is_module_changed("sktime.distances"),
+    reason="skip test if required soft dependency not available",
+)
 def test_lower_bounding() -> None:
     """Test for various lower bounding methods."""
     no_bounding = LowerBounding.NO_BOUNDING
@@ -172,6 +177,10 @@ def test_lower_bounding() -> None:
     )
 
 
+@pytest.mark.skipif(
+    not is_module_changed("sktime.distances"),
+    reason="skip test if required soft dependency not available",
+)
 def test_incorrect_parameters() -> None:
     """Test to check correct errors raised."""
     numpy_x = create_test_distance_numpy(10, 10)

--- a/sktime/distances/tests/test_lower_bounding.py
+++ b/sktime/distances/tests/test_lower_bounding.py
@@ -5,7 +5,7 @@ import pytest
 
 from sktime.distances.lower_bounding import LowerBounding
 from sktime.distances.tests._utils import create_test_distance_numpy
-from sktime.utils.git_diff import is_module_changed
+from sktime.tests.test_switch import run_test_module_changed
 
 
 def _validate_bounding_result(
@@ -147,8 +147,8 @@ def _validate_bounding(
 
 
 @pytest.mark.skipif(
-    not is_module_changed("sktime.distances"),
-    reason="skip test if required soft dependency not available",
+    not run_test_module_changed("sktime.distances"),
+    reason="Run test only if distances module has changed",
 )
 def test_lower_bounding() -> None:
     """Test for various lower bounding methods."""
@@ -178,8 +178,8 @@ def test_lower_bounding() -> None:
 
 
 @pytest.mark.skipif(
-    not is_module_changed("sktime.distances"),
-    reason="skip test if required soft dependency not available",
+    not run_test_module_changed("sktime.distances"),
+    reason="Run test only if distances module has changed",
 )
 def test_incorrect_parameters() -> None:
     """Test to check correct errors raised."""

--- a/sktime/distances/tests/test_numba_distance_parameters.py
+++ b/sktime/distances/tests/test_numba_distance_parameters.py
@@ -10,15 +10,14 @@ from sktime.distances._numba_utils import to_numba_timeseries
 from sktime.distances.base import MetricInfo
 from sktime.distances.tests._expected_results import _expected_distance_results_params
 from sktime.distances.tests._utils import create_test_distance_numpy
-from sktime.tests.test_switch import run_test_for_class
+from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
 from sktime.utils.dependencies import _check_soft_dependencies
-from sktime.utils.git_diff import is_module_changed
 from sktime.utils.numba.njit import njit
 
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("numba", severity="none")
-    or not is_module_changed("sktime.distances"),  # noqa: E501
+    or not run_test_module_changed("sktime.distances"),
     reason="skip test if required soft dependency not available",
 )
 def _test_distance_params(
@@ -83,7 +82,7 @@ DIST_PARAMS = {
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("numba", severity="none")
-    or not is_module_changed("sktime.distances"),  # noqa: E501
+    or not run_test_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("dist", _METRIC_INFOS)

--- a/sktime/distances/tests/test_numba_distance_parameters.py
+++ b/sktime/distances/tests/test_numba_distance_parameters.py
@@ -17,7 +17,8 @@ from sktime.utils.numba.njit import njit
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
+    not _check_soft_dependencies("numba", severity="none")
+    or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def _test_distance_params(
@@ -81,7 +82,8 @@ DIST_PARAMS = {
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
+    not _check_soft_dependencies("numba", severity="none")
+    or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("dist", _METRIC_INFOS)

--- a/sktime/distances/tests/test_numba_distance_parameters.py
+++ b/sktime/distances/tests/test_numba_distance_parameters.py
@@ -12,11 +12,12 @@ from sktime.distances.tests._expected_results import _expected_distance_results_
 from sktime.distances.tests._utils import create_test_distance_numpy
 from sktime.tests.test_switch import run_test_for_class
 from sktime.utils.dependencies import _check_soft_dependencies
+from sktime.utils.git_diff import is_module_changed
 from sktime.utils.numba.njit import njit
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
+    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def _test_distance_params(
@@ -80,7 +81,7 @@ DIST_PARAMS = {
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
+    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("dist", _METRIC_INFOS)

--- a/sktime/distances/tests/test_numba_distances.py
+++ b/sktime/distances/tests/test_numba_distances.py
@@ -150,7 +150,8 @@ def _validate_distance_result(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
+    not _check_soft_dependencies("numba", severity="none")
+    or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("dist", _METRIC_INFOS)
@@ -202,7 +203,8 @@ def test_distance(dist: MetricInfo) -> None:
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
+    not _check_soft_dependencies("numba", severity="none")
+    or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_metric_parameters():
@@ -211,7 +213,8 @@ def test_metric_parameters():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
+    not _check_soft_dependencies("numba", severity="none")
+    or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_incorrect_parameters():
@@ -220,7 +223,8 @@ def test_incorrect_parameters():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
+    not _check_soft_dependencies("numba", severity="none")
+    or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_distance_factory_1d():

--- a/sktime/distances/tests/test_numba_distances.py
+++ b/sktime/distances/tests/test_numba_distances.py
@@ -18,6 +18,7 @@ from sktime.distances.tests._shared_tests import (
 from sktime.distances.tests._utils import create_test_distance_numpy
 from sktime.tests.test_switch import run_test_for_class
 from sktime.utils.dependencies import _check_soft_dependencies
+from sktime.utils.git_diff import is_module_changed
 
 _ran_once = False
 
@@ -149,7 +150,7 @@ def _validate_distance_result(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
+    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("dist", _METRIC_INFOS)
@@ -201,7 +202,7 @@ def test_distance(dist: MetricInfo) -> None:
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
+    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_metric_parameters():
@@ -210,7 +211,7 @@ def test_metric_parameters():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
+    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_incorrect_parameters():
@@ -219,7 +220,7 @@ def test_incorrect_parameters():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
+    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_distance_factory_1d():

--- a/sktime/distances/tests/test_numba_distances.py
+++ b/sktime/distances/tests/test_numba_distances.py
@@ -16,9 +16,8 @@ from sktime.distances.tests._shared_tests import (
     _test_metric_parameters,
 )
 from sktime.distances.tests._utils import create_test_distance_numpy
-from sktime.tests.test_switch import run_test_for_class
+from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
 from sktime.utils.dependencies import _check_soft_dependencies
-from sktime.utils.git_diff import is_module_changed
 
 _ran_once = False
 
@@ -151,7 +150,7 @@ def _validate_distance_result(
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("numba", severity="none")
-    or not is_module_changed("sktime.distances"),  # noqa: E501
+    or not run_test_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("dist", _METRIC_INFOS)
@@ -204,7 +203,7 @@ def test_distance(dist: MetricInfo) -> None:
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("numba", severity="none")
-    or not is_module_changed("sktime.distances"),  # noqa: E501
+    or not run_test_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_metric_parameters():
@@ -214,7 +213,7 @@ def test_metric_parameters():
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("numba", severity="none")
-    or not is_module_changed("sktime.distances"),  # noqa: E501
+    or not run_test_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_incorrect_parameters():
@@ -224,7 +223,7 @@ def test_incorrect_parameters():
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("numba", severity="none")
-    or not is_module_changed("sktime.distances"),  # noqa: E501
+    or not run_test_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_distance_factory_1d():

--- a/sktime/distances/tests/test_pairwise_distances.py
+++ b/sktime/distances/tests/test_pairwise_distances.py
@@ -210,7 +210,8 @@ def _test_pw_equal_single_dists(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
+    not _check_soft_dependencies("numba", severity="none")
+    or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("dist", _METRIC_INFOS)
@@ -275,7 +276,8 @@ def test_pairwise_distance(dist: MetricInfo) -> None:
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
+    not _check_soft_dependencies("numba", severity="none")
+    or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_metric_parameters():
@@ -284,7 +286,8 @@ def test_metric_parameters():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
+    not _check_soft_dependencies("numba", severity="none")
+    or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_incorrect_parameters():

--- a/sktime/distances/tests/test_pairwise_distances.py
+++ b/sktime/distances/tests/test_pairwise_distances.py
@@ -15,8 +15,8 @@ from sktime.distances.tests._shared_tests import (
     _test_metric_parameters,
 )
 from sktime.distances.tests._utils import create_test_distance_numpy
+from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils.dependencies import _check_soft_dependencies
-from sktime.utils.git_diff import is_module_changed
 
 
 def _check_symmetric(x: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
@@ -211,7 +211,7 @@ def _test_pw_equal_single_dists(
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("numba", severity="none")
-    or not is_module_changed("sktime.distances"),  # noqa: E501
+    or not run_test_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("dist", _METRIC_INFOS)
@@ -277,7 +277,7 @@ def test_pairwise_distance(dist: MetricInfo) -> None:
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("numba", severity="none")
-    or not is_module_changed("sktime.distances"),  # noqa: E501
+    or not run_test_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_metric_parameters():
@@ -287,7 +287,7 @@ def test_metric_parameters():
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("numba", severity="none")
-    or not is_module_changed("sktime.distances"),  # noqa: E501
+    or not run_test_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_incorrect_parameters():

--- a/sktime/distances/tests/test_pairwise_distances.py
+++ b/sktime/distances/tests/test_pairwise_distances.py
@@ -16,6 +16,7 @@ from sktime.distances.tests._shared_tests import (
 )
 from sktime.distances.tests._utils import create_test_distance_numpy
 from sktime.utils.dependencies import _check_soft_dependencies
+from sktime.utils.git_diff import is_module_changed
 
 
 def _check_symmetric(x: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
@@ -209,7 +210,7 @@ def _test_pw_equal_single_dists(
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
+    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.parametrize("dist", _METRIC_INFOS)
@@ -274,7 +275,7 @@ def test_pairwise_distance(dist: MetricInfo) -> None:
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
+    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_metric_parameters():
@@ -283,7 +284,7 @@ def test_metric_parameters():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
+    not _check_soft_dependencies("numba", severity="none") or not is_module_changed("sktime.distances"),  # noqa: E501
     reason="skip test if required soft dependency not available",
 )
 def test_incorrect_parameters():

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -160,7 +160,6 @@ def _run_test_for_class(cls):
 
         If multiple reasons are present, the first one in the above list is returned.
     """
-
     from sktime.tests.test_all_estimators import ONLY_CHANGED_MODULES
     from sktime.utils.dependencies import _check_estimator_deps
     from sktime.utils.git_diff import get_packages_with_changed_specs, is_class_changed
@@ -247,3 +246,42 @@ def _run_test_for_class(cls):
     # if none of the conditions are met, do not run the test
     # reason is that there was no change
     return False, "False_no_change"
+
+
+def run_test_module_changed(module):
+    """Check if test should run based on module changes
+
+    This switch can be used to decorate tests not pertaining to a specific class.
+
+    The function can be used to switch tests on and off
+    based on whether a target module has changed.
+
+    This checks whether the module ``module``, or any of its child modules,
+    have changed.
+
+    If ``ONLY_CHANGED_MODULES`` is False, the test is always run,
+    i.e., this function always returns True.
+
+    Parameters
+    ----------
+    module : string, or list of strings
+        modules to check for changes, e.g., ``sktime.forecasting``
+
+    Returns
+    -------
+    bool : switch to run or skip the test
+        True iff: at least one of the modules or its submodules have changed,
+        or if ``ONLY_CHANGED_MODULES`` is False
+    """
+    from sktime.tests.test_all_estimators import ONLY_CHANGED_MODULES
+    from sktime.utils.git_diff import is_module_changed
+
+    # if ONLY_CHANGED_MODULES is off: always True
+    # tests are always run if soft dependencies are present
+    if not ONLY_CHANGED_MODULES:
+        return True
+
+    if not isinstance(module, (list, tuple)):
+        module = [module]
+
+    return any(is_module_changed(mod) for mod in module)

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -45,7 +45,10 @@ def get_path_from_module(module_str):
             raise ImportError(
                 f"Error in get_path_from_module, module '{module_str}' not found."
             )
-        return module_spec.origin
+        module_path = module_spec.origin
+        if module_path.endswith("__init__.py"):
+            return module_path[:-11]
+        return module_path
     except Exception as e:
         raise ImportError(f"Error finding module '{module_str}'") from e
 
@@ -54,6 +57,8 @@ def get_path_from_module(module_str):
 def is_module_changed(module_str):
     """Check if a module has changed compared to the main branch.
 
+    If a child module has changed, the parent module is considered changed as well.
+
     Parameters
     ----------
     module_str : str
@@ -61,6 +66,7 @@ def is_module_changed(module_str):
     """
     module_file_path = get_path_from_module(module_str)
     cmd = f"git diff remotes/origin/main -- {module_file_path}"
+    print(cmd)
     try:
         output = subprocess.check_output(cmd, shell=True, text=True)
         return bool(output)

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -66,7 +66,6 @@ def is_module_changed(module_str):
     """
     module_file_path = get_path_from_module(module_str)
     cmd = f"git diff remotes/origin/main -- {module_file_path}"
-    print(cmd)
     try:
         output = subprocess.check_output(cmd, shell=True, text=True)
         return bool(output)


### PR DESCRIPTION
This PR adds a switch that runs tests in the `distances` module only if it has changed. This will have a substantial impact on the test times, as this module adds up to lengthy testing.

Depends on https://github.com/sktime/sktime/pull/6518.

This PR *will* run tests in the `distances` module, as it has changed by virtue of introducing the pytest conditional testing decorators.