### PR TITLE
[ENH] Add padded f1 score for evaluating change point detection algorithms

### DIFF
--- a/sktime/performance_metrics/annotation/metrics.py
+++ b/sktime/performance_metrics/annotation/metrics.py
@@ -94,7 +94,7 @@ def prediction_ratio(
     return pred_change_points.size / true_change_points.size
 
 
-def padded_f1(true_change_points, pred_change_points, threshold):
+def padded_f1(true_change_points, pred_change_points, pad):
     """Calculate padded F1 score for change point detection.
 
     Parameters
@@ -103,25 +103,28 @@ def padded_f1(true_change_points, pred_change_points, threshold):
         True change point positions. Can be integers, floats or datetimes.
     precicted_change_points: pd.Series
         Precicted change point positions. Can be integers, floats or datetimes.
-    threshold: int, float, timdelta
-        Threshold used to pad the true change points. If a predicted change point falls
-        withing the interval of the padded change point, the true change point is
-        treated as having been correctly identified.
+    pad: int, float, timdelta
+        Used to pad the true change points. If a predicted change point falls within
+        the range of the padded change then then change point has been correctly
+        identified.
 
     Returns
     -------
-        Padded f1 ratio
+    float
+        Padded f1 score
     """
-    boundary_left = true_change_points - threshold
-    boundary_right = true_change_points + threshold
+    true_change_points = pd.Series(true_change_points)
+    pred_change_points = pd.Series(pred_change_points)
 
+    boundary_left = true_change_points - pad
+    boundary_right = true_change_points + pad
     true_cp_intervals = pd.IntervalIndex.from_arrays(boundary_left, boundary_right)
 
     false_positives = 0
     tp_and_fn = pd.Series(False, index=true_cp_intervals)
     for cp in pred_change_points:
-        boolean_mask = true_cp_intervals.contains(cp)
-        if boolean_mask.all():
+        boolean_mask = tp_and_fn.index.contains(cp)
+        if boolean_mask.any() is False:
             false_positives += 1
         else:
             tp_and_fn = tp_and_fn | boolean_mask
@@ -129,8 +132,10 @@ def padded_f1(true_change_points, pred_change_points, threshold):
     true_positives = tp_and_fn.sum()
     false_negatives = (~tp_and_fn).sum()
 
-    precision = true_positives / (true_positives + false_positives)
-    recall = true_positives / (true_positives + false_negatives)
+    # Avoid division by zero to mimic sklearn behaviour
+    denom = 2 * true_positives + false_positives + false_negatives
+    if denom == 0:
+        return 0.0
 
-    padded_f1 = (2 * precision * recall) / (precision + recall)
+    padded_f1 = 2 * true_positives / denom
     return padded_f1

--- a/sktime/performance_metrics/annotation/metrics.py
+++ b/sktime/performance_metrics/annotation/metrics.py
@@ -122,9 +122,10 @@ def padded_f1(true_change_points, pred_change_points, pad):
 
     false_positives = 0
     tp_and_fn = pd.Series(False, index=true_cp_intervals)
+
     for cp in pred_change_points:
         boolean_mask = tp_and_fn.index.contains(cp)
-        if boolean_mask.any() is False:
+        if not boolean_mask.any():
             false_positives += 1
         else:
             tp_and_fn = tp_and_fn | boolean_mask

--- a/sktime/performance_metrics/annotation/metrics.py
+++ b/sktime/performance_metrics/annotation/metrics.py
@@ -112,6 +112,11 @@ def padded_f1(true_change_points, pred_change_points, pad):
     -------
     float
         Padded f1 score
+
+    References
+    ----------
+    .. [1] Gerrit J. J. van den Burg and Christopher K. I. Williams, An Evaluation of
+           Change Point Detection Algorithms, 2022, https://arxiv.org/abs/2003.06222
     """
     true_change_points = pd.Series(true_change_points)
     pred_change_points = pd.Series(pred_change_points)

--- a/sktime/performance_metrics/tests/test_annotation_metrics.py
+++ b/sktime/performance_metrics/tests/test_annotation_metrics.py
@@ -1,11 +1,11 @@
 """Tests for classes in _classes module."""
 
-import numpy as np
 import pandas as pd
 import pytest
 from sklearn.metrics import f1_score
 
 from sktime.performance_metrics.annotation import metrics
+
 
 def test_padded_f1_with_sklearn():
     """Compare padded f1 with sklearn's f1 score.
@@ -16,49 +16,43 @@ def test_padded_f1_with_sklearn():
     true_change_points = pd.Series([10, 20])
     predicted_change_points = pd.Series([10])
 
-    padded_f1 = metrics.padded_f1(
-        true_change_points,
-        predicted_change_points,
-        pad=1
-    )
+    padded_f1 = metrics.padded_f1(true_change_points, predicted_change_points, pad=1)
     sklearn_f1 = f1_score([0.0, 1.0, 1.0], [0.0, 1.0, 0.0])
     assert padded_f1 == sklearn_f1
 
 
 @pytest.mark.parametrize(
-    "true_cps,pred_cps,pad", [
+    "true_cps,pred_cps,pad",
+    [
         ([5, 15], [5, 14], 2),
         (
             pd.Series(["2024-01-01", "2024-06-01"], dtype="datetime64[ns]"),
             pd.Series(["2023-12-01", "2024-06-15"], dtype="datetime64[ns]"),
-            pd.tseries.offsets.DateOffset(months=2)
+            pd.tseries.offsets.DateOffset(months=2),
         ),
         ([-0.5, 1.6, -5], [-0.3, 1.4, -5], 0.3),
-        pytest.param([5, 15], [5, 18], 2, marks=pytest.mark.xfail)
-    ]
+        pytest.param([5, 15], [5, 18], 2, marks=pytest.mark.xfail),
+    ],
 )
 def test_padded_f1_for_perfect_score(true_cps, pred_cps, pad):
     """Ensure padded F1 score returns 1.0 when all change points are detected."""
-    padded_f1 = metrics.padded_f1(
-        pd.Series(true_cps), pd.Series(pred_cps), pad
-    )
+    padded_f1 = metrics.padded_f1(pd.Series(true_cps), pd.Series(pred_cps), pad)
     assert padded_f1 == 1.0
 
 
 @pytest.mark.parametrize(
-    "true_cps,pred_cps,threshold", [
+    "true_cps,pred_cps,threshold",
+    [
         ([5, 15], [1, 10, 20], 2),
         (
             pd.Series(["2024-01-01", "2024-06-01"], dtype="datetime64[ns]"),
             pd.Series(["2023-06-01", "2024-04-01"]),
-            pd.tseries.offsets.DateOffset(months=1)
+            pd.tseries.offsets.DateOffset(months=1),
         ),
         ([-0.5, 1.6], [0.0, 1.0], 0.3),
-    ]
+    ],
 )
-def test_padded_f1_for_perfect_score(true_cps, pred_cps, threshold):
+def test_padded_f1_for_worst_score(true_cps, pred_cps, threshold):
     """Ensure padded F1 score returns 0.0 when no of the change points are detected."""
-    padded_f1 = metrics.padded_f1(
-        pd.Series(true_cps), pd.Series(pred_cps), threshold
-    )
+    padded_f1 = metrics.padded_f1(pd.Series(true_cps), pd.Series(pred_cps), threshold)
     assert padded_f1 == 0.0

--- a/sktime/performance_metrics/tests/test_annotation_metrics.py
+++ b/sktime/performance_metrics/tests/test_annotation_metrics.py
@@ -56,3 +56,18 @@ def test_padded_f1_for_worst_score(true_cps, pred_cps, threshold):
     """Ensure padded F1 score returns 0.0 when no of the change points are detected."""
     padded_f1 = metrics.padded_f1(pd.Series(true_cps), pd.Series(pred_cps), threshold)
     assert padded_f1 == 0.0
+
+
+@pytest.mark.parametrize(
+    "true_cps,pred_cps,thresh,expected_value",
+    [
+        ([5, 20], [5, 10], 2, 0.5),
+        ([5, 12, 13], [5, 10], 1, 0.4),
+        ([4, 10], [5, 12], 1, 0.5),
+        ([4, 10], [5, 12], 2, 1.0),
+    ],
+)
+def test_padded_f1_against_known_score(true_cps, pred_cps, thresh, expected_value):
+    """Test padded f1 against pre-calculated tests where we know the expected value"""
+    padded_f1 = metrics.padded_f1(pd.Series(true_cps), pd.Series(pred_cps), thresh)
+    assert padded_f1 == expected_value

--- a/sktime/performance_metrics/tests/test_annotation_metrics.py
+++ b/sktime/performance_metrics/tests/test_annotation_metrics.py
@@ -1,0 +1,64 @@
+"""Tests for classes in _classes module."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.metrics import f1_score
+
+from sktime.performance_metrics.annotation import metrics
+
+def test_padded_f1_with_sklearn():
+    """Compare padded f1 with sklearn's f1 score.
+
+    f1 score and padded f1 score should be the same when there is one change point per
+    interval.
+    """
+    true_change_points = pd.Series([10, 20])
+    predicted_change_points = pd.Series([10])
+
+    padded_f1 = metrics.padded_f1(
+        true_change_points,
+        predicted_change_points,
+        pad=1
+    )
+    sklearn_f1 = f1_score([0.0, 1.0, 1.0], [0.0, 1.0, 0.0])
+    assert padded_f1 == sklearn_f1
+
+
+@pytest.mark.parametrize(
+    "true_cps,pred_cps,pad", [
+        ([5, 15], [5, 14], 2),
+        (
+            pd.Series(["2024-01-01", "2024-06-01"], dtype="datetime64[ns]"),
+            pd.Series(["2023-12-01", "2024-06-15"], dtype="datetime64[ns]"),
+            pd.tseries.offsets.DateOffset(months=2)
+        ),
+        ([-0.5, 1.6, -5], [-0.3, 1.4, -5], 0.3),
+        pytest.param([5, 15], [5, 18], 2, marks=pytest.mark.xfail)
+    ]
+)
+def test_padded_f1_for_perfect_score(true_cps, pred_cps, pad):
+    """Ensure padded F1 score returns 1.0 when all change points are detected."""
+    padded_f1 = metrics.padded_f1(
+        pd.Series(true_cps), pd.Series(pred_cps), pad
+    )
+    assert padded_f1 == 1.0
+
+
+@pytest.mark.parametrize(
+    "true_cps,pred_cps,threshold", [
+        ([5, 15], [1, 10, 20], 2),
+        (
+            pd.Series(["2024-01-01", "2024-06-01"], dtype="datetime64[ns]"),
+            pd.Series(["2023-06-01", "2024-04-01"]),
+            pd.tseries.offsets.DateOffset(months=1)
+        ),
+        ([-0.5, 1.6], [0.0, 1.0], 0.3),
+    ]
+)
+def test_padded_f1_for_perfect_score(true_cps, pred_cps, threshold):
+    """Ensure padded F1 score returns 0.0 when no of the change points are detected."""
+    padded_f1 = metrics.padded_f1(
+        pd.Series(true_cps), pd.Series(pred_cps), threshold
+    )
+    assert padded_f1 == 0.0


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Closes #7031.

#### What does this implement/fix? Explain your changes.
Implements the padded F1 score metric. This is a metric for evaluating the quality for predicted change points. The metric is described in this paper https://arxiv.org/pdf/2003.06222.

#### Did you add any tests for the change?

Yes

#### Any other comments?

I have called this padded F1 score since it pads the true labels to be more forgiving of the predictions. Is anyone aware of another more appropriate name for this?

#### PR checklist


##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
