### PR TITLE
[BUG] Adding a parameter to `reconciler forecaster` to return a dataframe without the dunder levels

### DIFF
--- a/sktime/forecasting/reconcile.py
+++ b/sktime/forecasting/reconcile.py
@@ -48,6 +48,9 @@ class ReconcilerForecaster(BaseForecaster):
             * "wls_str" - weighted least squares (structural)
             * "bu" - bottom-up
             * "td_fcst" - top down based on forecast proportions
+    return_totals : bool
+        If True, returns the dataframe with __total values
+        If False, returns the dataframe without __total values
 
     See Also
     --------
@@ -110,11 +113,12 @@ class ReconcilerForecaster(BaseForecaster):
 
     TRFORM_LIST = Reconciler().METHOD_LIST
     METHOD_LIST = ["mint_cov", "mint_shrink", "wls_var"] + TRFORM_LIST
+    RETURN_TOTALS_LIST = [True, False]
 
-    def __init__(self, forecaster, method="mint_shrink", total=True):
+    def __init__(self, forecaster, method="mint_shrink", return_totals=True):
         self.forecaster = forecaster
         self.method = method
-        self.total = total
+        self.return_totals = return_totals
 
         super().__init__()
 
@@ -240,9 +244,15 @@ class ReconcilerForecaster(BaseForecaster):
         recon_fc = pd.concat(recon_fc, axis=0)
         recon_fc = recon_fc.sort_index()
 
-        if not self.total:
+        if not self.return_totals:
             n = recon_fc.index.get_slice_bound(label="__total", side="left")
-            return recon_fc[:n]
+            if len(recon_fc[:n]) == 0:
+                recon_fc = recon_fc[n:]
+            else:
+                recon_fc = recon_fc[:n]
+            level_values = recon_fc.index.get_level_values(-2)
+            recon_fc = recon_fc[~(level_values == "__total")]
+            return recon_fc
 
         return recon_fc
 
@@ -415,7 +425,9 @@ class ReconcilerForecaster(BaseForecaster):
             {
                 "forecaster": FORECASTER,
                 "method": x,
+                "return_totals": totals,
             }
             for x in cls.METHOD_LIST
+            for totals in cls.RETURN_TOTALS_LIST
         ]
         return params_list

--- a/sktime/forecasting/reconcile.py
+++ b/sktime/forecasting/reconcile.py
@@ -111,9 +111,10 @@ class ReconcilerForecaster(BaseForecaster):
     TRFORM_LIST = Reconciler().METHOD_LIST
     METHOD_LIST = ["mint_cov", "mint_shrink", "wls_var"] + TRFORM_LIST
 
-    def __init__(self, forecaster, method="mint_shrink"):
+    def __init__(self, forecaster, method="mint_shrink", total=True):
         self.forecaster = forecaster
         self.method = method
+        self.total = total
 
         super().__init__()
 
@@ -238,6 +239,10 @@ class ReconcilerForecaster(BaseForecaster):
 
         recon_fc = pd.concat(recon_fc, axis=0)
         recon_fc = recon_fc.sort_index()
+
+        if not self.total:
+            n = recon_fc.index.get_slice_bound(label="__total", side="left")
+            return recon_fc[:n]
 
         return recon_fc
 

--- a/sktime/forecasting/tests/test_reconcile.py
+++ b/sktime/forecasting/tests/test_reconcile.py
@@ -124,8 +124,7 @@ def test_reconcilerforecaster_exog(n_columns):
     estimator_instance.update(y=y_test, X=X_test)
 
 
-@pytest.mark.parametrize("return_totals", False)
-def test_reconcilerforecaster_return_totals(return_totals):
+def test_reconcilerforecaster_return_totals(return_totals=False):
     """Test that ReconcilerForecaster returns the dataframe without the dunder levels"""
     from sktime.datatypes._utilities import get_window
     from sktime.forecasting.reconcile import ReconcilerForecaster

--- a/sktime/forecasting/tests/test_reconcile.py
+++ b/sktime/forecasting/tests/test_reconcile.py
@@ -128,8 +128,8 @@ def test_reconcilerforecaster_exog(n_columns):
 def test_reconcilerforecaster_return_totals(return_totals):
     """Test that ReconcilerForecaster returns the dataframe without the dunder levels"""
     from sktime.datatypes._utilities import get_window
+    from sktime.forecasting.naive import NaiveForecaster
     from sktime.forecasting.reconcile import ReconcilerForecaster
