### PR TITLE
[MNT] differential testing and minor improvements to `forecasting.base` tests

### DIFF
--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -14,12 +14,12 @@ from pandas.testing import assert_series_equal
 
 from sktime.datatypes import check_is_mtype, convert
 from sktime.datatypes._utilities import get_cutoff, get_window
-from sktime.forecasting.arima import ARIMA
 from sktime.forecasting.compose import YfromX
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.forecasting.theta import ThetaForecaster
 from sktime.forecasting.var import VAR
 from sktime.split import temporal_train_test_split
+from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_panel
 from sktime.utils._testing.series import _make_series
@@ -34,8 +34,8 @@ BACKENDS = _get_parallel_test_fixtures("config")
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(ARIMA, severity="none"),
-    reason="skip test if required soft dependency for ARIMA not available",
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
 )
 @pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("mtype", PANEL_MTYPES)
@@ -49,7 +49,7 @@ def test_vectorization_series_to_panel(mtype, backend):
 
     y = _make_panel(n_instances=n_instances, random_state=42, return_mtype=mtype)
 
-    f = ARIMA()
+    f = YfromX.create_test_instance()
     f.set_config(**backend.copy())
     y_pred = f.fit(y).predict([1, 2, 3])
     valid, _, metadata = check_is_mtype(
@@ -87,8 +87,8 @@ def test_vectorization_series_to_panel(mtype, backend):
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(ARIMA, severity="none"),
-    reason="skip test if required soft dependency for ARIMA not available",
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
 )
 @pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("mtype", HIER_MTYPES)
@@ -104,7 +104,7 @@ def test_vectorization_series_to_hier(mtype, backend):
     y = _make_hierarchical(hierarchy_levels=hierarchy_levels, random_state=84)
     y = convert(y, from_type="pd_multiindex_hier", to_type=mtype)
 
-    f = ARIMA()
+    f = YfromX.create_test_instance()
     f.set_config(**backend.copy())
     y_pred = f.fit(y).predict([1, 2, 3])
     valid, _, metadata = check_is_mtype(
@@ -144,8 +144,8 @@ PROBA_DF_METHODS = ["predict_interval", "predict_quantiles", "predict_var"]
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(ARIMA, severity="none"),
-    reason="skip test if required soft dependency for ARIMA not available",
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
 )
 @pytest.mark.parametrize("method", PROBA_DF_METHODS)
 @pytest.mark.parametrize("mtype", PANEL_MTYPES)
@@ -159,7 +159,8 @@ def test_vectorization_series_to_panel_proba(method, mtype):
 
     y = _make_panel(n_instances=n_instances, random_state=42, return_mtype=mtype)
 
-    est = ARIMA().fit(y)
+    est = YfromX.create_test_instance()
+    est.fit(y)
     y_pred = getattr(est, method)([1, 2, 3])
 
     if method in ["predict_interval", "predict_quantiles"]:
@@ -182,8 +183,8 @@ def test_vectorization_series_to_panel_proba(method, mtype):
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(ARIMA, severity="none"),
-    reason="skip test if required soft dependency for ARIMA not available",
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
 )
 @pytest.mark.parametrize("method", PROBA_DF_METHODS)
 @pytest.mark.parametrize("mtype", HIER_MTYPES)
@@ -197,7 +198,8 @@ def test_vectorization_series_to_hier_proba(method, mtype):
     y = _make_hierarchical(hierarchy_levels=hierarchy_levels, random_state=84)
     y = convert(y, from_type="pd_multiindex_hier", to_type=mtype)
 
-    est = ARIMA().fit(y)
+    est = YfromX.create_test_instance()
+    est.fit(y)
     y_pred = getattr(est, method)([1, 2, 3])
 
     if method in ["predict_interval", "predict_quantiles"]:
