### PR TITLE
[MNT] reorganization of onboard libs - `pykalman`, `vmdpy`

### DIFF
--- a/sktime/libs/README.md
+++ b/sktime/libs/README.md
@@ -1,0 +1,10 @@
+# libraries distributed with ``sktime``
+
+This folder contains libraries directly distibuted with, and maintained by, ``sktime``.
+
+* ``pykalman`` - a package implementing the Kálmán Filter and variants.
+  Unofficial fork after ``pykalman`` was abandoned by its maintainers,
+  see [pykalman issue 109](https://github.com/pykalman/pykalman/issues/109).
+
+* ``vmdpy` - a package implementing Variational Mode Decomposition.
+  Official fork, maintained in ``sktime`` since August 2023.

--- a/sktime/libs/README.md
+++ b/sktime/libs/README.md
@@ -1,10 +1,10 @@
-# libraries distributed with ``sktime``
+# libraries distributed with `sktime`
 
-This folder contains libraries directly distibuted with, and maintained by, ``sktime``.
+This folder contains libraries directly distibuted with, and maintained by, `sktime`.
 
-* ``pykalman`` - a package implementing the Kálmán Filter and variants.
-  Unofficial fork after ``pykalman`` was abandoned by its maintainers,
+* `pykalman` - a package implementing the Kálmán Filter and variants.
+  Unofficial fork of abandoned package from June 2024 onwards,
   see [pykalman issue 109](https://github.com/pykalman/pykalman/issues/109).
 
-* ``vmdpy` - a package implementing Variational Mode Decomposition.
-  Official fork, maintained in ``sktime`` since August 2023.
+*``vmdpy` - a package implementing Variational Mode Decomposition.
+  Official fork, `vmdpy` is maintained in `sktime` since August 2023.

--- a/sktime/libs/pykalman/__init__.py
+++ b/sktime/libs/pykalman/__init__.py
@@ -3,8 +3,8 @@
 Unofficial fork of the ``pykalman`` package, maintained in ``sktime``.
 
 sktime migration: 2024, June
-Version 0.9.7 release: 2024, Mar 25
-Version 0.9.5 release: 2013, Jul 7
+Version 0.9.7 release: 2024, Mar 25 (mbalatsko, fkiraly)
+Version 0.9.5 release: 2013, Jul 7 (duckworthd)
 
 Original authors: Daniel Duckworth
 

--- a/sktime/libs/pykalman/__init__.py
+++ b/sktime/libs/pykalman/__init__.py
@@ -1,11 +1,48 @@
-"""Package - pykalman.
+"""Python implementations of Kalman Filters and Kalman Smoothers.
 
-=============
-Kalman Module
-=============
+Unofficial fork of the ``pykalman`` package, maintained in ``sktime``.
 
-This module provides inference methods for state-space estimation in continuous
-spaces.
+sktime migration: 2024, June
+Version 0.9.7 release: 2024, Mar 25
+Version 0.9.5 release: 2013, Jul 7
+
+Original authors: Daniel Duckworth
+
+2013 and 2024 releases subject to following license:
+
+All code contained except that in pykalman/utils.py is released under the
+license below. All code in pykalman/utils.py is released under the license
+contained therein.
+
+New BSD License
+
+Copyright (c) 2012 Daniel Duckworth.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  a. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  b. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  c. Neither the name of Daniel Duckworth nor the names of
+     its contributors may be used to endorse or promote products
+     derived from this software without specific prior written
+     permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
 """
 
 __authors__ = [

--- a/sktime/libs/vmdpy/README.md
+++ b/sktime/libs/vmdpy/README.md
@@ -9,6 +9,8 @@ the original [VMD MATLAB toolbox](https://www.mathworks.com/matlabcentral/fileex
 
 ## Installation 
 
+`vmdpy` is distributed with `sktime`.
+
 Install ``sktime`` via ``pip`` or ``conda``, i.e.,
 
 ```

--- a/sktime/libs/vmdpy/README.md
+++ b/sktime/libs/vmdpy/README.md
@@ -1,13 +1,13 @@
 # vmdpy: Variational mode decomposition in Python
 
 Function for decomposing a signal according to the Variational Mode Decomposition
-([Dragomiretskiy and Zosso, 2014](https://doi.org/10.1109/TSP.2013.2288675)) method.  
+([Dragomiretskiy and Zosso, 2014](https://doi.org/10.1109/TSP.2013.2288675)) method.
 
 This package is a Python translation of
-the original [VMD MATLAB toolbox](https://www.mathworks.com/matlabcentral/fileexchange/44765-variational-mode-decomposition)  
+the original [VMD MATLAB toolbox](https://www.mathworks.com/matlabcentral/fileexchange/44765-variational-mode-decomposition)
 
 
-## Installation 
+## Installation
 
 `vmdpy` is distributed with `sktime`.
 
@@ -29,7 +29,7 @@ For further details, see the [sktime installation guide](https://www.sktime.net/
 ## Citation and Contact
 Paper available at: https://doi.org/10.1016/j.bspc.2020.102073
 
-If you find this package useful, we kindly ask you to cite it in your work:   
+If you find this package useful, we kindly ask you to cite it in your work:
 Vinícius R. Carvalho, Márcio F.D. Moraes, Antônio P. Braga, Eduardo M.A.M. Mendes,
 Evaluating five different adaptive decomposition methods for EEG signal seizure detection and classification,
 Biomedical Signal Processing and Control,
@@ -37,7 +37,7 @@ Volume 62,
 2020,
 102073,
 ISSN 1746-8094,
-https://doi.org/10.1016/j.bspc.2020.102073.  
+https://doi.org/10.1016/j.bspc.2020.102073.
 
 For contributing new functionality or fixing anything in the package,
 kindly make a PR to the ``sktime`` repository (``libs.vmdpy`` module).
@@ -51,51 +51,51 @@ For suggestions, questions, comments:
 
 ## Example script
 ```python
-#%% Simple example: generate signal with 3 components + noise  
-import numpy as np  
-import matplotlib.pyplot as plt  
-from sktime.libs.vmdpy import VMD  
+#%% Simple example: generate signal with 3 components + noise
+import numpy as np
+import matplotlib.pyplot as plt
+from sktime.libs.vmdpy import VMD
 
-#. Time Domain 0 to T  
-T = 1000  
-fs = 1/T  
-t = np.arange(1,T+1)/T  
-freqs = 2*np.pi*(t-0.5-fs)/(fs)  
+# Time Domain 0 to T
+T = 1000
+fs = 1 / T
+t = np.arange(1, T + 1) / T
+freqs = 2 * np.pi * (t - 0.5 - fs) / (fs)
 
-#. center frequencies of components  
-f_1 = 2  
-f_2 = 24  
-f_3 = 288  
+# center frequencies of components
+f_1 = 2
+f_2 = 24
+f_3 = 288
 
-#. modes  
-v_1 = (np.cos(2*np.pi*f_1*t))  
-v_2 = 1/4*(np.cos(2*np.pi*f_2*t))  
-v_3 = 1/16*(np.cos(2*np.pi*f_3*t))  
+# modes
+v_1 = np.cos(2 * np.pi * f_1 * t)
+v_2 = 1 / 4 * (np.cos(2 * np.pi * f_2 * t))
+v_3 = 1 / 16 * (np.cos(2 * np.pi * f_3 * t))
 
-f = v_1 + v_2 + v_3 + 0.1*np.random.randn(v_1.size)  
+f = v_1 + v_2 + v_3 + 0.1 * np.random.randn(v_1.size)
 
-#. some sample parameters for VMD  
-alpha = 2000       # moderate bandwidth constraint  
-tau = 0.            # noise-tolerance (no strict fidelity enforcement)  
-K = 3              # 3 modes  
-DC = 0             # no DC part imposed  
-init = 1           # initialize omegas uniformly  
-tol = 1e-7  
+# some sample parameters for VMD
+alpha = 2000  # moderate bandwidth constraint
+tau = 0.0  # noise-tolerance (no strict fidelity enforcement)
+K = 3  # 3 modes
+DC = 0  # no DC part imposed
+init = 1  # initialize omegas uniformly
+tol = 1e-7
 
+# Run VMD
+u, u_hat, omega = VMD(f, alpha, tau, K, DC, init, tol)
 
-#. Run VMD 
-u, u_hat, omega = VMD(f, alpha, tau, K, DC, init, tol)  
-
-#. Visualize decomposed modes
+# Visualize decomposed modes
 plt.figure()
-plt.subplot(2,1,1)
+plt.subplot(2, 1, 1)
 plt.plot(f)
-plt.title('Original signal')
-plt.xlabel('time (s)')
-plt.subplot(2,1,2)
+plt.title("Original signal")
+plt.xlabel("time (s)")
+plt.subplot(2, 1, 2)
 plt.plot(u.T)
-plt.title('Decomposed modes')
-plt.xlabel('time (s)')
-plt.legend(['Mode %d'%m_i for m_i in range(u.shape[0])])
+plt.title("Decomposed modes")
+plt.xlabel("time (s)")
+plt.legend(["Mode %d" % m_i for m_i in range(u.shape[0])])
 plt.tight_layout()
+
 ```

--- a/sktime/libs/vmdpy/README.md
+++ b/sktime/libs/vmdpy/README.md
@@ -39,7 +39,8 @@ Volume 62,
 ISSN 1746-8094,
 https://doi.org/10.1016/j.bspc.2020.102073.  
 
-If you developed a new funcionality or fixed anything in the code, just provide me the corresponding files and which credit should I include in this readme file. 
+For contributing new functionality or fixing anything in the package,
+kindly make a PR to the ``sktime`` repository (``libs.vmdpy`` module).
 
 For suggestions, questions, comments:
 

--- a/sktime/libs/vmdpy/README.md
+++ b/sktime/libs/vmdpy/README.md
@@ -1,0 +1,98 @@
+# vmdpy: Variational mode decomposition in Python
+
+Function for decomposing a signal according to the Variational Mode Decomposition
+([Dragomiretskiy and Zosso, 2014](https://doi.org/10.1109/TSP.2013.2288675)) method.  
+
+This package is a Python translation of
+the original [VMD MATLAB toolbox](https://www.mathworks.com/matlabcentral/fileexchange/44765-variational-mode-decomposition)  
+
+
+## Installation 
+
+Install ``sktime`` via ``pip`` or ``conda``, i.e.,
+
+```
+pip install sktime
+```
+
+or
+
+```
+conda install sktime
+```
+
+For further details, see the [sktime installation guide](https://www.sktime.net/en/stable/installation.html)
+
+
+## Citation and Contact
+Paper available at: https://doi.org/10.1016/j.bspc.2020.102073
+
+If you find this package useful, we kindly ask you to cite it in your work:   
+Vinícius R. Carvalho, Márcio F.D. Moraes, Antônio P. Braga, Eduardo M.A.M. Mendes,
+Evaluating five different adaptive decomposition methods for EEG signal seizure detection and classification,
+Biomedical Signal Processing and Control,
+Volume 62,
+2020,
+102073,
+ISSN 1746-8094,
+https://doi.org/10.1016/j.bspc.2020.102073.  
+
+If you developed a new funcionality or fixed anything in the code, just provide me the corresponding files and which credit should I include in this readme file. 
+
+For suggestions, questions, comments:
+
+* [sktime issue tracker](https://github.com/sktime/sktime/issues) or [discussion forum](https://github.com/sktime/sktime/discussions),
+  please ping `vrcarva`
+* [sktime discord](https://discord.com/invite/54ACzaFsn7)
+
+
+## Example script
+```python
+#%% Simple example: generate signal with 3 components + noise  
+import numpy as np  
+import matplotlib.pyplot as plt  
+from sktime.libs.vmdpy import VMD  
+
+#. Time Domain 0 to T  
+T = 1000  
+fs = 1/T  
+t = np.arange(1,T+1)/T  
+freqs = 2*np.pi*(t-0.5-fs)/(fs)  
+
+#. center frequencies of components  
+f_1 = 2  
+f_2 = 24  
+f_3 = 288  
+
+#. modes  
+v_1 = (np.cos(2*np.pi*f_1*t))  
+v_2 = 1/4*(np.cos(2*np.pi*f_2*t))  
+v_3 = 1/16*(np.cos(2*np.pi*f_3*t))  
+
+f = v_1 + v_2 + v_3 + 0.1*np.random.randn(v_1.size)  
+
+#. some sample parameters for VMD  
+alpha = 2000       # moderate bandwidth constraint  
+tau = 0.            # noise-tolerance (no strict fidelity enforcement)  
+K = 3              # 3 modes  
+DC = 0             # no DC part imposed  
+init = 1           # initialize omegas uniformly  
+tol = 1e-7  
+
+
+#. Run VMD 
+u, u_hat, omega = VMD(f, alpha, tau, K, DC, init, tol)  
+
+#. Visualize decomposed modes
+plt.figure()
+plt.subplot(2,1,1)
+plt.plot(f)
+plt.title('Original signal')
+plt.xlabel('time (s)')
+plt.subplot(2,1,2)
+plt.plot(u.T)
+plt.title('Decomposed modes')
+plt.xlabel('time (s)')
+plt.legend(['Mode %d'%m_i for m_i in range(u.shape[0])])
+plt.tight_layout()
+```

--- a/sktime/libs/vmdpy/__init__.py
+++ b/sktime/libs/vmdpy/__init__.py
@@ -32,3 +32,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 __author__ = ["vcarvo"]
+
+from sktime.libs.vmdpy.vmdpy import VMD
+
+__all__ = ["VMD"]

--- a/sktime/libs/vmdpy/__init__.py
+++ b/sktime/libs/vmdpy/__init__.py
@@ -1,0 +1,34 @@
+"""Python implementation of the Variational Mode Decomposition method.
+
+Official fork of the ``vmdpy`` package, maintained in ``sktime``.
+
+sktime migration: 2023, August
+Version 0.2 release: 2020, Aug 11
+Version 0.1 release: 2019, Apr 9
+First version created on Wed Feb 20 19:24:58 2019
+
+Original author: Vinícius Rezende Carvalho
+
+2019 and 2020 releases subject to following license:
+
+Copyright (c) 2019 Vinícius Carvalho & Eduardo Mazoni
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+__author__ = ["vcarvo"]

--- a/sktime/libs/vmdpy/__init__.py
+++ b/sktime/libs/vmdpy/__init__.py
@@ -31,7 +31,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-__author__ = ["vcarvo"]
+__author__ = ["vrcarva"]
 
 from sktime.libs.vmdpy.vmdpy import VMD
 

--- a/sktime/libs/vmdpy/tests/__init__.py
+++ b/sktime/libs/vmdpy/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for vmdpy package."""

--- a/sktime/libs/vmdpy/tests/test_readme_example.py
+++ b/sktime/libs/vmdpy/tests/test_readme_example.py
@@ -13,6 +13,7 @@ from sktime.utils.dependencies import _check_soft_dependencies
 def test_readme_example():
     """Tests the example from the README.md"""
     import numpy as np
+
     from sktime.libs.vmdpy import VMD
 
     # Time Domain 0 to T

--- a/sktime/libs/vmdpy/tests/test_readme_example.py
+++ b/sktime/libs/vmdpy/tests/test_readme_example.py
@@ -1,0 +1,63 @@
+"""Tests for vmdpy package - readme example."""
+
+import pytest
+
+from sktime.tests.test_switch import run_test_module_changed
+from sktime.utils.dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.libs.vmdpy"),
+    reason="skip test if module not changed",
+)
+def test_readme_example():
+    """Tests the example from the README.md"""
+    import numpy as np
+    from sktime.libs.vmdpy import VMD
+
+    # Time Domain 0 to T
+    T = 1000
+    fs = 1 / T
+    t = np.arange(1, T + 1) / T
+    freqs = 2 * np.pi * (t - 0.5 - fs) / (fs)  # noqa: F841
+
+    # center frequencies of components
+    f_1 = 2
+    f_2 = 24
+    f_3 = 288
+
+    # modes
+    v_1 = np.cos(2 * np.pi * f_1 * t)
+    v_2 = 1 / 4 * (np.cos(2 * np.pi * f_2 * t))
+    v_3 = 1 / 16 * (np.cos(2 * np.pi * f_3 * t))
+
+    f = v_1 + v_2 + v_3 + 0.1 * np.random.randn(v_1.size)
+
+    # some sample parameters for VMD
+    alpha = 2000  # moderate bandwidth constraint
+    tau = 0.0  # noise-tolerance (no strict fidelity enforcement)
+    K = 3  # 3 modes
+    DC = 0  # no DC part imposed
+    init = 1  # initialize omegas uniformly
+    tol = 1e-7
+
+    # Run VMD
+    u, u_hat, omega = VMD(f, alpha, tau, K, DC, init, tol)
+
+    if not _check_soft_dependencies("matplotlib", severity="none"):
+        return None
+
+    import matplotlib.pyplot as plt
+
+    # Visualize decomposed modes
+    plt.figure()
+    plt.subplot(2, 1, 1)
+    plt.plot(f)
+    plt.title("Original signal")
+    plt.xlabel("time (s)")
+    plt.subplot(2, 1, 2)
+    plt.plot(u.T)
+    plt.title("Decomposed modes")
+    plt.xlabel("time (s)")
+    plt.legend(["Mode %d" % m_i for m_i in range(u.shape[0])])
+    plt.tight_layout()

--- a/sktime/libs/vmdpy/vmdpy.py
+++ b/sktime/libs/vmdpy/vmdpy.py
@@ -1,4 +1,5 @@
 """Python implementation of the Variational Mode Decomposition method."""
+
 import numpy as np
 
 __author__ = ["vrcarva"]

--- a/sktime/libs/vmdpy/vmdpy.py
+++ b/sktime/libs/vmdpy/vmdpy.py
@@ -1,36 +1,4 @@
-"""Python implementation of the Variational Mode Decomposition method.
-
-Official fork of the ``vmdpy`` package, maintained in ``sktime``.
-
-sktime migration: 2023, August
-Version 0.2 release: 2020, Aug 11
-Version 0.1 release: 2019, Apr 9
-First version created on Wed Feb 20 19:24:58 2019
-
-Original author: Vinícius Rezende Carvalho
-
-2019 and 2020 releases subject to following license:
-
-Copyright (c) 2019 Vinícius Carvalho & Eduardo Mazoni
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
+"""Python implementation of the Variational Mode Decomposition method."""
 import numpy as np
 
 __author__ = ["vcarvo"]

--- a/sktime/libs/vmdpy/vmdpy.py
+++ b/sktime/libs/vmdpy/vmdpy.py
@@ -1,7 +1,7 @@
 """Python implementation of the Variational Mode Decomposition method."""
 import numpy as np
 
-__author__ = ["vcarvo"]
+__author__ = ["vrcarva"]
 
 
 def VMD(f, alpha, tau, K, DC, init, tol):

--- a/sktime/transformations/series/tests/test_vmd.py
+++ b/sktime/transformations/series/tests/test_vmd.py
@@ -9,9 +9,9 @@ import pytest
 
 from sktime.forecasting.compose import TransformedTargetForecaster
 from sktime.forecasting.trend import TrendForecaster
+from sktime.libs.vmdpy import VMD
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.series.vmd import VmdTransformer
-from sktime.libs.vmdpy import VMD
 
 
 def _generate_vmd_testdata(T=1000, f_1=2, f_2=24, f_3=288, noise=0.1):

--- a/sktime/transformations/series/tests/test_vmd.py
+++ b/sktime/transformations/series/tests/test_vmd.py
@@ -10,8 +10,8 @@ import pytest
 from sktime.forecasting.compose import TransformedTargetForecaster
 from sktime.forecasting.trend import TrendForecaster
 from sktime.tests.test_switch import run_test_for_class
-from sktime.transformations.series.vmd._vmd import VmdTransformer
-from sktime.transformations.series.vmd._vmdpy import VMD
+from sktime.transformations.series.vmd import VmdTransformer
+from sktime.libs.vmdpy import VMD
 
 
 def _generate_vmd_testdata(T=1000, f_1=2, f_2=24, f_3=288, noise=0.1):

--- a/sktime/transformations/series/vmd.py
+++ b/sktime/transformations/series/vmd.py
@@ -6,14 +6,14 @@ import pandas as pd
 from sktime.transformations.base import BaseTransformer
 from sktime.libs.vmdpy import VMD
 
-__author__ = ["DaneLyttinen", "vcarvo"]
+__author__ = ["DaneLyttinen", "vrcarva"]
 
 
 class VmdTransformer(BaseTransformer):
     """Variational Mode Decomposition transformer.
 
     An implementation of the Variational Mode Decomposition method (2014) [1]_,
-    based on the ``vmdpy`` package [3]_ by ``vcarvo``, which in turn is based
+    based on the ``vmdpy`` package [3]_ by ``vrcarva``, which in turn is based
     on the original MATLAB implementation by Dragomiretskiy and Zosso [1]_.
 
     This transformer is the official continuation of the ``vmdpy`` package,
@@ -99,8 +99,8 @@ class VmdTransformer(BaseTransformer):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["DaneLyttinen", "vcarvo"],
-        "maintainers": ["DaneLyttinen", "vcarvo"],
+        "authors": ["DaneLyttinen", "vrcarva"],
+        "maintainers": ["DaneLyttinen", "vrcarva"],
         # estimator type
         # --------------
         "scitype:transform-input": "Series",

--- a/sktime/transformations/series/vmd.py
+++ b/sktime/transformations/series/vmd.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.transformations.base import BaseTransformer
-from sktime.transformations.series.vmd._vmdpy import VMD
+from sktime.libs.vmdpy import VMD
 
 __author__ = ["DaneLyttinen", "vcarvo"]
 

--- a/sktime/transformations/series/vmd.py
+++ b/sktime/transformations/series/vmd.py
@@ -3,8 +3,8 @@
 import numpy as np
 import pandas as pd
 
-from sktime.transformations.base import BaseTransformer
 from sktime.libs.vmdpy import VMD
+from sktime.transformations.base import BaseTransformer
 
 __author__ = ["DaneLyttinen", "vrcarva"]
 

--- a/sktime/transformations/series/vmd/__init__.py
+++ b/sktime/transformations/series/vmd/__init__.py
@@ -1,9 +1,0 @@
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""VMD transformer and VMD mini-package based on pyvmd."""
-
-__author__ = ["DaneLyttinen", "vcarvo"]
-
-
-from sktime.transformations.series.vmd._vmd import VmdTransformer
-
-__all__ = ["VmdTransformer"]

--- a/sktime/transformations/series/vmd/tests/__init__.py
+++ b/sktime/transformations/series/vmd/tests/__init__.py
@@ -1,2 +1,0 @@
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
-"""Tests for VMD transformer and VMD mini-package based on pyvmd."""


### PR DESCRIPTION
Cleans up folder structure and documentation for onboard libs `pykalman` and `vmdpy`.

* adds missing license statement and package preamble for `pykalman`
* moves `vmdpy` to public module in `sktime.libs` folder
* flatten structure of `vmd` module in `transformation` after removal of nested package contents
* adds `README` to `libs` folder and `vmdpy`
* add tests folder for `vmdpy` (currently only readme example)

The changes in `vmdpy` and `transformations` do not require deprecation, as no public interfaces change.