### PR TITLE
[MNT] Update `Callable` import from `typing` to `collections.abc`

### DIFF
--- a/sktime/annotation/eagglo.py
+++ b/sktime/annotation/eagglo.py
@@ -1,7 +1,7 @@
 """E-Agglo: agglomerative clustering algorithm that preserves observation order."""
 
 import warnings
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import pandas as pd

--- a/sktime/benchmarking/_base_kotsu.py
+++ b/sktime/benchmarking/_base_kotsu.py
@@ -2,7 +2,8 @@
 
 import re
 import warnings
-from typing import Callable, Optional, Union
+from collections.abc import Callable
+from typing import Optional, Union
 
 from sktime.benchmarking._lib_mini_kotsu.registration import _Registry, _Spec
 

--- a/sktime/benchmarking/_lib_mini_kotsu/registration.py
+++ b/sktime/benchmarking/_lib_mini_kotsu/registration.py
@@ -10,7 +10,8 @@ import importlib
 import logging
 import re
 import warnings
-from typing import Callable, Generic, Optional, TypeVar, Union
+from collections.abc import Callable
+from typing import Generic, Optional, TypeVar, Union
 
 logger = logging.getLogger(__name__)
 

--- a/sktime/benchmarking/benchmarks.py
+++ b/sktime/benchmarking/benchmarks.py
@@ -3,7 +3,8 @@
 Wraps kotsu benchmarking package.
 """
 
-from typing import Callable, Optional, Union
+from collections.abc import Callable
+from typing import Optional, Union
 
 import pandas as pd
 

--- a/sktime/benchmarking/forecasting.py
+++ b/sktime/benchmarking/forecasting.py
@@ -1,7 +1,8 @@
 """Benchmarking for forecasting estimators."""
 
 import functools
-from typing import Callable, Optional, Union
+from collections.abc import Callable
+from typing import Optional, Union
 
 from sktime.benchmarking.benchmarks import BaseBenchmark
 from sktime.forecasting.base import BaseForecaster

--- a/sktime/benchmarking/tests/test_benchmarks.py
+++ b/sktime/benchmarking/tests/test_benchmarks.py
@@ -1,6 +1,6 @@
 """Benchmarks tests."""
 
-from typing import Callable
+from collections.abc import Callable
 
 import pandas as pd
 import pytest

--- a/sktime/clustering/k_means/_k_means.py
+++ b/sktime/clustering/k_means/_k_means.py
@@ -1,8 +1,8 @@
 """Time series kmeans."""
 
 __author__ = ["chrisholder", "TonyBagnall"]
-
-from typing import Callable, Union
+from collections.abc import Callable
+from typing import Union
 
 import numpy as np
 from numpy.random import RandomState

--- a/sktime/clustering/k_medoids.py
+++ b/sktime/clustering/k_medoids.py
@@ -1,8 +1,8 @@
 """Time series kmedoids."""
 
 __author__ = ["chrisholder", "TonyBagnall"]
-
-from typing import Callable, Union
+from collections.abc import Callable
+from typing import Union
 
 import numpy as np
 from numpy.random import RandomState

--- a/sktime/clustering/metrics/averaging/_averaging.py
+++ b/sktime/clustering/metrics/averaging/_averaging.py
@@ -2,7 +2,7 @@
 
 __author__ = ["chrisholder", "TonyBagnall"]
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 

--- a/sktime/clustering/partitioning/_lloyds.py
+++ b/sktime/clustering/partitioning/_lloyds.py
@@ -1,7 +1,7 @@
 __author__ = ["chrisholder", "TonyBagnall"]
-
 from abc import abstractmethod
-from typing import Callable, Union
+from collections.abc import Callable
+from typing import Union
 
 import numpy as np
 from numpy.random import RandomState

--- a/sktime/clustering/tests/test_lloyds.py
+++ b/sktime/clustering/tests/test_lloyds.py
@@ -1,6 +1,6 @@
 """Tests for time series Lloyds partitioning."""
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import pytest

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -1153,13 +1153,13 @@ if _check_soft_dependencies("gluonts", severity="none"):
         convert_gluonts_listDataset_to_pandas
     )
 
-    convert_dict[
-        ("pd-multiindex", "gluonts_PandasDataset_panel", "Panel")
-    ] = convert_pandas_multiindex_to_gluonts_pandasDataset
+    convert_dict[("pd-multiindex", "gluonts_PandasDataset_panel", "Panel")] = (
+        convert_pandas_multiindex_to_gluonts_pandasDataset
+    )
 
-    convert_dict[
-        ("gluonts_PandasDataset_panel", "pd-multiindex", "Panel")
-    ] = convert_gluonts_pandasDataset_to_pandas_multiindex
+    convert_dict[("gluonts_PandasDataset_panel", "pd-multiindex", "Panel")] = (
+        convert_gluonts_pandasDataset_to_pandas_multiindex
+    )
 
     # Extending conversions
     _extend_conversions(

--- a/sktime/distances/_ddtw.py
+++ b/sktime/distances/_ddtw.py
@@ -1,7 +1,7 @@
 __author__ = ["chrisholder", "TonyBagnall"]
 
-
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 

--- a/sktime/distances/_distance.py
+++ b/sktime/distances/_distance.py
@@ -1,7 +1,7 @@
 __author__ = ["chrisholder", "TonyBagnall"]
 
-
-from typing import Any, Callable, Union
+from collections.abc import Callable
+from typing import Any, Union
 
 import numpy as np
 

--- a/sktime/distances/_numba_utils.py
+++ b/sktime/distances/_numba_utils.py
@@ -1,6 +1,6 @@
 __author__ = ["chrisholder", "TonyBagnall"]
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 

--- a/sktime/distances/_resolve_metric.py
+++ b/sktime/distances/_resolve_metric.py
@@ -1,7 +1,7 @@
 __author__ = ["chrisholder", "TonyBagnall"]
-
 import inspect
-from typing import Callable, Union
+from collections.abc import Callable
+from typing import Union
 
 import numpy as np
 

--- a/sktime/distances/base/_base.py
+++ b/sktime/distances/base/_base.py
@@ -1,7 +1,7 @@
 __author__ = ["chrisholder", "TonyBagnall"]
-
 from abc import abstractmethod
-from typing import Callable, NamedTuple
+from collections.abc import Callable
+from typing import NamedTuple
 
 import numpy as np
 

--- a/sktime/distances/base/_types.py
+++ b/sktime/distances/base/_types.py
@@ -7,8 +7,8 @@ __all__ = [
     "ValidCallableTypes",
     "AlignmentPathReturn",
 ]
-
-from typing import Callable, Union
+from collections.abc import Callable
+from typing import Union
 
 import numpy as np
 

--- a/sktime/distances/tests/_shared_tests.py
+++ b/sktime/distances/tests/_shared_tests.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import pytest

--- a/sktime/distances/tests/_utils.py
+++ b/sktime/distances/tests/_utils.py
@@ -1,5 +1,5 @@
 import time
-from typing import Callable
+from collections.abc import Callable
 
 from sktime.datatypes import convert_to
 from sktime.utils._testing.panel import _make_panel_X

--- a/sktime/distances/tests/test_numba_distance_parameters.py
+++ b/sktime/distances/tests/test_numba_distance_parameters.py
@@ -1,6 +1,6 @@
 """Test suite for numba distances with parameters."""
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import pytest

--- a/sktime/distances/tests/test_numba_distances.py
+++ b/sktime/distances/tests/test_numba_distances.py
@@ -2,7 +2,7 @@
 
 __author__ = ["chrisholder"]
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import pytest

--- a/sktime/distances/tests/test_pairwise_distances.py
+++ b/sktime/distances/tests/test_pairwise_distances.py
@@ -2,7 +2,7 @@
 
 __author__ = ["chrisholder"]
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import pytest

--- a/sktime/forecasting/compose/_skforecast_reduce.py
+++ b/sktime/forecasting/compose/_skforecast_reduce.py
@@ -1,7 +1,8 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements back-adapters for skforecast reduction models."""
 
-from typing import Callable, Optional, Union
+from collections.abc import Callable
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd

--- a/sktime/utils/_testing/_conditional_fixtures.py
+++ b/sktime/utils/_testing/_conditional_fixtures.py
@@ -7,8 +7,8 @@ __author__ = ["fkiraly"]
 
 __all__ = ["create_conditional_fixtures_and_names"]
 
+from collections.abc import Callable
 from copy import deepcopy
-from typing import Callable
 
 import numpy as np
 


### PR DESCRIPTION
As per official [documentation](https://docs.python.org/3.9/library/typing.html#typing.Callable), `typing.Callable` is deprecated in favour of `collections.abc.Callable`. This PR makes the corresponding changes in the imports, plus one fix single extra formatting issue in `sktime/datatypes/_panel/_convert.py`.