### PR TITLE
[BUG] Fix `nested_univ` converter inconsistent handling of index level names

### DIFF
--- a/examples/AA_datatypes_and_datasets.ipynb
+++ b/examples/AA_datatypes_and_datasets.ipynb
@@ -16,13 +16,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:36:59.221642Z",
+     "start_time": "2024-08-24T04:36:59.219912Z"
+    }
+   },
    "source": [
     "# from os import sys\n",
     "# sys.path.append(\"..\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 2
   },
   {
    "attachments": {},
@@ -93,13 +98,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
    "source": [
     "# import to retrieve examples\n",
     "from sktime.datatypes import get_examples"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "attachments": {},
@@ -129,11 +134,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.255151Z",
+     "start_time": "2024-08-24T04:37:00.248568Z"
+    }
+   },
+   "source": [
+    "get_examples(mtype=\"pd.DataFrame\", as_scitype=\"Series\")[0]"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "     a\n",
+       "0  1.0\n",
+       "1  4.0\n",
+       "2  0.5\n",
+       "3 -3.0"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -176,23 +195,14 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "     a\n",
-       "0  1.0\n",
-       "1  4.0\n",
-       "2  0.5\n",
-       "3 -3.0"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "get_examples(mtype=\"pd.DataFrame\", as_scitype=\"Series\")[0]"
-   ]
+   "execution_count": 4
   },
   {
    "attachments": {},
@@ -205,11 +215,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.260056Z",
+     "start_time": "2024-08-24T04:37:00.256008Z"
+    }
+   },
+   "source": [
+    "get_examples(mtype=\"pd.DataFrame\", as_scitype=\"Series\")[1]"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "     a         b\n",
+       "0  1.0  3.000000\n",
+       "1  4.0  7.000000\n",
+       "2  0.5  2.000000\n",
+       "3 -3.0 -0.428571"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -257,23 +281,14 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "     a         b\n",
-       "0  1.0  3.000000\n",
-       "1  4.0  7.000000\n",
-       "2  0.5  2.000000\n",
-       "3 -3.0 -0.428571"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "get_examples(mtype=\"pd.DataFrame\", as_scitype=\"Series\")[1]"
-   ]
+   "execution_count": 5
   },
   {
    "attachments": {},
@@ -303,8 +318,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.264775Z",
+     "start_time": "2024-08-24T04:37:00.261573Z"
+    }
+   },
+   "source": [
+    "get_examples(mtype=\"pd.Series\", as_scitype=\"Series\")[0]"
+   ],
    "outputs": [
     {
      "data": {
@@ -316,14 +338,12 @@
        "Name: a, dtype: float64"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "get_examples(mtype=\"pd.Series\", as_scitype=\"Series\")[0]"
-   ]
+   "execution_count": 6
   },
   {
    "attachments": {},
@@ -353,8 +373,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.268202Z",
+     "start_time": "2024-08-24T04:37:00.265604Z"
+    }
+   },
+   "source": [
+    "get_examples(mtype=\"np.ndarray\", as_scitype=\"Series\")[0]"
+   ],
    "outputs": [
     {
      "data": {
@@ -365,14 +392,12 @@
        "       [-3. ]])"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "get_examples(mtype=\"np.ndarray\", as_scitype=\"Series\")[0]"
-   ]
+   "execution_count": 7
   },
   {
    "attachments": {},
@@ -385,8 +410,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.271341Z",
+     "start_time": "2024-08-24T04:37:00.269052Z"
+    }
+   },
+   "source": [
+    "get_examples(mtype=\"np.ndarray\", as_scitype=\"Series\")[1]"
+   ],
    "outputs": [
     {
      "data": {
@@ -397,14 +429,12 @@
        "       [-3.        , -0.42857143]])"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "get_examples(mtype=\"np.ndarray\", as_scitype=\"Series\")[1]"
-   ]
+   "execution_count": 8
   },
   {
    "attachments": {},
@@ -461,11 +491,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.276656Z",
+     "start_time": "2024-08-24T04:37:00.272162Z"
+    }
+   },
+   "source": [
+    "get_examples(mtype=\"pd-multiindex\", as_scitype=\"Panel\")[0]"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "                      var_0  var_1\n",
+       "instances timepoints              \n",
+       "0         0               1      4\n",
+       "          1               2      5\n",
+       "          2               3      6\n",
+       "1         0               1      4\n",
+       "          1               2     55\n",
+       "          2               3      6\n",
+       "2         0               1     42\n",
+       "          1               2      5\n",
+       "          2               3      6"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -548,29 +598,14 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                      var_0  var_1\n",
-       "instances timepoints              \n",
-       "0         0               1      4\n",
-       "          1               2      5\n",
-       "          2               3      6\n",
-       "1         0               1      4\n",
-       "          1               2     55\n",
-       "          2               3      6\n",
-       "2         0               1     42\n",
-       "          1               2      5\n",
-       "          2               3      6"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "get_examples(mtype=\"pd-multiindex\", as_scitype=\"Panel\")[0]"
-   ]
+   "execution_count": 9
   },
   {
    "attachments": {},
@@ -602,8 +637,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.279741Z",
+     "start_time": "2024-08-24T04:37:00.277305Z"
+    }
+   },
+   "source": [
+    "get_examples(mtype=\"numpy3D\", as_scitype=\"Panel\")[0]"
+   ],
    "outputs": [
     {
      "data": {
@@ -615,17 +657,15 @@
        "        [ 4, 55,  6]],\n",
        "\n",
        "       [[ 1,  2,  3],\n",
-       "        [42,  5,  6]]], dtype=int64)"
+       "        [42,  5,  6]]])"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "get_examples(mtype=\"numpy3D\", as_scitype=\"Panel\")[0]"
-   ]
+   "execution_count": 10
   },
   {
    "attachments": {},
@@ -657,8 +697,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.283703Z",
+     "start_time": "2024-08-24T04:37:00.280381Z"
+    }
+   },
+   "source": [
+    "get_examples(mtype=\"df-list\", as_scitype=\"Panel\")[0]"
+   ],
    "outputs": [
     {
      "data": {
@@ -677,14 +724,12 @@
        " 2      3      6]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "get_examples(mtype=\"df-list\", as_scitype=\"Panel\")[0]"
-   ]
+   "execution_count": 11
   },
   {
    "attachments": {},
@@ -717,11 +762,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.291587Z",
+     "start_time": "2024-08-24T04:37:00.286467Z"
+    }
+   },
+   "source": [
+    "get_examples(mtype=\"pd_multiindex_hier\", as_scitype=\"Hierarchical\")[0]"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "                    var_0  var_1\n",
+       "foo bar timepoints              \n",
+       "a   0   0               1      4\n",
+       "        1               2      5\n",
+       "        2               3      6\n",
+       "    1   0               1      4\n",
+       "        1               2     55\n",
+       "        2               3      6\n",
+       "    2   0               1     42\n",
+       "        1               2      5\n",
+       "        2               3      6\n",
+       "b   0   0               1      4\n",
+       "        1               2      5\n",
+       "        2               3      6\n",
+       "    1   0               1      4\n",
+       "        1               2     55\n",
+       "        2               3      6\n",
+       "    2   0               1     42\n",
+       "        1               2      5\n",
+       "        2               3      6"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -856,38 +930,14 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                    var_0  var_1\n",
-       "foo bar timepoints              \n",
-       "a   0   0               1      4\n",
-       "        1               2      5\n",
-       "        2               3      6\n",
-       "    1   0               1      4\n",
-       "        1               2     55\n",
-       "        2               3      6\n",
-       "    2   0               1     42\n",
-       "        1               2      5\n",
-       "        2               3      6\n",
-       "b   0   0               1      4\n",
-       "        1               2      5\n",
-       "        2               3      6\n",
-       "    1   0               1      4\n",
-       "        1               2     55\n",
-       "        2               3      6\n",
-       "    2   0               1     42\n",
-       "        1               2      5\n",
-       "        2               3      6"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "get_examples(mtype=\"pd_multiindex_hier\", as_scitype=\"Hierarchical\")[0]"
-   ]
+   "execution_count": 12
   },
   {
    "attachments": {},
@@ -934,14 +984,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.294310Z",
+     "start_time": "2024-08-24T04:37:00.292268Z"
+    }
+   },
    "source": [
     "import numpy as np\n",
     "\n",
     "y = np.array([1, 6, 3, 7, 2])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 13
   },
   {
    "attachments": {},
@@ -955,14 +1010,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.296674Z",
+     "start_time": "2024-08-24T04:37:00.294992Z"
+    }
+   },
    "source": [
     "from sktime.datatypes import check_raise\n",
     "\n",
     "# check_raise(y, mtype=\"np.ndarray\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 14
   },
   {
    "attachments": {},
@@ -974,8 +1034,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.299892Z",
+     "start_time": "2024-08-24T04:37:00.297537Z"
+    }
+   },
+   "source": [
+    "check_raise(y.reshape(-1, 1), mtype=\"np.ndarray\")"
+   ],
    "outputs": [
     {
      "data": {
@@ -983,14 +1050,12 @@
        "True"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "check_raise(y.reshape(-1, 1), mtype=\"np.ndarray\")"
-   ]
+   "execution_count": 15
   },
   {
    "attachments": {},
@@ -1002,45 +1067,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(True,\n",
-       " None,\n",
-       " {'is_empty': False,\n",
-       "  'is_univariate': True,\n",
-       "  'is_equally_spaced': True,\n",
-       "  'has_nans': False,\n",
-       "  'mtype': 'np.ndarray',\n",
-       "  'scitype': 'Series'})"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.303245Z",
+     "start_time": "2024-08-24T04:37:00.300571Z"
     }
-   ],
+   },
    "source": [
     "from sktime.datatypes import check_is_mtype\n",
     "\n",
     "check_is_mtype(y, mtype=\"np.ndarray\", return_metadata=True)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "and metadata is produced if the argument passes the validity check:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
+   ],
    "outputs": [
     {
      "data": {
@@ -1049,6 +1086,10 @@
        " None,\n",
        " {'is_empty': False,\n",
        "  'is_univariate': True,\n",
+       "  'n_features': 1,\n",
+       "  'feature_names': [0],\n",
+       "  'dtypekind_dfip': [<DtypeKind.FLOAT: 2>],\n",
+       "  'feature_kind': [<DtypeKind.FLOAT: 2>],\n",
        "  'is_equally_spaced': True,\n",
        "  'has_nans': False,\n",
        "  'mtype': 'np.ndarray',\n",
@@ -1060,9 +1101,51 @@
      "output_type": "execute_result"
     }
    ],
+   "execution_count": 16
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and metadata is produced if the argument passes the validity check:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.307016Z",
+     "start_time": "2024-08-24T04:37:00.304102Z"
+    }
+   },
    "source": [
     "check_is_mtype(y.reshape(-1, 1), mtype=\"np.ndarray\", return_metadata=True)"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True,\n",
+       " None,\n",
+       " {'is_empty': False,\n",
+       "  'is_univariate': True,\n",
+       "  'n_features': 1,\n",
+       "  'feature_names': [0],\n",
+       "  'dtypekind_dfip': [<DtypeKind.FLOAT: 2>],\n",
+       "  'feature_kind': [<DtypeKind.FLOAT: 2>],\n",
+       "  'is_equally_spaced': True,\n",
+       "  'has_nans': False,\n",
+       "  'mtype': 'np.ndarray',\n",
+       "  'scitype': 'Series'})"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 17
   },
   {
    "attachments": {},
@@ -1074,8 +1157,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.310436Z",
+     "start_time": "2024-08-24T04:37:00.307965Z"
+    }
+   },
+   "source": [
+    "check_is_mtype(y, mtype=\"np.ndarray\", scitype=\"Series\")"
+   ],
    "outputs": [
     {
      "data": {
@@ -1083,14 +1173,12 @@
        "True"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "check_is_mtype(y, mtype=\"np.ndarray\", scitype=\"Series\")"
-   ]
+   "execution_count": 18
   },
   {
    "attachments": {},
@@ -1104,9 +1192,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.315941Z",
+     "start_time": "2024-08-24T04:37:00.311315Z"
+    }
+   },
    "source": [
     "import pandas as pd\n",
     "\n",
@@ -1118,7 +1209,9 @@
     "        pd.DataFrame([[2, 0, 1, 42], [2, 1, 2, 5], [2, 2, 3, 6]], columns=cols),\n",
     "    ]\n",
     ").set_index([\"instances\", \"time points\"])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 19
   },
   {
    "attachments": {},
@@ -1132,14 +1225,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.318597Z",
+     "start_time": "2024-08-24T04:37:00.316810Z"
+    }
+   },
    "source": [
     "from sktime.datatypes import check_raise\n",
     "\n",
     "# check_raise(X, mtype=\"pd-multiindex\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 20
   },
   {
    "attachments": {},
@@ -1151,12 +1249,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.321952Z",
+     "start_time": "2024-08-24T04:37:00.319590Z"
+    }
+   },
    "source": [
     "X.index.names = [\"instances\", \"timepoints\"]"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 21
   },
   {
    "attachments": {},
@@ -1168,8 +1271,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.325471Z",
+     "start_time": "2024-08-24T04:37:00.322698Z"
+    }
+   },
+   "source": [
+    "check_raise(X, mtype=\"pd-multiindex\")"
+   ],
    "outputs": [
     {
      "data": {
@@ -1177,14 +1287,12 @@
        "True"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "check_raise(X, mtype=\"pd-multiindex\")"
-   ]
+   "execution_count": 22
   },
   {
    "attachments": {},
@@ -1198,8 +1306,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.328851Z",
+     "start_time": "2024-08-24T04:37:00.326274Z"
+    }
+   },
+   "source": [
+    "from sktime.datatypes import mtype\n",
+    "\n",
+    "mtype(X, as_scitype=\"Panel\")"
+   ],
    "outputs": [
     {
      "data": {
@@ -1207,16 +1324,12 @@
        "'pd-multiindex'"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "from sktime.datatypes import mtype\n",
-    "\n",
-    "mtype(X, as_scitype=\"Panel\")"
-   ]
+   "execution_count": 23
   },
   {
    "attachments": {},
@@ -1242,8 +1355,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.332333Z",
+     "start_time": "2024-08-24T04:37:00.329572Z"
+    }
+   },
+   "source": [
+    "from sktime.datatypes import get_examples\n",
+    "\n",
+    "X = get_examples(mtype=\"numpy3D\", as_scitype=\"Panel\")[0]\n",
+    "X"
+   ],
    "outputs": [
     {
      "data": {
@@ -1255,123 +1378,7 @@
        "        [ 4, 55,  6]],\n",
        "\n",
        "       [[ 1,  2,  3],\n",
-       "        [42,  5,  6]]], dtype=int64)"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from sktime.datatypes import get_examples\n",
-    "\n",
-    "X = get_examples(mtype=\"numpy3D\", as_scitype=\"Panel\")[0]\n",
-    "X"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th>var_0</th>\n",
-       "      <th>var_1</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>instances</th>\n",
-       "      <th>timepoints</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th rowspan=\"3\" valign=\"top\">0</th>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th rowspan=\"3\" valign=\"top\">1</th>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>55</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th rowspan=\"3\" valign=\"top\">2</th>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>42</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                      var_0  var_1\n",
-       "instances timepoints              \n",
-       "0         0               1      4\n",
-       "          1               2      5\n",
-       "          2               3      6\n",
-       "1         0               1      4\n",
-       "          1               2     55\n",
-       "          2               3      6\n",
-       "2         0               1     42\n",
-       "          1               2      5\n",
-       "          2               3      6"
+       "        [42,  5,  6]]])"
       ]
      },
      "execution_count": 24,
@@ -1379,19 +1386,37 @@
      "output_type": "execute_result"
     }
    ],
