### PR TITLE
[BUG] fix `AUCalibration` probabilistic metric for `multivariate` case

### DIFF
--- a/sktime/performance_metrics/forecasting/probabilistic/_classes.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/_classes.py
@@ -1044,6 +1044,9 @@ class AUCalibration(_BaseDistrForecastingMetric):
         diagonal = np.arange(1, n + 1).reshape(-1, 1) / n
 
         res = (cdfs_ranked - diagonal).abs()
+
+        if self.multivariate:
+            return pd.DataFrame(res.mean(axis=1), columns=["score"])
         return res
 
     @classmethod

--- a/sktime/performance_metrics/forecasting/probabilistic/tests/test_distr_metrics.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/tests/test_distr_metrics.py
@@ -4,14 +4,18 @@ import warnings
 import pandas as pd
 import pytest
 
-from sktime.performance_metrics.forecasting.probabilistic._classes import CRPS, LogLoss
+from sktime.performance_metrics.forecasting.probabilistic._classes import (
+    CRPS,
+    AUCalibration,
+    LogLoss,
+)
 from sktime.proba.normal import Normal
 from sktime.proba.tfp import TFNormal
 from sktime.utils.dependencies import _check_soft_dependencies
 
 warnings.filterwarnings("ignore", category=FutureWarning)
 
-DISTR_METRICS = [CRPS, LogLoss]
+DISTR_METRICS = [CRPS, AUCalibration, LogLoss]
 
 
 if _check_soft_dependencies("tensorflow_probability", severity="none"):


### PR DESCRIPTION
The `AUCalibration` probabilistic metric was broken in the `multivariate` case and was not tested.

This PR fixes that, and adds the metric to tests.