### PR TITLE
&toandaominh1997 [BUG] fix dependency checkers in case of multiple distributions available in environment, e.g., on databricks

### DIFF
--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -282,7 +282,8 @@ def _get_installed_packages_private():
     # in this case, the *first* occurrence of the package in the list is the one
     # that gets imported, not the last. Thus, for correct version checking,
     # we need to reverse the list.
-    packages = {dist.metadata["Name"]: dist.version for dist in reversed(dists)}
+    dists = reversed(list(dists))  # cast to list because chain is not reversible
+    packages = {dist.metadata["Name"]: dist.version for dist in dists}
     return packages
 
 

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -274,7 +274,15 @@ def _get_installed_packages_private():
     by accident.
     """
     dists = distributions()
-    packages = {dist.metadata["Name"]: dist.version for dist in dists}
+    # we reverse the list to deal with the case where multiple distributions
+    # of the same package are installed, for instance in deployment setups
+    # with a base environment that has a certain version, that is overridden
+    # by a more recent version in a virtual environment, e.g., on databricks
+    #
+    # in this case, the *first* occurrence of the package in the list is the one
+    # that gets imported, not the last. Thus, for correct version checking,
+    # we need to reverse the list.
+    packages = {dist.metadata["Name"]: dist.version for dist in reversed(dists)}
     return packages
 
 


### PR DESCRIPTION
This fixes https://github.com/sktime/sktime/issues/6987, i.e., all environment checks in case multiple distributions of a package are present in an environment.

This situation may arise for instance in deployment setups with a base environment that has a certain version, that is overridden by a more recent version in a virtual environment, e.g., on databricks.

In this case, present code returns the version of the *first* occurrence of the package in `sys.path`, but the *last* occurrence is the one that gets imported when doing `from package import something`.

The fix uses an idea of @toandaominh1997: instead of parsing the result of `distributions` for package names and versions, we just parse it for package names, and obtain the version from the `importlib.metadata.version` method. In case of multiple distributions of the same package present, this will always retrieve the version of the one that is imported when doing `from package import`.