@@ -220,8 +222,8 @@ def test_vectorization_series_to_hier_proba(method, mtype):
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(ARIMA, severity="none"),
-    reason="skip test if required soft dependency for ARIMA not available",
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
 )
 @pytest.mark.parametrize("method", PROBA_DF_METHODS)
 def test_vectorization_preserves_row_index_names(method):
@@ -229,7 +231,8 @@ def test_vectorization_preserves_row_index_names(method):
     hierarchy_levels = (2, 4)
     y = _make_hierarchical(hierarchy_levels=hierarchy_levels, random_state=84)
 
-    est = ARIMA().fit(y, fh=[1, 2, 3])
+    est = YfromX.create_test_instance()
+    est.fit(y, fh=[1, 2, 3])
     y_pred = getattr(est, method)()
 
     msg = (
@@ -241,8 +244,8 @@ def test_vectorization_preserves_row_index_names(method):
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(ARIMA, severity="none"),
-    reason="skip test if required soft dependency for ARIMA not available",
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
 )
 @pytest.mark.parametrize("mtype", HIER_MTYPES)
 @pytest.mark.parametrize("exogeneous", [True, False])
@@ -264,7 +267,8 @@ def test_vectorization_multivariate(mtype, exogeneous):
         X_fit = None
         X_pred = None
 
-    est = ARIMA().fit(y=y_fit, X=X_fit, fh=[1, 2, 3])
+    est = YfromX.create_test_instance()
+    est.fit(y=y_fit, X=X_fit, fh=[1, 2, 3])
     y_pred = est.predict(X=X_pred)
     valid, _, metadata = check_is_mtype(
         y_pred, mtype, return_metadata=True, msg_return_dict="list"
@@ -298,6 +302,10 @@ def test_vectorization_multivariate(mtype, exogeneous):
     assert y_pred_equal_length, msg
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.forecasting.base"),
+    reason="run only if base module has changed",
+)
 def test_col_vectorization_correct_col_order():
     """Test that forecaster vectorization preserves column index ordering.
 
@@ -321,6 +329,10 @@ def test_col_vectorization_correct_col_order():
     assert (y_pred == y.iloc[4]).all().all()
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.forecasting.base"),
+    reason="run only if base module has changed",
+)
 def test_row_vectorization_correct_row_order():
     """Test that forecaster vectorization preserves row index ordering.
 
@@ -394,8 +406,8 @@ def test_predict_residuals():
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(ARIMA, severity="none"),
-    reason="skip test if required soft dependency not available",
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
 )
 @pytest.mark.parametrize("nullable_type", ["Int64", "Float64", "boolean"])
 def test_nullable_dtypes(nullable_type):
@@ -410,7 +422,7 @@ def test_nullable_dtypes(nullable_type):
     y = pd.Series([1, 0] * 20, dtype=dtype)
     y.index = pd.date_range("1/1/21", periods=40)
 
-    f = ARIMA()
+    f = YfromX.create_test_instance()
 
     fh = list(range(1, len(X_test) + 1))
     f.fit(X=X_train, y=y, fh=fh)
@@ -421,8 +433,9 @@ def test_nullable_dtypes(nullable_type):
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(VAR, severity="none"),
-    reason="skip test if required soft dependency not available",
+    not _check_estimator_deps(VAR, severity="none")
+    or not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
 )
 def test_range_fh_in_fit():
     """Test using ``range`` in ``fit``."""
@@ -436,8 +449,9 @@ def test_range_fh_in_fit():
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(VAR, severity="none"),
-    reason="skip test if required soft dependency not available",
+    not _check_estimator_deps(VAR, severity="none")
+    or not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
 )
 def test_range_fh_in_predict():
     """Test using ``range`` in ``predict``."""
@@ -460,6 +474,10 @@ def test_range_fh_in_predict():
     assert var_predictions.shape == (10 * 2, 5)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_remember_data():
     """Test that the ``remember_data`` flag works as expected."""
     from sktime.datasets import load_airline