+   "execution_count": 24
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.341912Z",
+     "start_time": "2024-08-24T04:37:00.336041Z"
+    }
+   },
    "source": [
     "from sktime.datatypes import convert\n",
     "\n",
     "convert(X, from_type=\"numpy3D\", to_type=\"pd-multiindex\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "                      var_0  var_1\n",
+       "instances timepoints              \n",
+       "0         0               1      4\n",
+       "          1               2      5\n",
+       "          2               3      6\n",
+       "1         0               1      4\n",
+       "          1               2     55\n",
+       "          2               3      6\n",
+       "2         0               1     42\n",
+       "          1               2      5\n",
+       "          2               3      6"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -1474,7 +1499,31 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 25
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.365394Z",
+     "start_time": "2024-08-24T04:37:00.359673Z"
+    }
+   },
+   "source": [
+    "from sktime.datatypes import convert_to\n",
+    "\n",
+    "convert_to(X, to_type=\"pd-multiindex\")"
+   ],
+   "outputs": [
+    {
+     "data": {
       "text/plain": [
        "                      var_0  var_1\n",
        "instances timepoints              \n",
@@ -1487,18 +1536,97 @@
        "2         0               1     42\n",
        "          1               2      5\n",
        "          2               3      6"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>var_0</th>\n",
+       "      <th>var_1</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>instances</th>\n",
+       "      <th>timepoints</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">0</th>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">1</th>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>55</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">2</th>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>42</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "from sktime.datatypes import convert_to\n",
-    "\n",
-    "convert_to(X, to_type=\"pd-multiindex\")"
-   ]
+   "execution_count": 26
   },
   {
    "attachments": {},
@@ -1514,38 +1642,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[[ 1,  2,  3],\n",
-       "        [ 4,  5,  6]],\n",
-       "\n",
-       "       [[ 1,  2,  3],\n",
-       "        [ 4, 55,  6]],\n",
-       "\n",
-       "       [[ 1,  2,  3],\n",
-       "        [42,  5,  6]]], dtype=int64)"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.625382Z",
+     "start_time": "2024-08-24T04:37:00.622134Z"
     }
-   ],
+   },
    "source": [
     "from sktime.datatypes import get_examples\n",
     "\n",
     "X = get_examples(mtype=\"numpy3D\", as_scitype=\"Panel\")[0]\n",
     "X"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
+   ],
    "outputs": [
     {
      "data": {
@@ -1557,7 +1665,7 @@
        "        [ 4, 55,  6]],\n",
        "\n",
        "       [[ 1,  2,  3],\n",
-       "        [42,  5,  6]]], dtype=int64)"
+       "        [42,  5,  6]]])"
       ]
      },
      "execution_count": 27,
@@ -1565,16 +1673,54 @@
      "output_type": "execute_result"
     }
    ],
