### PR TITLE
[MNT] `esig` based estimators: add `numpy<2` bound

### DIFF
--- a/sktime/classification/feature_based/_signature_classifier.py
+++ b/sktime/classification/feature_based/_signature_classifier.py
@@ -95,7 +95,7 @@ class SignatureClassifier(BaseClassifier):
         # --------------
         "authors": "jambo6",
         "maintainers": "jambo6",
-        "python_dependencies": "esig",
+        "python_dependencies": ["esig", "numpy<2.0"],
         "python_version": "<3.10",
         # estimator type
         # --------------


### PR DESCRIPTION
It appears that `esig` is incompatible with `numpy 2`. See #7023.

This adds `numpy 2` bounds to the respective estimators.