### PR TITLE
[ENH] change `test_inheritance` to be more lenient to framework level extensions

### DIFF
--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -25,8 +25,8 @@ from sktime.dists_kernels.base import (
     BasePairwiseTransformerPanel,
 )
 from sktime.exceptions import NotFittedError
-from sktime.forecasting.base import BaseForecaster, _BaseGlobalForecaster
-from sktime.registry import all_estimators, get_base_class_list, scitype
+from sktime.forecasting.base import BaseForecaster
+from sktime.registry import all_estimators, get_base_class_lookup, scitype
 from sktime.regression.deep_learning.base import BaseDeepRegressor
 from sktime.tests._config import (
     EXCLUDE_ESTIMATORS,
@@ -917,29 +917,22 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
                 f"estimator: {estimator_class} has fit method, but"
                 f"is not a sub-class of BaseEstimator."
             )
-        from sktime.pipeline import Pipeline
 
-        if issubclass(estimator_class, Pipeline):
-            return
+        est_scitypes = scitype(
+            estimator_class, force_single_scitype=False, coerce_to_list=True
+        )
 
-        VALID_BASE_CLS = tuple(get_base_class_list(include_baseobjs=False))
-        VALID_MIXIN = get_base_class_list(mixin=True)
-        VALID_SECOND_CLS = tuple(VALID_MIXIN + [_BaseGlobalForecaster])
+        class_lookup = get_base_class_lookup()
 
-        # Usually estimators inherit only from one BaseEstimator type, but in some cases
-        # they may be predictor and transformer at the same time (e.g. pipelines)
-        n_base_types = sum(issubclass(estimator_class, cls) for cls in VALID_BASE_CLS)
-
-        assert 2 >= n_base_types >= 1
-
-        # If the estimator inherits from more than one base estimator type, we check if
-        # one of them is a transformer base type or _BaseGlobalForecaster type
-        # Global forecasters inherit from _BaseGlobalForecaster,
-        # _BaseGlobalForecaster inherit from BaseForecaster
-        # therefore, global forecasters is subclass of
-        # _BaseGlobalForecaster and BaseForecaster
-        if n_base_types > 1:
-            assert issubclass(estimator_class, VALID_SECOND_CLS)
+        for est_scitype in est_scitypes:
+            if est_scitype in class_lookup:
+                expected_parent = class_lookup[est_scitype]
+                msg = (	
+                    f"Estimator: {estimator_class} is tagged as having scitype "
+                    f"{est_scitype} via tag object_type, but is not a sub-class of "
+                    f"the corresponding base class {expected_parent.__name__}."
+                )
+                assert issubclass(estimator_class, expected_parent), msg
 
     def test_has_common_interface(self, estimator_class):
         """Check estimator implements the common interface."""

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -927,7 +927,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         for est_scitype in est_scitypes:
             if est_scitype in class_lookup:
                 expected_parent = class_lookup[est_scitype]
-                msg = (	
+                msg = (
                     f"Estimator: {estimator_class} is tagged as having scitype "
                     f"{est_scitype} via tag object_type, but is not a sub-class of "
                     f"the corresponding base class {expected_parent.__name__}."


### PR DESCRIPTION
This changes the `test_inheritance` contract to:

* check base class inheritance only based on registered scitypes strings occurring in `object_type`
* no longer require a certain number of mid level base classes to be present (no longer: at least one, and at most two, and two only if from a special list)

This also addresses four cases that had required special treatment, three of which already had one-off exception treatment in the test, contributing to a contract consisting more of exceptions than the rule in terms of code:

* the global forecaster extension by @XinyuWuu
* the polymorphic `Pipeline` by @benHeid 
* the legacy transformation mixins
* the `skchange` package of @tveten which includes extensions with new base classes and scitypes

Comments and feedback appreciated, especially from @tveten on whether this change avoids the contract breakage and is future-proof for `skchange`, as intended.