### PR TITLE
[MNT] remove <3.11 restriction for `pytorch-forecasting`, add upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,7 +288,7 @@ dl = [
   'torch; python_version < "3.12"',
   'transformers[torch]<4.41.0; python_version < "3.12"',
   'pykan<0.2.2,>=0.2; python_version > "3.9.7"',
-  'pytorch-forecasting>=1.0.0, <1.2.0',
+  'pytorch-forecasting>=1.0.0,<1.2.0',
 ]
 mlflow = [
   "mlflow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,7 +288,7 @@ dl = [
   'torch; python_version < "3.12"',
   'transformers[torch]<4.41.0; python_version < "3.12"',
   'pykan<0.2.2,>=0.2; python_version > "3.9.7"',
-  'pytorch-forecasting>=1.0.0; python_version < "3.11"',
+  'pytorch-forecasting>=1.0.0, <1.2.0',
 ]
 mlflow = [
   "mlflow",


### PR DESCRIPTION
With the 1.1.0 release, `pytorch-forecasting` supports python 3.12.

This Pr:
* removes the <3.11 restriction for `pytorch-forecasting`
* adds upper bound `<1.2.0`