### PR TITLE
[MNT] switch windows runners to 2019 image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -267,7 +267,7 @@ jobs:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -33,7 +33,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
-          - windows-latest
+          - windows-2019
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: checkout pull request branch
@@ -64,7 +64,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
-          - windows-latest
+          - windows-2019
         sktime-component:
           - alignment
           - annotation
@@ -106,7 +106,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
-          - windows-latest
+          - windows-2019
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: checkout pull request branch

--- a/.github/workflows/test_base.yml
+++ b/.github/workflows/test_base.yml
@@ -33,7 +33,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
-          - windows-latest
+          - windows-2019
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: checkout pull request branch

--- a/.github/workflows/test_module.yml
+++ b/.github/workflows/test_module.yml
@@ -65,7 +65,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
-          - windows-latest
+          - windows-2019
         sktime-component: ${{ fromJSON(needs.detect.outputs.module_changes) }}
     runs-on: ${{ matrix.operating-system }}
     steps:

--- a/.github/workflows/test_other.yml
+++ b/.github/workflows/test_other.yml
@@ -46,7 +46,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
-          - windows-latest
+          - windows-2019
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: checkout pull request branch


### PR DESCRIPTION
Changes windows runners to 2019 in an attempt to diagnose https://github.com/sktime/sktime/issues/6884.

May be a solution, but we should not merge yet.