### PR TITLE
0.33.0 deprecations

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -149,7 +149,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         """,
     }
 
-    # TODO 0.33.0: check whether python 3.8 has reached EoL.
+    # TODO 0.34.0: check whether python 3.8 has reached EoL.
     # If so, remove warning altogether
     def __init__(self):
         super().__init__()
@@ -163,7 +163,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         py39_or_higher = SpecifierSet(">=3.9")
         sys_version = sys.version.split(" ")[0]
 
-        # todo 0.33.0 - check whether python 3.8 eol is reached.
+        # todo 0.34.0 - check whether python 3.8 eol is reached.
         # If yes, remove this msg.
         if sys_version not in py39_or_higher:
             warn(
@@ -184,7 +184,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         # for rationale, see _handle_numpy2_softdeps
         self._handle_numpy2_softdeps()
 
-    # TODO 0.33.0: check list of numpy 2 incompatible soft deps
+    # TODO 0.34.0: check list of numpy 2 incompatible soft deps
     # remove any from NOT_NP2_COMPATIBLE that become compatible
     def _handle_numpy2_softdeps(self):
         """Handle tags for soft deps that are not numpy 2 compatible.

--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -20,7 +20,7 @@ from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.utils.validation.panel import check_X
 
 
-# TODO: fix this in 0.33.0
+# TODO: fix this in 0.34.0
 # base class should have been changed to BaseEarlyClassifier
 class ProbabilityThresholdEarlyClassifier(BaseClassifier):
     """Probability Threshold Early Classifier.

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -806,7 +806,7 @@ def _to_relative(fh: ForecastingHorizon, cutoff=None) -> ForecastingHorizon:
             absolute = _coerce_to_period(absolute, freq=fh._freq)
             cutoff = _coerce_to_period(cutoff, freq=fh._freq)
 
-        # TODO: 0.33.0:
+        # TODO: 0.34.0:
         # Check at every minor release whether lower pandas bound >=0.15.0
         # if yes, can remove the workaround in the "else" condition and the check
         #

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -733,7 +733,7 @@ def test_exponential_smoothing_case_with_naive():
 
 
 # TODO: Replace this long running test with fast unit test
-# todo 0.33.0: check whether numpy 2 bound is still necessary
+# todo 0.34.0: check whether numpy 2 bound is still necessary
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
     or not _check_estimator_deps(AutoARIMA, severity="none")

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -163,7 +163,7 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                         if len(levels) == 1:
                             levels = levels[0]
                         yt[ix] = y.xs(ix, level=levels, axis=1)
-                        # todo 0.33.0 - check why this cannot be easily removed
+                        # todo 0.34.0 - check why this cannot be easily removed
                         # in theory, we should get rid of the "Coverage" case treatment
                         # (the legacy naming convention was removed in 0.23.0)
                         # deal with the "Coverage" case, we need to get rid of this
@@ -1816,7 +1816,7 @@ class ForecastX(BaseForecaster):
         params1 = {"forecaster_X": fx, "forecaster_y": fy}
 
         # example with probabilistic capability
-        # todo 0.33.0: check if numpy<2 is still needed
+        # todo 0.34.0: check if numpy<2 is still needed
         if _check_soft_dependencies(["pmdarima", "numpy<2"], severity="none"):
             fy_proba = ARIMA()
         else:

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1828,10 +1828,6 @@ class _ReducerMixin:
         return fh_idx
 
 
-# TODO (release 0.33.0)
-# change the default of `windows_identical` to `False`
-# update the docstring for parameter `windows_identical`
-# remove the corresponding warning and simplify __init__
 class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
     """Direct reduction forecaster, incl single-output, multi-output, exogeneous Dir.
 
@@ -1898,7 +1894,7 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         "panel" = second lowest level, one reduced model per panel level (-2)
         if there are 2 or less levels, "global" and "panel" result in the same
         if there is only 1 level (single time series), all three settings agree
-    windows_identical : bool, optional, default=True
+    windows_identical : bool, optional, default=False
         Specifies whether all direct models use the same number of observations
         or a different number of observations.
 
@@ -1911,8 +1907,6 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         * `False` : Window size differs for each forecasting horizon. Window
           length corresponds to (total observations + 1 - window_length +
           forecasting horizon).
