### PR TITLE
[MNT] credit doberbauer for pykalman python 3.11 compatibility fix

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2873,6 +2873,16 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "doberbauer",
+      "name": "Daniel Oberbauer",
+      "avatar_url": "https://avatars.githubusercontent.com/u/81889558?v=4",
+      "profile": "https://github.com/doberbauer",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Re: pykalman utils.py PR 107  

https://github.com/pykalman/pykalman/pull/107

contributed to the python 3.11 compatibility upgrade for `pykalman`:

replaced deprecated `inspect.getargspec` by `inspect.getfullargspec `