+   "execution_count": 27
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.840857Z",
+     "start_time": "2024-08-24T04:37:00.838019Z"
+    }
+   },
    "source": [
     "from sktime.datatypes import convert_to\n",
     "\n",
     "convert_to(X, to_type=[\"pd-multiindex\", \"numpy3D\"])"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[[ 1,  2,  3],\n",
+       "        [ 4,  5,  6]],\n",
+       "\n",
+       "       [[ 1,  2,  3],\n",
+       "        [ 4, 55,  6]],\n",
+       "\n",
+       "       [[ 1,  2,  3],\n",
+       "        [42,  5,  6]]])"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 28
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:00.935929Z",
+     "start_time": "2024-08-24T04:37:00.931750Z"
+    }
+   },
+   "source": [
+    "X = get_examples(mtype=\"df-list\", as_scitype=\"Panel\")[0]\n",
+    "X"
+   ],
    "outputs": [
     {
      "data": {
@@ -1593,23 +1739,40 @@
        " 2      3      6]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "X = get_examples(mtype=\"df-list\", as_scitype=\"Panel\")[0]\n",
-    "X"
-   ]
+   "execution_count": 29
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.029148Z",
+     "start_time": "2024-08-24T04:37:01.023979Z"
+    }
+   },
+   "source": [
+    "convert_to(X, to_type=[\"pd-multiindex\", \"numpy3D\"])"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "                      var_0  var_1\n",
+       "instances timepoints              \n",
+       "0         0               1      4\n",
+       "          1               2      5\n",
+       "          2               3      6\n",
+       "1         0               1      4\n",
+       "          1               2     55\n",
+       "          2               3      6\n",
+       "2         0               1     42\n",
+       "          1               2      5\n",
+       "          2               3      6"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -1692,29 +1855,14 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                      var_0  var_1\n",
-       "instances timepoints              \n",
-       "0         0               1      4\n",
-       "          1               2      5\n",
-       "          2               3      6\n",
-       "1         0               1      4\n",
-       "          1               2     55\n",
-       "          2               3      6\n",
-       "2         0               1     42\n",
-       "          1               2      5\n",
-       "          2               3      6"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "convert_to(X, to_type=[\"pd-multiindex\", \"numpy3D\"])"
-   ]
+   "execution_count": 30
   },
   {
    "attachments": {},
@@ -1729,11 +1877,65 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.064335Z",
+     "start_time": "2024-08-24T04:37:01.058735Z"
+    }
+   },
+   "source": [
+    "from sktime.datatypes._convert import _conversions_defined\n",
+    "\n",
+    "_conversions_defined(scitype=\"Panel\")"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "                             df-list  gluonts_ListDataset_panel  \\\n",
+       "df-list                            1                          1   \n",
+       "gluonts_ListDataset_panel          1                          1   \n",
+       "gluonts_PandasDataset_panel        1                          1   \n",
+       "nested_univ                        1                          1   \n",
+       "numpy3D                            1                          1   \n",
+       "numpyflat                          1                          1   \n",
+       "pd-long                            1                          1   \n",
+       "pd-multiindex                      1                          1   \n",
+       "pd-wide                            0                          0   \n",
+       "\n",
+       "                             gluonts_PandasDataset_panel  nested_univ  \\\n",
+       "df-list                                                1            1   \n",
+       "gluonts_ListDataset_panel                              1            1   \n",
+       "gluonts_PandasDataset_panel                            1            1   \n",
+       "nested_univ                                            1            1   \n",
+       "numpy3D                                                1            1   \n",
+       "numpyflat                                              1            1   \n",
+       "pd-long                                                1            1   \n",
+       "pd-multiindex                                          1            1   \n",
+       "pd-wide                                                0            1   \n",
+       "\n",
+       "                             numpy3D  numpyflat  pd-long  pd-multiindex  \\\n",
+       "df-list                            1          1        1              1   \n",
+       "gluonts_ListDataset_panel          1          1        1              1   \n",
+       "gluonts_PandasDataset_panel        1          1        1              1   \n",
+       "nested_univ                        1          1        1              1   \n",
+       "numpy3D                            1          1        1              1   \n",
+       "numpyflat                          1          1        1              1   \n",
+       "pd-long                            1          1        1              1   \n",
+       "pd-multiindex                      1          1        1              1   \n",
+       "pd-wide                            0          0        0              0   \n",
+       "\n",
+       "                             pd-wide  \n",
+       "df-list                            0  \n",
+       "gluonts_ListDataset_panel          0  \n",
+       "gluonts_PandasDataset_panel        0  \n",
+       "nested_univ                        1  \n",
+       "numpy3D                            0  \n",
+       "numpyflat                          0  \n",
+       "pd-long                            0  \n",
+       "pd-multiindex                      0  \n",
+       "pd-wide                            1  "
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -1753,8 +1955,9 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>dask_panel</th>\n",
        "      <th>df-list</th>\n",
+       "      <th>gluonts_ListDataset_panel</th>\n",
+       "      <th>gluonts_PandasDataset_panel</th>\n",
        "      <th>nested_univ</th>\n",
        "      <th>numpy3D</th>\n",
        "      <th>numpyflat</th>\n",
@@ -1765,7 +1968,8 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>dask_panel</th>\n",
+       "      <th>df-list</th>\n",
+       "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
@@ -1776,7 +1980,20 @@
        "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>df-list</th>\n",
+       "      <th>gluonts_ListDataset_panel</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gluonts_PandasDataset_panel</th>\n",
+       "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
@@ -1796,9 +2013,11 @@
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>numpy3D</th>\n",
+       "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
@@ -1817,10 +2036,12 @@
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
+       "      <td>1</td>\n",
        "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>pd-long</th>\n",
+       "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
@@ -1839,10 +2060,12 @@
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
+       "      <td>1</td>\n",
        "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>pd-wide</th>\n",
+       "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>1</td>\n",
@@ -1855,39 +2078,14 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "               dask_panel  df-list  nested_univ  numpy3D  numpyflat  pd-long  \\\n",
-       "dask_panel              1        1            1        1          1        1   \n",
-       "df-list                 1        1            1        1          1        1   \n",
-       "nested_univ             1        1            1        1          1        1   \n",
-       "numpy3D                 1        1            1        1          1        1   \n",
-       "numpyflat               1        1            1        1          1        1   \n",
-       "pd-long                 1        1            1        1          1        1   \n",
-       "pd-multiindex           1        1            1        1          1        1   \n",
-       "pd-wide                 0        0            1        0          0        0   \n",
-       "\n",
-       "               pd-multiindex  pd-wide  \n",
-       "dask_panel                 1        0  \n",
-       "df-list                    1        0  \n",
-       "nested_univ                1        1  \n",
-       "numpy3D                    1        0  \n",
-       "numpyflat                  1        0  \n",
-       "pd-long                    1        0  \n",
-       "pd-multiindex              1        0  \n",
-       "pd-wide                    0        1  "
       ]
      },
