### PR TITLE
[ENH] converter framework tests in `datatypes` to cover all types, including those requiring soft dependencies

### DIFF
--- a/sktime/datatypes/tests/test_convert.py
+++ b/sktime/datatypes/tests/test_convert.py
@@ -29,7 +29,7 @@ def _generate_fixture_tuples():
 
         conv_mat = _conversions_defined(scitype)
 
-        mtypes = scitype_to_mtype(scitype, softdeps="exclude")
+        mtypes = scitype_to_mtype(scitype, softdeps="present")
 
         if len(mtypes) == 0:
             # if there are no mtypes, this must have been reached by mistake/bug


### PR DESCRIPTION
So far, converter framework tests in `datatypes` were run only between mtypes without soft dependencies.

This PR switches the setting to cover all types, including those requiring soft dependencies, for soft dependencies present in the given environment.