### PR TITLE
[MNT] `scipy` `1.14.0` compatibility for `deep_equals` plugin for `csr_matrix`

### DIFF
--- a/sktime/datatypes/tests/test_convert.py
+++ b/sktime/datatypes/tests/test_convert.py
@@ -75,7 +75,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.mark.skipif(
-    not run_test_module_changed("sktime.datatypes", "sktime.utils.deep_equals"),
+    not run_test_module_changed(["sktime.datatypes", "sktime.utils.deep_equals"]),
     reason="Test only if sktime.datatypes or utils.deep_equals has been changed",
 )
 def test_convert(scitype, from_mtype, to_mtype, fixture_index):

--- a/sktime/datatypes/tests/test_convert.py
+++ b/sktime/datatypes/tests/test_convert.py
@@ -75,8 +75,8 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.mark.skipif(
-    not run_test_module_changed("sktime.datatypes"),
-    reason="Test only if sktime.datatypes or utils.parallel has been changed",
+    not run_test_module_changed("sktime.datatypes", "sktime.utils.deep_equals"),
+    reason="Test only if sktime.datatypes or utils.deep_equals has been changed",
 )
 def test_convert(scitype, from_mtype, to_mtype, fixture_index):
     """Tests that conversions for scitype agree with from/to example fixtures.

--- a/sktime/datatypes/tests/test_convert_to.py
+++ b/sktime/datatypes/tests/test_convert_to.py
@@ -17,7 +17,7 @@ MTYPES_PANEL = ["pd-multiindex", "df-list", "numpy3D"]
 
 
 @pytest.mark.skipif(
-    not run_test_module_changed("sktime.datatypes", "sktime.utils.deep_equals"),
+    not run_test_module_changed(["sktime.datatypes", "sktime.utils.deep_equals"]),
     reason="Test only if sktime.datatypes or utils.deep_equals has been changed",
 )
 def test_convert_to_simple():
@@ -37,7 +37,7 @@ def test_convert_to_simple():
 
 
 @pytest.mark.skipif(
-    not run_test_module_changed("sktime.datatypes", "sktime.utils.deep_equals"),
+    not run_test_module_changed(["sktime.datatypes", "sktime.utils.deep_equals"]),
     reason="Test only if sktime.datatypes or utils.deep_equals has been changed",
 )
 def test_convert_to_without_scitype():
@@ -57,7 +57,7 @@ def test_convert_to_without_scitype():
 
 
 @pytest.mark.skipif(
-    not run_test_module_changed("sktime.datatypes", "sktime.utils.deep_equals"),
+    not run_test_module_changed(["sktime.datatypes", "sktime.utils.deep_equals"]),
     reason="Test only if sktime.datatypes or utils.deep_equals has been changed",
 )
 def test_convert_to_mtype_list():
@@ -87,7 +87,7 @@ def test_convert_to_mtype_list():
 
 
 @pytest.mark.skipif(
-    not run_test_module_changed("sktime.datatypes", "sktime.utils.deep_equals"),
+    not run_test_module_changed(["sktime.datatypes", "sktime.utils.deep_equals"]),
     reason="Test only if sktime.datatypes or utils.deep_equals has been changed",
 )
 def test_convert_to_mtype_list_different_scitype():

--- a/sktime/datatypes/tests/test_convert_to.py
+++ b/sktime/datatypes/tests/test_convert_to.py
@@ -17,8 +17,8 @@ MTYPES_PANEL = ["pd-multiindex", "df-list", "numpy3D"]
 
 
 @pytest.mark.skipif(
-    not run_test_module_changed("sktime.datatypes"),
-    reason="Test only if sktime.datatypes or utils.parallel has been changed",
+    not run_test_module_changed("sktime.datatypes", "sktime.utils.deep_equals"),
+    reason="Test only if sktime.datatypes or utils.deep_equals has been changed",
 )
 def test_convert_to_simple():
     """Testing convert_to basic call works."""
@@ -37,8 +37,8 @@ def test_convert_to_simple():
 
 
 @pytest.mark.skipif(
-    not run_test_module_changed("sktime.datatypes"),
-    reason="Test only if sktime.datatypes or utils.parallel has been changed",
+    not run_test_module_changed("sktime.datatypes", "sktime.utils.deep_equals"),
+    reason="Test only if sktime.datatypes or utils.deep_equals has been changed",
 )
 def test_convert_to_without_scitype():
     """Testing convert_to call without scitype specification."""
@@ -57,8 +57,8 @@ def test_convert_to_without_scitype():
 
 
 @pytest.mark.skipif(
-    not run_test_module_changed("sktime.datatypes"),
-    reason="Test only if sktime.datatypes or utils.parallel has been changed",
+    not run_test_module_changed("sktime.datatypes", "sktime.utils.deep_equals"),
+    reason="Test only if sktime.datatypes or utils.deep_equals has been changed",
 )
 def test_convert_to_mtype_list():
     """Testing convert_to call to_type being a list, of same scitype."""
@@ -87,8 +87,8 @@ def test_convert_to_mtype_list():
 
 
 @pytest.mark.skipif(
-    not run_test_module_changed("sktime.datatypes"),
-    reason="Test only if sktime.datatypes or utils.parallel has been changed",
+    not run_test_module_changed("sktime.datatypes", "sktime.utils.deep_equals"),
+    reason="Test only if sktime.datatypes or utils.deep_equals has been changed",
 )
 def test_convert_to_mtype_list_different_scitype():
     """Testing convert_to call to_type being a list, of different scitypes."""

--- a/sktime/utils/deep_equals/_deep_equals.py
+++ b/sktime/utils/deep_equals/_deep_equals.py
@@ -135,15 +135,15 @@ def _csr_matrix_equals_plugin(x, y, return_msg=False, deep_equals=None):
     if type(x).__name__ != "csr_matrix":  # isinstance(x, csr_matrix):
         return None
 
-    import numpy as np
-
     ret = _make_ret(return_msg)
 
-    # csr-matrix must not be compared using np.any(x!=y)
-    if not np.allclose(x.A, y.A):
+    if x.shape != y.shape:
         return ret(False, " !=, {} != {}", [x, y])
 
-    return ret(True, "")
+    if (x != y).nnz == 0:
+        return ret(True, "")
+
+    return ret(False, " !=, {} != {}", [x, y])
 
 
 def _dask_dataframe_equals_plugin(x, y, return_msg=False, deep_equals=None):


### PR DESCRIPTION
The  `deep_equals` plugin for `scipy` `csr_matrix` is not compatible with the latest version `1.14`.

This PR changes the logic so it is.

Also ensures key locations in `sktime.datatypes` are tested if `deep_equals` plugins in `sktime` change.