### PR TITLE
[ENH] moved ignores-exog tag check to before scitype checks in base forecaster

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1544,6 +1544,10 @@ class BaseForecaster(BaseEstimator):
             requires_vectorization = False
         # end checking y
 
+        # check: if X is ignored by inner methods, pass None to them
+        if self.get_tag("ignores-exogeneous-X"):
+            X = None
+
         # checking X
         if X is not None:
             # request only required metadata from checks
@@ -1587,10 +1591,6 @@ class BaseForecaster(BaseEstimator):
             # X_scitype is used below - set to None if X is None
             X_scitype = None
 
-        # extra check: if X is ignored by inner methods, pass None to them
-        if self.get_tag("ignores-exogeneous-X"):
-            X = None
-            X_scitype = None
         # end checking X
 
         # compatibility checks between X and y


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Initially, in the base forecaster, `X` undergoes the scitype and compatibility checks, then the `ignores-exogeneous-X` tag is checked and if it is `True`, then `X` is set to `None`. This means that the checks are unnecessary.
So this PR moves the check for the `ignores-exogeneous-X` tag to before the scitype checks and sets X to None(if ignored). This avoids the unnecessary checks of X compatibility.
#### Does your contribution introduce a new dependency? If yes, which one?
<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->
No.


#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
No new tests added.
#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.


<!--
Thanks for contributing!
-->
