### PR TITLE
[BUG] - Fix Prophet `_get_fitted_params `error when the timeseries is constant

### DIFF
--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -300,7 +300,7 @@ class _ProphetAdapter(BaseForecaster):
         """
         fitted_params = {}
         for name in ["k", "m", "sigma_obs"]:
-            fitted_params[name] = self._forecaster.params[name][0][0]
+            fitted_params[name] = self._forecaster.params[name].flatten()[0]
         for name in ["delta", "beta"]:
             fitted_params[name] = self._forecaster.params[name][0]
         return fitted_params

--- a/sktime/forecasting/tests/test_prophet.py
+++ b/sktime/forecasting/tests/test_prophet.py
@@ -104,3 +104,41 @@ def test_prophet_fit_kwargs_are_passed_down(fit_kwargs: dict):
         # we don't care about its actual value here
         call_kwargs.pop("df")
         assert call_kwargs == (fit_kwargs or {})
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(Prophet),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize("constant_timeseries", [True, False])
+def test_prophet_fitted_params(constant_timeseries):
+    """
+    Test if the fitted parameters have the expected number of dimensions.
+    
+    For constant timeseries, get_fitted_params was raising unexpeceted error
+    (see issue #6982)
+    """
+
+    expected_param_ndims = {
+        "k": 0,
+        "m": 0,
+        "sigma_obs": 0,
+        "delta": 1,
+        "beta": 1,
+    }
+
+    if not constant_timeseries:
+        from sktime.datasets import load_airline
+        y = load_airline()
+    else:
+        y = pd.DataFrame(
+            index=pd.period_range(start="2022-01", periods=18, freq="Q"),
+            data={"value": 0},
+        )
+    forecaster = Prophet()
+    forecaster.fit(y)
+    fitted_params = forecaster.get_fitted_params()
+
+    # Assert parameters have the expected number of dimensions
+    for param, expected_ndim in expected_param_ndims.items():
+        assert fitted_params[param].ndim == expected_ndim

--- a/sktime/forecasting/tests/test_prophet.py
+++ b/sktime/forecasting/tests/test_prophet.py
@@ -114,11 +114,10 @@ def test_prophet_fit_kwargs_are_passed_down(fit_kwargs: dict):
 def test_prophet_fitted_params(constant_timeseries):
     """
     Test if the fitted parameters have the expected number of dimensions.
-    
+
     For constant timeseries, get_fitted_params was raising unexpeceted error
     (see issue #6982)
     """
-
     expected_param_ndims = {
         "k": 0,
         "m": 0,
@@ -129,6 +128,7 @@ def test_prophet_fitted_params(constant_timeseries):
 
     if not constant_timeseries:
         from sktime.datasets import load_airline
+
         y = load_airline()
     else:
         y = pd.DataFrame(


### PR DESCRIPTION
This PR introduces a minor change in fbprophet adapter, flattening an array to get first value instead of calling `[0][0]` twice.

#### Reference Issues/PRs
 Fixes #6982 

#### What does this implement/fix? Explain your changes.

Prophet().fit(y).get_fitted_params() was raising error if the the dataframe `y` contained a series with only constant values.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### Did you add any tests for the change?

No, but could add if needed


