### PR TITLE
[MNT] handle more `pandas` deprecations

### DIFF
--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -335,8 +335,8 @@ def test_shift_index(length1_index, by):
 
 
 DURATIONS_ALLOWED = [
-    pd.TimedeltaIndex(range(3), unit="D", freq="D"),
-    pd.TimedeltaIndex(range(0, 9, 3), unit="D", freq="3D"),
+    pd.to_timedelta(range(3), unit="D"),
+    pd.TimedeltaIndex(pd.to_timedelta(range(0, 9, 3), unit="D"), freq="3D"),
     pd.tseries.offsets.MonthEnd(3),
     # we also support pd.Timedelta, but it does not have freqstr so we
     # cannot automatically infer the unit during testing

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -335,7 +335,7 @@ def test_shift_index(length1_index, by):
 
 
 DURATIONS_ALLOWED = [
-    pd.to_timedelta(range(3), unit="D"),
+    pd.TimedeltaIndex(pd.to_timedelta(range(3), unit="D"), freq="D"),
     pd.TimedeltaIndex(pd.to_timedelta(range(0, 9, 3), unit="D"), freq="3D"),
     pd.tseries.offsets.MonthEnd(3),
     # we also support pd.Timedelta, but it does not have freqstr so we

--- a/sktime/forecasting/tests/test_varmax.py
+++ b/sktime/forecasting/tests/test_varmax.py
@@ -69,6 +69,20 @@ def test_VARMAX_against_statsmodels_with_exog():
     """
     from statsmodels.tsa.api import VARMAX as _VARMAX
 
+    pandas2 = _check_soft_dependencies("pandas>=2.0.0", severity="none")
+    if pandas2:
+        freq = "ME"
+    else:
+        freq = "M"
+
+    np.random.seed(13455)
+    index = pd.date_range(start="2020-01", end="2021-12", freq=freq)
+    df = pd.DataFrame(
+        np.random.randint(0, 100, size=(23, 3)),
+        columns=list("ABC"),
+        index=pd.PeriodIndex(index),
+    )
+
     train, test = temporal_train_test_split(df.astype("float64"))
     y_train, X_train = train[["A", "B"]], train[["C"]]
     _, X_test = test[["A", "B"]], test[["C"]]

--- a/sktime/forecasting/tests/test_varmax.py
+++ b/sktime/forecasting/tests/test_varmax.py
@@ -11,14 +11,7 @@ from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.varmax import VARMAX
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
-
-np.random.seed(13455)
-index = pd.date_range(start="2020-01", end="2021-12", freq="M")
-df = pd.DataFrame(
-    np.random.randint(0, 100, size=(23, 3)),
-    columns=list("ABC"),
-    index=pd.PeriodIndex(index),
-)
+from sktime.utils.dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skip(reason="undiagnosed failure, see #6260")
@@ -32,6 +25,20 @@ def test_VARMAX_against_statsmodels():
     with default variables.
     """
     from statsmodels.tsa.api import VARMAX as _VARMAX
+
+    pandas2 = _check_soft_dependencies("pandas>=2.0.0", severity="none")
+    if pandas2:
+        freq = "ME"
+    else:
+        freq = "M"
+
+    np.random.seed(13455)
+    index = pd.date_range(start="2020-01", end="2021-12", freq=freq)
+    df = pd.DataFrame(
+        np.random.randint(0, 100, size=(23, 3)),
+        columns=list("ABC"),
+        index=pd.PeriodIndex(index),
+    )
 
     train, _ = temporal_train_test_split(df.astype("float64"))
     y = train[["A", "B"]]


### PR DESCRIPTION
This PR handles some remaining `pandas` related deprecation warnings:

* `"M"` and `"ME"` freqenties
* time delta `unit` argument