### PR TITLE
[MNT] Resolve the issue with diacritics failing to be decoded on Windows

### DIFF
--- a/sktime/libs/README.md
+++ b/sktime/libs/README.md
@@ -12,7 +12,7 @@ This folder contains libraries directly distributed with, and maintained by, `sk
 
 # Snippets from other libraries:
 
-This folder contains also some snippets from other libraries Kálmán checking for invalid characters. č, ě, ň, ř, š, Ť, ů, ž, Č, Ě, Ň, Ř, Š, Ť, Ů, Ž
+This folder contains also some snippets from other libraries
 
 * Parts of the `EnbPI` class from aws-fortuna.
   The installation of the original package is not working due to dependency

--- a/sktime/libs/README.md
+++ b/sktime/libs/README.md
@@ -12,7 +12,7 @@ This folder contains libraries directly distributed with, and maintained by, `sk
 
 # Snippets from other libraries:
 
-This folder contains also some snippets from other libraries
+This folder contains also some snippets from other libraries Kálmán checking for invalid characters. č, ě, ň, ř, š, Ť, ů, ž, Č, Ě, Ň, Ř, Š, Ť, Ů, Ž
 
 * Parts of the `EnbPI` class from aws-fortuna.
   The installation of the original package is not working due to dependency

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -67,7 +67,7 @@ def is_module_changed(module_str):
     module_file_path = get_path_from_module(module_str)
     cmd = f"git diff remotes/origin/main -- {module_file_path}"
     try:
-        output = subprocess.check_output(cmd, shell=True, text=True)
+        output = subprocess.check_output(cmd, shell=True, text=True, encoding="utf-8")
         return bool(output)
     except subprocess.CalledProcessError:
         return True


### PR DESCRIPTION
This PR resolves diacritics being decoded on windows and raises a decode error(`'charmap' codec can't decode byte 0x9d in position 3519: character maps to <undefined>`). Added the parameter to enforce encoding inside the `subprocess.check_output` function call.