### PR TITLE
[ENH] making `self._is_vectorized` access more defensive in `BaseTransformer`

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -610,7 +610,7 @@ class BaseTransformer(BaseEstimator):
         X_inner, y_inner, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
 
         # check if we need to vectorize
-        if self._is_vectorized == "unknown":
+        if self.getattr("_is_vectorized", "unknown") == "unknown":
             vectorization_needed = isinstance(X_inner, VectorizedDF)
         else:
             vectorization_needed = self._is_vectorized
@@ -776,7 +776,7 @@ class BaseTransformer(BaseEstimator):
         X_inner, y_inner, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
 
         # check if we need to vectorize
-        if self._is_vectorized == "unknown":
+        if self.getattr("_is_vectorized", "unknown") == "unknown":
             vectorization_needed = isinstance(X_inner, VectorizedDF)
         else:
             vectorization_needed = self._is_vectorized

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -610,7 +610,7 @@ class BaseTransformer(BaseEstimator):
         X_inner, y_inner, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
 
         # check if we need to vectorize
-        if self.getattr("_is_vectorized", "unknown") == "unknown":
+        if getattr(self, "_is_vectorized", "unknown") == "unknown":
             vectorization_needed = isinstance(X_inner, VectorizedDF)
         else:
             vectorization_needed = self._is_vectorized
@@ -776,7 +776,7 @@ class BaseTransformer(BaseEstimator):
         X_inner, y_inner, metadata = self._check_X_y(X=X, y=y, return_metadata=True)
 
         # check if we need to vectorize
-        if self.getattr("_is_vectorized", "unknown") == "unknown":
+        if getattr(self, "_is_vectorized", "unknown") == "unknown":
             vectorization_needed = isinstance(X_inner, VectorizedDF)
         else:
             vectorization_needed = self._is_vectorized

--- a/sktime/transformations/panel/dictionary_based/_sfa.py
+++ b/sktime/transformations/panel/dictionary_based/_sfa.py
@@ -252,6 +252,7 @@ class SFA(BaseTransformer):
         self.breakpoints = self._binning(X, y)
 
         self._is_fitted = True
+        self._is_vectorized = False
         return self
 
     def _transform(self, X, y=None):

