### PR TITLE
[MNT] 0.32.0 deprecations and change actions

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -149,7 +149,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         """,
     }
 
-    # TODO 0.32.0: check whether python 3.8 has reached EoL.
+    # TODO 0.33.0: check whether python 3.8 has reached EoL.
     # If so, remove warning altogether
     def __init__(self):
         super().__init__()
@@ -163,7 +163,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         py39_or_higher = SpecifierSet(">=3.9")
         sys_version = sys.version.split(" ")[0]
 
-        # todo 0.32.0 - check whether python 3.8 eol is reached.
+        # todo 0.33.0 - check whether python 3.8 eol is reached.
         # If yes, remove this msg.
         if sys_version not in py39_or_higher:
             warn(
@@ -184,7 +184,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         # for rationale, see _handle_numpy2_softdeps
         self._handle_numpy2_softdeps()
 
-    # TODO 0.32.0: check list of numpy 2 incompatible soft deps
+    # TODO 0.33.0: check list of numpy 2 incompatible soft deps
     # remove any from NOT_NP2_COMPATIBLE that become compatible
     def _handle_numpy2_softdeps(self):
         """Handle tags for soft deps that are not numpy 2 compatible.

--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -20,7 +20,7 @@ from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.utils.validation.panel import check_X
 
 
-# TODO: fix this in 0.32.0
+# TODO: fix this in 0.33.0
 # base class should have been changed to BaseEarlyClassifier
 class ProbabilityThresholdEarlyClassifier(BaseClassifier):
     """Probability Threshold Early Classifier.

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -806,7 +806,7 @@ def _to_relative(fh: ForecastingHorizon, cutoff=None) -> ForecastingHorizon:
             absolute = _coerce_to_period(absolute, freq=fh._freq)
             cutoff = _coerce_to_period(cutoff, freq=fh._freq)
 
-        # TODO: 0.32.0:
+        # TODO: 0.33.0:
         # Check at every minor release whether lower pandas bound >=0.15.0
         # if yes, can remove the workaround in the "else" condition and the check
         #

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -163,7 +163,7 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                         if len(levels) == 1:
                             levels = levels[0]
                         yt[ix] = y.xs(ix, level=levels, axis=1)
-                        # todo 0.32.0 - check why this cannot be easily removed
+                        # todo 0.33.0 - check why this cannot be easily removed
                         # in theory, we should get rid of the "Coverage" case treatment
                         # (the legacy naming convention was removed in 0.23.0)
                         # deal with the "Coverage" case, we need to get rid of this

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1807,7 +1807,7 @@ class _ReducerMixin:
         return fh_idx
 
 
-# TODO (release 0.32.0)
+# TODO (release 0.33.0)
 # change the default of `windows_identical` to `False`
 # update the docstring for parameter `windows_identical`
 # remove the corresponding warning and simplify __init__
@@ -1891,7 +1891,7 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
           length corresponds to (total observations + 1 - window_length +
           forecasting horizon).
 
-        Default value will change to `False` in version 0.32.0.
+        Default value will change to `False` in version 0.33.0.
     """
 
     _tags = {
@@ -1924,7 +1924,7 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         if windows_identical == "changing_value":
             warn(
                 "In `DirectReductionForecaster`, the default value of parameter "
-                "`windows_identical` will change to `False` in version 0.32.0. "
+                "`windows_identical` will change to `False` in version 0.33.0. "
                 "Before the introduction of `windows_identical`, the parameter "
                 "defaulted implicitly to `True` when `X_treatment` was set to "
                 "`shifted`, and to `False` when `X_treatment` was set to "

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -20,7 +20,7 @@ from sktime.forecasting.model_selection._tune import (
 )
 
 
-# todo 0.32.0 - check whether we should remove, otherwise bump
+# todo 0.33.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def temporal_train_test_split(
     y, X=None, test_size=None, train_size=None, fh=None, anchor="start"
@@ -47,7 +47,7 @@ def temporal_train_test_split(
     )
 
 
-# todo 0.32.0 - check whether we should remove, otherwise bump
+# todo 0.33.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
     """Legacy export of Expanding window splitter.
@@ -70,7 +70,7 @@ def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
     return _EWSplitter(fh=fh, initial_window=initial_window, step_length=step_length)
 
 
-# todo 0.32.0 - check whether we should remove, otherwise bump
+# todo 0.33.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def SlidingWindowSplitter(
     fh=1, window_length=10, step_length=1, initial_window=None, start_with_window=True

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -22,7 +22,6 @@ def _check_soft_dependencies(
     severity="error",
     obj=None,
     msg=None,
-    suppress_import_stdout="deprecated",
     normalize_reqs=True,
 ):
     """Check if required soft dependencies are installed and raise error or warning.
@@ -83,18 +82,13 @@ def _check_soft_dependencies(
     -------
     boolean - whether all packages are installed, only if no exception is raised
     """
-    # todo 0.32.0: remove this warning
-    if suppress_import_stdout != "deprecated":
+    # todo 0.33.0: remove this warning
+    if package_import_alias != "deprecated":
         warnings.warn(
-            "In sktime _check_soft_dependencies, the suppress_import_stdout argument "
+            "In sktime _check_soft_dependencies, the package_import_alias argument "
             "is deprecated and no longer has any effect. "
-            "The argument will be removed in version 0.32.0, so users of the "
-            "_check_soft_dependencies utility should not pass this argument anymore. "
-            "The _check_soft_dependencies utility also no longer causes imports, "
-            "hence no stdout "
-            "output is created from imports, for any setting of the "
-            "suppress_import_stdout argument. If you wish to import packages "
-            "and make use of stdout prints, import the package directly instead.",
+            "The argument will be removed in version 0.33.0, so users of the "
+            "_check_soft_dependencies utility should not pass this argument anymore.",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
Carries out deprecations and change actions scheduled for 0.32.0:

* remove `suppress_import_stdout` argument in `_check_soft_dependencies`
* bump deprecation/change checks scheduled for 0.32.0 to 0.33.0