### PR TITLE
[MNT] updates and fixes to type hints

### DIFF
--- a/sktime/datatypes/_convert.py
+++ b/sktime/datatypes/_convert.py
@@ -65,7 +65,7 @@ __all__ = [
 ]
 
 from copy import deepcopy
-from typing import Union, List, Optional
+from typing import Union, Optional
 
 import numpy as np
 import pandas as pd
@@ -90,7 +90,7 @@ convert_dict.update(convert_dict_Proba)
 def convert(
     obj,
     from_type: str,
-    to_type: Union[str, List[str]],
+    to_type: Union[str, list[str]],
     as_scitype: Optional[str] = None,
     store=None,
     store_behaviour: Optional[str] = None,
@@ -191,8 +191,8 @@ def convert(
 # conversion based on queryable type to specified target
 def convert_to(
     obj,
-    to_type: Union[str, List[str]],
-    as_scitype: Optional[Union[str, List[str]]] = None,
+    to_type: Union[str, list[str]],
+    as_scitype: Optional[Union[str, list[str]]] = None,
     store=None,
     store_behaviour: Optional[str] = None,
     return_to_mtype: bool = False,

--- a/sktime/datatypes/_convert.py
+++ b/sktime/datatypes/_convert.py
@@ -65,6 +65,7 @@ __all__ = [
 ]
 
 from copy import deepcopy
+from typing import Union, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -89,10 +90,10 @@ convert_dict.update(convert_dict_Proba)
 def convert(
     obj,
     from_type: str,
-    to_type: str,
-    as_scitype: str = None,
+    to_type: Union[str, List[str]],
+    as_scitype: Optional[str] = None,
     store=None,
-    store_behaviour: str = None,
+    store_behaviour: Optional[str] = None,
     return_to_mtype: bool = False,
 ):
     """Convert objects between different machine representations, subject to scitype.
@@ -190,8 +191,8 @@ def convert(
 # conversion based on queryable type to specified target
 def convert_to(
     obj,
-    to_type: str,
-    as_scitype: str = None,
+    to_type: Union[str, List[str]],
+    as_scitype: Optional[Union[str, List[str]]] = None,
     store=None,
     store_behaviour: str = None,
     return_to_mtype: bool = False,

--- a/sktime/datatypes/_convert.py
+++ b/sktime/datatypes/_convert.py
@@ -194,7 +194,7 @@ def convert_to(
     to_type: Union[str, List[str]],
     as_scitype: Optional[Union[str, List[str]]] = None,
     store=None,
-    store_behaviour: str = None,
+    store_behaviour: Optional[str] = None,
     return_to_mtype: bool = False,
 ):
     """Convert object to a different machine representation, subject to scitype.

--- a/sktime/datatypes/_convert.py
+++ b/sktime/datatypes/_convert.py
@@ -65,7 +65,7 @@ __all__ = [
 ]
 
 from copy import deepcopy
-from typing import Union, Optional
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -91,9 +91,9 @@ def convert(
     obj,
     from_type: str,
     to_type: Union[str, list[str]],
-    as_scitype: Optional[str] = None,
+    as_scitype: str = None,
     store=None,
-    store_behaviour: Optional[str] = None,
+    store_behaviour: str = None,
     return_to_mtype: bool = False,
 ):
     """Convert objects between different machine representations, subject to scitype.
@@ -192,9 +192,9 @@ def convert(
 def convert_to(
     obj,
     to_type: Union[str, list[str]],
-    as_scitype: Optional[Union[str, list[str]]] = None,
+    as_scitype: Union[str, list[str]] = None,
     store=None,
-    store_behaviour: Optional[str] = None,
+    store_behaviour: str = None,
     return_to_mtype: bool = False,
 ):
     """Convert object to a different machine representation, subject to scitype.


### PR DESCRIPTION
## Description
Fix Several type check warnings reported by Pyre@Google, which were outdated after code modifications.

## Detail
1. update the argument `to_type` in function `convert` from `str` to `Union[str, List[str]]`, since it could be str or list of str after commit 0094f868c2930ceb3f246972dd34d15348469809
2. update the argument `as_scitype` in function `convert` from `str` to `Optional[str]`, since it could be str or None after commit 105ad4c4411fefbdc8ad587727f666a41a47ad1c 
3. update the argument `store_behaviour` in function `convert` from `str` to `Optional[str]`, since it could be str or None after commit b02a98b55c30b9fee3ab82af4c2636b03472022
4. update the argument `to_type` in function `convert_to` from `str` to `Union[str, List[str]]`, since it could be str or list of str after commit b6e02967998e9d9a55dff9f9e28f538e7f51d558
5. update the argument `as_scitype` in function `convert_to` from `str` to `Optional[Union[str, List[str]]]`, since it could be str ,None, or list of str after commit b6e02967998e9d9a55dff9f9e28f538e7f51d558
6. update the argument `store_behaviour` in function `convert_to` from `str` to `Optional[str]`, since it could be str or None after commit b02a98b55c30b9fee3ab82af4c2636b03472022