### PR TITLE
[MNT] Fix `pykan` import and dependency checks

### DIFF
--- a/sktime/forecasting/pykan_forecaster.py
+++ b/sktime/forecasting/pykan_forecaster.py
@@ -59,6 +59,14 @@ class PyKANForecaster(BaseForecaster):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["benheid"],
+        "maintainers": ["benheid"],
+        "python_version": None,
+        "python_dependencies": ["pykan", "torch"],
+        # estimator type
+        # --------------
         "y_inner_mtype": "pd.Series",
         "X_inner_mtype": "pd.DataFrame",
         "scitype:y": "univariate",
@@ -70,9 +78,6 @@ class PyKANForecaster(BaseForecaster):
         "capability:pred_int": False,
         "capability:pred_int:insample": False,
         "capability:insample": False,
-        "python_version": None,
-        "python_dependencies": ["pykan", "torch"],
-        "python_dependencies_alias": {"pykan": "kan"},
     }
 
     def __init__(

--- a/sktime/forecasting/pykan_forecaster.py
+++ b/sktime/forecasting/pykan_forecaster.py
@@ -1,7 +1,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Dummy forecasters."""
 
-__author__ = ["bheidri"]
+__author__ = ["benheid"]
 
 import pandas as pd
 from skbase.utils.dependencies import _check_soft_dependencies
@@ -18,7 +18,7 @@ else:
         """Dummy class if torch is unavailable."""
 
 
-if _check_soft_dependencies("kan", severity="none"):
+if _check_soft_dependencies("pykan", severity="none"):
     from kan import KAN
 
 

--- a/sktime/forecasting/pykan_forecaster.py
+++ b/sktime/forecasting/pykan_forecaster.py
@@ -4,12 +4,12 @@
 __author__ = ["benheid"]
 
 import pandas as pd
-from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import BaseForecaster
 from sktime.split import temporal_train_test_split
+from sktime.utils.dependencies import _check_soft_dependencies
 
-if _check_soft_dependencies("torch", severity="none"):
+if _check_soft_dependencies(["pykan", "torch"], severity="none"):
     import torch
     from torch.utils.data import Dataset
 else:
@@ -18,7 +18,7 @@ else:
         """Dummy class if torch is unavailable."""
 
 
-if _check_soft_dependencies("pykan", severity="none"):
+if _check_soft_dependencies(["pykan", "torch"], severity="none"):
     from kan import KAN
 
 


### PR DESCRIPTION
Fixes some `pykan` related imports and dependency checks.

* `_check_soft_dependencies` to use correct PEP 440 specifier
* removed dependencies alias from the `pykan` based forecaster

There are failures on main which are also fixed by this.