-     "execution_count": 30,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "from sktime.datatypes._convert import _conversions_defined\n",
-    "\n",
-    "_conversions_defined(scitype=\"Panel\")"
-   ]
+   "execution_count": 31
   },
   {
    "attachments": {},
@@ -1939,8 +2137,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.695736Z",
+     "start_time": "2024-08-24T04:37:01.121299Z"
+    }
+   },
+   "source": [
+    "from sktime.datasets import load_airline\n",
+    "\n",
+    "load_airline()"
+   ],
    "outputs": [
     {
      "data": {
@@ -1960,16 +2167,12 @@
        "Freq: M, Name: Number of airline passengers, Length: 144, dtype: float64"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "from sktime.datasets import load_airline\n",
-    "\n",
-    "load_airline()"
-   ]
+   "execution_count": 32
   },
   {
    "attachments": {},
@@ -1983,8 +2186,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.703421Z",
+     "start_time": "2024-08-24T04:37:01.696880Z"
+    }
+   },
+   "source": [
+    "from sktime.datasets import load_longley\n",
+    "\n",
+    "load_longley()"
+   ],
    "outputs": [
     {
      "data": {
@@ -2006,7 +2218,7 @@
        " 1960    69564.0\n",
        " 1961    69331.0\n",
        " 1962    70551.0\n",
-       " Freq: A-DEC, Name: TOTEMP, dtype: float64,\n",
+       " Freq: Y-DEC, Name: TOTEMP, dtype: float64,\n",
        "         GNPDEFL       GNP   UNEMP   ARMED       POP\n",
        " Period                                             \n",
        " 1947       83.0  234289.0  2356.0  1590.0  107608.0\n",
@@ -2027,16 +2239,12 @@
        " 1962      116.9  554894.0  4007.0  2827.0  130081.0)"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "from sktime.datasets import load_longley\n",
-    "\n",
-    "load_longley()"
-   ]
+   "execution_count": 33
   },
   {
    "attachments": {},
@@ -2048,17 +2256,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.707961Z",
+     "start_time": "2024-08-24T04:37:01.704400Z"
+    }
+   },
    "source": [
     "y, X = load_longley(y_name=\"TOTEMP\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 34
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.713321Z",
+     "start_time": "2024-08-24T04:37:01.709803Z"
+    }
+   },
+   "source": [
+    "y"
+   ],
    "outputs": [
     {
      "data": {
@@ -2080,25 +2300,50 @@
        "1960    69564.0\n",
        "1961    69331.0\n",
        "1962    70551.0\n",
-       "Freq: A-DEC, Name: TOTEMP, dtype: float64"
+       "Freq: Y-DEC, Name: TOTEMP, dtype: float64"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "y"
-   ]
+   "execution_count": 35
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.720632Z",
+     "start_time": "2024-08-24T04:37:01.714112Z"
+    }
+   },
+   "source": [
+    "X"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "        GNPDEFL       GNP   UNEMP   ARMED       POP\n",
+       "Period                                             \n",
+       "1947       83.0  234289.0  2356.0  1590.0  107608.0\n",
+       "1948       88.5  259426.0  2325.0  1456.0  108632.0\n",
+       "1949       88.2  258054.0  3682.0  1616.0  109773.0\n",
+       "1950       89.5  284599.0  3351.0  1650.0  110929.0\n",
+       "1951       96.2  328975.0  2099.0  3099.0  112075.0\n",
+       "1952       98.1  346999.0  1932.0  3594.0  113270.0\n",
+       "1953       99.0  365385.0  1870.0  3547.0  115094.0\n",
+       "1954      100.0  363112.0  3578.0  3350.0  116219.0\n",
+       "1955      101.2  397469.0  2904.0  3048.0  117388.0\n",
+       "1956      104.6  419180.0  2822.0  2857.0  118734.0\n",
+       "1957      108.4  442769.0  2936.0  2798.0  120445.0\n",
+       "1958      110.8  444546.0  4681.0  2637.0  121950.0\n",
+       "1959      112.6  482704.0  3813.0  2552.0  123366.0\n",
+       "1960      114.2  502601.0  3931.0  2514.0  125368.0\n",
+       "1961      115.7  518173.0  4806.0  2572.0  127852.0\n",
+       "1962      116.9  554894.0  4007.0  2827.0  130081.0"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -2265,36 +2510,14 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "        GNPDEFL       GNP   UNEMP   ARMED       POP\n",
-       "Period                                             \n",
-       "1947       83.0  234289.0  2356.0  1590.0  107608.0\n",
-       "1948       88.5  259426.0  2325.0  1456.0  108632.0\n",
-       "1949       88.2  258054.0  3682.0  1616.0  109773.0\n",
-       "1950       89.5  284599.0  3351.0  1650.0  110929.0\n",
-       "1951       96.2  328975.0  2099.0  3099.0  112075.0\n",
-       "1952       98.1  346999.0  1932.0  3594.0  113270.0\n",
-       "1953       99.0  365385.0  1870.0  3547.0  115094.0\n",
-       "1954      100.0  363112.0  3578.0  3350.0  116219.0\n",
-       "1955      101.2  397469.0  2904.0  3048.0  117388.0\n",
-       "1956      104.6  419180.0  2822.0  2857.0  118734.0\n",
-       "1957      108.4  442769.0  2936.0  2798.0  120445.0\n",
-       "1958      110.8  444546.0  4681.0  2637.0  121950.0\n",
-       "1959      112.6  482704.0  3813.0  2552.0  123366.0\n",
-       "1960      114.2  502601.0  3931.0  2514.0  125368.0\n",
-       "1961      115.7  518173.0  4806.0  2572.0  127852.0\n",
-       "1962      116.9  554894.0  4007.0  2827.0  130081.0"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "X"
-   ]
+   "execution_count": 36
   },
   {
    "attachments": {},
@@ -2335,22 +2558,70 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.742436Z",
+     "start_time": "2024-08-24T04:37:01.721627Z"
+    }
+   },
    "source": [
     "from sktime.datasets import load_arrow_head\n",
     "\n",
     "X, y = load_arrow_head(return_X_y=True)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 37
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.754321Z",
+     "start_time": "2024-08-24T04:37:01.743200Z"
+    }
+   },
+   "source": [
+    "X"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "                                                 dim_0\n",
+       "0    0     -1.963009\n",
+       "1     -1.957825\n",
+       "2     -1.95614...\n",
+       "1    0     -1.774571\n",
+       "1     -1.774036\n",
+       "2     -1.77658...\n",
+       "2    0     -1.866021\n",
+       "1     -1.841991\n",
+       "2     -1.83502...\n",
+       "3    0     -2.073758\n",
+       "1     -2.073301\n",
+       "2     -2.04460...\n",
+       "4    0     -1.746255\n",
+       "1     -1.741263\n",
+       "2     -1.72274...\n",
+       "..                                                 ...\n",
+       "206  0     -1.625142\n",
+       "1     -1.622988\n",
+       "2     -1.62606...\n",
+       "207  0     -1.657757\n",
+       "1     -1.664673\n",
+       "2     -1.63264...\n",
+       "208  0     -1.603279\n",
+       "1     -1.587365\n",
+       "2     -1.57740...\n",
+       "209  0     -1.739020\n",
+       "1     -1.741534\n",
+       "2     -1.73286...\n",
+       "210  0     -1.630727\n",
+       "1     -1.629918\n",
+       "2     -1.62055...\n",
+       "\n",
+       "[211 rows x 1 columns]"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -2442,57 +2713,26 @@
        "</table>\n",
        "<p>211 rows × 1 columns</p>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                                                 dim_0\n",
-       "0    0     -1.963009\n",
-       "1     -1.957825\n",
-       "2     -1.95614...\n",
-       "1    0     -1.774571\n",
-       "1     -1.774036\n",
-       "2     -1.77658...\n",
-       "2    0     -1.866021\n",
-       "1     -1.841991\n",
-       "2     -1.83502...\n",
-       "3    0     -2.073758\n",
-       "1     -2.073301\n",
-       "2     -2.04460...\n",
-       "4    0     -1.746255\n",
-       "1     -1.741263\n",
-       "2     -1.72274...\n",
-       "..                                                 ...\n",
-       "206  0     -1.625142\n",
-       "1     -1.622988\n",
-       "2     -1.62606...\n",
-       "207  0     -1.657757\n",
-       "1     -1.664673\n",
-       "2     -1.63264...\n",
-       "208  0     -1.603279\n",
-       "1     -1.587365\n",
-       "2     -1.57740...\n",
-       "209  0     -1.739020\n",
-       "1     -1.741534\n",
-       "2     -1.73286...\n",
-       "210  0     -1.630727\n",
-       "1     -1.629918\n",
-       "2     -1.62055...\n",
-       "\n",
-       "[211 rows x 1 columns]"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "X"
-   ]
+   "execution_count": 38
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.757522Z",
+     "start_time": "2024-08-24T04:37:01.755123Z"
+    }
+   },
+   "source": [
+    "y"
+   ],
    "outputs": [
     {
      "data": {
@@ -2516,14 +2756,12 @@
        "       '2', '2', '2'], dtype='<U1')"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "y"
-   ]
+   "execution_count": 39
   },
   {
    "attachments": {},
@@ -2535,11 +2773,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.818063Z",
+     "start_time": "2024-08-24T04:37:01.758439Z"
+    }
+   },
+   "source": [
+    "from sktime.datatypes import convert_to\n",
+    "\n",
+    "convert_to(X, to_type=\"pd-multiindex\")"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "            dim_0\n",
+       "0   0   -1.963009\n",
+       "    1   -1.957825\n",
+       "    2   -1.956145\n",
+       "    3   -1.938289\n",
+       "    4   -1.896657\n",
+       "...           ...\n",
+       "210 246 -1.513637\n",
+       "    247 -1.550431\n",
+       "    248 -1.581576\n",
+       "    249 -1.595273\n",
+       "    250 -1.620783\n",
+       "\n",
+       "[52961 rows x 1 columns]"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -2561,11 +2824,6 @@
        "      <th></th>\n",
        "      <th></th>\n",
        "      <th>dim_0</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th></th>\n",
-       "      <th>timepoints</th>\n",
-       "      <th></th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -2620,35 +2878,14 @@
        "</table>\n",
        "<p>52961 rows × 1 columns</p>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                   dim_0\n",
-       "    timepoints          \n",
-       "0   0          -1.963009\n",
-       "    1          -1.957825\n",
-       "    2          -1.956145\n",
-       "    3          -1.938289\n",
-       "    4          -1.896657\n",
-       "...                  ...\n",
-       "210 246        -1.513637\n",
-       "    247        -1.550431\n",
-       "    248        -1.581576\n",
-       "    249        -1.595273\n",
-       "    250        -1.620783\n",
-       "\n",
-       "[52961 rows x 1 columns]"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "from sktime.datatypes import convert_to\n",
-    "\n",
-    "convert_to(X, to_type=\"pd-multiindex\")"
-   ]
+   "execution_count": 40
   },
   {
    "attachments": {},
@@ -2660,14 +2897,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.840587Z",
+     "start_time": "2024-08-24T04:37:01.820440Z"
+    }
+   },
    "source": [
     "X_train, y_train = load_arrow_head(return_X_y=True, split=\"train\")\n",
     "X_test, y_test = load_arrow_head(return_X_y=True, split=\"test\")\n",
     "# this retrieves training and test X/y for reproducible use in studies"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 41
   },
   {
    "attachments": {},
@@ -2683,12 +2925,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.843750Z",
+     "start_time": "2024-08-24T04:37:01.841323Z"
+    }
+   },
    "source": [
     "from sktime.datasets.tsc_dataset_names import univariate"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 42
   },
   {
    "attachments": {},
@@ -2714,8 +2961,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.847485Z",
+     "start_time": "2024-08-24T04:37:01.844473Z"
+    }
+   },
+   "source": [
+    "univariate"
+   ],
    "outputs": [
     {
      "data": {
@@ -2850,14 +3104,12 @@
        " 'WormsTwoClass']"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "univariate"
-   ]
+   "execution_count": 43
   },
   {
    "attachments": {},
@@ -2869,14 +3121,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.868896Z",
+     "start_time": "2024-08-24T04:37:01.848185Z"
+    }
+   },
    "source": [
     "from sktime.datasets import load_UCR_UEA_dataset\n",
     "\n",
     "X, y = load_UCR_UEA_dataset(name=\"ArrowHead\", return_X_y=True)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 44
   },
   {
    "attachments": {},
@@ -2921,11 +3178,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.874459Z",
+     "start_time": "2024-08-24T04:37:01.869647Z"
+    }
+   },
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "df_series = pd.read_csv(\"../sktime/datasets/data/Airline/Airline.csv\")\n",
+    "df_series.head()"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "      Date  Passengers\n",
+       "0  1949-01         112\n",
+       "1  1949-02         118\n",
+       "2  1949-03         132\n",
+       "3  1949-04         129\n",
+       "4  1949-05         121"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -2978,44 +3253,43 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "      Date  Passengers\n",
-       "0  1949-01         112\n",
-       "1  1949-02         118\n",
-       "2  1949-03         132\n",
-       "3  1949-04         129\n",
-       "4  1949-05         121"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "import pandas as pd\n",
-    "\n",
-    "df_series = pd.read_csv(\"../sktime/datasets/data/Airline/Airline.csv\")\n",
-    "df_series.head()"
-   ]
+   "execution_count": 45
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.878130Z",
+     "start_time": "2024-08-24T04:37:01.875373Z"
+    }
+   },
    "source": [
     "df_series = df_series.set_index(\n",
     "    \"Date\"\n",
     ").squeeze()  # replace \"Period\" with the column name of the time index\n",
     "df_series.index = pd.DatetimeIndex(df_series.index)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 46
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:37:01.881579Z",
+     "start_time": "2024-08-24T04:37:01.879006Z"
+    }
+   },
+   "source": [
+    "mtype(df_series, as_scitype=\"Series\")"
+   ],
    "outputs": [
     {
      "data": {
@@ -3023,14 +3297,12 @@
        "'pd.Series'"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "mtype(df_series, as_scitype=\"Series\")"
-   ]
+   "execution_count": 47
   },
   {
    "attachments": {},
@@ -3042,26 +3314,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-26T08:04:46.421637Z",
+     "start_time": "2024-08-26T08:04:46.411573Z"
+    }
+   },
    "source": [
     "# mimicking a scenario where we already have a csv file in the right format\n",
     "from sktime.datasets import load_arrow_head\n",
-    "from sktime.datatypes import convert_to\n",
     "\n",
-    "df_panel = load_arrow_head(split=\"TRAIN\")[0]\n",
-    "df_panel = convert_to(df_panel, \"pd-multiindex\").reset_index()\n",
+    "df_panel = load_arrow_head(split=\"TRAIN\", return_type=\"pd-multiindex\")[0].reset_index()\n",
     "# imagine this is the result of df_panel = pd.read_csv"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 10
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-26T08:04:48.440141Z",
+     "start_time": "2024-08-26T08:04:48.435921Z"
+    }
+   },
+   "source": [
+    "df_panel.head()"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "   level_0  level_1     dim_0\n",
+       "0        0        0 -1.963009\n",
+       "1        0        1 -1.957825\n",
+       "2        0        2 -1.956145\n",
+       "3        0        3 -1.938289\n",
+       "4        0        4 -1.896657"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -3082,7 +3372,7 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>level_0</th>\n",
-       "      <th>timepoints</th>\n",
+       "      <th>level_1</th>\n",
        "      <th>dim_0</th>\n",
        "    </tr>\n",
        "  </thead>\n",
@@ -3120,24 +3410,14 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "   level_0  timepoints     dim_0\n",
-       "0        0           0 -1.963009\n",
-       "1        0           1 -1.957825\n",
-       "2        0           2 -1.956145\n",
-       "3        0           3 -1.938289\n",
-       "4        0           4 -1.896657"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "df_panel.head()"
-   ]
+   "execution_count": 11
   },
   {
    "attachments": {},
@@ -3151,8 +3431,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-26T08:05:24.994024Z",
+     "start_time": "2024-08-26T08:05:24.989950Z"
+    }
+   },
+   "source": [
+    "df_panel = df_panel.set_index([\"level_0\", \"level_1\"])\n",
+    "type(df_panel.index)"
+   ],
    "outputs": [
     {
      "data": {
@@ -3160,15 +3448,12 @@
        "pandas.core.indexes.multi.MultiIndex"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "df_panel = df_panel.set_index([\"level_0\", \"timepoints\"])\n",
-    "type(df_panel.index)"
-   ]
+   "execution_count": 12
   },
   {
    "attachments": {},
@@ -3180,26 +3465,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'pd-multiindex'"
-      ]
-     },
-     "execution_count": 50,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "mtype(df_panel, as_scitype=\"Panel\")\n",
     "# in general:\n",
     "# replace \"timepoints\" with the time index column name\n",
     "# replace \"level_0\" with the higher level column name of your file"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "attachments": {},
