### PR TITLE
[BUG] fix `MSTL` inverse transform and use in forecasting pipeline

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -608,7 +608,7 @@ class BaseTransformer(BaseEstimator):
         # input check and conversion for X/y
         X_inner, y_inner, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
 
-        if not isinstance(X_inner, VectorizedDF):
+        if not self._is_vectorized:
             Xt = self._transform(X=X_inner, y=y_inner)
         else:
             # otherwise we call the vectorized version of predict
@@ -767,7 +767,9 @@ class BaseTransformer(BaseEstimator):
         # input check and conversion for X/y
         X_inner, y_inner, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
 
-        if not isinstance(X_inner, VectorizedDF):
+        if not self._is_vectorized:
+            if isinstance(X_inner, VectorizedDF):
+                X_inner = X_inner.X_multiindex
             Xt = self._inverse_transform(X=X_inner, y=y_inner)
         else:
             # otherwise we call the vectorized version of predict

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -477,6 +477,7 @@ class BaseTransformer(BaseEstimator):
         # skip everything if fit_is_empty is True and we do not need to remember data
         if self.get_tag("fit_is_empty") and not self.get_tag("remember_data", False):
             self._is_fitted = True
+            self._is_vectorized = "unknown"
             return self
 
         # if requires_X is set, X is required in fit and update
@@ -608,7 +609,14 @@ class BaseTransformer(BaseEstimator):
         # input check and conversion for X/y
         X_inner, y_inner, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
 
-        if not self._is_vectorized:
+        # check if we need to vectorize
+        if self._is_vectorized == "unknown":
+            vectorization_needed = isinstance(X_inner, VectorizedDF)
+        else:
+            vectorization_needed = self._is_vectorized
+
+        # if no vectorization needed, we call _transform directly
+        if not vectorization_needed:
             Xt = self._transform(X=X_inner, y=y_inner)
         else:
             # otherwise we call the vectorized version of predict
@@ -767,7 +775,19 @@ class BaseTransformer(BaseEstimator):
         # input check and conversion for X/y
         X_inner, y_inner, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
 
-        if not self._is_vectorized:
+        # check if we need to vectorize
+        if self._is_vectorized == "unknown":
+            vectorization_needed = isinstance(X_inner, VectorizedDF)
+        else:
+            vectorization_needed = self._is_vectorized
+
+        # if no vectorization needed, we call _inverse_transform directly
+        if not vectorization_needed:
+            # capture edge condition where:
+            # transformer is univariate, transform produces multivariate
+            # in this case the check_X_y will convert to VectorizedDF,
+            # but inverse_transform expects a DataFrame
+            # example: time series decomposition algorithms
             if isinstance(X_inner, VectorizedDF):
                 X_inner = X_inner.X_multiindex
             Xt = self._inverse_transform(X=X_inner, y=y_inner)
