### PR TITLE
[MNT] `numpy 2` compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ classifiers = [
 # this set should be kept minimal!
 dependencies = [
   "joblib<1.5,>=1.2.0",  # required for parallel processing
-  "numpy<1.27,>=1.21",  # required for framework layer and base class logic
+  "numpy<2.1,>=1.21",  # required for framework layer and base class logic
   "packaging",  # for estimator specific dependency parsing
   "pandas<2.3.0,>=1.1",  # pandas is the main in-memory data container
   "scikit-base>=0.6.1,<0.9.0",  # base module for sklearn compatible base API


### PR DESCRIPTION
This PR raises the `numpy` bound to `<2.1`.

This should install right away because core dependencies `sklearn`, `pandas`, `scipy` are afaik all compatible already.

We will need to run a full test for all estimators before release.