### PR TITLE
[ENH] improvements to `BaseSeriesAnnotator` base class for anomaly, changepoint, segments

### DIFF
--- a/sktime/annotation/base/_base.py
+++ b/sktime/annotation/base/_base.py
@@ -71,8 +71,8 @@ class BaseSeriesAnnotator(BaseEstimator):
     }  # for unit test cases
 
     def __init__(self):
-        self.task = self.get_class_tag("task")
-        self.learning_type = self.get_class_tag("learning_type")
+        self.task = self.get_tag("task")
+        self.learning_type = self.get_tag("learning_type")
 
         self._is_fitted = False
 


### PR DESCRIPTION
This PR improves the structure of the `BaseSeriesAnnotator` class, with the goal to:

* remove some obstacles that prevented the class from being easily composable
* make the extender interface clearer

Changes: 

* the `task` and `learning_type` params in the init were set using the class tag, which prevented dynamic setting in class, this is changed to `set_tag`
* in the boilerplate, `self.task` was used instead of the tag - this is changed in a move to use the tag system entirely. `self.task` is left for downwards compatibility.
* defaults are implemented for `_predict_segments` and `predict_points`, this allows extenders to focus on implementing `_predict` only.