### PR TITLE
[ENH] placeholder record decorator

### DIFF
--- a/sktime/forecasting/prophetverse.py
+++ b/sktime/forecasting/prophetverse.py
@@ -6,29 +6,10 @@ __author__ = ["felipeangelimvieira"]  # fkiraly for adapter
 import pandas as pd
 
 from sktime.forecasting.base._delegate import _DelegatedForecaster
+from sktime.utils.dependencies import _placeholder_record
 
 
-def placeholder(cls):
-    """Delegate to prophetverse if installed, otherwise use placeholder.
-
-    If prophetverse 0.3 or higher is installed, this will directly
-    return the forecaster imported from prophetverse.
-    """
-    from sktime.utils.dependencies import _check_soft_dependencies
-
-    try:
-        if _check_soft_dependencies("prophetverse>=0.3.0", severity="none"):
-            from prophetverse.sktime import Prophetverse
-
-            return Prophetverse
-    except Exception:  # noqa: S110
-        pass
-
-    # else we return the placeholder, which is a delegator
-    return cls
-
-
-@placeholder
+@_placeholder_record("prophetverse.sktime", dependencies="prophetverse>=0.3.0")
 class Prophetverse(_DelegatedForecaster):
     """Univariate prophetverse forecaster - prophet model implemented in numpyro.
 

--- a/sktime/utils/dependencies/__init__.py
+++ b/sktime/utils/dependencies/__init__.py
@@ -8,6 +8,7 @@ from sktime.utils.dependencies._dependencies import (
     _check_python_version,
     _check_soft_dependencies,
 )
+from sktime.utils.dependencies._placeholder import _placeholder_record
 
 __all__ = [
     "_check_dl_dependencies",
@@ -16,4 +17,5 @@ __all__ = [
     "_check_mlflow_dependencies",
     "_check_python_version",
     "_check_soft_dependencies",
+    "_placeholder_record",
 ]

--- a/sktime/utils/dependencies/_placeholder.py
+++ b/sktime/utils/dependencies/_placeholder.py
@@ -6,7 +6,9 @@ e.g., estimators with sktime compatible interfaces from 2nd and 3rd party packag
 """
 
 
-def placeholder(cls, module_name, obj_name=None, dependencies=None, condition=True):
+def _placeholder_record(
+    cls, module_name, obj_name=None, dependencies=None, condition=True
+):
     """Replace placeholder cls with imported object if installed, otherwise return it.
 
     Ensures that decorated object is replaced with

--- a/sktime/utils/dependencies/_placeholder.py
+++ b/sktime/utils/dependencies/_placeholder.py
@@ -1,0 +1,68 @@
+"""Decorator to create placeholder records in sktime.
+
+Placeholder records are used for lookup and documentation generation,
+and can be used to point to direct imports from external packages,
+e.g., estimators with sktime compatible interfaces from 2nd and 3rd party packages.
+"""
+
+
+def placeholder(cls, module_name, obj_name=None, dependencies=None, condition=True):
+    """Replace placeholder cls with imported object if installed, otherwise return it.
+
+    Ensures that decorated object is replaced with
+    the object of name ``obj_name``, imported from ``module_name``, if possible.
+
+    Replacement is done if all of the following conditions are met:
+
+    * object ``obj_name`` exists at module ``module_name``.
+      If no ``obj_name`` is provided, the name of ``cls`` is used.
+    * if ``condition`` is True (default)
+    * if all dependencies of ``cls`` - i.e., the placeholder record - are satisfied
+    * if all dependencies in ``dependencies`` are satisfied, if any are provided,
+      these are checked via ``_check_soft_dependencies``.
+
+    Parameters
+    ----------
+    cls : class
+        Placeholder record to be replaced.
+    module_name : str
+        Name of the module to import from.
+    obj_name : str, optional, default = name of cls
+        Name of the object to import.
+        If None, the name of ``cls`` is used.
+    dependencies : optional, default=None
+        Dependencies to check. Passed as argument to ``_check_soft_dependencies``.
+    condition : bool, optional, default=True
+        Condition to check before loading the object.
+    """
+    from sktime.utils.dependencies import _check_estimator_deps
+
+    if obj_name is None:
+        obj_name = cls.__name__
+
+    load_condition = condition
+
+    deps_satisfied = _check_estimator_deps(cls, severity="none")
+
+    if dependencies is not None:
+        from sktime.utils.dependencies import _check_soft_dependencies
+
+        added_deps_satisfied = _check_soft_dependencies(dependencies, severity="none")
+        deps_satisfied = deps_satisfied and added_deps_satisfied
+
+    load_condition = load_condition and deps_satisfied
+
+    if not load_condition:
+        return cls
+
+    try:
+        # parse import_str to get the module and class name
+        module = __import__(module_name, fromlist=[obj_name])
+        imported_cls = getattr(module, obj_name)
+
+        return imported_cls
+    except Exception:  # noqa: S110
+        pass
+
+    # on failure, we also return the placeholder record itself
+    return cls

--- a/sktime/utils/dependencies/_placeholder.py
+++ b/sktime/utils/dependencies/_placeholder.py
@@ -35,6 +35,7 @@ def _placeholder_record(module_name, obj_name=None, dependencies=None, condition
     condition : bool, optional, default=True
         Condition to check before loading the object.
     """
+
     def decorator(cls):
         from sktime.utils.dependencies import _check_estimator_deps
 

--- a/sktime/utils/dependencies/_placeholder.py
+++ b/sktime/utils/dependencies/_placeholder.py
@@ -37,6 +37,7 @@ def _placeholder_record(module_name, obj_name=None, dependencies=None, condition
     """
 
     def decorator(cls):
+        nonlocal obj_name
         from sktime.utils.dependencies import _check_estimator_deps
 
         if obj_name is None:  # noqa: F823

--- a/sktime/utils/dependencies/_placeholder.py
+++ b/sktime/utils/dependencies/_placeholder.py
@@ -37,11 +37,14 @@ def _placeholder_record(module_name, obj_name=None, dependencies=None, condition
     """
 
     def decorator(cls):
-        nonlocal obj_name
         from sktime.utils.dependencies import _check_estimator_deps
 
-        if obj_name is None:  # noqa: F823
-            obj_name = cls.__name__
+        # we need to write to a new var _obj_name
+        # or obj_name will be considered local and lead to "not assigned" error
+        if obj_name is None:
+            _obj_name = cls.__name__
+        else:
+            _obj_name = obj_name
 
         load_condition = condition
 
@@ -60,8 +63,8 @@ def _placeholder_record(module_name, obj_name=None, dependencies=None, condition
 
         try:
             # parse import_str to get the module and class name
-            module = __import__(module_name, fromlist=[obj_name])
-            imported_cls = getattr(module, obj_name)
+            module = __import__(module_name, fromlist=[_obj_name])
+            imported_cls = getattr(module, _obj_name)
 
             return imported_cls
         except Exception:  # noqa: S110


### PR DESCRIPTION
This adds a placeholder record decorator for easy addition of external estimators to the index data records discoverable by the estimator overview or `all_estimators`.

It also replaces the current ad-hoc decorator for `Prophetverse` with this more general decorator.