### PR TITLE
[ENH] add missing `feature_kind` metadata fields to `gluonts` based datasets

### DIFF
--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -47,7 +47,11 @@ import pandas as pd
 from pandas.core.dtypes.cast import is_nested_object
 
 from sktime.datatypes._common import _req, _ret
-from sktime.datatypes._dtypekind import _get_feature_kind, _get_panel_dtypekind
+from sktime.datatypes._dtypekind import (
+    DtypeKind,
+    _get_feature_kind,
+    _get_panel_dtypekind,
+)
 from sktime.datatypes._series._check import (
     _index_equally_spaced,
     check_pddataframe_series,
@@ -563,13 +567,22 @@ if _check_soft_dependencies("gluonts", severity="none"):
             else:
                 metadata["is_univariate"] = obj[0]["target"].shape[1] == 1
 
-        if _req("n_features", return_metadata):
+        req_n_feat = ["n_features", "feature_names", "feature_kind", "dtypekind_dfip"]
+        if _req(req_n_feat, return_metadata):
             # Check first if the ListDataset is empty
             if len(obj) < 1:
-                metadata["n_features"] = 0
-
+                n_features = 0
             else:
-                metadata["n_features"] = obj[0]["target"].shape[1]
+                n_features = obj[0]["target"].shape[1]
+
+        if _req("n_features", return_metadata):
+            metadata["n_features"] = n_features
+
+        if _req("feature_kind", return_metadata):
+            metadata["feature_kind"] = [DtypeKind.FLOAT] * n_features
+
+        if _req("dtypekind_dfip", return_metadata):
+            metadata["dtypekind_dfip"] = [DtypeKind.FLOAT] * n_features
 
         if _req("n_instances", return_metadata):
             metadata["n_instances"] = len(obj)
@@ -581,11 +594,8 @@ if _check_soft_dependencies("gluonts", severity="none"):
             # Check first if the ListDataset is empty
             if len(obj) < 1:
                 metadata["feature_names"] = []
-
             else:
-                metadata["feature_names"] = [
-                    f"value_{i}" for i in range(obj[0]["target"].shape[1])
-                ]
+                metadata["feature_names"] = [f"value_{i}" for i in range(n_features)]
 
         for series in obj:
             # check that no dtype is object
@@ -636,8 +646,18 @@ if _check_soft_dependencies("gluonts", severity="none"):
         if _req("is_univariate", return_metadata):
             metadata["is_univariate"] = len(df[0][1].columns) == 1
 
+        req_n_feat = ["n_features", "feature_kind", "dtypekind_dfip"]
+        if _req(req_n_feat, return_metadata):
+            n_features = len(df[0][1].columns)
+
         if _req("n_features", return_metadata):
-            metadata["n_features"] = len(df[0][1].columns)
+            metadata["n_features"] = n_features
+
+        if _req("feature_kind", return_metadata):
+            metadata["feature_kind"] = [DtypeKind.FLOAT] * n_features
+
+        if _req("dtypekind_dfip", return_metadata):
+            metadata["dtypekind_dfip"] = [DtypeKind.FLOAT] * n_features
 
         if _req("n_instances", return_metadata):
             metadata["n_instances"] = len(df)

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -44,7 +44,11 @@ import pandas as pd
 
 from sktime.datatypes._common import _req
 from sktime.datatypes._common import _ret as ret
-from sktime.datatypes._dtypekind import _get_feature_kind, _get_series_dtypekind
+from sktime.datatypes._dtypekind import (
+    DtypeKind,
+    _get_feature_kind,
+    _get_series_dtypekind,
+)
 from sktime.utils.dependencies import _check_soft_dependencies
 from sktime.utils.validation.series import is_in_valid_index_types
 
@@ -407,26 +411,28 @@ if _check_soft_dependencies("gluonts", severity="none"):
             else:
                 metadata["is_univariate"] = obj[0]["target"].shape[1] == 1
 
-        if _req("n_features", return_metadata):
+        req_n_feat = ["n_features", "feature_names", "feature_kind", "dtypekind_dfip"]
+        if _req(req_n_feat, return_metadata):
             # Check first if the ListDataset is empty
             if len(obj) < 1:
-                metadata["n_features"] = 0
-
+                n_features = 0
             else:
-                metadata["n_features"] = obj[0]["target"].shape[1]
+                n_features = obj[0]["target"].shape[1]
+
+        if _req("n_features", return_metadata):
+            metadata["n_features"] = n_features
+
+        if _req("feature_kind", return_metadata):
+            metadata["feature_kind"] = [DtypeKind.FLOAT] * n_features
+
+        if _req("dtypekind_dfip", return_metadata):
+            metadata["dtypekind_dfip"] = [DtypeKind.FLOAT] * n_features
 
         if _req("n_instances", return_metadata):
             metadata["n_instances"] = 1
 
         if _req("feature_names", return_metadata):
-            # Check first if the ListDataset is empty
-            if len(obj) < 1:
-                metadata["feature_names"] = []
-
-            else:
-                metadata["feature_names"] = [
-                    f"value_{i}" for i in range(obj[0]["target"].shape[1])
-                ]
+            metadata["feature_names"] = [f"value_{i}" for i in range(n_features)]
 
         for series in obj:
             # check that no dtype is object
@@ -503,6 +509,12 @@ if _check_soft_dependencies("gluonts", severity="none"):
 
         if _req("has_nans", return_metadata):
             metadata["has_nans"] = df.isna().any().any()
+
+        if _req("feature_kind", return_metadata):
+            metadata["feature_kind"] = [DtypeKind.FLOAT]
+
+        if _req("dtypekind_dfip", return_metadata):
+            metadata["dtypekind_dfip"] = [DtypeKind.FLOAT]
 
         return ret(True, None, metadata, return_metadata)
 


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/6860 by ensuring the required fields are returned.
Currently returns Float for everything, but this can be changed later, this is just to remedy the omission.

Also does some minor refactoring to reduce code duplication.