### PR TITLE
[BUG] ensure correct setting of `requires_X` and `requires_y` tag for `FeatureUnion`

### DIFF
--- a/sktime/transformations/compose/_featureunion.py
+++ b/sktime/transformations/compose/_featureunion.py
@@ -113,6 +113,10 @@ class FeatureUnion(_HeterogenousMetaEstimator, BaseTransformer):
         self._anytagis_then_set("handles-missing-data", False, True, ests)
         self._anytagis_then_set("univariate-only", True, False, ests)
 
+        # if any of the components require_X or require_y, set it for the composite
+        self._anytagis_then_set("requires_X", True, False, ests)
+        self._anytagis_then_set("requires_y", True, False, ests)
+
     @property
     def _transformer_list(self):
         return self._get_estimator_tuples(self.transformer_list, clone_ests=False)


### PR DESCRIPTION
Fixes #6678 by ensuring that the `requires_X` and `requires_y` tags are correctly set for `FeatureUnion`, based on component tags:

* `requires_X` is True if and only if *at least one* transformer in the pipeline requires `X` per `requires_X`
* `requires_y` is True if and only if *at least one* transformer in the pipeline requires `y` per `requires_y`