### PR TITLE
[BUG] fix `test_softdep_error` dependency handling check if environment marker tag is not satisfied

### DIFF
--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -90,8 +90,11 @@ def is_soft_dep_missing_message(msg):
     # special message for deep learning dependencies
     error_msg_dl = "required for deep learning"
     cond3 = error_msg_dl in msg
+    # message if environment marker not satisfied
+    error_msg_marker = "packaging marker"
+    cond4 = error_msg_marker in msg
 
-    return cond1 or cond2 or cond3
+    return cond1 or cond2 or cond3 or cond4
 
 
 @pytest.mark.parametrize("module", modules)


### PR DESCRIPTION
The `test_softdep_error` dependency handling check would incorrectly fail if only the environment marker tag was not satisfied, this is an unreported bug apparent in the CI of https://github.com/sktime/sktime/pull/6571 - the first onboard estimator using the `env_marker` tag.

This bug does not impact `check_estimator`, i.e., external API checks, as this is a separate test.

The reason for the failure was that the error message raised in the case that only the marker is mismatched was not caught as one of multiple potential, expected error messages, this has been fixed.