### PR TITLE
[MNT] remove `numpy 2` incompatibility flag from `numba` based estimators

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -205,7 +205,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         from packaging.requirements import Requirement
 
         # pypi package names of soft dependencies that are not numpy 2 compatibleS
-        NOT_NP2_COMPATIBLE = ["prophet", "numba"]
+        NOT_NP2_COMPATIBLE = ["prophet"]
 
         softdeps = self.get_class_tag("python_dependencies", [])
         if softdeps is None:


### PR DESCRIPTION
`numba` used to be incompatible with `numpy 2`, requiring us to dynamically set estimator specific version bounds.

This PR removes the flag, as `numba` seems to be compatible with `numpy 2` now.