### PR TITLE
[ENH] add second test params dict to Aggregator

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2894,6 +2894,16 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "fr1ll",
+      "name": "Will Sanger",
+      "avatar_url": "https://avatars.githubusercontent.com/u/29168593?v=4",
+      "profile": "https://github.com/fr1ll",
+      "contributions": [
+        "code",
+        "doc"
+      ]
     }
   ]
 }

--- a/sktime/transformations/hierarchical/aggregate.py
+++ b/sktime/transformations/hierarchical/aggregate.py
@@ -201,9 +201,10 @@ class Aggregator(BaseTransformer):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
-        params = {"flatten_single_levels": True}
+        param1 = {"flatten_single_levels": True}
+        param2 = {"flatten_single_levels": False}
 
-        return params
+        return [param1, param2]
 
 
 def _check_index_no_total(X):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes part of #3429.

#### What does this implement/fix? Explain your changes.

Adds second test parameter to `Aggregator` transformation

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

#### Did you add any tests for the change?

No

#### Any other comments?


#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.