@@ -897,7 +917,12 @@ class BaseTransformer(BaseEstimator):
               e.g., `[componentname]__[componentcomponentname]__[paramname]`, etc
         """
         # if self is not vectorized, run the default get_fitted_params
-        if not getattr(self, "_is_vectorized", False):
+        # the condition is: _is_vectorized is boolean, False, or "unknown"
+        is_vectorized = getattr(self, "_is_vectorized", False)
+        is_not_vectorized = isinstance(is_vectorized, bool) and not is_vectorized
+        is_not_vectorized = is_not_vectorized or is_vectorized == "unknown"
+
+        if is_not_vectorized:
             return super().get_fitted_params(deep=deep)
 
         # otherwise, we delegate to the instances' get_fitted_params

--- a/sktime/transformations/series/detrend/mstl.py
+++ b/sktime/transformations/series/detrend/mstl.py
@@ -239,7 +239,7 @@ class MSTL(BaseTransformer):
         # for inverse transform, we sum up the columns
         # this will be close if return_components=True
         row_sums = X.sum(axis=1)
-        row_sums.columns = self.fit_column_names
+        row_sums.name = self._X.name
         return row_sums
 
     def _make_return_object(self, X, mstl):

--- a/sktime/transformations/series/detrend/mstl.py
+++ b/sktime/transformations/series/detrend/mstl.py
@@ -20,16 +20,21 @@ class MSTL(BaseTransformer):
 
     ``fit`` stores the decomposed values in self.trend_, self.seasonal_, and
     self.resid_.
+
     If ``return_components=False``, then ``transform`` returns a pd.Series of the
-    deseasonalized values. The seasonal and residual components can be found in
+    deseasonalized values, i.e., trend plus residual component.
+    The individual seasonal and residual components can be found in
     self.trend_ and self.resid_.
-    If ``return_components=True``, then ``transform`` returns the transformed series, as
-    well as three components as variables in the returned multivariate series
-    (DataFrame cols)
-        "transformed" - the transformed series
-        "seasonal" - the seasonal component(s), summed up if multiple
-        "trend" - the trend component
-        "resid" - the residuals after de-trending, de-seasonalizing
+
+    If ``return_components=True``, then ``transform`` returns
+    a full components decomposition,
+    in a DataFrame with cols (for each input column):
+
+    * "seasonal_<period>" - the seasonal component(s),
+      where <period> is an integer indicating the periodicity,
+      one such component per element in ``periods``
+    * "trend" - the trend component
+    * "resid" - the residuals after de-trending, de-seasonalizing
 
     ``MSTL`` performs ``inverse_transform`` by summing any components,
     and can be used for pipelining in a ``TransformedTargetForecaster``.

--- a/sktime/transformations/series/detrend/mstl.py
+++ b/sktime/transformations/series/detrend/mstl.py
@@ -279,7 +279,10 @@ class MSTL(BaseTransformer):
         # for inverse transform, we sum up the columns
         # this will be close if return_components=True
         if self.return_components or self.periods is None:
-            row_sums = X.sum(axis=1)
+            if isinstance(X, pd.DataFrame):
+                row_sums = X.sum(axis=1)
+            else:
+                row_sums = X
             row_sums.name = self._X.name
             return row_sums
         # otherwise, we make naive seasonal forecasts, and add them to "transformed"

--- a/sktime/transformations/series/detrend/mstl.py
+++ b/sktime/transformations/series/detrend/mstl.py
@@ -119,7 +119,11 @@ class MSTL(BaseTransformer):
     >>> plt.tight_layout()  # doctest: +SKIP
     >>> plt.show()  # doctest: +SKIP
 
-    MSTL can be pipelined with a forecaster for multiple deseasonalized forecasts:
+    MSTL can be pipelined with a forecaster for multiple deseasonalized forecasts.
+    The following example uses a simple trend forecaster, applied
+    to a series deseasonalized with MSTL at periods 2 and 12.
+    After the trend forecast, the seasonal components
+    are added back to the forecast automatically.
     >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.detrend import MSTL
     >>> from sktime.forecasting.trend import TrendForecaster
@@ -130,9 +134,17 @@ class MSTL(BaseTransformer):
     >>> mstl_deseason_fcst.fit(y, fh=[1, 2, 3])
     >>> y_pred = mstl_deseason_fcst.predict()
 
-    To make forecasts using the full component decomposition,
-    set ``return_components=True``. The forecaster will then see
-    a multivariate series with the components as columns:
+    MSTL can also be used to make forecasts using the full component decomposition.
+    For this, set ``return_components=True`` when pipelining.
+    The forecaster in the pipeline will then be given a multivariate series
+    with the components as columns,
+    i.e., "trend", "resid", "seasonal_2", "seasonal_12".
+    To apply different forecasters to different components, use a
+    ``ColumnEnsembleForecaster``; to apply the same forecaster to all components,
+    simply pipeline with the forecaster.
+    The following example uses a ``TrendForecaster`` for the trend,
+    a seasonal naive forecaster for the seasonal components, with different
+    seasonalities, and a naive forecaster for the residuals.
     >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.detrend import MSTL
     >>> from sktime.forecasting.compose import ColumnEnsembleForecaster

--- a/sktime/transformations/series/detrend/mstl.py
+++ b/sktime/transformations/series/detrend/mstl.py
@@ -42,8 +42,8 @@ class MSTL(BaseTransformer):
       one such component per element in ``periods``, if
       ``periods`` is an array-like of integers.
 
-    ``MSTL`` performs ``inverse_transform`` by reconstituting the components,
-    and can be used for pipelining in a ``TransformedTargetForecaster``,
+    ``MSTL`` performs ``inverse_transform`` by reconstituting the signal from its
+    components, and can be used for pipelining in a ``TransformedTargetForecaster``,
     see examples below.
 
     * if ``periods`` are provided, the transformation will deseasonalize,

--- a/sktime/transformations/series/detrend/mstl.py
+++ b/sktime/transformations/series/detrend/mstl.py
@@ -286,7 +286,7 @@ class MSTL(BaseTransformer):
             row_sums.name = self._X.name
             return row_sums
         # otherwise, we make naive seasonal forecasts, and add them to "transformed"
-        # since "transformed" is trend + resid, this will resture the full series
+        # since "transformed" is trend + resid, this will restore the full series
         from sktime.forecasting.base import ForecastingHorizon
         from sktime.forecasting.naive import NaiveForecaster
 

--- a/sktime/transformations/series/detrend/mstl.py
+++ b/sktime/transformations/series/detrend/mstl.py
@@ -56,6 +56,10 @@ class MSTL(BaseTransformer):
 
     See the examples below for usage.
 
+    For automated detection of seasonalities using a custom seasonality detection
+    algorithm, pipeline ``MSTL`` with the respective estimator, e.g.,
+    ``SeasonalityACF``.
+
     Parameters
     ----------
     endog : array_like

--- a/sktime/transformations/series/detrend/mstl.py
+++ b/sktime/transformations/series/detrend/mstl.py
@@ -15,7 +15,9 @@ from sktime.transformations.base import BaseTransformer
 class MSTL(BaseTransformer):
     """Season-Trend decomposition using LOESS for multiple seasonalities.
 