@@ -3233,11 +3507,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:38:39.741633Z",
+     "start_time": "2024-08-24T04:38:39.727502Z"
+    }
+   },
+   "source": [
+    "# 1, 2 - dealing with the separator and header\n",
+    "import pandas as pd\n",
+    "\n",
+    "df_panel = pd.read_csv(\n",
+    "    \"../sktime/datasets/data/ArrowHead/ArrowHead_TRAIN.tsv\",\n",
+    "    sep=\"\\t\",\n",
+    "    header=None,\n",
+    ")\n",
+    "df_panel.head()"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "   0         1         2         3         4         5         6         7    \\\n",
+       "0    0 -1.963009 -1.957825 -1.956145 -1.938289 -1.896657 -1.869857 -1.838705   \n",
+       "1    1 -1.774571 -1.774036 -1.776586 -1.730749 -1.696268 -1.657377 -1.636227   \n",
+       "2    2 -1.866021 -1.841991 -1.835025 -1.811902 -1.764390 -1.707687 -1.648280   \n",
+       "3    0 -2.073758 -2.073301 -2.044607 -2.038346 -1.959043 -1.874494 -1.805619   \n",
+       "4    1 -1.746255 -1.741263 -1.722741 -1.698640 -1.677223 -1.630356 -1.579440   \n",
+       "\n",
+       "        8         9    ...       242       243       244       245       246  \\\n",
+       "0 -1.812289 -1.736433  ... -1.583857 -1.655329 -1.719153 -1.750881 -1.796273   \n",
+       "1 -1.609807 -1.543439  ... -1.471688 -1.484666 -1.539972 -1.590150 -1.635663   \n",
+       "2 -1.582643 -1.531502  ... -1.584132 -1.652337 -1.684565 -1.743972 -1.799117   \n",
+       "3 -1.731043 -1.712653  ... -1.678942 -1.743732 -1.819801 -1.858136 -1.886146   \n",
+       "4 -1.551225 -1.473980  ... -1.547111 -1.607101 -1.635137 -1.686346 -1.691274   \n",
+       "\n",
+       "        247       248       249       250       251  \n",
+       "0 -1.841345 -1.884289 -1.905393 -1.923905 -1.909153  \n",
+       "1 -1.639989 -1.678683 -1.729227 -1.775670 -1.789324  \n",
+       "2 -1.829069 -1.875828 -1.862512 -1.863368 -1.846493  \n",
+       "3 -1.951247 -2.012927 -2.026963 -2.073405 -2.075292  \n",
+       "4 -1.716886 -1.740726 -1.743442 -1.762729 -1.763428  \n",
+       "\n",
+       "[5 rows x 252 columns]"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -3405,60 +3718,31 @@
        "</table>\n",
        "<p>5 rows × 252 columns</p>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "   0         1         2         3         4         5         6         7    \\\n",
-       "0    0 -1.963009 -1.957825 -1.956145 -1.938289 -1.896657 -1.869857 -1.838705   \n",
-       "1    1 -1.774571 -1.774036 -1.776586 -1.730749 -1.696268 -1.657377 -1.636227   \n",
-       "2    2 -1.866021 -1.841991 -1.835025 -1.811902 -1.764390 -1.707687 -1.648280   \n",
-       "3    0 -2.073758 -2.073301 -2.044607 -2.038346 -1.959043 -1.874494 -1.805619   \n",
-       "4    1 -1.746255 -1.741263 -1.722741 -1.698640 -1.677223 -1.630356 -1.579440   \n",
-       "\n",
-       "        8         9    ...       242       243       244       245       246  \\\n",
-       "0 -1.812289 -1.736433  ... -1.583857 -1.655329 -1.719153 -1.750881 -1.796273   \n",
-       "1 -1.609807 -1.543439  ... -1.471688 -1.484666 -1.539972 -1.590150 -1.635663   \n",
-       "2 -1.582643 -1.531502  ... -1.584132 -1.652337 -1.684565 -1.743972 -1.799117   \n",
-       "3 -1.731043 -1.712653  ... -1.678942 -1.743732 -1.819801 -1.858136 -1.886146   \n",
-       "4 -1.551225 -1.473980  ... -1.547111 -1.607101 -1.635137 -1.686346 -1.691274   \n",
-       "\n",
-       "        247       248       249       250       251  \n",
-       "0 -1.841345 -1.884289 -1.905393 -1.923905 -1.909153  \n",
-       "1 -1.639989 -1.678683 -1.729227 -1.775670 -1.789324  \n",
-       "2 -1.829069 -1.875828 -1.862512 -1.863368 -1.846493  \n",
-       "3 -1.951247 -2.012927 -2.026963 -2.073405 -2.075292  \n",
-       "4 -1.716886 -1.740726 -1.743442 -1.762729 -1.763428  \n",
-       "\n",
-       "[5 rows x 252 columns]"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "# 1, 2 - dealing with the separator and header\n",
-    "import pandas as pd\n",
-    "\n",
-    "df_panel = pd.read_csv(\n",
-    "    \"../sktime/datasets/data/ArrowHead/ArrowHead_TRAIN.tsv\",\n",
-    "    sep=\"\\t\",\n",
-    "    header=None,\n",
-    ")\n",
-    "df_panel.head()"
-   ]
+   "execution_count": 55
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:38:42.732377Z",
+     "start_time": "2024-08-24T04:38:42.729663Z"
+    }
+   },
    "source": [
     "# 2 - adding an instance index manually\n",
     "import numpy as np\n",
     "\n",
     "df_panel[\"instance\"] = np.repeat(range(len(df_panel) // 3), 3)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 56
   },
   {
    "attachments": {},
@@ -3470,23 +3754,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:38:50.793042Z",
+     "start_time": "2024-08-24T04:38:50.771758Z"
+    }
+   },
    "source": [
     "# 3 - add instance index\n",
     "df_panel.columns = [\"var\"] + [f\"value{i}\" for i in range(251)] + [\"instance\"]\n",
     "# 4 - move to long format\n",
     "df_panel = pd.wide_to_long(df_panel, \"value\", i=[\"var\", \"instance\"], j=\"time\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 57
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:38:52.982581Z",
+     "start_time": "2024-08-24T04:38:52.977727Z"
+    }
+   },
+   "source": [
+    "df_panel.head()"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "                      value\n",
+       "var instance time          \n",
+       "0   0        0    -1.963009\n",
+       "             1    -1.957825\n",
+       "             2    -1.956145\n",
+       "             3    -1.938289\n",
+       "             4    -1.896657"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -3543,25 +3848,14 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                      value\n",
-       "var instance time          \n",
-       "0   0        0    -1.963009\n",
-       "             1    -1.957825\n",
-       "             2    -1.956145\n",
-       "             3    -1.938289\n",
-       "             4    -1.896657"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "df_panel.head()"
-   ]
+   "execution_count": 58
   },
   {
    "attachments": {},
@@ -3573,22 +3867,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:38:58.150883Z",
+     "start_time": "2024-08-24T04:38:58.144495Z"
+    }
+   },
    "source": [
     "# 3 - move variable index to columns\n",
     "df_panel = df_panel.reset_index(\"var\")\n",
     "df_panel = df_panel.pivot(columns=\"var\", values=\"value\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 59
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:38:59.920937Z",
+     "start_time": "2024-08-24T04:38:59.916344Z"
+    }
+   },
+   "source": [
+    "df_panel.head()"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "var                   0         1         2\n",
+       "instance time                              \n",
+       "0        0    -1.963009 -1.774571 -1.866021\n",
+       "         1    -1.957825 -1.774036 -1.841991\n",
+       "         2    -1.956145 -1.776586 -1.835025\n",
+       "         3    -1.938289 -1.730749 -1.811902\n",
+       "         4    -1.896657 -1.696268 -1.764390"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -3656,25 +3971,14 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "var                   0         1         2\n",
-       "instance time                              \n",
-       "0        0    -1.963009 -1.774571 -1.866021\n",
-       "         1    -1.957825 -1.774036 -1.841991\n",
-       "         2    -1.956145 -1.776586 -1.835025\n",
-       "         3    -1.938289 -1.730749 -1.811902\n",
-       "         4    -1.896657 -1.696268 -1.764390"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "df_panel.head()"
-   ]
+   "execution_count": 60
   },
   {
    "attachments": {},
@@ -3686,8 +3990,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-24T04:39:02.332143Z",
+     "start_time": "2024-08-24T04:39:02.329056Z"
+    }
+   },
+   "source": [
+    "mtype(df_panel, as_scitype=\"Panel\")"
+   ],
    "outputs": [
     {
      "data": {
@@ -3695,14 +4006,12 @@
        "'pd-multiindex'"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "mtype(df_panel, as_scitype=\"Panel\")"
-   ]
+   "execution_count": 61
   },
   {
    "attachments": {},
@@ -3712,6 +4021,13 @@
     "an alternative route would be removing the index,\n",
     "and using reshapes in `numpy`."
    ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": ""
   }
  ],
  "metadata": {

--- a/examples/AA_datatypes_and_datasets.ipynb
+++ b/examples/AA_datatypes_and_datasets.ipynb
@@ -18,8 +18,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:36:59.221642Z",
-     "start_time": "2024-08-24T04:36:59.219912Z"
+     "end_time": "2024-08-26T08:15:00.541675Z",
+     "start_time": "2024-08-26T08:15:00.539225Z"
     }
    },
    "source": [
@@ -27,7 +27,7 @@
     "# sys.path.append(\"..\")"
    ],
    "outputs": [],
-   "execution_count": 2
+   "execution_count": 1
   },
   {
    "attachments": {},
@@ -98,13 +98,18 @@
   },
   {
    "cell_type": "code",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-26T08:15:01.636492Z",
+     "start_time": "2024-08-26T08:15:01.009422Z"
+    }
+   },
    "source": [
     "# import to retrieve examples\n",
     "from sktime.datatypes import get_examples"
    ],
    "outputs": [],
