### PR TITLE
[BUG] in `Differencer`, make explicit clone to avoid `SettingWithCopyWarning`

### DIFF
--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -156,12 +156,12 @@ def _inverse_diff(X, lags, X_diff_seq=None):
         # shifted original time series that are available in the differenced time
         # series (intersection). These are the indices for which no valid differenced
         # values exist.
-        X.loc[
-            X_diff_orig.index.difference(
-                _shift(X_diff_orig.index, sum(lags) + lag_last)
-            ).intersection(X.index)
-        ] = np.nan
-        X = X.combine_first(X_update)
+        mask = X_diff_orig.index.difference(
+            _shift(X_diff_orig.index, sum(lags) + lag_last)
+        ).intersection(X.index)
+        X_ = X.copy()
+        X_.loc[mask] = np.nan
+        X = X_.combine_first(X_update)
 
     X_diff_last = X.copy()
 


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes #6480 by making the copy explicit. 

#### What does this implement/fix? Explain your changes.
Make the copy explicit so that the warning is not shown. 

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?


#### Did you add any tests for the change?


#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