@@ -482,6 +500,10 @@ def test_remember_data():
     assert f._y is not None
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_panel_with_inner_freq():
     """Test that panel data with inner frequency set returns the correct predictions."""
     from sktime.datasets import load_airline

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -35,7 +35,7 @@ BACKENDS = _get_parallel_test_fixtures("config")
 
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
-    or not _check_soft_dependencies("skpro"),
+    or not _check_soft_dependencies("skpro", severity="none"),
     reason="run only if base module has changed or datatypes module has changed",
 )
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -148,7 +148,7 @@ PROBA_DF_METHODS = ["predict_interval", "predict_quantiles", "predict_var"]
 
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
-    or not _check_soft_dependencies("skpro"),
+    or not _check_soft_dependencies("skpro", severity="none"),
     reason="run only if base module has changed or datatypes module has changed",
 )
 @pytest.mark.parametrize("method", PROBA_DF_METHODS)
@@ -188,7 +188,7 @@ def test_vectorization_series_to_panel_proba(method, mtype):
 
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
-    or not _check_soft_dependencies("skpro"),
+    or not _check_soft_dependencies("skpro", severity="none"),
     reason="run only if base module has changed or datatypes module has changed",
 )
 @pytest.mark.parametrize("method", PROBA_DF_METHODS)
@@ -228,7 +228,7 @@ def test_vectorization_series_to_hier_proba(method, mtype):
 
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
-    or not _check_soft_dependencies("skpro"),
+    or not _check_soft_dependencies("skpro", severity="none"),
     reason="run only if base module has changed or datatypes module has changed",
 )
 @pytest.mark.parametrize("method", PROBA_DF_METHODS)

--- a/sktime/forecasting/base/tests/test_base_bugs.py
+++ b/sktime/forecasting/base/tests/test_base_bugs.py
@@ -10,6 +10,7 @@ from sktime.forecasting.naive import NaiveForecaster
 from sktime.forecasting.reconcile import ReconcilerForecaster
 from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.split import ExpandingWindowSplitter
+from sktime.tests.test_switch import run_test_module_changed
 from sktime.transformations.hierarchical.aggregate import Aggregator
 from sktime.transformations.series.difference import Differencer
 from sktime.utils._testing.hierarchical import _make_hierarchical
@@ -17,8 +18,9 @@ from sktime.utils.dependencies import _check_estimator_deps
 
 
 @pytest.mark.skipif(
-    not _check_estimator_deps(ExponentialSmoothing, severity="none"),
-    reason="skip test if required soft dependency not available",
+    not run_test_module_changed("sktime.forecasting.base")
+    or not _check_estimator_deps(ExponentialSmoothing, severity="none"),
+    reason="run only if base module has changed",
 )
 def test_heterogeneous_get_fitted_params():
     """Regression test for bugfix #4574, related to get_fitted_params."""
@@ -60,6 +62,10 @@ def test_heterogeneous_get_fitted_params():
     reconciler.get_fitted_params()  # triggers an error pre-fix
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.forecasting.base"),
+    reason="run only if base module has changed",
+)
 def test_predict_residuals_conversion():
     """Regression test for bugfix #4766, related to predict_residuals internal type."""
     from sktime.datasets import load_longley

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -30,7 +30,7 @@ from sktime.forecasting.tests._config import (
     VALID_INDEX_FH_COMBINATIONS,
 )
 from sktime.split import temporal_train_test_split
