### PR TITLE
[ENH] `ThetaForecaster` - add one more parameter set

### DIFF
--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -320,8 +320,9 @@ class ThetaForecaster(ExponentialSmoothing):
         params0 = {}
         params1 = {"sp": 2, "deseasonalize": True}
         params2 = {"deseasonalize": False}
+        params3 = {"initial_level": 0.5}
 
-        return [params0, params1, params2]
+        return [params0, params1, params2, params3]
 
 
 def _zscore(level: float, two_tailed: bool = True) -> float:


### PR DESCRIPTION
I noticed that the parameter `initial_level` was not covered in the test paramater selections of `ThetaForecaster`.

This PR adds one more parameter set in `get_test_params`, so we also test a non-default for `inital_level`.