### PR TITLE
[BUG] Fix bug in fitted parameter override in `pyts` and `tslearn` adapters

### DIFF
--- a/sktime/base/adapters/_pyts.py
+++ b/sktime/base/adapters/_pyts.py
@@ -89,7 +89,7 @@ class _PytsAdapter:
         self._call_with_y_optional(pyts_est.fit, X, y)
 
         # write fitted params to self
-        _clone_fitted_params(pyts_est, self)
+        _clone_fitted_params(to_obj=self, from_obj=pyts_est)
 
         return self
 

--- a/sktime/base/adapters/_tslearn.py
+++ b/sktime/base/adapters/_tslearn.py
@@ -76,7 +76,7 @@ class _TslearnAdapter:
             tslearn_est.fit(X)
 
         # write fitted params to self
-        _clone_fitted_params(tslearn_est, self)
+        _clone_fitted_params(to_obj=self, from_obj=tslearn_est, overwrite=True)
 
         return self
 

--- a/sktime/base/adapters/_tslearn.py
+++ b/sktime/base/adapters/_tslearn.py
@@ -76,7 +76,7 @@ class _TslearnAdapter:
             tslearn_est.fit(X)
 
         # write fitted params to self
-        _clone_fitted_params(to_obj=self, from_obj=tslearn_est, overwrite=True)
+        _clone_fitted_params(to_obj=self, from_obj=tslearn_est)
 
         return self
 


### PR DESCRIPTION
The parameter forward refactor introduced a bug in `pyts` and `tslearn` adapters, where the direcation of forwarding was wrong - from the `self` to the wrapped estimator.

This is fixed, and should be merged quickly before release as the fixed bug has not been released yet.