### PR TITLE
URLs changed on CRAN; updated _fpp3_loaders.py accordingly

### DIFF
--- a/sktime/datasets/_fpp3_loaders.py
+++ b/sktime/datasets/_fpp3_loaders.py
@@ -70,8 +70,8 @@ DATASET_NAMES_FPP3 = fpp3 + tsibble + tsibbledata
 
 
 def _get_dataset_url(dataset_name):
-    url_fpp3 = "https://cran.r-project.org/src/contrib/fpp3_0.5.tar.gz"
-    url_tsibble = "https://cran.r-project.org/src/contrib/tsibble_1.1.4.tar.gz"
+    url_fpp3 = "https://cran.r-project.org/src/contrib/fpp3_1.0.0.tar.gz"
+    url_tsibble = "https://cran.r-project.org/src/contrib/tsibble_1.1.5.tar.gz"
     url_tsibbledata = "https://cran.r-project.org/src/contrib/tsibbledata_0.4.1.tar.gz"
 
     if dataset_name in fpp3:

--- a/sktime/datasets/tests/test_datadownload.py
+++ b/sktime/datasets/tests/test_datadownload.py
@@ -110,6 +110,22 @@ def test_load_forecasting_data_invalid_name(name):
 @pytest.mark.datadownload
 def test_load_fpp3():
     """Test loading downloaded dataset from ."""
+
+    import requests
+
+    from sktime.datasets._fpp3_loaders import _get_dataset_url
+
+    for dataset_name in ["aus_accommodation", "pedestrian", "ansett"]:
+        ret, url = _get_dataset_url(dataset_name)
+        assert ret is True
+        try:
+            response = requests.head(url)
+            if response.status_code != 200:
+                ret = False
+        except requests.RequestException:
+            ret = False
+        assert ret is True
+
     olympic_running = load_fpp3("olympic_running")
 
     assert isinstance(olympic_running, pd.DataFrame)


### PR DESCRIPTION
FPP3 datasets are loaded from CRAN, using fixed URLs. CRAN updated two of the three URLs used by _fpp3_loaders.py. This PR updates the URLs accordingly (otherwise the functionality is broken.)

A reviewer can run the following code to test the change, if desired. 

```
import matplotlib.pyplot as plt
from sktime.datasets import load_fpp3
from sktime.utils.plotting import plot_series
y = load_fpp3('aus_production')['Beer']
fig, ax = plot_series(y)
plt.show()
```
