### PR TITLE
[ENH] simplify and add differential testing to `forecasting.compose.tests` module

### DIFF
--- a/sktime/forecasting/compose/tests/test_multiplex.py
+++ b/sktime/forecasting/compose/tests/test_multiplex.py
@@ -7,15 +7,12 @@ __author__ = ["miraep8"]
 import pytest
 
 from sktime.datasets import load_shampoo_sales
-from sktime.forecasting.arima import AutoARIMA
-from sktime.forecasting.compose import MultiplexForecaster
-from sktime.forecasting.ets import AutoETS
+from sktime.forecasting.compose import MultiplexForecaster, YfromX
 from sktime.forecasting.model_evaluation import evaluate
 from sktime.forecasting.model_selection import ForecastingGridSearchCV
 from sktime.forecasting.naive import NaiveForecaster
-from sktime.forecasting.theta import ThetaForecaster
 from sktime.split import ExpandingWindowSplitter
-from sktime.utils.dependencies import _check_estimator_deps
+from sktime.tests.test_switch import run_test_for_class
 from sktime.utils.validation.forecasting import check_scoring
 
 
@@ -35,8 +32,8 @@ def _score_forecasters(forecasters, cv, y):
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(ThetaForecaster, severity="none"),
-    reason="skip test if required soft dependency is not available",
+    not run_test_for_class(MultiplexForecaster),
+    reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_multiplex_forecaster_alone():
     """Test results of MultiplexForecaster.
@@ -51,7 +48,7 @@ def test_multiplex_forecaster_alone():
     # Note - we select two forecasters which are deterministic.
     forecaster_tuples = [
         ("naive", NaiveForecaster()),
-        ("theta", ThetaForecaster()),
+        ("naive2", NaiveForecaster(strategy="mean")),
     ]
     forecaster_names = [name for name, _ in forecaster_tuples]
     forecasters = [forecaster for _, forecaster in forecaster_tuples]
@@ -100,8 +97,8 @@ def test_multiplex_with_grid_search():
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(AutoARIMA, severity="none"),
-    reason="skip test if required soft dependency for AutoARIMA not available",
+    not run_test_for_class(MultiplexForecaster),
+    reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_multiplex_or_dunder():
     """Test that the MultiplexForecaster magic "|" dunder method behaves as expected.
