### PR TITLE
[ENH] retrieval utilities for all functions or classes in a module

### DIFF
--- a/sktime/utils/retrieval.py
+++ b/sktime/utils/retrieval.py
@@ -1,0 +1,99 @@
+"""Utility functions for retrieving objects from modules."""
+import importlib
+import inspect
+import pkgutil
+from functools import lru_cache
+
+EXCLUDE_MODULES_STARTING_WITH = ("all", "test", "contrib")
+
+
+def _all_functions(module_name):
+    """Get all functions from a module, including submodules.
+
+    Excludes modules starting with 'all' or 'test'.
+
+    Parameters
+    ----------
+    module_name : str
+        Name of the module.
+
+    Returns
+    -------
+    functions_list : list
+        List of tuples (function_name: str, function_object: function).
+    """
+    # copy to avoid modifying the cache
+    return _all_cond(module_name, inspect.isfunction).copy()
+
+
+def _all_classes(module_name):
+    """Get all classes from a module, including submodules.
+
+    Excludes modules starting with 'all' or 'test'.
+
+    Parameters
+    ----------
+    module_name : str
+        Name of the module.
+
+    Returns
+    -------
+    classes_list : list
+        List of tuples (class_name: str, class_ref: class).
+    """
+    # copy to avoid modifying the cache
+    return _all_cond(module_name, inspect.isclass).copy()
+
+
+@lru_cache
+def _all_cond(module_name, cond):
+    """Get all objects from a module satisfying a condition.
+
+    The condition should be a hashable callable,
+    of signature ``condition(obj) -> bool``.
+
+    Excludes modules starting with 'all' or 'test'.
+
+    Parameters
+    ----------
+    module_name : str
+        Name of the module.
+    cond : callable
+        Condition to satisfy.
+        Signature: ``condition(obj) -> bool``,
+        passed as predicate to ``inspect.getmembers``.
+
+    Returns
+    -------
+    functions_list : list
+        List of tuples (function_name, function_object).
+    """
+    # Import the package
+    package = importlib.import_module(module_name)
+
+    # Initialize an empty list to hold all objects
+    obj_list = []
+
+    # Walk through the package's modules
+    package_path = package.__path__[0]
+    for _, modname, _ in pkgutil.walk_packages(
+        path=[package_path], prefix=package.__name__ + "."
+    ):
+        # Skip modules starting with 'all' or 'test'
+        if modname.split(".")[-1].startswith(EXCLUDE_MODULES_STARTING_WITH):
+            continue
+
+        # Import the module
+        module = importlib.import_module(modname)
+        print(modname)
+        print(inspect.getmembers(module, cond))
+
+        # Get all objects from the module
+        for name, obj in inspect.getmembers(module, cond):
+            # if object is imported from another module, skip it
+            if obj.__module__ != module.__name__:
+                continue
+            # add the object to the list
+            obj_list.append((name, obj))
+
+    return obj_list

--- a/sktime/utils/retrieval.py
+++ b/sktime/utils/retrieval.py
@@ -1,4 +1,5 @@
 """Utility functions for retrieving objects from modules."""
+
 import importlib
 import inspect
 import pkgutil

--- a/sktime/utils/tests/test_retrieval.py
+++ b/sktime/utils/tests/test_retrieval.py
@@ -12,7 +12,7 @@ from sktime.utils.retrieval import _all_classes, _all_functions
 )
 def test_all_functions():
     """Test that _all_functions retrieves all functions."""
-    res =_all_functions("sktime.utils.adapters")
+    res = _all_functions("sktime.utils.adapters")
     names = [name for name, _ in res]
 
     assert {"_clone_fitted_params", "_get_fitted_params_safe"} == set(names)

--- a/sktime/utils/tests/test_retrieval.py
+++ b/sktime/utils/tests/test_retrieval.py
@@ -28,8 +28,3 @@ def test_all_classes():
     names = [name for name, _ in res]
 
     assert "MockForecaster" in names
-
-
-
-
-

--- a/sktime/utils/tests/test_retrieval.py
+++ b/sktime/utils/tests/test_retrieval.py
@@ -1,0 +1,35 @@
+"""Testing retrieval utilities."""
+
+import pytest
+
+from sktime.tests.test_switch import run_test_module_changed
+from sktime.utils.retrieval import _all_classes, _all_functions
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils.retrieval", "sktime.utils.adapters"]),
+    reason="Run if relevant content has changed.",
+)
+def test_all_functions():
+    """Test that _all_functions retrieves all functions."""
+    res =_all_functions("sktime.utils.adapters")
+    names = [name for name, _ in res]
+
+    assert {"_clone_fitted_params", "_get_fitted_params_safe"} == set(names)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils.retrieval", "sktime.utils.estimators"]),
+    reason="Run if relevant content has changed.",
+)
+def test_all_classes():
+    """Test that _all_classes retrieves all classes."""
+    res = _all_classes("sktime.utils.estimators")
+    names = [name for name, _ in res]
+
+    assert "MockForecaster" in names
+
+
+
+
+


### PR DESCRIPTION
This PR adds general retrieval utilities for all functions or classes in a module - this will be needed for a refactor of the `datatypes` module. Includes tests.