-    Direct interface for ``statsmodels.tsa.seasonal.MSTL``.
+    Direct interface for ``statsmodels.tsa.seasonal.MSTL`` for ``transform``,
+    with ``sktime`` native extensions to allow use in forecasting pipelines.
+
     ``MSTL`` can be used to perform deseasonalization or decomposition:
 
     ``fit`` stores the decomposed values in self.trend_, self.seasonal_, and
@@ -40,13 +42,19 @@ class MSTL(BaseTransformer):
       one such component per element in ``periods``, if
       ``periods`` is an array-like of integers.
 
-    ``MSTL`` performs ``inverse_transform`` by summing any components,
-    and can be used for pipelining in a ``TransformedTargetForecaster``.
+    ``MSTL`` performs ``inverse_transform`` by reconstituting the components,
+    and can be used for pipelining in a ``TransformedTargetForecaster``,
+    see examples below.
 
-    Important: for separate forecasts of trend and seasonalities, and an
-    inverse transform that respects seasonality, ensure
-    that ``return_components=True`` is set, otherwise the inverse will just
-    return the trend component.
+    * if ``periods`` are provided, the transformation will deseasonalize,
+      and reseasonalize after forecast.
+    * if ``periods`` are not provided, and ``return_components=False``,
+      the forecast will be a pure trend forecast, using sum of trend and residual
+      components.
+    * if ``return_components=True``, the forecaster has access to
+      all components, and can apply different forecasters to different components.
+
+    See the examples below for usage.
 
     Parameters
     ----------
@@ -168,7 +176,7 @@ class MSTL(BaseTransformer):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["luca-miniati"],
+        "authors": ["luca-miniati", "fkiraly"],
         "maintainers": ["luca-miniati"],
         "python_dependencies": "statsmodels",
         # estimator type

