### PR TITLE
[ENH] Adding `u8darts` to forecasting soft dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ forecasting = [
   'statsforecast<1.8.0,>=1.0.0; python_version < "3.12"',
   "statsmodels<0.15,>=0.12.1",
   'tbats<1.2,>=1.1; python_version < "3.12"',
+  "u8darts<0.31,>=0.29.0",
 ]
 networks = [
   "keras-self-attention<0.52,>=0.51",

--- a/sktime/forecasting/darts.py
+++ b/sktime/forecasting/darts.py
@@ -407,8 +407,8 @@ class DartsXGBModel(_DartsRegressionModelsAdapter):
 
         params = [
             {
-                "num_samples": 100,
-                "lags": 12,
+                "num_samples": 50,
+                "lags": 6,
                 "output_chunk_length": 1,
                 "add_encoders": None,
                 "likelihood": "quantile",
@@ -422,7 +422,7 @@ class DartsXGBModel(_DartsRegressionModelsAdapter):
             },
             {
                 "num_samples": 50,
-                "lags": 12,
+                "lags": 6,
                 "output_chunk_length": 3,
                 "add_encoders": None,
                 "likelihood": "poisson",

--- a/sktime/forecasting/darts.py
+++ b/sktime/forecasting/darts.py
@@ -421,7 +421,7 @@ class DartsXGBModel(_DartsRegressionModelsAdapter):
                 },
             },
             {
-                "num_samples": 200,
+                "num_samples": 50,
                 "lags": 12,
                 "output_chunk_length": 3,
                 "add_encoders": None,


### PR DESCRIPTION
This PR simplify the use of current supported darts models, by enabling users to install them through `pip install sktime\[forecastin\]`

FYI @fkiraly 