### PR TITLE
[MNT] update versions of `pre-commit` hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.1
+    rev: v0.5.7
     hooks:
       - id: ruff-format
       - id: ruff


### PR DESCRIPTION
Simple maintenance PR

1. `pre-commit autoupdate` -> bumped `ruff`
2. `pre-commit run --all-files` -> made no changes -> indicates all files on `main` are well formatted