-    from sktime.forecasting.sarimax import SARIMAX
 
     y = _make_hierarchical(
         hierarchy_levels=(4, 3),  # (m, n) = (4, 3)
@@ -152,7 +152,7 @@ def test_reconcilerforecaster_return_totals(return_totals):
     X_train = get_window(X, lag=2)
     X_test = get_window(X, window_length=2)
 
-    forecaster = SARIMAX()
+    forecaster = NaiveForecaster()
     estimator_instance = ReconcilerForecaster(
         forecaster, method="mint_shrink", return_totals=return_totals
     )

--- a/sktime/forecasting/tests/test_reconcile.py
+++ b/sktime/forecasting/tests/test_reconcile.py
@@ -124,14 +124,15 @@ def test_reconcilerforecaster_exog(n_columns):
     estimator_instance.update(y=y_test, X=X_test)
 
 
-def test_reconcilerforecaster_return_totals(return_totals=False):
+@pytest.mark.parametrize("return_totals", [True, False])
+def test_reconcilerforecaster_return_totals(return_totals):
     """Test that ReconcilerForecaster returns the dataframe without the dunder levels"""
     from sktime.datatypes._utilities import get_window
     from sktime.forecasting.reconcile import ReconcilerForecaster
     from sktime.forecasting.sarimax import SARIMAX
 
     y = _make_hierarchical(
-        hierarchy_levels=(4, 3),
+        hierarchy_levels=(4, 3),  # (m, n) = (4, 3)
         n_columns=1,
         min_timepoints=12,
         max_timepoints=12,
@@ -158,4 +159,9 @@ def test_reconcilerforecaster_return_totals(return_totals=False):
     fh = [1, 2]
     estimator_instance.fit(y=y_train, X=X_train, fh=fh)
     y_pred = estimator_instance.predict(X=X_test)
-    assert len(y_test) == len(y_pred)
+    if return_totals:
+        # for hierarchy_levels=(m, n), len(y_pred) = len(y_test) + (1 + m) * 2
+        assert len(y_pred) == (len(y_test) + (1 + 4) * 2)
+    else:
+        assert len(y_test) == len(y_pred)
+        assert y_test.index.equals(y_pred.index)

--- a/sktime/forecasting/tests/test_reconcile.py
+++ b/sktime/forecasting/tests/test_reconcile.py
@@ -128,7 +128,7 @@ def test_reconcilerforecaster_exog(n_columns):
 def test_reconcilerforecaster_return_totals(return_totals):
     """Test that ReconcilerForecaster returns the dataframe without the dunder levels"""
     from sktime.datatypes._utilities import get_window
-    from sktime.forecasting.naive import NaiveForecaster
+    from sktime.forecasting.compose import YfromX
     from sktime.forecasting.reconcile import ReconcilerForecaster
 
     y = _make_hierarchical(
@@ -152,7 +152,7 @@ def test_reconcilerforecaster_return_totals(return_totals):
     X_train = get_window(X, lag=2)
     X_test = get_window(X, window_length=2)
 
-    forecaster = NaiveForecaster()
+    forecaster = YfromX.create_test_instance()
     estimator_instance = ReconcilerForecaster(
         forecaster, method="mint_shrink", return_totals=return_totals
     )

--- a/sktime/forecasting/tests/test_reconcile.py
+++ b/sktime/forecasting/tests/test_reconcile.py
@@ -122,3 +122,41 @@ def test_reconcilerforecaster_exog(n_columns):
     estimator_instance.fit(y=y_train, X=X_train, fh=fh)
     estimator_instance.predict(X=X_test)
     estimator_instance.update(y=y_test, X=X_test)
+
+
+@pytest.mark.parametrize("return_totals", False)
+def test_reconcilerforecaster_return_totals(return_totals):
+    """Test that ReconcilerForecaster returns the dataframe without the dunder levels"""
+    from sktime.datatypes._utilities import get_window
+    from sktime.forecasting.reconcile import ReconcilerForecaster
+    from sktime.forecasting.sarimax import SARIMAX
+
+    y = _make_hierarchical(
+        hierarchy_levels=(4, 3),
+        n_columns=1,
+        min_timepoints=12,
+        max_timepoints=12,
+        index_type="period",
+    )
+    y_train = get_window(y, lag=2)
+    y_test = get_window(y, window_length=2)
+
+    X = _make_hierarchical(
+        hierarchy_levels=(4, 3),
+        n_columns=2,
+        min_timepoints=12,
+        max_timepoints=12,
+        index_type="period",
+    )
+    X.columns = ["foo", "bar"]
+    X_train = get_window(X, lag=2)
+    X_test = get_window(X, window_length=2)
+
+    forecaster = SARIMAX()
+    estimator_instance = ReconcilerForecaster(
+        forecaster, method="mint_shrink", return_totals=return_totals
+    )
+    fh = [1, 2]
+    estimator_instance.fit(y=y_train, X=X_train, fh=fh)
+    y_pred = estimator_instance.predict(X=X_test)
+    assert len(y_test) == len(y_pred)


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->  #7107 and  #4767


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.

--> 
Adds a parameter `total` to the reconciler forecaster which when False returns the dataframe without the dunder (__total) levels


