### PR TITLE
[MNT] differential testing for `split` module

### DIFF
--- a/sktime/split/tests/test_cutoff.py
+++ b/sktime/split/tests/test_cutoff.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.tests._config import (
     TEST_CUTOFFS,
     TEST_FHS,
@@ -15,8 +16,13 @@ from sktime.forecasting.tests._config import (
 from sktime.split import CutoffFhSplitter, CutoffSplitter
 from sktime.split.base._common import _inputs_are_supported
 from sktime.split.tests.test_split import _check_cv
+from sktime.tests.test_switch import run_test_for_class
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(CutoffSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("y", TEST_YS)
 @pytest.mark.parametrize("cutoffs", TEST_CUTOFFS)
 @pytest.mark.parametrize("fh", [*TEST_FHS, *TEST_FHS_TIMEDELTA])
@@ -33,9 +39,12 @@ def test_cutoff_window_splitter(y, cutoffs, fh, window_length):
             CutoffSplitter(cutoffs, fh=fh, window_length=window_length)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([CutoffFhSplitter, ForecastingHorizon]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_cutoff_fh_splitter():
     """Test CutoffFhSplitter."""
-    from sktime.forecasting.base import ForecastingHorizon
     from sktime.utils._testing.series import _make_series
 
     y = _make_series()

--- a/sktime/split/tests/test_cutoff.py
+++ b/sktime/split/tests/test_cutoff.py
@@ -20,7 +20,7 @@ from sktime.tests.test_switch import run_test_for_class
 
 
 @pytest.mark.skipif(
-    not run_test_for_class(CutoffSplitter),
+    not run_test_for_class([CutoffSplitter, ForecastingHorizon]),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 @pytest.mark.parametrize("y", TEST_YS)

--- a/sktime/split/tests/test_expandingcutoff.py
+++ b/sktime/split/tests/test_expandingcutoff.py
@@ -8,10 +8,15 @@ import pytest
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.split import ExpandingCutoffSplitter
 from sktime.split.tests.test_split import _check_cv
+from sktime.tests.test_switch import run_test_for_class
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.series import _make_series
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingCutoffSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expandingcutoff_datelike_index_001():
     """Test datetime index with _check_cv"""
     y = _make_series(n_timepoints=10, random_state=42)
@@ -22,6 +27,10 @@ def test_expandingcutoff_datelike_index_001():
     np.testing.assert_array_equal(cutoffs, cv.get_cutoffs(y))
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingCutoffSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expandingcutoff_int_index_002():
     """Test int index with _check_cv"""
     y = _make_series(n_timepoints=10, index_type="int", random_state=42)
@@ -32,6 +41,10 @@ def test_expandingcutoff_int_index_002():
     np.testing.assert_array_equal(cutoffs, cv.get_cutoffs(y))
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingCutoffSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expandingcutoff_ytype_cutofftype_combos_003a():
     """Test invalid param combo"""
     # Datetime cutoff
@@ -46,6 +59,10 @@ def test_expandingcutoff_ytype_cutofftype_combos_003a():
             _check_cv(cv1, y1)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingCutoffSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expandingcutoff_ytype_cutofftype_combos_003b():
     """Test invalid param combo"""
     # Datetime cutoff
@@ -59,6 +76,10 @@ def test_expandingcutoff_ytype_cutofftype_combos_003b():
             _check_cv(cv1, y1)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingCutoffSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expandingcutoff_ytype_cutofftype_combos_003c():
     """Test invalid param combo"""
     # Datetime cutoff
@@ -72,6 +93,10 @@ def test_expandingcutoff_ytype_cutofftype_combos_003c():
         _check_cv(cv1, y1)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingCutoffSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expandingcutoff_splitloc_004():
     """Test split loc"""
     y = _make_series(n_timepoints=10, random_state=42)
@@ -87,6 +112,10 @@ def test_expandingcutoff_splitloc_004():
         np.testing.assert_array_equal(expected.values, actual.values)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingCutoffSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expandingcutoff_hiearchical_splitloc_005():
     """Test hiearchical splitloc with datetime"""
     y = _make_hierarchical(
@@ -123,6 +152,10 @@ def test_expandingcutoff_hiearchical_splitloc_005():
     )
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingCutoffSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expandingcutoff_hiearchical_forecastbylevel_006():
     """Test hiearchical with forecast by level"""
     from sktime.forecasting.compose import ForecastByLevel
@@ -156,6 +189,10 @@ def test_expandingcutoff_hiearchical_forecastbylevel_006():
     assert expected_last_forecast_date, actual_last_forecast_date
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingCutoffSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expandingcutoff_fh_list_007():
     """Test fh as list with _check_cv"""
     y = _make_series(n_timepoints=10, random_state=42)
@@ -166,6 +203,10 @@ def test_expandingcutoff_fh_list_007():
     np.testing.assert_array_equal(cutoffs, cv.get_cutoffs(y))
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingCutoffSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expanding_cutoff_period_008():
     date_range = pd.date_range(
         start=pd.Timestamp("2020-Q1"), end=pd.Timestamp("2021-Q4"), freq="QS"
@@ -194,6 +235,10 @@ def _make_splits_listlike(splits):
     return splits_new
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingCutoffSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expanding_cutoff_docstring_examples():
     date_range = pd.date_range(start="2020-Q1", end="2021-Q3", freq="QS")
     y = pd.DataFrame(index=pd.PeriodIndex(date_range, freq="Q"))

--- a/sktime/split/tests/test_expandinggreedy.py
+++ b/sktime/split/tests/test_expandinggreedy.py
@@ -3,12 +3,18 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from sktime.split import ExpandingGreedySplitter
+from sktime.tests.test_switch import run_test_for_class
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.series import _make_series
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingGreedySplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expanding_greedy_splitter_lengths():
     """Test that ExpandingGreedySplitter returns the correct lengths."""
     y = np.arange(10)
@@ -18,6 +24,10 @@ def test_expanding_greedy_splitter_lengths():
     assert lengths == [(4, 2), (6, 2), (8, 2)]
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingGreedySplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expanding_greedy_splitter_dates():
     """Test that ExpandingGreedySplitter splits on dates correctly."""
     ts = _make_series(index_type="period")
@@ -42,6 +52,10 @@ def test_expanding_greedy_splitter_dates():
     assert test_ends == [last_date - 4, last_date - 2, last_date]
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingGreedySplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expanding_greedy_splitter_hierarchy():
     """Test that ExpandingGreedySplitter handles uneven hierarchical data."""
     y_panel = _make_hierarchical(
@@ -70,6 +84,10 @@ def test_expanding_greedy_splitter_hierarchy():
     assert last_test_dates_actual.eq(last_test_dates_expected).all()
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingGreedySplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_expanding_greedy_splitter_consecutive():
     """Test that ExpandingGreedySplitter results in consecutive test periods."""
     y_panel = _make_hierarchical(

--- a/sktime/split/tests/test_expandingwindow.py
+++ b/sktime/split/tests/test_expandingwindow.py
@@ -14,6 +14,7 @@ from sktime.forecasting.tests._config import (
 from sktime.split import ExpandingWindowSplitter
 from sktime.split.base._common import _inputs_are_supported
 from sktime.split.tests.test_split import _check_cv, _get_n_incomplete_windows
+from sktime.tests.test_switch import run_test_for_class
 from sktime.utils.datetime import _coerce_duration_to_int
 from sktime.utils.validation.forecasting import check_fh
 
@@ -29,6 +30,10 @@ def _check_expanding_windows(windows):
         assert current[-1] > previous[-1]
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingWindowSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("y", TEST_YS)
 @pytest.mark.parametrize("fh", [*TEST_FHS, *TEST_FHS_TIMEDELTA])
 @pytest.mark.parametrize("step_length", TEST_STEP_LENGTHS)
@@ -54,6 +59,10 @@ def test_expanding_window_splitter_start_with_initial_window_zero(y, fh, step_le
             )
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingWindowSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("y", TEST_YS)
 @pytest.mark.parametrize("fh", [*TEST_FHS, *TEST_FHS_TIMEDELTA])
 @pytest.mark.parametrize("initial_window", TEST_WINDOW_LENGTHS)
@@ -84,6 +93,10 @@ def test_expanding_window_splitter_start_with_empty_window(
             )
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingWindowSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("y", TEST_YS)
 @pytest.mark.parametrize("fh", [*TEST_FHS, *TEST_FHS_TIMEDELTA])
 @pytest.mark.parametrize("initial_window", TEST_WINDOW_LENGTHS)

--- a/sktime/split/tests/test_sameloc.py
+++ b/sktime/split/tests/test_sameloc.py
@@ -2,11 +2,17 @@
 """Tests for SameLoc splitter."""
 
 import numpy as np
+import pytest
 
 from sktime.split import ExpandingWindowSplitter, SameLocSplitter
+from sktime.tests.test_switch import run_test_for_class
 from sktime.utils._testing.hierarchical import _make_hierarchical
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([ExpandingWindowSplitter, SameLocSplitter]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_same_loc_splitter():
     """Test that SameLocSplitter works as intended."""
     from sktime.datasets import load_airline
@@ -35,6 +41,10 @@ def test_same_loc_splitter():
         assert np.all(tt1 == tt2)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([ExpandingWindowSplitter, SameLocSplitter]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_same_loc_splitter_hierarchical():
     """Test that SameLocSplitter works as intended for hierarchical data."""
     hierarchy_levels1 = (2, 2)

--- a/sktime/split/tests/test_singlewindow.py
+++ b/sktime/split/tests/test_singlewindow.py
@@ -13,11 +13,16 @@ from sktime.forecasting.tests._config import (
 from sktime.split import SingleWindowSplitter
 from sktime.split.base._common import _inputs_are_supported
 from sktime.split.tests.test_split import _check_cv
+from sktime.tests.test_switch import run_test_for_class
 from sktime.utils.datetime import _coerce_duration_to_int
 from sktime.utils.validation import array_is_int
 from sktime.utils.validation.forecasting import check_fh
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(SingleWindowSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("y", TEST_YS)
 @pytest.mark.parametrize("fh", [*TEST_FHS, *TEST_FHS_TIMEDELTA])
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
@@ -48,6 +53,10 @@ def test_single_window_splitter(y, fh, window_length):
             SingleWindowSplitter(fh=fh, window_length=window_length)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(SingleWindowSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("y", TEST_YS)
 @pytest.mark.parametrize("fh", [*TEST_FHS, *TEST_FHS_TIMEDELTA])
 def test_single_window_splitter_default_window_length(y, fh):

--- a/sktime/split/tests/test_slidingwindow.py
+++ b/sktime/split/tests/test_slidingwindow.py
@@ -15,11 +15,16 @@ from sktime.forecasting.tests._config import (
 from sktime.split import SlidingWindowSplitter
 from sktime.split.base._common import _inputs_are_supported
 from sktime.split.tests.test_split import _check_cv, _get_n_incomplete_windows
+from sktime.tests.test_switch import run_test_for_class
 from sktime.utils._testing.series import _make_series
 from sktime.utils.datetime import _coerce_duration_to_int
 from sktime.utils.validation.forecasting import check_fh
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(SlidingWindowSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("y", TEST_YS)
 @pytest.mark.parametrize("fh", [*TEST_FHS, *TEST_FHS_TIMEDELTA])
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
@@ -51,6 +56,10 @@ def test_sliding_window_splitter(y, fh, window_length, step_length):
             )
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(SlidingWindowSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("y", TEST_YS)
 @pytest.mark.parametrize("fh", [*TEST_FHS, *TEST_FHS_TIMEDELTA])
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
@@ -90,6 +99,10 @@ def test_sliding_window_splitter_with_initial_window(
             )
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(SlidingWindowSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("y", TEST_YS)
 @pytest.mark.parametrize("fh", [*TEST_FHS, *TEST_FHS_TIMEDELTA])
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS)
@@ -130,6 +143,10 @@ def test_sliding_window_splitter_start_with_empty_window(
             )
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(SlidingWindowSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_sliding_window_splitter_initial_window_start_with_empty_window_raises_error():
     """Test SlidingWindowSplitter."""
     y = _make_series()
@@ -143,6 +160,10 @@ def test_sliding_window_splitter_initial_window_start_with_empty_window_raises_e
         next(cv.split(y))
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(SlidingWindowSplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_sliding_window_splitter_initial_window_smaller_than_window_raise_error():
     """Test SlidingWindowSplitter."""
     y = _make_series()

--- a/sktime/split/tests/test_split.py
+++ b/sktime/split/tests/test_split.py
@@ -8,6 +8,7 @@ import pytest
 
 from sktime.forecasting.base import ForecastingHorizon
 from sktime.split import ExpandingWindowSplitter, SlidingWindowSplitter
+from sktime.tests.test_switch import run_test_for_class
 from sktime.utils.datetime import _coerce_duration_to_int
 from sktime.utils.validation import (
     array_is_datetime64,
@@ -109,6 +110,12 @@ def _get_n_incomplete_windows(window_length, step_length) -> int:
     )
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(
+        [SlidingWindowSplitter, ExpandingWindowSplitter, ForecastingHorizon]
+    ),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("CV", [SlidingWindowSplitter, ExpandingWindowSplitter])
 def test_window_splitter_in_sample_fh_smaller_than_window_length(CV):
     """Test WindowSplitter."""
@@ -121,6 +128,12 @@ def test_window_splitter_in_sample_fh_smaller_than_window_length(CV):
     np.testing.assert_array_equal(train_windows[0], np.array([0, 1, 2]))
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(
+        [SlidingWindowSplitter, ExpandingWindowSplitter, ForecastingHorizon]
+    ),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("CV", [SlidingWindowSplitter, ExpandingWindowSplitter])
 def test_window_splitter_in_sample_fh_greater_than_window_length(CV):
     """Test WindowSplitter."""

--- a/sktime/split/tests/test_temporaltraintest.py
+++ b/sktime/split/tests/test_temporaltraintest.py
@@ -8,7 +8,8 @@ import pytest
 from sktime.datasets import load_airline
 from sktime.datatypes._utilities import get_cutoff
 from sktime.forecasting.tests._config import TEST_OOS_FHS, VALID_INDEX_FH_COMBINATIONS
-from sktime.split import temporal_train_test_split
+from sktime.split import TemporalTrainTestSplitter, temporal_train_test_split
+from sktime.tests.test_switch import run_test_for_class
 from sktime.utils._testing.forecasting import _make_fh
 from sktime.utils._testing.series import _make_series
 
@@ -29,6 +30,10 @@ def _check_train_test_split_y(fh, split):
     np.testing.assert_array_equal(test.index, fh.to_absolute(cutoff).to_numpy())
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([TemporalTrainTestSplitter, temporal_train_test_split]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize(
     "index_type, fh_type, is_relative", VALID_INDEX_FH_COMBINATIONS
 )
@@ -47,6 +52,10 @@ def test_split_by_fh(index_type, fh_type, is_relative, values):
     _check_train_test_split_y(fh, split)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([TemporalTrainTestSplitter, temporal_train_test_split]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_temporal_train_test_split_float_only_y():
     """Test temporal_train_test_split expected output on float size inputs."""
     y = load_airline()
@@ -79,6 +88,10 @@ def test_temporal_train_test_split_float_only_y():
     assert (y[43 : (43 + 29)] == y_test).all()
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([TemporalTrainTestSplitter, temporal_train_test_split]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_temporal_train_test_split_int_only_y():
     """Test temporal_train_test_split expected output on float size inputs."""
     y = load_airline()
@@ -111,6 +124,10 @@ def test_temporal_train_test_split_int_only_y():
     assert (y[43 : (43 + 29)] == y_test).all()
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([TemporalTrainTestSplitter, temporal_train_test_split]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_temporal_train_test_split_hierarchical():
     """Test correctness of temporal_train_test_split for hierarchical data.
 


### PR DESCRIPTION
Decorates all low-level tests in the `split` module to be executed only if the tested estimators have changed.

Towards #2890.