### PR TITLE
[ENH] Add binary segmentation annotator for change point detection

### DIFF
--- a/sktime/annotation/bs.py
+++ b/sktime/annotation/bs.py
@@ -94,7 +94,7 @@ class BinarySegmentation(BaseSeriesAnnotator):
 
         return np.abs(cumsum_statistic)
 
-    def _find_change_points(self, X, threshold, min_segment_length=0):
+    def _find_change_points(self, X, threshold, min_segment_length=0, max_iter=10000):
         """Find change points in 'X' between the 'start' and 'end' index.
 
         All change points are appended to 'change_points'.
@@ -107,6 +107,8 @@ class BinarySegmentation(BaseSeriesAnnotator):
             Threshold for a change point to be kept.
         min_segment_length : int
             Minimum distance between change points.
+        max_iter : int
+            Maximum number of interations before the found change points are returned.
 
         Returns
         -------
@@ -119,7 +121,9 @@ class BinarySegmentation(BaseSeriesAnnotator):
         # points are searched
         segment_indexes = deque([(0, len(X) - 1)])
 
-        while True:
+        i = 0
+        while i < max_iter:
+            i += 1
             if len(segment_indexes) == 0:
                 return change_points
 
@@ -142,6 +146,8 @@ class BinarySegmentation(BaseSeriesAnnotator):
                 change_points.append(new_change_point)
                 segment_indexes.append((start, new_change_point))
                 segment_indexes.append((new_change_point + 1, end))
+
+        return change_points
 
     def _fit(self, X, Y=None):
         return self

--- a/sktime/annotation/bs.py
+++ b/sktime/annotation/bs.py
@@ -1,4 +1,4 @@
-"""Binary Segmentation."""
+"""Binary segmentation annotator for change point detection."""
 
 from collections import deque
 
@@ -28,7 +28,7 @@ class BinarySegmentation(BaseSeriesAnnotator):
 
     Notes
     -----
-    This is base on the implementation of binary segmentation described in [1]_.
+    This is based on the implementation of binary segmentation described in [1]_.
 
     References
     ----------
@@ -106,8 +106,6 @@ class BinarySegmentation(BaseSeriesAnnotator):
     def _find_change_points(self, X, threshold, min_cp_distance=0, max_iter=10000):
         """Find change points in 'X' between the 'start' and 'end' index.
 
-        All change points are appended to 'change_points'.
-
         Parameters
         ----------
         X : pd.Series
@@ -159,6 +157,7 @@ class BinarySegmentation(BaseSeriesAnnotator):
         return change_points
 
     def _fit(self, X, Y=None):
+        """Fit method for compatibitility with sklearn-type interface."""
         return self
 
     def _predict(self, X, Y=None):

--- a/sktime/annotation/bs.py
+++ b/sktime/annotation/bs.py
@@ -54,6 +54,7 @@ class BinarySegmentation(BaseSeriesAnnotator):
 
     _tags = {
         "fit_is_empty": True,
+        "univariate-only": True,
         "task": "change_point_detection",
         "learning_type": "unsupervised",
     }