-
-        Default value will change to `False` in version 0.33.0.
     """
 
     _tags = {
@@ -1932,7 +1926,7 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         X_treatment="concurrent",
         impute_method="bfill",
         pooling="local",
-        windows_identical="changing_value",
+        windows_identical=False,
     ):
         self.window_length = window_length
         self.transformers = transformers
@@ -1942,22 +1936,6 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         self.impute_method = impute_method
         self.pooling = pooling
         self.windows_identical = windows_identical
-        if windows_identical == "changing_value":
-            warn(
-                "In `DirectReductionForecaster`, the default value of parameter "
-                "`windows_identical` will change to `False` in version 0.33.0. "
-                "Before the introduction of `windows_identical`, the parameter "
-                "defaulted implicitly to `True` when `X_treatment` was set to "
-                "`shifted`, and to `False` when `X_treatment` was set to "
-                "`concurrent`. To keep current behaviour and to silence this "
-                "warning, set `windows_identical` explicitly.",
-            )
-            if X_treatment == "shifted":
-                self._windows_identical = True
-            else:
-                self._windows_identical = False
-        else:
-            self._windows_identical = windows_identical
         self._lags = list(range(window_length))
         super().__init__()
 
@@ -1985,7 +1963,7 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         """Fit dispatcher based on X_treatment and windows_identical."""
         # shifted X (future X unknown) and identical windows reduce to
         # multioutput regression, o/w fit multiple individual estimators
-        if (self.X_treatment == "shifted") and (self._windows_identical is True):
+        if (self.X_treatment == "shifted") and (self.windows_identical is True):
             return self._fit_multioutput(y=y, X=X, fh=fh)
         else:
             return self._fit_multiple(y=y, X=X, fh=fh)
@@ -1993,7 +1971,7 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
     def _predict(self, X=None, fh=None):
         """Predict dispatcher based on X_treatment and windows_identical."""
         if self.X_treatment == "shifted":
-            if self._windows_identical is True:
+            if self.windows_identical is True:
                 return self._predict_multioutput(X=X, fh=fh)
             else:
                 return self._predict_multiple(X=self._X, fh=fh)
@@ -2085,7 +2063,7 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
 
         impute_method = self.impute_method
         X_treatment = self.X_treatment
-        windows_identical = self._windows_identical
+        windows_identical = self.windows_identical
 
         # lagger_y_to_X_ will lag y to obtain the sklearn X
         lags = self._lags

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -20,7 +20,7 @@ from sktime.forecasting.model_selection._tune import (
 )
 
 
-# todo 0.33.0 - check whether we should remove, otherwise bump
+# todo 0.34.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def temporal_train_test_split(
     y, X=None, test_size=None, train_size=None, fh=None, anchor="start"
@@ -47,7 +47,7 @@ def temporal_train_test_split(
     )
 
 
-# todo 0.33.0 - check whether we should remove, otherwise bump
+# todo 0.34.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
     """Legacy export of Expanding window splitter.
@@ -70,7 +70,7 @@ def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
     return _EWSplitter(fh=fh, initial_window=initial_window, step_length=step_length)
 
 
-# todo 0.33.0 - check whether we should remove, otherwise bump
+# todo 0.34.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def SlidingWindowSplitter(
     fh=1, window_length=10, step_length=1, initial_window=None, start_with_window=True

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -2,7 +2,6 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements grid search functionality to tune forecasters."""
 
-__author__ = ["mloning", "fkiraly", "aiwalter"]
 __all__ = [
     "ForecastingGridSearchCV",
     "ForecastingRandomizedSearchCV",
@@ -85,7 +84,7 @@ class BaseGridSearch(_DelegatedForecaster):
         if tune_by_variable:
             self.set_tags(**{"scitype:y": "univariate"})
 
-        # todo 0.33.0: check if this is still necessary
+        # todo 0.34.0: check if this is still necessary
         # n_jobs is deprecated, left due to use in tutorials, books, blog posts
         if n_jobs != "deprecated":
             warn(

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -16,7 +16,6 @@ from packaging.version import InvalidVersion, Version
 
 def _check_soft_dependencies(
     *packages,
-    package_import_alias="deprecated",
     severity="error",
     obj=None,
     msg=None,
@@ -36,8 +35,6 @@ def _check_soft_dependencies(
         ``_check_soft_dependencies("package1", "package2")``
         ``_check_soft_dependencies(("package1", "package2"))``
         ``_check_soft_dependencies(["package1", "package2"])``
-
-    package_import_alias : ignored, present only for backwards compatibility
 
     severity : str, "error" (default), "warning", "none"
         behaviour for raising errors or warnings
@@ -80,17 +77,6 @@ def _check_soft_dependencies(
     -------
     boolean - whether all packages are installed, only if no exception is raised
     """
-    # todo 0.33.0: remove this warning
-    if package_import_alias != "deprecated":
-        warnings.warn(
-            "In sktime _check_soft_dependencies, the package_import_alias argument "
-            "is deprecated and no longer has any effect. "
-            "The argument will be removed in version 0.33.0, so users of the "
-            "_check_soft_dependencies utility should not pass this argument anymore.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
     if len(packages) == 1 and isinstance(packages[0], (tuple, list)):
         packages = packages[0]
     if not all(isinstance(x, str) for x in packages):


### PR DESCRIPTION
Carries out deprecations and change actions scheduled for 0.33.0:

* remove `package_import_alias` argument in `_check_soft_dependencies`
* in `DirectReductionForecaster`, change `windows_identical` default to `False`
* bump deprecation/change checks scheduled for 0.33.0 to 0.34.0