### PR TITLE
[MNT] enable differential testing in `benchmarking` module

### DIFF
--- a/sktime/benchmarking/evaluation.py
+++ b/sktime/benchmarking/evaluation.py
@@ -13,8 +13,6 @@ from sktime.benchmarking.base import BaseResults
 from sktime.exceptions import NotEvaluatedError
 from sktime.utils.dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("matplotlib", "scikit_posthocs", severity="warning")
-
 
 class Evaluator:
     """Analyze results of machine learning experiments."""

--- a/sktime/benchmarking/tests/test_TSCStrategy.py
+++ b/sktime/benchmarking/tests/test_TSCStrategy.py
@@ -5,6 +5,7 @@ from sktime.benchmarking.strategies import TSCStrategy
 from sktime.benchmarking.tasks import TSCTask
 from sktime.classification.ensemble import ComposableTimeSeriesForestClassifier
 from sktime.datasets import load_gunpoint, load_italy_power_demand
+from sktime.tests.test_switch import run_test_module_changed
 
 classifier = ComposableTimeSeriesForestClassifier(n_estimators=2)
 
@@ -12,6 +13,10 @@ DATASET_LOADERS = (load_gunpoint, load_italy_power_demand)
 
 
 # Test output of time-series classification strategies
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
+)
 @pytest.mark.parametrize("dataset", DATASET_LOADERS)
 def test_TSCStrategy(dataset):
     """Test strategy."""

--- a/sktime/benchmarking/tests/test_benchmarks.py
+++ b/sktime/benchmarking/tests/test_benchmarks.py
@@ -7,7 +7,7 @@ import pytest
 from sktime.base import BaseEstimator
 from sktime.benchmarking import benchmarks
 from sktime.forecasting.naive import NaiveForecaster
-from sktime.utils.dependencies import _check_soft_dependencies
+from sktime.tests.test_switch import run_test_module_changed
 
 
 def factory_estimator_class_task(**kwargs) -> Callable:
@@ -24,8 +24,8 @@ def factory_estimator_class_task(**kwargs) -> Callable:
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("kotsu", severity="none"),
-    reason="skip test if required soft dependencies not available",
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
 )
 def test_basebenchmark(tmp_path):
     """Test registering estimator, registering a simple task, and running."""
@@ -57,8 +57,8 @@ def test_basebenchmark(tmp_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("kotsu", severity="none"),
-    reason="skip test if required soft dependencies not available",
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
 )
 def test_add_estimator_args(tmp_path):
     """Test adding estimator with args specified."""
@@ -77,8 +77,8 @@ def test_add_estimator_args(tmp_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("kotsu", severity="none"),
-    reason="skip test if required soft dependencies not available",
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
 )
 def test_add_task_args(tmp_path):
     """Test adding task with args specified."""
@@ -98,8 +98,8 @@ def test_add_task_args(tmp_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("kotsu", severity="none"),
-    reason="skip test if required soft dependencies not available",
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
 )
 def test_add_task_string_entrypoint(tmp_path):
     """Test adding task using string of entrypoint."""
@@ -117,8 +117,8 @@ def test_add_task_string_entrypoint(tmp_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("kotsu", severity="none"),
-    reason="skip test if required soft dependencies not available",
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
 )
 def test_raise_id_restraint():
     """Test to ensure ID format is raised for malformed input ID."""

--- a/sktime/benchmarking/tests/test_evaluator.py
+++ b/sktime/benchmarking/tests/test_evaluator.py
@@ -9,6 +9,7 @@ from sktime.benchmarking.evaluation import Evaluator
 from sktime.benchmarking.metrics import PairwiseMetric
 from sktime.benchmarking.results import RAMResults
 from sktime.series_as_features.model_selection import PresplitFilesCV
+from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils.dependencies import _check_soft_dependencies
 
 
@@ -114,6 +115,10 @@ def evaluator_setup(score_function):
     return evaluator, metrics_by_strategy
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
+)
 def test_rank():
     """Test rank."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
@@ -127,6 +132,10 @@ def test_rank():
     assert expected_ranks.equals(generated_ranks)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
+)
 def test_accuracy_score():
     """Test accuracy score."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
@@ -142,6 +151,10 @@ def test_accuracy_score():
     assert metrics_by_strategy.equals(expected_accuracy)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
+)
 def test_sign_test():
     """Test sign_test."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
@@ -150,6 +163,10 @@ def test_sign_test():
     assert np.array_equal(expected, results)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
+)
 def test_ranksum_test():
     """Test ranksum_test."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
@@ -165,6 +182,10 @@ def test_ranksum_test():
     assert np.array_equal(results, expected)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
