### PR TITLE
&yarnabrina [DOC] cross-reference estimator search from tags API reference

### DIFF
--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -20,7 +20,7 @@ This API reference lists all tags available in ``sktime``, and key utilities
 for their usage.
 
 To search estimators by tags on the ``sktime`` webpage, use the
-`Estimator Search Page <https://www.sktime.net/en/latest/estimator_overview.html>`_
+:doc:`Estimator Search Page </estimator_overview>`_
 
 
 Inspecting tags, retrieving by tags

--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -20,7 +20,7 @@ This API reference lists all tags available in ``sktime``, and key utilities
 for their usage.
 
 To search estimators by tags on the ``sktime`` webpage, use the
-:doc:`Estimator Search Page </estimator_overview>`_
+:doc:`Estimator Search Page </estimator_overview>`
 
 
 Inspecting tags, retrieving by tags

--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -19,9 +19,14 @@ for this tag.
 This API reference lists all tags available in ``sktime``, and key utilities
 for their usage.
 
+To search estimators by tags on the ``sktime`` webpage, use the
+`Estimator Search Page <https://www.sktime.net/en/latest/estimator_overview.html>`_
+
 
 Inspecting tags, retrieving by tags
 -----------------------------------
+
+Tags can be inspected at runtime using the following utilities:
 
 * to get the tags of an object, use the ``get_tags`` method.
   An object's tags can depend on its hyper-parameters.


### PR DESCRIPTION
This small PR adds a cross-reference to the estimator search at the start of the tags API reference.