### PR TITLE
[BUG] Fix `ForecastX.update` when the `forecaster_X_exogeneous` is set to `"complement"`

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -1650,7 +1650,10 @@ class ForecastX(BaseForecaster):
         self : an instance of self
         """
         if self.behaviour == "update" and X is not None:
-            self.forecaster_X_.update(y=self._get_Xcols(X), update_params=update_params)
+            X_for_fcX = self._get_X_for_fcX(X)
+            self.forecaster_X_.update(
+                y=self._get_Xcols(X), X=X_for_fcX, update_params=update_params
+            )
         self.forecaster_y_.update(y=y, X=X, update_params=update_params)
 
         return self

--- a/sktime/forecasting/compose/tests/test_forecastx.py
+++ b/sktime/forecasting/compose/tests/test_forecastx.py
@@ -411,14 +411,16 @@ def test_use_of_passed_unknown_X(predict_behaviour_option: str) -> None:
 )
 @pytest.mark.parametrize("cols_to_forecast", [["GNPDEFL", "GNP"], ["ARMED", "POP"]])
 def test_forecaster_X_exogeneous(cols_to_forecast):
-    """Test that ForecastX forecaster_X uses exogenous data as told by parameter."""
+    """Test that ForecastX uses exogenous data as told by parameter."""
     from sktime.forecasting.compose import ForecastX
     from sktime.split import temporal_train_test_split
 
     y, X = load_longley()
 
     fh = [1, 2, 3, 4]
-    y_train, _, X_train, X_test = temporal_train_test_split(y, X, test_size=max(fh))
+    y_train, y_test, X_train, X_test = temporal_train_test_split(
+        y, X, test_size=max(fh)
+    )
 
     forecaster = ARIMA()
     pipeline1 = ForecastX(
@@ -441,3 +443,7 @@ def test_forecaster_X_exogeneous(cols_to_forecast):
     pipeline2.fit(y_train, X=X_train, fh=fh)
     y_pred2 = pipeline2.predict(X=X_test.drop(columns=cols_to_forecast))
     np.testing.assert_array_equal(y_pred1.index, y_pred2.index)
+
+    # check that the update method doesn't break on
+    # forecaster_X_exogeneous = "complement"
+    pipeline1.update(y_test, X=X_test, update_params=True)


### PR DESCRIPTION
This PR fixes the issue that caused the `update` method to fail by getting the new values for `X` depending on the forecaster parameters when calling the update method.

fixes https://github.com/sktime/sktime/issues/6724