### PR TITLE
[MNT] remove `tsbootstrap` dependency from public dependency sets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ all_extras = [
   'tbats>=1.1',
   'temporian<0.9.0,>=0.7.0,!=0.8.0; python_version < "3.12" and sys_platform != "win32"',
   'tensorflow<2.17,>=2; python_version < "3.12"',
-  'tsbootstrap<0.2,>=0.1.0',
   'tsfresh>=0.17; python_version < "3.12"',
   'tslearn<0.7.0,!=0.6.0,>=0.5.2; python_version < "3.11"',
   "xarray",
@@ -223,7 +222,6 @@ transformations = [
   "statsmodels<0.15,>=0.12.1",
   'stumpy<1.13,>=1.5.1; python_version < "3.12"',
   'temporian<0.9.0,>=0.7.0,!=0.8.0; python_version < "3.12" and sys_platform != "win32"',
-  'tsbootstrap<0.2,>=0.1.0',
   'tsfresh<0.21,>=0.17; python_version < "3.12"',
 ]
 


### PR DESCRIPTION
It appears that the maintainer of `tsbootstrap` is planning a narrowing of dependency bounds of multiple packages. This is likely going to cause dependency conflicts and problematic resolutions.
See https://github.com/astrogilda/tsbootstrap/pull/165

To prevent issues from reaching users, I propose to remove `tsbootstrap` from public facing dependency sets.

The interfaces will still be tested through the `all_extras_pandas2` set, although that may also be impacted by the changes.