@@ -110,14 +107,18 @@ def test_multiplex_or_dunder():
     forecaster or MultiplexForecaster objects. Here we test that it performs as expected
     on all the use cases, and raises the expected error in some others.
     """
+    yfromx = YfromX.create_test_instance()
+    naive = NaiveForecaster()
+    naive2 = NaiveForecaster(strategy="mean")
+
     # test a simple | example with two forecasters:
-    multiplex_two_forecaster = AutoETS() | NaiveForecaster()
+    multiplex_two_forecaster = yfromx | naive
     assert isinstance(multiplex_two_forecaster, MultiplexForecaster)
     assert len(multiplex_two_forecaster.forecasters) == 2
     # now test that | also works on two MultiplexForecasters:
-    multiplex_one = MultiplexForecaster([("arima", AutoARIMA()), ("ets", AutoETS())])
+    multiplex_one = MultiplexForecaster([("yfromx", yfromx), ("naive2", naive2)])
     multiplex_two = MultiplexForecaster(
-        [("theta", ThetaForecaster()), ("naive", NaiveForecaster())]
+        [("yfromx2", yfromx), ("naive", NaiveForecaster())]
     )
     multiplex_two_multiplex = multiplex_one | multiplex_two
     assert isinstance(multiplex_two_multiplex, MultiplexForecaster)

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -176,7 +176,7 @@ def test_pipeline_with_detrender():
             OptionalPassthrough,
             ForecastingPipeline,
             TabularToSeriesAdaptor,
-            make_reduction
+            make_reduction,
         ]
     ),
     reason="run test only if softdeps are present and incrementally (if requested)",
@@ -408,9 +408,7 @@ def test_forecasting_pipeline_dunder_exog():
 
 
 @pytest.mark.skipif(
-    not run_test_for_class(
-        [TransformedTargetForecaster, ForecastingPipeline, Imputer]
-    ),
+    not run_test_for_class([TransformedTargetForecaster, ForecastingPipeline, Imputer]),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_tag_handles_missing_data():
@@ -501,7 +499,7 @@ def test_featurizer_forecastingpipeline_logic():
 
     lagged_y_trafo = YtoX() * Lag(1, index_out="original") * Imputer()
     # we need to specify index_out="original" as otherwise ARIMA gets 1 and 2 ahead
-    forecaster = lagged_y_trafo ** f  # this uses lagged_y_trafo to generate X
+    forecaster = lagged_y_trafo**f  # this uses lagged_y_trafo to generate X
 
     forecaster.fit(y_train, X=X_train, fh=[1])  # try to forecast next year
     forecaster.predict(X=X_test)  # dummy X to predict next year

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -14,7 +14,6 @@ from sklearn.svm import SVR
 from sktime.datasets import load_airline, load_longley
 from sktime.datatypes import get_examples
 from sktime.datatypes._utilities import get_window
-from sktime.forecasting.arima import ARIMA
 from sktime.forecasting.compose import (
     ForecastingPipeline,
     TransformedTargetForecaster,
@@ -26,6 +25,7 @@ from sktime.forecasting.naive import NaiveForecaster
 from sktime.forecasting.sarimax import SARIMAX
 from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.split import ExpandingWindowSplitter, temporal_train_test_split
+from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.compose import OptionalPassthrough, YtoX
 from sktime.transformations.hierarchical.aggregate import Aggregator
 from sktime.transformations.series.adapt import TabularToSeriesAdaptor
@@ -33,14 +33,20 @@ from sktime.transformations.series.boxcox import LogTransformer
 from sktime.transformations.series.detrend import Detrender
 from sktime.transformations.series.difference import Differencer
 from sktime.transformations.series.exponent import ExponentTransformer
+from sktime.transformations.series.feature_selection import FeatureSelection
+from sktime.transformations.series.fourier import FourierFeatures
 from sktime.transformations.series.impute import Imputer
+from sktime.transformations.series.lag import Lag
 from sktime.transformations.series.outlier_detection import HampelFilter
 from sktime.utils._testing.estimator_checks import _assert_array_almost_equal
 from sktime.utils._testing.series import _make_series
-from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.estimators import MockForecaster
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([TransformedTargetForecaster, TabularToSeriesAdaptor]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_pipeline():
     """Test results of TransformedTargetForecaster."""
     y = load_airline()
@@ -77,6 +83,10 @@ def test_pipeline():
     np.testing.assert_array_equal(actual, expected)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(TransformedTargetForecaster),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_skip_inverse_transform():
     """Test transformers with skip-inverse-transform tag in pipeline."""
     y = load_airline()
@@ -99,12 +109,18 @@ def test_skip_inverse_transform():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("statsmodels", severity="none"),
-    reason="skip test if required soft dependency is not available",
+    not run_test_for_class(
+        [
+            TransformedTargetForecaster,
+            OptionalPassthrough,
+            ForecastingPipeline,
+        ]
+    ),
+    reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_nesting_pipelines():
     """Test that nesting of pipelines works."""
-    from sktime.forecasting.ets import AutoETS
+    from sktime.forecasting.compose import YfromX
     from sktime.transformations.compose import OptionalPassthrough
     from sktime.transformations.series.boxcox import LogTransformer
     from sktime.transformations.series.detrend import Detrender
@@ -112,16 +128,18 @@ def test_nesting_pipelines():
         ForecasterFitPredictUnivariateWithX,
     )
 
+    yfromx = YfromX.create_test_instance()
+
     pipe = ForecastingPipeline(
         steps=[
             ("logX", OptionalPassthrough(LogTransformer())),
-            ("detrenderX", OptionalPassthrough(Detrender(forecaster=AutoETS()))),
+            ("detrenderX", OptionalPassthrough(Detrender(forecaster=yfromx))),
             (
                 "etsforecaster",
                 TransformedTargetForecaster(
                     steps=[
                         ("log", OptionalPassthrough(LogTransformer())),
-                        ("autoETS", AutoETS()),
+                        ("yfromx", yfromx),
                     ]
                 ),
             ),
@@ -133,6 +151,10 @@ def test_nesting_pipelines():
     scenario.run(pipe, method_sequence=["fit", "predict"])
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(TransformedTargetForecaster),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_pipeline_with_detrender():
     """Tests a specific pipeline that triggers multiple back/forth conversions."""
     y = load_airline()
@@ -147,6 +169,18 @@ def test_pipeline_with_detrender():
     trans_fc.predict(1)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(
+        [
+            TransformedTargetForecaster,
+            OptionalPassthrough,
+            ForecastingPipeline,
+            TabularToSeriesAdaptor,
+            make_reduction
+        ]
+    ),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_pipeline_with_dimension_changing_transformer():
     """Example of pipeline with dimension changing transformer.
 
