### PR TITLE
DIAGNOSTIC - `numpy 2` and no soft dependencies, test all estimators

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -286,7 +286,7 @@ jobs:
 
       - name: Install sktime and dependencies
         run: |
-          python -m pip install .[all_extras_pandas2,dev,dl] --no-cache-dir
+          python -m pip install .[dev] --no-cache-dir
 
       - name: Show dependencies
         run: python -m pip list
@@ -326,7 +326,7 @@ jobs:
 
       - name: Install sktime and dependencies
         run: |
-          python -m pip install .[all_extras,dev,pandas1] --no-cache-dir
+          python -m pip install .[dev,pandas1] --no-cache-dir
 
       - name: Show dependencies
         run: python -m pip list

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ addopts =
     --timeout 600
     --showlocals
     --matrixdesign True
-    --only_changed_modules True
+    --only_changed_modules False
     -n auto
 filterwarnings =
     ignore::UserWarning


### PR DESCRIPTION
Diagnostic - do not merge.

This PR tests all estimators that require no soft dependencies with `numpy 2`, on the full matrix of OS and python versions.