### PR TITLE
[MNT] add `xfail` for `test_auto_arima` until final fix/diagnosis

### DIFF
--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -733,6 +733,7 @@ def test_exponential_smoothing_case_with_naive():
 
 
 # TODO: Replace this long running test with fast unit test
+@pytest.mark.xfail
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
     or not _check_estimator_deps(AutoARIMA, severity="none"),


### PR DESCRIPTION
This PR adds an `xfail` for `test_auto_arima` until final fix/diagnosis of https://github.com/sktime/sktime/issues/6975

The error seems to indicate `numpy 2` incompatibility.