### PR TITLE
[BUG] ForecastingBenchmark giving an error when the dataloader returns the tuple (y, X)

### DIFF
--- a/sktime/benchmarking/forecasting.py
+++ b/sktime/benchmarking/forecasting.py
@@ -72,14 +72,27 @@ def forecasting_validation(
     """
     y = dataset_loader()
     results = {}
-    scores_df = evaluate(
-        forecaster=estimator,
-        y=y,
-        cv=cv_splitter,
-        scoring=scorers,
-        backend=backend,
-        backend_params=backend_params,
-    )
+    if isinstance(y, tuple):
+        y, X = y
+        scores_df = evaluate(
+            forecaster=estimator,
+            y=y,
+            X=X,
+            cv=cv_splitter,
+            scoring=scorers,
+            backend=backend,
+            backend_params=backend_params,
+        )
+    else:
+        scores_df = evaluate(
+            forecaster=estimator,
+            y=y,
+            cv=cv_splitter,
+            scoring=scorers,
+            backend=backend,
+            backend_params=backend_params,
+        )
+
     for scorer in scorers:
         scorer_name = scorer.name
         for ix, row in scores_df.iterrows():

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -526,6 +526,9 @@ def evaluate(
 
     ALLOWED_SCITYPES = ["Series", "Panel", "Hierarchical"]
 
+    if isinstance(y, tuple):
+        y, X = y
+
     y_valid, _, _ = check_is_scitype(y, scitype=ALLOWED_SCITYPES, return_metadata=True)
     if not y_valid:
         raise TypeError(

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -526,9 +526,6 @@ def evaluate(
 
     ALLOWED_SCITYPES = ["Series", "Panel", "Hierarchical"]
 
-    if isinstance(y, tuple):
-        y, X = y
-
     y_valid, _, _ = check_is_scitype(y, scitype=ALLOWED_SCITYPES, return_metadata=True)
     if not y_valid:
         raise TypeError(


### PR DESCRIPTION

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
--> Fixes #6964 


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
--> Checks if the parameter `y` is an instance of tuple. if yes it unpacks the tuple into two variables y and X


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
