### PR TITLE
[BUG] fix html display for `TransformedTargetForecaster` and `ForecastingPipeline`

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -280,15 +280,8 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
         return [params1, params2, params3]
 
     def _sk_visual_block_(self):
-        _, estimators = zip(*self.steps)
+        names, estimators = zip(*self._steps)
 
-        def _get_name(name, est):
-            if est is None or est == "passthrough":
-                return f"{name}: passthrough"
-            # Is an estimator
-            return f"{name}: {est.__class__.__name__}"
-
-        names = [_get_name(name, est) for name, est in self.steps]
         name_details = [str(est) for est in estimators]
         return _VisualBlock(
             "serial",

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -604,3 +604,13 @@ def test_pipeline_featurizer_noexog():
     # if the pipeline skips the FourierFeatures step,
     # then the predictions would be all constant, we test that this is not the case
     assert not np.allclose(y_pred.diff()[1:], np.zeros_like(y_pred[1:]))
+
+
+def test_pipeline_display():
+    """Test that pipeline displays correctly."""
+    from sktime.forecasting.compose import TransformedTargetForecaster, YfromX
+    from sktime.transformations.series.detrend import Detrender
+
+    f = TransformedTargetForecaster([Detrender(), YfromX.create_test_instance()])
+
+    f._sk_visual_block_()

--- a/sktime/forecasting/compose/tests/test_pipeline.py
+++ b/sktime/forecasting/compose/tests/test_pipeline.py
@@ -606,11 +606,19 @@ def test_pipeline_featurizer_noexog():
     assert not np.allclose(y_pred.diff()[1:], np.zeros_like(y_pred[1:]))
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(
+        [ForecastingPipeline, TransformedTargetForecaster, YfromX, Detrender],
+    ),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_pipeline_display():
     """Test that pipeline displays correctly."""
     from sktime.forecasting.compose import TransformedTargetForecaster, YfromX
     from sktime.transformations.series.detrend import Detrender
 
     f = TransformedTargetForecaster([Detrender(), YfromX.create_test_instance()])
+    f._sk_visual_block_()
 
+    f = ForecastingPipeline([Detrender(), YfromX.create_test_instance()])
     f._sk_visual_block_()


### PR DESCRIPTION
The html display for `TransformedTargetForecaster` is failing since #6930, if estimators are passed as a list instead of list of tuples.

This is fixed by using the attribute that always returns a list of tuples. A test is also added.