### PR TITLE
[DOC] fix docstring formatting of `evaluate`

### DIFF
--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -348,20 +348,20 @@ def evaluate(
     2. Fit the ``forecaster`` to :math:`y_{train, 1}`, :math:`X_{train, 1}`,
        with ``fh`` set to the absolute indices of :math:`y_{test, 1}`.
     3. Use the ``forecaster`` to make a prediction ``y_pred`` with the exogeneous
-      data :math:`X_{test, i}`. Predictions are made using either ``predict``,
-      ``predict_proba`` or ``predict_quantiles``, depending on ``scoring``.
+        data :math:`X_{test, i}`. Predictions are made using either ``predict``,
+        ``predict_proba`` or ``predict_quantiles``, depending on ``scoring``.
     4. Compute the ``scoring`` function on ``y_pred`` versus :math:`y_{test, i}`
     5. If ``i == K``, terminate, otherwise
     6. Set ``i = i + 1``
     7. Ingest more data :math:`y_{train, i}`, :math:`X_{train, i}`,
        how depends on ``strategy``:
 
-        - if ``strategy == "refit"``, reset and fit ``forecaster`` via ``fit``,
-          on :math:`y_{train, i}`, :math:`X_{train, i}` to forecast :math:`y_{test, i}`
-        - if ``strategy == "update"``, update ``forecaster`` via ``update``,
-          on :math:`y_{train, i}`, :math:`X_{train, i}` to forecast :math:`y_{test, i}`
-        - if ``strategy == "no-update_params"``, forward ``forecaster`` via ``update``,
-          with argument ``update_params=False``, to the cutoff of :math:`y_{train, i}`
+      - if ``strategy == "refit"``, reset and fit ``forecaster`` via ``fit``,
+        on :math:`y_{train, i}`, :math:`X_{train, i}` to forecast :math:`y_{test, i}`
+      - if ``strategy == "update"``, update ``forecaster`` via ``update``,
+        on :math:`y_{train, i}`, :math:`X_{train, i}` to forecast :math:`y_{test, i}`
+      - if ``strategy == "no-update_params"``, forward ``forecaster`` via ``update``,
+        with argument ``update_params=False``, to the cutoff of :math:`y_{train, i}`
 
     8. Go to 3
 


### PR DESCRIPTION
This PR fixes docstring formatting of forecasting `evaluate`, which has some odd indentations in places where line breaks are intended.