### PR TITLE
[ENH] enable multivariate data passed to `autots` interface

### DIFF
--- a/sktime/forecasting/autots.py
+++ b/sktime/forecasting/autots.py
@@ -207,7 +207,7 @@ class AutoTS(BaseForecaster):
     """
 
     _tags = {
-        "scitype:y": "univariate",
+        "scitype:y": "both",
         "authors": ["winedarksea", "MBristle"],  # winedarksea for autots library
         "maintainers": ["MBristle"],
         "y_inner_mtype": "pd.DataFrame",


### PR DESCRIPTION
This PR enables by tag the passing of multivariate data to `AutoTS`.

This does not change any internal logic, it's just a check whether passing of multivariate data was disabled by mistake.