### PR TITLE
[ENH] further refactor of knn classifier and regressor

### DIFF
--- a/sktime/base/_panel/knn.py
+++ b/sktime/base/_panel/knn.py
@@ -17,7 +17,15 @@ class _BaseKnnTimeSeriesEstimator:
         y : {array-like, sparse matrix}
             Target values of shape = [n]
         """
-        self.n_vars_ = X.shape[1]
+        # internal import to avoid circular imports
+        from sktime.dists_kernels.base.adapters._sklearn import _SklearnDistanceAdapter
+
+        self._dist_adapt = _SklearnDistanceAdapter(
+            distance=self.distance,
+            distance_params=self.distance_params,
+            n_vars=self._X_metadata["n_features"],
+            is_equal_length=self._X_metadata["is_equal_length"],
+        )
         if self.algorithm == "brute":
             return self._fit_precomp(X=X, y=y)
         else:

--- a/sktime/base/_panel/knn.py
+++ b/sktime/base/_panel/knn.py
@@ -69,7 +69,6 @@ class _BaseKnnTimeSeriesEstimator:
             n_neighbors=n_neighbors,
             algorithm=_algorithm,
             metric="precomputed",
-            metric_params=distance_params,
             leaf_size=leaf_size,
             n_jobs=n_jobs,
             weights=weights,

--- a/sktime/base/_panel/knn.py
+++ b/sktime/base/_panel/knn.py
@@ -6,8 +6,95 @@ __all__ = ["_BaseKnnTimeSeriesEstimator"]
 import numpy as np
 
 
+# add new distance string codes here
+DISTANCES_SUPPORTED = [
+    "euclidean",
+    # Euclidean will default to the base class distance
+    "squared",
+    "dtw",
+    "ddtw",
+    "wdtw",
+    "wddtw",
+    "lcss",
+    "edr",
+    "erp",
+    "msm",
+    "twe",
+]
+
+
 class _BaseKnnTimeSeriesEstimator:
     """Base KNeighbors Time Series Estimator."""
+
+    def __init__(
+        self,
+        n_neighbors=1,
+        weights="uniform",
+        algorithm="brute",
+        distance="dtw",
+        distance_params=None,
+        distance_mtype=None,
+        pass_train_distances=False,
+        leaf_size=30,
+        n_jobs=None,
+    ):
+        self.n_neighbors = n_neighbors
+        self.weights = weights
+        self.algorithm = algorithm
+        self.distance = distance
+        self.distance_params = distance_params
+        self.distance_mtype = distance_mtype
+        self.pass_train_distances = pass_train_distances
+        self.leaf_size = leaf_size
+        self.n_jobs = n_jobs
+
+        super().__init__()
+
+        # input check for supported distance strings
+        if isinstance(distance, str) and distance not in DISTANCES_SUPPORTED:
+            raise ValueError(
+                f"Unrecognised distance measure string: {distance}. "
+                f"Allowed values for string codes are: {DISTANCES_SUPPORTED}. "
+                "Alternatively, pass a callable distance measure into the constructor."
+            )
+
+        knn_cls = self._knn_cls
+
+        if algorithm == "brute_incr":
+            # brute_incr is not a valid sklearn algorithm
+            _algorithm = "brute"
+        else:
+            _algorithm = algorithm
+
+        self.knn_estimator_ = knn_cls(
+            n_neighbors=n_neighbors,
+            algorithm=_algorithm,
+            metric="precomputed",
+            metric_params=distance_params,
+            leaf_size=leaf_size,
+            n_jobs=n_jobs,
+            weights=weights,
+        )
+
+        # the distances in sktime.distances want numpy3D
+        #   otherwise all Panel formats are ok
+        if isinstance(distance, str):
+            self.set_tags(X_inner_mtype="numpy3D")
+            self.set_tags(**{"capability:unequal_length": False})
+            self.set_tags(**{"capability:missing_values": False})
+        elif distance_mtype is not None:
+            self.set_tags(X_inner_mtype=distance_mtype)
+
+        from sktime.dists_kernels import BasePairwiseTransformerPanel
+
+        # inherit capability tags from distance, if it is an estimator
+        if isinstance(distance, BasePairwiseTransformerPanel):
+            inherit_tags = [
+                "capability:missing_values",
+                "capability:unequal_length",
+                "capability:multivariate",
+            ]
+            self.clone_tags(distance, inherit_tags)
 
     def _fit(self, X, y):
         """Fit the model using X as training data and y as target values.
