### PR TITLE
[DOC] clarify docs on ARIMA estimators, add author credits for upstream

### DIFF
--- a/sktime/forecasting/arima/_pmdarima.py
+++ b/sktime/forecasting/arima/_pmdarima.py
@@ -271,7 +271,15 @@ class AutoARIMA(_PmdArimaAdapter):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["mloning", "hyang1996", "fkiraly", "ilkersigirci"],
+        "authors": [
+            "tgsmith61591",  # for pmdarima
+            "charlesdrotar",  # for pmdarima
+            "aaronreidsmith",  # for pmdarima
+            "mloning",
+            "hyang1996",
+            "fkiraly",
+            "ilkersigirci",
+        ],
         "maintainers": ["hyang1996"],
         # python_dependencies: "pmdarima" - inherited from _PmdArimaAdapter
         # estimator type
@@ -676,7 +684,15 @@ class ARIMA(_PmdArimaAdapter):
     """  # noqa: E501
 
     _tags = {
-        "authors": ["mloning", "hyang1996", "fkiraly", "ilkersigirci"],
+        "authors": [
+            "tgsmith61591",  # for pmdarima
+            "charlesdrotar",  # for pmdarima
+            "aaronreidsmith",  # for pmdarima
+            "mloning",
+            "hyang1996",
+            "fkiraly",
+            "ilkersigirci",
+        ],
         "maintainers": ["hyang1996"],
         "handles-missing-data": True,
     }

--- a/sktime/forecasting/arima/_statsmodels.py
+++ b/sktime/forecasting/arima/_statsmodels.py
@@ -25,7 +25,8 @@ class StatsModelsARIMA(_StatsModelsAdapter):
     These are implementations of the same underlying model, (S)ARIMA(X),
     but with different
     fitting strategies, fitted parameters, and slightly differring behaviour.
-    Users should refer to the statsmodels documentation for further details.
+    Users should refer to the statsmodels documentation for further details:
+    https://www.statsmodels.org/dev/examples/notebooks/generated/statespace_sarimax_faq.html  # noqa: E501
 
     Parameters
     ----------

--- a/sktime/forecasting/arima/_statsmodels.py
+++ b/sktime/forecasting/arima/_statsmodels.py
@@ -14,9 +14,18 @@ from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
 
 class StatsModelsARIMA(_StatsModelsAdapter):
-    """ARIMA forecaster, from statsmodels package.
+    """(S)ARIMA(X) forecaster, from statsmodels, tsa.arima module.
 
     Direct interface for ``statsmodels.tsa.arima.model.ARIMA``.
+
+    Users should note that statsmodels contains two separate implementations of
+    (S)ARIMA(X), the ARIMA and the SARIMAX class, in different modules:
+    ``tsa.arima.model.ARIMA`` and ``tsa.statespace.SARIMAX``.
+
+    These are implementations of the same underlying model, (S)ARIMA(X),
+    but with different
+    fitting strategies, fitted parameters, and slightly differring behaviour.
+    Users should refer to the statsmodels documentation for further details.
 
     Parameters
     ----------

--- a/sktime/forecasting/arima/_statsmodels.py
+++ b/sktime/forecasting/arima/_statsmodels.py
@@ -163,7 +163,8 @@ class StatsModelsARIMA(_StatsModelsAdapter):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["arnaujc91"],
+        "authors": ["chadfulton", "bashtage", "jbrockmendel", "arnaujc91"],
+        # chadfulton, bashtage, jbrockmendel for statsmodels implementation
         "maintainers": ["arnaujc91"],
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,

--- a/sktime/forecasting/sarimax.py
+++ b/sktime/forecasting/sarimax.py
@@ -22,7 +22,8 @@ class SARIMAX(_StatsModelsAdapter):
     These are implementations of the same underlying model, (S)ARIMA(X),
     but with different
     fitting strategies, fitted parameters, and slightly differring behaviour.
-    Users should refer to the statsmodels documentation for further details.
+    Users should refer to the statsmodels documentation for further details:
+    https://www.statsmodels.org/dev/examples/notebooks/generated/statespace_sarimax_faq.html  # noqa: E501
 
     Parameters
     ----------

--- a/sktime/forecasting/sarimax.py
+++ b/sktime/forecasting/sarimax.py
@@ -224,7 +224,14 @@ class SARIMAX(_StatsModelsAdapter):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["TNTran92", "yarnabrina"],
+        "authors": [
+            "chadfulton",  # for statsmodels
+            "bashtage",  # for statsmodels
+            "jbrockmendel",  # for statsmodels
+            "jackzyliu",  # for statsmodels
+            "TNTran92",
+            "yarnabrina",
+        ],
         "maintainers": ["TNTran92", "yarnabrina"],
         # "python_dependencnies": "statsmodels" - inherited from _StatsModelsAdapter
         # estimator type

--- a/sktime/forecasting/sarimax.py
+++ b/sktime/forecasting/sarimax.py
@@ -11,9 +11,18 @@ from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
 
 class SARIMAX(_StatsModelsAdapter):
-    """SARIMAX forecaster.
+    """(S)ARIMA(X) forecaster, from statsmodels, tsa.statespace module.
 
-    Direct interface for ``statsmodels.tsa.api.SARIMAX``.
+    Direct interface for ``statsmodels.tsa.statespace.SARIMAX``.
+
+    Users should note that statsmodels contains two separate implementations of
+    (S)ARIMA(X), the ARIMA and the SARIMAX class, in different modules:
+    ``tsa.arima.model.ARIMA`` and ``tsa.statespace.SARIMAX``.
+
+    These are implementations of the same underlying model, (S)ARIMA(X),
+    but with different
+    fitting strategies, fitted parameters, and slightly differring behaviour.
+    Users should refer to the statsmodels documentation for further details.
 
     Parameters
     ----------

--- a/sktime/forecasting/var.py
+++ b/sktime/forecasting/var.py
@@ -13,10 +13,12 @@ from sktime.forecasting.base.adapters import _StatsModelsAdapter
 
 
 class VAR(_StatsModelsAdapter):
-    """A VAR model is a generalisation of the univariate autoregressive.
+    """VAR model from statsmodels.
 
-    Direct interface for ``statsmodels.tsa.vector_ar``
-    A model for forecasting a vector of time series[1].
+    Direct interface to ``statsmodels.tsa.vector_ar``.
+
+    A VAR model is a generalisation of the univariate autoregressive model
+    to multivariate time series, see [1]_.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR clarifies the different ARIMA estimators in the code base, and adds author credits for upstream.

Most confusingly, it seems there are two (S)ARIMA(X) models in `statsmodels`, both by the same set of authors, one inheriting from the other - `ARIMA` and `SARIMAX`. Unlike the naming implies, these are both (S)ARIMA(X) models.

I have no idea what is going on and neither the `statsmodels` docs nor the code base are illuminating on a superficial glance, so I am just adding clearer pointers that explain to the user what they are getting.

Also adds upstream sets of authors for credit, for `statsmodels` and `pmdarima` ARIMA models.

FYI @arnaujc91, or @yarnabrina (interface authors), do you know?