### PR TITLE
[MNT] CI steps to test by estimator with estimator specific dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,51 @@ jobs:
         run: build_tools/run_blogposts.sh
         shell: bash
 
+  detect-changed-classes:
+    runs-on: ubuntu-latest
+    outputs:
+      obj_list: ${{ steps.get-change-list.outputs.obj_list }}
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Get list of class names
+      id: get-change-list
+      run: |
+        echo "::set-output name=obj_list::$(python -c 'from sktime.tests.test_switch import _get_all_changed_classes; import json; print(json.dumps(_get_all_changed_classes()))')"
+
+  test-est:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flag: ${{ fromJson(needs.detect-changed-classes.outputs.obj_list) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install sktime with dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+
+      - name: Install dependencies for ${{ matrix.flag }}
+        run: |
+          # Run the Python script to get the list of requirements for the flag
+          pip install -r <(python -c "from sktime.registry import deps; print('\n'.join(deps('${{ matrix.flag }}')))")
+
+      - name: Run tests with ${{ matrix.flag }}
+        env:
+          FLAG: ${{ matrix.flag }}
+        run: python -c "from sktime.utils import check_estimator; from sktime.registry import craft; check_estimator(craft('${{ matrix.flag }}'), raise_exceptions=True)"
+
   detect-package-change:
     needs: code-quality
     name: detect package changes

--- a/sktime/tests/test_class_register.py
+++ b/sktime/tests/test_class_register.py
@@ -6,6 +6,7 @@ Module does not contain tests, only test utilities.
 
 __author__ = ["fkiraly"]
 
+from functools import lru_cache
 from inspect import isclass
 
 
@@ -69,6 +70,7 @@ def get_test_class_registry():
     return testclass_dict
 
 
+@lru_cache
 def get_test_classes_for_obj(obj):
     """Get all test classes relevant for an object or estimator.
 

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -85,6 +85,7 @@ def run_test_for_class(cls, return_reason=False):
         * otherwise, any reasons to run cause the entire list to be run
         * otherwise, the list is not run due to "no change"
     """
+    from sktime.tests.test_all_estimators import ONLY_CHANGED_MODULES
 
     def _return(run, reason):
         if return_reason:
@@ -135,12 +136,12 @@ def run_test_for_class(cls, return_reason=False):
 
     # now we know that cls is a class or function,
     # and not on the exclude list
-    run, reason = _run_test_for_class(cls)
+    run, reason = _run_test_for_class(cls, only_changed_modules=ONLY_CHANGED_MODULES)
     return _return(run, reason)
 
 
 @lru_cache
-def _run_test_for_class(cls):
+def _run_test_for_class(cls, ignore_deps=False, only_changed_modules=True):
     """Check if test should run - cached with hashable cls.
 
     Parameters
@@ -162,7 +163,6 @@ def _run_test_for_class(cls):
 
         If multiple reasons are present, the first one in the above list is returned.
     """
-    from sktime.tests.test_all_estimators import ONLY_CHANGED_MODULES
     from sktime.utils.dependencies import _check_estimator_deps
     from sktime.utils.git_diff import get_packages_with_changed_specs, is_class_changed
 
@@ -213,13 +213,13 @@ def _run_test_for_class(cls):
 
     # Condition 1:
     # if any of the required soft dependencies are not present, do not run the test
-    if not _required_deps_present(cls):
+    if not ignore_deps and not _required_deps_present(cls):
         return False, "False_required_deps_missing"
     # otherwise, continue
 
     # if ONLY_CHANGED_MODULES is off: always True
     # tests are always run if soft dependencies are present
-    if not ONLY_CHANGED_MODULES:
+    if not only_changed_modules:
         return True, "True_run_always"
 
     # run the test if and only if at least one of the conditions 2-4 are met
@@ -287,3 +287,24 @@ def run_test_module_changed(module):
         module = [module]
 
     return any(is_module_changed(mod) for mod in module)
+
+
+@lru_cache
+def _get_all_changed_classes():
+    """Get all sktime object classes that have changed compared to the main branch.
+
+    Returns a tuple of string class names of object classes that have changed.
+
+    Returns
+    -------
+    tuple of string sof class names : object classes that have changed
+    """
+    from sktime.registry import all_estimators
+
+    def _changed_class(cls):
+        """Check if a class has changed compared to the main branch."""
+        changed, _ = _run_test_for_class(cls, ignore_deps=True)
+        return changed
+
+    names = [name for name, est in all_estimators() if _changed_class(est)]
+    return names


### PR DESCRIPTION
Closes https://github.com/sktime/sktime/issues/5719, implements a prototype CI workflow that runs all tests per estimator, for every estimator impacted by one of the change conditions currently used in `run_test_for_class`.

This is a prototype, with some todos:

* matrix of python versions, as supported by the estimator via `python_dependencies` tag
* matrix of operating systems, as supported by the estimator via `env_marker` tag
* granular running of tests instead of a single `check_estimator` run, for better diagnosis