### PR TITLE
[MNT] Try to reduce load for the runners

### DIFF
--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -804,8 +804,8 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                         "logger": False,
                     },
                     "model_params": {
-                        "cell_type": "GRU",
-                        "rnn_layers": 2,
+                        "cell_type": "LSTM",
+                        "rnn_layers": 1,
                         "hidden_size": 3,
                         "log_interval": -1,
                     },
@@ -854,8 +854,8 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                         "logger": False,
                     },
                     "model_params": {
-                        "cell_type": "GRU",
-                        "rnn_layers": 3,
+                        "cell_type": "LSTM",
+                        "rnn_layers": 1,
                         "log_interval": -1,
                     },
                     "dataset_params": {
@@ -1074,7 +1074,7 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
                     },
                     "train_to_dataloader_params": {"batch_size": 2},
                     "model_params": {
-                        "hidden_size": 8,
+                        "hidden_size": 4,
                         "n_blocks": [1, 1],
                         "n_layers": 1,
                         "log_interval": -1,
@@ -1091,7 +1091,7 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
                     "model_params": {
                         "interpolation_mode": "nearest",
                         "activation": "Tanh",
-                        "hidden_size": 8,
+                        "hidden_size": 4,
                         "n_blocks": [1, 1],
                         "n_layers": 1,
                         "log_interval": -1,
@@ -1122,7 +1122,7 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
                         "logger": False,
                     },
                     "model_params": {
-                        "hidden_size": 8,
+                        "hidden_size": 4,
                         "n_blocks": [1, 1],
                         "n_layers": 1,
                         "log_interval": -1,
@@ -1144,7 +1144,7 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
                     "model_params": {
                         "interpolation_mode": "nearest",
                         "activation": "Tanh",
-                        "hidden_size": 8,
+                        "hidden_size": 4,
                         "n_blocks": [1, 1],
                         "n_layers": 1,
                         "log_interval": -1,

--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -66,7 +66,7 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
     >>> model = PytorchForecastingTFT(
     ...     trainer_params={
     ...         "max_epochs": 5,  # for quick test
-    ...         "limit_train_batches": 10,  # for quick test
+    ...         "limit_train_batches": 2,  # for quick test
     ...     },
     ... )
     >>> # fit and predict
@@ -204,7 +204,7 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
                 {
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
@@ -212,27 +212,29 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
                         "max_encoder_length": 3,
                     },
                     "model_params": {
-                        "hidden_size": 8,
+                        "hidden_size": 4,
                         "lstm_layers": 1,
                         "log_interval": -1,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "random_log_path": True,  # fix multiprocess file access error in CI
                 },
                 {
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
                     "model_params": {
-                        "hidden_size": 8,
+                        "hidden_size": 4,
                         "lstm_layers": 1,
                         "dropout": 0.1,
                         "optimizer": "Adam",
                         # avoid jdb78/pytorch-forecasting#1571 bug in the CI
                         "log_interval": -1,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
@@ -255,30 +257,31 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
                 {
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
                     "model_params": {
                         "log_interval": -1,
-                        "hidden_size": 8,
+                        "hidden_size": 4,
                         "lstm_layers": 1,
                     },
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "random_log_path": True,  # fix multiprocess file access error in CI
                 },
                 {
                     "trainer_params": {
                         "callbacks": [early_stop_callback],
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
                     "model_params": {
-                        "hidden_size": 8,
+                        "hidden_size": 4,
                         "lstm_layers": 1,
                         "dropout": 0.1,
                         # "loss": QuantileLoss(),
@@ -291,6 +294,7 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "random_log_path": True,  # fix multiprocess file access error in CI
                 },
             ]
@@ -482,13 +486,14 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
                 {
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "model_params": {
                         "num_blocks": [1, 1],
                         "num_block_layers": [1, 1],
@@ -500,7 +505,7 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
                 {
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
@@ -514,6 +519,7 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "random_log_path": True,  # fix multiprocess file access error in CI
                 },
             ]
@@ -531,7 +537,7 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
                 {
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
@@ -544,13 +550,14 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "random_log_path": True,  # fix multiprocess file access error in CI
                 },
                 {
                     "trainer_params": {
                         "callbacks": [early_stop_callback],
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
@@ -565,6 +572,7 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "random_log_path": True,  # fix multiprocess file access error in CI
                 },
             ]
@@ -770,7 +778,7 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                 {
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
@@ -784,13 +792,14 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "random_log_path": True,  # fix multiprocess file access error in CI
                     "deterministic": True,  # to pass test_score
                 },
                 {
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
@@ -803,6 +812,7 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "random_log_path": True,  # fix multiprocess file access error in CI
                     "deterministic": True,  # to pass test_score
                 },
@@ -821,7 +831,7 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                 {
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
@@ -831,6 +841,7 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "random_log_path": True,  # fix multiprocess file access error in CI
                     "deterministic": True,  # to pass test_score
                 },
@@ -838,7 +849,7 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                     "trainer_params": {
                         "callbacks": [early_stop_callback],
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
@@ -850,6 +861,7 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "random_log_path": True,  # fix multiprocess file access error in CI
                     "deterministic": True,  # to pass test_score
                 },
@@ -1053,13 +1065,14 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
                 {
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "model_params": {
                         "hidden_size": 8,
                         "n_blocks": [1, 1],
@@ -1071,7 +1084,7 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
                 {
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
@@ -1086,6 +1099,7 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "random_log_path": True,  # fix multiprocess file access error in CI
                 },
             ]
@@ -1103,7 +1117,7 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
                 {
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
@@ -1116,13 +1130,14 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "random_log_path": True,  # fix multiprocess file access error in CI
                 },
                 {
                     "trainer_params": {
                         "callbacks": [early_stop_callback],
                         "max_epochs": 1,  # for quick test
-                        "limit_train_batches": 10,  # for quick test
+                        "limit_train_batches": 2,  # for quick test
                         "enable_checkpointing": False,
                         "logger": False,
                     },
@@ -1137,6 +1152,7 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
                     "dataset_params": {
                         "max_encoder_length": 3,
                     },
+                    "train_to_dataloader_params": {"batch_size": 2},
                     "random_log_path": True,  # fix multiprocess file access error in CI
                 },
             ]

--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -785,7 +785,6 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                         "cell_type": "GRU",
                         "rnn_layers": 1,
                         "hidden_size": 2,
-                        "enable_checkpointing": False,
                         "log_interval": -1,
                     },
                     "dataset_params": {
@@ -836,7 +835,6 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                         "cell_type": "GRU",
                         "rnn_layers": 1,
                         "hidden_size": 2,
-                        "enable_checkpointing": False,
                         "log_interval": -1,
                     },
                     "dataset_params": {

--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -779,7 +779,6 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
                         "limit_train_batches": 2,  # for quick test
-                        "enable_checkpointing": False,
                         "logger": False,
                     },
                     "model_params": {
@@ -800,7 +799,6 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
                         "limit_train_batches": 2,  # for quick test
-                        "enable_checkpointing": False,
                         "logger": False,
                     },
                     "model_params": {
@@ -832,7 +830,6 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                     "trainer_params": {
                         "max_epochs": 1,  # for quick test
                         "limit_train_batches": 2,  # for quick test
-                        "enable_checkpointing": False,
                         "logger": False,
                     },
                     "model_params": {
@@ -854,7 +851,6 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                         "callbacks": [early_stop_callback],
                         "max_epochs": 1,  # for quick test
                         "limit_train_batches": 2,  # for quick test
-                        "enable_checkpointing": False,
                         "logger": False,
                     },
                     "model_params": {

--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -785,7 +785,7 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                     "model_params": {
                         "cell_type": "GRU",
                         "rnn_layers": 1,
-                        "hidden_size": 3,
+                        "hidden_size": 2,
                         "enable_checkpointing": False,
                         "log_interval": -1,
                     },
@@ -806,7 +806,7 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                     "model_params": {
                         "cell_type": "LSTM",
                         "rnn_layers": 1,
-                        "hidden_size": 3,
+                        "hidden_size": 2,
                         "log_interval": -1,
                     },
                     "dataset_params": {
@@ -836,6 +836,10 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                         "logger": False,
                     },
                     "model_params": {
+                        "cell_type": "GRU",
+                        "rnn_layers": 1,
+                        "hidden_size": 2,
+                        "enable_checkpointing": False,
                         "log_interval": -1,
                     },
                     "dataset_params": {
@@ -857,6 +861,7 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                         "cell_type": "LSTM",
                         "rnn_layers": 1,
                         "log_interval": -1,
+                        "hidden_size": 2,
                     },
                     "dataset_params": {
                         "max_encoder_length": 3,


### PR DESCRIPTION
See also https://github.com/jdb78/pytorch-forecasting/issues/1632


I tried to reduce the load for the runner by reducing the batch size in the PyTorch forecasting models and reduced the model size of the TFT.


In my opinion, this PR is successful if in multiple runs, the CI is not crashing because of HEAP errors and crashed runners... 