### PR TITLE
[MNT] update tests._config to skip various tests for Proximity Forest and Proximity Tree

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -97,12 +97,15 @@ EXCLUDED_TESTS = {
         "test_fit_does_not_overwrite_hyper_params",
         "test_save_estimators_to_file",
         "test_multiprocessing_idempotent",  # see 5658
+        "test_fit_idempotent",  # see 6637
     ],
     "ProximityForest": [
         "test_persistence_via_pickle",
         "test_fit_does_not_overwrite_hyper_params",
         "test_save_estimators_to_file",
         "test_fit_idempotent",  # see 6201
+        "test_multiprocessing_idempotent",  # see 6637
+        "test_classifier_output",  # see 6637
     ],
     # TapNet fails due to Lambda layer, see #3539 and #3616
     "TapNetClassifier": [

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -105,7 +105,6 @@ EXCLUDED_TESTS = {
         "test_save_estimators_to_file",
         "test_fit_idempotent",  # see 6201
         "test_multiprocessing_idempotent",  # see 6637
-        "test_classifier_output",  # see 6637
     ],
     # TapNet fails due to Lambda layer, see #3539 and #3616
     "TapNetClassifier": [


### PR DESCRIPTION
This PR aims to skip a few tests during the CI workflow for known and existing bugs to sporadic behaviour for `ProximityForest` and `ProximityTree`. For reference - see #6637.

In this PR we are planning to skip `test_multiprocessing_idempotent` and `test_classifier_output` for `ProximityForest` and `test_fit_idempotent` for `ProximityTree`. 

Hopefully that allows the CI workflows to pass successfully

