### PR TITLE
[MNT] suppress aggressive `freq` related warnings from `pandas 2.2`

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -171,7 +171,7 @@ def _check_freq(obj):
         return _extract_freq_from_cutoff(obj)
     elif isinstance(obj, str) or obj is None:
         with _suppress_pd22_warning:
-            offset = pd.to_offset(obj)
+            offset = to_offset(obj)
         return offset
     else:
         return None

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -28,6 +28,7 @@ from sktime.utils.validation.series import (
     is_in_valid_relative_index_types,
     is_integer_index,
 )
+from sktime.utils.warnings import _suppress_pd22_warning
 
 VALID_FORECASTING_HORIZON_TYPES = (int, list, np.ndarray, pd.Index)
 
@@ -169,7 +170,9 @@ def _check_freq(obj):
     elif isinstance(obj, (pd.Period, pd.Index)):
         return _extract_freq_from_cutoff(obj)
     elif isinstance(obj, str) or obj is None:
-        return to_offset(obj)
+        with _suppress_pd22_warning:
+            offset = pd.to_offset(obj)
+        return offset
     else:
         return None
 
@@ -397,7 +400,9 @@ class ForecastingHorizon:
             freq_from_self = None
 
         if freq_from_self is not None and freq_from_obj is not None:
-            if freq_from_self != freq_from_obj:
+            with _suppress_pd22_warning:
+                freqs_unequal = freq_from_self != freq_from_obj
+            if freqs_unequal:
                 raise ValueError(
                     "Frequencies from two sources do not coincide: "
                     f"Current: {freq_from_self}, from update: {freq_from_obj}."

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -14,6 +14,7 @@ import pandas as pd
 from sktime.datatypes import VectorizedDF
 from sktime.datatypes._utilities import get_time_index
 from sktime.utils.validation.series import check_time_index, is_integer_index
+from sktime.utils.warnings import _suppress_pd22_warning
 
 
 def _coerce_duration_to_int(
@@ -70,7 +71,8 @@ def _get_intervals_count_and_unit(freq: str) -> tuple[int, str]:
     if freq is None:
         raise ValueError("frequency is missing")
     else:
-        offset = pd.tseries.frequencies.to_offset(freq)
+        with _suppress_pd22_warning:
+            offset = pd.tseries.frequencies.to_offset(freq)
         count, unit = offset.n, offset.base.freqstr
         return count, unit
 

--- a/sktime/utils/warnings.py
+++ b/sktime/utils/warnings.py
@@ -2,6 +2,8 @@
 
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
+import re
+import warnings
 from warnings import warn as _warn
 
 __author__ = ["fkiraly"]
@@ -38,3 +40,42 @@ def warn(msg, category=None, obj=None, stacklevel=2):
         return _warn(msg, category=category, stacklevel=stacklevel)
     else:
         return None
+
+
+class _SuppressWarningPattern:
+    """Context manager to suppress warnings of a given type and message pattern.
+
+    Parameters
+    ----------
+    warning_type : type, warning class, e.g., FutureWarning
+        type of the warning
+    message_pattern : str, regex pattern
+        pattern to match the warning message
+    """
+    def __init__(self, warning_type, message_pattern):
+        self.warning_type = warning_type
+        self.message_pattern = re.compile(message_pattern)
+
+    def __enter__(self):
+        self.original_filters = warnings.filters[:]
+        warnings.simplefilter('default', self.warning_type)
+        self.original_showwarning = warnings.showwarning
+        warnings.showwarning = self._custom_showwarning
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        warnings.filters = self.original_filters
+        warnings.showwarning = self.original_showwarning
+
+    def _custom_showwarning(
+        self, message, category, filename, lineno, file=None, line=None
+    ):
+        right_type = issubclass(category, self.warning_type)
+        fits_pattern = self.message_pattern.search(str(message))
+        if not (right_type and fits_pattern):
+            self.original_showwarning(message, category, filename, lineno, file, line)
+
+
+_suppress_pd22_warning = _SuppressWarningPattern(
+    FutureWarning,
+    r"'[A-Z]+' is deprecated and will be removed in a future version, please use '[A-Z]+' instead",  # noqa
+)

--- a/sktime/utils/warnings.py
+++ b/sktime/utils/warnings.py
@@ -52,13 +52,14 @@ class _SuppressWarningPattern:
     message_pattern : str, regex pattern
         pattern to match the warning message
     """
+
     def __init__(self, warning_type, message_pattern):
         self.warning_type = warning_type
         self.message_pattern = re.compile(message_pattern)
 
     def __enter__(self):
         self.original_filters = warnings.filters[:]
-        warnings.simplefilter('default', self.warning_type)
+        warnings.simplefilter("default", self.warning_type)
         self.original_showwarning = warnings.showwarning
         warnings.showwarning = self._custom_showwarning
 


### PR DESCRIPTION
This PR adds suppressions for aggressive `freq` related warnings from `pandas 2.2`, as reported in https://github.com/sktime/sktime/issues/6694 (fixes #6694)

See https://github.com/sktime/sktime/issues/6245 for more permanent solutions