### PR TITLE
[DOC] remove references to `nested_univ` from extension templates

### DIFF
--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -100,8 +100,9 @@ class MyTimeSeriesClassifier(BaseClassifier):
         # --------------
         "X_inner_mtype": "numpy3D",  # which type do _fit/_predict accept, usually
         "y_inner_mtype": "numpy1D",  # which type do _fit/_predict return, usually
-        # this is either "numpy3D", "pd-multiindex" or "nested_univ" (nested df). Other
-        # types are allowable, see datatypes/panel/_registry.py for options.
+        # this is one of "numpy3D" (instance, variable, time point),
+        # "pd-multiindex" (row index: instance, time; column index: variable) or other
+        # machine types, see datatypes/panel/_registry.py for options.
         "capability:multivariate": False,  # ability to handle multivariate X
         "capability:multioutput": False,  # ability to predict multiple columns in y
         "capability:unequal_length": False,

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -97,8 +97,9 @@ class MyClusterer(BaseClusterer):
         # estimator tags
         # --------------
         "X_inner_mtype": "numpy3D",  # which type do _fit/_predict accept, usually
-        # this is either "numpy3D" or "nested_univ" (nested pd.DataFrame). Other
-        # types are allowable, see datatypes/panel/_registry.py for options.
+        # this is one of "numpy3D" (instance, variable, time point),
+        # "pd-multiindex" (row index: instance, time; column index: variable) or other
+        # machine types, see datatypes/panel/_registry.py for options.
         "capability:multivariate": False,
         "capability:unequal_length": False,
         "capability:missing_values": False,


### PR DESCRIPTION
This PR removes references to `nested_univ` from the classification and clustering extension templates. Reason, this mtype is semi-deprecated and not recommended.