### PR TITLE
[ENH] `parametrize_with_checks` utility for granular API compliance test setup in 2nd/3rd party libraries

### DIFF
--- a/docs/source/developer_guide/add_estimators.rst
+++ b/docs/source/developer_guide/add_estimators.rst
@@ -221,7 +221,7 @@ the ``sktime`` test suite can be imported and extended in the following ways:
         from sktime.utils.estimator_checks import parametrize_with_checks
 
         @parametrize_with_checks(OBJS_TO_TEST)
-        def test_estimator_interface_compliance(obj, test_name):
+        def test_sktime_api_compliance(obj, test_name):
             check_estimator(obj, tests_to_run=test_name, raise_exceptions=True)
 
 *   importing test classes, e.g., ``test_all_estimators.TestAllEstimators`` or

--- a/docs/source/developer_guide/add_estimators.rst
+++ b/docs/source/developer_guide/add_estimators.rst
@@ -204,13 +204,30 @@ Testing within a third party extension package
 
 For third party extension packages to ``sktime`` (open or closed),
 or third party modules that aim for interface compliance with ``sktime``,
-the ``sktime`` test suite can be imported and extended in two ways:
+the ``sktime`` test suite can be imported and extended in the following ways:
 
-*   importing ``check_estimator``, this will carry out the tests defined in ``sktime``
+* importing ``check_estimator``, this will carry out the tests defined in ``sktime``
+  in a single go. ``check_estimator`` can be run within any test framework, including
+  ``unittest`` and ``pytest``.
+
+* importing ``parametrize_with_checks`` from ``sktime.utils.estimator_checks``.
+  When used in a ``pytest`` test suite, this will parametrize a test function with
+  all tests defined in ``sktime`` for a list of estimator classes or instances,
+  running each estimator-test combination as a separate test case.
+  This pattern requires adding the following test function to the test suite:
+
+    .. code-block:: python
+    
+        from sktime.utils.estimator_checks import parametrize_with_checks
+    
+        @parametrize_with_checks(OBJS_TO_TEST)
+        def test_estimator_interface_compliance(obj, test_name):
+            check_estimator(obj, tests_to_run=test_name, raise_exceptions=True)
 
 *   importing test classes, e.g., ``test_all_estimators.TestAllEstimators`` or
     ``test_all_forecasters.TestAllForecasters``. The imports will be discovered directly
     by ``pytest``. The test suite also be extended by inheriting from the test classes.
+
 
 Adding an ``sktime`` compatible estimator to ``sktime``
 =======================================================

--- a/docs/source/developer_guide/add_estimators.rst
+++ b/docs/source/developer_guide/add_estimators.rst
@@ -217,9 +217,9 @@ the ``sktime`` test suite can be imported and extended in the following ways:
   This pattern requires adding the following test function to the test suite:
 
     .. code-block:: python
-    
+
         from sktime.utils.estimator_checks import parametrize_with_checks
-    
+
         @parametrize_with_checks(OBJS_TO_TEST)
         def test_estimator_interface_compliance(obj, test_name):
             check_estimator(obj, tests_to_run=test_name, raise_exceptions=True)

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -208,13 +208,14 @@ def parametrize_with_checks(objs, obj_varname="obj", check_varname="test_name"):
     Examples
     --------
     >>> from sktime.utils.estimator_checks import parametrize_with_checks
+    >>> from sktime.forecasting.croston import Croston
     >>> from sktime.forecasting.naive import NaiveForecaster
 
     >>> @parametrize_with_checks(NaiveForecaster, obj_varname='estimator')
     ... def test_sktime_compatible_estimator(estimator, test_name):
     ...     check_estimator(estimator, tests_to_run=test_name, raise_exceptions=True)
 
-    >>> @parametrize_with_checks([NaiveForecaster, ExponentialSmoothing])
+    >>> @parametrize_with_checks([NaiveForecaster, Croston])
     ... def test_sktime_compatible_estimators(obj, test_name):
     ...     check_estimator(obj, tests_to_run=test_name, raise_exceptions=True)
     """

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -183,11 +183,10 @@ def _get_test_names_for_obj(obj):
 def parametrize_with_checks(objs, obj_varname="obj", check_varname="test_name"):
     """Pytest specific decorator for parametrizing estimator checks.
 
