### PR TITLE
[MNT] restrict failing Mr-SEQL version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,7 +270,7 @@ binder = [
   "pandas<2.0.0",
 ]
 cython_extras = [
-  "mrseql < 0.0.4",
+  "mrseql < 0.0.3",
   'mrsqm; python_version < "3.11"',
   "numba<0.61",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,7 +270,7 @@ binder = [
   "pandas<2.0.0",
 ]
 cython_extras = [
-  "mrseql < 0.4.0",
+  "mrseql < 0.0.4",
   'mrsqm; python_version < "3.11"',
   "numba<0.61",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,7 +270,7 @@ binder = [
   "pandas<2.0.0",
 ]
 cython_extras = [
-  "mrseql",
+  "mrseql < 0.4.0",
   'mrsqm; python_version < "3.11"',
   "numba<0.61",
 ]


### PR DESCRIPTION
Mr-SEQL versions 0.0.3 and 0.0.4 was released on Aug 2, and it breaks the sktime interface conformance tests, see https://github.com/sktime/sktime/issues/6880

This PR restricts mrseql to <0.0.3 until the underlying issue is fixed.