+)
 def test_t_test_bonfer():
     """Test t_test_bonfer."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)
@@ -174,7 +195,8 @@ def test_t_test_bonfer():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("scikit_posthocs", severity="none"),
+    not run_test_module_changed("sktime.benchmarking")
+    or not _check_soft_dependencies("scikit_posthocs", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_nemenyi():
@@ -194,7 +216,8 @@ def test_nemenyi():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("matplotlib", severity="none"),
+    not run_test_module_changed("sktime.benchmarking")
+    or not _check_soft_dependencies("matplotlib", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 @pytest.mark.xfail(reason="known sporadic failure of unknown cause, see #2368")
@@ -205,6 +228,11 @@ def test_plots():
     evaluator.t_test()
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking")
+    or not _check_soft_dependencies("scikit_posthocs", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_wilcoxon():
     """Test wilcoxon."""
     expected = pd.DataFrame(
@@ -215,6 +243,11 @@ def test_wilcoxon():
     assert results[expected.columns].equals(expected)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking")
+    or not _check_soft_dependencies("scikit_posthocs", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_run_times():
     """Test run_times."""
     evaluator, metrics_by_strategy = evaluator_setup(score_function=accuracy_score)

--- a/sktime/benchmarking/tests/test_experiments.py
+++ b/sktime/benchmarking/tests/test_experiments.py
@@ -8,11 +8,13 @@ from sktime.benchmarking.experiments import (
 from sktime.classification.interval_based import TimeSeriesForestClassifier
 from sktime.clustering.k_means import TimeSeriesKMeans
 from sktime.datasets import load_unit_test
+from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
+    not run_test_module_changed("sktime.benchmarking")
+    or not _check_soft_dependencies("numba", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_run_clustering_experiment(tmp_path):
@@ -44,7 +46,8 @@ def test_run_clustering_experiment(tmp_path):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("numba", severity="none"),
+    not run_test_module_changed("sktime.benchmarking")
+    or not _check_soft_dependencies("numba", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_run_classification_experiment(tmp_path):

--- a/sktime/benchmarking/tests/test_forecasting.py
+++ b/sktime/benchmarking/tests/test_forecasting.py
@@ -13,7 +13,7 @@ from sktime.performance_metrics.forecasting import (
     MeanSquaredPercentageError,
 )
 from sktime.split import ExpandingWindowSplitter
-from sktime.utils.dependencies import _check_soft_dependencies
+from sktime.tests.test_switch import run_test_module_changed
 
 EXPECTED_RESULTS_1 = pd.DataFrame(
     data={
@@ -73,8 +73,8 @@ def data_loader_simple() -> pd.DataFrame:
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("kotsu", severity="none"),
-    reason="skip test if required soft dependencies not available",
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
 )
 @pytest.mark.parametrize(
     "expected_results_df, scorers",
@@ -106,6 +106,10 @@ def test_forecastingbenchmark(tmp_path, expected_results_df, scorers):
     )
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
+)
 @pytest.mark.parametrize("estimator, estimator_id, expected_output", COER_CASES)
 def test_coerce_estimator_and_id(estimator, estimator_id, expected_output):
     """Test coerce_estimator_and_id return expected output."""
@@ -115,8 +119,8 @@ def test_coerce_estimator_and_id(estimator, estimator_id, expected_output):
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("kotsu", severity="none"),
-    reason="skip test if required soft dependencies not available",
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
 )
 @pytest.mark.parametrize(
     "estimators",

--- a/sktime/benchmarking/tests/test_orchestration.py
+++ b/sktime/benchmarking/tests/test_orchestration.py
@@ -24,6 +24,7 @@ from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
 from sktime.classification.ensemble import ComposableTimeSeriesForestClassifier
 from sktime.datasets import load_arrow_head, load_gunpoint
 from sktime.series_as_features.model_selection import SingleSplit
+from sktime.tests.test_switch import run_test_module_changed
 from sktime.transformations.panel.reduce import Tabularizer
 
 REPOPATH = os.path.dirname(sktime.__file__)
@@ -37,6 +38,10 @@ def make_reduction_pipeline(estimator):
 
 
 # simple test of orchestration and metric evaluation
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
+)
 @pytest.mark.parametrize("data_loader", [load_gunpoint, load_arrow_head])
 def test_automated_orchestration_vs_manual(data_loader):
     """Test orchestration."""
@@ -159,6 +164,10 @@ def test_single_dataset_single_strategy_against_sklearn(
 
 
 # simple test of sign test and ranks
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
+)
 def test_stat():
     """Test sign ranks."""
     data = load_gunpoint(split="train", return_X_y=False)[:7]

--- a/sktime/benchmarking/tests/test_tasks.py
+++ b/sktime/benchmarking/tests/test_tasks.py
@@ -7,6 +7,7 @@ from pytest import raises
 
 from sktime.benchmarking.tasks import BaseTask, TSCTask, TSRTask
 from sktime.datasets import load_gunpoint, load_shampoo_sales
+from sktime.tests.test_switch import run_test_module_changed
 
 TASKS = (TSCTask, TSRTask)
 
@@ -17,6 +18,10 @@ BASE_READONLY_ATTRS = ("target", "features", "metadata")
 
 
 # Test read-only attributes of base task
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
+)
 @pytest.mark.parametrize("attr", BASE_READONLY_ATTRS)
 def test_readonly_attributes(attr):
     """Test read-only attributes."""
@@ -26,6 +31,10 @@ def test_readonly_attributes(attr):
 
 
 # Test data compatibility checks
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
+)
 @pytest.mark.parametrize("task", TASKS)
 def test_check_data_compatibility(task):
     """Check data compatibility."""
@@ -48,6 +57,10 @@ def check_set_metadata(task, target, metadata):
         task.set_metadata(metadata)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.benchmarking"),
+    reason="run test only if benchmarking module has changed",
+)
 @pytest.mark.parametrize("task", [TSRTask, TSCTask])
 def test_set_metadata_supervised(task):
     """Test check_set_metadata."""


### PR DESCRIPTION
This PR adds differential testing decorators to the benchmarking module.

It also removes conditional skips based on the soft dependency `kotsu`, which is no longer used.

Towards #2890.