-    The `id` of each check is set to be a pprint version of the estimator
-    and the name of the check with its keyword arguments.
-    This allows to use `pytest -k` to specify which tests to run::
+    Designed for setting up API compliance checks in compatible 2nd and 3rd party
+    libraries, using ``pytest.mark.parametrize``.
 
-        pytest test_check_estimators.py -k check_estimators_fit_returns_self
+    Inspired by the ``sklearn`` utility of the same name.
 
     Parameters
     ----------
@@ -213,11 +212,11 @@ def parametrize_with_checks(objs, obj_varname="obj", check_varname="test_name"):
 
     >>> @parametrize_with_checks(NaiveForecaster, obj_varname='estimator')
     ... def test_sktime_compatible_estimator(estimator, test_name):
-    ...     check_estimator(estimator, tests_to_run=test_name)
+    ...     check_estimator(estimator, tests_to_run=test_name, raise_exceptions=True)
 
     >>> @parametrize_with_checks([NaiveForecaster, ExponentialSmoothing])
     ... def test_sktime_compatible_estimators(obj, test_name):
-    ...     check_estimator(obj, tests_to_run=test_name)
+    ...     check_estimator(obj, tests_to_run=test_name, raise_exceptions=True)
     """
     import pytest
 

--- a/sktime/utils/estimator_checks.py
+++ b/sktime/utils/estimator_checks.py
@@ -136,3 +136,98 @@ def check_estimator(
         print(msg)  # noqa T001
 
     return results
+
+
+def _get_test_names_from_class(test_cls):
+    """Get all test names from a test class.
+
+    Parameters
+    ----------
+    test_cls : class
+        class of the test
+
+    Returns
+    -------
+    test_names : list of str
+        list of test names
+    """
+    test_names = [attr for attr in dir(test_cls) if attr.startswith("test")]
+
+    return test_names
+
+
+def _get_test_names_for_obj(obj):
+    """Get all test names for an object.
+
+    Parameters
+    ----------
+    obj : object
+        object to get tests for
+
+    Returns
+    -------
+    test_names : list of str
+        list of test names
+    """
+    from sktime.tests.test_class_register import get_test_classes_for_obj
+
+    test_clss_for_obj = get_test_classes_for_obj(obj)
+
+    test_names = []
+    for test_cls in test_clss_for_obj:
+        test_names.extend(_get_test_names_from_class(test_cls))
+
+    return test_names
+
+
+def parametrize_with_checks(objs, obj_varname="obj", check_varname="test_name"):
+    """Pytest specific decorator for parametrizing estimator checks.
+
+    The `id` of each check is set to be a pprint version of the estimator
+    and the name of the check with its keyword arguments.
+    This allows to use `pytest -k` to specify which tests to run::
+
+        pytest test_check_estimators.py -k check_estimators_fit_returns_self
+
+    Parameters
+    ----------
+    objs : objects class or instance, or list thereof
+        Objects to generate test names for.
+    obj_varname : str, optional, default = 'obj'
+        Name of the variable for objects to use in the parametrization.
+    check_varname : str, optional, default = 'test_name'
+        Name of the variable for test name strings to use in the parametrization.
+
+    Returns
+    -------
+    decorator : `pytest.mark.parametrize`
+
+    See Also
+    --------
+    check_estimator : Check if estimator adheres to sktime APi contracts.
+
+    Examples
+    --------
+    >>> from sktime.utils.estimator_checks import parametrize_with_checks
+    >>> from sktime.forecasting.naive import NaiveForecaster
+
+    >>> @parametrize_with_checks(NaiveForecaster, obj_varname='estimator')
+    ... def test_sktime_compatible_estimator(estimator, test_name):
+    ...     check_estimator(estimator, tests_to_run=test_name)
+
+    >>> @parametrize_with_checks([NaiveForecaster, ExponentialSmoothing])
+    ... def test_sktime_compatible_estimators(obj, test_name):
+    ...     check_estimator(obj, tests_to_run=test_name)
+    """
+    import pytest
+
+    if not isinstance(objs, list):
+        objs = [objs]
+
+    test_names = []
+    for obj in objs:
+        tests_for_obj = _get_test_names_for_obj(obj)
+        test_names.extend([(obj, test) for test in tests_for_obj])
+
+    var_str = f"{obj_varname}, {check_varname}"
+    return pytest.mark.parametrize(var_str, test_names)

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -7,9 +7,14 @@ import pytest
 from sktime.classification.dummy import DummyClassifier
 from sktime.forecasting.dummy import ForecastKnownValues
 from sktime.transformations.series.exponent import ExponentTransformer
-from sktime.utils.estimator_checks import check_estimator
+from sktime.utils.estimator_checks import (
+    _get_test_names_for_obj,
+    check_estimator,
+    parametrize_with_checks,
+)
 
 EXAMPLE_CLASSES = [DummyClassifier, ForecastKnownValues, ExponentTransformer]
+EXAMPLE_INSTANCES = [cls.create_test_instance() for cls in EXAMPLE_CLASSES]
 
 
 @pytest.mark.parametrize("estimator_class", EXAMPLE_CLASSES)
@@ -76,3 +81,31 @@ def test_check_estimator_subset_tests():
     results_tests = {x.split("[")[0] for x in results.keys()}
 
     assert results_tests == expected_tests
+
+
+def test_get_test_names():
+    """Test that get_test_names returns the correct test names."""
+    expected_tests = [
+        "test_get_params",
+        "test_set_params",
+        "test_clone",
+        "test_repr",
+        "test_capability_inverse_tag_is_correct",
+        "test_remember_data_tag_is_correct",
+    ]
+
+    test_names = _get_test_names_for_obj(ExponentTransformer)
+
+    assert set(expected_tests).issubset(test_names)
+
+
+@parametrize_with_checks(EXAMPLE_CLASSES)
+def test_parametrize_with_checks_objects(obj, test_name):
+    """Test that parametrize_with_checks works as intended - classes."""
+    check_estimator(obj, verbose=False, raise_exceptions=True, tests_to_run=test_name)
+
+
+@parametrize_with_checks(EXAMPLE_INSTANCES, obj_varname="foo", check_varname="bar")
+def test_parametrize_with_checks_instances(foo, bar):
+    """Test that parametrize_with_checks works as intended - instances, var names."""
+    check_estimator(foo, verbose=False, raise_exceptions=True, tests_to_run=bar)

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -6,6 +6,7 @@ import pytest
 
 from sktime.classification.dummy import DummyClassifier
 from sktime.forecasting.dummy import ForecastKnownValues
+from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.series.exponent import ExponentTransformer
 from sktime.utils.estimator_checks import (
     _get_test_names_for_obj,
@@ -83,6 +84,10 @@ def test_check_estimator_subset_tests():
     assert results_tests == expected_tests
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(_get_test_names_for_obj),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_get_test_names():
     """Test that get_test_names returns the correct test names."""
     expected_tests = [
@@ -99,12 +104,20 @@ def test_get_test_names():
     assert set(expected_tests).issubset(test_names)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(parametrize_with_checks),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @parametrize_with_checks(EXAMPLE_CLASSES)
 def test_parametrize_with_checks_objects(obj, test_name):
     """Test that parametrize_with_checks works as intended - classes."""
     check_estimator(obj, verbose=False, raise_exceptions=True, tests_to_run=test_name)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(parametrize_with_checks),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @parametrize_with_checks(EXAMPLE_INSTANCES, obj_varname="foo", check_varname="bar")
 def test_parametrize_with_checks_instances(foo, bar):
     """Test that parametrize_with_checks works as intended - instances, var names."""


### PR DESCRIPTION
This PR adds a `paramterize_with_checks` decorator utility for granular test setup of API compliance tests in 2nd/3rd party libraries.

It is a `pytest` decorator, inspired by [the `sklearn` utility of the same name](https://scikit-learn.org/stable/modules/generated/sklearn.utils.estimator_checks.parametrize_with_checks.html#sklearn.utils.estimator_checks.parametrize_with_checks).

Maintainers of third party libraries can use this with the following pattern to set up tests granular by test name:

```python
@parametrize_with_checks([NaiveForecaster, ExponentialSmoothing])
def test_sktime_compatible_estimators(obj, test_name):
    check_estimator(obj, tests_to_run=test_name, raise_exceptions=True)
```

Supports both classes and instances, and all object types supported by `check_estimator`.
In case of classes, `get_test_params` is used to generate instances.