-   "execution_count": null
+   "execution_count": 2
   },
   {
    "attachments": {},
@@ -136,8 +141,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.255151Z",
-     "start_time": "2024-08-24T04:37:00.248568Z"
+     "end_time": "2024-08-26T08:15:01.642609Z",
+     "start_time": "2024-08-26T08:15:01.637335Z"
     }
    },
    "source": [
@@ -197,12 +202,12 @@
        "</div>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 4
+   "execution_count": 3
   },
   {
    "attachments": {},
@@ -217,8 +222,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.260056Z",
-     "start_time": "2024-08-24T04:37:00.256008Z"
+     "end_time": "2024-08-26T08:15:01.646536Z",
+     "start_time": "2024-08-26T08:15:01.643114Z"
     }
    },
    "source": [
@@ -283,12 +288,12 @@
        "</div>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 5
+   "execution_count": 4
   },
   {
    "attachments": {},
@@ -320,8 +325,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.264775Z",
-     "start_time": "2024-08-24T04:37:00.261573Z"
+     "end_time": "2024-08-26T08:15:01.650297Z",
+     "start_time": "2024-08-26T08:15:01.647873Z"
     }
    },
    "source": [
@@ -338,12 +343,12 @@
        "Name: a, dtype: float64"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 6
+   "execution_count": 5
   },
   {
    "attachments": {},
@@ -375,8 +380,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.268202Z",
-     "start_time": "2024-08-24T04:37:00.265604Z"
+     "end_time": "2024-08-26T08:15:01.653165Z",
+     "start_time": "2024-08-26T08:15:01.650789Z"
     }
    },
    "source": [
@@ -392,12 +397,12 @@
        "       [-3. ]])"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 7
+   "execution_count": 6
   },
   {
    "attachments": {},
@@ -412,8 +417,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.271341Z",
-     "start_time": "2024-08-24T04:37:00.269052Z"
+     "end_time": "2024-08-26T08:15:01.656017Z",
+     "start_time": "2024-08-26T08:15:01.653685Z"
     }
    },
    "source": [
@@ -429,12 +434,12 @@
        "       [-3.        , -0.42857143]])"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 8
+   "execution_count": 7
   },
   {
    "attachments": {},
@@ -493,8 +498,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.276656Z",
-     "start_time": "2024-08-24T04:37:00.272162Z"
+     "end_time": "2024-08-26T08:15:01.660173Z",
+     "start_time": "2024-08-26T08:15:01.656703Z"
     }
    },
    "source": [
@@ -600,12 +605,12 @@
        "</div>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 9
+   "execution_count": 8
   },
   {
    "attachments": {},
@@ -639,8 +644,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.279741Z",
-     "start_time": "2024-08-24T04:37:00.277305Z"
+     "end_time": "2024-08-26T08:15:01.662919Z",
+     "start_time": "2024-08-26T08:15:01.660635Z"
     }
    },
    "source": [
@@ -660,12 +665,12 @@
        "        [42,  5,  6]]])"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 10
+   "execution_count": 9
   },
   {
    "attachments": {},
@@ -699,8 +704,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.283703Z",
-     "start_time": "2024-08-24T04:37:00.280381Z"
+     "end_time": "2024-08-26T08:15:01.666518Z",
+     "start_time": "2024-08-26T08:15:01.663587Z"
     }
    },
    "source": [
@@ -724,12 +729,12 @@
        " 2      3      6]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 11
+   "execution_count": 10
   },
   {
    "attachments": {},
@@ -764,8 +769,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.291587Z",
-     "start_time": "2024-08-24T04:37:00.286467Z"
+     "end_time": "2024-08-26T08:15:01.672217Z",
+     "start_time": "2024-08-26T08:15:01.668364Z"
     }
    },
    "source": [
@@ -932,12 +937,12 @@
        "</div>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 12
+   "execution_count": 11
   },
   {
    "attachments": {},
@@ -986,8 +991,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.294310Z",
-     "start_time": "2024-08-24T04:37:00.292268Z"
+     "end_time": "2024-08-26T08:15:01.674744Z",
+     "start_time": "2024-08-26T08:15:01.673096Z"
     }
    },
    "source": [
@@ -996,7 +1001,7 @@
     "y = np.array([1, 6, 3, 7, 2])"
    ],
    "outputs": [],
-   "execution_count": 13
+   "execution_count": 12
   },
   {
    "attachments": {},
@@ -1012,8 +1017,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.296674Z",
-     "start_time": "2024-08-24T04:37:00.294992Z"
+     "end_time": "2024-08-26T08:15:01.676786Z",
+     "start_time": "2024-08-26T08:15:01.675343Z"
     }
    },
    "source": [
@@ -1022,7 +1027,7 @@
     "# check_raise(y, mtype=\"np.ndarray\")"
    ],
    "outputs": [],
-   "execution_count": 14
+   "execution_count": 13
   },
   {
    "attachments": {},
@@ -1036,8 +1041,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.299892Z",
-     "start_time": "2024-08-24T04:37:00.297537Z"
+     "end_time": "2024-08-26T08:15:01.679999Z",
+     "start_time": "2024-08-26T08:15:01.677888Z"
     }
    },
    "source": [
@@ -1048,6 +1053,52 @@
      "data": {
       "text/plain": [
        "True"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 14
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For use in own code or additional metadata, the error message can be obtained using the `check_is_mtype` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-26T08:15:01.683186Z",
+     "start_time": "2024-08-26T08:15:01.680900Z"
+    }
+   },
+   "source": [
+    "from sktime.datatypes import check_is_mtype\n",
+    "\n",
+    "check_is_mtype(y, mtype=\"np.ndarray\", return_metadata=True)"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True,\n",
+       " None,\n",
+       " {'is_empty': False,\n",
+       "  'is_univariate': True,\n",
+       "  'n_features': 1,\n",
+       "  'feature_names': [0],\n",
+       "  'dtypekind_dfip': [<DtypeKind.FLOAT: 2>],\n",
+       "  'feature_kind': [<DtypeKind.FLOAT: 2>],\n",
+       "  'is_equally_spaced': True,\n",
+       "  'has_nans': False,\n",
+       "  'mtype': 'np.ndarray',\n",
+       "  'scitype': 'Series'})"
       ]
      },
      "execution_count": 15,
@@ -1062,21 +1113,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For use in own code or additional metadata, the error message can be obtained using the `check_is_mtype` function:"
+    "and metadata is produced if the argument passes the validity check:"
    ]
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.303245Z",
-     "start_time": "2024-08-24T04:37:00.300571Z"
+     "end_time": "2024-08-26T08:15:01.686608Z",
+     "start_time": "2024-08-26T08:15:01.683671Z"
     }
    },
    "source": [
-    "from sktime.datatypes import check_is_mtype\n",
-    "\n",
-    "check_is_mtype(y, mtype=\"np.ndarray\", return_metadata=True)"
+    "check_is_mtype(y.reshape(-1, 1), mtype=\"np.ndarray\", return_metadata=True)"
    ],
    "outputs": [
     {
@@ -1108,50 +1157,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "and metadata is produced if the argument passes the validity check:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.307016Z",
-     "start_time": "2024-08-24T04:37:00.304102Z"
-    }
-   },
-   "source": [
-    "check_is_mtype(y.reshape(-1, 1), mtype=\"np.ndarray\", return_metadata=True)"
-   ],
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(True,\n",
-       " None,\n",
-       " {'is_empty': False,\n",
-       "  'is_univariate': True,\n",
-       "  'n_features': 1,\n",
-       "  'feature_names': [0],\n",
-       "  'dtypekind_dfip': [<DtypeKind.FLOAT: 2>],\n",
-       "  'feature_kind': [<DtypeKind.FLOAT: 2>],\n",
-       "  'is_equally_spaced': True,\n",
-       "  'has_nans': False,\n",
-       "  'mtype': 'np.ndarray',\n",
-       "  'scitype': 'Series'})"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 17
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Note: if the name of the mtype is ambiguous and can refer to multiple scitypes, the additional argument `scitype` must be provided. This should not be the case for any common in-memory containers, we mention this for completeness."
    ]
   },
@@ -1159,8 +1164,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.310436Z",
-     "start_time": "2024-08-24T04:37:00.307965Z"
+     "end_time": "2024-08-26T08:15:01.691767Z",
+     "start_time": "2024-08-26T08:15:01.687186Z"
     }
    },
    "source": [
@@ -1173,12 +1178,12 @@
        "True"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 18
+   "execution_count": 17
   },
   {
    "attachments": {},
@@ -1194,8 +1199,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.315941Z",
-     "start_time": "2024-08-24T04:37:00.311315Z"
+     "end_time": "2024-08-26T08:15:01.724156Z",
+     "start_time": "2024-08-26T08:15:01.692858Z"
     }
    },
    "source": [
@@ -1211,7 +1216,7 @@
     ").set_index([\"instances\", \"time points\"])"
    ],
    "outputs": [],
-   "execution_count": 19
+   "execution_count": 18
   },
   {
    "attachments": {},
@@ -1227,8 +1232,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.318597Z",
-     "start_time": "2024-08-24T04:37:00.316810Z"
+     "end_time": "2024-08-26T08:15:01.726294Z",
+     "start_time": "2024-08-26T08:15:01.724947Z"
     }
    },
    "source": [
@@ -1237,7 +1242,7 @@
     "# check_raise(X, mtype=\"pd-multiindex\")"
    ],
    "outputs": [],
-   "execution_count": 20
+   "execution_count": 19
   },
   {
    "attachments": {},
@@ -1251,15 +1256,15 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.321952Z",
-     "start_time": "2024-08-24T04:37:00.319590Z"
+     "end_time": "2024-08-26T08:15:01.728287Z",
+     "start_time": "2024-08-26T08:15:01.726842Z"
     }
    },
    "source": [
     "X.index.names = [\"instances\", \"timepoints\"]"
    ],
    "outputs": [],
