### PR TITLE
[BUG] Fix Xt_msg type in tranformations.base

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1316,7 +1316,7 @@ class BaseTransformer(BaseEstimator):
                 Xt_valid, Xt_msg, metadata = check_is_mtype(
                     Xt,
                     ALLOWED_OUT_MTYPES,
-                    msg_return_dict="list",
+                    msg_return_dict="dict",
                     return_metadata=Xt_metadata_required,
                 )
 


### PR DESCRIPTION
I noticed this bug while working on #6650. `Xt_msg` should be `dict`, not `list` (`Xt_msg.items` is called immediately afterwards).