### PR TITLE
[DOC] Modify editable install to make cross-platform

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -16,6 +16,7 @@ See here for a `full list of precompiled wheels available on PyPI <https://pypi.
 For frequent issues with installation, consult the `Release versions - troubleshooting`_ section.
 
 There are three different installation types:
+
 * Installing sktime releases
 * Installing the latest sktime development version
 * For developers of sktime and 3rd party extensions: Developer setup
@@ -135,7 +136,7 @@ For a developer install that updates the package each time the local source code
 
 .. code-block:: bash
 
-    pip install --editable .[dev]
+    pip install --editable '.[dev]'
 
 This allows editing and extending the code in-place. See also
 `pip reference on editable installs <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_).


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
- add apostrophes to make dev install cross-platform (doesn't work on ~Mac~ `zsh` without apostrophes)
- Add indent before "install options" bullets to fix formatting


#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?


#### Did you add any tests for the change?
No

#### Any other comments?
Issue with apostrophes was discovered at SciPy sprint

#### PR checklist


##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