-   "execution_count": 21
+   "execution_count": 20
   },
   {
    "attachments": {},
@@ -1273,8 +1278,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.325471Z",
-     "start_time": "2024-08-24T04:37:00.322698Z"
+     "end_time": "2024-08-26T08:15:01.731347Z",
+     "start_time": "2024-08-26T08:15:01.729014Z"
     }
    },
    "source": [
@@ -1287,12 +1292,12 @@
        "True"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 22
+   "execution_count": 21
   },
   {
    "attachments": {},
@@ -1308,8 +1313,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.328851Z",
-     "start_time": "2024-08-24T04:37:00.326274Z"
+     "end_time": "2024-08-26T08:15:01.734278Z",
+     "start_time": "2024-08-26T08:15:01.731899Z"
     }
    },
    "source": [
@@ -1324,12 +1329,12 @@
        "'pd-multiindex'"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 23
+   "execution_count": 22
   },
   {
    "attachments": {},
@@ -1357,8 +1362,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.332333Z",
-     "start_time": "2024-08-24T04:37:00.329572Z"
+     "end_time": "2024-08-26T08:15:01.737149Z",
+     "start_time": "2024-08-26T08:15:01.734847Z"
     }
    },
    "source": [
@@ -1381,6 +1386,126 @@
        "        [42,  5,  6]]])"
       ]
      },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 23
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-26T08:15:01.742985Z",
+     "start_time": "2024-08-26T08:15:01.737766Z"
+    }
+   },
+   "source": [
+    "from sktime.datatypes import convert\n",
+    "\n",
+    "convert(X, from_type=\"numpy3D\", to_type=\"pd-multiindex\")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "                      var_0  var_1\n",
+       "instances timepoints              \n",
+       "0         0               1      4\n",
+       "          1               2      5\n",
+       "          2               3      6\n",
+       "1         0               1      4\n",
+       "          1               2     55\n",
+       "          2               3      6\n",
+       "2         0               1     42\n",
+       "          1               2      5\n",
+       "          2               3      6"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>var_0</th>\n",
+       "      <th>var_1</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>instances</th>\n",
+       "      <th>timepoints</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">0</th>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">1</th>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>55</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">2</th>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>42</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
      "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
@@ -1392,14 +1517,14 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.341912Z",
-     "start_time": "2024-08-24T04:37:00.336041Z"
+     "end_time": "2024-08-26T08:15:01.747765Z",
+     "start_time": "2024-08-26T08:15:01.743572Z"
     }
    },
    "source": [
-    "from sktime.datatypes import convert\n",
+    "from sktime.datatypes import convert_to\n",
     "\n",
-    "convert(X, from_type=\"numpy3D\", to_type=\"pd-multiindex\")"
+    "convert_to(X, to_type=\"pd-multiindex\")"
    ],
    "outputs": [
     {
@@ -1509,126 +1634,6 @@
    "execution_count": 25
   },
   {
-   "cell_type": "code",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.365394Z",
-     "start_time": "2024-08-24T04:37:00.359673Z"
-    }
-   },
-   "source": [
-    "from sktime.datatypes import convert_to\n",
-    "\n",
-    "convert_to(X, to_type=\"pd-multiindex\")"
-   ],
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "                      var_0  var_1\n",
-       "instances timepoints              \n",
-       "0         0               1      4\n",
-       "          1               2      5\n",
-       "          2               3      6\n",
-       "1         0               1      4\n",
-       "          1               2     55\n",
-       "          2               3      6\n",
-       "2         0               1     42\n",
-       "          1               2      5\n",
-       "          2               3      6"
-      ],
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th>var_0</th>\n",
-       "      <th>var_1</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>instances</th>\n",
-       "      <th>timepoints</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th rowspan=\"3\" valign=\"top\">0</th>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th rowspan=\"3\" valign=\"top\">1</th>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>55</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th rowspan=\"3\" valign=\"top\">2</th>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>42</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 26
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -1644,8 +1649,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.625382Z",
-     "start_time": "2024-08-24T04:37:00.622134Z"
+     "end_time": "2024-08-26T08:15:01.750561Z",
+     "start_time": "2024-08-26T08:15:01.748492Z"
     }
    },
    "source": [
@@ -1653,6 +1658,40 @@
     "\n",
     "X = get_examples(mtype=\"numpy3D\", as_scitype=\"Panel\")[0]\n",
     "X"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[[ 1,  2,  3],\n",
+       "        [ 4,  5,  6]],\n",
+       "\n",
+       "       [[ 1,  2,  3],\n",
+       "        [ 4, 55,  6]],\n",
+       "\n",
+       "       [[ 1,  2,  3],\n",
+       "        [42,  5,  6]]])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 26
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-26T08:15:01.753548Z",
+     "start_time": "2024-08-26T08:15:01.751221Z"
+    }
+   },
+   "source": [
+    "from sktime.datatypes import convert_to\n",
+    "\n",
+    "convert_to(X, to_type=[\"pd-multiindex\", \"numpy3D\"])"
    ],
    "outputs": [
     {
@@ -1679,42 +1718,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.840857Z",
-     "start_time": "2024-08-24T04:37:00.838019Z"
-    }
-   },
-   "source": [
-    "from sktime.datatypes import convert_to\n",
-    "\n",
-    "convert_to(X, to_type=[\"pd-multiindex\", \"numpy3D\"])"
-   ],
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[[ 1,  2,  3],\n",
-       "        [ 4,  5,  6]],\n",
-       "\n",
-       "       [[ 1,  2,  3],\n",
-       "        [ 4, 55,  6]],\n",
-       "\n",
-       "       [[ 1,  2,  3],\n",
-       "        [42,  5,  6]]])"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 28
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:00.935929Z",
-     "start_time": "2024-08-24T04:37:00.931750Z"
+     "end_time": "2024-08-26T08:15:01.757043Z",
+     "start_time": "2024-08-26T08:15:01.754070Z"
     }
    },
    "source": [
@@ -1739,19 +1744,19 @@
        " 2      3      6]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 29
+   "execution_count": 28
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.029148Z",
-     "start_time": "2024-08-24T04:37:01.023979Z"
+     "end_time": "2024-08-26T08:15:01.763974Z",
+     "start_time": "2024-08-26T08:15:01.760386Z"
     }
    },
    "source": [
@@ -1857,12 +1862,12 @@
        "</div>"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 30
+   "execution_count": 29
   },
   {
    "attachments": {},
@@ -1879,8 +1884,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.064335Z",
-     "start_time": "2024-08-24T04:37:01.058735Z"
+     "end_time": "2024-08-26T08:15:01.768232Z",
+     "start_time": "2024-08-26T08:15:01.764493Z"
     }
    },
    "source": [
@@ -2080,12 +2085,12 @@
        "</div>"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 31
+   "execution_count": 30
   },
   {
    "attachments": {},
@@ -2139,8 +2144,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.695736Z",
-     "start_time": "2024-08-24T04:37:01.121299Z"
+     "end_time": "2024-08-26T08:15:02.256504Z",
+     "start_time": "2024-08-26T08:15:01.768865Z"
     }
    },
    "source": [
@@ -2167,12 +2172,12 @@
        "Freq: M, Name: Number of airline passengers, Length: 144, dtype: float64"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 32
+   "execution_count": 31
   },
   {
    "attachments": {},
@@ -2188,8 +2193,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.703421Z",
-     "start_time": "2024-08-24T04:37:01.696880Z"
+     "end_time": "2024-08-26T08:15:02.263181Z",
+     "start_time": "2024-08-26T08:15:02.257302Z"
     }
    },
    "source": [
@@ -2218,7 +2223,7 @@
        " 1960    69564.0\n",
        " 1961    69331.0\n",
        " 1962    70551.0\n",
-       " Freq: Y-DEC, Name: TOTEMP, dtype: float64,\n",
+       " Freq: A-DEC, Name: TOTEMP, dtype: float64,\n",
        "         GNPDEFL       GNP   UNEMP   ARMED       POP\n",
        " Period                                             \n",
        " 1947       83.0  234289.0  2356.0  1590.0  107608.0\n",
@@ -2239,12 +2244,12 @@
        " 1962      116.9  554894.0  4007.0  2827.0  130081.0)"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 33
+   "execution_count": 32
   },
   {
    "attachments": {},
@@ -2258,22 +2263,22 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.707961Z",
-     "start_time": "2024-08-24T04:37:01.704400Z"
+     "end_time": "2024-08-26T08:15:02.266849Z",
+     "start_time": "2024-08-26T08:15:02.263930Z"
     }
    },
    "source": [
     "y, X = load_longley(y_name=\"TOTEMP\")"
    ],
    "outputs": [],
-   "execution_count": 34
+   "execution_count": 33
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.713321Z",
-     "start_time": "2024-08-24T04:37:01.709803Z"
+     "end_time": "2024-08-26T08:15:02.269877Z",
+     "start_time": "2024-08-26T08:15:02.267392Z"
     }
    },
    "source": [
@@ -2300,22 +2305,22 @@
        "1960    69564.0\n",
        "1961    69331.0\n",
        "1962    70551.0\n",
-       "Freq: Y-DEC, Name: TOTEMP, dtype: float64"
+       "Freq: A-DEC, Name: TOTEMP, dtype: float64"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 35
+   "execution_count": 34
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.720632Z",
-     "start_time": "2024-08-24T04:37:01.714112Z"
+     "end_time": "2024-08-26T08:15:02.276256Z",
+     "start_time": "2024-08-26T08:15:02.271327Z"
     }
    },
    "source": [
@@ -2512,12 +2517,12 @@
        "</div>"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 36
+   "execution_count": 35
   },
   {
    "attachments": {},
@@ -2560,8 +2565,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.742436Z",
-     "start_time": "2024-08-24T04:37:01.721627Z"
+     "end_time": "2024-08-26T08:15:02.291103Z",
+     "start_time": "2024-08-26T08:15:02.276735Z"
     }
    },
    "source": [
@@ -2570,14 +2575,14 @@
     "X, y = load_arrow_head(return_X_y=True)"
    ],
    "outputs": [],
-   "execution_count": 37
+   "execution_count": 36
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.754321Z",
-     "start_time": "2024-08-24T04:37:01.743200Z"
+     "end_time": "2024-08-26T08:15:02.538352Z",
+     "start_time": "2024-08-26T08:15:02.531020Z"
     }
    },
    "source": [
@@ -2715,19 +2720,19 @@
        "</div>"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 38
+   "execution_count": 37
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.757522Z",
-     "start_time": "2024-08-24T04:37:01.755123Z"
+     "end_time": "2024-08-26T08:15:02.633126Z",
+     "start_time": "2024-08-26T08:15:02.630801Z"
     }
    },
    "source": [
@@ -2756,12 +2761,12 @@
        "       '2', '2', '2'], dtype='<U1')"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 39
+   "execution_count": 38
   },
   {
    "attachments": {},
@@ -2775,8 +2780,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.818063Z",
-     "start_time": "2024-08-24T04:37:01.758439Z"
+     "end_time": "2024-08-26T08:15:02.883197Z",
+     "start_time": "2024-08-26T08:15:02.824744Z"
     }
    },
    "source": [
@@ -2880,12 +2885,12 @@
        "</div>"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 40
+   "execution_count": 39
   },
   {
    "attachments": {},
@@ -2899,8 +2904,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.840587Z",
-     "start_time": "2024-08-24T04:37:01.820440Z"
+     "end_time": "2024-08-26T08:15:02.919909Z",
+     "start_time": "2024-08-26T08:15:02.905862Z"
     }
    },
    "source": [
@@ -2909,7 +2914,7 @@
     "# this retrieves training and test X/y for reproducible use in studies"
    ],
    "outputs": [],
-   "execution_count": 41
+   "execution_count": 40
   },
   {
    "attachments": {},
@@ -2927,15 +2932,15 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.843750Z",
-     "start_time": "2024-08-24T04:37:01.841323Z"
+     "end_time": "2024-08-26T08:15:02.996321Z",
+     "start_time": "2024-08-26T08:15:02.992695Z"
     }
    },
    "source": [
     "from sktime.datasets.tsc_dataset_names import univariate"
    ],
    "outputs": [],
-   "execution_count": 42
+   "execution_count": 41
   },
   {
    "attachments": {},
@@ -2963,8 +2968,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.847485Z",
-     "start_time": "2024-08-24T04:37:01.844473Z"
+     "end_time": "2024-08-26T08:15:03.035382Z",
+     "start_time": "2024-08-26T08:15:03.032483Z"
     }
    },
    "source": [
@@ -3104,12 +3109,12 @@
        " 'WormsTwoClass']"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 43
+   "execution_count": 42
   },
   {
    "attachments": {},
@@ -3123,8 +3128,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.868896Z",
-     "start_time": "2024-08-24T04:37:01.848185Z"
+     "end_time": "2024-08-26T08:15:03.109424Z",
+     "start_time": "2024-08-26T08:15:03.095040Z"
     }
    },
    "source": [
@@ -3133,7 +3138,7 @@
     "X, y = load_UCR_UEA_dataset(name=\"ArrowHead\", return_X_y=True)"
    ],
    "outputs": [],
