### PR TITLE
[BUG] revert `pytest.skip` change from #6233

### DIFF
--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -212,10 +212,12 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         """
         index_type, fh_type, is_relative = index_fh_comb
         if fh_type == "timedelta":
-            pytest.skip(
-                "ForecastingHorizon with timedelta values "
-                "is currently experimental and not supported everywhere"
-            )
+            return None
+            # todo: ensure check_estimator works with pytest.skip like below
+            # pytest.skip(
+            #    "ForecastingHorizon with timedelta values "
+            #     "is currently experimental and not supported everywhere"
+            # )
         y_train = _make_series(
             n_columns=n_columns, index_type=index_type, n_timepoints=50
         )
@@ -266,10 +268,12 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         """Check that predicted time index matches forecasting horizon."""
         index_type, fh_type, is_relative = index_fh_comb
         if fh_type == "timedelta":
-            pytest.skip(
-                "ForecastingHorizon with timedelta values "
-                "is currently experimental and not supported everywhere"
-            )
+            return None
+            # todo: ensure check_estimator works with pytest.skip like below
+            # pytest.skip(
+            #    "ForecastingHorizon with timedelta values "
+            #     "is currently experimental and not supported everywhere"
+            # )
         z, X = make_forecasting_problem(index_type=index_type, make_X=True)
 
         # Some estimators may not support all time index types and fh types, hence we
@@ -304,10 +308,12 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         """Check that predicted time index equals fh for full in-sample predictions."""
         index_type, fh_type, is_relative = index_fh_comb
         if fh_type == "timedelta":
-            pytest.skip(
-                "ForecastingHorizon with timedelta values "
-                "is currently experimental and not supported everywhere"
-            )
+            return None
+            # todo: ensure check_estimator works with pytest.skip like below
+            # pytest.skip(
+            #    "ForecastingHorizon with timedelta values "
+            #     "is currently experimental and not supported everywhere"
+            # )
         y_train = _make_series(n_columns=n_columns, index_type=index_type)
         cutoff = get_cutoff(y_train, return_index=True)
         steps = -np.arange(len(y_train))


### PR DESCRIPTION
Reverts parts of https://github.com/sktime/sktime/pull/6233 which cause `check_estimator` based tests in third party libraries to be always skipped.

This is due to `QuickTester.run_tests` propagating the skip conditoin up, affecting the entire test in the 3rd party package instead of just a single `sktime` test.

FYI @YelenaYY