### PR TITLE
[MNT] downgrade pykan version to <0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,7 +285,7 @@ dl = [
   'tensorflow<2.17,>=2; python_version < "3.12"',
   'torch; python_version < "3.12"',
   'transformers[torch]<4.41.0; python_version < "3.12"',
-  'pykan<0.3,>=0.2; python_version > "3.9.7"',
+  'pykan<0.2.2,>=0.2; python_version > "3.9.7"',
   'pytorch-forecasting>=1.0.0; python_version < "3.11"',
 ]
 mlflow = [


### PR DESCRIPTION
Latest pykan versions are causing to fail some test cases for pykan that affects the CI for all workflows. This PR bounds the versions to `pykan<0.2.2,>=0.2`, ensuring stable working of `PyKANForecaster` and not blocking other workflows.