### PR TITLE
[MNT] improved environment package version check

### DIFF
--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -285,7 +285,7 @@ def _get_installed_packages_private():
     by accident.
     """
     dists = distributions()
-    packages = {dist.metadata['Name']: dist.version for dist in dists}
+    packages = {dist.metadata["Name"]: dist.version for dist in dists}
     return packages
 
 

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -301,7 +301,6 @@ def _get_installed_packages():
     return _get_installed_packages_private().copy()
 
 
-@lru_cache
 def _get_pkg_version(package_name, package_import_name=None):
     """Check whether package is available in environment, and return its version if yes.
 

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -2,10 +2,10 @@
 
 __author__ = ["fkiraly", "mloning"]
 
-import subprocess
 import sys
 import warnings
 from functools import lru_cache
+from importlib.metadata import distributions
 from importlib.util import find_spec
 from inspect import isclass
 
@@ -284,24 +284,8 @@ def _get_installed_packages_private():
     Same as _get_installed_packages, but internal to avoid mutating the lru_cache
     by accident.
     """
-    result = subprocess.run(  # noqa: S603
-        ["pip", "list", "--format=json"],  # noqa: S607
-        capture_output=True,
-        text=True,
-    )
-    packages = {}
-    if result.returncode == 0:
-        package_list = result.stdout
-        import json
-
-        package_data = json.loads(package_list)
-        for package in package_data:
-            packages[package["name"]] = package["version"]
-    else:
-        raise RuntimeError(
-            "Error in _get_installed_package - pip list command failed."
-            f"Return code: {result.returncode}, stderr: {result.stderr}"
-        )
+    dists = distributions()
+    packages = {dist.metadata['Name']: dist.version for dist in dists}
     return packages
 
 

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -285,8 +285,8 @@ def _get_installed_packages_private():
     by accident.
     """
     result = subprocess.run(
-        ["pip", "list", "--format=json"], capture_output=True, text=True  # noqa: S603, S607
-    )
+        ["pip", "list", "--format=json"], capture_output=True, text=True
+    )  # noqa: S603, S607
     packages = {}
     if result.returncode == 0:
         package_list = result.stdout

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -284,13 +284,14 @@ def _get_installed_packages_private():
     Same as _get_installed_packages, but internal to avoid mutating the lru_cache
     by accident.
     """
-    result = subprocess.run(
-        ["pip", "list", "--format=json"], capture_output=True, text=True
-    )  # noqa: S603, S607
+    result = subprocess.run(  # noqa: S603
+        ["pip", "list", "--format=json"], capture_output=True, text=True  # noqa: S607
+    )
     packages = {}
     if result.returncode == 0:
         package_list = result.stdout
         import json
+
         package_data = json.loads(package_list)
         for package in package_data:
             packages[package["name"]] = package["version"]

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -285,9 +285,7 @@ def _get_installed_packages_private():
     by accident.
     """
     result = subprocess.run(  # noqa: S603
-        ["pip", "list", "--format=json"],  # noqa: S607
-        capture_output=True,
-        text=True,
+        ["pip", "list", "--format=json"], capture_output=True, text=True  # noqa: S607
     )
     packages = {}
     if result.returncode == 0:

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -285,7 +285,9 @@ def _get_installed_packages_private():
     by accident.
     """
     result = subprocess.run(  # noqa: S603
-        ["pip", "list", "--format=json"], capture_output=True, text=True  # noqa: S607
+        ["pip", "list", "--format=json"],  # noqa: S607
+        capture_output=True,
+        text=True,
     )
     packages = {}
     if result.returncode == 0:

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -284,14 +284,16 @@ def _get_installed_packages_private():
     Same as _get_installed_packages, but internal to avoid mutating the lru_cache
     by accident.
     """
-    result = subprocess.run(['pip', 'list', '--format=json'], capture_output=True, text=True)
+    result = subprocess.run(
+        ["pip", "list", "--format=json"], capture_output=True, text=True  # noqa: S603, S607
+    )
     packages = {}
     if result.returncode == 0:
         package_list = result.stdout
         import json
         package_data = json.loads(package_list)
         for package in package_data:
-            packages[package['name']] = package['version']
+            packages[package["name"]] = package["version"]
     else:
         raise RuntimeError(
             "Error in _get_installed_package - pip list command failed."

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -18,7 +18,7 @@ from packaging.version import InvalidVersion, Version
 # todo 0.32.0: remove suppress_import_stdout argument
 def _check_soft_dependencies(
     *packages,
-    package_import_alias=None,
+    package_import_alias="deprecated",
     severity="error",
     obj=None,
     msg=None,
@@ -38,19 +38,24 @@ def _check_soft_dependencies(
         `_check_soft_dependencies("package1", "package2")`
         `_check_soft_dependencies(("package1", "package2"))`
         `_check_soft_dependencies(["package1", "package2"])`
+
     package_import_alias : ignored, present only for backwards compatibility
+
     severity : str, "error" (default), "warning", "none"
         behaviour for raising errors or warnings
-        "error" - raises a `ModuleNotFoundError` if one of packages is not installed
-        "warning" - raises a warning if one of packages is not installed
-            function returns False if one of packages is not installed, otherwise True
-        "none" - does not raise exception or warning
-            function returns False if one of packages is not installed, otherwise True
+
+        * "error" - raises a `ModuleNotFoundError` if one of packages is not installed
+        * "warning" - raises a warning if one of packages is not installed
+          function returns False if one of packages is not installed, otherwise True
+        * "none" - does not raise exception or warning
+          function returns False if one of packages is not installed, otherwise True
+
     obj : python class, object, str, or None, default=None
         if self is passed here when _check_soft_dependencies is called within __init__,
         or a class is passed when it is called at the start of a single-class module,
         the error message is more informative and will refer to the class/object;
         if str is passed, will be used as name of the class/object or module
+
     msg : str, or None, default=None
         if str, will override the error message or warning shown with msg
 

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -2,10 +2,10 @@
 
 __author__ = ["fkiraly", "mloning"]
 
+import subprocess
 import sys
 import warnings
 from functools import lru_cache
-from importlib.metadata import distributions
 from importlib.util import find_spec
 from inspect import isclass
 
@@ -284,8 +284,24 @@ def _get_installed_packages_private():
     Same as _get_installed_packages, but internal to avoid mutating the lru_cache
     by accident.
     """
-    dists = distributions()
-    packages = {dist.metadata['Name']: dist.version for dist in dists}
+    result = subprocess.run(  # noqa: S603
+        ["pip", "list", "--format=json"],  # noqa: S607
+        capture_output=True,
+        text=True,
+    )
+    packages = {}
+    if result.returncode == 0:
+        package_list = result.stdout
+        import json
+
+        package_data = json.loads(package_list)
+        for package in package_data:
+            packages[package["name"]] = package["version"]
+    else:
+        raise RuntimeError(
+            "Error in _get_installed_package - pip list command failed."
+            f"Return code: {result.returncode}, stderr: {result.stderr}"
+        )
     return packages
 
 


### PR DESCRIPTION
This PR switches out the current logic in the dependency checking module for retrieving installed package versions:

* all installed packages and their versions are queried only once and are cached, preventing additional runtime for any repeated checks
* the internal logic uses `importlib.metadata.distributions` directly
* as a consequence, package aliases and the install name are no longer needed, so given this we could even deprecate the respective tags (which are regularly leading to developer confusion)

The idea for this PR was contibuted by @dinobektesevic (using `pip`, but this is now using `importlib` instead)