### PR TITLE
[BUG] patch over `pandas 2.2.X` issue in `freq` timestamp/period round trip conversion for period start timestamps such as `"MonthBegin"`

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -883,7 +883,17 @@ def _to_absolute(fh: ForecastingHorizon, cutoff) -> ForecastingHorizon:
 
         if is_timestamp:
             # coerce back to DatetimeIndex after operation
-            absolute = absolute.to_timestamp(fh._freq)
+            try:
+                absolute = absolute.to_timestamp(fh._freq)
+            # this try-except block is a workaround for what seems like a bug in pandas
+            # when trying to convert a PeriodIndex to a DatetimeIndex with a frequency
+            # of type month-begin, which should be supported, a ValueError is raised
+            # see issue #6752 for details
+            except ValueError as e:
+                if "not supported" in str(e):
+                    absolute = absolute.to_timestamp()
+                else:
+                    raise e
 
         if old_tz is not None:
             absolute = absolute.tz_localize(old_tz)

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -809,7 +809,16 @@ FREQ_STR_FOR_PD22 = ["Y", "2Y", "M", "3M"]
 
 if _check_soft_dependencies("pandas>=2.1.0", severity="none"):
     FREQ_STR_FOR_PD22 += [
-        "YE", "2YE", "ME", "3ME", "MS", "3MS", "QS", "3QS", "YS", "3YS"
+        "YE",
+        "2YE",
+        "ME",
+        "3ME",
+        "MS",
+        "3MS",
+        "QS",
+        "3QS",
+        "YS",
+        "3YS",
     ]
 
 

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -839,7 +839,7 @@ def test_pandas22_freq(freq):
 
 
 @pytest.mark.parametrize("ts", [True, False])
-def test_pandas22_freq_roundtrip(ts=True):
+def test_pandas22_freq_roundtrip(ts):
     """Test that to_absolute and to_relative conversions work with the airline data.
 
     Failure case in bug #6572.

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -815,7 +815,7 @@ if _check_soft_dependencies("pandas>=2.1.0", severity="none"):
 def test_pandas22_freq(freq):
     """Test that to_absolute and to_relative conversions work with all freqs.
 
-    Failure cas in bug #6499.
+    Failure case in bug #6499.
     """
     fh = ForecastingHorizon([1, 2, 3])
 
@@ -825,3 +825,19 @@ def test_pandas22_freq(freq):
 
     fh.to_absolute(cutoff)  # failure 1
     fh.to_absolute(cutoff).to_relative(cutoff)  # failure 2
+
+
+def test_pandas22_freq_roundtrip():
+    """Test that to_absolute and to_relative conversions work with all freqs.
+
+    Failure case in bug #6572.
+    """
+    y = load_airline()
+    y.index = y.index.to_timestamp()
+
+    f = NaiveForecaster(strategy="last")
+    f.fit(y)
+
+    fh = ForecastingHorizon([0], is_relative=True)
+    fh.to_absolute(f.cutoff)
+    fh.to_absolute(f.cutoff).to_relative(f.cutoff)

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -838,6 +838,10 @@ def test_pandas22_freq(freq):
     fh.to_absolute(cutoff).to_relative(cutoff)  # failure 2
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("pandas>=2.1.0", severity="none"),
+    reason="frequency logic requires pandas>=2.1.0",
+)
 @pytest.mark.parametrize("ts", [True, False])
 def test_pandas22_freq_roundtrip(ts):
     """Test that to_absolute and to_relative conversions work with the airline data.

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -808,7 +808,9 @@ def test_tz_preserved():
 FREQ_STR_FOR_PD22 = ["Y", "2Y", "M", "3M"]
 
 if _check_soft_dependencies("pandas>=2.1.0", severity="none"):
-    FREQ_STR_FOR_PD22 += ["YE", "2YE", "ME", "3ME"]
+    FREQ_STR_FOR_PD22 += [
+        "YE", "2YE", "ME", "3ME", "MS", "3MS", "QS", "3QS", "YS", "3YS"
+    ]
 
 
 @pytest.mark.parametrize("freq", FREQ_STR_FOR_PD22)
@@ -827,13 +829,15 @@ def test_pandas22_freq(freq):
     fh.to_absolute(cutoff).to_relative(cutoff)  # failure 2
 
 
-def test_pandas22_freq_roundtrip():
-    """Test that to_absolute and to_relative conversions work with all freqs.
+@pytest.mark.parametrize("ts", [True, False])
+def test_pandas22_freq_roundtrip(ts=True):
+    """Test that to_absolute and to_relative conversions work with the airline data.
 
     Failure case in bug #6572.
     """
     y = load_airline()
-    y.index = y.index.to_timestamp()
+    if ts:
+        y.index = y.index.to_timestamp()
 
     f = NaiveForecaster(strategy="last")
     f.fit(y)


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/6572 by patching over what seems like a `pandas` bug, using a try/except.