### PR TITLE
[BUG] fix passing of `y` in `ForecastingPipeline`

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -700,6 +700,9 @@ class ForecastingPipeline(_Pipeline):
                 if isinstance(y, ForecastingHorizon) and requires_y:
                     y = y.to_absolute_index(self.cutoff)
                     y = pd.DataFrame(index=y)
+                elif isinstance(y, ForecastingHorizon) and not requires_y:
+                    y = None
+                # else we just pass on y
                 X = transformer.transform(X=X, y=y)
         return X
 

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -700,8 +700,6 @@ class ForecastingPipeline(_Pipeline):
                 if isinstance(y, ForecastingHorizon) and requires_y:
                     y = y.to_absolute_index(self.cutoff)
                     y = pd.DataFrame(index=y)
-                else:
-                    y = None
                 X = transformer.transform(X=X, y=y)
         return X
 


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/6678, which resulted in `y` set erroneously to `None` in `ForecastingPipeline`