### PR TITLE
[MNT] deprecate unused `_check_soft_dependencies` argument `suppress_import_stdout`

### DIFF
--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -14,13 +14,14 @@ from packaging.specifiers import InvalidSpecifier, Specifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
 
+# todo 0.32.0: remove suppress_import_stdout argument
 def _check_soft_dependencies(
     *packages,
     package_import_alias=None,
     severity="error",
     obj=None,
     msg=None,
-    suppress_import_stdout=False,
+    suppress_import_stdout="deprecated",
 ):
     """Check if required soft dependencies are installed and raise error or warning.
 
@@ -54,8 +55,6 @@ def _check_soft_dependencies(
         if str is passed, will be used as name of the class/object or module
     msg : str, or None, default=None
         if str, will override the error message or warning shown with msg
-    suppress_import_stdout : bool, optional. Default=False
-        whether to suppress stdout printout upon import.
 
     Raises
     ------
@@ -66,6 +65,22 @@ def _check_soft_dependencies(
     -------
     boolean - whether all packages are installed, only if no exception is raised
     """
+    # todo 0.32.0: remove this warning
+    if suppress_import_stdout != "deprecated":
+        warnings.warn(
+            "In sktime _check_soft_dependencies, the suppress_import_stdout argument "
+            "is deprecated and no longer has any effect. "
+            "The argument will be removed in version 0.32.0, so users of the "
+            "_check_soft_dependencies utility should not pass this argument anymore. "
+            "The _check_soft_dependencies utility also no longer causes imports, "
+            "hence no stdout "
+            "output is created from imports, for any setting of the "
+            "suppress_import_stdout argument. If you wish to import packages "
+            "and make use of stdout prints, import the package directly instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if len(packages) == 1 and isinstance(packages[0], (tuple, list)):
         packages = packages[0]
     if not all(isinstance(x, str) for x in packages):

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -273,9 +273,7 @@ def _check_dl_dependencies(msg=None, severity="error"):
             )
 
 
-def _check_mlflow_dependencies(
-    msg=None, severity="error", suppress_import_stdout=False
-):
+def _check_mlflow_dependencies(msg=None, severity="error"):
     """Check if `mlflow` and its dependencies are installed.
 
     Parameters
@@ -308,12 +306,7 @@ def _check_mlflow_dependencies(
             "or `pip install sktime[mlflow]` to install the package."
         )
 
-    return _check_soft_dependencies(
-        "mlflow",
-        msg=msg,
-        severity=severity,
-        suppress_import_stdout=suppress_import_stdout,
-    )
+    return _check_soft_dependencies("mlflow", msg=msg, severity=severity)
 
 
 def _check_python_version(obj, package=None, msg=None, severity="error"):


### PR DESCRIPTION
After https://github.com/sktime/sktime/pull/6355, the `suppress_import_stdout` argument of `_check_soft_dependencies` no longer has any effect.

It is hence scheduled for deprecation with the 0.32.0 release.