### PR TITLE
[MNT] make `pyproject.toml` parsing for differential testing more robust against non-package relevant changes

### DIFF
--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -175,7 +175,7 @@ def _get_packages_with_changed_specs():
         if ";" in req:
             req = req.split(";")[0]
 
-        try:
+        try:  # deal with lines that are not package requirement strings
             pkg = Requirement(req).name
         except InvalidRequirement:
             continue

--- a/sktime/utils/git_diff.py
+++ b/sktime/utils/git_diff.py
@@ -152,7 +152,7 @@ def _get_packages_with_changed_specs():
     -------
     tuple of str : names of packages with changed or added specs
     """
-    from packaging.requirements import Requirement
+    from packaging.requirements import InvalidRequirement, Requirement
 
     changed_lines = get_changed_lines("pyproject.toml")
 
@@ -175,8 +175,12 @@ def _get_packages_with_changed_specs():
         if ";" in req:
             req = req.split(";")[0]
 
-        pkg = Requirement(req).name
-        packages.append(pkg)
+        try:
+            pkg = Requirement(req).name
+        except InvalidRequirement:
+            continue
+        else:
+            packages.append(pkg)
 
     # make unique
     packages = tuple(set(packages))


### PR DESCRIPTION
This PR makes `pyproject.toml` parsing for differential testing more robust against non-package relevant changes, e.g., if a line is added that is not a valid package requirement string, such as in a case where `pyproject.toml` is changed outside the dependency specifications block.

Currently, this leads to an exception in `_get_packages_with_changed_specs`.

With the change, no exception is raised, as it is caught and considered a non-package related line.

