### PR TITLE
[BUG] fix `_check_soft_dependencies` for post and pre versions of patch versions

### DIFF
--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -23,7 +23,7 @@ def _check_soft_dependencies(
     obj=None,
     msg=None,
     suppress_import_stdout="deprecated",
-    normalize_reqs=False,
+    normalize_reqs=True,
 ):
     """Check if required soft dependencies are installed and raise error or warning.
 
@@ -60,7 +60,7 @@ def _check_soft_dependencies(
     msg : str, or None, default=None
         if str, will override the error message or warning shown with msg
 
-    normalize_reqs : bool, default=False
+    normalize_reqs : bool, default=True
         whether to normalize the requirement strings before checking them,
         by removing build metadata from versions.
         If set True, pre, post, and dev versions are removed from all version strings.

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -62,7 +62,8 @@ def _check_soft_dependencies(
 
     normalize_reqs : bool, default=False
         whether to normalize the requirement strings before checking them,
-        by removing build metadata from versions
+        by removing build metadata from versions.
+        If set True, build metadata will be ignored in both requirements and actuals.
 
         Example: requirement "my_pkg==2.3.4.post1" will be normalized to "my_pkg==2.3.4"
 

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -23,6 +23,7 @@ def _check_soft_dependencies(
     obj=None,
     msg=None,
     suppress_import_stdout="deprecated",
+    normalize_reqs=False,
 ):
     """Check if required soft dependencies are installed and raise error or warning.
 
@@ -58,6 +59,12 @@ def _check_soft_dependencies(
 
     msg : str, or None, default=None
         if str, will override the error message or warning shown with msg
+
+    normalize_reqs : bool, default=False
+        whether to normalize the requirement strings before checking them,
+        by removing build metadata from versions
+
+        Example: requirement "my_pkg==2.3.4.post1" will be normalized to "my_pkg==2.3.4"
 
     Raises
     ------
@@ -120,7 +127,8 @@ def _check_soft_dependencies(
     for package in packages:
         try:
             req = Requirement(package)
-            req = _normalize_requirement(req)
+            if normalize_reqs:
+                req = _normalize_requirement(req)
         except InvalidRequirement:
             msg_version = (
                 f"wrong format for package requirement string, "
@@ -134,6 +142,8 @@ def _check_soft_dependencies(
         package_version_req = req.specifier
 
         pkg_env_version = _get_pkg_version(package_name)
+        if normalize_reqs:
+            pkg_env_version = _normalize_version(pkg_env_version)
 
         # if package not present, make the user aware of installation reqs
         if pkg_env_version is None:
@@ -543,12 +553,9 @@ def _normalize_requirement(req):
     # Process each specifier in the requirement
     normalized_specs = []
     for spec in req.specifier:
-        # Parse the version and remove the build metadata
-        spec_v = Version(spec.version)
-        version_wo_build_metadata = f"{spec_v.major}.{spec_v.minor}.{spec_v.micro}"
-
         # Create a new specifier without the build metadata
-        normalized_spec = Specifier(f"{spec.operator}{version_wo_build_metadata}")
+        normalized_version = _normalize_version(spec.version)
+        normalized_spec = Specifier(f"{spec.operator}{normalized_version}")
         normalized_specs.append(normalized_spec)
 
     # Reconstruct the specifier set
@@ -558,6 +565,29 @@ def _normalize_requirement(req):
     normalized_req = Requirement(f"{req.name}{normalized_specifier_set}")
 
     return normalized_req
+
+
+def _normalize_version(version):
+    """Normalize version string by removing build metadata.
+
+    Parameters
+    ----------
+    version : packaging.version.Version
+        version object to normalize, e.g., Version("1.2.3+foobar")
+
+    Returns
+    -------
+    normalized_version : packaging.version.Version
+        normalized version object with build metadata removed, e.g., Version("1.2.3")
+    """
+    if version is None:
+        return None
+    if not isinstance(version, Version):
+        version_obj = Version(version)
+    else:
+        version_obj = version
+    normalized_version = f"{version_obj.major}.{version_obj.minor}.{version_obj.micro}"
+    return normalized_version
 
 
 def _raise_at_severity(

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -63,9 +63,12 @@ def _check_soft_dependencies(
     normalize_reqs : bool, default=False
         whether to normalize the requirement strings before checking them,
         by removing build metadata from versions.
-        If set True, build metadata will be ignored in both requirements and actuals.
+        If set True, pre, post, and dev versions are removed from all version strings.
 
-        Example: requirement "my_pkg==2.3.4.post1" will be normalized to "my_pkg==2.3.4"
+        Example if True:
+        requirement "my_pkg==2.3.4.post1" will be normalized to "my_pkg==2.3.4";
+        an actual version "my_pkg==2.3.4.post1" will be considered compatible with
+        "my_pkg==2.3.4". If False, the this situation would raise an error.
 
     Raises
     ------


### PR DESCRIPTION
Currently, `_check_soft_dependencies` behaves unexpectedly for post and pre versions of patch releases, for requirements and/or actuals such as `"my_pkg=2.3.4.post0"`.

This PR fixes the utility for that case, and adds a flag that determines whether pre/post identifiers should be ignored consistently.

This should also fix the current CI failures due to `matplotlib` `post` versions.