### PR TITLE
[BUG] fix type inconsistency in conversion `pandas` to `xarray` based `Series`

### DIFF
--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -206,9 +206,12 @@ if _check_soft_dependencies("xarray", severity="none"):
         index = obj.indexes[obj.dims[0]]
         columns = obj.indexes[obj.dims[1]] if len(obj.dims) == 2 else None
         df = pd.DataFrame(obj.values, index=index, columns=columns)
+        # int64 coercions are needed due to inconsistencies specifically on windows
         df = df.astype(
             {col: "int64" for col in df.select_dtypes(include="int32").columns}
-        )  # this coercion is needed due to inconsistency on windows
+        )
+        if df.index.dtype == "int32":
+            df.index = df.index.astype("int64")
         return df
 
     convert_dict[("xr.DataArray", "pd.DataFrame", "Series")] = (

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -207,7 +207,7 @@ if _check_soft_dependencies("xarray", severity="none"):
         columns = obj.indexes[obj.dims[1]] if len(obj.dims) == 2 else None
         df = pd.DataFrame(obj.values, index=index, columns=columns)
         df = df.astype(
-            {col: "int64" for col in df.select_dtypes(include="int32").columns}
+            {col: 'int64' for col in df.select_dtypes(include='int32').columns}
         )  # this coercion is needed due to inconsistency on windows
         return df
 

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -205,7 +205,11 @@ if _check_soft_dependencies("xarray", severity="none"):
 
         index = obj.indexes[obj.dims[0]]
         columns = obj.indexes[obj.dims[1]] if len(obj.dims) == 2 else None
-        return pd.DataFrame(obj.values, index=index, columns=columns)
+        df = pd.DataFrame(obj.values, index=index, columns=columns)
+        df = df.astype(
+            {col: 'int64' for col in df.select_dtypes(include='int32').columns}
+        )  # this coercion is needed due to inconsistency on windows
+        return df
 
     convert_dict[("xr.DataArray", "pd.DataFrame", "Series")] = (
         convert_xrdataarray_to_Mvs_as_Series

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -207,7 +207,7 @@ if _check_soft_dependencies("xarray", severity="none"):
         columns = obj.indexes[obj.dims[1]] if len(obj.dims) == 2 else None
         df = pd.DataFrame(obj.values, index=index, columns=columns)
         df = df.astype(
-            {col: 'int64' for col in df.select_dtypes(include='int32').columns}
+            {col: "int64" for col in df.select_dtypes(include="int32").columns}
         )  # this coercion is needed due to inconsistency on windows
         return df
 


### PR DESCRIPTION
Fixes a type inconsistency in conversion `pandas` to `xarray` based `Series`.

On windows - and only on windows - integer types may be converted to `int32` instead of `int64`.