### PR TITLE
[BUG] changelog utility: fix termination condition to retrieve merged PR

### DIFF
--- a/build_tools/changelog.py
+++ b/build_tools/changelog.py
@@ -61,7 +61,7 @@ def fetch_pull_requests_since_last_release() -> list[dict]:
         all_pulls.extend(
             [p for p in pulls if parser.parse(p["merged_at"]) > published_at]
         )
-        is_exhausted = any(parser.parse(p["merged_at"]) < published_at for p in pulls)
+        is_exhausted = any(parser.parse(p["updated_at"]) < published_at for p in pulls)
         page += 1
     return all_pulls
 


### PR DESCRIPTION
This PR fixes a bug in the changelog utility, namely the termination condition to retrieve all merged PR since the last release.

The bug manifests as less PR being retrieved than merged.

The reason for this is the termination condition: the script retrieves PR, sorted by "updated at", until a PR is encountered that was merged before the release.

This terminates too early, in all cases where a merged PR before the last release gets updated so it ends up more recent than the last page that contains merged PR after the last release. The subsequent pages of PRs are incorrectly cut off then.

The fix is simple, the termination condition should be when a PR is encountered whose latest *update* was before the last release. Since PR are ordered by when the latest update was, this ensures that all PRs that got updated later than the release get checked. The set of PR that got merged is a subset of these, so the condition is sufficient to check all relevant PRs.