### PR TITLE
[ENH] in estimator html repr, make version retrieval safer and more flexible

### DIFF
--- a/sktime/utils/_estimator_html_repr.py
+++ b/sktime/utils/_estimator_html_repr.py
@@ -1,6 +1,8 @@
 """Functionality to represent instance of BaseObject as html."""
+# based on the slearn module of the same name
 
 import html
+import importlib
 import uuid
 from contextlib import closing
 from io import StringIO
@@ -9,9 +11,7 @@ from string import Template
 
 from packaging.version import parse as parse_version
 
-from .. import __version__
-
-__author__ = ["RNKuhns"]
+__author__ = ["RNKuhns", "mateuszkasprowicz"]
 
 
 class _VisualBlock:
@@ -257,9 +257,13 @@ class _HTMLDocumentationLinkMixin:
     _doc_link_module = "sktime"
     _doc_link_url_param_generator = None
 
+    def _get_version(self):
+        module = importlib.import_module(self._doc_link_module)
+        return parse_version(module.__version__).base_version
+
     @property
     def _doc_link_template(self):
-        sktime_version = parse_version(__version__).base_version
+        sktime_version = self._get_version()
         return getattr(
             self,
             "__doc_link_template",

--- a/sktime/utils/tests/test_estimator_html_repr.py
+++ b/sktime/utils/tests/test_estimator_html_repr.py
@@ -13,7 +13,7 @@ def test_html_documentation_link_mixin_sktime(mock_version):
     """
 
     # mock the `__version__` where the mixin is located
-    with patch("sktime.utils._estimator_html_repr.__version__", mock_version):
+    with patch("sktime.__version__", mock_version):
         mixin = _HTMLDocumentationLinkMixin()
 
         assert mixin._doc_link_module == "sktime"


### PR DESCRIPTION
This PR makes the version retrieval for the html repr safer and more flexible, by replacing a relative import with an import that uses the doc source attribute as a reference instead.