### PR TITLE
[DOC] clarify column handling in docstring of `FourierFeatures`

### DIFF
--- a/sktime/transformations/series/fourier.py
+++ b/sktime/transformations/series/fourier.py
@@ -26,7 +26,14 @@ class FourierFeatures(BaseTransformer):
     Where :math:`t` is the elapsed time since the beginning of the seasonal period and
     :math:`sp` the total time of the seasonal period.
 
-    The transformed output is a pandas DataFrame that includes the fourier terms as
+    The transformed output is a series that contains all requested Fourier terms.
+
+    Warning: the output will contain only the Fourier terms under default settings,
+    and discard the original columns of the input data, to avoid multiplication
+    of the original data in a pipeline or ``FeatureUnion``.
+    To keep the original columns, set ``keep_original_columns=True``.
+
+    Names of the columns are generated as follows:
     additional columns with the naming convention stated above (sin_sp_k and cos_sp_k).
     The numbers of Fourier terms :math:`K` in the fourier_terms_list
     determines the number of Fourier terms that will be used for each seasonal period,


### PR DESCRIPTION
This PR clarifies the docstring of `FourierFeatures` about handling of the original columns. Previously, this was not too clear from the preamble, and only became evident after looking at all parameters.

This addition is to prevent the confusion in https://github.com/sktime/sktime/issues/6674 - when the transformer is used in isolation, a user might expect the original columns to be retained. However, by default, the columns are dropped, to ensure the expected behaviour when used as part of a pipeline.

FYI @kdekker-private, let me know if this seems clearer now.