--- a/sktime/transformations/panel/dictionary_based/_sfa_fast.py
+++ b/sktime/transformations/panel/dictionary_based/_sfa_fast.py
@@ -28,92 +28,90 @@ class SFAFast(BaseTransformer):
     """Symbolic Fourier Approximation (SFA) Transformer.
 
     Overview: for each series:
-        run a sliding window across the series
-        for each window
-            shorten the series with DFT
-            discretise the shortened series into bins set by MFC
-            form a word from these discrete values
-    by default SFA produces a single word per series (window_size=0)
+    run a sliding window across the series;
+    for each window, shorten the series with DFT;
+    discretise the shortened series into bins set by MFC;
+    form a word from these discrete values,
+    by default SFA produces a single word per series (window_size=0);
     if a window is used, it forms a histogram of counts of words.
 
     Parameters
     ----------
-        word_length:         int, default = 8
-            length of word to shorten window to (using PAA)
+    word_length:         int, default = 8
+        length of word to shorten window to (using PAA)
 
-        alphabet_size:       int, default = 4
-            number of values to discretise each value to
+    alphabet_size:       int, default = 4
+        number of values to discretise each value to
 
-        window_size:         int, default = 12
-            size of window for sliding. Input series
-            length for whole series transform
+    window_size:         int, default = 12
+        size of window for sliding. Input series
+        length for whole series transform
 
-        norm:                boolean, default = False
-            mean normalise words by dropping first fourier coefficient
+    norm:                boolean, default = False
+        mean normalise words by dropping first fourier coefficient
 
-        binning_method:      {"equi-depth", "equi-width", "information-gain", "kmeans",
-                              "quantile"},
-                             default="equi-depth"
-            the binning method used to derive the breakpoints.
+    binning_method:      {"equi-depth", "equi-width", "information-gain", "kmeans",
+                            "quantile"},
+                            default="equi-depth"
+        the binning method used to derive the breakpoints.
 
-        anova:               boolean, default = False
-            If True, the Fourier coefficient selection is done via a one-way
-            ANOVA test. If False, the first Fourier coefficients are selected.
-            Only applicable if labels are given
+    anova:               boolean, default = False
+        If True, the Fourier coefficient selection is done via a one-way
+        ANOVA test. If False, the first Fourier coefficients are selected.
+        Only applicable if labels are given
 
-        variance:               boolean, default = False
-            If True, the Fourier coefficient selection is done via the largest
-            variance. If False, the first Fourier coefficients are selected.
-            Only applicable if labels are given
+    variance:               boolean, default = False
+        If True, the Fourier coefficient selection is done via the largest
+        variance. If False, the first Fourier coefficients are selected.
+        Only applicable if labels are given
 
-        save_words:          boolean, default = False
-            whether to save the words generated for each series (default False)
+    save_words:          boolean, default = False
+        whether to save the words generated for each series (default False)
 
-        bigrams:             boolean, default = False
-            whether to create bigrams of SFA words
+    bigrams:             boolean, default = False
+        whether to create bigrams of SFA words
 
-        feature_selection: {"chi2", "none", "random"}, default: chi2
-            Sets the feature selections strategy to be used. Chi2 reduces the number
-            of words significantly and is thus much faster (preferred). Random also
-            reduces the number significantly. None applies not feature selectiona and
-            yields large bag of words, e.g. much memory may be needed.
+    feature_selection: {"chi2", "none", "random"}, default: chi2
+        Sets the feature selections strategy to be used. Chi2 reduces the number
+        of words significantly and is thus much faster (preferred). Random also
+        reduces the number significantly. None applies not feature selectiona and
+        yields large bag of words, e.g. much memory may be needed.
 
-        p_threshold:  int, default=0.05 (disabled by default)
-            If feature_selection=chi2 is chosen, feature selection is applied based on
-            the chi-squared test. This is the p-value threshold to use for chi-squared
-            test on bag-of-words (lower means more strict). 1 indicates that the test
-            should not be performed.
+    p_threshold:  int, default=0.05 (disabled by default)
+        If feature_selection=chi2 is chosen, feature selection is applied based on
+        the chi-squared test. This is the p-value threshold to use for chi-squared
+        test on bag-of-words (lower means more strict). 1 indicates that the test
+        should not be performed.
 
-        max_feature_count:  int, default=256
-            If feature_selection=random is chosen, this parameter defines the number of
-            randomly chosen unique words used.
+    max_feature_count:  int, default=256
+        If feature_selection=random is chosen, this parameter defines the number of
+        randomly chosen unique words used.
 
-        skip_grams:     boolean, default = False
-            whether to create skip-grams of SFA words
+    skip_grams:     boolean, default = False
+        whether to create skip-grams of SFA words
 
-        remove_repeat_words: boolean, default = False
-            whether to use numerosity reduction (default False)
+    remove_repeat_words: boolean, default = False
+        whether to use numerosity reduction (default False)
 
-        return_sparse:  boolean, default=True
-            if set to true, a scipy sparse matrix will be returned as BOP model.
-            If set to false a dense array will be returned as BOP model. Sparse
-            arrays are much more compact.
+    return_sparse:  boolean, default=True
+        if set to true, a scipy sparse matrix will be returned as BOP model.
+        If set to false a dense array will be returned as BOP model. Sparse
+        arrays are much more compact.
 
-        n_jobs:     int, optional, default = 1
-            The number of jobs to run in parallel for both `transform`.
-            ``-1`` means using all processors.
+    n_jobs:     int, optional, default = 1
+        The number of jobs to run in parallel for both `transform`.
+        ``-1`` means using all processors.
 
-        return_pandas_data_series:          boolean, default = False
-            set to true to return Pandas Series as a result of transform.
-            setting to true reduces speed significantly but is required for
-            automatic test.
+    return_pandas_data_series:          boolean, default = False
+        set to true to return Pandas Series as a result of transform.
+        setting to true reduces speed significantly but is required for
+        automatic test.
 
     Attributes
     ----------
     breakpoints: = []
     num_insts = 0
     num_atts = 0
-
 
     References
     ----------


### PR DESCRIPTION
This PR makes the new access points for `self._is_vectorized` in `BaseTransformer` more defensive, by using `getattr` with a default instead of direct attribute access. The changes were introduced in https://github.com/sktime/sktime/pull/6825 to fix a bug with vectorization ov `inverse_transform`.

As @Abhay-Lejith has pointed out, the `SFA` transformer is failing as it overrides `fit` but not `transform` (see https://github.com/sktime/sktime/actions/runs/10147989805/job/28060326703?pr=6732).

This is not something an estimator should do, as it breaks the API extension pattern, but in case downstream users copied this pattern, at least they will not be impacted.

Also makes some minor changes to `SFA` transformer (setting the attribute in `fit`), and `SFAfast` (docstring formatting).