### PR TITLE
[DOC] TruncationTransformer New Example

### DIFF
--- a/sktime/transformations/panel/truncation.py
+++ b/sktime/transformations/panel/truncation.py
@@ -21,11 +21,12 @@ class TruncationTransformer(BaseTransformer):
     upper : int, optional (default=None) maximum length, exclusive
                 This is used to calculate the range between.
                 If None, will truncate to the lower bound.
+
     Examples
     --------
     >>> from sktime.transformations.panel.truncation import TruncationTransformer
     >>> from sktime.utils._testing.hierarchical import _make_hierarchical
-    >>> X = _make_hierarchical(min_timepoints=3, max_timepoints=5, same_cutoff=False)
+    >>> X = _make_hierarchical(same_cutoff=False)
     >>> tt = TruncationTransformer()
     >>> tt.fit(X)
     >>> X_transformed = tt.transform(X)

--- a/sktime/transformations/panel/truncation.py
+++ b/sktime/transformations/panel/truncation.py
@@ -10,19 +10,25 @@ __author__ = ["abostrom"]
 
 
 class TruncationTransformer(BaseTransformer):
-    """Truncate unequal length panels to lower/upper bounds.
-
-    Truncates all series in panel between lower/upper range bounds.
+    """
+    Truncates unequal length panels between lower/upper length ranges.
 
     Parameters
     ----------
-    lower : int, optional (default=None) bottom range of the values to
-                truncate can also be used to truncate to a specific length
-                if None, will find the shortest sequence and use instead.
-    upper : int, optional (default=None) upper range, only required when
-                paired with lower.
-                This is used to calculate the range between. exclusive.
-                if None, will truncate from 0 to the lower bound.
+    lower : int, optional (default=None) minimum length, inclusive
+                Cannot be less than the length of the shortest series in the panel.
+                If None, will find the length of the shortest series and use instead.
+    upper : int, optional (default=None) maximum length, exclusive
+                This is used to calculate the range between.
+                If None, will truncate to the lower bound.
+    Examples
+    --------
+    >>> from sktime.transformations.panel.truncation import TruncationTransformer
+    >>> from sktime.utils._testing.hierarchical import _make_hierarchical
+    >>> X = _make_hierarchical(min_timepoints=3, max_timepoints=5, same_cutoff=False)
+    >>> tt = TruncationTransformer()
+    >>> tt.fit(X)
+    >>> X_transformed = tt.transform(X)
     """
 
     _tags = {


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->


#### What does this implement/fix? Explain your changes.
Added an example to the documentation for trunctransformer, and clarified the wording a bit.

#### Does your contribution introduce a new dependency? If yes, which one?

Nope.

#### What should a reviewer concentrate their feedback on?

Does the example work? Is it a clearer description?

#### Did you add any tests for the change?

No new test functions, since it's just documentation, but I did test that the example works

#### Any other comments?

I'm at SciPy 2024 learning about contributing to open source!

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
