### PR TITLE
[BUG] ensure correct setting of `requires_X` and `requires_y` tag for `TransformerPipeline`

### DIFF
--- a/sktime/transformations/compose/_pipeline.py
+++ b/sktime/transformations/compose/_pipeline.py
@@ -45,6 +45,11 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
         where ``trafo[i].update`` and ``trafo[i].transform`` receive as input
         the output of ``trafo[i-1].transform``
 
+    For transformers in the pipeline that use the ``y`` argument, the ``y`` argument
+    passed to ``TransformerPipeline.fit`` or ``transform`` is passed to
+    all such transformers in the pipeline. No transformations or inverse transformations
+    are applied to ``y`` in the pipeline.
+
     The ``get_params``, ``set_params`` uses ``sklearn`` compatible nesting interface
     if list is unnamed, names are generated as names of classes
     if names are non-unique, ``f"_{str(i)}"`` is appended to each name string
@@ -149,6 +154,8 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
 
         # input mtype and input type are as of the first estimator
         self.clone_tags(first_trafo, ["scitype:transform-input"])
+        # chain requires X if and only if first estimator requires X
+        self.clone_tags(first_trafo, ["requires_X"])
         # output type is that of last estimator, if no "Primitives" occur in the middle
         # if "Primitives" occur in the middle, then output is set to that too
         # this is in a case where "Series-to-Series" is applied to primitive df
@@ -166,6 +173,7 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
         self._anytagis_then_set("fit_is_empty", False, True, ests)
         self._anytagis_then_set("transform-returns-same-time-index", False, True, ests)
         self._anytagis_then_set("skip-inverse-transform", False, True, ests)
+        self._anytagis_then_set("requires_y", True, False, ests)
 
         # self can inverse transform if for all est, we either skip or can inv-transform
         skips = [est.get_tag("skip-inverse-transform") for _, est in ests]

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -377,3 +377,36 @@ def test_input_output_series_panel_chain():
     Xt = bootstrap_trafo.fit_transform(X)
     assert isinstance(Xt, pd.DataFrame)
     assert isinstance(Xt.index, pd.MultiIndex)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.transformations"),
+    reason="run test only if anything in sktime.transformations module has changed",
+)
+def test_requires_tags_trafopipe():
+    """Test correct handling of requires_X tag, failure case in ."""
+    from sktime.transformations.compose import YtoX, TransformerPipeline
+    from sktime.transformations.series.fourier import FourierFeatures
+
+    # data with no exogenous features
+    X = load_airline()
+
+    # create a pipeline with Fourier features and ARIMA
+    pipe = TransformerPipeline(
+        steps=[
+            YtoX(),
+            FourierFeatures(
+                sp_list=[24, 24 * 7],
+                fourier_terms_list=[10, 5],
+                keep_original_columns=True,
+            )
+        ]
+    )
+
+    assert not pipe.get_tags()["requires_X"]
+    # should not requires X as input, because YtoX does not
+
+    assert pipe.get_tags()["requires_y"]
+    # should require y as input, because YtoX does
+
+    pipe.fit_transform(X=None, y=X)

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -385,7 +385,7 @@ def test_input_output_series_panel_chain():
 )
 def test_requires_tags_trafopipe():
     """Test correct handling of requires_X tag, failure case in ."""
-    from sktime.transformations.compose import YtoX, TransformerPipeline
+    from sktime.transformations.compose import TransformerPipeline, YtoX
     from sktime.transformations.series.fourier import FourierFeatures
 
     # data with no exogenous features
@@ -399,7 +399,7 @@ def test_requires_tags_trafopipe():
                 sp_list=[24, 24 * 7],
                 fourier_terms_list=[10, 5],
                 keep_original_columns=True,
-            )
+            ),
         ]
     )
 


### PR DESCRIPTION
Fixes #6674 by ensuring that the `requires_X` and `requires_y` tags are correctly set for `TransformerPipeline`, based on component tags:

* `requires_X` is True if and only the *first* transformer in the pipeline requires `X`. This in particular should resolve #6674.
* `requires_y` is True if and only if *at least one* transformer in the pipeline requires `y`.