### PR TITLE
[ENH] improve test_global_forecasting_tag

### DIFF
--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -950,7 +950,9 @@ class TestAllGlobalForecasters(TestAllObjects):
     estimator_type_filter = "global_forecaster"
 
     def test_global_forecasting_tag(self, estimator_class):
-        global_forecasting_tag = estimator_class._tags["capability:global_forecasting"]
+        global_forecasting_tag = estimator_class.get_class_tag(
+            "capability:global_forecasting"
+        )
         assert global_forecasting_tag is True
 
     def test_pridect_signature(self, estimator_class):


### PR DESCRIPTION
This PR fixes `test_global_forecasting_tag` to incorporate classes that are not inherited by `_BaseGlobalForecaster` rather inherit a class that inherits this. Current behaviour does not detect that the estimator supports global forecasting if it does not directly inherit `_BaseGlobalForecaster` and the global tests are not executed.

Problem was identified in https://github.com/sktime/sktime/pull/6928 where `LTSFLinearForecaster` inherits `BaseDeepNetworkPyTorch` which inherits `_BaseGlobalForecaster` and global capability could not be detected during tests.