### PR TITLE
[MNT] bound `prophet` based forecasters to `numpy<2` due to incompatibility of `prophet`

### DIFF
--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -23,7 +23,7 @@ class _ProphetAdapter(BaseForecaster):
         "requires-fh-in-fit": False,
         "handles-missing-data": False,
         "y_inner_mtype": "pd.DataFrame",
-        "python_dependencies": "prophet",
+        "python_dependencies": ["prophet", "numpy<2.0"],
     }
 
     def _convert_int_to_date(self, y):

--- a/sktime/forecasting/trend/_pwl_trend_forecaster.py
+++ b/sktime/forecasting/trend/_pwl_trend_forecaster.py
@@ -91,7 +91,7 @@ class ProphetPiecewiseLinearTrendForecaster(_ProphetAdapter):
         "X_inner_mtype": "pd.DataFrame",
         "ignores-exogeneous-X": True,
         "requires-fh-in-fit": False,
-        "python_dependencies": "prophet",
+        "python_dependencies": ["prophet", "numpy<2.0"],
     }
 
     def __init__(


### PR DESCRIPTION
Temporary silencing of issue https://github.com/sktime/sktime/issues/6720, `prophet` incompatibility with `numpy<2`.