--- a/sktime/annotation/bs.py
+++ b/sktime/annotation/bs.py
@@ -1,0 +1,176 @@
+"""Binary Segmentation."""
+
+import numpy as np
+import pandas as pd
+
+from sktime.annotation.base._base import BaseSeriesAnnotator
+
+
+class BinarySegmentation(BaseSeriesAnnotator):
+    """Binary segmentation change point detector.
+
+    This method finds change points by fitting piecewise constant functions to a
+    timeseries. Change points are selected according to the CUMSUM statistic.
+
+    Parameters
+    ----------
+    threshold : float
+        Threshold for the CUMSUM statistic. Change points that do not increase the
+        CUMSUM statistic above this threshold are ignored.
+
+    Notes
+    -----
+    This is base on the implementation of binary segmentation described in [1]_.
+
+    References
+    ----------
+    .. [1] Fryzlewicz, Piotr. "WILD BINARY SEGMENTATION FOR MULTIPLE CHANGE-POINT
+           DETECTION." The Annals of Statistics, vol. 42, no. 6, 2014, pp. 2243–81.
+           JSTOR, http://www.jstor.org/stable/43556493. Accessed 4 July 2024.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.annotation.bs import BinarySegmentation
+    >>> model = BinarySegmentation(threshold=1)
+    >>> X = pd.Series([1, 1, 1, 1, 5, 5, 5, 5])
+    >>> model.fit_predict(X)
+    0    3
+    dtype: int64
+    >>> X = pd.Series([1.1, 1.3, -1.4, -1.4, 5.5, 5.6])
+    >>> model.fit_predict(X)
+    0    1
+    1    3
+    dtype: int64
+    """
+
+    _tags = {
+        "fit_is_empty": True,
+        "task": "change_point_detection",
+        "learning_type": "unsupervised",
+    }
+
+    def __init__(self, threshold):
+        self.threshold = threshold
+        super().__init__()
+
+    def _cumsum_statistic(self, X, start, end, change_point):
+        """Calculate CUMSUM statistic to evaluate a change point.
+
+        The CUMSUM statistic measures the quality of the fit on 'X' of a piecewise
+        constant function that starts at 'start', ends at 'end', and has one change
+        point at 'change_point'. This is taken from [1]_.
+
+        Parameters
+        ----------
+        X : pd.Series
+            Timeseries on which the cumsum statistic is calculated.
+        start : int
+            Index (in terms of 'iloc') of the start of the left segment.
+        end : int
+            Index (in terms of 'iloc') of the end of the right segment.
+        change_point : int
+            Index (in terms of 'iloc') of the change point in the piecewise constant
+            function.
+
+        Returns
+        -------
+        float
+            The CUMSUM statistic which is a positive float. A larger value indicates a
+            bigger difference between the left and right segments.
+        """
+        if change_point < start or change_point >= end:
+            raise RuntimeError("The change point must be within 'start' and 'end'.")
+
+        n = end - start + 1
+        w_left = np.sqrt((end - change_point) / (n * (change_point - start + 1)))
+        w_right = np.sqrt((change_point - start + 1) / (n * (end - change_point)))
+
+        left = X.iloc[start : change_point + 1].to_numpy()
+        right = X.iloc[change_point + 1 : end + 1].to_numpy()
+        cumsum_statistic = w_left * np.sum(left) - w_right * np.sum(right)
+
+        return np.abs(cumsum_statistic)
+
+    def _find_change_points(self, X, start, end, threshold, change_points):
+        """Find change points in 'X' between the 'start' and 'end' index.
+
+        All change points are appended to 'change_points'.
+
+        Parameters
+        ----------
+        X : pd.Series
+            Timeseries data on which the change points will be found.
+        start : int
+            Starting index of the window in which the change points will be found.
+        end : int
+            Final index of the window in which the change points will be found. The
+            value at this index will be included in the window (inclusive).
+        threshold : float
+            Threshold for a change point to be kept.
+        change_points : list[int]
+            Indexes of change points. Newly detected change points are appended to this
+            list.
+        """
+        if end - start < 1:
+            return
+
+        costs = []
+        for change_point in range(start, end):
+            costs.append(self._cumsum_statistic(X, start, end, change_point))
+
+        if np.max(costs) > threshold:
+            new_change_point = start + np.argmax(costs)
+            change_points.append(new_change_point)
+            self._find_change_points(
+                X, start, new_change_point, threshold, change_points
+            )
+            self._find_change_points(
+                X, new_change_point + 1, end, threshold, change_points
+            )
+        else:
+            return
+
+    def _fit(self, X, Y=None):
+        return self
+
+    def _predict(self, X, Y=None):
+        """Find the change points on 'X'.
+
+        Parameters
+        ----------
+        X : pd.Series
+            Timeseries on which the change points will be detected.
+        Y : any
+            Unused argument. Included for compatability with sklearn.
+
+        Returns
+        -------
+        pd.Series
+            Series whose values are the indexes of the change points.
+        """
+        change_points = []
+        self._find_change_points(X, 0, len(X) - 1, self.threshold, change_points)
+        change_points.sort()
+        return pd.Series(X.index[change_points])
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            ``MyClass(**params)`` or ``MyClass(**params[i])`` creates a valid test
+            instance.
+            ``create_test_instance`` uses the first (or only) dictionary in ``params``
+        """
+        return {"threshold": 1}

--- a/sktime/annotation/bs.py
+++ b/sktime/annotation/bs.py
@@ -7,6 +7,8 @@ import pandas as pd
 
 from sktime.annotation.base._base import BaseSeriesAnnotator
 
+__author__ = ["Alex-JG3"]
+
 
 class BinarySegmentation(BaseSeriesAnnotator):
     """Binary segmentation change point detector.