-from sktime.tests.test_switch import run_test_for_class
+from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils._testing.forecasting import _make_fh, make_forecasting_problem
 from sktime.utils._testing.series import _make_index, _make_series
 from sktime.utils.datetime import (
@@ -41,7 +41,7 @@ from sktime.utils.datetime import (
     _shift,
     infer_freq,
 )
-from sktime.utils.dependencies import _check_soft_dependencies
+from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
 from sktime.utils.validation.series import is_in_valid_index_types, is_integer_index
 
 
@@ -52,6 +52,10 @@ def _assert_index_equal(a, b):
     assert a.equals(b)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize(
     "index_type, fh_type, is_relative", VALID_INDEX_FH_COMBINATIONS
 )
@@ -152,6 +156,10 @@ def test_fh(index_type, fh_type, is_relative, steps):
     assert fh.is_all_out_of_sample(cutoff) == is_oos
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_fh_method_delegation():
     """Test ForecastingHorizon delegated methods."""
     fh = ForecastingHorizon(1)
@@ -169,6 +177,10 @@ BAD_INPUT_ARGS = (
 )
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("arg", BAD_INPUT_ARGS)
 def test_check_fh_values_bad_input_types(arg):
     """Negative test for bad ForecastingHorizon arguments."""
@@ -179,6 +191,10 @@ def test_check_fh_values_bad_input_types(arg):
 DUPLICATE_INPUT_ARGS = (np.array([1, 2, 2]), [3, 3, 1])
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("arg", DUPLICATE_INPUT_ARGS)
 def test_check_fh_values_duplicate_input_values(arg):
     """Negative test for ForecastingHorizon input arguments."""
@@ -196,6 +212,10 @@ GOOD_ABSOLUTE_INPUT_ARGS = (
 )
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("arg", GOOD_ABSOLUTE_INPUT_ARGS)
 def test_check_fh_absolute_values_input_conversion_to_pandas_index(arg):
     """Test conversion of absolute horizons to pandas index."""
@@ -211,6 +231,10 @@ GOOD_RELATIVE_INPUT_ARGS = [
 ]
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("arg", GOOD_RELATIVE_INPUT_ARGS)
 def test_check_fh_relative_values_input_conversion_to_pandas_index(arg):
     """Test conversion of relative horizons to pandas index."""
@@ -229,6 +253,10 @@ LENGTH1_INDICES = [pd.Index([x]) for x in TIMEPOINTS]
 LENGTH1_INDICES += [pd.DatetimeIndex(["2000-01-01"], freq="D")]
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("timepoint", TIMEPOINTS)
 @pytest.mark.parametrize("by", [-3, -1, 0, 1, 3])
 def test_shift(timepoint, by):
@@ -244,6 +272,10 @@ def test_shift(timepoint, by):
         assert timepoint == ret
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("timepoint", LENGTH1_INDICES)
 @pytest.mark.parametrize("by", [-3, -1, 0, 1, 3])
 def test_shift_index(timepoint, by):
@@ -275,6 +307,10 @@ DURATIONS_NOT_ALLOWED = [
 ]
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("duration", DURATIONS_ALLOWED)
 def test_coerce_duration_to_int(duration):
     """Test coercion of duration to int."""
@@ -291,6 +327,10 @@ def test_coerce_duration_to_int(duration):
         assert ret == 1
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("duration", DURATIONS_NOT_ALLOWED)
 def test_coerce_duration_to_int_with_non_allowed_durations(duration):
     """Test coercion of duration to int."""
@@ -298,6 +338,10 @@ def test_coerce_duration_to_int_with_non_allowed_durations(duration):
         _coerce_duration_to_int(duration, freq=_get_freq(duration))
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("n_timepoints", [3, 5])
 @pytest.mark.parametrize("index_type", INDEX_TYPE_LOOKUP.keys())
 def test_get_duration(n_timepoints, index_type):
@@ -339,6 +383,10 @@ def _get_expected_freqstr(freqstr):
     return freqstr
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("freqstr", FREQUENCY_STRINGS)
 def test_to_absolute_freq(freqstr):
     """Test conversion when anchorings included in frequency."""
@@ -350,6 +398,10 @@ def test_to_absolute_freq(freqstr):
     assert abs_fh._values.freqstr == _get_expected_freqstr(freqstr)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("freqstr", FREQUENCY_STRINGS)
 def test_absolute_to_absolute_with_integer_horizon(freqstr):
     """Test converting between absolute and relative with integer horizon."""
@@ -365,6 +417,10 @@ def test_absolute_to_absolute_with_integer_horizon(freqstr):
     assert fh_freqstr == _get_expected_freqstr(freqstr)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("freqstr", FIXED_FREQUENCY_STRINGS)
 def test_absolute_to_absolute_with_timedelta_horizon(freqstr):
     """Test converting between absolute and relative."""
@@ -383,6 +439,10 @@ def test_absolute_to_absolute_with_timedelta_horizon(freqstr):
     assert converted_abs_fh._values.freqstr == _get_expected_freqstr(freqstr)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("freqstr", FREQUENCY_STRINGS)
 def test_relative_to_relative_with_integer_horizon(freqstr):
     """Test converting between relative and absolute with integer horizons."""
@@ -396,6 +456,10 @@ def test_relative_to_relative_with_integer_horizon(freqstr):
     assert_array_equal(fh, converted_rel_fh)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("freqstr", FIXED_FREQUENCY_STRINGS)
 def test_relative_to_relative_with_timedelta_horizon(freqstr):
     """Test converting between relative and absolute with timedelta horizons."""
@@ -412,6 +476,10 @@ def test_relative_to_relative_with_timedelta_horizon(freqstr):
     assert_array_equal(converted_rel_fh, np.arange(1, 4))
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("freq", FREQUENCY_STRINGS)
 def test_to_relative(freq: str):
     """Test conversion to relative.
@@ -427,6 +495,10 @@ def test_to_relative(freq: str):
     assert_array_equal(fh_rel, np.arange(5))
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("idx", range(5))
 @pytest.mark.parametrize("freq", FREQUENCY_STRINGS)
 def test_to_absolute_int(idx: int, freq: str):
@@ -440,6 +512,10 @@ def test_to_absolute_int(idx: int, freq: str):
     assert_array_equal(fh + idx, absolute_int)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("idx", range(5))
 @pytest.mark.parametrize("freq", FREQUENCY_STRINGS)
 def test_to_absolute_int_fh_with_freq(idx: int, freq: str):
@@ -452,6 +528,10 @@ def test_to_absolute_int_fh_with_freq(idx: int, freq: str):
     assert_array_equal(fh + idx, absolute_int)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("freqstr", ["W-WED", "W-SUN", "W-SAT"])
 def test_estimator_fh(freqstr):
     """Test model fitting with anchored frequency."""
@@ -467,6 +547,10 @@ def test_estimator_fh(freqstr):
     assert_array_equal(pred.index.to_numpy(), expected_fh.to_numpy())
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("freq", ["G", "W1"])
 def test_error_with_incorrect_string_frequency(freq: str):
     """Test error with incorrect string frequency string."""
@@ -478,6 +562,10 @@ def test_error_with_incorrect_string_frequency(freq: str):
         fh.freq = freq
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("freqstr", ["M", "D"])
 def test_frequency_setter(freqstr):
     """Test frequency setter."""
@@ -493,7 +581,8 @@ def test_frequency_setter(freqstr):
 
 # TODO: Replace this long running test with fast unit test
 @pytest.mark.skipif(
-    not run_test_for_class(AutoETS),
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
+    or not _check_estimator_deps(AutoETS, severity="none"),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_auto_ets():
@@ -515,6 +604,10 @@ def test_auto_ets():
     )
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_auto_ets_case_with_naive():
     """Test failure case from #1435.
 
@@ -538,7 +631,8 @@ def test_auto_ets_case_with_naive():
 
 # TODO: Replace this long running test with fast unit test
 @pytest.mark.skipif(
-    not run_test_for_class(ExponentialSmoothing),
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
+    or not _check_estimator_deps(ExponentialSmoothing, severity="none"),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_exponential_smoothing():
@@ -565,6 +659,10 @@ def test_exponential_smoothing():
     )
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_exponential_smoothing_case_with_naive():
     """Test failure case from #1876.
 
@@ -593,8 +691,9 @@ def test_exponential_smoothing_case_with_naive():
 
 # TODO: Replace this long running test with fast unit test
 @pytest.mark.skipif(
-    not run_test_for_class(AutoARIMA),
-    reason="run test only if softdeps are present and incrementally (if requested)",
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
+    or not _check_estimator_deps(AutoARIMA, severity="none"),
+    reason="run only if base module has changed or datatypes module has changed",
 )
 def test_auto_arima():
     """Test failure case from #805.
@@ -638,6 +737,10 @@ def test_auto_arima():
     )
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_auto_arima_case_with_naive():
     """Test failure case from #805.
 
@@ -682,6 +785,10 @@ def test_auto_arima_case_with_naive():
     )
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_extract_freq_from_inputs() -> None:
     """Test extract frequency from inputs."""
     assert _check_freq(None) is None
@@ -690,18 +797,30 @@ def test_extract_freq_from_inputs() -> None:
     assert _check_freq("D") == "D"
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("freq", FREQUENCY_STRINGS)
 def test_extract_freq_from_cutoff(freq: str) -> None:
     """Test extract frequency from cutoff."""
     assert _extract_freq_from_cutoff(pd.Period("2020", freq=freq)) == freq
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("x", [1, pd.Timestamp("2020")])
 def test_extract_freq_from_cutoff_with_wrong_input(x) -> None:
     """Test extract frequency from cutoff with wrong input."""
     assert _extract_freq_from_cutoff(x) is None
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_regular_spaced_fh_of_different_periodicity():
     """Test for failure condition from bug #4462.
 
