### PR TITLE
[MNT] add `numpy 2` incompatibility flag to `pmdarima` dependency

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -205,7 +205,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         from packaging.requirements import Requirement
 
         # pypi package names of soft dependencies that are not numpy 2 compatibleS
-        NOT_NP2_COMPATIBLE = ["prophet"]
+        NOT_NP2_COMPATIBLE = ["prophet", "pmdarima"]
 
         softdeps = self.get_class_tag("python_dependencies", [])
         if softdeps is None:

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -1789,7 +1789,7 @@ class ForecastX(BaseForecaster):
         from sktime.forecasting.arima import ARIMA
         from sktime.forecasting.compose import YfromX
         from sktime.forecasting.naive import NaiveForecaster
-        from sktime.utils.dependencies import _check_estimator_deps
+        from sktime.utils.dependencies import _check_soft_dependencies
 
         fs, _ = YfromX.create_test_instances_and_names()
         fx = fs[0]
@@ -1798,7 +1798,8 @@ class ForecastX(BaseForecaster):
         params1 = {"forecaster_X": fx, "forecaster_y": fy}
 
         # example with probabilistic capability
-        if _check_estimator_deps(ARIMA, severity="none"):
+        # todo 0.33.0: check if numpy<2 is still needed
+        if _check_soft_dependencies(["pmdarima", "numpy<2"], severity="none"):
             fy_proba = ARIMA()
         else:
             fy_proba = NaiveForecaster()

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -13,7 +13,6 @@ from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.base._delegate import _DelegatedForecaster
 from sktime.forecasting.base._fh import ForecastingHorizon
 from sktime.registry import scitype
-from sktime.utils.dependencies import _check_soft_dependencies
 from sktime.utils.validation.series import check_series
 from sktime.utils.warnings import warn
 
@@ -1787,8 +1786,10 @@ class ForecastX(BaseForecaster):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
+        from sktime.forecasting.arima import ARIMA
         from sktime.forecasting.compose import YfromX
         from sktime.forecasting.naive import NaiveForecaster
+        from sktime.utils.dependencies import _check_estimator_deps
 
         fs, _ = YfromX.create_test_instances_and_names()
         fx = fs[0]
@@ -1797,9 +1798,7 @@ class ForecastX(BaseForecaster):
         params1 = {"forecaster_X": fx, "forecaster_y": fy}
 
         # example with probabilistic capability
-        if _check_soft_dependencies("pmdarima", severity="none"):
-            from sktime.forecasting.arima import ARIMA
-
+        if _check_estimator_deps(ARIMA, severity="none"):
             fy_proba = ARIMA()
         else:
             fy_proba = NaiveForecaster()


### PR DESCRIPTION
This PR adds a `numpy 2` incompatibility flag to the `pmdarima` dependency. The aim is to address https://github.com/sktime/sktime/issues/6975

This will result in test skips, but also raising an error message for users of `pmdarima` estimators with `numpy 2`.

My major concern is that the failure (a) does not seem to have appeared until recently, and (b) it is localized to a custom test and not the contract tests of `pmdarima` based estimators.

So, we may be breaking working code, say, if the `numpy 2` incompatibility of `pmdarima` is only localized or sporadic.