### PR TITLE
[BUG] fix `make_reduction` type inference for non-sklearn estimators

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,7 +290,7 @@ jobs:
 
       - name: Install sktime and dependencies
         shell: bash
-        run: python -m pip install .[all_extras_pandas2,dev,dl] --no-cache-dir
+        run: python -m pip install .[all_extras_pandas2,dev,dl,compatibility_tests] --no-cache-dir
 
       - name: Show dependencies
         run: python -m pip list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,6 +305,9 @@ numpy1 = [
 pandas1 = [
   "pandas<2.0.0",
 ]
+compatibility_tests = [
+  "catboost",
+]
 
 [project.urls]
 "API Reference" = "https://www.sktime.net/en/stable/api_reference.html"

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -2268,7 +2268,7 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         if _check_soft_dependencies("catboost", severity="none"):
             from catboost import CatBoostRegressor
 
-            est = CatBoostRegressor(learning_rate=1, depth=6, loss_function='RMSE')
+            est = CatBoostRegressor(learning_rate=1, depth=6, loss_function="RMSE")
             params6 = {"estimator": est, "window_length": 3}
             params.append(params6)
         return params

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1631,7 +1631,7 @@ def _infer_scitype(estimator):
     if is_sklearn_estimator(estimator):
         return f"tabular-{sklearn_scitype(estimator)}"
     else:
-        inferred_skt_scitype = scitype(estimator)
+        inferred_skt_scitype = scitype(estimator, raise_on_unknown=False)
         if inferred_skt_scitype in ["object", "estimator"]:
             return "tabular-regressor"
         if inferred_skt_scitype == "regressor":

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -2271,11 +2271,11 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         # left here for future reference, e.g., test for non-compliant estimators
         #
         # if _check_soft_dependencies("catboost", severity="none"):
-            # from catboost import CatBoostRegressor
-
-            # est = CatBoostRegressor(learning_rate=1, depth=6, loss_function="RMSE")
-            # params6 = {"estimator": est, "window_length": 3}
-            # params.append(params6)
+        #     from catboost import CatBoostRegressor
+        #
+        #     est = CatBoostRegressor(learning_rate=1, depth=6, loss_function="RMSE")
+        #     params6 = {"estimator": est, "window_length": 3}
+        #     params.append(params6)
         return params
 
 

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -2230,8 +2230,6 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         """
         from sklearn.linear_model import LinearRegression
 
-        from sktime.utils.dependencies import _check_soft_dependencies
-
         est = LinearRegression()
         params1 = {
             "estimator": est,

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -2265,12 +2265,17 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
 
         params = [params1, params2, params3, params4, params5]
 
-        if _check_soft_dependencies("catboost", severity="none"):
-            from catboost import CatBoostRegressor
+        # this fails because catboost is not sklearn compatible
+        # and fails set_params contracts already in sklearn;
+        # so it also fails them in sktime...
+        # left here for future reference, e.g., test for non-compliant estimators
+        #
+        # if _check_soft_dependencies("catboost", severity="none"):
+            # from catboost import CatBoostRegressor
 
-            est = CatBoostRegressor(learning_rate=1, depth=6, loss_function="RMSE")
-            params6 = {"estimator": est, "window_length": 3}
-            params.append(params6)
+            # est = CatBoostRegressor(learning_rate=1, depth=6, loss_function="RMSE")
+            # params6 = {"estimator": est, "window_length": 3}
+            # params.append(params6)
         return params
 
 

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -2230,6 +2230,8 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         """
         from sklearn.linear_model import LinearRegression
 
+        from sktime.utils.dependencies import _check_soft_dependencies
+
         est = LinearRegression()
         params1 = {
             "estimator": est,
@@ -2260,7 +2262,16 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
             "windows_identical": False,
         }
         params5 = {"estimator": est, "window_length": 0}
-        return [params1, params2, params3, params4, params5]
+
+        params = [params1, params2, params3, params4, params5]
+
+        if _check_soft_dependencies("catboost", severity="none"):
+            from catboost import CatBoostRegressor
+
+            est = CatBoostRegressor(learning_rate=1, depth=6, loss_function='RMSE')
+            params6 = {"estimator": est, "window_length": 3}
+            params.append(params6)
+        return params
 
 
 class RecursiveReductionForecaster(BaseForecaster, _ReducerMixin):

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -455,7 +455,9 @@ def test_make_reduction_with_catboost():
     """
     from catboost import CatBoostRegressor
 
-    estimator = CatBoostRegressor(learning_rate=1, depth=6, loss_function="RMSE")
+    estimator = CatBoostRegressor(
+        learning_rate=1, depth=6, loss_function="RMSE", verbose=False
+    )
 
     forecaster = make_reduction(estimator, scitype="infer")
     assert forecaster._estimator_scitype == "tabular-regressor"

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -442,6 +442,31 @@ def test_make_reduction_infer_scitype_for_sklearn_pipeline():
 
 
 @pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting", "sktime.split"])
+    or not _check_soft_dependencies("catboost", severity="none"),
+    reason="run test only if forecasting or split module has changed",
+)
+def test_make_reduction_with_catboost():
+    """Test make_reduction with catboost.
+
+    catboost is an example of a package that does not fully comply with the
+    sklearn API. We therefore need to rely on the branch of scitype inference
+    that assumes the estimator is a tabular regressor.
+    """
+    from catboost import CatBoostRegressor
+
+    estimator = CatBoostRegressor(learning_rate=1, depth=6, loss_function='RMSE')
+
+    forecaster = make_reduction(estimator, scitype="infer")
+    assert forecaster._estimator_scitype == "tabular-regressor"
+
+    fh = [1, 2, 3]
+    y, X = make_forecasting_problem(make_X=True)
+    y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, fh=fh)
+    forecaster.fit(y_train, X_train, fh=fh).predict(fh, X_test)
+
+
+@pytest.mark.skipif(
     not run_test_module_changed(["sktime.forecasting.compose._reduce"]),
     reason="run test only if reduce module has changed",
 )

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -455,7 +455,7 @@ def test_make_reduction_with_catboost():
     """
     from catboost import CatBoostRegressor
 
-    estimator = CatBoostRegressor(learning_rate=1, depth=6, loss_function='RMSE')
+    estimator = CatBoostRegressor(learning_rate=1, depth=6, loss_function="RMSE")
 
     forecaster = make_reduction(estimator, scitype="infer")
     assert forecaster._estimator_scitype == "tabular-regressor"


### PR DESCRIPTION
`make_reduction` type inference breaks for non-sklearn estimators that follow the interface but do not inherit from `sklearn` `BaseEstimator`, e.g., `CatBoostRegressor`.

This is due to an accidental raise on such estimators, fixed by this PR.