### PR TITLE
[ENH] Add Windowed Local Outlier Factor Anomaly Detector

### DIFF
--- a/sktime/annotation/lof.py
+++ b/sktime/annotation/lof.py
@@ -1,0 +1,217 @@
+"""Windowed local outlier factor."""
+import datetime
+import math
+
+import pandas as pd
+from sklearn.neighbors import LocalOutlierFactor
+
+from sktime.annotation.base import BaseSeriesAnnotator
+
+
+class SubLOF(BaseSeriesAnnotator):
+    """Timeseries version of local outlier factor.
+
+    Parameters
+    ----------
+        n_neighbors : int, default=20
+        Number of neighbors to use by default for :meth:`kneighbors` queries.
+        If n_neighbors is larger than the number of samples provided,
+        all samples will be used.
+
+    algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, default='auto'
+        Algorithm used to compute the nearest neighbors:
+
+        - 'ball_tree' will use :class:`BallTree`
+        - 'kd_tree' will use :class:`KDTree`
+        - 'brute' will use a brute-force search.
+        - 'auto' will attempt to decide the most appropriate algorithm
+          based on the values passed to :meth:`fit` method.
+
+        Note: fitting on sparse input will override the setting of
+        this parameter, using brute force.
+
+    leaf_size : int, default=30
+        Leaf is size passed to :class:`BallTree` or :class:`KDTree`. This can
+        affect the speed of the construction and query, as well as the memory
+        required to store the tree. The optimal value depends on the
+        nature of the problem.
+
+    metric : str or callable, default='minkowski'
+        Metric to use for distance computation. Default is "minkowski", which
+        results in the standard Euclidean distance when p = 2. See the
+        documentation of `scipy.spatial.distance
+        <https://docs.scipy.org/doc/scipy/reference/spatial.distance.html>`_ and
+        the metrics listed in
+        :class:`~sklearn.metrics.pairwise.distance_metrics` for valid metric
+        values.
+
+        If metric is "precomputed", X is assumed to be a distance matrix and
+        must be square during fit. X may be a :term:`sparse graph`, in which
+        case only "nonzero" elements may be considered neighbors.
+
+        If metric is a callable function, it takes two arrays representing 1D
+        vectors as inputs and must return one value indicating the distance
+        between those vectors. This works for Scipy's metrics, but is less
+        efficient than passing the metric name as a string.
+
+    p : float, default=2
+        Parameter for the Minkowski metric from
+        :func:`sklearn.metrics.pairwise_distances`. When p = 1, this
+        is equivalent to using manhattan_distance (l1), and euclidean_distance
+        (l2) for p = 2. For arbitrary p, minkowski_distance (l_p) is used.
+
+    metric_params : dict, default=None
+        Additional keyword arguments for the metric function.
+
+    contamination : 'auto' or float, default='auto'
+        The amount of contamination of the data set, i.e. the proportion
+        of outliers in the data set. When fitting this is used to define the
+        threshold on the scores of the samples.
+
+        - if 'auto', the threshold is determined as in the
+          original paper,
+        - if a float, the contamination should be in the range (0, 0.5].
+
+        .. versionchanged:: 0.22
+           The default value of ``contamination`` changed from 0.1
+           to ``'auto'``.
+
+    novelty : bool, default=False
+        By default, LocalOutlierFactor is only meant to be used for outlier
+        detection (novelty=False). Set novelty to True if you want to use
+        LocalOutlierFactor for novelty detection. In this case be aware that
+        you should only use predict, decision_function and score_samples
+        on new unseen data and not on the training set; and note that the
+        results obtained this way may differ from the standard LOF results.
+
+        .. versionadded:: 0.20
+
+    n_jobs : int, default=None
+        The number of parallel jobs to run for neighbors search.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
+    """
+
+    _tags = {
+        "task": "anomaly_detection",
+        "learning_type": "unsupervised",
+        "univariate-only": True,
+        "fit_is_empty": True,
+    }
+
+    def __init__(
+        self,
+        n_neighbors,
+        window_size,
+        *,
+        algorithm="auto",
+        leaf_size=30,
+        metric="minkowski",
+        p=2,
+        metric_params=None,
+        contamination="auto",
+        novelty=False,
+        n_jobs=None,
+    ):
+        self.window_size = window_size
+        self.model_params = {
+            "n_neighbors": n_neighbors,
+            "algorithm": algorithm,
+            "leaf_size": leaf_size,
+            "metric": metric,
+            "p": p,
+            "metric_params": metric_params,
+            "contamination": contamination,
+            "novelty": novelty,
+            "n_jobs": n_jobs,
+        }
+        self.models = None
+        super().__init__()
+
+    def _fit(self, X, Y=None):
+        """Fit the LOF model to ``X``.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Training data to fit model to (time series).
+        """
+        if isinstance(X, pd.Series):
+            X = X.to_frame()
+
+        intervals = self.split_into_intervals(X.index, self.window_size)
+        self.models = {
+            interval: LocalOutlierFactor(**self.model_params) for interval in intervals
+        }
+
+        for interval, model in self.models.items():
+            mask = (X.index >= interval.left) & (X.index < interval.right)
+            model.fit(X.loc[mask])
+
+    @staticmethod
+    def split_into_intervals(x, interval_size):
+        """Split the range of ``x`` into equally sized intervals."""
+        x_max = x.max()
+        x_min = x.min()
+        n_intervals = math.floor((x_max - x_min) / interval_size) + 1
+
+        if x_max >= x_min + (n_intervals - 1) * interval_size:
+            n_intervals += 1
+
+        breaks = [x_min + interval_size * i for i in range(n_intervals)]
+        interval_range = pd.IntervalIndex.from_breaks(breaks, closed="left")
+        return interval_range
+
+    def _predict(self, X):
+        """Create annotations on test/deployment data.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Data to annotate (time series).
+
+        Returns
+        -------
+        Y : pd.Series or an IntervalSeries
+            Change points in sequence X.
+        """
+        if isinstance(X, pd.Series):
+            X = X.to_frame()
+
+        y_all = []
+        for interval, model in self.models.items():
+            X_subset = X.loc[(X.index >= interval.left) & (X.index < interval.right)]
+
+            if len(X_subset) == 0:
+                continue
+
+            y_subset = model.predict(X_subset)
+            anomaly_indexes = X_subset.index[y_subset == -1]
+            y_all.append(pd.Series(anomaly_indexes))
+
+        if len(y_all) == 0:
+            return pd.Series()
+
+        return pd.concat(y_all, ignore_index=True).reset_index(drop=True)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+
+        Returns
+        -------
+        params : dict or list of dict
+        """
+        params = {
+            "n_neighbors": 5,
+            "window_size": datetime.timedelta(days=25),
+            "novelty": True,
+        }
+        return params


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->

Related to #6481.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Adds a windowed local outlier factor model for anomaly detection.

A description of the model can be found here https://www.vldb.org/pvldb/vol15/p1779-wenig.pdf. This implementation was inspired by the implentation by the authors here https://github.com/TimeEval/evaluation-paper.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->
No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
