### PR TITLE
[ENH] Add `transformations.series.hurst`

### DIFF
--- a/sktime/transformations/series/hurst.py
+++ b/sktime/transformations/series/hurst.py
@@ -1,0 +1,224 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Hurst Exponent Transformer for time series analysis."""
+
+# __author__ = ["phoeenniixx"]
+
+import numpy as np
+import pandas as pd
+from typing import Union, List, Optional
+import matplotlib.pyplot as plt
+from scipy import stats
+
+from sktime.transformations.base import BaseTransformer
+
+
+class HurstExponentTransformer(BaseTransformer):
+    """Transformer for calculating the Hurst exponent of a time series.
+
+    This transformer calculates the Hurst exponent, which is used to evaluate
+    the autocorrelation properties of time series, particularly the degree of
+    long-range dependence.
+
+    Parameters
+    ----------
+    lags : Optional[Union[List[int], range]], default=None
+        The lags to use for calculation. If None, uses a range based on min_lag and max_lag.
+    method : str, default='rs'
+        The method to use for Hurst exponent calculation. Either 'rs' (rescaled range)
+        or 'dfa' (detrended fluctuation analysis).
+    min_lag : int, default=2
+        The minimum lag to use if lags is None.
+    max_lag : int, default=100
+        The maximum lag to use if lags is None.
+    fit_trend : str, default='c'
+        The trend component to include in the calculation.
+    confidence_level : float, default=0.95
+        The confidence level for the confidence interval calculation.
+
+    Attributes
+    ----------
+    hurst_estimate_ : float
+        The estimated Hurst exponent.
+    confidence_interval_ : tuple
+        The confidence interval for the Hurst exponent estimate.
+    """
+
+    _tags = {
+        "scitype:transform-input": "Series",
+        "scitype:transform-output": "Series",
+        "scitype:instancewise": True,
+        "scitype:transform-labels": "None",
+        "X_inner_mtype": "pd.Series",
+        "y_inner_mtype": "None",
+        "univariate-only": True,
+        "requires_y": False,
+        "fit_is_empty": False,
+        "capability:inverse_transform": False,
+        "capability:unequal_length": True,
+        "handles-missing-data": False,
+        "authors": ["phoeenniixx"],
+        "maintainers": ["fkiraly"],
+    }
+
+    def __init__(
+            self,
+            lags: Optional[Union[List[int], range]] = None,
+            method: str = 'rs',
+            min_lag: int = 2,
+            max_lag: int = 100,
+            fit_trend: str = 'c',
+            confidence_level: float = 0.95
+    ):
+        self.lags = lags
+        self.method = method
+        self.min_lag = min_lag
+        self.max_lag = max_lag
+        self.fit_trend = fit_trend
+        self.confidence_level = confidence_level
+
+        super().__init__()
+
+    def _fit(self, X: pd.Series, y=None):
+        """Fit transformer to X and y.
+
+        Parameters
+        ----------
+        X : pd.Series
+            The time series data to fit.
+        y : None
+            Ignored.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        self.hurst_estimate_ = self._hurst_exponent(X)
+        return self
+
+    def _transform(self, X: pd.Series, y=None):
+        """Transform X and return a transformed version.
+
+        Parameters
+        ----------
+        X : pd.Series
+            The time series data to transform.
+        y : None
+            Ignored.
+
+        Returns
+        -------
+        X_transformed : pd.Series
+            The input series with its Hurst exponent appended as metadata.
+        """
+        X_transformed = X.copy()
+        X_transformed.attrs['hurst_exponent'] = self.hurst_estimate_
+        X_transformed.attrs['hurst_confidence_interval'] = self.confidence_interval_
+        return X_transformed
+
+    def _hurst_exponent(self, ts: pd.Series) -> float:
+        """Calculate Hurst exponent for a single time series."""
+        if self.method == 'rs':
+            return self._rs_method(ts)
+        elif self.method == 'dfa':
+            return self._dfa_method(ts)
+        else:
+            raise ValueError("Invalid method. Choose 'rs' or 'dfa'.")
+
+    def _rs_method(self, ts: pd.Series) -> float:
+        """Rescaled range (R/S) method for Hurst exponent calculation."""
+        lags = self.lags or range(self.min_lag, min(self.max_lag, len(ts) // 2))
+        tau = [self._calculate_rs(ts, lag) for lag in lags]
+        return self._fit_hurst(lags, tau)
+
+    def _dfa_method(self, ts: pd.Series) -> float:
+        """Detrended Fluctuation Analysis (DFA) method for Hurst exponent calculation."""
+        lags = self.lags or range(self.min_lag, min(self.max_lag, len(ts) // 4))
+        tau = [self._calculate_dfa(ts, lag) for lag in lags]
+        return self._fit_hurst(lags, tau)
+
+    def _calculate_rs(self, ts: pd.Series, lag: int) -> float:
+        """Calculate rescaled range for a given lag."""
+        rolling_mean = ts.rolling(window=lag).mean()
+        dev_from_mean = ts - rolling_mean
+        range_ts = dev_from_mean.rolling(window=lag).max() - dev_from_mean.rolling(window=lag).min()
+        std_ts = ts.rolling(window=lag).std()
+        rs = range_ts / std_ts
+        return np.nanmean(rs)
+
+    def _calculate_dfa(self, ts: pd.Series, lag: int) -> float:
+        """Calculate DFA fluctuation for a given lag."""
+        y = ts.cumsum() - ts.mean()
+        y_len = len(y)
+        n_segments = y_len // lag
+        fluctuations = []
+        for i in range(n_segments):
+            segment = y[i * lag:(i + 1) * lag]
+            x = np.arange(lag)
+            coef = np.polyfit(x, segment, 1)
+            trend = np.polyval(coef, x)
+            fluctuation = np.sqrt(np.mean((segment - trend) ** 2))
+            fluctuations.append(fluctuation)
+        return np.mean(fluctuations)
+
+    def _fit_hurst(self, lags: Union[List[int], range], tau: List[float]) -> float:
+        """Fit Hurst exponent from log-log plot."""
+        log_lags = np.log(lags)
+        log_tau = np.log(tau)
+
+        slope, intercept, r_value, p_value, std_err = stats.linregress(log_lags, log_tau)
+
+        self._calculate_confidence_interval(slope, std_err, len(lags))
+
+        return slope
+
+    def _calculate_confidence_interval(self, slope, std_err, n):
+        """Calculate confidence interval for the Hurst exponent."""
+        df = n - 2
+        t_value = stats.t.ppf((1 + self.confidence_level) / 2, df)
+        margin_of_error = t_value * std_err
+
+        self.confidence_interval_ = (slope - margin_of_error, slope + margin_of_error)
+
+    def plot_log_log(self, ts: pd.Series):
+        """Plot the log-log graph used in Hurst exponent calculation."""
+        lags = self.lags or range(self.min_lag, min(self.max_lag, len(ts) // 2))
+        if self.method == 'rs':
+            tau = [self._calculate_rs(ts, lag) for lag in lags]
+            y_label = 'log(R/S)'
+        else:  # DFA method
+            tau = [self._calculate_dfa(ts, lag) for lag in lags]
+            y_label = 'log(F)'
+
+        log_lags = np.log(lags)
+        log_tau = np.log(tau)
+
+        plt.figure(figsize=(10, 6))
+        plt.scatter(log_lags, log_tau, alpha=0.5)
+        plt.plot(log_lags, self.hurst_estimate_ * log_lags + np.mean(log_tau - self.hurst_estimate_ * log_lags),
+                 color='r', label=f'Hurst = {self.hurst_estimate_:.3f}')
+        plt.xlabel('log(lag)')
+        plt.ylabel(y_label)
+        plt.title(f'Log-Log Plot for Hurst Exponent Estimation ({self.method.upper()} method)')
+        plt.legend()
+        plt.grid(True, which="both", ls="-", alpha=0.2)
+        plt.show()
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : list of dict
+            Parameters to create testing instances of the class
+        """
+        params1 = {"method": "rs", "min_lag": 2, "max_lag": 20}
+        params2 = {"method": "dfa", "min_lag": 5, "max_lag": 50}
+        return [params1, params2]


### PR DESCRIPTION

<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
Fixes issue #7049 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Added the Hurst exponent calculation feature under `transformations.series`.
```python
>>> from sktime.transformations.series.hurst import HurstExponentTransformer
>>> import numpy as np
>>> import pandas as pd
>>> np.random.seed(42)
>>> ts = pd.Series(np.cumsum(np.random.randn(1000)))
>>> het = HurstExponentTransformer()
>>> het.fit(ts)
>>> print(f"Hurst exponent: {het.hurst_estimate_:.4f}")
Hurst exponent: 0.1403
>>> print(f"Confidence interval: {het.confidence_interval_}")
Confidence interval: (np.float64(0.12549060340837073), np.float64(0.15517463759165231))
>>> transformed_ts = het.transform(ts)
>>> print(f"Hurst exponent in transformed series metadata: {transformed_ts.attrs['hurst_exponent']:.4f}")
Hurst exponent in transformed series metadata: 0.1403
```
#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->
This PR is just to test the hurst transformer class 
#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