@@ -214,8 +248,8 @@ def test_pipeline_with_dimension_changing_transformer():
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(SARIMAX, severity="none"),
-    reason="skip test if required soft dependency is not available",
+    not run_test_for_class([Aggregator, ForecastingPipeline]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_nested_pipeline_with_index_creation_y_before_X():
     """Tests a nested pipeline where y indices are created before X indices.
@@ -230,8 +264,11 @@ def test_nested_pipeline_with_index_creation_y_before_X():
     y_train = get_window(y, lag=1)
     X_test = get_window(X, window_length=1)
 
+    # simple forecaster that can deal with exogenous data
+    yfromx = YfromX.create_test_instance()
+
     # Aggregator creates indices for y (via *), then for X (via ForecastingPipeline)
-    f = Aggregator() * ForecastingPipeline([Aggregator(), SARIMAX()])
+    f = Aggregator() * ForecastingPipeline([Aggregator(), yfromx])
 
     f.fit(y=y_train, X=X_train, fh=1)
     y_pred = f.predict(X=X_test)
@@ -243,8 +280,8 @@ def test_nested_pipeline_with_index_creation_y_before_X():
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(SARIMAX, severity="none"),
-    reason="skip test if required soft dependency is not available",
+    not run_test_for_class([Aggregator, ForecastingPipeline]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_nested_pipeline_with_index_creation_X_before_y():
     """Tests a nested pipeline where X indices are created before y indices.
@@ -259,8 +296,11 @@ def test_nested_pipeline_with_index_creation_X_before_y():
     y_train = get_window(y, lag=1)
     X_test = get_window(X, window_length=1)
 
+    # simple forecaster that can deal with exogenous data
+    yfromx = YfromX.create_test_instance()
+
     # Aggregator creates indices for X (via ForecastingPipeline), then for y (via *)
-    f = ForecastingPipeline([Aggregator(), Aggregator() * SARIMAX()])
+    f = ForecastingPipeline([Aggregator(), Aggregator() * yfromx])
 
     f.fit(y=y_train, X=X_train, fh=1)
     y_pred = f.predict(X=X_test)
@@ -271,6 +311,10 @@ def test_nested_pipeline_with_index_creation_X_before_y():
     assert len(y_pred) == 9
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([TabularToSeriesAdaptor, TransformedTargetForecaster]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_forecasting_pipeline_dunder_endog():
     """Test forecasting pipeline dunder for endogeneous transformation."""
     y = load_airline()
@@ -308,8 +352,8 @@ def test_forecasting_pipeline_dunder_endog():
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(SARIMAX, severity="none"),
-    reason="skip test if required soft dependency is not available",
+    not run_test_for_class([TabularToSeriesAdaptor, ForecastingPipeline]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_forecasting_pipeline_dunder_exog():
     """Test forecasting pipeline dunder for exogeneous transformation."""
@@ -318,8 +362,11 @@ def test_forecasting_pipeline_dunder_exog():
     X = _make_series(n_columns=2)
     X_train, X_test = temporal_train_test_split(X)
 
-    forecaster = ExponentTransformer() ** MinMaxScaler() ** SARIMAX(random_state=3)
-    forecaster_alt = (ExponentTransformer() * MinMaxScaler()) ** SARIMAX(random_state=3)
+    # simple forecaster that can deal with exogenous data
+    yfromx = YfromX.create_test_instance()
+
+    forecaster = ExponentTransformer() ** MinMaxScaler() ** yfromx
+    forecaster_alt = (ExponentTransformer() * MinMaxScaler()) ** yfromx
 
     assert isinstance(forecaster, ForecastingPipeline)
     assert isinstance(forecaster.steps[0], ExponentTransformer)
@@ -360,6 +407,12 @@ def test_forecasting_pipeline_dunder_exog():
     _assert_array_almost_equal(actual_alt, expected, decimal=2)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(
+        [TransformedTargetForecaster, ForecastingPipeline, Imputer]
+    ),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_tag_handles_missing_data():
     """Test missing data with Imputer in pipelines.
 
@@ -388,8 +441,8 @@ def test_tag_handles_missing_data():
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(SARIMAX, severity="none"),
-    reason="skip test if required soft dependency is not available",
+    not run_test_for_class([TransformedTargetForecaster, ForecastingPipeline]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_subset_getitem():
     """Test subsetting using the [ ] dunder, __getitem__."""
@@ -400,7 +453,8 @@ def test_subset_getitem():
     X.columns = ["a", "b", "c"]
     X_train, X_test = temporal_train_test_split(X)
 
-    f = SARIMAX(random_state=3)
+    # simple forecaster that can deal with exogenous data
+    f = YfromX.create_test_instance()
 
     f_before = f[["a", "b"]]
     f_before_with_colon = f[["a", "b"], :]
@@ -412,7 +466,7 @@ def test_subset_getitem():
     assert isinstance(f_after_with_colon, TransformedTargetForecaster)
     assert isinstance(f_before_with_colon, ForecastingPipeline)
     assert isinstance(f_both, TransformedTargetForecaster)
-    assert isinstance(f_none, SARIMAX)
+    assert isinstance(f_none, YfromX)
 
     y_pred = f.fit(y_train, X_train, fh=X_test.index).predict(X=X_test)
 
@@ -434,27 +488,29 @@ def test_subset_getitem():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("statsmodels", severity="none"),
-    reason="skip test if required soft dependency is not available",
+    not run_test_for_class([YfromX, YtoX, Lag, Imputer]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_featurizer_forecastingpipeline_logic():
     """Test that ForecastingPipeline works with featurizer transformers without exog."""
-    from sktime.forecasting.sarimax import SARIMAX
-    from sktime.transformations.compose import YtoX
-    from sktime.transformations.series.impute import Imputer
-    from sktime.transformations.series.lag import Lag
-
     y, X = load_longley()
     y_train, y_test, X_train, X_test = temporal_train_test_split(y, X)
 
+    # simple forecaster that can deal with exogenous data
+    f = YfromX.create_test_instance()
+
     lagged_y_trafo = YtoX() * Lag(1, index_out="original") * Imputer()
     # we need to specify index_out="original" as otherwise ARIMA gets 1 and 2 ahead
-    forecaster = lagged_y_trafo ** SARIMAX()  # this uses lagged_y_trafo to generate X
+    forecaster = lagged_y_trafo ** f  # this uses lagged_y_trafo to generate X
 
     forecaster.fit(y_train, X=X_train, fh=[1])  # try to forecast next year
     forecaster.predict(X=X_test)  # dummy X to predict next year
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([YfromX, FeatureSelection, TransformedTargetForecaster]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_exogenousx_ignore_tag_set():
     """Tests that TransformedTargetForecaster sets X tag for feature selection.
 
@@ -466,9 +522,6 @@ def test_exogenousx_ignore_tag_set():
     More generally, the tag should be set to True iff all steps in the pipeline
     ignore X.
     """
-    from sktime.forecasting.compose import YfromX
-    from sktime.transformations.series.feature_selection import FeatureSelection
-
     fcst_does_not_ignore_x = YfromX.create_test_instance()
     fcst_ignores_x = NaiveForecaster()
 
@@ -500,20 +553,21 @@ def test_exogenousx_ignore_tag_set():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("pmdarima", severity="none"),
-    reason="skip test if required soft dependency is not available",
+    not run_test_for_class([YfromX, ForecastingPipeline, FeatureSelection]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_pipeline_exogenous_none():
     """Test ForecastingPipeline works with a transformer returning None."""
-    from sktime.transformations.series.feature_selection import FeatureSelection
-
     y, X = load_longley()
     y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, test_size=3)
+
+    # simple forecaster that can deal with exogenous data
+    yfromx = YfromX.create_test_instance()
 
     pipe = ForecastingPipeline(
         [
             ("select_X", FeatureSelection(method="none")),
-            ("arima", ARIMA()),
+            ("yfromx", yfromx),
         ]
     )
 
@@ -522,6 +576,10 @@ def test_pipeline_exogenous_none():
     assert np.all(y_pred.index == y_test.index)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([ForecastingPipeline, YfromX, FourierFeatures]),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_pipeline_featurizer_noexog():
     """Test that ForecastingPipeline works with featurizer transformers without exog
 
@@ -529,8 +587,6 @@ def test_pipeline_featurizer_noexog():
     Compared to test_pipeline_exogenous_none,
     this tests that transformers are executed properly even if X=None.
     """
-    from sktime.transformations.series.fourier import FourierFeatures
-
     calls_per_min_low = 100 * 60
     calls_per_min_high = 500 * 60
     data = np.random.randint(low=calls_per_min_low, high=calls_per_min_high, size=100)

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -32,6 +32,7 @@ from sktime.regression.base import BaseRegressor
 from sktime.regression.interval_based import TimeSeriesForestRegressor
 from sktime.split import SlidingWindowSplitter, temporal_train_test_split
 from sktime.split.tests.test_split import _get_windows
+from sktime.tests.test_switch import run_test_module_changed
 from sktime.transformations.panel.reduce import Tabularizer
 from sktime.utils._testing.forecasting import make_forecasting_problem
 from sktime.utils.validation.forecasting import check_fh
@@ -42,6 +43,10 @@ STRATEGIES = ["recursive", "direct", "multioutput", "dirrec"]
 FH = ForecastingHorizon(1)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting", "sktime.split"]),
+    reason="run test only if forecasting or split module has changed",
+)
 @pytest.mark.parametrize("n_timepoints", N_TIMEPOINTS)
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
@@ -77,6 +82,10 @@ def _make_y_X(n_timepoints, n_variables):
     return y, X
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting", "sktime.split"]),
+    reason="run test only if forecasting or split module has changed",
+)
 @pytest.mark.parametrize("n_timepoints", N_TIMEPOINTS)
 @pytest.mark.parametrize("n_variables", N_VARIABLES)
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
@@ -107,6 +116,10 @@ def test_sliding_window_transform_tabular(n_timepoints, window_length, n_variabl
     assert np.all(Xt < yt[:, [0]])
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting", "sktime.split"]),
+    reason="run test only if forecasting or split module has changed",
+)
 @pytest.mark.parametrize("n_timepoints", N_TIMEPOINTS)
 @pytest.mark.parametrize("n_variables", N_VARIABLES)
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
@@ -136,6 +149,10 @@ def test_sliding_window_transform_panel(n_timepoints, window_length, n_variables
     assert np.all(Xt < yt[:, np.newaxis, [0]])
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting", "sktime.split"]),
+    reason="run test only if forecasting or split module has changed",
+)
 def test_sliding_window_transform_explicit():
     """Test sliding window transform explicit.
 
@@ -188,6 +205,10 @@ def _make_y(start, end, method="linear-trend", slope=1):
     return y
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting", "sktime.split"]),
+    reason="run test only if forecasting or split module has changed",
+)
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
 @pytest.mark.parametrize("strategy", STRATEGIES)
@@ -226,6 +247,10 @@ def test_linear_extrapolation_endogenous_only(
     np.testing.assert_almost_equal(actual, expected)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting", "sktime.split"]),
+    reason="run test only if forecasting or split module has changed",
+)
 @pytest.mark.parametrize("fh", [1, 3, 5])
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
 @pytest.mark.parametrize("strategy", STRATEGIES)
@@ -311,6 +336,10 @@ class _TestTimeSeriesRegressor(_Recorder, BaseRegressor):
         """
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting", "sktime.split"]),
+    reason="run test only if forecasting or split module has changed",
+)
 @pytest.mark.parametrize(
     "estimator", [_TestTabularRegressor(), _TestTimeSeriesRegressor()]
 )
@@ -363,6 +392,10 @@ def test_consistent_data_passing_to_component_estimators_in_fit_and_predict(
     assert np.all(X_fit < y_fit[:, np.newaxis, :])
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.compose._reduce"]),
+    reason="run test only if reduce module has changed",
+)
 @pytest.mark.parametrize("scitype, strategy, klass", _REGISTRY)
 @pytest.mark.parametrize("window_length", TEST_WINDOW_LENGTHS_INT)
 def test_make_reduction_construct_instance(scitype, strategy, klass, window_length):
@@ -375,6 +408,10 @@ def test_make_reduction_construct_instance(scitype, strategy, klass, window_leng
     assert forecaster.get_params()["window_length"] == window_length
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting", "sktime.regression"]),
+    reason="run test only if forecasting or regression module has changed",
+)
 @pytest.mark.parametrize(
     "estimator, scitype",
     [
@@ -388,6 +425,10 @@ def test_make_reduction_infer_scitype(estimator, scitype):
     assert forecaster._estimator_scitype == scitype
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting", "sktime.split"]),
+    reason="run test only if forecasting or split module has changed",
+)
 def test_make_reduction_infer_scitype_for_sklearn_pipeline():
     """Test make_reduction.
 
@@ -399,6 +440,10 @@ def test_make_reduction_infer_scitype_for_sklearn_pipeline():
     assert forecaster._estimator_scitype == "tabular-regressor"
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.compose._reduce"]),
+    reason="run test only if reduce module has changed",
+)
 @pytest.mark.parametrize("fh", TEST_OOS_FHS)
 def test_multioutput_direct_equivalence_tabular_linear_regression(fh):
     """Test multioutput and direct strategies with linear regression.
@@ -477,6 +522,10 @@ EXPECTED_AIRLINE_LINEAR_DIRECT = [
 ]
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.compose._reduce"]),
+    reason="run test only if reduce module has changed",
+)
 @pytest.mark.parametrize(
     "forecaster, expected",
     [
@@ -536,6 +585,10 @@ def test_reductions_airline_data(forecaster, expected):
     np.testing.assert_almost_equal(actual, expected)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.compose._reduce"]),
+    reason="run test only if reduce module has changed",
+)
 def test_dirrec_against_recursive_accumulated_error():
     """Test recursive and dirrec regressor strategies.
 
@@ -559,6 +612,10 @@ def test_dirrec_against_recursive_accumulated_error():
     ) < mean_absolute_percentage_error(y_test, preds_recursive)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.compose._reduce"]),
+    reason="run test only if reduce module has changed",
+)
 def test_direct_vs_recursive():
     """Test reduction forecasters.
 
@@ -590,6 +647,10 @@ def test_direct_vs_recursive():
     assert not pred_dir_max.head(1).equals(pred_dir_spec.head(1))
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.compose._reduce"]),
+    reason="run test only if reduce module has changed",
+)
 def test_recursive_reducer_X_not_fit_to_fh():
     """Test recursive reducer with X that do not fit the fh.
 

--- a/sktime/forecasting/compose/tests/test_reduce_global.py
+++ b/sktime/forecasting/compose/tests/test_reduce_global.py
@@ -361,6 +361,10 @@ def test_nofreq_pass():
     )
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(_RecursiveReducer),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_timezoneaware_index():
     y = load_solar(api_version=None)
     y_notz = y.copy().tz_localize(None)


### PR DESCRIPTION
This PR:

* simplifies tests in the `forecasting.compose.tests` module, by removing estimators with soft dependencies, and using fast forecasters in testing the framework
* adds differential testing for all tests in the module

Towards #2890.