### PR TITLE
[BUG] Fix bug when predicting segments from clasp change point annotator

### DIFF
--- a/sktime/annotation/base/_base.py
+++ b/sktime/annotation/base/_base.py
@@ -365,7 +365,9 @@ class BaseSeriesAnnotator(BaseEstimator):
         X = check_series(X)
 
         if self.task == "change_point_detection":
-            return self.segments_to_change_points(self.predict_points(X))
+            return self.change_points_to_segments(
+                self.predict_points(X), start=X.index.min(), end=X.index.max()
+            )
         elif self.task == "segmentation":
             return self._predict_segments(X)
 

--- a/sktime/annotation/tests/test_clasp.py
+++ b/sktime/annotation/tests/test_clasp.py
@@ -4,6 +4,7 @@ __author__ = ["patrickzib"]
 __all__ = []
 
 import pytest
+from pandas.api.types import is_interval_dtype
 
 from sktime.annotation.clasp import ClaSPSegmentation
 from sktime.datasets import load_gun_point_segmentation
@@ -54,3 +55,26 @@ def test_clasp_dense():
     assert len(changepoint_indicator) == len(ts)
     # no longer true because predict_scores is always sparse
     # assert np.argmax(profile) == 893
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ClaSPSegmentation),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_clasp_predict_segments():
+    """Tests predict_segments for ClaSP.
+
+    Check the output is the correct data type.
+    """
+    # load the test dataset
+    ts, period_size, cps = load_gun_point_segmentation()
+
+    # compute a ClaSP segmentation
+    clasp = ClaSPSegmentation(period_size, n_cps=1)
+    clasp.fit(ts)
+
+    segments = clasp.predict_segments(ts)
+
+    assert len(segments) == 2  # With one change point there should be 2 two segments
+    assert is_interval_dtype(segments.index)
+    assert segments.index[-1].left == 893


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs

Closes #6741.

#### What does this implement/fix? Explain your changes.

The `predict_segments` method was failing for change point detection algorithm because it was calling `segments_to_change_points` not `change_points_to_segments`.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### Did you add any tests for the change?

No but it highlights the need for better annotation module tests. I will open a related issue.

#### Any other comments?

The original issue contained a minimal example demonstrating the bug. This is now fixed.

```python
# main.py

from sktime.annotation.clasp import ClaSPSegmentation
from sktime.datasets import load_gun_point_segmentation                                                                                                                                   from sktime.tests.test_switch import run_test_for_class
 
ts, period_size, cps = load_gun_point_segmentation()

clasp = ClaSPSegmentation(period_size, n_cps=1)
clasp.fit(ts)

segments = clasp.predict_segments(ts)                                                                                                                                                      print(segments)
```

Here is the output from `main.py`.

```python
$ python main.py
[1, 893)      -1
[893, 1875)    1
dtype: int64
```

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