-   "execution_count": 44
+   "execution_count": 43
   },
   {
    "attachments": {},
@@ -3180,8 +3185,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.874459Z",
-     "start_time": "2024-08-24T04:37:01.869647Z"
+     "end_time": "2024-08-26T08:15:03.140980Z",
+     "start_time": "2024-08-26T08:15:03.136675Z"
     }
    },
    "source": [
@@ -3255,19 +3260,19 @@
        "</div>"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 45
+   "execution_count": 44
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.878130Z",
-     "start_time": "2024-08-24T04:37:01.875373Z"
+     "end_time": "2024-08-26T08:15:03.224606Z",
+     "start_time": "2024-08-26T08:15:03.222309Z"
     }
    },
    "source": [
@@ -3277,14 +3282,14 @@
     "df_series.index = pd.DatetimeIndex(df_series.index)"
    ],
    "outputs": [],
-   "execution_count": 46
+   "execution_count": 45
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:37:01.881579Z",
-     "start_time": "2024-08-24T04:37:01.879006Z"
+     "end_time": "2024-08-26T08:15:03.253907Z",
+     "start_time": "2024-08-26T08:15:03.251507Z"
     }
    },
    "source": [
@@ -3297,12 +3302,12 @@
        "'pd.Series'"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 47
+   "execution_count": 46
   },
   {
    "attachments": {},
@@ -3316,8 +3321,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-26T08:04:46.421637Z",
-     "start_time": "2024-08-26T08:04:46.411573Z"
+     "end_time": "2024-08-26T08:15:03.307312Z",
+     "start_time": "2024-08-26T08:15:03.297934Z"
     }
    },
    "source": [
@@ -3328,14 +3333,14 @@
     "# imagine this is the result of df_panel = pd.read_csv"
    ],
    "outputs": [],
-   "execution_count": 10
+   "execution_count": 47
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-26T08:04:48.440141Z",
-     "start_time": "2024-08-26T08:04:48.435921Z"
+     "end_time": "2024-08-26T08:15:03.340912Z",
+     "start_time": "2024-08-26T08:15:03.337587Z"
     }
    },
    "source": [
@@ -3412,12 +3417,12 @@
        "</div>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 11
+   "execution_count": 48
   },
   {
    "attachments": {},
@@ -3433,8 +3438,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-26T08:05:24.994024Z",
-     "start_time": "2024-08-26T08:05:24.989950Z"
+     "end_time": "2024-08-26T08:15:03.426051Z",
+     "start_time": "2024-08-26T08:15:03.422039Z"
     }
    },
    "source": [
@@ -3448,12 +3453,12 @@
        "pandas.core.indexes.multi.MultiIndex"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 12
+   "execution_count": 49
   },
   {
    "attachments": {},
@@ -3465,15 +3470,31 @@
   },
   {
    "cell_type": "code",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-26T08:15:03.450593Z",
+     "start_time": "2024-08-26T08:15:03.447597Z"
+    }
+   },
    "source": [
     "mtype(df_panel, as_scitype=\"Panel\")\n",
     "# in general:\n",
     "# replace \"timepoints\" with the time index column name\n",
     "# replace \"level_0\" with the higher level column name of your file"
    ],
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'pd-multiindex'"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 50
   },
   {
    "attachments": {},
@@ -3509,8 +3530,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:38:39.741633Z",
-     "start_time": "2024-08-24T04:38:39.727502Z"
+     "end_time": "2024-08-26T08:15:03.500809Z",
+     "start_time": "2024-08-26T08:15:03.491052Z"
     }
    },
    "source": [
@@ -3720,19 +3741,19 @@
        "</div>"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 55
+   "execution_count": 51
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:38:42.732377Z",
-     "start_time": "2024-08-24T04:38:42.729663Z"
+     "end_time": "2024-08-26T08:15:03.530403Z",
+     "start_time": "2024-08-26T08:15:03.528096Z"
     }
    },
    "source": [
@@ -3742,7 +3763,7 @@
     "df_panel[\"instance\"] = np.repeat(range(len(df_panel) // 3), 3)"
    ],
    "outputs": [],
-   "execution_count": 56
+   "execution_count": 52
   },
   {
    "attachments": {},
@@ -3756,8 +3777,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:38:50.793042Z",
-     "start_time": "2024-08-24T04:38:50.771758Z"
+     "end_time": "2024-08-26T08:15:03.641750Z",
+     "start_time": "2024-08-26T08:15:03.624513Z"
     }
    },
    "source": [
@@ -3767,14 +3788,14 @@
     "df_panel = pd.wide_to_long(df_panel, \"value\", i=[\"var\", \"instance\"], j=\"time\")"
    ],
    "outputs": [],
-   "execution_count": 57
+   "execution_count": 53
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:38:52.982581Z",
-     "start_time": "2024-08-24T04:38:52.977727Z"
+     "end_time": "2024-08-26T08:15:03.680180Z",
+     "start_time": "2024-08-26T08:15:03.676811Z"
     }
    },
    "source": [
@@ -3850,12 +3871,12 @@
        "</div>"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 58
+   "execution_count": 54
   },
   {
    "attachments": {},
@@ -3869,8 +3890,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:38:58.150883Z",
-     "start_time": "2024-08-24T04:38:58.144495Z"
+     "end_time": "2024-08-26T08:15:03.779723Z",
+     "start_time": "2024-08-26T08:15:03.775017Z"
     }
    },
    "source": [
@@ -3879,14 +3900,14 @@
     "df_panel = df_panel.pivot(columns=\"var\", values=\"value\")"
    ],
    "outputs": [],
-   "execution_count": 59
+   "execution_count": 55
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:38:59.920937Z",
-     "start_time": "2024-08-24T04:38:59.916344Z"
+     "end_time": "2024-08-26T08:15:03.810384Z",
+     "start_time": "2024-08-26T08:15:03.806842Z"
     }
    },
    "source": [
@@ -3973,12 +3994,12 @@
        "</div>"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 60
+   "execution_count": 56
   },
   {
    "attachments": {},
@@ -3992,8 +4013,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-24T04:39:02.332143Z",
-     "start_time": "2024-08-24T04:39:02.329056Z"
+     "end_time": "2024-08-26T08:15:03.849489Z",
+     "start_time": "2024-08-26T08:15:03.847128Z"
     }
    },
    "source": [
@@ -4006,12 +4027,12 @@
        "'pd-multiindex'"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 61
+   "execution_count": 57
   },
   {
    "attachments": {},
@@ -4023,11 +4044,16 @@
    ]
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-26T08:15:03.912748Z",
+     "start_time": "2024-08-26T08:15:03.911203Z"
+    }
+   },
    "cell_type": "code",
+   "source": "",
    "outputs": [],
-   "execution_count": null,
-   "source": ""
+   "execution_count": 57
   }
  ],
  "metadata": {

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -845,7 +845,11 @@ def from_nested_to_multi_index_adp(obj, store=None):
         time_index = store["index_names"][1]
     else:
         instance_index = obj.index.names[0]
-        time_index = obj.iloc[0, 0].index.names[0]
+        ser = obj.iloc[0, 0]
+        if hasattr(ser, "index"):
+            time_index = ser.index.names[0]
+        else:
+            time_index = None
 
     res = from_nested_to_multi_index(
         X=obj, instance_index=instance_index, time_index=time_index

--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -845,7 +845,7 @@ def from_nested_to_multi_index_adp(obj, store=None):
         time_index = store["index_names"][1]
     else:
         instance_index = obj.index.names[0]
-        time_index = "timepoints"
+        time_index = obj.iloc[0, 0].index.names[0]
 
     res = from_nested_to_multi_index(
         X=obj, instance_index=instance_index, time_index=time_index

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -70,13 +70,19 @@ example_dict_lossy[("pd-multiindex", "Panel", 0)] = False
 
 cols = [f"var_{i}" for i in range(2)]
 X = pd.DataFrame(columns=cols, index=pd.RangeIndex(3))
-X["var_0"] = pd.Series(
-    [pd.Series([1, 2, 3]), pd.Series([1, 2, 3]), pd.Series([1, 2, 3])]
-)
-
-X["var_1"] = pd.Series(
-    [pd.Series([4, 5, 6]), pd.Series([4, 55, 6]), pd.Series([42, 5, 6])]
-)
+nestes_series = [
+    pd.Series([1, 2, 3], index=pd.Index([0, 1, 2], name="timepoints")),
+    pd.Series([1, 2, 3], index=pd.Index([0, 1, 2], name="timepoints")),
+    pd.Series([1, 2, 3], index=pd.Index([0, 1, 2], name="timepoints")),
+]
+X["var_0"] = pd.Series(nestes_series)
+nestes_series_2 = [
+    pd.Series([4, 5, 6], index=pd.Index([0, 1, 2], name="timepoints")),
+    pd.Series([4, 55, 6], index=pd.Index([0, 1, 2], name="timepoints")),
+    pd.Series([42, 5, 6], index=pd.Index([0, 1, 2], name="timepoints")),
+]
+X["var_1"] = pd.Series(nestes_series_2)
+X.index.name = "instances"
 
 example_dict[("nested_univ", "Panel", 0)] = X
 example_dict_lossy[("nested_univ", "Panel", 0)] = False
@@ -172,9 +178,13 @@ example_dict_lossy[("pd-multiindex", "Panel", 1)] = False
 
 cols = [f"var_{i}" for i in range(1)]
 X = pd.DataFrame(columns=cols, index=pd.RangeIndex(3))
-X["var_0"] = pd.Series(
-    [pd.Series([4, 5, 6]), pd.Series([4, 55, 6]), pd.Series([42, 5, 6])]
-)
+data = [
+    pd.Series([4, 5, 6], index=pd.Index([0, 1, 2], name="timepoints")),
+    pd.Series([4, 55, 6], index=pd.Index([0, 1, 2], name="timepoints")),
+    pd.Series([42, 5, 6], index=pd.Index([0, 1, 2], name="timepoints")),
+]
+X["var_0"] = pd.Series(data)
+X.index.name = "instances"
 
 example_dict[("nested_univ", "Panel", 1)] = X
 example_dict_lossy[("nested_univ", "Panel", 1)] = False
@@ -262,7 +272,10 @@ example_dict_lossy[("pd-multiindex", "Panel", 2)] = False
 
 cols = [f"var_{i}" for i in range(1)]
 X = pd.DataFrame(columns=cols, index=pd.RangeIndex(1))
-X["var_0"] = pd.Series([pd.Series([4, 5, 6])])
+X["var_0"] = pd.Series(
+    [pd.Series([4, 5, 6], index=pd.Index([0, 1, 2], name="timepoints"))]
+)
+X.index.name = "instances"
 
 example_dict[("nested_univ", "Panel", 2)] = X
 example_dict_lossy[("nested_univ", "Panel", 2)] = False


### PR DESCRIPTION
This PR fixes the `nested_univ` converter, to return the index name of series nested in the dataframe. 
Fixes #7025



