### PR TITLE
[DOC] update soft dependency handling guide for estimators

### DIFF
--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -50,6 +50,8 @@ Tags can be inspected at runtime using the following utilities:
     all_estimators
 
 
+.. _packaging_tags:
+
 General tags, packaging
 -----------------------
 

--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -38,15 +38,12 @@ Estimators with a soft dependency need to ensure the following:
 *  imports of the soft dependency only happen inside the estimator,
    e.g., in ``_fit`` or ``__init__`` methods of the estimator.
    In ``__init__``, imports should happen only after calls to ``super(cls).__init__``.
-*  the ``python_dependencies`` tag of the estimator is populated with a ``str``,
-   or a ``list`` of ``str``, of dependency requirements, where ``str`` are PEP 440 compliant version specification ``str``
-   such as ``pandas>=2.0.1``. Exceptions will automatically be raised when constructing the estimator
+*  the packaging tags of the estimator are populated, i.e., ``python_dependencies``
+   with PEP 440 compliant dependency specifier strings such as ``pandas>=2.0.1``, and optionally
+   ``python_version`` and ``env_marker`` if specific markers are needed.
+   Exceptions will automatically be raised when constructing the estimator
    in an environment where the requirements are not met.
-*  In a case where the package import differs from the package name, i.e., ``import package_string`` is different from
-   ``pip install different-package-string`` (usually the case for packages containing a dash in the name), the ``python_dependencies_alias`` tag
-   should be populated to pass the information on package and import strings as ``dict`` such as ``{"scikit-learn": "sklearn"}``.
-*  If the soft dependencies require specific python versions, the ``python_version``
-   tag should also be populated, with a PEP 440 compliant version specification ``str`` such as ``"<3.10"`` or ``">3.6,~=3.8"``.
+   For further details, see the tag API reference, :ref:`packaging_tags`.
 *  Decorate all ``pytest`` tests that import soft dependencies with a ``@pytest.mark.skipif(...)`` conditional on a soft dependency check.
    If the test is specific to a single estimator or object, use ``run_test_for_class`` from ``sktime.tests.test_switch``
    to mediate the condition through the class tags.


### PR DESCRIPTION
This PR updates the soft dependency handling guide for estimators with:

* links to packaging tag API reference
* removal of the requirement to populate the dependency alias tag