--- a/sktime/transformations/series/detrend/mstl.py
+++ b/sktime/transformations/series/detrend/mstl.py
@@ -28,13 +28,17 @@ class MSTL(BaseTransformer):
 
     If ``return_components=True``, then ``transform`` returns
     a full components decomposition,
-    in a DataFrame with cols (for each input column):
+    in a DataFrame with cols (for each input column),
+    in this order:
 
-    * "seasonal_<period>" - the seasonal component(s),
-      where <period> is an integer indicating the periodicity,
-      one such component per element in ``periods``
     * "trend" - the trend component
     * "resid" - the residuals after de-trending, de-seasonalizing
+    * "seasonal" - a single sum-of-seasonalities component, if
+      ``periods`` is ``None``.
+    * "seasonal_<period>" - the seasonal component(s),
+      where <period> is an integer indicating the periodicity,
+      one such component per element in ``periods``, if
+      ``periods`` is an array-like of integers.
 
     ``MSTL`` performs ``inverse_transform`` by summing any components,
     and can be used for pipelining in a ``TransformedTargetForecaster``.
@@ -73,11 +77,13 @@ class MSTL(BaseTransformer):
         * if True, will return all components of the decomposition,
             a multivariate series with DataFrame cols (for each input column):
 
+            * "trend" - the trend component
+            * "resid" - the residuals after de-trending, de-seasonalizing
+            * "seasonal" - a single sum-of-seasonalities component, if
+            ``periods`` is ``None``.
             * "seasonal_<period>" - the seasonal component(s),
               where <period> is an integer indicating the periodicity,
               one such component per element in ``periods``
-            * "trend" - the trend component
-            * "resid" - the residuals after de-trending, de-seasonalizing
 
             All components together sum up to the original series, in-sample.
 
@@ -85,13 +91,14 @@ class MSTL(BaseTransformer):
     ----------
     trend_ : pd.Series
         Trend component of series seen in fit.
-    seasonal_ : pd.Series or list of pd.Series
-        If ``periods`` is a single value, this contains the seasonal component of the
-        series observed during fitting.
-        If ``periods`` is a list of values, this contains multiple pd.Series, each
-        corresponding to a different period.
     resid_ : pd.Series
         Residuals component of series seen in fit.
+    seasonal_ : pd.DataFrame
+        If ``periods`` is ``None``, this contains a single column,
+        with the sum of all seasonal components of the ``X`` seen in ``fit``.
+        If ``periods`` is an array-like of integers, this consists
+        of multiple columns ``seasonal_<period>``, each
+        corresponding to a seasonal component of the series.
 
     References
     ----------
@@ -106,13 +113,22 @@ class MSTL(BaseTransformer):
     >>> y = load_airline()
     >>> y.index = y.index.to_timestamp()
     >>> mstl = MSTL(return_components=True)
-    >>> fitted = mstl.fit(y)
-    >>> res = fitted.transform(y)
+    >>> mstl.fit(y)
+    >>> res = mstl.transform(y)
     >>> res.plot()  # doctest: +SKIP
     >>> plt.tight_layout()  # doctest: +SKIP
     >>> plt.show()  # doctest: +SKIP
 
     MSTL can be pipelined with a forecaster for multiple deseasonalized forecasts:
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.transformations.series.detrend import MSTL
+    >>> from sktime.forecasting.trend import TrendForecaster
+    >>>
+    >>> mstl_trafo = MSTL(periods=[2, 12])
+    >>> mstl_deseason_fcst = mstl_trafo * TrendForecaster()
+    >>> y = load_airline()
+    >>> mstl_deseason_fcst.fit(y, fh=[1, 2, 3])
+    >>> y_pred = mstl_deseason_fcst.predict()
 
     To make forecasts using the full component decomposition,
     set ``return_components=True``. The forecaster will then see
@@ -123,8 +139,8 @@ class MSTL(BaseTransformer):
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.forecasting.trend import TrendForecaster
     >>>
