### PR TITLE
[BUG] fix `drop_na` and update mode of `Differencer` transformation

### DIFF
--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -343,8 +343,6 @@ class Differencer(BaseTransformer):
 
         Xt = _diff_transform(X, self._lags)
 
-        Xt = Xt.loc[X_orig_index]
-
         na_handling = self.na_handling
         if na_handling == "drop_na":
             Xt = Xt.iloc[self._lagsum :]
@@ -357,6 +355,12 @@ class Differencer(BaseTransformer):
                 "unreachable condition, invalid na_handling value encountered: "
                 f"{na_handling}"
             )
+
+        if na_handling != "drop_na":
+            Xt = Xt.loc[X_orig_index]
+        else:
+            new_index = Xt.index.intersection(X_orig_index)
+            Xt = Xt.loc[new_index]
 
         return Xt
 

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -19,7 +19,7 @@ from sktime.utils.validation import is_int
 def _check_lags(lags):
     msg = " ".join(
         [
-            "`lags` should be provided as a positive integer scaler, or",
+            "`lags` should be provided as a positive integer scaler, or ",
             "a list, tuple or np.ndarray of positive integers,"
             f"but found {type(lags)}.",
         ]

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -338,6 +338,7 @@ class Differencer(BaseTransformer):
         X_orig_index = X.index
 
         X = update_data(X=self._X, X_new=X)
+        X = X.sort_index()
 
         X = self._check_freq(X)
 

--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -240,3 +240,51 @@ def test_differencer_inverse_does_not_memorize():
 
     # model output should not be similar to train input
     assert not np.allclose(y_train[1:].to_numpy(), model_ins.to_numpy())
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(Differencer),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_dropna_pipeline():
+    """Test that Differencer works in a pipeline with a forecaster.
+
+    Failure case of #7076.
+    """
+    from sklearn.linear_model import ElasticNetCV
+
+    from sktime.datasets import load_longley
+    from sktime.forecasting.compose import (
+        ForecastingPipeline,
+        TransformedTargetForecaster,
+        YfromX,
+    )
+
+    # Load the data
+    y, X = load_longley()
+
+    # Create separate transformers for y and X
+    transformer = Differencer(na_handling='drop_na')
+
+    # Define the TransformedTargetForecaster for y
+    pipe_y = TransformedTargetForecaster(
+        steps=[
+            ("transform_y", transformer),
+            ("forecaster", YfromX(estimator=ElasticNetCV(max_iter=50000)))
+        ]
+    )
+
+    # Create the ForecastingPipeline for y and X
+    pipe_yX = ForecastingPipeline(
+        steps=[
+            ("transform_X", transformer),
+            ("pipe_y", pipe_y)
+        ]
+    )
+
+    # Fit the pipeline to your data
+    pipe_yX.fit(y=y.iloc[:-1], X=X.iloc[:-1, :])
+
+    # Predict
+    y_pred = pipe_yX.predict(fh=[1], X=X.iloc[-1:, :])
+    assert len(y_pred) == 1

--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -264,22 +264,19 @@ def test_dropna_pipeline():
     y, X = load_longley()
 
     # Create separate transformers for y and X
-    transformer = Differencer(na_handling='drop_na')
+    transformer = Differencer(na_handling="drop_na")
 
     # Define the TransformedTargetForecaster for y
     pipe_y = TransformedTargetForecaster(
         steps=[
             ("transform_y", transformer),
-            ("forecaster", YfromX(estimator=ElasticNetCV(max_iter=50000)))
+            ("forecaster", YfromX(estimator=ElasticNetCV(max_iter=50000))),
         ]
     )
 
     # Create the ForecastingPipeline for y and X
     pipe_yX = ForecastingPipeline(
-        steps=[
-            ("transform_X", transformer),
-            ("pipe_y", pipe_y)
-        ]
+        steps=[("transform_X", transformer), ("pipe_y", pipe_y)]
     )
 
     # Fit the pipeline to your data

--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -48,6 +48,34 @@ def test_differencer_produces_expected_results(na_handling):
     not run_test_for_class(Differencer),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
+@pytest.mark.parametrize("na_handling", Differencer.VALID_NA_HANDLING_STR)
+def test_differencer_transform_memory(na_handling, lags=[1, 12, (1, 2)]):
+    """Test that Differencer remembers data seen in fit.
+
+    We will create three transformed data, with the same lags, and different
+    na_handling. All should be the same, because:
+
+    * the Differencer should remember data seen in fit
+    * the values affected by na_handling are cut off at the start of the series
+    """
+    y_airline = load_airline()
+    y_airline_start = y_airline[:120]
+    y_airline_end = y_airline[120:]
+
+    transformer = Differencer(na_handling=na_handling, lags=lags)
+    transformer.fit(y_airline_start)
+    yt_separate = transformer.transform(y_airline_end)
+    yt_together_trafo = transformer.transform(y_airline)[120:]
+    yt_together_fit = transformer.fit_transform(y_airline)[120:]
+
+    _assert_array_almost_equal(yt_separate, yt_together_trafo)
+    _assert_array_almost_equal(yt_separate, yt_together_fit)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(Differencer),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("y", test_cases)
 @pytest.mark.parametrize("lags", lags_to_test)
 @pytest.mark.parametrize("index_type", ["int", "datetime"])

--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -49,7 +49,8 @@ def test_differencer_produces_expected_results(na_handling):
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 @pytest.mark.parametrize("na_handling", Differencer.VALID_NA_HANDLING_STR)
-def test_differencer_transform_memory(na_handling, lags=[1, 12, (1, 2)]):
+@pytest.mark.parametrize("lags", lags_to_test)
+def test_differencer_transform_memory(na_handling, lags):
     """Test that Differencer remembers data seen in fit.
 
     We will create three transformed data, with the same lags, and different

--- a/sktime/transformations/series/tests/test_differencer.py
+++ b/sktime/transformations/series/tests/test_differencer.py
@@ -60,14 +60,14 @@ def test_differencer_transform_memory(na_handling, lags):
     * the values affected by na_handling are cut off at the start of the series
     """
     y_airline = load_airline()
-    y_airline_start = y_airline[:120]
-    y_airline_end = y_airline[120:]
+    y_airline_start = y_airline[:-24]
+    y_airline_end = y_airline[-24:]
 
     transformer = Differencer(na_handling=na_handling, lags=lags)
     transformer.fit(y_airline_start)
     yt_separate = transformer.transform(y_airline_end)
-    yt_together_trafo = transformer.transform(y_airline)[120:]
-    yt_together_fit = transformer.fit_transform(y_airline)[120:]
+    yt_together_trafo = transformer.transform(y_airline)[-24:]
+    yt_together_fit = transformer.fit_transform(y_airline)[-24:]
 
     _assert_array_almost_equal(yt_separate, yt_together_trafo)
     _assert_array_almost_equal(yt_separate, yt_together_fit)


### PR DESCRIPTION
This PR fixes the bug with `drop_na` reported in #7076, and further issues that arise when `transform` is called on data different from `fit`.

Adds tests covering the change:
* the example from #7076
* test cases where `fit` and `transform` indices are different