### PR TITLE
[ENH] Added support for GluonTS PandasDataset as a series scitype

### DIFF
--- a/sktime/datatypes/_adapter/gluonts.py
+++ b/sktime/datatypes/_adapter/gluonts.py
@@ -58,8 +58,12 @@ def convert_pandas_to_listDataset(pd_dataframe: pd.DataFrame, is_single: bool = 
         if isinstance(pd_dataframe.index, pd.DatetimeIndex):
             freq = pd_dataframe.index.inferred_freq
 
-        else:
+        elif isinstance(pd_dataframe.index, pd.PeriodIndex):
             freq = pd_dataframe.index.freq
+
+        # This is in the case of a RangeIndex
+        else:
+            freq = "D"
 
         return ListDataset(
             [{FieldName.START: start_datetime, FieldName.TARGET: target_values}],
@@ -249,7 +253,7 @@ def convert_pandas_multiindex_to_pandasDataset(
         # Obtain the index name for the timestamp
         for value in pd_dataframe.index.levels:
             # Found the timepoints level
-            if isinstance(value, (pd.DatetimeIndex, pd.PeriodIndex)):
+            if isinstance(value, (pd.DatetimeIndex, pd.PeriodIndex, pd.RangeIndex)):
                 timepoints = value.name
                 break
 
@@ -264,7 +268,7 @@ def convert_pandas_multiindex_to_pandasDataset(
 
         for value in pd_dataframe.index.levels:
             # Found the timepoints level
-            if not isinstance(value, (pd.DatetimeIndex, pd.PeriodIndex)):
+            if not isinstance(value, (pd.DatetimeIndex, pd.PeriodIndex, pd.RangeIndex)):
                 item_id = value.name
                 break
 

--- a/sktime/datatypes/_adapter/gluonts.py
+++ b/sktime/datatypes/_adapter/gluonts.py
@@ -49,6 +49,9 @@ def convert_pandas_to_listDataset(pd_dataframe: pd.DataFrame):
         if isinstance(pd_dataframe.index, pd.DatetimeIndex):
             freq = pd_dataframe.index.inferred_freq
 
+        elif isinstance(pd_dataframe.index, pd.PeriodIndex):
+            freq = pd_dataframe.index.freq
+
         else:
             start_datetime = pd.Timestamp(start_datetime)
             freq = "D"
@@ -64,12 +67,19 @@ def convert_pandas_to_listDataset(pd_dataframe: pd.DataFrame):
     # By maintaining 2 levels in the DataFrame's indices
     # we can access each series and its timestep values with ease!
     for _, data in pd_dataframe.groupby(level=0):
-        # Getting the starting time for each series (assumed to be min value)
-        start_datetime = data.index.get_level_values(level=1).min()
+        data = data.reset_index(level=0, drop=True)
+
+        # Getting the starting time for each series
+        start_datetime = data.index[0]
+
+        if not isinstance(data.index, (pd.DatetimeIndex, pd.PeriodIndex)):
+            start_datetime = pd.Timestamp(start_datetime)
 
         # Isolating multivariate values for each time series
         target_column = data.columns[:]
+
         target_values = data[target_column]
+        target_values = target_values.reset_index(drop=True)
 
         dataset.append(
             {
@@ -79,13 +89,22 @@ def convert_pandas_to_listDataset(pd_dataframe: pd.DataFrame):
         )
 
     # Obtain the total amount of timesteps to assist with inferring frequency
-    n_steps = pd_dataframe.index.get_level_values(level=1).nunique()
-    fr = pd.infer_freq(pd_dataframe.index.get_level_values(level=1)[:n_steps])
+    time_index = pd_dataframe.index.get_level_values(1)
+    freq = None
+
+    if isinstance(time_index, pd.DatetimeIndex):
+        freq = time_index.inferred_freq
+
+    elif isinstance(time_index, pd.PeriodIndex):
+        freq = time_index.freq
+
+    if freq is None:
+        freq = "D"
 
     # Converting the dataset to a GluonTS ListDataset
     list_dataset = ListDataset(
         dataset,
-        freq=fr,
+        freq=freq,
         one_dim_target=False,
     )
 
@@ -198,8 +217,8 @@ def convert_pandasDataset_to_pandas_dataframe(pandasDataset):
 def convert_pandas_multiindex_to_pandasDataset(
     pd_dataframe: pd.DataFrame,
     target=None,
-    item_id=None,
-    timepoints=None,
+    item_id="instances",
+    timepoints="timepoints",
     freq="D",
 ):
     """Convert a given pandas DataFrame (multiindex) to a gluonTS PandasDataset.
@@ -213,17 +232,17 @@ def convert_pandas_multiindex_to_pandasDataset(
         The column that corresponds to target values.
         If no value provided, all column(s) assumed to be targets.
 
-    item_id : str (optional, default=None)
+    item_id : str (optional, default="instances")
         A column dedicated to time series labels.
-        If no value provided, inferred automatically
+        "Instances" by default
 
-    timepoints: str (optional, default=None)
+    timepoints: str (optional, default="timepoints")
         The level name corresponding to the timepoints.
-        If no value provided, inferred automatically
+        "timepoints" by default
 
     freq : str (optional, default="D")
         The frequency of the given timepoints.
-        If no value provided, assumed to be daily
+        "D" by default
 
     Returns
     -------
@@ -237,42 +256,26 @@ def convert_pandas_multiindex_to_pandasDataset(
     """
     from gluonts.dataset.pandas import PandasDataset
 
-    if timepoints is None:
-        # Obtain the index name for the timestamp
-        for value in pd_dataframe.index.levels:
-            # Found the timepoints level
-            if isinstance(value, (pd.DatetimeIndex, pd.PeriodIndex, pd.RangeIndex)):
-                timepoints = value.name
-                break
-
-        if timepoints is None:
-            raise ValueError(
-                "Could not find a valid `timepoints` level in the DataFrame!"
-            )
-
-    if item_id is None:
-        # If no item_id is provided, the first non-timepoints level
-        # is assumed to contain the IDs
-
-        for value in pd_dataframe.index.levels:
-            # Found the timepoints level
-            if not isinstance(value, (pd.DatetimeIndex, pd.PeriodIndex, pd.RangeIndex)):
-                item_id = value.name
-                break
-
-        if item_id is None:
-            raise ValueError("Could not find a valid `item_id` level in the DataFrame!")
-
-    # If no target is provided, we assume all columns to be valid targets
+    # Assume all columns to be valid targets here
     if target is None:
         target = list(pd_dataframe.columns)
-
-    # Assists with finding level-based values
-    pd_dataframe = pd_dataframe.reset_index()
 
     # Converting to float32 for MPS compatibility
     float64_cols = list(pd_dataframe.select_dtypes(include="float64"))
     pd_dataframe[float64_cols] = pd_dataframe[float64_cols].astype("float32")
+
+    # Assists with finding level-based values
+    pd_dataframe = pd_dataframe.reset_index()
+
+    if not isinstance(
+        pd_dataframe[timepoints][0], pd._libs.tslibs.timestamps.Timestamp
+    ):
+        pd_dataframe[timepoints] = pd_dataframe[timepoints].apply(
+            lambda x: pd.Timestamp(x)
+        )
+
+    if item_id not in pd_dataframe:
+        pd_dataframe = pd_dataframe.rename({pd_dataframe.columns[0]: item_id}, axis=1)
 
     # Finally, we create and return a PandasDataset
     return PandasDataset.from_long_dataframe(
@@ -280,7 +283,9 @@ def convert_pandas_multiindex_to_pandasDataset(
     )
 
 
-def convert_pandasDataset_to_pandas(pandasDataset, item_id=None, timepoints=None):
+def convert_pandasDataset_to_pandas(
+    pandasDataset, item_id="instances", timepoints="timepoints", convert_time=True
+):
     """Convert a GluonTS PandasDataset to a pd.DataFrame.
 
     Parameters
@@ -288,74 +293,42 @@ def convert_pandasDataset_to_pandas(pandasDataset, item_id=None, timepoints=None
     pandasDataset : gluonts.dataset.pandas.PandasDataset
         A gluonTS PandasDataset
 
-    item_id : str (optional, default=None)
-        A column dedicated to time series labels, if not given, inferred automatically
+    item_id : str (optional, default="instances")
+        A column dedicated to time series labels, "instances" by default
 
-    timepoints: str (optional, default=None)
-        The name of the timepoints column, if not given, inferred automatically
+    timepoints: str (optional, default="timepoints")
+        The name of the timepoints column, "timepoints" by default
+
+    convert_time : bool (default=False)
+        If True, converts the timepoints' ns back into integers
 
     Returns
     -------
     Returns a valid pandas DataFrame
     """
-    # Extracting the inner iterable from the PandasDataset StarMap
-    iterables = pandasDataset._data_entries.iterable.iterable
+    # Extracting the DataFrame
+    iterable = pandasDataset._data_entries.iterable.iterable
 
-    all_dfs = []
+    # Merging the DataFrame
+    dfs = [df[1] for df in iterable]
+    dfs = pd.concat(dfs, keys=range(len(dfs)))
 
-    for item in iterables:
-        # Each individual time series is stored here
-        df = item[1]
+    # Remove duplicate timepoints if it exists
+    dfs = dfs.drop("timepoints", axis=1)
+    merged_df = dfs.reset_index()
 
-        if not isinstance(df, pd.DataFrame):
-            df = pd.DataFrame(df)
+    # If True, converts timestamps' nanoseconds back into integers
+    if convert_time:
+        merged_df["timepoints"] = merged_df["timepoints"].apply(lambda x: x.nanosecond)
 
-        all_dfs.append(df)
-
-    df = pd.concat(all_dfs, ignore_index=False)
-
-    if timepoints is None:
-        # Obtain the index name for the timestamp
-        for value in df.columns:
-            # Found the timepoints level
-            if isinstance(df[value][0], pd._libs.tslibs.timestamps.Timestamp):
-                timepoints = value
-                break
-
-        if timepoints is None:
-            raise ValueError(
-                "Could not find a valid `timepoints` level in the DataFrame!"
-            )
-
-    if item_id is None:
-        # If no item_id is provided, the first non-timepoints level
-        # is assumed to contain the IDs
-
-        for value in df.columns:
-            # Found the timepoints level
-            if not isinstance(df[value][0], pd._libs.tslibs.timestamps.Timestamp):
-                item_id = value
-                break
-
-        if item_id is None:
-            raise ValueError("Could not find a valid `item_id` level in the DataFrame!")
-
-    # Drop extra mentions of time
-    if "time" in df.columns:
-        df = df.drop("time", axis=1)
-
-    # Drop extra mentions of time
-    if "timepoints" in df.columns:
-        df = df.drop("timepoints", axis=1)
-
-    df = df.reset_index().set_index([item_id, timepoints])
-    df = df.sort_index()
+    merged_df = merged_df.set_index([item_id, timepoints])
+    merged_df = merged_df.drop("level_0", axis=1)
 
     # Converting to float32 for MPS compatibility
-    float64_cols = list(df.select_dtypes(include="float64"))
-    df[float64_cols] = df[float64_cols].astype("float32")
+    float64_cols = list(merged_df.select_dtypes(include="float64"))
+    merged_df[float64_cols] = merged_df[float64_cols].astype("float32")
 
-    return df
+    return merged_df
 
 
 def convert_pandas_collection_to_pandasDataset(

--- a/sktime/datatypes/_adapter/gluonts.py
+++ b/sktime/datatypes/_adapter/gluonts.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 
-def convert_pandas_to_listDataset(pd_dataframe: pd.DataFrame, is_single: bool = False):
+def convert_pandas_to_listDataset(pd_dataframe: pd.DataFrame):
     """Convert a given pandas DataFrame to a gluonTS ListDataset.
 
     Parameters
@@ -9,19 +9,10 @@ def convert_pandas_to_listDataset(pd_dataframe: pd.DataFrame, is_single: bool = 
     pd_dataframe : pd.DataFrame
         A valid pandas DataFrame
 
-    is_single : bool (default=False)
-        True if there is only 1 time series, false if there are multiple series
-        (Allows reusability with _series and _panel implementations)
-
     Returns
     -------
     gluonts.dataset.common.ListDataset
         A gluonTS ListDataset formed from `pd_dataframe`
-
-    Raises
-    ------
-    ValueError
-        If is_single is True, but multiple rows of entries exist in `pd_dataframe`
 
     Example
     --------
@@ -49,7 +40,7 @@ def convert_pandas_to_listDataset(pd_dataframe: pd.DataFrame, is_single: bool = 
     from gluonts.dataset.field_names import FieldName
 
     # For non-multiindexed DataFrames
-    if is_single:
+    if not isinstance(pd_dataframe.index, pd.MultiIndex):
         start_datetime = pd_dataframe.index[0]
 
         target_columns = pd_dataframe.columns[:]
@@ -58,8 +49,9 @@ def convert_pandas_to_listDataset(pd_dataframe: pd.DataFrame, is_single: bool = 
         if isinstance(pd_dataframe.index, pd.DatetimeIndex):
             freq = pd_dataframe.index.inferred_freq
 
-        elif isinstance(pd_dataframe.index, pd.PeriodIndex):
-            freq = pd_dataframe.index.freq
+        else:
+            start_datetime = pd.Timestamp(start_datetime)
+            freq = "D"
 
         # This is in the case of a RangeIndex
         else:

--- a/sktime/datatypes/_adapter/gluonts.py
+++ b/sktime/datatypes/_adapter/gluonts.py
@@ -53,10 +53,6 @@ def convert_pandas_to_listDataset(pd_dataframe: pd.DataFrame):
             start_datetime = pd.Timestamp(start_datetime)
             freq = "D"
 
-        # This is in the case of a RangeIndex
-        else:
-            freq = "D"
-
         return ListDataset(
             [{FieldName.START: start_datetime, FieldName.TARGET: target_values}],
             freq=freq,

--- a/sktime/datatypes/_adapter/tests/test_gluonts.py
+++ b/sktime/datatypes/_adapter/tests/test_gluonts.py
@@ -21,8 +21,8 @@ from sktime.utils.dependencies import _check_soft_dependencies
         (
             pd.DataFrame(
                 {
-                    "series_id": np.zeros(50, dtype=int),
-                    "time": pd.date_range("2022-01-01", periods=50, freq="D"),
+                    "instances": np.zeros(50, dtype=int),
+                    "timepoints": pd.date_range("2022-01-01", periods=50, freq="D"),
                     "target": np.random.randn(50),
                 }
             )
@@ -30,8 +30,8 @@ from sktime.utils.dependencies import _check_soft_dependencies
         (
             pd.DataFrame(
                 {
-                    "series_id": np.repeat(np.arange(3), 50),
-                    "time": np.tile(
+                    "instances": np.repeat(np.arange(3), 50),
+                    "timepoints": np.tile(
                         pd.date_range("2022-01-01", periods=50, freq="D"), 3
                     ),
                     "0": np.random.randn(150),
@@ -44,7 +44,7 @@ from sktime.utils.dependencies import _check_soft_dependencies
 )
 def test_pandas_to_ListDataset(pandas_df):
     # Make the pandas DF multiindex
-    pandas_df = pandas_df.set_index(["series_id", "time"])
+    pandas_df = pandas_df.set_index(["instances", "timepoints"])
 
     generated_list = convert_pandas_to_listDataset(pandas_df)
     idx = 0
@@ -66,12 +66,12 @@ def test_pandas_to_ListDataset(pandas_df):
         (
             pd.DataFrame(
                 {
-                    "series_id": ["A", "A", "A", "B", "B", "B", "C", "C", "C"],
+                    "instances": ["A", "A", "A", "B", "B", "B", "C", "C", "C"],
                     "timepoints": pd.date_range("2022-01-01", periods=9, freq="D"),
                     "target": np.random.randn(9),
                 },
             )
-            .set_index(["series_id", "timepoints"])
+            .set_index(["instances", "timepoints"])
             .sort_index(),
             convert_pandas_multiindex_to_pandasDataset,
         ),
@@ -79,19 +79,19 @@ def test_pandas_to_ListDataset(pandas_df):
             {
                 "A": pd.DataFrame(
                     {
-                        "timestamp": pd.date_range("2022-01-01", periods=50, freq="D"),
+                        "timepoints": pd.date_range("2022-01-01", periods=50, freq="D"),
                         "target": np.random.randn(50),
                     }
                 ),
                 "B": pd.DataFrame(
                     {
-                        "timestamp": pd.date_range("2022-01-01", periods=50, freq="D"),
+                        "timepoints": pd.date_range("2022-01-01", periods=50, freq="D"),
                         "target": np.random.randn(50),
                     }
                 ),
                 "C": pd.DataFrame(
                     {
-                        "timestamp": pd.date_range("2022-01-01", periods=50, freq="D"),
+                        "timepoints": pd.date_range("2022-01-01", periods=50, freq="D"),
                         "target": np.random.randn(50),
                     }
                 ),

--- a/sktime/datatypes/_adapter/tests/test_gluonts.py
+++ b/sktime/datatypes/_adapter/tests/test_gluonts.py
@@ -4,8 +4,8 @@ import pytest
 
 from sktime.datatypes._adapter.gluonts import (
     convert_pandas_collection_to_pandasDataset,
+    convert_pandas_dataframe_to_pandasDataset,
     convert_pandas_multiindex_to_pandasDataset,
-    convert_pandas_series_to_pandasDataset,
     convert_pandas_to_listDataset,
 )
 from sktime.utils.dependencies import _check_soft_dependencies
@@ -99,11 +99,11 @@ def test_pandas_to_ListDataset(pandas_df):
             convert_pandas_collection_to_pandasDataset,
         ),
         (
-            pd.Series(
+            pd.DataFrame(
                 np.random.randn(50),
                 index=pd.date_range("2022-01-01", periods=50, freq="D"),
             ),
-            convert_pandas_series_to_pandasDataset,
+            convert_pandas_dataframe_to_pandasDataset,
         ),
     ],
 )

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -621,8 +621,14 @@ if _check_soft_dependencies("gluonts", severity="none"):
             msg = f"{var_name} must be a gluonts.PandasDataset, found {type(obj)}"
             return _ret(False, msg, None, return_metadata)
 
+        if not hasattr(obj._data_entries.iterable, "iterable"):
+            msg = f"{var_name} must be formed with a multiindex DataFrame to "
+            +"be a valid `pandasDataset_panel`"
+            return _ret(False, msg, None, return_metadata)
+
         # Convert to a pandas DF for easier checks
         df = pd.DataFrame(obj._data_entries)
+
         df = df.explode("target")
 
         # Check if there are no values

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -627,38 +627,32 @@ if _check_soft_dependencies("gluonts", severity="none"):
             return _ret(False, msg, None, return_metadata)
 
         # Convert to a pandas DF for easier checks
-        df = pd.DataFrame(obj._data_entries)
-
-        df = df.explode("target")
+        df = obj._data_entries.iterable.iterable
 
         # Check if there are no values
         if _req("is_empty", return_metadata):
             metadata["is_empty"] = len(obj._data_entries) == 0
 
         if _req("is_univariate", return_metadata):
-            metadata["is_univariate"] = "item_id" not in df.columns
+            metadata["is_univariate"] = len(df[0][1].columns) == 1
 
         if _req("n_features", return_metadata):
-            metadata["n_features"] = len(df.columns)
+            metadata["n_features"] = len(df[0][1].columns)
 
         if _req("n_instances", return_metadata):
-            if "item_id" not in df.columns:
-                metadata["n_instances"] = 1
-
-            else:
-                metadata["n_instances"] = len(df["item_id"].unique())
+            metadata["n_instances"] = len(df)
 
         if _req("n_panels", return_metadata):
-            metadata["n_panels"] = 1
+            metadata["n_panels"] = len(df)
 
         if _req("feature_names", return_metadata):
-            metadata["feature_names"] = df.columns
+            metadata["feature_names"] = df[0][1].columns
 
         if _req("is_equally_spaced", return_metadata):
             metadata["is_equally_spaced"] = True
 
         if _req("has_nans", return_metadata):
-            metadata["has_nans"] = df.isna().any().any()
+            metadata["has_nans"] = False
 
         return _ret(True, None, metadata, return_metadata)
 

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -102,10 +102,10 @@ if _check_soft_dependencies("gluonts", severity="none"):
     # Updating the DF to have pandas Datetime objects
     dfs = [
         df.assign(
-            series_id=series_id,
+            instances=instances,
             timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
-        ).set_index(["series_id", "timepoints"])
-        for series_id, df in enumerate(Xlist)
+        ).set_index(["instances", "timepoints"])
+        for instances, df in enumerate(Xlist)
     ]
 
     # Updating the DataFrame
@@ -120,9 +120,9 @@ if _check_soft_dependencies("gluonts", severity="none"):
     df = example_dict[("pd-multiindex", "Panel", 0)]
 
     df = df.assign(
-        series_id=np.repeat([0, 1, 2], 3),
+        instances=np.repeat([0, 1, 2], 3),
         timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
-    ).set_index(["series_id", "timepoints"])
+    ).set_index(["instances", "timepoints"])
 
     pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
         df, item_id="instances", timepoints="timepoints", target=["var_0", "var_1"]
@@ -213,10 +213,10 @@ if _check_soft_dependencies("gluonts", severity="none"):
     # Updating the DF to have pandas Datetime objects
     dfs = [
         df.assign(
-            series_id=series_id,
+            instances=instances,
             timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
-        ).set_index(["series_id", "timepoints"])
-        for series_id, df in enumerate(Xlist)
+        ).set_index(["instances", "timepoints"])
+        for instances, df in enumerate(Xlist)
     ]
 
     # Updating the DataFrame
@@ -231,9 +231,9 @@ if _check_soft_dependencies("gluonts", severity="none"):
     df = example_dict[("pd-multiindex", "Panel", 1)]
 
     df = df.assign(
-        series_id=np.repeat([0, 1, 2], 3),
+        instances=np.repeat([0, 1, 2], 3),
         timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
-    ).set_index(["series_id", "timepoints"])
+    ).set_index(["instances", "timepoints"])
 
     pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
         df, item_id="instances", timepoints="timepoints", target=["var_0"]
@@ -318,10 +318,10 @@ if _check_soft_dependencies("gluonts", severity="none"):
     # Updating the DF to have pandas Datetime objects
     dfs = [
         df.assign(
-            series_id=series_id,
+            instances=instances,
             timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
-        ).set_index(["series_id", "timepoints"])
-        for series_id, df in enumerate(Xlist)
+        ).set_index(["instances", "timepoints"])
+        for instances, df in enumerate(Xlist)
     ]
 
     # Updating the DataFrame
@@ -336,9 +336,9 @@ if _check_soft_dependencies("gluonts", severity="none"):
     df = example_dict[("pd-multiindex", "Panel", 2)]
 
     df = df.assign(
-        series_id=[0, 0, 0],
+        instances=[0, 0, 0],
         timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
-    ).set_index(["series_id", "timepoints"])
+    ).set_index(["instances", "timepoints"])
 
     pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
         df, item_id="instances", timepoints="timepoints", target=["var_0"]

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -100,17 +100,6 @@ if _check_soft_dependencies("gluonts", severity="none"):
     df = example_dict[("pd-multiindex", "Panel", 0)]
 
     # Updating the DF to have pandas Datetime objects
-    dfs = [
-        df.assign(
-            instances=instances,
-            timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
-        ).set_index(["instances", "timepoints"])
-        for instances, df in enumerate(Xlist)
-    ]
-
-    # Updating the DataFrame
-    df = pd.concat(dfs, names=["instances", "timestamp"])
-
     list_dataset = convert_pandas_to_listDataset(df)
 
     example_dict[("gluonts_ListDataset_panel", "Panel", 0)] = list_dataset
@@ -118,11 +107,6 @@ if _check_soft_dependencies("gluonts", severity="none"):
 
     # Beginning example tests for PandasDataset
     df = example_dict[("pd-multiindex", "Panel", 0)]
-
-    df = df.assign(
-        instances=np.repeat([0, 1, 2], 3),
-        timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
-    ).set_index(["instances", "timepoints"])
 
     pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
         df, item_id="instances", timepoints="timepoints", target=["var_0", "var_1"]
@@ -210,18 +194,6 @@ if _check_soft_dependencies("gluonts", severity="none"):
 
     df = example_dict[("pd-multiindex", "Panel", 1)]
 
-    # Updating the DF to have pandas Datetime objects
-    dfs = [
-        df.assign(
-            instances=instances,
-            timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
-        ).set_index(["instances", "timepoints"])
-        for instances, df in enumerate(Xlist)
-    ]
-
-    # Updating the DataFrame
-    df = pd.concat(dfs, names=["instances", "timestamp"])
-
     list_dataset = convert_pandas_to_listDataset(df)
 
     example_dict[("gluonts_ListDataset_panel", "Panel", 1)] = list_dataset
@@ -229,11 +201,6 @@ if _check_soft_dependencies("gluonts", severity="none"):
 
     # Beginning example tests for PandasDataset
     df = example_dict[("pd-multiindex", "Panel", 1)]
-
-    df = df.assign(
-        instances=np.repeat([0, 1, 2], 3),
-        timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
-    ).set_index(["instances", "timepoints"])
 
     pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
         df, item_id="instances", timepoints="timepoints", target=["var_0"]
@@ -315,18 +282,6 @@ if _check_soft_dependencies("gluonts", severity="none"):
 
     df = example_dict[("pd-multiindex", "Panel", 2)]
 
-    # Updating the DF to have pandas Datetime objects
-    dfs = [
-        df.assign(
-            instances=instances,
-            timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
-        ).set_index(["instances", "timepoints"])
-        for instances, df in enumerate(Xlist)
-    ]
-
-    # Updating the DataFrame
-    df = pd.concat(dfs, names=["instances", "timestamp"])
-
     list_dataset = convert_pandas_to_listDataset(df)
 
     example_dict[("gluonts_ListDataset_panel", "Panel", 2)] = list_dataset
@@ -334,11 +289,6 @@ if _check_soft_dependencies("gluonts", severity="none"):
 
     # Beginning example tests for PandasDataset
     df = example_dict[("pd-multiindex", "Panel", 2)]
-
-    df = df.assign(
-        instances=[0, 0, 0],
-        timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
-    ).set_index(["instances", "timepoints"])
 
     pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
         df, item_id="instances", timepoints="timepoints", target=["var_0"]

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -104,12 +104,12 @@ if _check_soft_dependencies("gluonts", severity="none"):
         df.assign(
             series_id=series_id,
             timepoints=pd.date_range(start="2023-01-01", periods=len(df), freq="D"),
-        ).set_index(["series_id", "timepoints"])
+        ).set_index(["instances", "timepoints"])
         for series_id, df in enumerate(Xlist)
     ]
 
     # Updating the DataFrame
-    df = pd.concat(dfs, names=["series_id", "timestamp"])
+    df = pd.concat(dfs, names=["instances", "timestamp"])
 
     list_dataset = convert_pandas_to_listDataset(df, is_single=False)
 
@@ -120,12 +120,12 @@ if _check_soft_dependencies("gluonts", severity="none"):
     df = example_dict[("pd-multiindex", "Panel", 0)]
 
     df = df.assign(
-        series_id=np.repeat([0, 1, 2], 3),
+        instances=np.repeat([0, 1, 2], 3),
         timepoints=pd.date_range(start="2023-01-01", periods=len(df), freq="D"),
-    ).set_index(["series_id", "timepoints"])
+    ).set_index(["instances", "timepoints"])
 
     pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
-        df, item_id="series_id", target=["var_0", "var_1"]
+        df, item_id="instances", timepoints="timepoints", target=["var_0", "var_1"]
     )
 
     example_dict[("gluonts_PandasDataset_panel", "Panel", 0)] = pandas_dataset
@@ -215,12 +215,12 @@ if _check_soft_dependencies("gluonts", severity="none"):
         df.assign(
             series_id=series_id,
             timepoints=pd.date_range(start="2023-01-01", periods=len(df), freq="D"),
-        ).set_index(["series_id", "timepoints"])
+        ).set_index(["instances", "timepoints"])
         for series_id, df in enumerate(Xlist)
     ]
 
     # Updating the DataFrame
-    df = pd.concat(dfs, names=["series_id", "timestamp"])
+    df = pd.concat(dfs, names=["instances", "timestamp"])
 
     list_dataset = convert_pandas_to_listDataset(df, is_single=False)
 
@@ -231,12 +231,12 @@ if _check_soft_dependencies("gluonts", severity="none"):
     df = example_dict[("pd-multiindex", "Panel", 1)]
 
     df = df.assign(
-        series_id=np.repeat([0, 1, 2], 3),
+        instances=np.repeat([0, 1, 2], 3),
         timepoints=pd.date_range(start="2023-01-01", periods=len(df), freq="D"),
-    ).set_index(["series_id", "timepoints"])
+    ).set_index(["instances", "timepoints"])
 
     pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
-        df, item_id="series_id", target=["var_0"]
+        df, item_id="instances", timepoints="timepoints", target=["var_0"]
     )
 
     example_dict[("gluonts_PandasDataset_panel", "Panel", 1)] = pandas_dataset
@@ -318,14 +318,14 @@ if _check_soft_dependencies("gluonts", severity="none"):
     # Updating the DF to have pandas Datetime objects
     dfs = [
         df.assign(
-            series_id=series_id,
+            instances=series_id,
             timepoints=pd.date_range(start="2023-01-01", periods=len(df), freq="D"),
-        ).set_index(["series_id", "timepoints"])
+        ).set_index(["instances", "timepoints"])
         for series_id, df in enumerate(Xlist)
     ]
 
     # Updating the DataFrame
-    df = pd.concat(dfs, names=["series_id", "timestamp"])
+    df = pd.concat(dfs, names=["instances", "timestamp"])
 
     list_dataset = convert_pandas_to_listDataset(df, is_single=False)
 
@@ -336,12 +336,12 @@ if _check_soft_dependencies("gluonts", severity="none"):
     df = example_dict[("pd-multiindex", "Panel", 2)]
 
     df = df.assign(
-        series_id=[0, 0, 0],
+        instances=[0, 0, 0],
         timepoints=pd.date_range(start="2023-01-01", periods=len(df), freq="D"),
-    ).set_index(["series_id", "timepoints"])
+    ).set_index(["instances", "timepoints"])
 
     pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
-        df, item_id="series_id", target=["var_0"]
+        df, item_id="instances", timepoints="timepoints", target=["var_0"]
     )
 
     example_dict[("gluonts_PandasDataset_panel", "Panel", 2)] = pandas_dataset

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -103,15 +103,15 @@ if _check_soft_dependencies("gluonts", severity="none"):
     dfs = [
         df.assign(
             series_id=series_id,
-            timepoints=pd.date_range(start="2023-01-01", periods=len(df), freq="D"),
-        ).set_index(["instances", "timepoints"])
+            timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
+        ).set_index(["series_id", "timepoints"])
         for series_id, df in enumerate(Xlist)
     ]
 
     # Updating the DataFrame
     df = pd.concat(dfs, names=["instances", "timestamp"])
 
-    list_dataset = convert_pandas_to_listDataset(df, is_single=False)
+    list_dataset = convert_pandas_to_listDataset(df)
 
     example_dict[("gluonts_ListDataset_panel", "Panel", 0)] = list_dataset
     example_dict_lossy[("gluonts_ListDataset_panel", "Panel", 0)] = True
@@ -120,9 +120,9 @@ if _check_soft_dependencies("gluonts", severity="none"):
     df = example_dict[("pd-multiindex", "Panel", 0)]
 
     df = df.assign(
-        instances=np.repeat([0, 1, 2], 3),
-        timepoints=pd.date_range(start="2023-01-01", periods=len(df), freq="D"),
-    ).set_index(["instances", "timepoints"])
+        series_id=np.repeat([0, 1, 2], 3),
+        timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
+    ).set_index(["series_id", "timepoints"])
 
     pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
         df, item_id="instances", timepoints="timepoints", target=["var_0", "var_1"]
@@ -214,15 +214,15 @@ if _check_soft_dependencies("gluonts", severity="none"):
     dfs = [
         df.assign(
             series_id=series_id,
-            timepoints=pd.date_range(start="2023-01-01", periods=len(df), freq="D"),
-        ).set_index(["instances", "timepoints"])
+            timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
+        ).set_index(["series_id", "timepoints"])
         for series_id, df in enumerate(Xlist)
     ]
 
     # Updating the DataFrame
     df = pd.concat(dfs, names=["instances", "timestamp"])
 
-    list_dataset = convert_pandas_to_listDataset(df, is_single=False)
+    list_dataset = convert_pandas_to_listDataset(df)
 
     example_dict[("gluonts_ListDataset_panel", "Panel", 1)] = list_dataset
     example_dict_lossy[("gluonts_ListDataset_panel", "Panel", 1)] = True
@@ -231,9 +231,9 @@ if _check_soft_dependencies("gluonts", severity="none"):
     df = example_dict[("pd-multiindex", "Panel", 1)]
 
     df = df.assign(
-        instances=np.repeat([0, 1, 2], 3),
-        timepoints=pd.date_range(start="2023-01-01", periods=len(df), freq="D"),
-    ).set_index(["instances", "timepoints"])
+        series_id=np.repeat([0, 1, 2], 3),
+        timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
+    ).set_index(["series_id", "timepoints"])
 
     pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
         df, item_id="instances", timepoints="timepoints", target=["var_0"]
@@ -318,16 +318,16 @@ if _check_soft_dependencies("gluonts", severity="none"):
     # Updating the DF to have pandas Datetime objects
     dfs = [
         df.assign(
-            instances=series_id,
-            timepoints=pd.date_range(start="2023-01-01", periods=len(df), freq="D"),
-        ).set_index(["instances", "timepoints"])
+            series_id=series_id,
+            timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
+        ).set_index(["series_id", "timepoints"])
         for series_id, df in enumerate(Xlist)
     ]
 
     # Updating the DataFrame
     df = pd.concat(dfs, names=["instances", "timestamp"])
 
-    list_dataset = convert_pandas_to_listDataset(df, is_single=False)
+    list_dataset = convert_pandas_to_listDataset(df)
 
     example_dict[("gluonts_ListDataset_panel", "Panel", 2)] = list_dataset
     example_dict_lossy[("gluonts_ListDataset_panel", "Panel", 2)] = True
@@ -336,9 +336,9 @@ if _check_soft_dependencies("gluonts", severity="none"):
     df = example_dict[("pd-multiindex", "Panel", 2)]
 
     df = df.assign(
-        instances=[0, 0, 0],
-        timepoints=pd.date_range(start="2023-01-01", periods=len(df), freq="D"),
-    ).set_index(["instances", "timepoints"])
+        series_id=[0, 0, 0],
+        timepoints=pd.date_range(start="1970-01-01", periods=len(df), freq="D"),
+    ).set_index(["series_id", "timepoints"])
 
     pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
         df, item_id="instances", timepoints="timepoints", target=["var_0"]

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -455,6 +455,61 @@ if _check_soft_dependencies("gluonts", severity="none"):
 
         return ret(True, None, metadata, return_metadata)
 
+    def check_gluonTS_pandasDataset_series(obj, return_metadata=False, var_name="obj"):
+        from gluonts.dataset.pandas import PandasDataset
+
+        metadata = dict()
+
+        # Check for type correctness
+        if not isinstance(obj, PandasDataset):
+            msg = f"{var_name} must be a gluonts.PandasDataset, found {type(obj)}"
+            return ret(False, msg, None, return_metadata)
+
+        # Convert to a pandas DF for easier checks
+        df = obj._data_entries.iterable
+
+        # Checking if the DataFrame is stored in the appropriate place
+        if (
+            not isinstance(df, list)
+            or not isinstance(df[0], tuple)
+            or not isinstance(df[0][1], pd.DataFrame)
+        ):
+            msg = f"{var_name} was not formed with a single-instance pandas DataFrame"
+            return ret(False, msg, None, return_metadata)
+
+        df = df[0][1]
+
+        # Check if there are no values
+        if _req("is_empty", return_metadata):
+            metadata["is_empty"] = len(obj._data_entries) == 0
+
+        if _req("is_univariate", return_metadata):
+            metadata["is_univariate"] = len(df.columns) == 1
+
+        if _req("n_features", return_metadata):
+            metadata["n_features"] = 1
+
+        if _req("n_instances", return_metadata):
+            metadata["n_instances"] = 1
+
+        if _req("n_panels", return_metadata):
+            metadata["n_panels"] = 1
+
+        if _req("feature_names", return_metadata):
+            metadata["feature_names"] = df.columns
+
+        if _req("is_equally_spaced", return_metadata):
+            metadata["is_equally_spaced"] = True
+
+        if _req("has_nans", return_metadata):
+            metadata["has_nans"] = df.isna().any().any()
+
+        return ret(True, None, metadata, return_metadata)
+
     check_dict[("gluonts_ListDataset_series", "Series")] = (
         check_gluonTS_listDataset_series
+    )
+
+    check_dict[("gluonts_PandasDataset_series", "Series")] = (
+        check_gluonTS_pandasDataset_series
     )

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -272,7 +272,7 @@ if _check_soft_dependencies("gluonts", severity="none"):
         return convert_listDataset_to_pandas(obj)
 
     def convert_pandas_to_gluonts_listDataset(obj, store=None):
-        return convert_pandas_to_listDataset(obj, is_single=True)
+        return convert_pandas_to_listDataset(obj)
 
     def convert_gluonts_PandasDataset_to_pandas(obj, store=None):
         return convert_pandasDataset_to_pandas_dataframe(obj)

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -262,7 +262,9 @@ if _check_soft_dependencies("dask", severity="none"):
 if _check_soft_dependencies("gluonts", severity="none"):
     from sktime.datatypes._adapter.gluonts import (
         convert_listDataset_to_pandas,
+        convert_pandas_dataframe_to_pandasDataset,
         convert_pandas_to_listDataset,
+        convert_pandasDataset_to_pandas_dataframe,
     )
 
     # Utilizing functions defined in _adapter/gluonts.py
@@ -271,6 +273,12 @@ if _check_soft_dependencies("gluonts", severity="none"):
 
     def convert_pandas_to_gluonts_listDataset(obj, store=None):
         return convert_pandas_to_listDataset(obj, is_single=True)
+
+    def convert_gluonts_PandasDataset_to_pandas(obj, store=None):
+        return convert_pandasDataset_to_pandas_dataframe(obj)
+
+    def convert_pandas_to_gluonts_PandasDataset(obj, store=None):
+        return convert_pandas_dataframe_to_pandasDataset(obj)
 
     # Storing functions in convert_dict
     convert_dict[("pd.DataFrame", "gluonts_ListDataset_series", "Series")] = (
@@ -281,9 +289,24 @@ if _check_soft_dependencies("gluonts", severity="none"):
         convert_gluonts_listDataset_to_pandas
     )
 
+    convert_dict[("pd.DataFrame", "gluonts_PandasDataset_series", "Series")] = (
+        convert_pandas_to_gluonts_PandasDataset
+    )
+
+    convert_dict[("gluonts_PandasDataset_series", "pd.DataFrame", "Series")] = (
+        convert_gluonts_PandasDataset_to_pandas
+    )
+
     # Extending conversions
     _extend_conversions(
         "gluonts_ListDataset_series",
+        "pd.DataFrame",
+        convert_dict,
+        mtype_universe=MTYPE_LIST_SERIES,
+    )
+
+    _extend_conversions(
+        "gluonts_PandasDataset_series",
         "pd.DataFrame",
         convert_dict,
         mtype_universe=MTYPE_LIST_SERIES,

--- a/sktime/datatypes/_series/_examples.py
+++ b/sktime/datatypes/_series/_examples.py
@@ -77,12 +77,9 @@ if _check_soft_dependencies("dask", severity="none"):
 
 
 if _check_soft_dependencies("gluonts", severity="none"):
-    from gluonts.dataset.common import ListDataset
-    from gluonts.dataset.field_names import FieldName
+    from sktime.datatypes._adapter.gluonts import convert_pandas_to_listDataset
 
-    list_dataset = ListDataset(
-        [{FieldName.TARGET: s, FieldName.START: pd.Timestamp(2023, 1, 1)}], freq="D"
-    )
+    list_dataset = convert_pandas_to_listDataset(df)
 
     example_dict[("gluonts_ListDataset_series", "Series", 0)] = list_dataset
     example_dict_lossy[("gluonts_ListDataset_series", "Series", 0)] = True
@@ -132,19 +129,9 @@ if _check_soft_dependencies("dask", severity="none"):
     example_dict_lossy[("dask_series", "Series", 1)] = False
 
 if _check_soft_dependencies("gluonts", severity="none"):
-    from gluonts.dataset.common import ListDataset
-    from gluonts.dataset.field_names import FieldName
+    from sktime.datatypes._adapter.gluonts import convert_pandas_to_listDataset
 
-    list_dataset = ListDataset(
-        [
-            {
-                FieldName.TARGET: df,
-                FieldName.START: pd.Timestamp(2023, 1, 1),
-            }
-        ],
-        freq="D",
-        one_dim_target=False,  # Must be specified for multivariate datasets
-    )
+    list_dataset = convert_pandas_to_listDataset(df)
 
     example_dict[("gluonts_ListDataset_series", "Series", 1)] = list_dataset
     example_dict_lossy[("gluonts_ListDataset_series", "Series", 1)] = True
@@ -195,19 +182,9 @@ if _check_soft_dependencies("dask", severity="none"):
     example_dict_lossy[("dask_series", "Series", 2)] = False
 
 if _check_soft_dependencies("gluonts", severity="none"):
-    from gluonts.dataset.common import ListDataset
-    from gluonts.dataset.field_names import FieldName
+    from sktime.datatypes._adapter.gluonts import convert_pandas_to_listDataset
 
-    list_dataset = ListDataset(
-        [
-            {
-                FieldName.TARGET: df,
-                FieldName.START: pd.Timestamp(2023, 1, 1),
-            }
-        ],
-        freq="D",
-        one_dim_target=False,  # Must be specified for multivariate datasets
-    )
+    list_dataset = convert_pandas_to_listDataset(df)
 
     example_dict[("gluonts_ListDataset_series", "Series", 2)] = list_dataset
     example_dict_lossy[("gluonts_ListDataset_series", "Series", 2)] = True
@@ -252,19 +229,9 @@ if _check_soft_dependencies("xarray", severity="none"):
     example_dict_lossy[("xr.DataArray", "Series", 3)] = False
 
 if _check_soft_dependencies("gluonts", severity="none"):
-    from gluonts.dataset.common import ListDataset
-    from gluonts.dataset.field_names import FieldName
+    from sktime.datatypes._adapter.gluonts import convert_pandas_to_listDataset
 
-    list_dataset = ListDataset(
-        [
-            {
-                FieldName.TARGET: df,
-                FieldName.START: pd.Timestamp(2023, 1, 1),
-            }
-        ],
-        freq="D",
-        one_dim_target=False,  # Must be specified for multivariate datasets
-    )
+    list_dataset = convert_pandas_to_listDataset(df)
 
     example_dict[("gluonts_ListDataset_series", "Series", 3)] = list_dataset
     example_dict_lossy[("gluonts_ListDataset_series", "Series", 3)] = True

--- a/sktime/datatypes/tests/test_convert.py
+++ b/sktime/datatypes/tests/test_convert.py
@@ -29,7 +29,7 @@ def _generate_fixture_tuples():
 
         conv_mat = _conversions_defined(scitype)
 
-        mtypes = scitype_to_mtype(scitype, softdeps="exclude")
+        mtypes = scitype_to_mtype(scitype, softdeps="present")
 
         if len(mtypes) == 0:
             # if there are no mtypes, this must have been reached by mistake/bug

--- a/sktime/datatypes/tests/test_convert.py
+++ b/sktime/datatypes/tests/test_convert.py
@@ -124,6 +124,9 @@ def test_convert(scitype, from_mtype, to_mtype, fixture_index):
             as_scitype=scitype,
         )
 
+        print(f"Converted: \n{converted_fixture_i}")
+        print(f"Ground Truth: \n{to_fixture[0]}")
+
         equals, deep_equals_msg = deep_equals(
             converted_fixture_i,
             to_fixture[0],

--- a/sktime/forecasting/tests/test_interval_wrappers.py
+++ b/sktime/forecasting/tests/test_interval_wrappers.py
@@ -44,9 +44,6 @@ def test_wrapper_series_mtype(wrapper, override_y_mtype, mtype):
     We do this with a trick: the vanilla NaiveForecaster can accept both; we mimic a
     "pd.DataFrame only" forecaster by restricting its y_inner_mtype tag to pd.Series.
     """
-    if mtype == "gluonts_ListDataset_series":
-        return None
-
     y = load_airline()
     y = convert_to(y, to_type=mtype)
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This implements support for the GluonTS PandasDataset object as an sktime series scitype, and adds conversion functions to convert pd.DataFrame to a GluonTS PandasDataset. 

In addition, it fixes some prior GluonTS code and now enforces the test_interval_wrappers function!

Depends on https://github.com/sktime/sktime/pull/6838

#### Does your contribution introduce a new dependency? If yes, which one?
GluonTS, but that was added prior already

#### What should a reviewer concentrate their feedback on?
A reviewer should focus on the sktime/datatypes/_adapter/gluonts.py file for the new changes

#### Did you add any tests for the change?
No, I had already defined tests in a prior PR

#### Any other comments?
Assists with the #6659 PR.


##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