--- a/sktime/annotation/bs.py
+++ b/sktime/annotation/bs.py
@@ -19,6 +19,10 @@ class BinarySegmentation(BaseSeriesAnnotator):
     threshold : float
         Threshold for the CUMSUM statistic. Change points that do not increase the
         CUMSUM statistic above this threshold are ignored.
+    min_cp_distance : int
+        Minimum distance between change points.
+    max_iter : int
+        Maximum number of interations before the found change points are returned.
 
     Notes
     -----
@@ -52,7 +56,7 @@ class BinarySegmentation(BaseSeriesAnnotator):
         "learning_type": "unsupervised",
     }
 
-    def __init__(self, threshold):
+    def __init__(self, threshold, min_cp_distance=0, max_iter=10000):
         self.threshold = threshold
         super().__init__()
 
@@ -94,7 +98,7 @@ class BinarySegmentation(BaseSeriesAnnotator):
 
         return np.abs(cumsum_statistic)
 
-    def _find_change_points(self, X, threshold, min_segment_length=0, max_iter=10000):
+    def _find_change_points(self, X, threshold, min_cp_distance=0, max_iter=10000):
         """Find change points in 'X' between the 'start' and 'end' index.
 
         All change points are appended to 'change_points'.
@@ -105,7 +109,7 @@ class BinarySegmentation(BaseSeriesAnnotator):
             Timeseries data on which the change points will be found.
         threshold : float
             Threshold for a change point to be kept.
-        min_segment_length : int
+        min_cp_distance : int
             Minimum distance between change points.
         max_iter : int
             Maximum number of interations before the found change points are returned.
@@ -132,8 +136,8 @@ class BinarySegmentation(BaseSeriesAnnotator):
 
             # Skip change points at the start and end of the segment to avoid segments
             # that are too small
-            cp_start = start + min_segment_length
-            cp_end = end - min_segment_length
+            cp_start = start + min_cp_distance
+            cp_end = end - min_cp_distance
 
             if cp_end <= cp_start:
                 continue
@@ -142,7 +146,7 @@ class BinarySegmentation(BaseSeriesAnnotator):
                 costs.append(self._cumsum_statistic(X, start, end, change_point))
 
             if np.max(costs) > threshold:
-                new_change_point = start + min_segment_length + np.argmax(costs)
+                new_change_point = start + min_cp_distance + np.argmax(costs)
                 change_points.append(new_change_point)
                 segment_indexes.append((start, new_change_point))
                 segment_indexes.append((new_change_point + 1, end))

--- a/sktime/annotation/bs.py
+++ b/sktime/annotation/bs.py
@@ -61,6 +61,8 @@ class BinarySegmentation(BaseSeriesAnnotator):
 
     def __init__(self, threshold, min_cp_distance=0, max_iter=10000):
         self.threshold = threshold
+        self.min_cp_distance = min_cp_distance
+        self.max_iter = max_iter
         super().__init__()
 
     def _cumsum_statistic(self, X, start, end, change_point):
@@ -174,7 +176,9 @@ class BinarySegmentation(BaseSeriesAnnotator):
         pd.Series
             Series whose values are the indexes of the change points.
         """
-        change_points = self._find_change_points(X, self.threshold)
+        change_points = self._find_change_points(
+            X, self.threshold, self.min_cp_distance, self.max_iter
+        )
         change_points.sort()
         return pd.Series(X.index[change_points])
 

