### PR TITLE
[MNT] remove doctest skips

### DIFF
--- a/sktime/alignment/dtw_numba.py
+++ b/sktime/alignment/dtw_numba.py
@@ -110,10 +110,10 @@ class AlignerDtwNumba(BaseAligner):
     >>> from sktime.utils._testing.series import _make_series
     >>> from sktime.alignment.dtw_numba import AlignerDtwNumba
     >>>
-    >>> X0 = _make_series(return_mtype="pd.DataFrame")  # doctest: +SKIP
-    >>> X1 = _make_series(return_mtype="pd.DataFrame")  # doctest: +SKIP
-    >>> d = AlignerDtwNumba(weighted=True, derivative=True)  # doctest: +SKIP
-    >>> align = d.fit([X0, X1]).get_alignment()  # doctest: +SKIP
+    >>> X0 = _make_series(return_mtype="pd.DataFrame")
+    >>> X1 = _make_series(return_mtype="pd.DataFrame")
+    >>> d = AlignerDtwNumba(weighted=True, derivative=True)
+    >>> align = d.fit([X0, X1]).get_alignment()
     """
 
     _tags = {

--- a/sktime/alignment/edit_numba.py
+++ b/sktime/alignment/edit_numba.py
@@ -103,12 +103,12 @@ class AlignerEditNumba(BaseAligner):
     >>> from sktime.datasets import load_unit_test
     >>> from sktime.dists_kernels.edit_dist import EditDist
     >>>
-    >>> X, _ = load_unit_test(return_type="pd-multiindex")  # doctest: +SKIP
-    >>> d = EditDist("edr")  # doctest: +SKIP
-    >>> distmat = d.transform(X)  # doctest: +SKIP
+    >>> X, _ = load_unit_test(return_type="pd-multiindex")
+    >>> d = EditDist("edr")
+    >>> distmat = d.transform(X)
 
     distances are also callable, this does the same:
-    >>> distmat = d(X)  # doctest: +SKIP
+    >>> distmat = d(X)
     """
 
     _tags = {

--- a/sktime/annotation/clasp.py
+++ b/sktime/annotation/clasp.py
@@ -206,12 +206,12 @@ class ClaSPSegmentation(BaseSeriesAnnotator):
     >>> from sktime.annotation.clasp import ClaSPSegmentation
     >>> from sktime.annotation.clasp import find_dominant_window_sizes
     >>> from sktime.datasets import load_gun_point_segmentation
-    >>> X, true_period_size, cps = load_gun_point_segmentation() # doctest: +SKIP
-    >>> dominant_period_size = find_dominant_window_sizes(X) # doctest: +SKIP
-    >>> clasp = ClaSPSegmentation(dominant_period_size, n_cps=1) # doctest: +SKIP
-    >>> found_cps = clasp.fit_predict(X) # doctest: +SKIP
-    >>> profiles = clasp.profiles # doctest: +SKIP
-    >>> scores = clasp.scores # doctest: +SKIP
+    >>> X, true_period_size, cps = load_gun_point_segmentation()
+    >>> dominant_period_size = find_dominant_window_sizes(X)
+    >>> clasp = ClaSPSegmentation(dominant_period_size, n_cps=1)
+    >>> found_cps = clasp.fit_predict(X)
+    >>> profiles = clasp.profiles
+    >>> scores = clasp.scores
     """
 
     _tags = {

--- a/sktime/annotation/datagen.py
+++ b/sktime/annotation/datagen.py
@@ -160,18 +160,18 @@ def piecewise_normal(
     Examples
     --------
     >>> from sktime.annotation.datagen import piecewise_normal
-    >>> piecewise_normal([1, 2, 3], lengths=[2, 4, 8], random_state=42) # doctest: +SKIP
+    >>> piecewise_normal([1, 2, 3], lengths=[2, 4, 8], random_state=42)
     array([1.49671415, 0.8617357 , 2.64768854, 3.52302986, 1.76584663,
         1.76586304, 4.57921282, 3.76743473, 2.53052561, 3.54256004,
         2.53658231, 2.53427025, 3.24196227, 1.08671976])
 
     >>> from sktime.annotation.datagen import piecewise_normal
-    >>> piecewise_normal([1, 2, 3], lengths=[2, 4, 8], std_dev=0) # doctest: +SKIP
+    >>> piecewise_normal([1, 2, 3], lengths=[2, 4, 8], std_dev=0)
     array([1., 1., 2., 2., 2., 2., 3., 3., 3., 3., 3., 3., 3., 3.])
 
     >>> from sktime.annotation.datagen import piecewise_normal
     >>> piecewise_normal([1, 2, 3], lengths=[2, 4, 8], std_dev=[0, 0.5, 1.0])\
-        # doctest: +SKIP
+      
     array([1.        , 1.        , 2.32384427, 2.76151493, 1.88292331,
         1.88293152, 4.57921282, 3.76743473, 2.53052561, 3.54256004,
         2.53658231, 2.53427025, 3.24196227, 1.08671976])
@@ -226,7 +226,7 @@ def piecewise_multinomial(
     --------
     >>> from sktime.annotation.datagen import piecewise_multinomial
     >>> piecewise_multinomial(20, lengths=[3, 2], p_vals=[[1/4, 3/4], \
-        [3/4, 1/4]], random_state=42) # doctest: +SKIP
+        [3/4, 1/4]], random_state=42)
     array([[ 4, 16],
        [ 8, 12],
        [ 6, 14],
@@ -235,7 +235,7 @@ def piecewise_multinomial(
 
     >>> from sktime.annotation.datagen import piecewise_multinomial
     >>> piecewise_multinomial(10, lengths=[2, 4, 8], \
-        p_vals=[[1, 0], [0, 1], [1, 0]]) # doctest: +SKIP
+        p_vals=[[1, 0], [0, 1], [1, 0]])
     array([[10,  0],
        [10,  0],
        [ 0, 10],

--- a/sktime/annotation/hmm_learn/gaussian.py
+++ b/sktime/annotation/hmm_learn/gaussian.py
@@ -91,14 +91,14 @@ class GaussianHMM(BaseHMMLearn):
 
     Examples
     --------
-    >>> from sktime.annotation.hmm_learn import GaussianHMM # doctest: +SKIP
-    >>> from sktime.annotation.datagen import piecewise_normal # doctest: +SKIP
-    >>> data = piecewise_normal( # doctest: +SKIP
+    >>> from sktime.annotation.hmm_learn import GaussianHMM
+    >>> from sktime.annotation.datagen import piecewise_normal
+    >>> data = piecewise_normal(
     ...    means=[2, 4, 1], lengths=[10, 35, 40], random_state=7
     ...    ).reshape((-1, 1))
-    >>> model = GaussianHMM(algorithm='viterbi', n_components=2) # doctest: +SKIP
-    >>> model = model.fit(data) # doctest: +SKIP
-    >>> labeled_data = model.predict(data) # doctest: +SKIP
+    >>> model = GaussianHMM(algorithm='viterbi', n_components=2)
+    >>> model = model.fit(data)
+    >>> labeled_data = model.predict(data)
     """
 
     def __init__(

--- a/sktime/annotation/hmm_learn/gmm.py
+++ b/sktime/annotation/hmm_learn/gmm.py
@@ -97,14 +97,14 @@ class GMMHMM(BaseHMMLearn):
 
     Examples
     --------
-    >>> from sktime.annotation.hmm_learn import GMMHMM # doctest: +SKIP
-    >>> from sktime.annotation.datagen import piecewise_normal # doctest: +SKIP
-    >>> data = piecewise_normal( # doctest: +SKIP
+    >>> from sktime.annotation.hmm_learn import GMMHMM
+    >>> from sktime.annotation.datagen import piecewise_normal
+    >>> data = piecewise_normal(
     ...    means=[2, 4, 1], lengths=[10, 35, 40], random_state=7
     ...    ).reshape((-1, 1))
-    >>> model = GMMHMM(n_components=3) # doctest: +SKIP
-    >>> model = model.fit(data) # doctest: +SKIP
-    >>> labeled_data = model.predict(data) # doctest: +SKIP
+    >>> model = GMMHMM(n_components=3)
+    >>> model = model.fit(data)
+    >>> labeled_data = model.predict(data)
     """
 
     def __init__(

--- a/sktime/annotation/hmm_learn/poisson.py
+++ b/sktime/annotation/hmm_learn/poisson.py
@@ -64,14 +64,14 @@ class PoissonHMM(BaseHMMLearn):
 
     Examples
     --------
-    >>> from sktime.annotation.hmm_learn import PoissonHMM # doctest: +SKIP
-    >>> from sktime.annotation.datagen import piecewise_poisson # doctest: +SKIP
-    >>> data = piecewise_poisson( # doctest: +SKIP
+    >>> from sktime.annotation.hmm_learn import PoissonHMM
+    >>> from sktime.annotation.datagen import piecewise_poisson
+    >>> data = piecewise_poisson(
     ...    lambdas=[1, 2, 3], lengths=[2, 4, 8], random_state=7
     ...    ).reshape((-1, 1))
-    >>> model = PoissonHMM(n_components=3) # doctest: +SKIP
-    >>> model = model.fit(data) # doctest: +SKIP
-    >>> labeled_data = model.predict(data) # doctest: +SKIP
+    >>> model = PoissonHMM(n_components=3)
+    >>> model = model.fit(data)
+    >>> labeled_data = model.predict(data)
     """
 
     _tags = {

--- a/sktime/annotation/igts.py
+++ b/sktime/annotation/igts.py
@@ -375,10 +375,10 @@ class InformationGainSegmentation(SegmentationMixin, BaseEstimator):
     ... means=[[0.0, 1.0], [11.0, 10.0], [5.0, 3.0], [2.0, 2.0]],
     ... variances=0.5,
     ... )
-    >>> X_scaled = MinMaxScaler(feature_range=(0, 1)).fit_transform(X) # doctest: +SKIP
-    >>> from sktime.annotation.igts import InformationGainSegmentation # doctest: +SKIP
-    >>> igts = InformationGainSegmentation(k_max=3, step=2) # doctest: +SKIP
-    >>> y = igts.fit_predict(X_scaled) # doctest: +SKIP
+    >>> X_scaled = MinMaxScaler(feature_range=(0, 1)).fit_transform(X)
+    >>> from sktime.annotation.igts import InformationGainSegmentation
+    >>> igts = InformationGainSegmentation(k_max=3, step=2)
+    >>> y = igts.fit_predict(X_scaled)
     """
 
     def __init__(

--- a/sktime/classification/compose/_column_ensemble.py
+++ b/sktime/classification/compose/_column_ensemble.py
@@ -224,19 +224,19 @@ class ColumnEnsembleClassifier(BaseColumnEnsembleClassifier):
     >>> from sktime.classification.dictionary_based import ContractableBOSS
     >>> from sktime.classification.interval_based import CanonicalIntervalForest
     >>> from sktime.datasets import load_basic_motions
-    >>> X_train, y_train = load_basic_motions(split="train") # doctest: +SKIP
-    >>> X_test, y_test = load_basic_motions(split="test") # doctest: +SKIP
+    >>> X_train, y_train = load_basic_motions(split="train")
+    >>> X_test, y_test = load_basic_motions(split="test")
     >>> cboss = ContractableBOSS(
     ...     n_parameter_samples=4, max_ensemble_size=2, random_state=0
-    ... ) # doctest: +SKIP
+    ... )
     >>> cif = CanonicalIntervalForest(
     ...     n_estimators=2, n_intervals=4, att_subsample_size=4, random_state=0
-    ... ) # doctest: +SKIP
-    >>> estimators = [("cBOSS", cboss, 5), ("CIF", cif, [3, 4])] # doctest: +SKIP
-    >>> col_ens = ColumnEnsembleClassifier(estimators=estimators) # doctest: +SKIP
-    >>> col_ens.fit(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> estimators = [("cBOSS", cboss, 5), ("CIF", cif, [3, 4])]
+    >>> col_ens = ColumnEnsembleClassifier(estimators=estimators)
+    >>> col_ens.fit(X_train, y_train)
     ColumnEnsembleClassifier(...)
-    >>> y_pred = col_ens.predict(X_test) # doctest: +SKIP
+    >>> y_pred = col_ens.predict(X_test)
     """
 
     # for default get_params/set_params from _HeterogenousMetaEstimator

--- a/sktime/classification/deep_learning/cnn.py
+++ b/sktime/classification/deep_learning/cnn.py
@@ -67,8 +67,8 @@ class CNNClassifier(BaseDeepClassifier):
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train")
     >>> X_test, y_test = load_unit_test(split="test")
-    >>> cnn = CNNClassifier(n_epochs=20,batch_size=4)  # doctest: +SKIP
-    >>> cnn.fit(X_train, y_train)  # doctest: +SKIP
+    >>> cnn = CNNClassifier(n_epochs=20,batch_size=4)
+    >>> cnn.fit(X_train, y_train)
     CNNClassifier(...)
     """
 

--- a/sktime/classification/deep_learning/cntc.py
+++ b/sktime/classification/deep_learning/cntc.py
@@ -67,9 +67,9 @@ class CNTCClassifier(BaseDeepClassifier):
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
     >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
-    >>> cntc = CNTCClassifier() # doctest: +SKIP
-    >>> cntc.fit(X_train, y_train) # doctest: +SKIP
-    CNTCClassifier(...) # doctest: +SKIP
+    >>> cntc = CNTCClassifier()
+    >>> cntc.fit(X_train, y_train)
+    CNTCClassifier(...)
     """
 
     _tags = {

--- a/sktime/classification/deep_learning/fcn.py
+++ b/sktime/classification/deep_learning/fcn.py
@@ -55,8 +55,8 @@ class FCNClassifier(BaseDeepClassifier):
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
     >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
-    >>> fcn = FCNClassifier(n_epochs=20,batch_size=4)  # doctest: +SKIP
-    >>> fcn.fit(X_train, y_train)  # doctest: +SKIP
+    >>> fcn = FCNClassifier(n_epochs=20,batch_size=4)
+    >>> fcn.fit(X_train, y_train)
     FCNClassifier(...)
     """
 

--- a/sktime/classification/deep_learning/inceptiontime.py
+++ b/sktime/classification/deep_learning/inceptiontime.py
@@ -46,11 +46,11 @@ class InceptionTimeClassifier(BaseDeepClassifier):
     Examples
     --------
     >>> from sktime.classification.deep_learning import InceptionTimeClassifier
-    >>> from sktime.datasets import load_unit_test  # doctest: +SKIP
-    >>> X_train, y_train = load_unit_test(split="train")  # doctest: +SKIP
-    >>> X_test, y_test = load_unit_test(split="test")  # doctest: +SKIP
-    >>> clf = InceptionTimeClassifier()  # doctest: +SKIP
-    >>> clf.fit(X_train, y_train)  # doctest: +SKIP
+    >>> from sktime.datasets import load_unit_test
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
+    >>> clf = InceptionTimeClassifier()
+    >>> clf.fit(X_train, y_train)
     InceptionTimeClassifier(...)
     """
 

--- a/sktime/classification/deep_learning/lstmfcn.py
+++ b/sktime/classification/deep_learning/lstmfcn.py
@@ -56,13 +56,13 @@ class LSTMFCNClassifier(BaseDeepClassifier):
 
     Examples
     --------
-    >>> import sktime.classification.deep_learning as dl_clf  # doctest: +SKIP
-    >>> from dl_clf.lstmfcn import LSTMFCNClassifier  # doctest: +SKIP
+    >>> import sktime.classification.deep_learning as dl_clf
+    >>> from dl_clf.lstmfcn import LSTMFCNClassifier
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
     >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
-    >>> lstmfcn = FCNClassifier(n_epochs=20,batch_size=4)  # doctest: +SKIP
-    >>> lstmfcn.fit(X_train, y_train)  # doctest: +SKIP
+    >>> lstmfcn = FCNClassifier(n_epochs=20,batch_size=4)
+    >>> lstmfcn.fit(X_train, y_train)
     FCNClassifier(...)
     """
 

--- a/sktime/classification/deep_learning/macnn.py
+++ b/sktime/classification/deep_learning/macnn.py
@@ -72,8 +72,8 @@ class MACNNClassifier(BaseDeepClassifier):
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train")
     >>> X_test, y_test = load_unit_test(split="test")
-    >>> macnn = MACNNClassifier(n_epochs=3) # doctest: +SKIP
-    >>> macnn.fit(X_train, y_train) # doctest: +SKIP
+    >>> macnn = MACNNClassifier(n_epochs=3)
+    >>> macnn.fit(X_train, y_train)
     MACNNClassifier(...)
     """
 

--- a/sktime/classification/deep_learning/mcdcnn.py
+++ b/sktime/classification/deep_learning/mcdcnn.py
@@ -73,8 +73,8 @@ class MCDCNNClassifier(BaseDeepClassifier):
     >>> from sktime.classification.deep_learning.mcdcnn import MCDCNNClassifier
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_tain = load_unit_test(split="train")
-    >>> mcdcnn = MCDCNNClassifier()     # doctest: +SKIP
-    >>> mcdcnn.fit(X_train, y_train)    # doctest: +SKIP
+    >>> mcdcnn = MCDCNNClassifier()   
+    >>> mcdcnn.fit(X_train, y_train)  
     MCDCNNClassifier(...)
     """
 

--- a/sktime/classification/deep_learning/mlp.py
+++ b/sktime/classification/deep_learning/mlp.py
@@ -55,8 +55,8 @@ class MLPClassifier(BaseDeepClassifier):
     >>> from sktime.classification.deep_learning.mlp import MLPClassifier
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train")
-    >>> mlp = MLPClassifier(n_epochs=20,batch_size=4)  # doctest: +SKIP
-    >>> mlp.fit(X_train, y_train)  # doctest: +SKIP
+    >>> mlp = MLPClassifier(n_epochs=20,batch_size=4)
+    >>> mlp.fit(X_train, y_train)
     MLPClassifier(...)
     """
 

--- a/sktime/classification/deep_learning/mvts_transformer.py
+++ b/sktime/classification/deep_learning/mvts_transformer.py
@@ -78,8 +78,8 @@ class MVTSTransformerClassifier(BaseDeepClassifierPytorch):
     >>> X_test, _ = load_unit_test(split="test")
     >>>
     >>> model = MVTSTransformerClassifier()
-    >>> model.fit(X_train, y_train)  # doctest: +SKIP
-    >>> preds = model.predict(X_test)  # doctest: +SKIP
+    >>> model.fit(X_train, y_train)
+    >>> preds = model.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/deep_learning/resnet.py
+++ b/sktime/classification/deep_learning/resnet.py
@@ -55,8 +55,8 @@ class ResNetClassifier(BaseDeepClassifier):
     >>> from sktime.classification.deep_learning.resnet import ResNetClassifier
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train")
-    >>> clf = ResNetClassifier(n_epochs=20) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    >>> clf = ResNetClassifier(n_epochs=20)
+    >>> clf.fit(X_train, y_train)
     ResNetClassifier(...)
     """
 

--- a/sktime/classification/deep_learning/rnn.py
+++ b/sktime/classification/deep_learning/rnn.py
@@ -53,8 +53,8 @@ class SimpleRNNClassifier(BaseDeepClassifier):
     >>> from sktime.classification.deep_learning.rnn import SimpleRNNClassifier
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train")
-    >>> clf = SimpleRNNClassifier(n_epochs=20,batch_size=20) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    >>> clf = SimpleRNNClassifier(n_epochs=20,batch_size=20)
+    >>> clf.fit(X_train, y_train)
     ResNetClassifier(...)
     """
 

--- a/sktime/classification/deep_learning/tapnet.py
+++ b/sktime/classification/deep_learning/tapnet.py
@@ -80,8 +80,8 @@ class TapNetClassifier(BaseDeepClassifier):
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train")
     >>> X_test, y_test = load_unit_test(split="test")
-    >>> tapnet = TapNetClassifier(n_epochs=20,batch_size=4)  # doctest: +SKIP
-    >>> tapnet.fit(X_train, y_train) # doctest: +SKIP
+    >>> tapnet = TapNetClassifier(n_epochs=20,batch_size=4)
+    >>> tapnet.fit(X_train, y_train)
     TapNetClassifier(...)
     """
 

--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -122,11 +122,11 @@ class BOSSEnsemble(BaseClassifier):
     >>> from sktime.classification.dictionary_based import BOSSEnsemble
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
-    >>> clf = BOSSEnsemble(max_ensemble_size=3) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
+    >>> clf = BOSSEnsemble(max_ensemble_size=3)
+    >>> clf.fit(X_train, y_train)
     BOSSEnsemble(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {
@@ -535,11 +535,11 @@ class IndividualBOSS(BaseClassifier):
     >>> from sktime.classification.dictionary_based import IndividualBOSS
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
-    >>> clf = IndividualBOSS() # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
+    >>> clf = IndividualBOSS()
+    >>> clf.fit(X_train, y_train)
     IndividualBOSS(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/dictionary_based/_cboss.py
+++ b/sktime/classification/dictionary_based/_cboss.py
@@ -123,10 +123,10 @@ class ContractableBOSS(BaseClassifier):
     >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
     >>> clf = ContractableBOSS(
     ...     n_parameter_samples=10, max_ensemble_size=3
-    ... ) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     ContractableBOSS(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/dictionary_based/_muse.py
+++ b/sktime/classification/dictionary_based/_muse.py
@@ -111,11 +111,11 @@ class MUSE(BaseClassifier):
     >>> from sktime.classification.dictionary_based import MUSE
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
-    >>> clf = MUSE(window_inc=4, use_first_order_differences=False) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
+    >>> clf = MUSE(window_inc=4, use_first_order_differences=False)
+    >>> clf.fit(X_train, y_train)
     MUSE(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/dictionary_based/_tde.py
+++ b/sktime/classification/dictionary_based/_tde.py
@@ -134,15 +134,15 @@ class TemporalDictionaryEnsemble(BaseClassifier):
     >>> from sktime.classification.dictionary_based import TemporalDictionaryEnsemble
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
     >>> clf = TemporalDictionaryEnsemble(
     ...     n_parameter_samples=10,
     ...     max_ensemble_size=3,
     ...     randomly_selected_params=5,
-    ... ) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     TemporalDictionaryEnsemble(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {
@@ -673,11 +673,11 @@ class IndividualTDE(BaseClassifier):
     >>> from sktime.classification.dictionary_based import IndividualTDE
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
-    >>> clf = IndividualTDE() # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
+    >>> clf = IndividualTDE()
+    >>> clf.fit(X_train, y_train)
     IndividualTDE(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/dictionary_based/_weasel.py
+++ b/sktime/classification/dictionary_based/_weasel.py
@@ -112,11 +112,11 @@ class WEASEL(BaseClassifier):
     >>> from sktime.classification.dictionary_based import WEASEL
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
-    >>> clf = WEASEL(window_inc=4) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
+    >>> clf = WEASEL(window_inc=4)
+    >>> clf.fit(X_train, y_train)
     WEASEL(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/distance_based/_elastic_ensemble.py
+++ b/sktime/classification/distance_based/_elastic_ensemble.py
@@ -74,18 +74,18 @@ class ElasticEnsemble(BaseClassifier):
     Examples
     --------
     >>> from sktime.classification.distance_based import ElasticEnsemble
-    >>> from sktime.datasets import load_unit_test  # doctest: +SKIP
-    >>> X_train, y_train = load_unit_test(split="train")  # doctest: +SKIP
-    >>> X_test, y_test = load_unit_test(split="test")  # doctest: +SKIP
+    >>> from sktime.datasets import load_unit_test
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
     >>> clf = ElasticEnsemble(
     ...     proportion_of_param_options=0.1,
     ...     proportion_train_for_test=0.1,
     ...     distance_measures = ["dtw","ddtw"],
     ...     majority_vote=True,
-    ... )  # doctest: +SKIP
-    >>> clf.fit(X_train, y_train)  # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     ElasticEnsemble(...)
-    >>> y_pred = clf.predict(X_test)  # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/distance_based/_proximity_forest.py
+++ b/sktime/classification/distance_based/_proximity_forest.py
@@ -670,12 +670,12 @@ class ProximityStump(BaseClassifier):
     --------
     >>> from sktime.classification.distance_based import ProximityStump
     >>> from sktime.datasets import load_unit_test
-    >>> X_train, y_train = load_unit_test(split="train")  # doctest: +SKIP
-    >>> X_test, y_test = load_unit_test(split="test")  # doctest: +SKIP
-    >>> clf = ProximityStump()  # doctest: +SKIP
-    >>> clf.fit(X_train, y_train)  # doctest: +SKIP
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
+    >>> clf = ProximityStump()
+    >>> clf.fit(X_train, y_train)
     ProximityStump(...)
-    >>> y_pred = clf.predict(X_test)  # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {
@@ -975,11 +975,11 @@ class ProximityTree(BaseClassifier):
     >>> from sktime.classification.distance_based import ProximityTree
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
-    >>> clf = ProximityTree(max_depth=2, n_stump_evaluations=1) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
+    >>> clf = ProximityTree(max_depth=2, n_stump_evaluations=1)
+    >>> clf.fit(X_train, y_train)
     ProximityTree(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {
@@ -1273,13 +1273,13 @@ class ProximityForest(BaseClassifier):
     >>> from sktime.classification.distance_based import ProximityForest
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
     >>> clf = ProximityForest(
     ...     n_estimators=2, max_depth=2, n_stump_evaluations=1
-    ... ) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     ProximityForest(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/distance_based/_shape_dtw.py
+++ b/sktime/classification/distance_based/_shape_dtw.py
@@ -112,18 +112,18 @@ class ShapeDTW(BaseClassifier):
     Examples
     --------
     >>> from sktime.classification.distance_based import ShapeDTW
-    >>> from sktime.datasets import load_unit_test  # doctest: +SKIP
-    >>> X_train, y_train = load_unit_test(split="train")  # doctest: +SKIP
-    >>> X_test, y_test = load_unit_test(split="test")  # doctest: +SKIP
+    >>> from sktime.datasets import load_unit_test
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
     >>> clf = ShapeDTW(n_neighbors=1,
     ...     subsequence_length=30,
     ...     shape_descriptor_function="raw",
     ...     shape_descriptor_functions=None,
     ...     metric_params=None,
-    ... )  # doctest: +SKIP
-    >>> clf.fit(X_train, y_train)  # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     ShapeDTW(...)
-    >>> y_pred = clf.predict(X_test)  # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/distance_based/_time_series_neighbors_pyts.py
+++ b/sktime/classification/distance_based/_time_series_neighbors_pyts.py
@@ -75,11 +75,11 @@ class KNeighborsTimeSeriesClassifierPyts(_PytsAdapter, BaseClassifier):
 
     Examples
     --------
-    >>> import sktime.classification.distance_based as clf_db  # doctest: +SKIP
-    >>> from clf_db import KNeighborsTimeSeriesClassifierPyts  # doctest: +SKIP
-    >>> from sktime.datasets import load_unit_test  # doctest: +SKIP
-    >>> X_train, y_train = load_unit_test(split="train")  # doctest: +SKIP
-    >>> X_test, y_test = load_unit_test(split="test")  # doctest: +SKIP
+    >>> import sktime.classification.distance_based as clf_db
+    >>> from clf_db import KNeighborsTimeSeriesClassifierPyts
+    >>> from sktime.datasets import load_unit_test
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
     >>> clf = KNeighborsTimeSeriesClassifierPyts(n_neighbors=1,
     ...     weights="uniform",
     ...     algorithm="auto",
@@ -88,10 +88,10 @@ class KNeighborsTimeSeriesClassifierPyts(_PytsAdapter, BaseClassifier):
     ...     metric="minkowski",
     ...     metric_params=None,
     ...     n_jobs=1,
-    ... )  # doctest: +SKIP
-    >>> clf.fit(X_train, y_train)  # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     KNeighborsTimeSeriesClassifierPyts(...)
-    >>> y_pred = clf.predict(X_test)  # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/distance_based/_time_series_neighbors_tslearn.py
+++ b/sktime/classification/distance_based/_time_series_neighbors_tslearn.py
@@ -59,11 +59,11 @@ class KNeighborsTimeSeriesClassifierTslearn(_TslearnAdapter, BaseClassifier):
 
     Examples
     --------
-    >>> import sktime.classification.distance_based as db_clf  # doctest: +SKIP
-    >>> from db_clf import KNeighborsTimeSeriesClassifierTslearn  # doctest: +SKIP
-    >>> from sktime.datasets import load_unit_test  # doctest: +SKIP
-    >>> X_train, y_train = load_unit_test(split="train")  # doctest: +SKIP
-    >>> X_test, y_test = load_unit_test(split="test")  # doctest: +SKIP
+    >>> import sktime.classification.distance_based as db_clf
+    >>> from db_clf import KNeighborsTimeSeriesClassifierTslearn
+    >>> from sktime.datasets import load_unit_test
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
     >>> clf = KNeighborsTimeSeriesClassifierTslearn(
     ...     n_neighbors=5,
     ...     weights="uniform",
@@ -71,10 +71,10 @@ class KNeighborsTimeSeriesClassifierTslearn(_TslearnAdapter, BaseClassifier):
     ...     metric_params=None,
     ...     n_jobs=None,
     ...     verbose=0,
-    ... )  # doctest: +SKIP
-    >>> clf.fit(X_train, y_train)  # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     KNeighborsTimeSeriesClassifierTslearn(...)
-    >>> y_pred = clf.predict(X_test)  # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/early_classification/_teaser.py
+++ b/sktime/classification/early_classification/_teaser.py
@@ -93,14 +93,14 @@ class TEASER(BaseEarlyClassifier):
     >>> from sktime.classification.interval_based import TimeSeriesForestClassifier
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
     >>> clf = TEASER(
     ...     classification_points=[6, 16, 24],
     ...     estimator=TimeSeriesForestClassifier(n_estimators=5),
-    ... ) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     TEASER(...)
-    >>> y_pred, decisions = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred, decisions = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/ensemble/_bagging.py
+++ b/sktime/classification/ensemble/_bagging.py
@@ -66,15 +66,15 @@ class BaggingClassifier(BaseClassifier):
     >>> from sktime.classification.ensemble import BaggingClassifier
     >>> from sktime.classification.kernel_based import RocketClassifier
     >>> from sktime.datasets import load_unit_test
-    >>> X_train, y_train = load_unit_test(split="train") # doctest: +SKIP
-    >>> X_test, y_test = load_unit_test(split="test") # doctest: +SKIP
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
     >>> clf = BaggingClassifier(
     ...     RocketClassifier(num_kernels=100),
     ...     n_estimators=10,
-    ... ) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     BaggingClassifier(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/ensemble/_ctsf.py
+++ b/sktime/classification/ensemble/_ctsf.py
@@ -177,15 +177,15 @@ class ComposableTimeSeriesForestClassifier(BaseTimeSeriesForest, BaseClassifier)
     >>> from sktime.classification.ensemble import ComposableTimeSeriesForestClassifier
     >>> from sktime.classification.kernel_based import RocketClassifier
     >>> from sktime.datasets import load_unit_test
-    >>> X_train, y_train = load_unit_test(split="train") # doctest: +SKIP
-    >>> X_test, y_test = load_unit_test(split="test") # doctest: +SKIP
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
     >>> clf = ComposableTimeSeriesForestClassifier(
     ...     RocketClassifier(num_kernels=100),
     ...     n_estimators=10,
-    ... )  # doctest: +SKIP
-    >>> clf.fit(X_train, y_train)  # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     ComposableTimeSeriesForestClassifier(...)
-    >>> y_pred = clf.predict(X_test)  # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/ensemble/_weighted.py
+++ b/sktime/classification/ensemble/_weighted.py
@@ -73,15 +73,15 @@ class WeightedEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
     >>> from sktime.classification.dummy import DummyClassifier
     >>> from sktime.classification.kernel_based import RocketClassifier
     >>> from sktime.datasets import load_unit_test
-    >>> X_train, y_train = load_unit_test(split="train") # doctest: +SKIP
-    >>> X_test, y_test = load_unit_test(split="test") # doctest: +SKIP
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
     >>> clf = WeightedEnsembleClassifier(
     ...     [DummyClassifier(), RocketClassifier(num_kernels=100)],
     ...     weights=2,
-    ... ) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     WeightedEnsembleClassifier(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/feature_based/_catch22_classifier.py
+++ b/sktime/classification/feature_based/_catch22_classifier.py
@@ -70,14 +70,14 @@ class Catch22Classifier(_DelegatedClassifier):
     >>> from sklearn.ensemble import RandomForestClassifier
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
     >>> clf = Catch22Classifier(
     ...     estimator=RandomForestClassifier(n_estimators=5),
     ...     outlier_norm=True,
-    ... ) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     Catch22Classifier(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/feature_based/_fresh_prince.py
+++ b/sktime/classification/feature_based/_fresh_prince.py
@@ -63,17 +63,17 @@ class FreshPRINCE(BaseClassifier):
     >>> from sktime.classification.feature_based import FreshPRINCE
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
     >>> clf = FreshPRINCE(
     ...     default_fc_parameters="comprehensive",
     ...     n_estimators=200,
     ...     save_transformed_data=False,
     ...     verbose=0,
     ...     n_jobs=1,
-    ... ) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train)  # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     FreshPRINCE(...)
-    >>> y_pred = clf.predict(X_test)  # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/feature_based/_matrix_profile_classifier.py
+++ b/sktime/classification/feature_based/_matrix_profile_classifier.py
@@ -57,11 +57,11 @@ class MatrixProfileClassifier(BaseClassifier):
     >>> from sktime.classification.feature_based import MatrixProfileClassifier
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)  # doctest: +SKIP
-    >>> clf = MatrixProfileClassifier()  # doctest: +SKIP
-    >>> clf.fit(X_train, y_train)  # doctest: +SKIP
-    MatrixProfileClassifier(...)  # doctest: +SKIP
-    >>> y_pred = clf.predict(X_test)  # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
+    >>> clf = MatrixProfileClassifier()
+    >>> clf.fit(X_train, y_train)
+    MatrixProfileClassifier(...)
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/feature_based/_random_interval_classifier.py
+++ b/sktime/classification/feature_based/_random_interval_classifier.py
@@ -56,13 +56,13 @@ class RandomIntervalClassifier(BaseClassifier):
     >>> from sklearn.ensemble import RandomForestClassifier
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
     >>> clf = RandomIntervalClassifier(
     ...     estimator=RandomForestClassifier(n_estimators=5)
-    ... )  # doctest: +SKIP
-    >>> clf.fit(X_train, y_train)  # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     RandomIntervalClassifier(...)
-    >>> y_pred = clf.predict(X_test)  # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/feature_based/_tsfresh_classifier.py
+++ b/sktime/classification/feature_based/_tsfresh_classifier.py
@@ -69,14 +69,14 @@ class TSFreshClassifier(BaseClassifier):
     >>> from sklearn.ensemble import RandomForestClassifier
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
     >>> clf = TSFreshClassifier(
     ...     estimator=RandomForestClassifier(n_estimators=5),
     ...     default_fc_parameters="efficient",
-    ... ) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train)  # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     TSFreshClassifier(...)
-    >>> y_pred = clf.predict(X_test)  # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/interval_based/_cif.py
+++ b/sktime/classification/interval_based/_cif.py
@@ -106,13 +106,13 @@ class CanonicalIntervalForest(BaseClassifier):
     >>> from sktime.classification.interval_based import CanonicalIntervalForest
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
     >>> clf = CanonicalIntervalForest(
     ...     n_estimators=3, n_intervals=2, att_subsample_size=2
-    ... ) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     CanonicalIntervalForest(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/interval_based/_drcif.py
+++ b/sktime/classification/interval_based/_drcif.py
@@ -130,13 +130,13 @@ class DrCIF(BaseClassifier):
     >>> from sktime.classification.interval_based import DrCIF
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
     >>> clf = DrCIF(
     ...     n_estimators=3, n_intervals=2, att_subsample_size=2
-    ... ) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     DrCIF(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/kernel_based/_arsenal.py
+++ b/sktime/classification/kernel_based/_arsenal.py
@@ -102,11 +102,11 @@ class Arsenal(BaseClassifier):
     >>> from sktime.classification.kernel_based import Arsenal
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test =load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
-    >>> clf = Arsenal(num_kernels=100, n_estimators=5) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    >>> X_test, y_test =load_unit_test(split="test", return_X_y=True)
+    >>> clf = Arsenal(num_kernels=100, n_estimators=5)
+    >>> clf.fit(X_train, y_train)
     Arsenal(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/kernel_based/_rocket_classifier.py
+++ b/sktime/classification/kernel_based/_rocket_classifier.py
@@ -106,11 +106,11 @@ class RocketClassifier(_DelegatedClassifier):
     >>> from sktime.classification.kernel_based import RocketClassifier
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
-    >>> clf = RocketClassifier(num_kernels=500) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
+    >>> clf = RocketClassifier(num_kernels=500)
+    >>> clf.fit(X_train, y_train)
     RocketClassifier(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/classification/shapelet_based/_stc.py
+++ b/sktime/classification/shapelet_based/_stc.py
@@ -114,16 +114,16 @@ class ShapeletTransformClassifier(BaseClassifier):
     >>> from sktime.classification.sklearn import RotationForest
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
     >>> clf = ShapeletTransformClassifier(
     ...     estimator=RotationForest(n_estimators=3),
     ...     n_shapelet_samples=100,
     ...     max_shapelets=10,
     ...     batch_size=20,
-    ... ) # doctest: +SKIP
-    >>> clf.fit(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> clf.fit(X_train, y_train)
     ShapeletTransformClassifier(...)
-    >>> y_pred = clf.predict(X_test) # doctest: +SKIP
+    >>> y_pred = clf.predict(X_test)
     """
 
     _tags = {

--- a/sktime/clustering/compose/_pipeline.py
+++ b/sktime/clustering/compose/_pipeline.py
@@ -78,18 +78,18 @@ class ClustererPipeline(_HeterogenousMetaEstimator, BaseClusterer):
     >>> from sktime.clustering.k_means import TimeSeriesKMeans
     >>> from sktime.datasets import load_unit_test
     >>> from sktime.clustering.compose import ClustererPipeline
-    >>> X_train, y_train = load_unit_test(split="train") # doctest: +SKIP
-    >>> X_test, y_test = load_unit_test(split="test") # doctest: +SKIP
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
     >>> pipeline = ClustererPipeline(
     ...     TimeSeriesKMeans(), [PCATransformer()]
-    ... ) # doctest: +SKIP
-    >>> pipeline.fit(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> pipeline.fit(X_train, y_train)
     ClustererPipeline(...)
-    >>> y_pred = pipeline.predict(X_test) # doctest: +SKIP
+    >>> y_pred = pipeline.predict(X_test)
 
     Alternative construction via dunder method:
 
-    >>> pipeline = PCATransformer() * TimeSeriesKMeans() # doctest: +SKIP
+    >>> pipeline = PCATransformer() * TimeSeriesKMeans()
     """
 
     _tags = {

--- a/sktime/clustering/k_means/_k_means.py
+++ b/sktime/clustering/k_means/_k_means.py
@@ -77,10 +77,10 @@ class TimeSeriesKMeans(TimeSeriesLloyds):
     >>> from sktime.clustering.k_means import TimeSeriesKMeans
     >>> X_train, y_train = load_arrow_head(split="train")
     >>> X_test, y_test = load_arrow_head(split="test")
-    >>> clusterer = TimeSeriesKMeans(n_clusters=3)  # doctest: +SKIP
-    >>> clusterer.fit(X_train)  # doctest: +SKIP
+    >>> clusterer = TimeSeriesKMeans(n_clusters=3)
+    >>> clusterer.fit(X_train)
     TimeSeriesKMeans(n_clusters=3)
-    >>> y_pred = clusterer.predict(X_test)  # doctest: +SKIP
+    >>> y_pred = clusterer.predict(X_test)
     """
 
     _tags = {

--- a/sktime/clustering/k_medoids.py
+++ b/sktime/clustering/k_medoids.py
@@ -71,10 +71,10 @@ class TimeSeriesKMedoids(TimeSeriesLloyds):
     >>> from sktime.clustering.k_medoids import TimeSeriesKMedoids
     >>> X_train, y_train = load_arrow_head(split="train")
     >>> X_test, y_test = load_arrow_head(split="test")
-    >>> clusterer = TimeSeriesKMedoids(n_clusters=3)  # doctest: +SKIP
-    >>> clusterer.fit(X_train)  # doctest: +SKIP
+    >>> clusterer = TimeSeriesKMedoids(n_clusters=3)
+    >>> clusterer.fit(X_train)
     TimeSeriesKMedoids(n_clusters=3)
-    >>> y_pred = clusterer.predict(X_test)  # doctest: +SKIP
+    >>> y_pred = clusterer.predict(X_test)
     """
 
     _tags = {

--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -1131,7 +1131,7 @@ def load_macroeconomic():
     Examples
     --------
     >>> from sktime.datasets import load_macroeconomic
-    >>> y = load_macroeconomic()  # doctest: +SKIP
+    >>> y = load_macroeconomic()
 
     Notes
     -----
@@ -1243,8 +1243,8 @@ def load_solar(
 
     Examples
     --------
-    >>> from sktime.datasets import load_solar  # doctest: +SKIP
-    >>> y = load_solar()  # doctest: +SKIP
+    >>> from sktime.datasets import load_solar
+    >>> y = load_solar()
     """
     name = "solar"
     fname = name + ".csv"

--- a/sktime/distances/_distance.py
+++ b/sktime/distances/_distance.py
@@ -377,12 +377,12 @@ def wddtw_distance(
     >>> from sktime.distances import wddtw_distance
     >>> x_1d = np.array([1, 2, 3, 4])  # 1d array
     >>> y_1d = np.array([5, 6, 7, 8])  # 1d array
-    >>> wddtw_distance(x_1d, y_1d) # doctest: +SKIP
+    >>> wddtw_distance(x_1d, y_1d)
     0.0
 
     >>> x_2d = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])  # 2d array
     >>> y_2d = np.array([[9, 10, 11, 12], [13, 14, 15, 16]])  # 2d array
-    >>> wddtw_distance(x_2d, y_2d) # doctest: +SKIP
+    >>> wddtw_distance(x_2d, y_2d)
     0.0
 
     References
@@ -582,12 +582,12 @@ def ddtw_distance(
     >>> from sktime.distances import ddtw_distance
     >>> x_1d = np.array([1, 2, 3, 4])  # 1d array
     >>> y_1d = np.array([5, 6, 7, 8])  # 1d array
-    >>> ddtw_distance(x_1d, y_1d) # doctest: +SKIP
+    >>> ddtw_distance(x_1d, y_1d)
     0.0
 
     >>> x_2d = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])  # 2d array
     >>> y_2d = np.array([[9, 10, 11, 12], [13, 14, 15, 16]])  # 2d array
-    >>> ddtw_distance(x_2d, y_2d) # doctest: +SKIP
+    >>> ddtw_distance(x_2d, y_2d)
     0.0
 
     References
@@ -2112,10 +2112,10 @@ def pairwise_distance(
     Examples
     --------
     >>> import numpy as np
-    >>> from sktime.distances import pairwise_distance  # doctest: +SKIP
+    >>> from sktime.distances import pairwise_distance
     >>> x_1d = np.array([1, 2, 3, 4])  # 1d array
     >>> y_1d = np.array([5, 6, 7, 8])  # 1d array
-    >>> pairwise_distance(x_1d, y_1d, metric='dtw')  # doctest: +SKIP
+    >>> pairwise_distance(x_1d, y_1d, metric='dtw')
     array([[16., 25., 36., 49.],
            [ 9., 16., 25., 36.],
            [ 4.,  9., 16., 25.],
@@ -2123,19 +2123,19 @@ def pairwise_distance(
 
     >>> x_2d = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])  # 2d array
     >>> y_2d = np.array([[9, 10, 11, 12], [13, 14, 15, 16]])  # 2d array
-    >>> pairwise_distance(x_2d, y_2d, metric='dtw')  # doctest: +SKIP
+    >>> pairwise_distance(x_2d, y_2d, metric='dtw')
     array([[256., 576.],
            [ 58., 256.]])
 
     >>> x_3d = np.array([[[1], [2], [3], [4]], [[5], [6], [7], [8]]])  # 3d array
     >>> y_3d = np.array([[[9], [10], [11], [12]], [[13], [14], [15], [16]]])  # 3d array
-    >>> pairwise_distance(x_3d, y_3d, metric='dtw')  # doctest: +SKIP
+    >>> pairwise_distance(x_3d, y_3d, metric='dtw')
     array([[256., 576.],
            [ 64., 256.]])
 
     >>> x_2d = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])  # 2d array
     >>> y_2d = np.array([[9, 10, 11, 12], [13, 14, 15, 16]])  # 2d array
-    >>> pairwise_distance(x_2d, y_2d, metric='dtw', window=0.5)  # doctest: +SKIP
+    >>> pairwise_distance(x_2d, y_2d, metric='dtw', window=0.5)
     array([[256., 576.],
            [ 58., 256.]])
     """

--- a/sktime/dists_kernels/dtw/_dtw_sktime.py
+++ b/sktime/dists_kernels/dtw/_dtw_sktime.py
@@ -113,13 +113,13 @@ class DtwDist(BasePairwiseTransformerPanel):
     >>> from sktime.datasets import load_unit_test
     >>> from sktime.dists_kernels.dtw import DtwDist
     >>>
-    >>> X, _ = load_unit_test(return_type="pd-multiindex")  # doctest: +SKIP
-    >>> d = DtwDist(weighted=True, derivative=True)  # doctest: +SKIP
-    >>> distmat = d.transform(X)  # doctest: +SKIP
+    >>> X, _ = load_unit_test(return_type="pd-multiindex")
+    >>> d = DtwDist(weighted=True, derivative=True)
+    >>> distmat = d.transform(X)
 
     distances are also callable, this does the same:
 
-    >>> distmat = d(X)  # doctest: +SKIP
+    >>> distmat = d(X)
     """
 
     _tags = {

--- a/sktime/dists_kernels/edit_dist.py
+++ b/sktime/dists_kernels/edit_dist.py
@@ -105,13 +105,13 @@ class EditDist(BasePairwiseTransformerPanel):
     >>> from sktime.datasets import load_unit_test
     >>> from sktime.dists_kernels.edit_dist import EditDist
     >>>
-    >>> X, _ = load_unit_test(return_type="pd-multiindex")  # doctest: +SKIP
-    >>> d = EditDist("edr")  # doctest: +SKIP
-    >>> distmat = d.transform(X)  # doctest: +SKIP
+    >>> X, _ = load_unit_test(return_type="pd-multiindex")
+    >>> d = EditDist("edr")
+    >>> distmat = d.transform(X)
 
     distances are also callable, this does the same:
 
-    >>> distmat = d(X)  # doctest: +SKIP
+    >>> distmat = d(X)
     """
 
     _tags = {

--- a/sktime/forecasting/arch/_uarch.py
+++ b/sktime/forecasting/arch/_uarch.py
@@ -142,13 +142,13 @@ class ARCH(BaseForecaster):
 
     Examples
     --------
-    >>> from sktime.datasets import load_airline  # doctest: +SKIP
-    >>> from sktime.forecasting.arch import ARCH  # doctest: +SKIP
-    >>> y = load_airline()  # doctest: +SKIP
-    >>> forecaster = ARCH()  # doctest: +SKIP
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.arch import ARCH
+    >>> y = load_airline()
+    >>> forecaster = ARCH()
+    >>> forecaster.fit(y)
     ARCH(...)
-    >>> y_pred = forecaster.predict(fh=1)  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=1)
     """
 
     _tags = {

--- a/sktime/forecasting/ardl.py
+++ b/sktime/forecasting/ardl.py
@@ -179,18 +179,18 @@ class ARDL(_StatsModelsAdapter):
     >>> from sktime.datasets import load_macroeconomic
     >>> from sktime.forecasting.ardl import ARDL
     >>> from sktime.forecasting.base import ForecastingHorizon
-    >>> data = load_macroeconomic()  # doctest: +SKIP
-    >>> oos = data.iloc[-5:, :]  # doctest: +SKIP
-    >>> data = data.iloc[:-5, :]  # doctest: +SKIP
-    >>> y = data.realgdp  # doctest: +SKIP
-    >>> X = data[["realcons", "realinv"]]  # doctest: +SKIP
-    >>> X_oos = oos[["realcons", "realinv"]]  # doctest: +SKIP
+    >>> data = load_macroeconomic()
+    >>> oos = data.iloc[-5:, :]
+    >>> data = data.iloc[:-5, :]
+    >>> y = data.realgdp
+    >>> X = data[["realcons", "realinv"]]
+    >>> X_oos = oos[["realcons", "realinv"]]
     >>> ardl = ARDL(lags=2, order={"realcons": 1, "realinv": 2}, trend="c")\
-    # doctest: +SKIP
-    >>> ardl.fit(y=y, X=X)  # doctest: +SKIP
+  
+    >>> ardl.fit(y=y, X=X)
     ARDL(lags=2, order={'realcons': 1, 'realinv': 2})
-    >>> fh = ForecastingHorizon([1, 2, 3])  # doctest: +SKIP
-    >>> y_pred = ardl.predict(fh=fh, X=X_oos)  # doctest: +SKIP
+    >>> fh = ForecastingHorizon([1, 2, 3])
+    >>> y_pred = ardl.predict(fh=fh, X=X_oos)
     """
 
     _tags = {

--- a/sktime/forecasting/arima/_pmdarima.py
+++ b/sktime/forecasting/arima/_pmdarima.py
@@ -262,10 +262,10 @@ class AutoARIMA(_PmdArimaAdapter):
     >>> y = load_airline()
     >>> forecaster = AutoARIMA(
     ...     sp=12, d=0, max_p=2, max_q=2, suppress_warnings=True
-    ... ) # doctest: +SKIP
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    ... )
+    >>> forecaster.fit(y)
     AutoARIMA(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
     """  # noqa: E501
 
     _tags = {
@@ -674,13 +674,13 @@ class ARIMA(_PmdArimaAdapter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.arima import ARIMA
     >>> y = load_airline()
-    >>> forecaster = ARIMA(  # doctest: +SKIP
+    >>> forecaster = ARIMA(
     ...     order=(1, 1, 0),
     ...     seasonal_order=(0, 1, 0, 12),
     ...     suppress_warnings=True)
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster.fit(y)
     ARIMA(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
     """  # noqa: E501
 
     _tags = {

--- a/sktime/forecasting/arima/_statsmodels.py
+++ b/sktime/forecasting/arima/_statsmodels.py
@@ -157,9 +157,9 @@ class StatsModelsARIMA(_StatsModelsAdapter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.arima import StatsModelsARIMA
     >>> y = load_airline()
-    >>> forecaster = StatsModelsARIMA(order=(0, 0, 12))  # doctest: +SKIP
-    >>> forecaster.fit(y)  # doctest: +SKIP
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> forecaster = StatsModelsARIMA(order=(0, 0, 12))
+    >>> forecaster.fit(y)
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
     """  # noqa: E501
 
     _tags = {

--- a/sktime/forecasting/auto_reg.py
+++ b/sktime/forecasting/auto_reg.py
@@ -65,31 +65,31 @@ class AutoREG(_StatsModelsAdapter):
     --------
     Use AutoREG to forecast univariate data.
 
-    >>> from sktime.forecasting.auto_reg import AutoREG  # doctest: +SKIP
+    >>> from sktime.forecasting.auto_reg import AutoREG
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.base import ForecastingHorizon
     >>> data = load_airline()
-    >>> autoreg_sktime = AutoREG(lags=2, trend="c")  # doctest: +SKIP
-    >>> autoreg_sktime.fit(y=data)  # doctest: +SKIP
+    >>> autoreg_sktime = AutoREG(lags=2, trend="c")
+    >>> autoreg_sktime.fit(y=data)
     AutoREG(lags=2)
     >>> fh = ForecastingHorizon([x for x in range(1, 13)])
-    >>> y_pred = autoreg_sktime.predict(fh=fh)  # doctest: +SKIP
+    >>> y_pred = autoreg_sktime.predict(fh=fh)
 
 
     Use AutoREG to forecast with exogenous data.
 
-    >>> from sktime.forecasting.auto_reg import AutoREG  # doctest: +SKIP
+    >>> from sktime.forecasting.auto_reg import AutoREG
     >>> from sktime.datasets import load_longley
     >>> from sktime.forecasting.base import ForecastingHorizon
     >>> y, X_og = load_longley()
     >>> X_oos = X_og.iloc[-5:, :]
     >>> y, X = y.iloc[:-5], X_og.iloc[:-5, :]
     >>> X, X_oos = X[["GNPDEFL", "GNP"]], X_oos[["GNPDEFL", "GNP"]]
-    >>> autoreg_sktime = AutoREG(lags=2, trend="c")  # doctest: +SKIP
-    >>> autoreg_sktime.fit(y=y, X=X)  # doctest: +SKIP
+    >>> autoreg_sktime = AutoREG(lags=2, trend="c")
+    >>> autoreg_sktime.fit(y=y, X=X)
     AutoREG(lags=2)
     >>> fh = ForecastingHorizon([x for x in range(1, 4)])
-    >>> y_pred = autoreg_sktime.predict(X=X_oos, fh=fh)  # doctest: +SKIP
+    >>> y_pred = autoreg_sktime.predict(X=X_oos, fh=fh)
     """
 
     _tags = {

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -225,17 +225,17 @@ class ForecastingHorizon:
 
         List as ForecastingHorizon
 
-    >>> ForecastingHorizon([1, 2, 3])  # doctest: +SKIP
+    >>> ForecastingHorizon([1, 2, 3])
     >>> # ForecastingHorizon([1, 2, 3], is_relative=True)
 
         Numpy as ForecastingHorizon
 
-    >>> ForecastingHorizon(np.arange(1, 7))  # doctest: +SKIP
+    >>> ForecastingHorizon(np.arange(1, 7))
     >>> # ForecastingHorizon([1, 2, 3, 4, 5, 6], is_relative=True)
 
         Absolute ForecastingHorizon with a pandas Index
 
-    >>> ForecastingHorizon(y_test.index, is_relative=False) # doctest: +SKIP
+    >>> ForecastingHorizon(y_test.index, is_relative=False)
     >>> # ForecastingHorizon(['1960-07', ..., '1960-12'], is_relative=False)
 
         Converting
@@ -246,12 +246,12 @@ class ForecastingHorizon:
     Period('1960-06', 'M')
     >>> # to_relative
     >>> fh = ForecastingHorizon(y_test.index, is_relative=False)
-    >>> fh.to_relative(cutoff=cutoff)  # doctest: +SKIP
+    >>> fh.to_relative(cutoff=cutoff)
     >>> # ForecastingHorizon([1, 2, 3, 4, 5, 6], is_relative=True)
 
     >>> # to_absolute
     >>> fh = ForecastingHorizon([1, 2, 3, 4, 5, 6], is_relative=True)
-    >>> fh = fh.to_absolute(cutoff=cutoff) # doctest: +SKIP
+    >>> fh = fh.to_absolute(cutoff=cutoff)
     >>> # ForecastingHorizon(['1960-07', ..., '1960-12'], is_relative=False)
 
         Automatically casted ForecastingHorizon from list when calling predict()
@@ -260,13 +260,13 @@ class ForecastingHorizon:
     >>> forecaster.fit(y_train)
     NaiveForecaster(...)
     >>> y_pred = forecaster.predict(fh=[1,2,3])
-    >>> forecaster.fh  # doctest: +SKIP
+    >>> forecaster.fh
     >>> # ForecastingHorizon([1, 2, 3], dtype='int64', is_relative=True)
 
         This is identical to give an object of ForecastingHorizon
 
     >>> y_pred = forecaster.predict(fh=ForecastingHorizon([1,2,3]))
-    >>> forecaster.fh  # doctest: +SKIP
+    >>> forecaster.fh
     >>> # ForecastingHorizon([1, 2, 3], dtype='int64', is_relative=True)
     """
 

--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -440,13 +440,13 @@ class StatsForecastBackAdapter:
     >>> from sktime.forecasting.ets import AutoETS
 
     >>> y = load_airline()
-    >>> trend_forecaster = AutoETS() # doctest: +SKIP
-    >>> model = StatsForecastMSTL( # doctest: +SKIP
+    >>> trend_forecaster = AutoETS()
+    >>> model = StatsForecastMSTL(
             season_length=[3,12],
             trend_forecaster=trend_forecaster
         )
-    >>> fitted_model = model.fit(y=y) # doctest: +SKIP
-    >>> y_pred = fitted_model.predict(fh=[1,2,3]) # doctest: +SKIP
+    >>> fitted_model = model.fit(y=y)
+    >>> y_pred = fitted_model.predict(fh=[1,2,3])
     """
 
     _tags = {

--- a/sktime/forecasting/bats.py
+++ b/sktime/forecasting/bats.py
@@ -98,16 +98,16 @@ class BATS(_TbatsAdapter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.bats import BATS
     >>> y = load_airline()
-    >>> forecaster = BATS(  # doctest: +SKIP
+    >>> forecaster = BATS(
     ...     use_box_cox=False,
     ...     use_trend=False,
     ...     use_damped_trend=False,
     ...     sp=12,
     ...     use_arma_errors=False,
     ...     n_jobs=1)
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster.fit(y)
     BATS(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
     """  # noqa: E501
 
     _fitted_param_names = "aic"

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -76,10 +76,10 @@ class BaggingForecaster(BaseForecaster):
     >>> y = load_airline()
     >>> forecaster = BaggingForecaster(
     ...     STLBootstrapTransformer(sp=12), NaiveForecaster(sp=12)
-    ... )  # doctest: +SKIP
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    ... )
+    >>> forecaster.fit(y)
     BaggingForecaster(...)
-    >>> y_hat = forecaster.predict([1,2,3])  # doctest: +SKIP
+    >>> y_hat = forecaster.predict([1,2,3])
     """
 
     _tags = {

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -67,13 +67,13 @@ class MultiplexForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
     >>> forecaster = MultiplexForecaster(forecasters=[
     ...     ("ets", AutoETS()),
     ...     ("theta", ThetaForecaster()),
-    ...     ("naive", NaiveForecaster())])  # doctest: +SKIP
-    >>> cv = ExpandingWindowSplitter(step_length=12)  # doctest: +SKIP
+    ...     ("naive", NaiveForecaster())])
+    >>> cv = ExpandingWindowSplitter(step_length=12)
     >>> gscv = ForecastingGridSearchCV(
     ...     cv=cv,
     ...     param_grid={"selected_forecaster":["ets", "theta", "naive"]},
-    ...     forecaster=forecaster)  # doctest: +SKIP
-    >>> gscv.fit(y)  # doctest: +SKIP
+    ...     forecaster=forecaster)
+    >>> gscv.fit(y)
     ForecastingGridSearchCV(...)
     """
 

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -1306,26 +1306,26 @@ class ForecastX(BaseForecaster):
 
     >>> y, X = load_longley()
     >>> fh = ForecastingHorizon([1, 2, 3])
-    >>> pipe = ForecastX(  # doctest: +SKIP
+    >>> pipe = ForecastX(
     ...     forecaster_X=VAR(),
     ...     forecaster_y=ARIMA(),
     ... )
-    >>> pipe = pipe.fit(y, X=X, fh=fh)  # doctest: +SKIP
+    >>> pipe = pipe.fit(y, X=X, fh=fh)
     >>> # this now works without X from the future of y!
-    >>> y_pred = pipe.predict(fh=fh)  # doctest: +SKIP
+    >>> y_pred = pipe.predict(fh=fh)
 
     to forecast only some columns, use the ``columns`` arg,
     and pass known columns to ``predict``:
 
     >>> columns = ["ARMED", "POP"]
-    >>> pipe = ForecastX(  # doctest: +SKIP
+    >>> pipe = ForecastX(
     ...     forecaster_X=VAR(),
     ...     forecaster_y=SARIMAX(),
     ...     columns=columns,
     ... )
-    >>> pipe = pipe.fit(y_train, X=X_train, fh=fh)  # doctest: +SKIP
+    >>> pipe = pipe.fit(y_train, X=X_train, fh=fh)
     >>> # dropping ["ARMED", "POP"] = columns where we expect not to have future values
-    >>> y_pred = pipe.predict(fh=fh, X=X_test.drop(columns=columns))  # doctest: +SKIP
+    >>> y_pred = pipe.predict(fh=fh, X=X_test.drop(columns=columns))
 
     Notes
     -----

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -2675,12 +2675,12 @@ class YfromX(BaseForecaster, _ReducerMixin):
 
     YfromX can also be used with skpro probabilistic regressors,
     in this case the resulting forecaster will be capable of probabilistic forecasts:
-    >>> from skpro.regression.residual import ResidualDouble  # doctest: +SKIP
-    >>> reg_proba = ResidualDouble(LinearRegression())  # doctest: +SKIP
-    >>> f = YfromX(reg_proba)  # doctest: +SKIP
-    >>> f.fit(y=y_train, X=X_train, fh=fh)  # doctest: +SKIP
+    >>> from skpro.regression.residual import ResidualDouble
+    >>> reg_proba = ResidualDouble(LinearRegression())
+    >>> f = YfromX(reg_proba)
+    >>> f.fit(y=y_train, X=X_train, fh=fh)
     YfromX(...)
-    >>> y_pred = f.predict_interval(X=X_test)  # doctest: +SKIP
+    >>> y_pred = f.predict_interval(X=X_test)
     """
 
     _tags = {

--- a/sktime/forecasting/compose/_skforecast_reduce.py
+++ b/sktime/forecasting/compose/_skforecast_reduce.py
@@ -71,16 +71,16 @@ class SkforecastAutoreg(BaseForecaster):
     >>> from sklearn.linear_model import LinearRegression
     >>> from sktime.datasets import load_airline
     >>> y = load_airline()
-    >>> forecaster = SkforecastAutoreg(  # doctest: +SKIP
+    >>> forecaster = SkforecastAutoreg(
     ...     LinearRegression(), 2
     ... )
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster.fit(y)
     SkforecastAutoreg(lags=2, regressor=LinearRegression())
-    >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
-    >>> y_pred_int = forecaster.predict_interval(  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])
+    >>> y_pred_int = forecaster.predict_interval(
     ...     fh=[2], coverage=[0.9, 0.95]
     ... )
-    >>> y_pred_qtl = forecaster.predict_quantiles(  # doctest: +SKIP
+    >>> y_pred_qtl = forecaster.predict_quantiles(
     ...     fh=[1, 3], alpha=[0.8, 0.3, 0.2, 0.7]
     ... )
 
@@ -93,16 +93,16 @@ class SkforecastAutoreg(BaseForecaster):
     >>> y_test = y.tail(n=4)
     >>> X_train = X.head(n=12)
     >>> X_test = X.tail(n=4)
-    >>> forecaster = SkforecastAutoreg(  # doctest: +SKIP
+    >>> forecaster = SkforecastAutoreg(
     ...     RandomForestRegressor(), [2, 4]
     ... )
-    >>> forecaster.fit(y_train, X=X_train)  # doctest: +SKIP
+    >>> forecaster.fit(y_train, X=X_train)
     SkforecastAutoreg(lags=[2, 4], regressor=RandomForestRegressor())
-    >>> y_pred = forecaster.predict(fh=[1, 2, 3], X=X_test)  # doctest: +SKIP
-    >>> y_pred_int = forecaster.predict_interval(  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3], X=X_test)
+    >>> y_pred_int = forecaster.predict_interval(
     ...     fh=[1, 3], X=X_test, coverage=[0.6, 0.4]
     ... )
-    >>> y_pred_qtl = forecaster.predict_quantiles(  # doctest: +SKIP
+    >>> y_pred_qtl = forecaster.predict_quantiles(
     ...     fh=[1, 3], X=X_test, alpha=[0.01, 0.5]
     ... )
 

--- a/sktime/forecasting/conditional_invertible_neural_network.py
+++ b/sktime/forecasting/conditional_invertible_neural_network.py
@@ -108,10 +108,10 @@ class CINNForecaster(BaseDeepNetworkPyTorch):
     ... )
     >>> from sktime.datasets import load_airline
     >>> y = load_airline()
-    >>> model = CINNForecaster() # doctest: +SKIP
-    >>> model.fit(y) # doctest: +SKIP
+    >>> model = CINNForecaster()
+    >>> model.fit(y)
     CINNForecaster(...)
-    >>> y_pred = model.predict(fh=[1,2,3]) # doctest: +SKIP
+    >>> y_pred = model.predict(fh=[1,2,3])
     """
 
     _tags = {

--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -76,15 +76,15 @@ class ConformalIntervals(BaseForecaster):
 
     Examples
     --------
-    >>> from sktime.datasets import load_airline  # doctest: +SKIP
-    >>> from sktime.forecasting.conformal import ConformalIntervals  # doctest: +SKIP
-    >>> from sktime.forecasting.naive import NaiveForecaster  # doctest: +SKIP
-    >>> y = load_airline()  # doctest: +SKIP
-    >>> forecaster = NaiveForecaster(strategy="drift")  # doctest: +SKIP
-    >>> conformal_forecaster = ConformalIntervals(forecaster)  # doctest: +SKIP
-    >>> conformal_forecaster.fit(y, fh=[1, 2, 3])  # doctest: +SKIP
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.conformal import ConformalIntervals
+    >>> from sktime.forecasting.naive import NaiveForecaster
+    >>> y = load_airline()
+    >>> forecaster = NaiveForecaster(strategy="drift")
+    >>> conformal_forecaster = ConformalIntervals(forecaster)
+    >>> conformal_forecaster.fit(y, fh=[1, 2, 3])
     ConformalIntervals(...)
-    >>> pred_int = conformal_forecaster.predict_interval()  # doctest: +SKIP
+    >>> pred_int = conformal_forecaster.predict_interval()
 
     recommended use of ConformalIntervals together with ForecastingGridSearch
     is by 1. first running grid search, 2. then ConformalIntervals on the tuned params
@@ -97,25 +97,25 @@ class ConformalIntervals(BaseForecaster):
     >>> from sktime.split import ExpandingWindowSplitter
     >>> from sktime.param_est.plugin import PluginParamsForecaster
     >>> # part 1 = grid search
-    >>> cv = ExpandingWindowSplitter(fh=[1, 2, 3])  # doctest: +SKIP
-    >>> forecaster = NaiveForecaster()  # doctest: +SKIP
-    >>> param_grid = {"strategy" : ["last", "mean", "drift"]}  # doctest: +SKIP
+    >>> cv = ExpandingWindowSplitter(fh=[1, 2, 3])
+    >>> forecaster = NaiveForecaster()
+    >>> param_grid = {"strategy" : ["last", "mean", "drift"]}
     >>> gscv = ForecastingGridSearchCV(
     ...     forecaster=forecaster,
     ...     param_grid=param_grid,
     ...     cv=cv,
-    ... )  # doctest: +SKIP
+    ... )
     >>> # part 2 = plug in results of grid search into conformal intervals estimator
     >>> conformal_with_fallback = ConformalIntervals(NaiveForecaster())
     >>> gscv_with_conformal = PluginParamsForecaster(
     ...     gscv,
     ...     conformal_with_fallback,
     ...     params={"forecaster": "best_forecaster"},
-    ... )  # doctest: +SKIP
-    >>> y = load_airline()  # doctest: +SKIP
-    >>> gscv_with_conformal.fit(y, fh=[1, 2, 3])  # doctest: +SKIP
+    ... )
+    >>> y = load_airline()
+    >>> gscv_with_conformal.fit(y, fh=[1, 2, 3])
     PluginParamsForecaster(...)
-    >>> y_pred_quantiles = gscv_with_conformal.predict_quantiles()  # doctest: +SKIP
+    >>> y_pred_quantiles = gscv_with_conformal.predict_quantiles()
     """
 
     _tags = {

--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -115,10 +115,10 @@ class DynamicFactor(_StatsModelsAdapter):
     >>> from sktime.utils._testing.series import _make_series
     >>> from sktime.forecasting.dynamic_factor import DynamicFactor
     >>> y = _make_series(n_columns=4)
-    >>> forecaster = DynamicFactor()  # doctest: +SKIP
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster = DynamicFactor()
+    >>> forecaster.fit(y)
     DynamicFactor(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
     """
 
     _tags = {

--- a/sktime/forecasting/ets.py
+++ b/sktime/forecasting/ets.py
@@ -167,10 +167,10 @@ class AutoETS(_StatsModelsAdapter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.ets import AutoETS
     >>> y = load_airline()
-    >>> forecaster = AutoETS(auto=True, n_jobs=-1, sp=12)  # doctest: +SKIP
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster = AutoETS(auto=True, n_jobs=-1, sp=12)
+    >>> forecaster.fit(y)
     AutoETS(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
     """
 
     _fitted_param_names = ("aic", "aicc", "bic", "hqic")

--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -104,10 +104,10 @@ class ExponentialSmoothing(_StatsModelsAdapter):
     >>> y = load_airline()
     >>> forecaster = ExponentialSmoothing(
     ...     trend='add', seasonal='multiplicative', sp=12
-    ... )  # doctest: +SKIP
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    ... )
+    >>> forecaster.fit(y)
     ExponentialSmoothing(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
     """
 
     _tags = {

--- a/sktime/forecasting/fbprophet.py
+++ b/sktime/forecasting/fbprophet.py
@@ -126,14 +126,14 @@ class Prophet(_ProphetAdapter):
     >>> from sktime.forecasting.fbprophet import Prophet
     >>> # Prophet requires to have data with a pandas.DatetimeIndex
     >>> y = load_airline().to_timestamp(freq='M')
-    >>> forecaster = Prophet(  # doctest: +SKIP
+    >>> forecaster = Prophet(
     ...     seasonality_mode='multiplicative',
     ...     n_changepoints=int(len(y) / 12),
     ...     add_country_holidays={'country_name': 'Germany'},
     ...     yearly_seasonality=True)
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster.fit(y)
     Prophet(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
     """
 
     def __init__(

--- a/sktime/forecasting/hf_transformers_forecaster.py
+++ b/sktime/forecasting/hf_transformers_forecaster.py
@@ -92,10 +92,10 @@ class HFTransformersForecaster(BaseForecaster):
     ...         "use_cpu": True,
     ...         "label_length": 2,
     ...    },
-    ... ) # doctest: +SKIP
-    >>> forecaster.fit(y) # doctest: +SKIP
+    ... )
+    >>> forecaster.fit(y)
     >>> fh = [1, 2, 3]
-    >>> y_pred = forecaster.predict(fh) # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh)
 
     >>> from sktime.forecasting.hf_transformers_forecaster import (
     ...     HFTransformersForecaster,
@@ -124,10 +124,10 @@ class HFTransformersForecaster(BaseForecaster):
     ...        target_modules=["q_proj", "v_proj"],
     ...        lora_dropout=0.01,
     ...    )
-    ... ) # doctest: +SKIP
-    >>> forecaster.fit(y) # doctest: +SKIP
+    ... )
+    >>> forecaster.fit(y)
     >>> fh = [1, 2, 3]
-    >>> y_pred = forecaster.predict(fh) # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh)
     """
 
     _tags = {

--- a/sktime/forecasting/ltsf.py
+++ b/sktime/forecasting/ltsf.py
@@ -54,14 +54,14 @@ class LTSFLinearForecaster(BaseDeepNetworkPyTorch):
 
     Examples
     --------
-    >>> from sktime.forecasting.ltsf import LTSFLinearForecaster # doctest: +SKIP
+    >>> from sktime.forecasting.ltsf import LTSFLinearForecaster
     >>> from sktime.datasets import load_airline
-    >>> model = LTSFLinearForecaster(10, 3) # doctest: +SKIP
+    >>> model = LTSFLinearForecaster(10, 3)
     >>> y = load_airline()
-    >>> model.fit(y, fh=[1,2,3]) # doctest: +SKIP
+    >>> model.fit(y, fh=[1,2,3])
     LTSFLinearForecaster(pred_len=3, seq_len=10)
-    >>> y_pred = model.predict() # doctest: +SKIP
-    >>> y_pred # doctest: +SKIP
+    >>> y_pred = model.predict()
+    >>> y_pred
     1961-01    515.456726
     1961-02    576.704712
     1961-03    559.859680
@@ -227,14 +227,14 @@ class LTSFDLinearForecaster(BaseDeepNetworkPyTorch):
 
     Examples
     --------
-    >>> from sktime.forecasting.ltsf import LTSFDLinearForecaster # doctest: +SKIP
+    >>> from sktime.forecasting.ltsf import LTSFDLinearForecaster
     >>> from sktime.datasets import load_airline
-    >>> model = LTSFDLinearForecaster(10, 3) # doctest: +SKIP
+    >>> model = LTSFDLinearForecaster(10, 3)
     >>> y = load_airline()
-    >>> model.fit(y, fh=[1,2,3]) # doctest: +SKIP
+    >>> model.fit(y, fh=[1,2,3])
     LTSFDLinearForecaster(pred_len=3, seq_len=10)
-    >>> y_pred = model.predict() # doctest: +SKIP
-    >>> y_pred # doctest: +SKIP
+    >>> y_pred = model.predict()
+    >>> y_pred
     1961-01    436.494476
     1961-02    433.659851
     1961-03    479.309631
@@ -400,14 +400,14 @@ class LTSFNLinearForecaster(BaseDeepNetworkPyTorch):
 
     Examples
     --------
-    >>> from sktime.forecasting.ltsf import LTSFNLinearForecaster # doctest: +SKIP
+    >>> from sktime.forecasting.ltsf import LTSFNLinearForecaster
     >>> from sktime.datasets import load_airline
-    >>> model = LTSFNLinearForecaster(10, 3) # doctest: +SKIP
+    >>> model = LTSFNLinearForecaster(10, 3)
     >>> y = load_airline()
-    >>> model.fit(y, fh=[1,2,3]) # doctest: +SKIP
+    >>> model.fit(y, fh=[1,2,3])
     LTSFNLinearForecaster(pred_len=3, seq_len=10)
-    >>> y_pred = model.predict() # doctest: +SKIP
-    >>> y_pred # doctest: +SKIP
+    >>> y_pred = model.predict()
+    >>> y_pred
     1961-01    455.628082
     1961-02    433.349640
     1961-03    437.045502
@@ -600,15 +600,15 @@ class LTSFTransformerForecaster(BaseDeepNetworkPyTorch):
 
     Examples
     --------
-    >>> from sktime.forecasting.ltsf import LTSFTransformerForecaster # doctest: +SKIP
+    >>> from sktime.forecasting.ltsf import LTSFTransformerForecaster
     >>> from sktime.datasets import load_airline
     >>>
     >>> y = load_airline()
     >>>
-    >>> model = LTSFTransformerForecaster(10, 5, 5) # doctest: +SKIP
-    >>> model.fit(y, fh=[1, 2, 3, 4, 5]) # doctest: +SKIP
+    >>> model = LTSFTransformerForecaster(10, 5, 5)
+    >>> model.fit(y, fh=[1, 2, 3, 4, 5])
     LTSFTransformerForecaster(context_len=5, pred_len=5, seq_len=10)
-    >>> pred = model.predict() # doctest: +SKIP
+    >>> pred = model.predict()
     """
 
     _tags = {

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -590,10 +590,10 @@ class ForecastingGridSearchCV(BaseGridSearch):
     ...     },
     ...     ],
     ...     cv=cv,
-    ... )  # doctest: +SKIP
-    >>> gscv.fit(y)  # doctest: +SKIP
+    ... )
+    >>> gscv.fit(y)
     ForecastingGridSearchCV(...)
-    >>> y_pred = gscv.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = gscv.predict(fh=[1,2,3])
     """
 
     def __init__(
@@ -1137,10 +1137,10 @@ class ForecastingSkoptSearchCV(BaseGridSearch):
     ...     param_distributions=param_distributions,
     ...     cv=cv,
     ...     n_iter=5,
-    ...     random_state=10)  # doctest: +SKIP
-    >>> sscv.fit(y)  # doctest: +SKIP
+    ...     random_state=10)
+    >>> sscv.fit(y)
     ForecastingSkoptSearchCV(...)
-    >>> y_pred = sscv.predict(fh)  # doctest: +SKIP
+    >>> y_pred = sscv.predict(fh)
     """
 
     _tags = {

--- a/sktime/forecasting/neuralforecast.py
+++ b/sktime/forecasting/neuralforecast.py
@@ -123,19 +123,19 @@ class NeuralForecastRNN(_NeuralForecastAdapter):
     >>> y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, test_size=4)
     >>>
     >>> # creating model instance configuring the hyperparameters
-    >>> model = NeuralForecastRNN(  # doctest: +SKIP
+    >>> model = NeuralForecastRNN(
     ...     "A-DEC", futr_exog_list=["ARMED", "POP"], max_steps=5
     ... )
     >>>
     >>> # fitting the model
-    >>> model.fit(y_train, X=X_train, fh=[1, 2, 3, 4])  # doctest: +SKIP
+    >>> model.fit(y_train, X=X_train, fh=[1, 2, 3, 4])
     Seed set to 1
     Epoch 4: 100%|█| 1/1 [00:00<00:00, 42.85it/s, v_num=870, train_loss_step=0.589,
     train_loss_epoc
     NeuralForecastRNN(freq='A-DEC', futr_exog_list=['ARMED', 'POP'], max_steps=5)
     >>>
     >>> # getting point predictions
-    >>> model.predict(X=X_test)  # doctest: +SKIP
+    >>> model.predict(X=X_test)
     Predicting DataLoader 0: 100%|██████████████████████████████████| 1/1 [00:00<00:00,
     198.64it/s]
     1959    66241.984375
@@ -497,18 +497,18 @@ class NeuralForecastLSTM(_NeuralForecastAdapter):
     >>> y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, test_size=4)
     >>>
     >>> # creating model instance configuring the hyperparameters
-    >>> model = NeuralForecastLSTM(  # doctest: +SKIP
+    >>> model = NeuralForecastLSTM(
     ...     "A-DEC", futr_exog_list=["ARMED", "POP"], max_steps=5
     ... )
     >>>
     >>> # fitting the model
-    >>> model.fit(y_train, X=X_train, fh=[1, 2, 3, 4])  # doctest: +SKIP
+    >>> model.fit(y_train, X=X_train, fh=[1, 2, 3, 4])
     Seed set to 1
     Epoch 4: 100%|█| 1/1 [00:00<00:00, 42.85it/s, v_num=870, train_loss_step=0.589, train_loss_epoc
     NeuralForecastLSTM(freq='A-DEC', futr_exog_list=['ARMED', 'POP'], max_steps=5)
     >>>
     >>> # getting point predictions
-    >>> model.predict(X=X_test)  # doctest: +SKIP
+    >>> model.predict(X=X_test)
     Predicting DataLoader 0: 100%|██████████████████████████████████| 1/1 [00:00<00:00, 198.64it/s]
     1959    64083.226562
     1960    64426.304688

--- a/sktime/forecasting/sarimax.py
+++ b/sktime/forecasting/sarimax.py
@@ -215,11 +215,11 @@ class SARIMAX(_StatsModelsAdapter):
     >>> from sktime.forecasting.sarimax import SARIMAX
     >>> y = load_airline()
     >>> forecaster = SARIMAX(
-    ...     order=(1, 0, 0), trend="t", seasonal_order=(1, 0, 0, 6))  # doctest: +SKIP
+    ...     order=(1, 0, 0), trend="t", seasonal_order=(1, 0, 0, 6))
     ... )
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster.fit(y)
     SARIMAX(...)
-    >>> y_pred = forecaster.predict(fh=y.index)  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=y.index)
     """  # noqa: E501
 
     _tags = {

--- a/sktime/forecasting/squaring_residuals.py
+++ b/sktime/forecasting/squaring_residuals.py
@@ -72,13 +72,13 @@ class SquaringResiduals(BaseForecaster):
     >>> from sktime.forecasting.theta import ThetaForecaster
     >>> from sktime.forecasting.squaring_residuals import SquaringResiduals
     >>> fc = NaiveForecaster()
-    >>> var_fc = ThetaForecaster()  # doctest: +SKIP
-    >>> y = load_macroeconomic().realgdp  # doctest: +SKIP
+    >>> var_fc = ThetaForecaster()
+    >>> y = load_macroeconomic().realgdp
     >>> sqr = SquaringResiduals(forecaster=fc, residual_forecaster=var_fc)
-    ... # doctest: +SKIP
-    >>> fh = ForecastingHorizon(values=[1, 2, 3])  # doctest: +SKIP
-    >>> sqr = sqr.fit(y, fh=fh)  # doctest: +SKIP
-    >>> pred_interval = sqr.predict_interval(coverage=0.95)  # doctest: +SKIP
+    ...
+    >>> fh = ForecastingHorizon(values=[1, 2, 3])
+    >>> sqr = sqr.fit(y, fh=fh)
+    >>> pred_interval = sqr.predict_interval(coverage=0.95)
     """
 
     _tags = {

--- a/sktime/forecasting/statsforecast.py
+++ b/sktime/forecasting/statsforecast.py
@@ -168,12 +168,12 @@ class StatsForecastAutoARIMA(_GeneralisedStatsForecastAdapter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.statsforecast import StatsForecastAutoARIMA
     >>> y = load_airline()
-    >>> forecaster = StatsForecastAutoARIMA(  # doctest: +SKIP
+    >>> forecaster = StatsForecastAutoARIMA(
     ...     sp=12, d=0, max_p=2, max_q=2
     ... )
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster.fit(y)
     StatsForecastAutoARIMA(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
     """
 
     _tags = {
@@ -838,9 +838,9 @@ class StatsForecastMSTL(_GeneralisedStatsForecastAdapter):
     >>> from sktime.forecasting.statsforecast import StatsForecastMSTL
 
     >>> y = load_airline()
-    >>> model = StatsForecastMSTL(season_length=[3,12]) # doctest: +SKIP
-    >>> fitted_model = model.fit(y=y) # doctest: +SKIP
-    >>> y_pred = fitted_model.predict(fh=[1,2,3]) # doctest: +SKIP
+    >>> model = StatsForecastMSTL(season_length=[3,12])
+    >>> fitted_model = model.fit(y=y)
+    >>> y_pred = fitted_model.predict(fh=[1,2,3])
     """
 
     _tags = {

--- a/sktime/forecasting/structural.py
+++ b/sktime/forecasting/structural.py
@@ -194,10 +194,10 @@ class UnobservedComponents(_StatsModelsAdapter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.structural import UnobservedComponents
     >>> y = load_airline()
-    >>> forecaster = UnobservedComponents(level='local linear trend')  # doctest: +SKIP
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster = UnobservedComponents(level='local linear trend')
+    >>> forecaster.fit(y)
     UnobservedComponents(...)
-    >>> y_pred = forecaster.predict(fh=[1, 2, 3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])
     """
 
     _tags = {

--- a/sktime/forecasting/tbats.py
+++ b/sktime/forecasting/tbats.py
@@ -100,16 +100,16 @@ class TBATS(_TbatsAdapter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.tbats import TBATS
     >>> y = load_airline()
-    >>> forecaster = TBATS(  # doctest: +SKIP
+    >>> forecaster = TBATS(
     ...     use_box_cox=False,
     ...     use_trend=False,
     ...     use_damped_trend=False,
     ...     sp=12,
     ...     use_arma_errors=False,
     ...     n_jobs=1)
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster.fit(y)
     TBATS(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
     """  # noqa: E501
 
     _fitted_param_names = "aic"

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -81,10 +81,10 @@ class ThetaForecaster(ExponentialSmoothing):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.theta import ThetaForecaster
     >>> y = load_airline()
-    >>> forecaster = ThetaForecaster(sp=12)  # doctest: +SKIP
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster = ThetaForecaster(sp=12)
+    >>> forecaster.fit(y)
     ThetaForecaster(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
     """
 
     _fitted_param_names = ("initial_level", "smoothing_level")

--- a/sktime/forecasting/trend/_pwl_trend_forecaster.py
+++ b/sktime/forecasting/trend/_pwl_trend_forecaster.py
@@ -77,10 +77,10 @@ class ProphetPiecewiseLinearTrendForecaster(_ProphetAdapter):
     >>> y =load_airline().to_timestamp(freq='M')
     >>> y_train, y_test = temporal_train_test_split(y)
     >>> fh = ForecastingHorizon(y.index, is_relative=False)
-    >>> forecaster =  ProphetPiecewiseLinearTrendForecaster() # doctest: +SKIP
-    >>> forecaster.fit(y_train) # doctest: +SKIP
+    >>> forecaster =  ProphetPiecewiseLinearTrendForecaster()
+    >>> forecaster.fit(y_train)
     ProphetPiecewiseLinearTrendForecaster(...)
-    >>> y_pred = forecaster.predict(fh) # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh)
     """
 
     _tags = {

--- a/sktime/forecasting/trend/_stl_forecaster.py
+++ b/sktime/forecasting/trend/_stl_forecaster.py
@@ -119,10 +119,10 @@ class STLForecaster(BaseForecaster):
     >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.trend import STLForecaster
     >>> y = load_airline()
-    >>> forecaster = STLForecaster(sp=12)  # doctest: +SKIP
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster = STLForecaster(sp=12)
+    >>> forecaster.fit(y)
     STLForecaster(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
 
     See Also
     --------

--- a/sktime/forecasting/ttm.py
+++ b/sktime/forecasting/ttm.py
@@ -90,9 +90,9 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     >>> from sktime.forecasting.ttm import TinyTimeMixerForecaster
     >>> from sktime.datasets import load_airline
     >>> y = load_airline()
-    >>> forecaster = TinyTimeMixerForecaster() # doctest: +SKIP
-    >>> forecaster.fit(y, fh=[1, 2, 3]) # doctest: +SKIP
-    >>> y_pred = forecaster.predict() # doctest: +SKIP
+    >>> forecaster = TinyTimeMixerForecaster()
+    >>> forecaster.fit(y, fh=[1, 2, 3])
+    >>> y_pred = forecaster.predict()
 
     >>> from sktime.forecasting.ttm import TinyTimeMixerForecaster
     >>> from sktime.datasets import load_tecator
@@ -115,11 +115,11 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     ...         "output_dir": "test_output",
     ...         "per_device_train_batch_size": 32,
     ...     },
-    ... ) # doctest: +SKIP
+    ... )
     >>>
     >>> # train and predict
-    >>> forecaster.fit(y, fh=[1, 2, 3]) # doctest: +SKIP
-    >>> y_pred = forecaster.predict() # doctest: +SKIP
+    >>> forecaster.fit(y, fh=[1, 2, 3])
+    >>> y_pred = forecaster.predict()
     """
 
     _tags = {

--- a/sktime/forecasting/var.py
+++ b/sktime/forecasting/var.py
@@ -65,10 +65,10 @@ class VAR(_StatsModelsAdapter):
     >>> from sktime.forecasting.var import VAR
     >>> from sktime.datasets import load_longley
     >>> _, y = load_longley()
-    >>> forecaster = VAR()  # doctest: +SKIP
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster = VAR()
+    >>> forecaster.fit(y)
     VAR(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
     """
 
     _fitted_param_names = ("aic", "fpe", "hqic", "bic")

--- a/sktime/forecasting/var_reduce.py
+++ b/sktime/forecasting/var_reduce.py
@@ -100,10 +100,10 @@ class VARReduce(BaseForecaster):
     >>> from sklearn.linear_model import Lasso
     >>> from sktime.datasets import load_longley
     >>> _, y = load_longley()
-    >>> forecaster = VARReduce(regressor=Lasso())  # doctest: +SKIP
-    >>> forecaster.fit(y)  # doctest: +SKIP
+    >>> forecaster = VARReduce(regressor=Lasso())
+    >>> forecaster.fit(y)
     VARReduce(...)
-    >>> y_pred = forecaster.predict(fh=[1,2,3])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,2,3])
     """
 
     _tags = {

--- a/sktime/forecasting/varmax.py
+++ b/sktime/forecasting/varmax.py
@@ -201,11 +201,11 @@ class VARMAX(_StatsModelsAdapter):
     >>> from sktime.forecasting.varmax import VARMAX
     >>> from sktime.datasets import load_macroeconomic
     >>> from sktime.split import temporal_train_test_split
-    >>> y = load_macroeconomic()  # doctest: +SKIP
-    >>> forecaster = VARMAX(suppress_warnings=True)  # doctest: +SKIP
-    >>> forecaster.fit(y[['realgdp', 'unemp']])  # doctest: +SKIP
+    >>> y = load_macroeconomic()
+    >>> forecaster = VARMAX(suppress_warnings=True)
+    >>> forecaster.fit(y[['realgdp', 'unemp']])
     VARMAX(...)
-    >>> y_pred = forecaster.predict(fh=[1,4,12])  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(fh=[1,4,12])
     """
 
     _tags = {

--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -72,10 +72,10 @@ class VECM(_StatsModelsAdapter):
     ... columns=list("AB"),
     ... index=pd.PeriodIndex(index))
     >>> train, test = temporal_train_test_split(df)
-    >>> sktime_model = VECM()  # doctest: +SKIP
+    >>> sktime_model = VECM()
     >>> fh = ForecastingHorizon([1, 3, 4, 5, 7, 9])
-    >>> _ = sktime_model.fit(train, fh=fh)  # doctest: +SKIP
-    >>> fc2 = sktime_model.predict(fh=fh)  # doctest: +SKIP
+    >>> _ = sktime_model.fit(train, fh=fh)
+    >>> fc2 = sktime_model.predict(fh=fh)
     """
 
     _tags = {

--- a/sktime/param_est/compose/_pipeline.py
+++ b/sktime/param_est/compose/_pipeline.py
@@ -79,15 +79,15 @@ class ParamFitterPipeline(_HeterogenousMetaEstimator, BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>>
     >>> X = load_airline()
-    >>> pipe = ParamFitterPipeline(SeasonalityACF(), [Differencer()])  # doctest: +SKIP
-    >>> pipe.fit(X)  # doctest: +SKIP
+    >>> pipe = ParamFitterPipeline(SeasonalityACF(), [Differencer()])
+    >>> pipe.fit(X)
     ParamFitterPipeline(...)
-    >>> pipe.get_fitted_params()["sp"]  # doctest: +SKIP
+    >>> pipe.get_fitted_params()["sp"]
     12
 
     Alternative construction via dunder method:
 
-    >>> pipe = Differencer() * SeasonalityACF()  # doctest: +SKIP
+    >>> pipe = Differencer() * SeasonalityACF()
     """
 
     _tags = {

--- a/sktime/param_est/plugin/_forecaster.py
+++ b/sktime/param_est/plugin/_forecaster.py
@@ -74,35 +74,35 @@ class PluginParamsForecaster(_DelegatedForecaster):
     >>> from sktime.param_est.seasonality import SeasonalityACF
     >>> from sktime.transformations.series.difference import Differencer
     >>>
-    >>> y = load_airline()  # doctest: +SKIP
+    >>> y = load_airline()
     >>>
     >>> # sp_est is a seasonality estimator
     >>> # ACF assumes stationarity so we concat with differencing first
-    >>> sp_est = Differencer() * SeasonalityACF()  # doctest: +SKIP
+    >>> sp_est = Differencer() * SeasonalityACF()
     >>>
     >>> # fcst is a forecaster with a "sp" parameter which we want to tune
-    >>> fcst = NaiveForecaster()  # doctest: +SKIP
+    >>> fcst = NaiveForecaster()
     >>>
     >>> # sp_auto is auto-tuned via PluginParamsForecaster
-    >>> sp_auto = PluginParamsForecaster(sp_est, fcst)  # doctest: +SKIP
+    >>> sp_auto = PluginParamsForecaster(sp_est, fcst)
     >>>
     >>> # fit sp_auto to data, predict, and inspect the tuned sp parameter
-    >>> sp_auto.fit(y, fh=[1, 2, 3])  # doctest: +SKIP
+    >>> sp_auto.fit(y, fh=[1, 2, 3])
     PluginParamsForecaster(...)
-    >>> y_pred = sp_auto.predict()  # doctest: +SKIP
-    >>> sp_auto.forecaster_.get_params()["sp"]  # doctest: +SKIP
+    >>> y_pred = sp_auto.predict()
+    >>> sp_auto.forecaster_.get_params()["sp"]
     12
     >>> # shorthand ways to specify sp_auto, via dunder, does the same
-    >>> sp_auto = sp_est * fcst  # doctest: +SKIP
+    >>> sp_auto = sp_est * fcst
     >>> # or entire pipeline in one go
-    >>> sp_auto = Differencer() * SeasonalityACF() * NaiveForecaster()  # doctest: +SKIP
+    >>> sp_auto = Differencer() * SeasonalityACF() * NaiveForecaster()
 
     using dictionary to plug "foo" parameter into "sp"
 
     >>> from sktime.param_est.fixed import FixedParams
     >>> sp_plugin = PluginParamsForecaster(
     ...     FixedParams({"foo": 12}), NaiveForecaster(), params={"sp": "foo"}
-    ... )  # doctest: +SKIP
+    ... )
     """
 
     _tags = {

--- a/sktime/param_est/plugin/_transformer.py
+++ b/sktime/param_est/plugin/_transformer.py
@@ -67,33 +67,33 @@ class PluginParamsTransformer(_DelegatedTransformer):
     >>> from sktime.transformations.series.detrend import Deseasonalizer
     >>> from sktime.transformations.series.difference import Differencer
     >>>
-    >>> X = load_airline()  # doctest: +SKIP
+    >>> X = load_airline()
     >>>
     >>> # sp_est is a seasonality estimator
     >>> # ACF assumes stationarity so we concat with differencing first
-    >>> sp_est = Differencer() * SeasonalityACF()  # doctest: +SKIP
+    >>> sp_est = Differencer() * SeasonalityACF()
 
     >>> # trafo is a forecaster with a "sp" parameter which we want to tune
-    >>> trafo = Deseasonalizer()  # doctest: +SKIP
-    >>> sp_auto = PluginParamsTransformer(sp_est, trafo)  # doctest: +SKIP
+    >>> trafo = Deseasonalizer()
+    >>> sp_auto = PluginParamsTransformer(sp_est, trafo)
     >>>
     >>> # fit sp_auto to data, transform, and inspect the tuned sp parameter
-    >>> sp_auto.fit(X)  # doctest: +SKIP
+    >>> sp_auto.fit(X)
     PluginParamsTransformer(...)
-    >>> Xt = sp_auto.transform(X)  # doctest: +SKIP
-    >>> sp_auto.transformer_.get_params()["sp"]  # doctest: +SKIP
+    >>> Xt = sp_auto.transform(X)
+    >>> sp_auto.transformer_.get_params()["sp"]
     12
     >>> # shorthand ways to specify sp_auto, via dunder, does the same
-    >>> sp_auto = sp_est * trafo  # doctest: +SKIP
+    >>> sp_auto = sp_est * trafo
     >>> # or entire pipeline in one go
-    >>> sp_auto = Differencer() * SeasonalityACF() * Deseasonalizer()  # doctest: +SKIP
+    >>> sp_auto = Differencer() * SeasonalityACF() * Deseasonalizer()
 
     using dictionary to plug "foo" parameter into "sp"
 
     >>> from sktime.param_est.fixed import FixedParams
     >>> sp_plugin = PluginParamsTransformer(
     ...     FixedParams({"foo": 12}), Deseasonalizer(), params={"sp": "foo"}
-    ... )  # doctest: +SKIP
+    ... )
     """
 
     _tags = {

--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -60,13 +60,13 @@ class SeasonalityACF(BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.seasonality import SeasonalityACF
     >>>
-    >>> X = load_airline().diff()[1:]  # doctest: +SKIP
-    >>> sp_est = SeasonalityACF()  # doctest: +SKIP
-    >>> sp_est.fit(X)  # doctest: +SKIP
+    >>> X = load_airline().diff()[1:]
+    >>> sp_est = SeasonalityACF()
+    >>> sp_est.fit(X)
     SeasonalityACF(...)
-    >>> sp_est.get_fitted_params()["sp"]  # doctest: +SKIP
+    >>> sp_est.get_fitted_params()["sp"]
     12
-    >>> sp_est.get_fitted_params()["sp_significant"]  # doctest: +SKIP
+    >>> sp_est.get_fitted_params()["sp_significant"]
     array([12, 11])
 
     Series should be stationary before applying ACF.
@@ -76,13 +76,13 @@ class SeasonalityACF(BaseParamFitter):
     >>> from sktime.param_est.seasonality import SeasonalityACF
     >>> from sktime.transformations.series.difference import Differencer
     >>>
-    >>> X = load_airline()  # doctest: +SKIP
-    >>> sp_est = Differencer() * SeasonalityACF()  # doctest: +SKIP
-    >>> sp_est.fit(X)  # doctest: +SKIP
+    >>> X = load_airline()
+    >>> sp_est = Differencer() * SeasonalityACF()
+    >>> sp_est.fit(X)
     ParamFitterPipeline(...)
-    >>> sp_est.get_fitted_params()["sp"]  # doctest: +SKIP
+    >>> sp_est.get_fitted_params()["sp"]
     12
-    >>> sp_est.get_fitted_params()["sp_significant"]  # doctest: +SKIP
+    >>> sp_est.get_fitted_params()["sp_significant"]
     array([12, 11])
     """
 
@@ -268,10 +268,10 @@ class SeasonalityACFqstat(BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.seasonality import SeasonalityACFqstat
     >>> X = load_airline().diff()[1:]
-    >>> sp_est = SeasonalityACFqstat(candidate_sp=[3, 7, 12])  # doctest: +SKIP
-    >>> sp_est.fit(X)  # doctest: +SKIP
+    >>> sp_est = SeasonalityACFqstat(candidate_sp=[3, 7, 12])
+    >>> sp_est.fit(X)
     SeasonalityACFqstat(...)
-    >>> sp_est.get_fitted_params()["sp_significant"]  # doctest: +SKIP
+    >>> sp_est.get_fitted_params()["sp_significant"]
     array([12,  7,  3])
     """
 
@@ -446,13 +446,13 @@ class SeasonalityPeriodogram(BaseParamFitter):
     --------
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.seasonality import SeasonalityPeriodogram
-    >>> X = load_airline().diff()[1:]  # doctest: +SKIP
-    >>> sp_est = SeasonalityPeriodogram()  # doctest: +SKIP
-    >>> sp_est.fit(X)  # doctest: +SKIP
+    >>> X = load_airline().diff()[1:]
+    >>> sp_est = SeasonalityPeriodogram()
+    >>> sp_est.fit(X)
     SeasonalityPeriodogram(...)
-    >>> sp_est.get_fitted_params()["sp"]  # doctest: +SKIP
+    >>> sp_est.get_fitted_params()["sp"]
     6
-    >>> sp_est.get_fitted_params()["sp_significant"]  # doctest: +SKIP
+    >>> sp_est.get_fitted_params()["sp_significant"]
     array([6, 12, 14, 4, 10, 5])
     """
 

--- a/sktime/param_est/stationarity/_arch.py
+++ b/sktime/param_est/stationarity/_arch.py
@@ -74,11 +74,11 @@ class StationarityADFArch(BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.stationarity import StationarityADFArch
     >>>
-    >>> X = load_airline()  # doctest: +SKIP
-    >>> sty_est = StationarityADFArch()  # doctest: +SKIP
-    >>> sty_est.fit(X)  # doctest: +SKIP
+    >>> X = load_airline()
+    >>> sty_est = StationarityADFArch()
+    >>> sty_est.fit(X)
     StationarityADFArch(...)
-    >>> sty_est.get_fitted_params()["stationary"]  # doctest: +SKIP
+    >>> sty_est.get_fitted_params()["stationary"]
     False
     """
 
@@ -231,11 +231,11 @@ class StationarityDFGLS(BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.stationarity import StationarityDFGLS
     >>>
-    >>> X = load_airline()  # doctest: +SKIP
-    >>> sty_est = StationarityDFGLS()  # doctest: +SKIP
-    >>> sty_est.fit(X)  # doctest: +SKIP
+    >>> X = load_airline()
+    >>> sty_est = StationarityDFGLS()
+    >>> sty_est.fit(X)
     StationarityDFGLS(...)
-    >>> sty_est.get_fitted_params()["stationary"]  # doctest: +SKIP
+    >>> sty_est.get_fitted_params()["stationary"]
     False
     """
 
@@ -378,11 +378,11 @@ class StationarityPhillipsPerron(BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.stationarity import StationarityPhillipsPerron
     >>>
-    >>> X = load_airline()  # doctest: +SKIP
-    >>> sty_est = StationarityPhillipsPerron()  # doctest: +SKIP
-    >>> sty_est.fit(X)  # doctest: +SKIP
+    >>> X = load_airline()
+    >>> sty_est = StationarityPhillipsPerron()
+    >>> sty_est.fit(X)
     StationarityPhillipsPerron(...)
-    >>> sty_est.get_fitted_params()["stationary"]  # doctest: +SKIP
+    >>> sty_est.get_fitted_params()["stationary"]
     False
     """
 
@@ -517,11 +517,11 @@ class StationarityKPSSArch(BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.stationarity import StationarityKPSSArch
     >>>
-    >>> X = load_airline()  # doctest: +SKIP
-    >>> sty_est = StationarityKPSSArch()  # doctest: +SKIP
-    >>> sty_est.fit(X)  # doctest: +SKIP
+    >>> X = load_airline()
+    >>> sty_est = StationarityKPSSArch()
+    >>> sty_est.fit(X)
     StationarityKPSSArch(...)
-    >>> sty_est.get_fitted_params()["stationary"]  # doctest: +SKIP
+    >>> sty_est.get_fitted_params()["stationary"]
     True
     """
 
@@ -663,11 +663,11 @@ class StationarityZivotAndrews(BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.stationarity import StationarityZivotAndrews
     >>>
-    >>> X = load_airline()  # doctest: +SKIP
-    >>> sty_est = StationarityZivotAndrews()  # doctest: +SKIP
-    >>> sty_est.fit(X)  # doctest: +SKIP
+    >>> X = load_airline()
+    >>> sty_est = StationarityZivotAndrews()
+    >>> sty_est.fit(X)
     StationarityZivotAndrews(...)
-    >>> sty_est.get_fitted_params()["stationary"]  # doctest: +SKIP
+    >>> sty_est.get_fitted_params()["stationary"]
     False
     """
 
@@ -817,11 +817,11 @@ class StationarityVarianceRatio(BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.stationarity import StationarityVarianceRatio
     >>>
-    >>> X = load_airline()  # doctest: +SKIP
-    >>> sty_est = StationarityVarianceRatio()  # doctest: +SKIP
-    >>> sty_est.fit(X)  # doctest: +SKIP
+    >>> X = load_airline()
+    >>> sty_est = StationarityVarianceRatio()
+    >>> sty_est.fit(X)
     StationarityVarianceRatio(...)
-    >>> sty_est.get_fitted_params()["stationary"]  # doctest: +SKIP
+    >>> sty_est.get_fitted_params()["stationary"]
     True
     """
 

--- a/sktime/param_est/stationarity/_statsmodels.py
+++ b/sktime/param_est/stationarity/_statsmodels.py
@@ -62,11 +62,11 @@ class StationarityADF(BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.stationarity import StationarityADF
     >>>
-    >>> X = load_airline()  # doctest: +SKIP
-    >>> sty_est = StationarityADF()  # doctest: +SKIP
-    >>> sty_est.fit(X)  # doctest: +SKIP
+    >>> X = load_airline()
+    >>> sty_est = StationarityADF()
+    >>> sty_est.fit(X)
     StationarityADF(...)
-    >>> sty_est.get_fitted_params()["stationary"]  # doctest: +SKIP
+    >>> sty_est.get_fitted_params()["stationary"]
     False
     """
 
@@ -204,11 +204,11 @@ class StationarityKPSS(BaseParamFitter):
     >>> from sktime.datasets import load_airline
     >>> from sktime.param_est.stationarity import StationarityKPSS
     >>>
-    >>> X = load_airline()  # doctest: +SKIP
-    >>> sty_est = StationarityKPSS()  # doctest: +SKIP
-    >>> sty_est.fit(X)  # doctest: +SKIP
+    >>> X = load_airline()
+    >>> sty_est = StationarityKPSS()
+    >>> sty_est.fit(X)
     StationarityKPSS(...)
-    >>> sty_est.get_fitted_params()["stationary"]  # doctest: +SKIP
+    >>> sty_est.get_fitted_params()["stationary"]
     False
     """
 

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -2097,30 +2097,30 @@ class GeometricMeanSquaredError(BaseForecastingErrorMetricFunc):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> gmse = GeometricMeanSquaredError()
-    >>> gmse(y_true, y_pred)  # doctest: +SKIP
+    >>> gmse(y_true, y_pred)
     2.80399089461488e-07
     >>> rgmse = GeometricMeanSquaredError(square_root=True)
-    >>> rgmse(y_true, y_pred)  # doctest: +SKIP
+    >>> rgmse(y_true, y_pred)
     0.000529527232030127
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> gmse = GeometricMeanSquaredError()
-    >>> gmse(y_true, y_pred)  # doctest: +SKIP
+    >>> gmse(y_true, y_pred)
     0.5000000000115499
     >>> rgmse = GeometricMeanSquaredError(square_root=True)
-    >>> rgmse(y_true, y_pred)  # doctest: +SKIP
+    >>> rgmse(y_true, y_pred)
     0.5000024031086919
     >>> gmse = GeometricMeanSquaredError(multioutput='raw_values')
-    >>> gmse(y_true, y_pred)  # doctest: +SKIP
+    >>> gmse(y_true, y_pred)
     array([2.30997255e-11, 1.00000000e+00])
     >>> rgmse = GeometricMeanSquaredError(multioutput='raw_values', square_root=True)
     >>> rgmse(y_true, y_pred)# doctest: +SKIP
     array([4.80621738e-06, 1.00000000e+00])
     >>> gmse = GeometricMeanSquaredError(multioutput=[0.3, 0.7])
-    >>> gmse(y_true, y_pred)  # doctest: +SKIP
+    >>> gmse(y_true, y_pred)
     0.7000000000069299
     >>> rgmse = GeometricMeanSquaredError(multioutput=[0.3, 0.7], square_root=True)
-    >>> rgmse(y_true, y_pred)  # doctest: +SKIP
+    >>> rgmse(y_true, y_pred)
     0.7000014418652152
     """
 
@@ -3097,26 +3097,26 @@ class MeanAsymmetricError(BaseForecastingErrorMetricFunc):
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> asymmetric_error = MeanAsymmetricError()
-    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
+    >>> asymmetric_error(y_true, y_pred)
     0.5
     >>> asymmetric_error = MeanAsymmetricError(left_error_function='absolute', \
     right_error_function='squared')
-    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
+    >>> asymmetric_error(y_true, y_pred)
     0.4625
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> asymmetric_error = MeanAsymmetricError()
-    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
+    >>> asymmetric_error(y_true, y_pred)
     0.75
     >>> asymmetric_error = MeanAsymmetricError(left_error_function='absolute', \
     right_error_function='squared')
-    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
+    >>> asymmetric_error(y_true, y_pred)
     0.7083333333333334
     >>> asymmetric_error = MeanAsymmetricError(multioutput='raw_values')
-    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
+    >>> asymmetric_error(y_true, y_pred)
     array([0.5, 1. ])
     >>> asymmetric_error = MeanAsymmetricError(multioutput=[0.3, 0.7])
-    >>> asymmetric_error(y_true, y_pred)  # doctest: +SKIP
+    >>> asymmetric_error(y_true, y_pred)
     0.85
     """
 
@@ -3234,27 +3234,27 @@ class MeanLinexError(BaseForecastingErrorMetricFunc):
     >>> linex_error = MeanLinexError()
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> linex_error(y_true, y_pred)
     0.19802627763937575
     >>> linex_error = MeanLinexError(b=2)
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> linex_error(y_true, y_pred)
     0.3960525552787515
     >>> linex_error = MeanLinexError(a=-1)
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> linex_error(y_true, y_pred)
     0.2391800623225643
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> linex_error = MeanLinexError()
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> linex_error(y_true, y_pred)
     0.2700398392309829
     >>> linex_error = MeanLinexError(a=-1)
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> linex_error(y_true, y_pred)
     0.49660966225813563
     >>> linex_error = MeanLinexError(multioutput='raw_values')
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> linex_error(y_true, y_pred)
     array([0.17220024, 0.36787944])
     >>> linex_error = MeanLinexError(multioutput=[0.3, 0.7])
-    >>> linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> linex_error(y_true, y_pred)
     0.30917568000716666
     """
 

--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -144,21 +144,21 @@ def mean_linex_error(
     >>> from sktime.performance_metrics.forecasting import mean_linex_error
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
-    >>> mean_linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> mean_linex_error(y_true, y_pred)
     0.19802627763937575
-    >>> mean_linex_error(y_true, y_pred, b=2)  # doctest: +SKIP
+    >>> mean_linex_error(y_true, y_pred, b=2)
     0.3960525552787515
-    >>> mean_linex_error(y_true, y_pred, a=-1)  # doctest: +SKIP
+    >>> mean_linex_error(y_true, y_pred, a=-1)
     0.2391800623225643
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> mean_linex_error(y_true, y_pred)  # doctest: +SKIP
+    >>> mean_linex_error(y_true, y_pred)
     0.2700398392309829
-    >>> mean_linex_error(y_true, y_pred, a=-1)  # doctest: +SKIP
+    >>> mean_linex_error(y_true, y_pred, a=-1)
     0.49660966225813563
-    >>> mean_linex_error(y_true, y_pred, multioutput='raw_values')  # doctest: +SKIP
+    >>> mean_linex_error(y_true, y_pred, multioutput='raw_values')
     array([0.17220024, 0.36787944])
-    >>> mean_linex_error(y_true, y_pred, multioutput=[0.3, 0.7])  # doctest: +SKIP
+    >>> mean_linex_error(y_true, y_pred, multioutput=[0.3, 0.7])
     0.30917568000716666
     """
     _, y_true, y_pred, multioutput = _check_reg_targets(y_true, y_pred, multioutput)
@@ -1407,25 +1407,25 @@ def geometric_mean_squared_error(
     geometric_mean_squared_error as gmse
     >>> y_true = np.array([3, -0.5, 2, 7, 2])
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
-    >>> gmse(y_true, y_pred)  # doctest: +SKIP
+    >>> gmse(y_true, y_pred)
     2.80399089461488e-07
-    >>> gmse(y_true, y_pred, square_root=True)  # doctest: +SKIP
+    >>> gmse(y_true, y_pred, square_root=True)
     0.000529527232030127
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
-    >>> gmse(y_true, y_pred)  # doctest: +SKIP
+    >>> gmse(y_true, y_pred)
     0.5000000000115499
-    >>> gmse(y_true, y_pred, square_root=True)  # doctest: +SKIP
+    >>> gmse(y_true, y_pred, square_root=True)
     0.5000024031086919
-    >>> gmse(y_true, y_pred, multioutput='raw_values')  # doctest: +SKIP
+    >>> gmse(y_true, y_pred, multioutput='raw_values')
     array([2.30997255e-11, 1.00000000e+00])
     >>> gmse(y_true, y_pred, multioutput='raw_values', \
-    square_root=True)  # doctest: +SKIP
+    square_root=True)
     array([4.80621738e-06, 1.00000000e+00])
-    >>> gmse(y_true, y_pred, multioutput=[0.3, 0.7])  # doctest: +SKIP
+    >>> gmse(y_true, y_pred, multioutput=[0.3, 0.7])
     0.7000000000069299
     >>> gmse(y_true, y_pred, multioutput=[0.3, 0.7], \
-    square_root=True)  # doctest: +SKIP
+    square_root=True)
     0.7000014418652152
     """
     _, y_true, y_pred, multioutput = _check_reg_targets(y_true, y_pred, multioutput)

--- a/sktime/pipeline/pipeline.py
+++ b/sktime/pipeline/pipeline.py
@@ -107,8 +107,8 @@ class Pipeline(BaseEstimator):
     ...     {"skobject": BoxCoxTransformer(), "name": "box", "edges": {"X": "exp"}},
     ...     ]:
     ...     general_pipeline = general_pipeline.add_step(**step)
-    >>> general_pipeline.fit(X=X) # doctest: +SKIP
-    >>> result_general = general_pipeline.transform(X) # doctest: +SKIP
+    >>> general_pipeline.fit(X=X)
+    >>> result_general = general_pipeline.transform(X)
 
         Example 2: Classification sequential pipeline using the generalized
          non-sequential pipeline implementation
@@ -120,8 +120,8 @@ class Pipeline(BaseEstimator):
     ...      "name": "knnclassifier",
     ...      "edges": {"X": "exp", "y": "y"}}]:
     ...     general_pipeline = general_pipeline.add_step(**step)
-    >>> general_pipeline.fit(X=X, y=y) # doctest: +SKIP
-    >>> result_general = general_pipeline.predict(X) # doctest: +SKIP
+    >>> general_pipeline.fit(X=X, y=y)
+    >>> result_general = general_pipeline.predict(X)
 
         Example 3: Forecasting pipeline with exogenous features using the
         generalized non-sequential pipeline implementation
@@ -134,8 +134,8 @@ class Pipeline(BaseEstimator):
     ...      "name": "SARIMAX",
     ...      "edges": {"X": "exp", "y": "y"}}]:
     ...     general_pipeline = general_pipeline.add_step(**step)
-    >>> general_pipeline.fit(y=y_train, X=X_train, fh=[1, 2, 3, 4]) # doctest: +SKIP
-    >>> result_general = general_pipeline.predict(X=X_test) # doctest: +SKIP
+    >>> general_pipeline.fit(y=y_train, X=X_train, fh=[1, 2, 3, 4])
+    >>> result_general = general_pipeline.predict(X=X_test)
 
     **Acknowledgements**
     This graphical pipeline is inspired by pyWATTS that is developed by the Institute

--- a/sktime/proba/tfp.py
+++ b/sktime/proba/tfp.py
@@ -24,9 +24,9 @@ class TFNormal(_BaseTFDistribution):
 
     Example
     -------
-    >>> from sktime.proba.tfp import TFNormal  # doctest: +SKIP
+    >>> from sktime.proba.tfp import TFNormal
 
-    >>> n = TFNormal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)  # doctest: +SKIP
+    >>> n = TFNormal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)
     """
 
     _tags = {

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -159,11 +159,11 @@ def all_estimators(
     --------
     >>> from sktime.registry import all_estimators
     >>> # return a complete list of estimators as pd.Dataframe
-    >>> all_estimators(as_dataframe=True)  # doctest: +SKIP
+    >>> all_estimators(as_dataframe=True)
     >>> # return all forecasters by filtering for estimator type
-    >>> all_estimators("forecaster")  # doctest: +SKIP
+    >>> all_estimators("forecaster")
     >>> # return all forecasters which handle missing data in the input by tag filtering
-    >>> all_estimators("forecaster", filter_tags={"handles-missing-data": True})  # doctest: +SKIP
+    >>> all_estimators("forecaster", filter_tags={"handles-missing-data": True})
 
     References
     ----------

--- a/sktime/regression/deep_learning/cnn.py
+++ b/sktime/regression/deep_learning/cnn.py
@@ -68,10 +68,10 @@ class CNNRegressor(BaseDeepRegressor):
     >>> from sktime.regression.deep_learning.cnn import CNNRegressor
     >>> X_train, y_train = load_unit_test(return_X_y=True, split="train")
     >>> X_test, y_test = load_unit_test(return_X_y=True, split="test")
-    >>> regressor = CNNRegressor() # doctest: +SKIP
-    >>> regressor.fit(X_train, y_train) # doctest: +SKIP
+    >>> regressor = CNNRegressor()
+    >>> regressor.fit(X_train, y_train)
     CNNRegressor(...)
-    >>> y_pred = regressor.predict(X_test) # doctest: +SKIP
+    >>> y_pred = regressor.predict(X_test)
     """
 
     _tags = {

--- a/sktime/regression/deep_learning/lstmfcn.py
+++ b/sktime/regression/deep_learning/lstmfcn.py
@@ -60,10 +60,10 @@ class LSTMFCNRegressor(BaseDeepRegressor):
     >>> from sktime.regression.deep_learning.lstmfcn import LSTMFCNRegressor
     >>> X_train, y_train = load_unit_test(return_X_y=True, split="train")
     >>> X_test, y_test = load_unit_test(return_X_y=True, split="test")
-    >>> regressor = LSTMFCNRegressor() # doctest: +SKIP
-    >>> regressor.fit(X_train, y_train) # doctest: +SKIP
+    >>> regressor = LSTMFCNRegressor()
+    >>> regressor.fit(X_train, y_train)
     LSTMFCNRegressor(...)
-    >>> y_pred = regressor.predict(X_test) # doctest: +SKIP
+    >>> y_pred = regressor.predict(X_test)
     """
 
     _tags = {

--- a/sktime/regression/deep_learning/mcdcnn.py
+++ b/sktime/regression/deep_learning/mcdcnn.py
@@ -72,8 +72,8 @@ class MCDCNNRegressor(BaseDeepRegressor):
     >>> from sktime.regression.deep_learning.mcdcnn import MCDCNNRegressor
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train")
-    >>> mcdcnn = MCDCNNRegressor(n_epochs=1, kernel_size=4) # doctest: +SKIP
-    >>> mcdcnn.fit(X_train, y_train) # doctest: +SKIP
+    >>> mcdcnn = MCDCNNRegressor(n_epochs=1, kernel_size=4)
+    >>> mcdcnn.fit(X_train, y_train)
     MCDCNRegressor(...)
     """
 

--- a/sktime/regression/deep_learning/mlp.py
+++ b/sktime/regression/deep_learning/mlp.py
@@ -55,10 +55,10 @@ class MLPRegressor(BaseDeepRegressor):
     >>> from sktime.regression.deep_learning.mlp import MLPRegressor
     >>> X_train, y_train = load_unit_test(return_X_y=True, split="train")
     >>> X_test, y_test = load_unit_test(return_X_y=True, split="test")
-    >>> regressor = MLPRegressor() # doctest: +SKIP
-    >>> regressor.fit(X_train, y_train) # doctest: +SKIP
+    >>> regressor = MLPRegressor()
+    >>> regressor.fit(X_train, y_train)
     MLPRegressor(...)
-    >>> y_pred = regressor.predict(X_test) # doctest: +SKIP
+    >>> y_pred = regressor.predict(X_test)
     """
 
     _tags = {

--- a/sktime/regression/deep_learning/resnet.py
+++ b/sktime/regression/deep_learning/resnet.py
@@ -54,8 +54,8 @@ class ResNetRegressor(BaseDeepRegressor):
     >>> from sktime.regression.deep_learning.resnet import ResNetRegressor
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train")
-    >>> clf = ResNetRegressor(n_epochs=20, batch_size=4) # doctest: +SKIP
-    >>> clf.fit(X_train, Y_train) # doctest: +SKIP
+    >>> clf = ResNetRegressor(n_epochs=20, batch_size=4)
+    >>> clf.fit(X_train, Y_train)
     ResNetRegressor(...)
     """
 

--- a/sktime/regression/deep_learning/rnn.py
+++ b/sktime/regression/deep_learning/rnn.py
@@ -53,8 +53,8 @@ class SimpleRNNRegressor(BaseDeepRegressor):
     >>> from sktime.regression.deep_learning.rnn import SimpleRNNRegressor
     >>> from sktime.datasets import load_unit_test
     >>> X_train, Y_train = load_unit_test(split="train")
-    >>> clf = SimpleRNNRegressor(n_epochs=20, batch_size=4) # doctest: +SKIP
-    >>> clf.fit(X_train, Y_train) # doctest: +SKIP
+    >>> clf = SimpleRNNRegressor(n_epochs=20, batch_size=4)
+    >>> clf.fit(X_train, Y_train)
     SimpleRNNRegressor(...)
     """
 

--- a/sktime/regression/dummy/_dummy.py
+++ b/sktime/regression/dummy/_dummy.py
@@ -51,10 +51,10 @@ class DummyRegressor(BaseRegressor):
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train")
     >>> X_test, y_test = load_unit_test(split="test")
-    >>> regressor = DummyRegressor(strategy="median") # doctest: +SKIP
-    >>> regressor.fit(X_train,y_train) # doctest: +SKIP
+    >>> regressor = DummyRegressor(strategy="median")
+    >>> regressor.fit(X_train,y_train)
     DummyRegressor(strategy='median')
-    >>> y_pred = regressor.predict(X_test) # doctest: +SKIP
+    >>> y_pred = regressor.predict(X_test)
     """
 
     _tags = {

--- a/sktime/regression/interval_based/_tsf.py
+++ b/sktime/regression/interval_based/_tsf.py
@@ -73,10 +73,10 @@ class TimeSeriesForestRegressor(BaseTimeSeriesForest, ForestRegressor, BaseRegre
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train")
     >>> X_test, y_test = load_unit_test(split="test")
-    >>> regressor = TimeSeriesForestRegressor(n_estimators=150) # doctest: +SKIP
-    >>> regressor.fit(X_train, y_train) # doctest: +SKIP
+    >>> regressor = TimeSeriesForestRegressor(n_estimators=150)
+    >>> regressor.fit(X_train, y_train)
     TimeSeriesForestRegressor(n_estimators=150)
-    >>> y_pred = regressor.predict(X_test) # doctest: +SKIP
+    >>> y_pred = regressor.predict(X_test)
     """
 
     _tags = {

--- a/sktime/regression/kernel_based/_rocket_regressor.py
+++ b/sktime/regression/kernel_based/_rocket_regressor.py
@@ -99,11 +99,11 @@ class RocketRegressor(_DelegatedRegressor, BaseRegressor):
     >>> from sktime.regression.kernel_based import RocketRegressor
     >>> from sktime.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True) # doctest: +SKIP
-    >>> reg = RocketRegressor(num_kernels=500) # doctest: +SKIP
-    >>> reg.fit(X_train, y_train) # doctest: +SKIP
+    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
+    >>> reg = RocketRegressor(num_kernels=500)
+    >>> reg.fit(X_train, y_train)
     RocketRegressor(...)
-    >>> y_pred = reg.predict(X_test) # doctest: +SKIP
+    >>> y_pred = reg.predict(X_test)
     """
 
     _tags = {

--- a/sktime/split/cutoff.py
+++ b/sktime/split/cutoff.py
@@ -151,7 +151,7 @@ class CutoffSplitter(BaseSplitter):
     >>> from sktime.split import CutoffSplitter
     >>> ts = np.arange(10)
     >>> splitter = CutoffSplitter(fh=[2, 4], cutoffs=np.array([3, 5]), window_length=3)
-    >>> list(splitter.split(ts)) # doctest: +SKIP
+    >>> list(splitter.split(ts))
     [(array([1, 2, 3]), array([5, 7])), (array([3, 4, 5]), array([7, 9]))]
     """
 

--- a/sktime/split/expandingcutoff.py
+++ b/sktime/split/expandingcutoff.py
@@ -87,7 +87,7 @@ class ExpandingCutoffSplitter(BaseSplitter):
     >>> y = pd.DataFrame(index=pd.PeriodIndex(date_range, freq='Q'))
     >>> cutoff = pd.Period('2021-Q1')
     >>> cv = ExpandingCutoffSplitter(cutoff=cutoff, fh=[1, 2], step_length=1)
-    >>> list(cv.split(y)) # doctest: +SKIP
+    >>> list(cv.split(y))
     [(array([0, 1, 2, 3]), array([4, 5])), (array([0, 1, 2, 3, 4]), array([5, 6]))]
     """
 

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -53,7 +53,7 @@ class ExpandingGreedySplitter(BaseSplitter):
 
     >>> ts = np.arange(10)
     >>> splitter = ExpandingGreedySplitter(test_size=3, folds=2)
-    >>> list(splitter.split(ts))  # doctest: +SKIP
+    >>> list(splitter.split(ts))
     [
         (array([0, 1, 2, 3]), array([4, 5, 6])),
         (array([0, 1, 2, 3, 4, 5, 6]), array([7, 8, 9]))

--- a/sktime/split/expandingwindow.py
+++ b/sktime/split/expandingwindow.py
@@ -63,7 +63,7 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
     >>> from sktime.split import ExpandingWindowSplitter
     >>> ts = np.arange(10)
     >>> splitter = ExpandingWindowSplitter(fh=[2, 4], initial_window=5, step_length=2)
-    >>> list(splitter.split(ts)) # doctest: +SKIP
+    >>> list(splitter.split(ts))
     '[(array([0, 1, 2, 3, 4]), array([6, 8]))]'
     """
 

--- a/sktime/split/instance.py
+++ b/sktime/split/instance.py
@@ -40,7 +40,7 @@ class InstanceSplitter(BaseSplitter):
     >>>
     >>> y = _make_hierarchical()
     >>> splitter = InstanceSplitter(KFold(n_splits=3))
-    >>> list(splitter.split(y))  # doctest: +SKIP
+    >>> list(splitter.split(y))
     """
 
     _tags = {

--- a/sktime/split/sameloc.py
+++ b/sktime/split/sameloc.py
@@ -47,8 +47,8 @@ class SameLocSplitter(BaseSplitter):
 
     these two are the same:
 
-    >>> list(cv_tpl.split(y_template)) # doctest: +SKIP
-    >>> list(splitter.split(y)) # doctest: +SKIP
+    >>> list(cv_tpl.split(y_template))
+    >>> list(splitter.split(y))
     """
 
     _tags = {

--- a/sktime/split/singlewindow.py
+++ b/sktime/split/singlewindow.py
@@ -57,7 +57,7 @@ class SingleWindowSplitter(BaseSplitter):
     >>> from sktime.split import SingleWindowSplitter
     >>> ts = np.arange(10)
     >>> splitter = SingleWindowSplitter(fh=[2, 4], window_length=3)
-    >>> list(splitter.split(ts)) # doctest: +SKIP
+    >>> list(splitter.split(ts))
     [(array([3, 4, 5]), array([7, 9]))]
     """
 

--- a/sktime/split/slidingwindow.py
+++ b/sktime/split/slidingwindow.py
@@ -69,7 +69,7 @@ class SlidingWindowSplitter(BaseWindowSplitter):
     >>> from sktime.split import SlidingWindowSplitter
     >>> ts = np.arange(10)
     >>> splitter = SlidingWindowSplitter(fh=[2, 4], window_length=3, step_length=2)
-    >>> list(splitter.split(ts)) # doctest: +SKIP
+    >>> list(splitter.split(ts))
     [(array([0, 1, 2]), array([4, 6])), (array([2, 3, 4]), array([6, 8]))]
     """
 

--- a/sktime/split/temporal_train_test_split.py
+++ b/sktime/split/temporal_train_test_split.py
@@ -183,7 +183,7 @@ class TemporalTrainTestSplitter(BaseSplitter):
     >>> from sktime.split import TemporalTrainTestSplitter
     >>> ts = np.arange(10)
     >>> splitter = TemporalTrainTestSplitter(test_size=0.3)
-    >>> list(splitter.split(ts)) # doctest: +SKIP
+    >>> list(splitter.split(ts))
     """
 
     _tags = {"split_hierarchical": False}

--- a/sktime/transformations/bootstrap/_mbb.py
+++ b/sktime/transformations/bootstrap/_mbb.py
@@ -142,19 +142,19 @@ class STLBootstrapTransformer(BaseTransformer):
     --------
     >>> from sktime.transformations.bootstrap import STLBootstrapTransformer
     >>> from sktime.datasets import load_airline
-    >>> from sktime.utils.plotting import plot_series  # doctest: +SKIP
-    >>> y = load_airline()  # doctest: +SKIP
-    >>> transformer = STLBootstrapTransformer(10)  # doctest: +SKIP
-    >>> y_hat = transformer.fit_transform(y)  # doctest: +SKIP
-    >>> series_list = []  # doctest: +SKIP
-    >>> names = []  # doctest: +SKIP
+    >>> from sktime.utils.plotting import plot_series
+    >>> y = load_airline()
+    >>> transformer = STLBootstrapTransformer(10)
+    >>> y_hat = transformer.fit_transform(y)
+    >>> series_list = []
+    >>> names = []
     >>> for group, series in y_hat.groupby(level=0, as_index=False):
     ...     series.index = series.index.droplevel(0)
     ...     series_list.append(series)
-    ...     names.append(group)  # doctest: +SKIP
-    >>> plot_series(*series_list, labels=names)  # doctest: +SKIP
+    ...     names.append(group)
+    >>> plot_series(*series_list, labels=names)
     (...)
-    >>> print(y_hat.head())  # doctest: +SKIP
+    >>> print(y_hat.head())
                           Number of airline passengers
     series_id time_index
     actual    1949-01                            112.0
@@ -462,7 +462,7 @@ class MovingBlockBootstrapTransformer(BaseTransformer):
     --------
     >>> from sktime.transformations.bootstrap import MovingBlockBootstrapTransformer
     >>> from sktime.datasets import load_airline
-    >>> from sktime.utils.plotting import plot_series  # doctest: +SKIP
+    >>> from sktime.utils.plotting import plot_series
     >>> y = load_airline()
     >>> transformer = MovingBlockBootstrapTransformer(10)
     >>> y_hat = transformer.fit_transform(y)
@@ -472,7 +472,7 @@ class MovingBlockBootstrapTransformer(BaseTransformer):
     ...     series.index = series.index.droplevel(0)
     ...     series_list.append(series)
     ...     names.append(group)
-    >>> plot_series(*series_list, labels=names)  # doctest: +SKIP
+    >>> plot_series(*series_list, labels=names)
     (...)
     >>> print(y_hat.head()) # doctest: +NORMALIZE_WHITESPACE
                           Number of airline passengers

--- a/sktime/transformations/bootstrap/_tsbootstrap.py
+++ b/sktime/transformations/bootstrap/_tsbootstrap.py
@@ -32,11 +32,11 @@ class TSBootstrapAdapter(BaseTransformer):
     >>> from tsbootstrap import (
     ...    MovingBlockBootstrap,
     ...    MovingBlockBootstrapConfig
-    ... ) # doctest: +SKIP
+    ... )
     >>> y = load_airline()
-    >>> config = MovingBlockBootstrapConfig(10, n_bootstraps=10)  # doctest: +SKIP
-    >>> bootstrap = TSBootstrapAdapter(MovingBlockBootstrap(config))  # doctest: +SKIP
-    >>> result = bootstrap.fit_transform(y)  # doctest: +SKIP
+    >>> config = MovingBlockBootstrapConfig(10, n_bootstraps=10)
+    >>> bootstrap = TSBootstrapAdapter(MovingBlockBootstrap(config))
+    >>> result = bootstrap.fit_transform(y)
     """
 
     _tags = {

--- a/sktime/transformations/compose/_optional.py
+++ b/sktime/transformations/compose/_optional.py
@@ -52,24 +52,24 @@ class OptionalPassthrough(_DelegatedTransformer):
     >>> pipe = TransformedTargetForecaster(steps=[
     ...     ("deseasonalizer", OptionalPassthrough(Deseasonalizer())),
     ...     ("scaler", OptionalPassthrough(TabularToSeriesAdaptor(StandardScaler()))),
-    ...     ("forecaster", NaiveForecaster())])  # doctest: +SKIP
+    ...     ("forecaster", NaiveForecaster())])
     >>> # putting it all together in a grid search
     >>> cv = SlidingWindowSplitter(
     ...     initial_window=60,
     ...     window_length=24,
     ...     start_with_window=True,
-    ...     step_length=48)  # doctest: +SKIP
+    ...     step_length=48)
     >>> param_grid = {
     ...     "deseasonalizer__passthrough" : [True, False],
     ...     "scaler__transformer__transformer__with_mean": [True, False],
     ...     "scaler__passthrough" : [True, False],
-    ...     "forecaster__strategy": ["drift", "mean", "last"]}  # doctest: +SKIP
+    ...     "forecaster__strategy": ["drift", "mean", "last"]}
     >>> gscv = ForecastingGridSearchCV(
     ...     forecaster=pipe,
     ...     param_grid=param_grid,
     ...     cv=cv,
-    ...     n_jobs=-1)  # doctest: +SKIP
-    >>> gscv_fitted = gscv.fit(load_airline())  # doctest: +SKIP
+    ...     n_jobs=-1)
+    >>> gscv_fitted = gscv.fit(load_airline())
     """
 
     _tags = {

--- a/sktime/transformations/compose/_transformif.py
+++ b/sktime/transformations/compose/_transformif.py
@@ -76,12 +76,12 @@ class TransformIf(_DelegatedTransformer):
     >>> from sktime.transformations.series.detrend import Deseasonalizer
     >>> from sktime.datasets import load_airline
     >>>
-    >>> y = load_airline()  # doctest: +SKIP
+    >>> y = load_airline()
     >>>
-    >>> seasonal = SeasonalityACF(candidate_sp=12)  # doctest: +SKIP
-    >>> deseason = Deseasonalizer(sp=12)  # doctest: +SKIP
-    >>> cond_deseason = TransformIf(seasonal, "sp", "!=", 1, deseason)  # doctest: +SKIP
-    >>> y_hat = cond_deseason.fit_transform(y)  # doctest: +SKIP
+    >>> seasonal = SeasonalityACF(candidate_sp=12)
+    >>> deseason = Deseasonalizer(sp=12)
+    >>> cond_deseason = TransformIf(seasonal, "sp", "!=", 1, deseason)
+    >>> y_hat = cond_deseason.fit_transform(y)
     """
 
     _tags = {

--- a/sktime/transformations/compose/_ytox.py
+++ b/sktime/transformations/compose/_ytox.py
@@ -45,12 +45,12 @@ class YtoX(BaseTransformer):
     ...     [
     ...             YtoX(),
     ...             FourierFeatures(sp_list=[24, 24 * 7], fourier_terms_list=[10, 5]),
-    ...             ARIMA(order=(1, 1, 1))  # doctest: +SKIP,
+    ...             ARIMA(order=(1, 1, 1)),
     ...     ]
-    ... )  # doctest: +SKIP
+    ... )
     >>>
     >>> # fit and forecast, using Fourier features as exogenous data
-    >>> pred = pipe.fit_predict(y, fh=[1, 2, 3, 4, 5])  # doctest: +SKIP
+    >>> pred = pipe.fit_predict(y, fh=[1, 2, 3, 4, 5])
 
     Use case: using lagged endogenous variables as exogeneous data.
 
@@ -68,11 +68,11 @@ class YtoX(BaseTransformer):
     >>>
     >>> # we need to specify index_out="original" as otherwise ARIMA gets 1 and 2 ahead
     >>> # use lagged_y_trafo to generate X
-    >>> forecaster = lagged_y_trafo ** SARIMAX()  # doctest: +SKIP
+    >>> forecaster = lagged_y_trafo ** SARIMAX()
     >>>
     >>> # fit and forecast next value, with lagged y as exogenous data
-    >>> forecaster.fit(y, fh=[1])  # doctest: +SKIP
-    >>> y_pred = forecaster.predict()  # doctest: +SKIP
+    >>> forecaster.fit(y, fh=[1])
+    >>> y_pred = forecaster.predict()
 
     Use case: using summarized endogenous variables as exogeneous data.
 
@@ -81,7 +81,7 @@ class YtoX(BaseTransformer):
     >>> from sktime.transformations.compose import YtoX
     >>> from sktime.forecasting.compose import make_reduction
     >>> from sktime.forecasting.compose import ForecastingPipeline
-    >>> from sklearn.ensemble import GradientBoostingRegressor  # doctest: +SKIP
+    >>> from sklearn.ensemble import GradientBoostingRegressor
     >>>
     >>> # data with no exogenous features
     >>> y = load_airline()
@@ -102,7 +102,7 @@ class YtoX(BaseTransformer):
     ...     strategy="recursive",
     ...     pooling="global",
     ...     window_length=12,
-    ... )  # doctest: +SKIP
+    ... )
     >>>
     >>> # create the pipeline
     >>> pipe = ForecastingPipeline(
@@ -111,10 +111,10 @@ class YtoX(BaseTransformer):
     ...         ("summarizer", WindowSummarizer(**kwargs)),
     ...         ("forecaster", forecaster),
     ...     ]
-    ... )  # doctest: +SKIP
+    ... )
     >>>
     >>> # fit and forecast, with summarized y as exogenous data
-    >>> preds = pipe.fit_predict(y=y, fh=range(1, 20))  # doctest: +SKIP
+    >>> preds = pipe.fit_predict(y=y, fh=range(1, 20))
     """
 
     _tags = {

--- a/sktime/transformations/panel/rocket/_minirocket.py
+++ b/sktime/transformations/panel/rocket/_minirocket.py
@@ -65,13 +65,13 @@ class MiniRocket(BaseTransformer):
     --------
      >>> from sktime.transformations.panel.rocket import MiniRocket
      >>> from sktime.datasets import load_unit_test
-     >>> X_train, y_train = load_unit_test(split="train") # doctest: +SKIP
-     >>> X_test, y_test = load_unit_test(split="test") # doctest: +SKIP
-     >>> trf = MiniRocket(num_kernels=512) # doctest: +SKIP
-     >>> trf.fit(X_train) # doctest: +SKIP
+     >>> X_train, y_train = load_unit_test(split="train")
+     >>> X_test, y_test = load_unit_test(split="test")
+     >>> trf = MiniRocket(num_kernels=512)
+     >>> trf.fit(X_train)
      MiniRocket(...)
-     >>> X_train = trf.transform(X_train) # doctest: +SKIP
-     >>> X_test = trf.transform(X_test) # doctest: +SKIP
+     >>> X_train = trf.transform(X_train)
+     >>> X_test = trf.transform(X_test)
     """
 
     _tags = {

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate.py
@@ -66,12 +66,12 @@ class MiniRocketMultivariate(BaseTransformer):
      >>> from sktime.transformations.panel.rocket import MiniRocketMultivariate
      >>> from sktime.datasets import load_basic_motions
      >>> X_train, y_train = load_basic_motions(split="train")
-     >>> X_test, y_test = load_basic_motions(split="test") # doctest: +SKIP
-     >>> trf = MiniRocketMultivariate(num_kernels=512) # doctest: +SKIP
-     >>> trf.fit(X_train) # doctest: +SKIP
+     >>> X_test, y_test = load_basic_motions(split="test")
+     >>> trf = MiniRocketMultivariate(num_kernels=512)
+     >>> trf.fit(X_train)
      MiniRocketMultivariate(...)
-     >>> X_train = trf.transform(X_train) # doctest: +SKIP
-     >>> X_test = trf.transform(X_test) # doctest: +SKIP
+     >>> X_train = trf.transform(X_train)
+     >>> X_test = trf.transform(X_test)
     """
 
     _tags = {

--- a/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
+++ b/sktime/transformations/panel/rocket/_minirocket_multivariate_variable.py
@@ -69,11 +69,11 @@ class MiniRocketMultivariateVariable(BaseTransformer):
     >>> X_test, _ = load_japanese_vowels(split="test", return_X_y=True)
     >>> pre_clf = MiniRocketMultivariateVariable(
     ...     pad_value_short_series=0.0
-    ... ) # doctest: +SKIP
-    >>> pre_clf.fit(X_train, y=None) # doctest: +SKIP
+    ... )
+    >>> pre_clf.fit(X_train, y=None)
     MiniRocketMultivariateVariable(...)
-    >>> X_transformed = pre_clf.transform(X_test) # doctest: +SKIP
-    >>> X_transformed.shape # doctest: +SKIP
+    >>> X_transformed = pre_clf.transform(X_test)
+    >>> X_transformed.shape
     (370, 9996)
 
     Raises

--- a/sktime/transformations/panel/rocket/_multirocket.py
+++ b/sktime/transformations/panel/rocket/_multirocket.py
@@ -78,13 +78,13 @@ class MultiRocket(BaseTransformer):
     --------
      >>> from sktime.transformations.panel.rocket import Rocket
      >>> from sktime.datasets import load_unit_test
-     >>> X_train, y_train = load_unit_test(split="train") # doctest: +SKIP
-     >>> X_test, y_test = load_unit_test(split="test") # doctest: +SKIP
-     >>> trf = MultiRocket(num_kernels=512) # doctest: +SKIP
-     >>> trf.fit(X_train) # doctest: +SKIP
+     >>> X_train, y_train = load_unit_test(split="train")
+     >>> X_test, y_test = load_unit_test(split="test")
+     >>> trf = MultiRocket(num_kernels=512)
+     >>> trf.fit(X_train)
      MultiRocket(...)
-     >>> X_train = trf.transform(X_train) # doctest: +SKIP
-     >>> X_test = trf.transform(X_test) # doctest: +SKIP
+     >>> X_train = trf.transform(X_train)
+     >>> X_test = trf.transform(X_test)
     """
 
     _tags = {

--- a/sktime/transformations/panel/rocket/_multirocket_multivariate.py
+++ b/sktime/transformations/panel/rocket/_multirocket_multivariate.py
@@ -74,13 +74,13 @@ class MultiRocketMultivariate(BaseTransformer):
     --------
      >>> from sktime.transformations.panel.rocket import Rocket
      >>> from sktime.datasets import load_basic_motions
-     >>> X_train, y_train = load_basic_motions(split="train") # doctest: +SKIP
-     >>> X_test, y_test = load_basic_motions(split="test") # doctest: +SKIP
-     >>> trf = MultiRocketMultivariate(num_kernels=512) # doctest: +SKIP
-     >>> trf.fit(X_train) # doctest: +SKIP
+     >>> X_train, y_train = load_basic_motions(split="train")
+     >>> X_test, y_test = load_basic_motions(split="test")
+     >>> trf = MultiRocketMultivariate(num_kernels=512)
+     >>> trf.fit(X_train)
      MultiRocketMultivariate(...)
-     >>> X_train = trf.transform(X_train) # doctest: +SKIP
-     >>> X_test = trf.transform(X_test) # doctest: +SKIP
+     >>> X_train = trf.transform(X_train)
+     >>> X_test = trf.transform(X_test)
     """
 
     _tags = {

--- a/sktime/transformations/panel/rocket/_rocket.py
+++ b/sktime/transformations/panel/rocket/_rocket.py
@@ -55,13 +55,13 @@ class Rocket(BaseTransformer):
     --------
     >>> from sktime.transformations.panel.rocket import Rocket
     >>> from sktime.datasets import load_unit_test
-    >>> X_train, y_train = load_unit_test(split="train") # doctest: +SKIP
-    >>> X_test, y_test = load_unit_test(split="test") # doctest: +SKIP
-    >>> trf = Rocket(num_kernels=512) # doctest: +SKIP
-    >>> trf.fit(X_train) # doctest: +SKIP
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
+    >>> trf = Rocket(num_kernels=512)
+    >>> trf.fit(X_train)
     Rocket(...)
-    >>> X_train = trf.transform(X_train) # doctest: +SKIP
-    >>> X_test = trf.transform(X_test) # doctest: +SKIP
+    >>> X_train = trf.transform(X_train)
+    >>> X_test = trf.transform(X_test)
     """
 
     _tags = {

--- a/sktime/transformations/panel/rocket/_rocket_pyts.py
+++ b/sktime/transformations/panel/rocket/_rocket_pyts.py
@@ -76,13 +76,13 @@ class RocketPyts(_PytsAdapter, BaseTransformer):
     --------
     >>> from sktime.transformations.panel.rocket import RocketPyts
     >>> from sktime.datasets import load_unit_test
-    >>> X_train, y_train = load_unit_test(split="train") # doctest: +SKIP
-    >>> X_test, y_test = load_unit_test(split="test") # doctest: +SKIP
-    >>> trf = RocketPyts(num_kernels=512) # doctest: +SKIP
-    >>> trf.fit(X_train) # doctest: +SKIP
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
+    >>> trf = RocketPyts(num_kernels=512)
+    >>> trf.fit(X_train)
     Rocket(...)
-    >>> X_train = trf.transform(X_train) # doctest: +SKIP
-    >>> X_test = trf.transform(X_test) # doctest: +SKIP
+    >>> X_train = trf.transform(X_train)
+    >>> X_test = trf.transform(X_test)
     """
 
     _tags = {

--- a/sktime/transformations/panel/shapelet_transform/_shapelet_transform.py
+++ b/sktime/transformations/panel/shapelet_transform/_shapelet_transform.py
@@ -1055,10 +1055,10 @@ class RandomShapeletTransform(BaseTransformer):
     ...     n_shapelet_samples=500,
     ...     max_shapelets=10,
     ...     batch_size=100,
-    ... ) # doctest: +SKIP
-    >>> t.fit(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> t.fit(X_train, y_train)
     RandomShapeletTransform(...)
-    >>> X_t = t.transform(X_train) # doctest: +SKIP
+    >>> X_t = t.transform(X_train)
     """
 
     _tags = {

--- a/sktime/transformations/panel/shapelet_transform/_shapelet_transform_pyts.py
+++ b/sktime/transformations/panel/shapelet_transform/_shapelet_transform_pyts.py
@@ -115,10 +115,10 @@ class ShapeletTransformPyts(_PytsAdapter, BaseTransformer):
     ...     ShapeletTransformPyts
     ... )
     >>> from sktime.datasets import load_unit_test
-    >>> X_train, y_train = load_unit_test(split="train") # doctest: +SKIP
-    >>> stp = ShapeletTransformPyts() # doctest: +SKIP
-    >>> stp.fit(X_train,y_train) # doctest: +SKIP
-    >>> stp.transform(X_train) # doctest: +SKIP
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> stp = ShapeletTransformPyts()
+    >>> stp.fit(X_train,y_train)
+    >>> stp.transform(X_train)
     """
 
     _tags = {

--- a/sktime/transformations/panel/tsfresh.py
+++ b/sktime/transformations/panel/tsfresh.py
@@ -218,8 +218,8 @@ class TSFreshFeatureExtractor(_TSFreshFeatureExtractor):
     >>> X_train, X_test, y_train, y_test = train_test_split(X, y)
     >>> ts_eff = TSFreshFeatureExtractor(
     ...     default_fc_parameters="efficient", disable_progressbar=True
-    ... ) # doctest: +SKIP
-    >>> X_transform1 = ts_eff.fit_transform(X_train) # doctest: +SKIP
+    ... )
+    >>> X_transform1 = ts_eff.fit_transform(X_train)
     >>> features_to_calc = [
     ...     "dim_0__quantile__q_0.6",
     ...     "dim_0__longest_strike_above_mean",
@@ -227,8 +227,8 @@ class TSFreshFeatureExtractor(_TSFreshFeatureExtractor):
     ... ]
     >>> ts_custom = TSFreshFeatureExtractor(
     ...     kind_to_fc_parameters=features_to_calc, disable_progressbar=True
-    ... ) # doctest: +SKIP
-    >>> X_transform2 = ts_custom.fit_transform(X_train) # doctest: +SKIP
+    ... )
+    >>> X_transform2 = ts_custom.fit_transform(X_train)
     """
 
     _tags = {"X_inner_mtype": "pd-long"}
@@ -441,8 +441,8 @@ class TSFreshRelevantFeatureExtractor(_TSFreshFeatureExtractor):
     >>> X_train, X_test, y_train, y_test = train_test_split(X, y)
     >>> ts_eff = TSFreshRelevantFeatureExtractor(
     ...     default_fc_parameters="efficient", disable_progressbar=True
-    ... ) # doctest: +SKIP
-    >>> X_transform1 = ts_eff.fit_transform(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> X_transform1 = ts_eff.fit_transform(X_train, y_train)
     >>> features_to_calc = [
     ...     "dim_0__quantile__q_0.6",
     ...     "dim_0__longest_strike_above_mean",
@@ -450,8 +450,8 @@ class TSFreshRelevantFeatureExtractor(_TSFreshFeatureExtractor):
     ... ]
     >>> ts_custom = TSFreshRelevantFeatureExtractor(
     ...     kind_to_fc_parameters=features_to_calc, disable_progressbar=True
-    ... ) # doctest: +SKIP
-    >>> X_transform2 = ts_custom.fit_transform(X_train, y_train) # doctest: +SKIP
+    ... )
+    >>> X_transform2 = ts_custom.fit_transform(X_train, y_train)
     """
 
     _tags = {

--- a/sktime/transformations/series/acf.py
+++ b/sktime/transformations/series/acf.py
@@ -61,9 +61,9 @@ class AutoCorrelationTransformer(BaseTransformer):
     --------
     >>> from sktime.transformations.series.acf import AutoCorrelationTransformer
     >>> from sktime.datasets import load_airline
-    >>> y = load_airline()  # doctest: +SKIP
-    >>> transformer = AutoCorrelationTransformer(n_lags=12)  # doctest: +SKIP
-    >>> y_hat = transformer.fit_transform(y)  # doctest: +SKIP
+    >>> y = load_airline()
+    >>> transformer = AutoCorrelationTransformer(n_lags=12)
+    >>> y_hat = transformer.fit_transform(y)
     """
 
     _tags = {
@@ -200,9 +200,9 @@ class PartialAutoCorrelationTransformer(BaseTransformer):
     --------
     >>> from sktime.transformations.series.acf import PartialAutoCorrelationTransformer
     >>> from sktime.datasets import load_airline
-    >>> y = load_airline()  # doctest: +SKIP
-    >>> transformer = PartialAutoCorrelationTransformer(n_lags=12)  # doctest: +SKIP
-    >>> y_hat = transformer.fit_transform(y)  # doctest: +SKIP
+    >>> y = load_airline()
+    >>> transformer = PartialAutoCorrelationTransformer(n_lags=12)
+    >>> y_hat = transformer.fit_transform(y)
     """
 
     _tags = {

--- a/sktime/transformations/series/bkfilter.py
+++ b/sktime/transformations/series/bkfilter.py
@@ -53,14 +53,14 @@ class BKFilter(BaseTransformer):
 
     Examples
     --------
-    >>> from sktime.transformations.series.bkfilter import BKFilter # doctest: +SKIP
-    >>> import pandas as pd # doctest: +SKIP
-    >>> import statsmodels.api as sm # doctest: +SKIP
-    >>> dta = sm.datasets.macrodata.load_pandas().data # doctest: +SKIP
-    >>> index = pd.date_range(start='1959Q1', end='2009Q4', freq='Q') # doctest: +SKIP
-    >>> dta.set_index(index, inplace=True) # doctest: +SKIP
-    >>> bk = BKFilter(6, 24, 12) # doctest: +SKIP
-    >>> cycles = bk.fit_transform(X=dta[['realinv']]) # doctest: +SKIP
+    >>> from sktime.transformations.series.bkfilter import BKFilter
+    >>> import pandas as pd
+    >>> import statsmodels.api as sm
+    >>> dta = sm.datasets.macrodata.load_pandas().data
+    >>> index = pd.date_range(start='1959Q1', end='2009Q4', freq='Q')
+    >>> dta.set_index(index, inplace=True)
+    >>> bk = BKFilter(6, 24, 12)
+    >>> cycles = bk.fit_transform(X=dta[['realinv']])
     """
 
     _tags = {

--- a/sktime/transformations/series/cffilter.py
+++ b/sktime/transformations/series/cffilter.py
@@ -41,14 +41,14 @@ class CFFilter(BaseTransformer):
 
     Examples
     --------
-    >>> from sktime.transformations.series.cffilter import CFFilter # doctest: +SKIP
-    >>> import pandas as pd # doctest: +SKIP
-    >>> import statsmodels.api as sm # doctest: +SKIP
-    >>> dta = sm.datasets.macrodata.load_pandas().data # doctest: +SKIP
-    >>> index = pd.date_range(start='1959Q1', end='2009Q4', freq='Q') # doctest: +SKIP
-    >>> dta.set_index(index, inplace=True) # doctest: +SKIP
-    >>> cf = CFFilter(6, 24, True) # doctest: +SKIP
-    >>> cycles = cf.fit_transform(X=dta[['realinv']]) # doctest: +SKIP
+    >>> from sktime.transformations.series.cffilter import CFFilter
+    >>> import pandas as pd
+    >>> import statsmodels.api as sm
+    >>> dta = sm.datasets.macrodata.load_pandas().data
+    >>> index = pd.date_range(start='1959Q1', end='2009Q4', freq='Q')
+    >>> dta.set_index(index, inplace=True)
+    >>> cf = CFFilter(6, 24, True)
+    >>> cycles = cf.fit_transform(X=dta[['realinv']])
     """
 
     _tags = {

--- a/sktime/transformations/series/clasp.py
+++ b/sktime/transformations/series/clasp.py
@@ -51,10 +51,10 @@ class ClaSPTransformer(BaseTransformer):
     >>> from sktime.annotation.clasp import find_dominant_window_sizes
     >>> from sktime.datasets import load_electric_devices_segmentation
     >>> X, true_period_size, true_cps = load_electric_devices_segmentation()
-    >>> dominant_period_size = find_dominant_window_sizes(X) # doctest: +SKIP
-    >>> clasp = ClaSPTransformer(window_length=dominant_period_size) # doctest: +SKIP
-    >>> clasp.fit(X) # doctest: +SKIP
-    >>> profile = clasp.transform(X) # doctest: +SKIP
+    >>> dominant_period_size = find_dominant_window_sizes(X)
+    >>> clasp = ClaSPTransformer(window_length=dominant_period_size)
+    >>> clasp.fit(X)
+    >>> profile = clasp.transform(X)
     """
 
     _tags = {

--- a/sktime/transformations/series/clear_sky.py
+++ b/sktime/transformations/series/clear_sky.py
@@ -63,12 +63,12 @@ class ClearSky(BaseTransformer):
 
     Examples
     --------
-    >>> from sktime.transformations.series.clear_sky import ClearSky  # doctest: +SKIP
-    >>> from sktime.datasets import load_solar  # doctest: +SKIP
-    >>> y = load_solar()  # doctest: +SKIP
-    >>> transformer = ClearSky()  # doctest: +SKIP
+    >>> from sktime.transformations.series.clear_sky import ClearSky
+    >>> from sktime.datasets import load_solar
+    >>> y = load_solar()
+    >>> transformer = ClearSky()
     >>> # takes ~1min
-    >>> y_trafo = transformer.fit_transform(y)  # doctest: +SKIP
+    >>> y_trafo = transformer.fit_transform(y)
     """
 
     _tags = {

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -59,9 +59,9 @@ class Deseasonalizer(BaseTransformer):
     --------
     >>> from sktime.transformations.series.detrend import Deseasonalizer
     >>> from sktime.datasets import load_airline
-    >>> y = load_airline()  # doctest: +SKIP
-    >>> transformer = Deseasonalizer()  # doctest: +SKIP
-    >>> y_hat = transformer.fit_transform(y)  # doctest: +SKIP
+    >>> y = load_airline()
+    >>> transformer = Deseasonalizer()
+    >>> y_hat = transformer.fit_transform(y)
     """
 
     _tags = {
@@ -295,9 +295,9 @@ class ConditionalDeseasonalizer(Deseasonalizer):
     --------
     >>> from sktime.transformations.series.detrend import ConditionalDeseasonalizer
     >>> from sktime.datasets import load_airline
-    >>> y = load_airline()  # doctest: +SKIP
-    >>> transformer = ConditionalDeseasonalizer(sp=12)  # doctest: +SKIP
-    >>> y_hat = transformer.fit_transform(y)  # doctest: +SKIP
+    >>> y = load_airline()
+    >>> transformer = ConditionalDeseasonalizer(sp=12)
+    >>> y_hat = transformer.fit_transform(y)
     """
 
     def __init__(self, seasonality_test=None, sp=1, model="additive"):
@@ -463,9 +463,9 @@ class STLTransformer(BaseTransformer):
     --------
     >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.detrend import STLTransformer
-    >>> X = load_airline()  # doctest: +SKIP
-    >>> transformer = STLTransformer(sp=12)  # doctest: +SKIP
-    >>> Xt = transformer.fit_transform(X)  # doctest: +SKIP
+    >>> X = load_airline()
+    >>> transformer = STLTransformer(sp=12)
+    >>> Xt = transformer.fit_transform(X)
     """
 
     _tags = {

--- a/sktime/transformations/series/detrend/mstl.py
+++ b/sktime/transformations/series/detrend/mstl.py
@@ -119,7 +119,7 @@ class MSTL(BaseTransformer):
     Examples
     --------
     Simple use case: decompose a time series into trend, seasonal, residual components
-    >>> import matplotlib.pyplot as plt  # doctest: +SKIP
+    >>> import matplotlib.pyplot as plt
     >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.detrend import MSTL
     >>> y = load_airline()
@@ -127,9 +127,9 @@ class MSTL(BaseTransformer):
     >>> mstl = MSTL(return_components=True)
     >>> mstl.fit(y)
     >>> res = mstl.transform(y)
-    >>> res.plot()  # doctest: +SKIP
-    >>> plt.tight_layout()  # doctest: +SKIP
-    >>> plt.show()  # doctest: +SKIP
+    >>> res.plot()
+    >>> plt.tight_layout()
+    >>> plt.show()
 
     MSTL can be pipelined with a forecaster for multiple deseasonalized forecasts.
     The following example uses a simple trend forecaster, applied

--- a/sktime/transformations/series/dobin.py
+++ b/sktime/transformations/series/dobin.py
@@ -58,17 +58,17 @@ class DOBIN(BaseTransformer):
 
     Examples
     --------
-    >>> from sktime.transformations.series.dobin import DOBIN  # doctest: +SKIP
-    >>> from sklearn.preprocessing import MinMaxScaler  # doctest: +SKIP
-    >>> import numpy as np  # doctest: +SKIP
-    >>> import pandas as pd  # doctest: +SKIP
-    >>> from sktime.datasets import load_uschange  # doctest: +SKIP
-    >>> _, X = load_uschange()  # doctest: +SKIP
-    >>> scaler = MinMaxScaler()  # doctest: +SKIP
-    >>> X = scaler.fit_transform(X)  # doctest: +SKIP
-    >>> model = DOBIN()  # doctest: +SKIP
-    >>> X_outlier = model.fit_transform(pd.DataFrame(X))  # doctest: +SKIP
-    >>> X_outlier.head()  # doctest: +SKIP
+    >>> from sktime.transformations.series.dobin import DOBIN
+    >>> from sklearn.preprocessing import MinMaxScaler
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from sktime.datasets import load_uschange
+    >>> _, X = load_uschange()
+    >>> scaler = MinMaxScaler()
+    >>> X = scaler.fit_transform(X)
+    >>> model = DOBIN()
+    >>> X_outlier = model.fit_transform(pd.DataFrame(X))
+    >>> X_outlier.head()
             DB0       DB1       DB2       DB3
     0  1.151965  0.116488  0.286064  0.288140
     1  1.191976  0.100772  0.050835  0.225985

--- a/sktime/transformations/series/holiday/_holidayfeats.py
+++ b/sktime/transformations/series/holiday/_holidayfeats.py
@@ -50,37 +50,37 @@ class HolidayFeatures(BaseTransformer):
 
     Examples
     --------
-    >>> import numpy as np  # doctest: +SKIP
-    >>> import pandas as pd  # doctest: +SKIP
-    >>> from datetime import date  # doctest: +SKIP
-    >>> from holidays import country_holidays, financial_holidays  # doctest: +SKIP
-    >>> values = np.random.normal(size=365)  # doctest: +SKIP
-    >>> index = pd.date_range("2000-01-01", periods=365, freq="D")  # doctest: +SKIP
-    >>> X = pd.DataFrame(values, index=index)  # doctest: +SKIP
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from datetime import date
+    >>> from holidays import country_holidays, financial_holidays
+    >>> values = np.random.normal(size=365)
+    >>> index = pd.date_range("2000-01-01", periods=365, freq="D")
+    >>> X = pd.DataFrame(values, index=index)
 
     Returns country holiday features with custom holiday windows
 
     >>> transformer = HolidayFeatures(
     ...    calendar=country_holidays(country="FR"),
     ...    return_categorical=True,
-    ...    holiday_windows={"Noël": (1, 3), "Jour de l'an": (1, 0)})  # doctest: +SKIP
-    >>> yt = transformer.fit_transform(X)  # doctest: +SKIP
+    ...    holiday_windows={"Noël": (1, 3), "Jour de l'an": (1, 0)})
+    >>> yt = transformer.fit_transform(X)
 
     Returns financial holiday features
 
     >>> transformer = HolidayFeatures(
     ...    calendar=financial_holidays(market="NYSE"),
     ...    return_categorical=True,
-    ...    include_weekend=True)  # doctest: +SKIP
-    >>> yt = transformer.fit_transform(X)  # doctest: +SKIP
+    ...    include_weekend=True)
+    >>> yt = transformer.fit_transform(X)
 
     Returns custom made holiday features
 
     >>> transformer = HolidayFeatures(
     ...    calendar={date(2000,1,14): "Regional Holiday",
     ...              date(2000, 1, 26): "Regional Holiday"},
-    ...    return_categorical=True)  # doctest: +SKIP
-    >>> yt = transformer.fit_transform(X)  # doctest: +SKIP
+    ...    return_categorical=True)
+    >>> yt = transformer.fit_transform(X)
 
     References
     ----------

--- a/sktime/transformations/series/holiday/country_holidays.py
+++ b/sktime/transformations/series/holiday/country_holidays.py
@@ -58,12 +58,12 @@ class CountryHolidaysTransformer(BaseTransformer):
     >>> from sktime.datasets import load_airline
     >>> y = load_airline()
     >>>
-    >>> y_t = CountryHolidaysTransformer("US").fit_transform(y)  # doctest: +SKIP
-    >>> y_t.dtype  # doctest: +SKIP
+    >>> y_t = CountryHolidaysTransformer("US").fit_transform(y)
+    >>> y_t.dtype
     dtype('bool')
-    >>> y_t.sum()  # doctest: +SKIP
+    >>> y_t.sum()
     14
-    >>> y_t.name  # doctest: +SKIP
+    >>> y_t.name
     'US_holidays'
     """
 

--- a/sktime/transformations/series/holiday/financial_holidays.py
+++ b/sktime/transformations/series/holiday/financial_holidays.py
@@ -59,12 +59,12 @@ class FinancialHolidaysTransformer(BaseTransformer):
     >>>
     >>> y = pandas.Series(data, index=index, name="random")
     >>>
-    >>> y_t = FinancialHolidaysTransformer("XNYS").fit_transform(y)  # doctest: +SKIP
-    >>> y_t.dtype  # doctest: +SKIP
+    >>> y_t = FinancialHolidaysTransformer("XNYS").fit_transform(y)
+    >>> y_t.dtype
     dtype('bool')
-    >>> y_t.sum()  # doctest: +SKIP
+    >>> y_t.sum()
     10
-    >>> y_t.name  # doctest: +SKIP
+    >>> y_t.name
     'XNYS_holidays'
     """
 

--- a/sktime/transformations/series/hpfilter.py
+++ b/sktime/transformations/series/hpfilter.py
@@ -44,14 +44,14 @@ class HPFilter(BaseTransformer):
 
     Examples
     --------
-    >>> from sktime.transformations.series.hpfilter import HPFilter # doctest: +SKIP
-    >>> import pandas as pd # doctest: +SKIP
-    >>> import statsmodels.api as sm # doctest: +SKIP
-    >>> dta = sm.datasets.macrodata.load_pandas().data # doctest: +SKIP
-    >>> index = pd.period_range('1959Q1', '2009Q3', freq='Q') # doctest: +SKIP
-    >>> dta.set_index(index, inplace=True) # doctest: +SKIP
-    >>> hp = HPFilter(1600) # doctest: +SKIP
-    >>> cycles = hp.fit_transform(X=dta[['realinv']]) # doctest: +SKIP
+    >>> from sktime.transformations.series.hpfilter import HPFilter
+    >>> import pandas as pd
+    >>> import statsmodels.api as sm
+    >>> dta = sm.datasets.macrodata.load_pandas().data
+    >>> index = pd.period_range('1959Q1', '2009Q3', freq='Q')
+    >>> dta.set_index(index, inplace=True)
+    >>> hp = HPFilter(1600)
+    >>> cycles = hp.fit_transform(X=dta[['realinv']])
     """
 
     _tags = {

--- a/sktime/transformations/series/kalman_filter.py
+++ b/sktime/transformations/series/kalman_filter.py
@@ -483,17 +483,17 @@ class KalmanFilterTransformerPK(BaseKalmanFilter, BaseTransformer):
     --------
         Basic example:
 
-    >>> import numpy as np  # doctest: +SKIP
+    >>> import numpy as np
     >>> import sktime.transformations.series.kalman_filter as kf
     >>> time_steps, state_dim, measurement_dim = 10, 2, 3
     >>>
     >>> X = np.random.rand(time_steps, measurement_dim) * 10
-    >>> transformer = kf.KalmanFilterTransformerPK(state_dim=state_dim) # doctest: +SKIP
-    >>> X_transformed = transformer.fit_transform(X=X)  # doctest: +SKIP
+    >>> transformer = kf.KalmanFilterTransformerPK(state_dim=state_dim)
+    >>> X_transformed = transformer.fit_transform(X=X)
 
         Example of - denoising, matrix estimation and missing values:
 
-    >>> import numpy as np  # doctest: +SKIP
+    >>> import numpy as np
     >>> import sktime.transformations.series.kalman_filter as kf
     >>> time_steps, state_dim, measurement_dim = 10, 2, 2
     >>>
@@ -503,18 +503,18 @@ class KalmanFilterTransformerPK(BaseKalmanFilter, BaseTransformer):
     >>>
     >>> # If matrices estimation is required, elements of ``estimate_matrices``
     >>> # are assumed to be constants.
-    >>> transformer = kf.KalmanFilterTransformerPK(  # doctest: +SKIP
+    >>> transformer = kf.KalmanFilterTransformerPK(
     ...     state_dim=state_dim,
     ...     measurement_noise=np.eye(measurement_dim),
     ...     denoising=True,
     ...     estimate_matrices=['measurement_noise']
     ...     )
     >>>
-    >>> X_transformed = transformer.fit_transform(X=X)  # doctest: +SKIP
+    >>> X_transformed = transformer.fit_transform(X=X)
 
         Example of - dynamic inputs (matrix per time-step) and missing values:
 
-    >>> import numpy as np  # doctest: +SKIP
+    >>> import numpy as np
     >>> import sktime.transformations.series.kalman_filter as kf
     >>> time_steps, state_dim, measurement_dim = 10, 4, 4
     >>>
@@ -524,13 +524,13 @@ class KalmanFilterTransformerPK(BaseKalmanFilter, BaseTransformer):
     >>>
     >>> # Dynamic input -
     >>> # ``state_transition`` provide different matrix for each time step.
-    >>> transformer = kf.KalmanFilterTransformerPK(  # doctest: +SKIP
+    >>> transformer = kf.KalmanFilterTransformerPK(
     ...     state_dim=state_dim,
     ...     state_transition=np.random.rand(time_steps, state_dim, state_dim),
     ...     estimate_matrices=['initial_state', 'initial_state_covariance']
     ...     )
     >>>
-    >>> X_transformed = transformer.fit_transform(X=X)  # doctest: +SKIP
+    >>> X_transformed = transformer.fit_transform(X=X)
     """
 
     _tags = {
@@ -968,16 +968,16 @@ class KalmanFilterTransformerFP(BaseKalmanFilter, BaseTransformer):
     --------
         Basic example:
 
-    >>> import numpy as np  # doctest: +SKIP
+    >>> import numpy as np
     >>> import sktime.transformations.series.kalman_filter as kf
     >>> time_steps, state_dim, measurement_dim = 10, 2, 3
     >>>
     >>> X = np.random.rand(time_steps, measurement_dim) * 10
-    >>> transformer = kf.KalmanFilterTransformerFP(state_dim=state_dim) # doctest: +SKIP
-    >>> Xt = transformer.fit_transform(X=X)  # doctest: +SKIP
+    >>> transformer = kf.KalmanFilterTransformerFP(state_dim=state_dim)
+    >>> Xt = transformer.fit_transform(X=X)
 
         Example of - denoising, matrix estimation, missing values and transform with y:
-    >>> import numpy as np  # doctest: +SKIP
+    >>> import numpy as np
     >>> import sktime.transformations.series.kalman_filter as kf
     >>> time_steps, state_dim, measurement_dim = 10, 3, 3
     >>> control_variable_dim = 2
@@ -991,17 +991,17 @@ class KalmanFilterTransformerFP(BaseKalmanFilter, BaseTransformer):
     >>>
     >>> # If matrices estimation is required, elements of ``estimate_matrices``
     >>> # are assumed to be constants.
-    >>> transformer = kf.KalmanFilterTransformerFP(  # doctest: +SKIP
+    >>> transformer = kf.KalmanFilterTransformerFP(
     ...     state_dim=state_dim,
     ...     measurement_noise=np.eye(measurement_dim),
     ...     denoising=True,
     ...     estimate_matrices='measurement_noise'
     ...     )
-    >>> Xt = transformer.fit_transform(X=X, y=control_variable)  # doctest: +SKIP
+    >>> Xt = transformer.fit_transform(X=X, y=control_variable)
 
         Example of - dynamic inputs (matrix per time-step), missing values:
 
-    >>> import numpy as np  # doctest: +SKIP
+    >>> import numpy as np
     >>> import sktime.transformations.series.kalman_filter as kf
     >>> time_steps, state_dim, measurement_dim = 10, 4, 4
     >>> control_variable_dim = 4
@@ -1015,12 +1015,12 @@ class KalmanFilterTransformerFP(BaseKalmanFilter, BaseTransformer):
     >>>
     >>> # Dynamic input -
     >>> # ``state_transition`` provide different matrix for each time step.
-    >>> transformer = kf.KalmanFilterTransformerFP(  # doctest: +SKIP
+    >>> transformer = kf.KalmanFilterTransformerFP(
     ...     state_dim=state_dim,
     ...     state_transition=np.random.rand(time_steps, state_dim, state_dim),
     ...     estimate_matrices=['initial_state', 'initial_state_covariance']
     ...     )
-    >>> Xt = transformer.fit_transform(X=X, y=control_variable)  # doctest: +SKIP
+    >>> Xt = transformer.fit_transform(X=X, y=control_variable)
     """
 
     _tags = {

--- a/sktime/transformations/series/matrix_profile.py
+++ b/sktime/transformations/series/matrix_profile.py
@@ -34,8 +34,8 @@ class MatrixProfileTransformer(BaseTransformer):
     MatrixProfileTransformer
     >>> from sktime.datasets import load_airline
     >>> y = load_airline()
-    >>> transformer = MatrixProfileTransformer()  # doctest: +SKIP
-    >>> y_hat = transformer.fit_transform(y)  # doctest: +SKIP
+    >>> transformer = MatrixProfileTransformer()
+    >>> y_hat = transformer.fit_transform(y)
     """
 
     _tags = {

--- a/sktime/transformations/series/paa.py
+++ b/sktime/transformations/series/paa.py
@@ -41,9 +41,9 @@ class PAA(BaseTransformer):
 
     >>> X = arange(10)
     >>> paa = PAA(frames=3)
-    >>> paa.fit_transform(X)  # doctest: +SKIP
+    >>> paa.fit_transform(X)
     array([1.2, 4.5, 7.8])
-    >>> paa = PAA(frame_size=3)  # doctest: +SKIP
+    >>> paa = PAA(frame_size=3)
     array([1, 4, 7, 9])
     """
 

--- a/sktime/transformations/series/peak.py
+++ b/sktime/transformations/series/peak.py
@@ -133,11 +133,11 @@ class PeakTimeFeature(BaseTransformer):
 
     Examples
     --------
-    >>> from sktime.transformations.series.peak import PeakTimeFeature  # doctest: +SKIP
-    >>> from sktime.datasets import   # doctest: +SKIP
-    >>> y = load_solar()  # doctest: +SKIP
-    >>> y = y.tz_localize(None)  # doctest: +SKIP
-    >>> y = y.asfreq("H")  # doctest: +SKIP
+    >>> from sktime.transformations.series.peak import PeakTimeFeature
+    >>> from sktime.datasets import 
+    >>> y = load_solar()
+    >>> y = y.tz_localize(None)
+    >>> y = y.asfreq("H")
 
     Example 1: one interval for peak hour and working hour.
     (based on one start/end interval)
@@ -147,8 +147,8 @@ class PeakTimeFeature(BaseTransformer):
     >>> transformer = PeakTimeFeature(ts_freq="H",
     ... peak_hour_start=[6], peak_hour_end=[9],
     ... working_hour_start=[8], working_hour_end=[16]
-    ... )  # doctest: +SKIP
-    >>> y_hat_peak = transformer.fit_transform(y)  # doctest: +SKIP
+    ... )
+    >>> y_hat_peak = transformer.fit_transform(y)
 
     Example 2: two intervals for peak hour and  working hour.
     (based on two start/end intervals)
@@ -158,8 +158,8 @@ class PeakTimeFeature(BaseTransformer):
     >>> transformer = PeakTimeFeature(ts_freq="H",
     ... peak_hour_start=[6, 16], peak_hour_end=[9, 20],
     ... working_hour_start=[8, 15], working_hour_end=[12, 19]
-    ... )  # doctest: +SKIP
-    >>> y_hat_peak = transformer.fit_transform(y)  # doctest: +SKIP
+    ... )
+    >>> y_hat_peak = transformer.fit_transform(y)
 
     Example 3: We may have peak for different seasonality
     Here is an example for peak hour, peak day, peak week, peak month for
@@ -172,8 +172,8 @@ class PeakTimeFeature(BaseTransformer):
     ... peak_day_start=[1, 2], peak_day_end=[2, 3],
     ... peak_week_start=[35, 45], peak_week_end=[40, 52],
     ... peak_month_start=[1, 7], peak_month_end=[6, 12]
-    ... )  # doctest: +SKIP
-    >>> y_hat_peak = transformer.fit_transform(y)  # doctest: +SKIP
+    ... )
+    >>> y_hat_peak = transformer.fit_transform(y)
     """
 
     _tags = {

--- a/sktime/transformations/series/sax.py
+++ b/sktime/transformations/series/sax.py
@@ -51,9 +51,9 @@ class SAX(BaseTransformer):
 
     >>> X = arange(10)
     >>> sax = SAX(word_size=3, alphabet_size=5)
-    >>> sax.fit_transform(X)  # doctest: +SKIP
+    >>> sax.fit_transform(X)
     array([0, 2, 4])
-    >>> sax = SAX(frame_size=2, alphabet_size=5)  # doctest: +SKIP
+    >>> sax = SAX(frame_size=2, alphabet_size=5)
     array([0, 1, 2, 3, 4])
     """
 

--- a/sktime/transformations/series/temporian.py
+++ b/sktime/transformations/series/temporian.py
@@ -30,14 +30,14 @@ class TemporianTransformer(BaseTransformer):
     --------
     >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.temporian import TemporianTransformer
-    >>> import temporian as tp  # doctest: +SKIP
+    >>> import temporian as tp
     >>>
-    >>> def function(evset):  # doctest: +SKIP
+    >>> def function(evset):
     ...     return evset.simple_moving_average(tp.duration.days(3 * 365))  \
-        # doctest: +SKIP
-    >>> transformer = TemporianTransformer(function=function)  # doctest: +SKIP
-    >>> X = load_airline()  # doctest: +SKIP
-    >>> X_averaged = transformer.fit_transform(X)  # doctest: +SKIP
+      
+    >>> transformer = TemporianTransformer(function=function)
+    >>> X = load_airline()
+    >>> X_averaged = transformer.fit_transform(X)
 
     References
     ----------

--- a/sktime/transformations/series/vmd.py
+++ b/sktime/transformations/series/vmd.py
@@ -92,18 +92,18 @@ class VmdTransformer(BaseTransformer):
 
     Examples
     --------
-    >>> from sktime.transformations.series.vmd import VmdTransformer  # doctest: +SKIP
-    >>> from sktime.datasets import load_solar  # doctest: +SKIP
-    >>> y = load_solar()  # doctest: +SKIP
-    >>> transformer = VmdTransformer()  # doctest: +SKIP
-    >>> modes = transformer.fit_transform(y)  # doctest: +SKIP
+    >>> from sktime.transformations.series.vmd import VmdTransformer
+    >>> from sktime.datasets import load_solar
+    >>> y = load_solar()
+    >>> transformer = VmdTransformer()
+    >>> modes = transformer.fit_transform(y)
 
     VmdTransformer can be used in a forecasting pipeline,
     to decompose, forecast individual components, then recompose:
-    >>> from sktime.forecasting.trend import TrendForecaster  # doctest: +SKIP
-    >>> pipe = VmdTransformer() * TrendForecaster()  # doctest: +SKIP
-    >>> pipe.fit(y, fh=[1, 2, 3])  # doctest: +SKIP
-    >>> y_pred = pipe.predict()  # doctest: +SKIP
+    >>> from sktime.forecasting.trend import TrendForecaster
+    >>> pipe = VmdTransformer() * TrendForecaster()
+    >>> pipe.fit(y, fh=[1, 2, 3])
+    >>> y_pred = pipe.predict()
     """
 
     _tags = {


### PR DESCRIPTION
This PR removes the skips from the doctests.

Since a few releases, doctests are executed only if required soft dependencies are present, therefore we no longer need to skip them.

#7015 is an example of a recent issue in a docstring that could have been detected with doctest execution.