@@ -717,36 +836,60 @@ def test_regular_spaced_fh_of_different_periodicity():
     naive.predict([1, 3, 5])
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_standard_range_in_fh():
     """Test using most common ``range`` without start/step."""
     standard_range = ForecastingHorizon(values=range(1, 5 + 1))
     assert (standard_range == ForecastingHorizon(values=[1, 2, 3, 4, 5])).all()
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_range_with_positive_step_in_fh():
     """Test using ``range`` with positive step."""
     range_with_positive_step = ForecastingHorizon(values=range(0, 5, 2))
     assert (range_with_positive_step == ForecastingHorizon(values=[0, 2, 4])).all()
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_range_with_negative_step_in_fh():
     """Test using ``range`` with negative step."""
     range_with_negative_step = ForecastingHorizon(values=range(3, -5, -2))
     assert (range_with_negative_step == ForecastingHorizon(values=[3, 1, -1, -3])).all()
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_range_sorting_in_fh():
     """Test that ``range`` is independent of order."""
     standard_range = ForecastingHorizon(values=range(5))
     assert (standard_range == ForecastingHorizon(values=[0, 3, 4, 1, 2])).all()
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_empty_range_in_fh():
     """Test when ``range`` has zero length."""
     empty_range = ForecastingHorizon(values=range(-5))
     assert (empty_range == ForecastingHorizon(values=[])).all()
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_fh_expected_pred():
     """Test for expected prediction index method."""
     fh = ForecastingHorizon([1, 2, 3])
@@ -793,6 +936,10 @@ def test_fh_expected_pred():
     assert y_pred_idx.equals(y_pred_idx_expected)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 def test_tz_preserved():
     """Test that time zone information is preserved in to_absolute.
 
@@ -811,6 +958,10 @@ if _check_soft_dependencies("pandas>=2.1.0", severity="none"):
     FREQ_STR_FOR_PD22 += ["YE", "2YE", "ME", "3ME"]
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
+    reason="run only if base module has changed or datatypes module has changed",
+)
 @pytest.mark.parametrize("freq", FREQ_STR_FOR_PD22)
 def test_pandas22_freq(freq):
     """Test that to_absolute and to_relative conversions work with all freqs.


### PR DESCRIPTION
This PR adds differential testing and makes minor improvements to `forecasting.base` tests:

* replaces `ARIMA` with a faster and internal alternative
* refactors fixture generation