-    >>> mstl_trafo = MSTL(periods=[2, 12], return_components=True)
-    >>> mstl_component_fcst = mstl_trafo * ColumnEnsembleForecaster(
+    >>> mstl_trafo_comp = MSTL(periods=[2, 12], return_components=True)
+    >>> mstl_component_fcst = mstl_trafo_comp * ColumnEnsembleForecaster(
     ...     [
     ...         ("trend", TrendForecaster(), "trend"),
     ...         ("sp2", NaiveForecaster(strategy="last", sp=2), "seasonal_2"),
@@ -192,7 +208,7 @@ class MSTL(BaseTransformer):
             stl_kwargs=self.stl_kwargs,
         ).fit()
 
-        self.seasonal_ = self.mstl_.seasonal
+        self.seasonal_ = _coerce_to_df(self.mstl_.seasonal)
         self.resid_ = pd.Series(self.mstl_.resid, index=X.index)
         self.trend_ = pd.Series(self.mstl_.trend, index=X.index)
 
@@ -238,17 +254,32 @@ class MSTL(BaseTransformer):
     def _inverse_transform(self, X, y=None):
         # for inverse transform, we sum up the columns
         # this will be close if return_components=True
-        row_sums = X.sum(axis=1)
-        row_sums.name = self._X.name
-        return row_sums
+        if self.return_components or self.periods is None:
+            row_sums = X.sum(axis=1)
+            row_sums.name = self._X.name
+            return row_sums
+        # otherwise, we make naive seasonal forecasts, and add them to "transformed"
+        # since "transformed" is trend + resid, this will resture the full series
+        from sktime.forecasting.base import ForecastingHorizon
+        from sktime.forecasting.naive import NaiveForecaster
+
+        seasonal = self.seasonal_
+
+        fcsts = []
+        for period in self.periods:
+            nf = NaiveForecaster(strategy="last", sp=period)
+            fh = ForecastingHorizon(X.index, is_relative=False)
+            sp_ix = f"seasonal_{period}"
+            nf_pred = nf.fit(seasonal[sp_ix], fh=fh).predict()
+            fcsts.append(nf_pred)
+        fcsts = pd.DataFrame(fcsts).T
+        return X + fcsts.sum(axis=1)
 
     def _make_return_object(self, X, mstl):
-        if len(mstl.seasonal.shape) > 1:
-            seasonal = mstl.seasonal.sum(axis=1)
-        else:
-            seasonal = mstl.seasonal
+        seasonal = _coerce_to_df(mstl.seasonal)
+        seasonal_sum = seasonal.sum(axis=1)
         # deseasonalize only
-        transformed = pd.Series(X.values - seasonal, index=X.index)
+        transformed = pd.Series(X.values - seasonal_sum, index=X.index)
         # transformed = pd.Series(X.values - stl.seasonal - stl.trend, index=X.index)
 
         if self.return_components:
@@ -257,7 +288,7 @@ class MSTL(BaseTransformer):
 
             ret = {"trend": trend, "resid": resid}
 
-            for column_name, column_data in mstl.seasonal.items():
+            for column_name, column_data in seasonal.items():
                 ret[column_name] = column_data
 
             ret = pd.DataFrame(ret)
@@ -303,3 +334,13 @@ class MSTL(BaseTransformer):
         }
 
         return [params1, params2, params3]
+
+
+def _coerce_to_df(x):
+    """Coerce pd.Series or pd.DataFrame to pd.DataFrame."""
+    if not isinstance(x, pd.DataFrame):
+        if isinstance(x, pd.Series):
+            x = pd.DataFrame(x)
+        else:
+            raise ValueError(f"Unexpected input type {type(x)}")
+    return x

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -48,3 +48,51 @@ def test_transform_returns_correct_components():
         "returned DataFrame columns are missing 'seasonal_12' "
         "variable."
     )
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(MSTL),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_mstl_deseason_pipeline():
+    """Test simple MSTL multiple deseasonalization pipeline."""
+    from sktime.forecasting.trend import TrendForecaster
+
+    mstl_trafo = MSTL(periods=[2, 12])
+    mstl_deseason_fcst = mstl_trafo * TrendForecaster()
+    y = load_airline()
+    mstl_deseason_fcst.fit(y, fh=[1, 2, 3])
+    y_pred = mstl_deseason_fcst.predict()
+
+    # check expected output shape
+    assert y_pred.shape == 3
+    # assert there are no nans
+    assert not y_pred.isna().any()
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(MSTL),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_mstl_component_pipeline():
+    """Test simple MSTL component forecasting pipeline."""
+    from sktime.forecasting.compose import ColumnEnsembleForecaster
+    from sktime.forecasting.naive import NaiveForecaster
+    from sktime.forecasting.trend import TrendForecaster
+
+    mstl_trafo_comp = MSTL(periods=[2, 12], return_components=True)
+    mstl_component_fcst = mstl_trafo_comp * ColumnEnsembleForecaster(
+        [
+            ("trend", TrendForecaster(), "trend"),
+            ("sp2", NaiveForecaster(strategy="last", sp=2), "seasonal_2"),
+            ("sp12", NaiveForecaster(strategy="last", sp=12), "seasonal_12"),
+            ("residual", NaiveForecaster(strategy="last"), "resid"),
+        ]
+    )
+    y = load_airline()
+    mstl_component_fcst.fit(y, fh=[1, 2, 3])
+    y_pred = mstl_component_fcst.predict()
+    # check expected output shape
+    assert y_pred.shape == 3
+    # assert there are no nans
+    assert not y_pred.isna().any()

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -65,7 +65,7 @@ def test_mstl_deseason_pipeline():
     y_pred = mstl_deseason_fcst.predict()
 
     # check expected output shape