@@ -38,11 +125,7 @@ class _BaseKnnTimeSeriesEstimator:
         # use distance adapter, see _BaseKnnTimeSeriesEstimator, _SklearnDistanceAdapter
         metric = self._dist_adapt
 
-        algorithm = self.algorithm
-        if algorithm == "brute_incr":
-            algorithm = "brute"
-
-        self.knn_estimator_.set_params(algorithm=algorithm, metric=metric)
+        self.knn_estimator_.set_params(metric=metric)
 
         X = self._dist_adapt._convert_X_to_sklearn(X)
         self.knn_estimator_.fit(X, y)

--- a/sktime/base/_panel/knn.py
+++ b/sktime/base/_panel/knn.py
@@ -59,7 +59,7 @@ class _BaseKnnTimeSeriesEstimator:
         X = self._check_convert_X_for_predict(X)
 
         # self._X should be the stored _X
-        dist_mat = self._distance(X, self._X)
+        dist_mat = self._dist_adapt._distance(X, self._X)
 
         result = self.knn_estimator_.kneighbors(
             dist_mat, n_neighbors=n_neighbors, return_distance=return_distance
@@ -95,6 +95,6 @@ class _BaseKnnTimeSeriesEstimator:
     def _predict_precomp(self, X):
         """Predict using precomputed distance matrix."""
         # self._X should be the stored _X
-        dist_mat = self._distance(X, self._X)
+        dist_mat = self._dist_adapt._distance(X, self._X)
         y_pred = self.knn_estimator_.predict(dist_mat)
         return y_pred

--- a/sktime/base/_panel/knn.py
+++ b/sktime/base/_panel/knn.py
@@ -88,7 +88,7 @@ class _BaseKnnTimeSeriesEstimator:
 
     def _predict_dist(self, X):
         """Predict using adapted distance metric."""
-        X = self._convert_X_to_sklearn(X)
+        X = self._dist_adapt._convert_X_to_sklearn(X)
         y_pred = self.knn_estimator_.predict(X)
         return y_pred
 

--- a/sktime/base/_panel/knn.py
+++ b/sktime/base/_panel/knn.py
@@ -23,7 +23,7 @@ class _BaseKnnTimeSeriesEstimator:
         self._dist_adapt = _SklearnDistanceAdapter(
             distance=self.distance,
             distance_params=self.distance_params,
-            n_vars=self._X_metadata["n_features"],
+            n_vars=X.shape[1],
             is_equal_length=self._X_metadata["is_equal_length"],
         )
         if self.algorithm == "brute":

--- a/sktime/base/_panel/knn.py
+++ b/sktime/base/_panel/knn.py
@@ -5,7 +5,6 @@ __all__ = ["_BaseKnnTimeSeriesEstimator"]
 
 import numpy as np
 
-
 # add new distance string codes here
 DISTANCES_SUPPORTED = [
     "euclidean",

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -223,7 +223,7 @@ class KNeighborsTimeSeriesClassifier(_BaseKnnTimeSeriesEstimator, BaseClassifier
             weights=self.weights,
         )
 
-        X = self._convert_X_to_sklearn(X)
+        X = self._dist_adapt._convert_X_to_sklearn(X)
         self.knn_estimator_.fit(X, y)
         return self
 
@@ -269,7 +269,7 @@ class KNeighborsTimeSeriesClassifier(_BaseKnnTimeSeriesEstimator, BaseClassifier
 
     def _predict_proba_dist(self, X):
         """Predict (proba) using adapted distance metric."""
-        X = self._convert_X_to_sklearn(X)
+        X = self._dist_adapt._convert_X_to_sklearn(X)
         y_pred = self.knn_estimator_.predict_proba(X)
         return y_pred
 

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -18,7 +18,6 @@ param_names=None)
 __author__ = ["fkiraly", "jasonlines", "TonyBagnall", "chrisholder"]
 __all__ = ["KNeighborsTimeSeriesClassifier"]
 
-import numpy as np
 from sklearn.neighbors import KNeighborsClassifier
 
 from sktime.base._panel.knn import _BaseKnnTimeSeriesEstimator
@@ -204,48 +203,6 @@ class KNeighborsTimeSeriesClassifier(_BaseKnnTimeSeriesEstimator, BaseClassifier
                 "capability:multivariate",
             ]
             self.clone_tags(distance, inherit_tags)
-
-    def _fit_dist(self, X, y):
-        """Fit the model using adapted distance metric."""
-        # use distance adapter, see _BaseKnnTimeSeriesEstimator, _SklearnDistanceAdapter
-        metric = self._dist_adapt
-
-        algorithm = self.algorithm
-        if algorithm == "brute_incr":
-            algorithm = "brute"
-
-        self.knn_estimator_ = KNeighborsClassifier(
-            n_neighbors=self.n_neighbors,
-            algorithm=algorithm,
-            metric=metric,
-            leaf_size=self.leaf_size,
-            n_jobs=self.n_jobs,
-            weights=self.weights,
-        )
-
-        X = self._dist_adapt._convert_X_to_sklearn(X)
-        self.knn_estimator_.fit(X, y)
-        return self
-
-    def _fit_precomp(self, X, y):
-        """Fit the model using precomputed distance matrix."""
-        # store full data as indexed X
-        self._X = X
-
-        if self.pass_train_distances:
-            dist_mat = self._dist_adapt._distance(X)
-        else:
-            n = self._X_metadata["n_instances"]
-            # if we do not want/need to pass train-train distances,
-            #   we still need to pass a zeros matrix, this means "do not consider"
-            # citing the sklearn KNeighborsClassifier docs on distance matrix input:
-            # "X may be a sparse graph, in which case only "nonzero" elements
-            #   may be considered neighbors."
-            dist_mat = np.zeros([n, n], dtype="float")
-
-        self.knn_estimator_.fit(dist_mat, y)
-
-        return self
 
     def _predict_proba(self, X):
         """Return probability estimates for the test data X.

--- a/sktime/dists_kernels/base/adapters/__init__.py
+++ b/sktime/dists_kernels/base/adapters/__init__.py
@@ -1,6 +1,6 @@
 """Adapter mixins for dists_kernels module."""
 
-from sktime.dists_kernels.base.adapters._sklearn import _SklearnDistMixin
+from sktime.dists_kernels.base.adapters._sklearn import _SklearnDistanceAdapter
 from sktime.dists_kernels.base.adapters._tslearn import _TslearnPwTrafoAdapter
 
-__all__ = ["_TslearnPwTrafoAdapter", "_SklearnDistMixin"]
+__all__ = ["_TslearnPwTrafoAdapter", "_SklearnDistanceAdapter"]

--- a/sktime/dists_kernels/base/adapters/_sklearn.py
+++ b/sktime/dists_kernels/base/adapters/_sklearn.py
@@ -42,6 +42,15 @@ class _SklearnDistanceAdapter:
     * ``n_vars``: number of variables in the time series data
     * ``is_equal_length``: whether the time series data is of equal length
 
+    If ``is_equal_length`` is True, the internal distance
+    is simply the distance applied to time series flattened to 1D,
+    and ``_convert_X_to_sklearn`` will flatten the time series data.
+
+    If ``is_equal_length`` is False, the internal distance
+    will have a leading scalar dimension encoding the length of the individual series,
+    and ``_convert_X_to_sklearn`` will produce a flattened vector
+    with the length encoded as the first column in addition.
+    
     Parameters
     ----------
     distance : sklearn BasePairwiseTransformerPanel distance, or str

--- a/sktime/dists_kernels/base/adapters/_sklearn.py
+++ b/sktime/dists_kernels/base/adapters/_sklearn.py
@@ -56,6 +56,7 @@ class _SklearnDistanceAdapter:
     is_equal_length : bool, optional, default=True
         Whether the time series data is of equal length.
     """
+
     def __init__(self, distance, distance_params=None, n_vars=1, is_equal_length=True):
         self.distance = distance
         self.distance_params = distance_params

--- a/sktime/dists_kernels/base/adapters/_sklearn.py
+++ b/sktime/dists_kernels/base/adapters/_sklearn.py
@@ -2,7 +2,9 @@
 """Implements adapter for sklearn distances."""
 
 __author__ = ["fkiraly", "Z-Fran"]
-__all__ = ["_SklearnDistMixin"]
+__all__ = ["_SklearnDistanceAdapter"]
+
+from inspect import signature
 
 import numpy as np
 import pandas as pd
@@ -10,23 +12,120 @@ import pandas as pd
 from sktime.datatypes import convert
 
 
-class _SklearnDistMixin:
-    """Base adapter mixin for sklearn distances of KNeighbors."""
+class _SklearnDistanceAdapter:
+    """Adapter mixin to pass multivariate unequal length distance as 2D distance.
+
+    Many sklearn compatible estimators, such as KNeighbors, can accept custom distances,
+    but will expect callables that take 2D arrays as input.
+
+    This mixin adapts time series distances to that interface,
+    which can in-principle take multivariate or unequal length time series.
+
+    The distance adapted is the parameter ``distance``.
+
+    The pattern to use is:
+
+    * use instances of this class internally, passed to the sklearn estimator.
+      Instances are callable, compatible with ``sklearn`` estimators,
+      of signature ``metric : (x: 1D np.ndarray, y: 1D np.ndarray) -> float``
+    * adapt the sklearn estimator, and convert time series data to 2D numpy arrays
+      via the ``_convert_X_to_sklearn`` method
+
+    This way, the initial conversion in this distance, and ``_convert_X_to_sklearn``
+    will cancel each other out, and distance or kernel based ``sklearn`` estimators
+    written only for tabular data can be applied to time series data
+    with ``sklearn`` compatible mtypes.
+
+    To avoid repetitive checks,
+    metadata of the time series must be passed to the adapter, as:
+
+    * ``n_vars``: number of variables in the time series data
+    * ``is_equal_length``: whether the time series data is of equal length
+
+    Parameters
+    ----------
+    distance : sklearn BasePairwiseTransformerPanel distance, or str
+        Distance object or string code for distance.
+        If string code, adapts one of the numba distances from ``sktime.distances``.
+    distance_params : dict, optional
+        Parameters to pass to the distance object.
+        For BasePairwiseTransformerPanel distances, parameters should be
+        directly passed as object parameters.
+    n_vars : int, optional, default=1
+        Number of variables in the time series data.
+    is_equal_length : bool, optional, default=True
+        Whether the time series data is of equal length.
+    """
+    def __init__(self, distance, distance_params=None, n_vars=1, is_equal_length=True):
+        self.distance = distance
+        self.distance_params = distance_params
+        self.n_vars = n_vars
+        self.is_equal_length = is_equal_length
+
+    def __call__(self, x, y):
+        """Compute distance - unified interface to str code and callable."""
+        # sklearn wants distance callable element-wise,
+        # numpy1D x numpy1D -> float
+        # sktime distance classes are Panel x Panel -> numpy2D
+        # and the numba distances are numpy3D x numpy3D -> numpy2D
+        # so we need to wrap the sktime distances
+        if isinstance(self.distance, str):
+            # numba distances
+            metric = self._one_element_distance_npdist
+        else:
+            # sktime distance classes
+            metric = self._one_element_distance_sktime_dist
+        return metric(x, y)
+
+    def _distance(self, X, X2=None):
+        """Compute distance - unified interface to str code and callable.
+
+        If self.distance is a string, it is assumed to be a numba distance,
+        and X, X2 are assumed in numpy3D format.
+
+        If self.distance is a callable, it is assumed to be a sktime distance,
+        and X, X2 are assumed in any of the sktime Panel formats,
+        e.g., pd-multiindex, numpy3D.
+
+        Consumers of this method should ensure that the input is in the correct format.
+
+        This method should not be used as a direct public interface,
+        only for internal use in estimators making use of this adapter.
+        """
+        distance = self.distance
+        distance_params = self.distance_params
+        if distance_params is None:
+            distance_params = {}
+        if isinstance(distance, str):
+            from sktime.distances import pairwise_distance
+
+            return pairwise_distance(X, X2, distance, **distance_params)
+        else:
+            if X2 is not None:
+                return distance(X, X2, **distance_params)
+            # if X2 is None, check if distance allows None X2 to mean "X2=X"
+            else:
+                sig = signature(distance).parameters
+                X2_sig = sig[list(sig.keys())[1]]
+                if X2_sig.default is not None:
+                    return distance(X, X2, **distance_params)
+                else:
+                    return distance(X, **distance_params)
 
     def _one_element_distance_npdist(self, x, y, n_vars=None):
         if n_vars is None:
-            n_vars = self.n_vars_
+            n_vars = self.n_vars
         x = np.reshape(x, (1, n_vars, -1))
         y = np.reshape(y, (1, n_vars, -1))
         return self._distance(x, y)[0, 0]
 
     def _one_element_distance_sktime_dist(self, x, y, n_vars=None):
         if n_vars is None:
-            n_vars = self.n_vars_
+            n_vars = self.n_vars
         if n_vars == 1:
             x = np.reshape(x, (1, n_vars, -1))
             y = np.reshape(y, (1, n_vars, -1))
-        elif self._X_metadata["is_equal_length"]:
+        elif self.is_equal_length:
             x = np.reshape(x, (-1, n_vars))
             y = np.reshape(y, (-1, n_vars))
             x_ix = pd.MultiIndex.from_product([[0], range(len(x))])
@@ -53,7 +152,7 @@ class _SklearnDistMixin:
     def _convert_X_to_sklearn(self, X):
         """Convert X to 2D numpy for sklearn."""
         # special treatment for unequal length series
-        if not self._X_metadata["is_equal_length"]:
+        if not self.is_equal_length:
             # then we know we are dealing with pd-multiindex
             # as a trick to deal with unequal length data,
             # we flatten encode the length as the first column

--- a/sktime/dists_kernels/base/adapters/_sklearn.py
+++ b/sktime/dists_kernels/base/adapters/_sklearn.py
@@ -50,7 +50,7 @@ class _SklearnDistanceAdapter:
     will have a leading scalar dimension encoding the length of the individual series,
     and ``_convert_X_to_sklearn`` will produce a flattened vector
     with the length encoded as the first column in addition.
-    
+
     Parameters
     ----------
     distance : sklearn BasePairwiseTransformerPanel distance, or str

--- a/sktime/regression/distance_based/_time_series_neighbors.py
+++ b/sktime/regression/distance_based/_time_series_neighbors.py
@@ -127,59 +127,23 @@ class KNeighborsTimeSeriesRegressor(_BaseKnnTimeSeriesEstimator, BaseRegressor):
         distance="dtw",
         distance_params=None,
         distance_mtype=None,
+        pass_train_distances=False,
         leaf_size=30,
         n_jobs=None,
-        pass_train_distances=False,
     ):
-        self.n_neighbors = n_neighbors
-        self.weights = weights
-        self.algorithm = algorithm
-        self.distance = distance
-        self.distance_params = distance_params
-        self.distance_mtype = distance_mtype
-        self.pass_train_distances = pass_train_distances
-        self.leaf_size = leaf_size
-        self.n_jobs = n_jobs
+        self._knn_cls = KNeighborsRegressor
 
-        super().__init__()
-
-        # translate distance strings into distance callables
-        if isinstance(distance, str) and distance not in DISTANCES_SUPPORTED:
-            raise ValueError(
-                f"Unrecognised distance measure string: {distance}. "
-                f"Allowed values for string codes are: {DISTANCES_SUPPORTED}. "
-                "Alternatively, pass a callable distance measure into the constructor."
-            )
-
-        self.knn_estimator_ = KNeighborsRegressor(
+        super().__init__(
             n_neighbors=n_neighbors,
+            weights=weights,
             algorithm=algorithm,
-            metric="precomputed",
-            metric_params=distance_params,
+            distance=distance,
+            distance_params=distance_params,
+            distance_mtype=distance_mtype,
+            pass_train_distances=pass_train_distances,
             leaf_size=leaf_size,
             n_jobs=n_jobs,
-            weights=weights,
         )
-
-        # the distances in sktime.distances want numpy3D
-        #   otherwise all Panel formats are ok
-        if isinstance(self.distance, str):
-            self.set_tags(X_inner_mtype="numpy3D")
-            self.set_tags(**{"capability:unequal_length": False})
-            self.set_tags(**{"capability:missing_values": False})
-        elif distance_mtype is not None:
-            self.set_tags(X_inner_mtype=distance_mtype)
-
-        from sktime.dists_kernels import BasePairwiseTransformerPanel
-
-        # inherit capability tags from distance, if it is an estimator
-        if isinstance(distance, BasePairwiseTransformerPanel):
-            inherit_tags = [
-                "capability:missing_values",
-                "capability:unequal_length",
-                "capability:multivariate",
-            ]
-            self.clone_tags(distance, inherit_tags)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/regression/distance_based/_time_series_neighbors.py
+++ b/sktime/regression/distance_based/_time_series_neighbors.py
@@ -191,7 +191,7 @@ class KNeighborsTimeSeriesRegressor(_BaseKnnTimeSeriesEstimator, BaseRegressor):
             n_jobs=self.n_jobs,
         )
 
-        X = self._convert_X_to_sklearn(X)
+        X = self._dist_adapt._convert_X_to_sklearn(X)
         self.knn_estimator_.fit(X, y)
         return self
 


### PR DESCRIPTION
This PR further refactors and deduplicates knn classifier and regressor.

* changes mixin to a callable distance adapter which can be passed to `sklearn`
* moves duplicative `_distance` function to distance adapter
* decouples distance adapter from assuming `self` attributes being set to explicit pass via constructor
* simplifies inheritance structure of knn classifier, regressor

The distance adapter - in particular uncoupling - ensures that it can be used more broadly across distance based estimators and adapters towards `sklearn` compatible estimators in the future.