### PR TITLE
marrov [ENH] Hierarchical sales toydata generator from workshops

### DIFF
--- a/docs/source/api_reference/datasets.rst
+++ b/docs/source/api_reference/datasets.rst
@@ -8,6 +8,7 @@ The ``datasets`` module contains:
 * loaders which fetch datasets from data repositories on the internet,
   and retrieve them as in-memory datasets in ``sktime`` compatible formats
 * loaders which fetch an individual dataset, usually for illustration purposes
+* toy data generators for didactic and illustrative purposes
 * utilities to write to, and load from, time series specific file formats
 
 Loaders from dataset repositories
@@ -64,7 +65,6 @@ Single time series
 Panels of time series
 ^^^^^^^^^^^^^^^^^^^^^
 
-
 .. automodule:: sktime.datasets
     :no-members:
     :no-inherited-members:
@@ -83,6 +83,25 @@ Panels of time series
     load_japanese_vowels
     load_macroeconomic
     load_osuleaf
+
+
+Toy data generators
+-------------------
+
+Hierarchical data
+^^^^^^^^^^^^^^^^^
+
+.. automodule:: sktime.datasets
+    :no-members:
+    :no-inherited-members:
+
+.. currentmodule:: sktime.datasets
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: function.rst
+
+    load_hierarchical_sales_toydata
 
 
 Loading from and writing to files

--- a/docs/source/api_reference/datasets.rst
+++ b/docs/source/api_reference/datasets.rst
@@ -88,8 +88,8 @@ Panels of time series
 Toy data generators
 -------------------
 
-Hierarchical data
-^^^^^^^^^^^^^^^^^
+Hierarchical time series data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: sktime.datasets
     :no-members:

--- a/sktime/datasets/__init__.py
+++ b/sktime/datasets/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "load_electric_devices_segmentation",
     "load_acsf1",
     "load_macroeconomic",
+    "load_hierarchical_sales_toydata",
     "generate_example_long_table",
     "load_from_arff_to_dataframe",
     "load_from_long_to_dataframe",
@@ -49,6 +50,7 @@ from sktime.datasets._data_io import (
     make_multi_index_dataframe,
 )
 from sktime.datasets._fpp3_loaders import DATASET_NAMES_FPP3, load_fpp3
+from sktime.datasets._hierarchical_demo import load_hierarchical_sales_toydata
 from sktime.datasets._readers_writers.arff import (
     load_from_arff_to_dataframe,
     write_tabular_transformation_to_arff,

--- a/sktime/datasets/_hierarchical_demo.py
+++ b/sktime/datasets/_hierarchical_demo.py
@@ -1,4 +1,5 @@
 """Demo data for hierarchical forecasting."""
+
 import numpy as np
 
 __author__ = ["marrov"]

--- a/sktime/datasets/_hierarchical_demo.py
+++ b/sktime/datasets/_hierarchical_demo.py
@@ -1,0 +1,76 @@
+"""Demo data for hierarchical forecasting."""
+import numpy as np
+
+__author__ = ["marrov"]
+
+
+def load_hierarchical_sales_toydata():
+    """Return hierarchical sales toy data to demonstrate hierarchical forecasting.
+
+    Return data covers 5 years of monthly sales data for 2 product lines,
+    and 4 product groups.
+
+    Hierarchical structure:
+
+    - Product line 1: Food preparation
+        - Product group 1A: Hobs
+        - Product group 1B: Ovens
+    - Product line 2: Food preservation
+        - Product group 2A: Fridges
+        - Product group 2B: Freezers
+
+    Returns
+    -------
+    hierarchy : pd.DataFrame in pd_multiindex_hier mtype format
+        Product hierarchy with row MultiIndex "Product line", "Product group", "Date".
+        Column "Sales" contains total sales for each product group in monthly period.
+    """
+    # Get daily historic sales and rename columns and indexes according to hierarchy
+    from sktime.utils._testing.hierarchical import _make_hierarchical
+
+    n_years = 5
+    y = (
+        _make_hierarchical(
+            hierarchy_levels=(2, 4),
+            min_timepoints=365 * n_years,
+            max_timepoints=365 * n_years,
+            random_state=0,
+        )
+        .drop(
+            index=[
+                ("h0_0", "h1_2"),
+                ("h0_0", "h1_3"),
+                ("h0_1", "h1_0"),
+                ("h0_1", "h1_1"),
+            ]
+        )
+        .rename(
+            index={
+                "h0_0": "Food preparation",
+                "h0_1": "Food preservation",
+                "h1_0": "Hobs",
+                "h1_1": "Ovens",
+                "h1_2": "Fridges",
+                "h1_3": "Freezers",
+            }
+        )
+        .reset_index()
+        .rename(
+            columns={
+                "h0": "Product line",
+                "h1": "Product group",
+                "time": "Date",
+                "c0": "Sales",
+            }
+        )
+    )
+
+    # Set date as monthly as sales as int and aggregate date
+    y["Date"] = y["Date"].dt.to_period("M")
+    y = y.groupby(by=["Product line", "Product group", "Date"]).sum()
+
+    # Add noise to have different time series
+    noise = np.random.RandomState(seed=0).normal(1, 0.3, np.shape(y))
+    y = (y * noise).round(0)
+
+    return y

--- a/sktime/datasets/tests/test_hierarchical_demo.py
+++ b/sktime/datasets/tests/test_hierarchical_demo.py
@@ -1,0 +1,18 @@
+"""Test functions for load_hierarchical_sales_toydata."""
+
+__author__ = ["fkiraly"]
+
+from sktime.datatypes import check_raise
+
+
+def test_load_hierarchical_sales_toydata():
+    """Test that load_hierarchical_sales_toydata runs and returns expected format."""
+    from sktime.datasets import load_hierarchical_sales_toydata
+
+    df = load_hierarchical_sales_toydata()
+
+    check_raise(
+        df,
+        "pd_multiindex_hier",
+        var_name="return of load_hierarchical_sales_toydata",
+    )

--- a/sktime/datasets/tests/test_loaders.py
+++ b/sktime/datasets/tests/test_loaders.py
@@ -1,4 +1,4 @@
-"""Test functions for loose loaers."""
+"""Test functions for loose loaders."""
 
 __author__ = ["fkiraly"]
 


### PR DESCRIPTION
This PR adds the hierarchical sales toydata generator, which has now been used in many workshops, to the `datasets` module.

The generator was originally written by @marrov.