-    assert y_pred.shape == 3
+    assert y_pred.shape == (3,)
     # assert there are no nans
     assert not y_pred.isna().any()
 
@@ -93,6 +93,6 @@ def test_mstl_component_pipeline():
     mstl_component_fcst.fit(y, fh=[1, 2, 3])
     y_pred = mstl_component_fcst.predict()
     # check expected output shape
-    assert y_pred.shape == 3
+    assert y_pred.shape == (3,)
     # assert there are no nans
     assert not y_pred.isna().any()

--- a/sktime/transformations/series/detrend/tests/test_mstl.py
+++ b/sktime/transformations/series/detrend/tests/test_mstl.py
@@ -30,11 +30,6 @@ def test_transform_returns_correct_components():
     transformed = transformer.transform(series)
 
     # Check if the transformed data has the expected components
-    assert "transformed" in transformed.columns, (
-        "Test of MSTL.transform failed with return_components=True, "
-        "returned DataFrame columns are missing 'transformed' "
-        "variable."
-    )
     assert "trend" in transformed.columns, (
         "Test of MSTL.transform failed with return_components=True, "
         "returned DataFrame columns are missing 'trend' variable."


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/6397, and more generally ensures that `MSTL` can be used in forecasting pipelines as expected. Also improves documentation, and fixes some unreported bugs in `MSTL`.

* `return_components` would not return components that sum to the original as expected. This has been fixed. I also consider the fact that the return in the case `return_components=True` included "transformed", which is "trend" plus "residual", a bug, since unexpected by the user.
* The docstring was incorrect in describing the components that were actually returned, in the case where `periods` were passed - not three components with seasonal components summed up, but seasonal components individually.
* `inverse_transform` did not work. This was also masked by the boilerplate issue solved in #6824. This is now also tested, which also covers the fix in #6824.
* The type of the `seasonal_` attribute was inconsistent across the cases of passing `periods` or not, and this was also incorrectly described in the docstring. The type has been rendered consistent (inconsistency was due to an unreported bug), `pd.DataFrame`, and this is now also described in the docstring.

Depends on https://github.com/sktime/sktime/pull/6824