--- a/sktime/annotation/tests/test_bs.py
+++ b/sktime/annotation/tests/test_bs.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+
+from sktime.annotation.bs import BinarySegmentation
+
+
+@pytest.mark.parametrize(
+    "X,expected_change_points",
+    [
+        (pd.Series([1, 1, 1, 1, 3, 3, 3, 3]), [3]),
+        (pd.Series([1, 1, 3, 3, -1, -1, 5, 5]), [1, 3, 5]),
+    ],
+)
+def test_find_change_points(X, expected_change_points):
+    change_points = []
+    model = BinarySegmentation(X)
+    model._find_change_points(X, 0, len(X) - 1, 1, change_points)
+    change_points.sort()
+    assert tuple(change_points) == tuple(expected_change_points)

--- a/sktime/annotation/tests/test_bs.py
+++ b/sktime/annotation/tests/test_bs.py
@@ -12,7 +12,40 @@ from sktime.annotation.bs import BinarySegmentation
     ],
 )
 def test_find_change_points(X, expected_change_points):
-    model = BinarySegmentation(X)
-    change_points = model._find_change_points(X, 1)
+    """Test the binary segmentation method for finding change points."""
+    model = BinarySegmentation(threshold=1)
+    change_points = model._find_change_points(X, threshold=1)
     change_points.sort()
-    assert tuple(change_points) == tuple(expected_change_points)
+    assert change_points == expected_change_points
+
+
+@pytest.mark.parametrize(
+    "X,expected_change_points",
+    [
+        (pd.Series([1, 1, 1, 1, 3, 3, 3, 3]), [3]),
+        (pd.Series([1, 1, 3, 3, -1, -1, 5, 5]), [1, 3, 5]),
+    ],
+)
+def test_fit_predict(X, expected_change_points):
+    """Tese the fit_predict method for binary segmentation."""
+    model = BinarySegmentation(threshold=1, min_cp_distance=1)
+    change_points = model.fit_predict(X)
+    assert change_points.values.tolist() == expected_change_points
+
+
+@pytest.mark.parametrize(
+    "X,expected_change_points,min_cp_distance",
+    [
+        (pd.Series([-5, -5, -5, -5, 5, 5, 3, 3]), [3, 5], 0),
+        (pd.Series([-5, -5, -5, -5, 5, 5, 3, 3]), [3, 5], 1),
+        (pd.Series([-5, -5, -5, -5, 5, 5, 3, 3]), [3], 2),
+        (pd.Series([-5, -5, -5, -5, 5, 5, 3, 3]), [3], 3),
+        (pd.Series([-5, -5, -5, -5, 5, 5, 3, 3]), [], 4),
+    ],
+)
+def test_min_seg_length(X, expected_change_points, min_cp_distance):
+    """Test the affect of change the minimum distance between change points."""
+    model = BinarySegmentation(X)
+    change_points = model._find_change_points(X, 1, min_cp_distance=min_cp_distance)
+    change_points.sort()
+    assert change_points == expected_change_points

--- a/sktime/annotation/tests/test_bs.py
+++ b/sktime/annotation/tests/test_bs.py
@@ -3,6 +3,8 @@ import pytest
 
 from sktime.annotation.bs import BinarySegmentation
 
+__author__ = ["Alex-JG3"]
+
 
 @pytest.mark.parametrize(
     "X,expected_change_points",

--- a/sktime/annotation/tests/test_bs.py
+++ b/sktime/annotation/tests/test_bs.py
@@ -12,8 +12,7 @@ from sktime.annotation.bs import BinarySegmentation
     ],
 )
 def test_find_change_points(X, expected_change_points):
-    change_points = []
     model = BinarySegmentation(X)
-    model._find_change_points(X, 0, len(X) - 1, 1, change_points)
+    change_points = model._find_change_points(X, 1)
     change_points.sort()
     assert tuple(change_points) == tuple(expected_change_points)


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs

Related to #6481.

#### What does this implement/fix? Explain your changes.

Implements binary segmentation as described in WILD BINARY SEGMENTATION FOR MULTIPLE
CHANGE-POINT DETECTION (https://arxiv.org/pdf/1411.0858).

#### Does your contribution introduce a new dependency? If yes, which one?

#### What should a reviewer concentrate their feedback on?

#### Did you add any tests for the change?

Yes, added tests for the algorithm in `test_bs.py`.

#### Any other comments?

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [x] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
