### PR TITLE
[MNT] rename base class `TimeSeriesLloyds` to `BaseTimeSeriesLloyds`

### DIFF
--- a/sktime/clustering/k_means/_k_means.py
+++ b/sktime/clustering/k_means/_k_means.py
@@ -8,11 +8,11 @@ import numpy as np
 from numpy.random import RandomState
 
 from sktime.clustering.metrics.averaging import _resolve_average_callable
-from sktime.clustering.partitioning import TimeSeriesLloyds
+from sktime.clustering.partitioning import BaseTimeSeriesLloyds
 from sktime.distances import pairwise_distance
 
 
-class TimeSeriesKMeans(TimeSeriesLloyds):
+class TimeSeriesKMeans(BaseTimeSeriesLloyds):
     """Time series K-mean implementation.
 
     Parameters

--- a/sktime/clustering/k_medoids.py
+++ b/sktime/clustering/k_medoids.py
@@ -8,11 +8,11 @@ import numpy as np
 from numpy.random import RandomState
 
 from sktime.clustering.metrics.medoids import medoids
-from sktime.clustering.partitioning import TimeSeriesLloyds
+from sktime.clustering.partitioning import BaseTimeSeriesLloyds
 from sktime.distances import pairwise_distance
 
 
-class TimeSeriesKMedoids(TimeSeriesLloyds):
+class TimeSeriesKMedoids(BaseTimeSeriesLloyds):
     """Time series K-medoids implementation.
 
     Parameters

--- a/sktime/clustering/partitioning/__init__.py
+++ b/sktime/clustering/partitioning/__init__.py
@@ -1,6 +1,6 @@
 """Module for general partitioning algorithms."""
 
-from sktime.clustering.partitioning._lloyds import TimeSeriesLloyds
+from sktime.clustering.partitioning._lloyds import BaseTimeSeriesLloyds
 
-__all__ = ["TimeSeriesLloyds"]
+__all__ = ["BaseTimeSeriesLloyds"]
 __author__ = ["chrisholder", "TonyBagnall"]

--- a/sktime/clustering/partitioning/_lloyds.py
+++ b/sktime/clustering/partitioning/_lloyds.py
@@ -154,7 +154,7 @@ def _kmeans_plus_plus(
     return centers
 
 
-class TimeSeriesLloyds(BaseClusterer):
+class BaseTimeSeriesLloyds(BaseClusterer):
     """Abstract class that implements time series Lloyds algorithm.
 
     Parameters

--- a/sktime/clustering/tests/test_lloyds.py
+++ b/sktime/clustering/tests/test_lloyds.py
@@ -8,7 +8,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.utils import check_random_state
 
 from sktime.clustering.partitioning._lloyds import (
-    TimeSeriesLloyds,
+    BaseTimeSeriesLloyds,
     _forgy_center_initializer,
     _kmeans_plus_plus,
     _random_center_initializer,
@@ -19,7 +19,7 @@ from sktime.distances.tests._utils import create_test_distance_numpy
 from sktime.tests.test_switch import run_test_for_class
 
 
-class _test_class(TimeSeriesLloyds):
+class _test_class(BaseTimeSeriesLloyds):
     def _compute_new_cluster_centers(
         self, X: np.ndarray, assignment_indexes: np.ndarray
     ) -> np.ndarray:
@@ -30,7 +30,7 @@ class _test_class(TimeSeriesLloyds):
 
 
 @pytest.mark.skipif(
-    not run_test_for_class(TimeSeriesLloyds),
+    not run_test_for_class(BaseTimeSeriesLloyds),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_lloyds():
@@ -60,7 +60,7 @@ CENTER_INIT_ALGO = [
 
 
 @pytest.mark.skipif(
-    not run_test_for_class(TimeSeriesLloyds),
+    not run_test_for_class(BaseTimeSeriesLloyds),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 @pytest.mark.parametrize("center_init_callable", CENTER_INIT_ALGO)

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -29,7 +29,6 @@ EXCLUDE_ESTIMATORS = [
     "TapNetClassifier",
     "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
     "LSTMFCNClassifier",  # unknown cause, see bug report #4033
-    "TimeSeriesLloyds",  # an abstract class, but does not follow naming convention
     # DL classifier suspected to cause hangs and memouts, see #4610
     "FCNClassifier",
     "MACNNClassifier",
@@ -376,7 +375,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "TimeSeriesForestRegressor",
         "TimeSeriesKMedoids",
         "TimeSeriesKernelKMeans",
-        "TimeSeriesLloyds",
         "ThetaModularForecaster",
         "TruncationTransformer",
         "UnobservedComponents",


### PR DESCRIPTION
This renames the base class `TimeSeriesLloyds` to `BaseTimeSeriesLloyds`, as the test framework interprets classes that are not private and not starting as `Base` as concrete, leading `TimeSeriesLloyds` to be collected and fail tests.

Also removes the test skips for the class.