### PR TITLE
[BUG] correct dependency tag for `pytorch-forecasting` forecasters: rename `pytorch_forecasting` to correct package name `pytorch-forecasting`

### DIFF
--- a/sktime/forecasting/base/adapters/_pytorchforecasting.py
+++ b/sktime/forecasting/base/adapters/_pytorchforecasting.py
@@ -53,7 +53,7 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         "authors": ["XinyuWu"],
         "maintainers": ["XinyuWu"],
         "python_version": ">3.8, <3.11",
-        "python_dependencies": ["pytorch_forecasting>=1.0.0"],
+        "python_dependencies": ["pytorch-forecasting>=1.0.0"],
         # estimator type
         # --------------
         "y_inner_mtype": [

--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -43,11 +43,11 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
         # --------------
         # "authors": ["XinyuWu"],
         # "maintainers": ["XinyuWu"],
-        # "python_dependencies": "pytorch_forecasting"
+        # "python_dependencies": "pytorch-forecasting"
         # inherited from _PytorchForecastingAdapter
         # estimator type
         # --------------
-        "python_dependencies": ["pytorch_forecasting>=1.0.0", "torch", "lightning"],
+        "python_dependencies": ["pytorch-forecasting>=1.0.0", "torch", "lightning"],
         "capability:global_forecasting": True,
         "capability:insample": False,
         "X-y-must-have-same-index": True,
@@ -124,7 +124,7 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
         del parameter_set  # to avoid being detected as unused by ``vulture`` etc.
 
         try:
-            _check_soft_dependencies("pytorch_forecasting", severity="error")
+            _check_soft_dependencies("pytorch-forecasting", severity="error")
         except ModuleNotFoundError:
             params = [
                 {
@@ -235,11 +235,11 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
         # --------------
         # "authors": ["XinyuWu"],
         # "maintainers": ["XinyuWu"],
-        # "python_dependencies": "pytorch_forecasting"
+        # "python_dependencies": "pytorch-forecasting"
         # inherited from _PytorchForecastingAdapter
         # estimator type
         # --------------
-        "python_dependencies": ["pytorch_forecasting>=1.0.0", "torch", "lightning"],
+        "python_dependencies": ["pytorch-forecasting>=1.0.0", "torch", "lightning"],
         "capability:global_forecasting": True,
         "ignores-exogeneous-X": True,
         "capability:insample": False,
@@ -308,7 +308,7 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
         del parameter_set  # to avoid being detected as unused by ``vulture`` etc.
 
         try:
-            _check_soft_dependencies("pytorch_forecasting", severity="error")
+            _check_soft_dependencies("pytorch-forecasting", severity="error")
         except ModuleNotFoundError:
             params = [
                 {

--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -123,9 +123,7 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
         """
         del parameter_set  # to avoid being detected as unused by ``vulture`` etc.
 
-        try:
-            _check_soft_dependencies("pytorch-forecasting", severity="error")
-        except ModuleNotFoundError:
+        if not _check_soft_dependencies("pytorch-forecasting", severity="none"):
             params = [
                 {
                     "trainer_params": {
@@ -307,9 +305,7 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
         """
         del parameter_set  # to avoid being detected as unused by ``vulture`` etc.
 
-        try:
-            _check_soft_dependencies("pytorch-forecasting", severity="error")
-        except ModuleNotFoundError:
+        if not _check_soft_dependencies("pytorch-forecasting", severity="none"):
             params = [
                 {
                     "trainer_params": {


### PR DESCRIPTION
This PR fixes incorrect setting of the `python_dependencies` tag on `PytorchForecastingTFT` and `PytorchForecastingNBeats` in branch main (was using the import name, not the pypi package name)

