### PR TITLE
[DOC] correct incorrect bounds mentioned in 0.33.0 changelog

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -29,9 +29,7 @@ For last non-maintenance content updates, see 0.32.4 and 0.32.2.
 Dependency changes
 ~~~~~~~~~~~~~~~~~~
 
-* ``numpy`` (core dependency) bounds have been updated to ``>=1.21,<2.2``
 * ``scikit-base`` (core dependency) bounds have been updated to ``>=0.6.1,<0.10.0``
-* ``skpro`` (soft dependency) bounds have been updated to ``>=2,<2.7.0``
 * ``holidays`` (transformations soft dependency) bounds have been updated to ``>=0.29,<0.57``
 * ``pykan`` (deep learning soft dependency) bounds have been updated to ``>=0.2,<0.2.7``
 * ``mne`` (transformations soft dependency) bounds have been updated to ``>=1.5,<1.9``
@@ -196,7 +194,7 @@ to assign cluster centers. The following boolean tags have been added:
 
 * ``capability:predict``, whether the clusterer can assign cluster labels via ``predict``
 * ``capability:predict_proba``, for probabilistic cluster assignment
-* ``capability: out_of_sample``, for out-of-sample cluster assignment.
+* ``capability:out_of_sample``, for out-of-sample cluster assignment.
   If False, the clusterer can only assign clusters to data points seen during fitting.
 
 Enhancements


### PR DESCRIPTION
This corrects some incorrect bounds mentioned in 0.33.0 changelog, changing the bounds in the changelog to the correct ones, as in the `pyproject.toml`.