### PR TITLE
[MNT] remove python version bound from `pytorch-forecasting` based estimators

### DIFF
--- a/sktime/forecasting/base/adapters/_pytorchforecasting.py
+++ b/sktime/forecasting/base/adapters/_pytorchforecasting.py
@@ -56,7 +56,6 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         # --------------
         "authors": ["XinyuWu"],
         "maintainers": ["XinyuWu"],
-        "python_version": ">3.8, <3.11",
         "python_dependencies": ["pytorch-forecasting>=1.0.0"],
         # estimator type
         # --------------


### PR DESCRIPTION
This PR removes the hard coded python version bound from `pytorch-forecasting` based estimators