### PR TITLE
[MNT] remove module level `numba` import warnings

### DIFF
--- a/sktime/utils/numba/general.py
+++ b/sktime/utils/numba/general.py
@@ -1,10 +1,5 @@
 """General numba utilities."""
-
-from sktime.utils.dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("numba", severity="warning")
-
-import numpy as np  # noqa E402
+import numpy as np
 
 import sktime.utils.numba.stats as stats  # noqa E402
 from sktime.utils.numba.njit import njit  # noqa E402

--- a/sktime/utils/numba/general.py
+++ b/sktime/utils/numba/general.py
@@ -1,4 +1,5 @@
 """General numba utilities."""
+
 import numpy as np
 
 import sktime.utils.numba.stats as stats  # noqa E402

--- a/sktime/utils/numba/njit.py
+++ b/sktime/utils/numba/njit.py
@@ -3,7 +3,7 @@
 from sktime.utils.dependencies import _check_soft_dependencies
 
 # exports numba.njit if numba is present, otherwise an identity njit
-if _check_soft_dependencies("numba", severity="warning"):
+if _check_soft_dependencies("numba", severity="none"):
     from numba import jit, njit  # noqa E402
 
 else:

--- a/sktime/utils/numba/stats.py
+++ b/sktime/utils/numba/stats.py
@@ -1,9 +1,5 @@
 """Numba statistics utilities."""
 
-from sktime.utils.dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("numba", severity="warning")
-
 import numpy as np  # noqa E402
 
 import sktime.utils.numba.general as general_numba  # noqa E402


### PR DESCRIPTION
This PR removes module level `numba` import warnings which could be erroneously raised in some crawling cases or by import chains.

The modules are not locations that a user would normally import from, making this change a net improvement in my opinion, as most raises would be erroneus or uninformative.