### PR TITLE
[ENH] refactor `datatypes` example fixtures to `BaseObject` classes

### DIFF
--- a/sktime/datatypes/_alignment/__init__.py
+++ b/sktime/datatypes/_alignment/__init__.py
@@ -1,7 +1,6 @@
 """Module exports: Alignment type checkers and mtype inference."""
 
 from sktime.datatypes._alignment._check import check_dict as check_dict_Alignment
-from sktime.datatypes._alignment._examples import example_dict as example_dict_Alignment
 from sktime.datatypes._alignment._registry import (
     MTYPE_LIST_ALIGNMENT,
     MTYPE_REGISTER_ALIGNMENT,
@@ -9,7 +8,6 @@ from sktime.datatypes._alignment._registry import (
 
 __all__ = [
     "check_dict_Alignment",
-    "example_dict_Alignment",
     "MTYPE_LIST_ALIGNMENT",
     "MTYPE_REGISTER_ALIGNMENT",
 ]

--- a/sktime/datatypes/_alignment/_examples.py
+++ b/sktime/datatypes/_alignment/_examples.py
@@ -28,6 +28,7 @@ from sktime.datatypes._base import BaseExample
 
 ###
 
+
 class _AlignmentSimple(BaseExample):
     _tags = {
         "scitype": "Alignment",
@@ -55,4 +56,4 @@ class _AlignmentSimpleAlignmentLoc(_AlignmentSimple):
     }
 
     def build(self):
-          return pd.DataFrame({"ind0": [2, 2.5, 2.5, 100], "ind1": [-1, -1, 2, 2]})
+        return pd.DataFrame({"ind0": [2, 2.5, 2.5, 100], "ind1": [-1, -1, 2, 2]})

--- a/sktime/datatypes/_alignment/_examples.py
+++ b/sktime/datatypes/_alignment/_examples.py
@@ -1,27 +1,58 @@
 """Example generation for testing.
 
-Exports dict of examples, useful for testing as fixtures.
+Exports examples of in-memory data containers, useful for testing as fixtures.
 
-example_dict: dict indexed by triple
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are data objects, considered examples for the mtype
-    all examples with same index are considered "same" on scitype content
-    if None, indicates that representation is not possible
+Examples come in clusters, tagged by scitype: str, index: int, and metadata: dict.
+
+All examples with the same index are considered "content-wise the same", i.e.,
+representing the same abstract data object. They differ by mtype, i.e.,
+machine type, which is the specific in-memory representation.
+
+If an example returns None, it indicates that representation
+with that specific mtype is not possible.
+
+If the tag "lossy" is True, the representation is considered incomplete,
+e.g., metadata such as column names are missing.
+
+Types of tests that can be performed with these examples:
+
+* the mtype and scitype of the example should be correctly inferred by checkers.
+* the metadata of hte example should be correctly inferred by checkers.
+* conversions from non-lossy representations to any other ones
+  should yield the element exactly, identically, for examples of the same index.
 """
 
 import pandas as pd
 
-example_dict = dict()
+from sktime.datatypes._base import BaseExample
 
 ###
 
-align = pd.DataFrame({"ind0": [1, 2, 2, 3], "ind1": [0, 0, 1, 1]})
+class _AlignmentSimple(BaseExample):
+    _tags = {
+        "scitype": "Alignment",
+        "index": 0,
+        "metadata": {},
+    }
 
-example_dict[("alignment", "Alignment", 0)] = align
+
+class _AlignmentSimpleAlignment(_AlignmentSimple):
+    _tags = {
+        "mtype": "alignment",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        return pd.DataFrame({"ind0": [1, 2, 2, 3], "ind1": [0, 0, 1, 1]})
 
 
-align = pd.DataFrame({"ind0": [2, 2.5, 2.5, 100], "ind1": [-1, -1, 2, 2]})
+class _AlignmentSimpleAlignmentLoc(_AlignmentSimple):
+    _tags = {
+        "mtype": "alignment_loc",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-example_dict[("alignment_loc", "Alignment", 0)] = align
+    def build(self):
+          return pd.DataFrame({"ind0": [2, 2.5, 2.5, 100], "ind1": [-1, -1, 2, 2]})

--- a/sktime/datatypes/_base/__init__.py
+++ b/sktime/datatypes/_base/__init__.py
@@ -1,0 +1,5 @@
+"""Base module for datatypes."""
+
+from sktime.datatypes._base._base import BaseConverter, BaseDatatype, BaseExample
+
+__all__ = ["BaseConverter", "BaseDatatype", "BaseExample"]

--- a/sktime/datatypes/_base/_base.py
+++ b/sktime/datatypes/_base/_base.py
@@ -1,0 +1,394 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Base class for data types."""
+
+__author__ = ["fkiraly"]
+
+from sktime.base import BaseObject
+from sktime.datatypes._common import _ret
+from sktime.utils.deep_equals import deep_equals
+
+
+class BaseDatatype(BaseObject):
+    """Base class for data types.
+
+    This class is the base class for all data types in sktime.
+    """
+
+    _tags = {
+        "object_type": "datatype",
+        "scitype": None,
+        "name": None,  # any string
+        "name_python": None,  # lower_snake_case
+        "name_aliases": [],
+        "python_version": None,
+        "python_dependencies": None,
+    }
+
+    def __init__(self):
+        super().__init__()
+
+    # call defaults to check
+    def __call__(self, obj, return_metadata=False, var_name="obj"):
+        """Check if obj is of this data type.
+
+        Parameters
+        ----------
+        obj : any
+            Object to check.
+        return_metadata : bool, optional (default=False)
+            Whether to return metadata.
+        var_name : str, optional (default="obj")
+            Name of the variable to check, for use in error messages.
+
+        Returns
+        -------
+        valid : bool
+            Whether obj is of this data type.
+        msg : str, only returned if return_metadata is True.
+            Error message if obj is not of this data type.
+        metadata : instance of self only returned if return_metadata is True.
+            Metadata dictionary.
+        """
+        return self._check(obj=obj, return_metadata=return_metadata, var_name=var_name)
+
+    def check(self, obj, return_metadata=False, var_name="obj"):
+        """Check if obj is of this data type.
+
+        If self has parameters set, the check will in addition
+        check whether metadata of obj is equal to self's parameters.
+        In this case, ``return_metadata`` will always include the
+        metadata fields required to check the parameters.
+
+        Parameters
+        ----------
+        obj : any
+            Object to check.
+        return_metadata : bool, optional (default=False)
+            Whether to return metadata.
+        var_name : str, optional (default="obj")
+            Name of the variable to check, for use in error messages.
+
+        Returns
+        -------
+        valid : bool
+            Whether obj is of this data type.
+        msg : str, only returned if return_metadata is True.
+            Error message if obj is not of this data type.
+        metadata : instance of self only returned if return_metadata is True.
+            Metadata dictionary.
+        """
+        self_params = self.get_params()
+
+        need_check = [k for k in self_params if self_params[k] is not None]
+        self_dict = {k: self_params[k] for k in need_check}
+
+        return_metadata_orig = return_metadata
+
+        # update return_metadata to retrieve any self_params
+        # return_metadata_bool has updated condition
+        if not len(need_check) == 0:
+            if isinstance(return_metadata, bool):
+                if not return_metadata:
+                    return_metadata = need_check
+                    return_metadata_bool = True
+            else:
+                return_metadata = set(return_metadata).union(need_check)
+                return_metadata = list(return_metadata)
+                return_metadata_bool = True
+        elif isinstance(return_metadata, bool):
+            return_metadata_bool = return_metadata
+        else:
+            return_metadata_bool = True
+
+        # call inner _check
+        check_res = self._check(
+            obj=obj, return_metadata=return_metadata, var_name=var_name
+        )
+
+        if return_metadata_bool:
+            valid = check_res[0]
+            msg = check_res[1]
+            metadata = check_res[2]
+        else:
+            valid = check_res
+            msg = ""
+
+        if not valid:
+            return _ret(False, msg, None, return_metadata_orig)
+
+        # now we know the check is valid, but we need to compare fields
+        metadata_sub = {k: metadata[k] for k in self_dict}
+        eqs, msg = deep_equals(self_dict, metadata_sub, return_msg=True)
+        if not eqs:
+            msg = f"metadata of type unequal, {msg}"
+            return _ret(False, msg, None, return_metadata_orig)
+
+        self_type = type(self)(**metadata)
+        return _ret(True, "", self_type, return_metadata_orig)
+
+    def _check(self, obj, return_metadata=False, var_name="obj"):
+        """Check if obj is of this data type.
+
+        Parameters
+        ----------
+        obj : any
+            Object to check.
+        return_metadata : bool, optional (default=False)
+            Whether to return metadata.
+        var_name : str, optional (default="obj")
+            Name of the variable to check, for use in error messages.
+
+        Returns
+        -------
+        valid : bool
+            Whether obj is of this data type.
+        msg : str, only returned if return_metadata is True.
+            Error message if obj is not of this data type.
+        metadata : dict, only returned if return_metadata is True.
+            Metadata dictionary.
+        """
+        raise NotImplementedError
+
+    def __getitem__(self, key):
+        """Get attribute by key.
+
+        Parameters
+        ----------
+        key : str
+            Attribute name.
+
+        Returns
+        -------
+        value : any
+            Attribute value.
+        """
+        return getattr(self, key)
+
+    def get(self, key, default=None):
+        """Get attribute by key.
+
+        Parameters
+        ----------
+        key : str
+            Attribute name.
+        default : any, optional (default=None)
+            Default value if attribute does not exist.
+
+        Returns
+        -------
+        value : any
+            Attribute value.
+        """
+        return getattr(self, key, default)
+
+    def _get_key(self):
+        """Get unique dictionary key corresponding to self.
+
+        Private function, used in collecting a dictionary of checks.
+        """
+        mtype = self.get_class_tag("name")
+        scitype = self.get_class_tag("scitype")
+        return (mtype, scitype)
+
+
+class BaseConverter(BaseObject):
+    """Base class for data type converters.
+
+    This class is the base class for all data type converters in sktime.
+    """
+
+    _tags = {
+        "object_type": "converter",
+        "mtype_from": None,  # type to convert from - BaseDatatype class or str
+        "mtype_to": None,  # type to convert to - BaseDatatype class or str
+        "multiple_conversions": False,  # whether converter encodes multiple conversions
+        "python_version": None,
+        "python_dependencies": None,
+    }
+
+    def __init__(self, mtype_from=None, mtype_to=None):
+        self.mtype_from = mtype_from
+        self.mtype_to = mtype_to
+        super().__init__()
+
+        if mtype_from is not None:
+            self.set_tags(**{"mtype_from": mtype_from})
+        if mtype_to is not None:
+            self.set_tags(**{"mtype_to": mtype_to})
+
+        mtype_from = self.get_tag("mtype_from")
+        mtype_to = self.get_tag("mtype_to")
+
+        if mtype_from is None:
+            raise ValueError(
+                f"Error in instantiating {self.__class__.__name__}: "
+                "mtype_from and mtype_to must be set if the class has no defaults. "
+                "For valid pairs of defaults, use get_conversions."
+            )
+        if mtype_to is None:
+            raise ValueError(
+                f"Error in instantiating {self.__class__.__name__}: "
+                "mtype_to must be set in constructor, as the class has no defaults. "
+                "For valid pairs of defaults, use get_conversions."
+            )
+        if (mtype_from, mtype_to) not in self.__class__.get_conversions():
+            raise ValueError(
+                f"Error in instantiating {self.__class__.__name__}: "
+                "mtype_from and mtype_to must be a valid pair of defaults. "
+                "For valid pairs of defaults, use get_conversions."
+            )
+
+    # call defaults to convert
+    def __call__(self, obj, store=None):
+        """Convert obj to another machine type.
+
+        Parameters
+        ----------
+        obj : any
+            Object to convert.
+        store : dict, optional (default=None)
+            Reference of storage for lossy conversions.
+
+        Returns
+        -------
+        converted_obj : any
+            Object obj converted to another machine type.
+        """
+        return self.convert(obj=obj, store=store)
+
+    def convert(self, obj, store=None):
+        """Convert obj to another machine type.
+
+        Parameters
+        ----------
+        obj : any
+            Object to convert.
+        store : dict, optional (default=None)
+            Reference of storage for lossy conversions.
+        """
+        return self._convert(obj, store)
+
+    def _convert(self, obj, store=None):
+        """Convert obj to another machine type.
+
+        Parameters
+        ----------
+        obj : any
+            Object to convert.
+        store : dict, optional (default=None)
+            Reference of storage for lossy conversions.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def get_conversions(cls):
+        """Get all conversions.
+
+        Returns
+        -------
+        list of tuples (BaseDatatype subclass, BaseDatatype subclass)
+            List of all conversions in this class.
+        """
+        cls_from = cls.get_class_tag("mtype_from")
+        cls_to = cls.get_class_tag("mtype_to")
+
+        if cls_from is not None and cls_to is not None:
+            return [(cls_from, cls_to)]
+        # if multiple conversions are encoded, this should be overridden
+        raise NotImplementedError
+
+    def _get_cls_from_to(self):
+        """Get classes from and to.
+
+        Returns
+        -------
+        cls_from : BaseDatatype subclass
+            Class to convert from.
+        cls_to : BaseDatatype subclass
+            Class to convert to.
+        """
+        cls_from = self.get_tag("mtype_from")
+        cls_to = self.get_tag("mtype_to")
+
+        cls_from = _coerce_str_to_cls(cls_from)
+        cls_to = _coerce_str_to_cls(cls_to)
+
+        return cls_from, cls_to
+
+    def _get_key(self):
+        """Get unique dictionary key corresponding to self.
+
+        Private function, used in collecting a dictionary of checks.
+        """
+        cls_from, cls_to = self._get_cls_from_to()
+
+        mtype_from = cls_from.get_class_tag("name")
+        mtype_to = cls_to.get_class_tag("name")
+        scitype = cls_to.get_class_tag("scitype")
+        return (mtype_from, mtype_to, scitype)
+
+
+class BaseExample(BaseObject):
+    """Base class for Example fixtures used in tests and get_examples."""
+
+    _tags = {
+        "object_type": "datatype_example",
+        "scitype": None,
+        "mtype": None,
+        "python_version": None,
+        "python_dependencies": None,
+        "index": None,  # integer index of the example to match with other mtypes
+        "lossy": False,  # whether the example is lossy
+    }
+
+    def __init__(self):
+        super().__init__()
+
+    def _get_key(self):
+        """Get unique dictionary key corresponding to self.
+
+        Private function, used in collecting a dictionary of examples.
+        """
+        mtype = self.get_class_tag("mtype")
+        scitype = self.get_class_tag("scitype")
+        index = self.get_class_tag("index")
+        return (mtype, scitype, index)
+
+    def build(self):
+        """Build example.
+
+        Returns
+        -------
+        obj : any
+            Example object.
+        """
+        raise NotImplementedError
+
+
+def _coerce_str_to_cls(cls_or_str):
+    """Get class from string.
+
+    Parameters
+    ----------
+    cls_or_str : str or class
+        Class or string. If string, assumed to be a unique mtype string from
+        one of the BaseDatatype subclasses.
+
+    Returns
+    -------
+    cls : cls_or_str, if was class; otherwise, class corresponding to string.
+    """
+    if not isinstance(cls_or_str, str):
+        return cls_or_str
+
+    # otherwise, we use the string to get the class from the check dict
+    # perhaps it is nicer to transfer this to a registry later.
+    from sktime.datatypes._check import get_check_dict
+
+    cd = get_check_dict(soft_deps="all")
+    cls = [cd[k].__class__ for k in cd if k[0] == cls_or_str]
+    if len(cls) > 1:
+        raise ValueError(f"Error in converting string to class: {cls_or_str}")
+    elif len(cls) < 1:
+        return None
+    return cls[0]

--- a/sktime/datatypes/_examples.py
+++ b/sktime/datatypes/_examples.py
@@ -32,7 +32,7 @@ def generate_example_dicts(soft_deps="present"):
     from sktime.utils.dependencies import _check_estimator_deps
     from sktime.utils.retrieval import _all_classes
 
-    classes = _all_classes("skpro.datatypes")
+    classes = _all_classes("sktime.datatypes")
     classes = [x[1] for x in classes]
     classes = [x for x in classes if issubclass(x, BaseExample)]
     classes = [x for x in classes if not x.__name__.startswith("Base")]

--- a/sktime/datatypes/_examples.py
+++ b/sktime/datatypes/_examples.py
@@ -14,6 +14,7 @@ the representation is considered "lossy" if the representation is incomplete
 """
 
 from copy import deepcopy
+from functools import lru_cache
 
 from sktime.datatypes._registry import mtype_to_scitype
 
@@ -23,55 +24,35 @@ __all__ = [
     "get_examples",
 ]
 
-from sktime.datatypes._alignment import example_dict_Alignment
-from sktime.datatypes._hierarchical import (
-    example_dict_Hierarchical,
-    example_dict_lossy_Hierarchical,
-    example_dict_metadata_Hierarchical,
-)
-from sktime.datatypes._panel import (
-    example_dict_lossy_Panel,
-    example_dict_metadata_Panel,
-    example_dict_Panel,
-)
-from sktime.datatypes._proba import (
-    example_dict_lossy_Proba,
-    example_dict_metadata_Proba,
-    example_dict_Proba,
-)
-from sktime.datatypes._series import (
-    example_dict_lossy_Series,
-    example_dict_metadata_Series,
-    example_dict_Series,
-)
-from sktime.datatypes._table import (
-    example_dict_lossy_Table,
-    example_dict_metadata_Table,
-    example_dict_Table,
-)
 
-# pool example_dict-s
-example_dict = dict()
-example_dict.update(example_dict_Alignment)
-example_dict.update(example_dict_Series)
-example_dict.update(example_dict_Panel)
-example_dict.update(example_dict_Hierarchical)
-example_dict.update(example_dict_Table)
-example_dict.update(example_dict_Proba)
+@lru_cache(maxsize=1)
+def generate_example_dicts(soft_deps="present"):
+    """Generate example dicts using lookup."""
+    from sktime.datatypes._base import BaseExample
+    from sktime.utils.dependencies import _check_estimator_deps
+    from sktime.utils.retrieval import _all_classes
 
-example_dict_lossy = dict()
-example_dict_lossy.update(example_dict_lossy_Series)
-example_dict_lossy.update(example_dict_lossy_Panel)
-example_dict_lossy.update(example_dict_lossy_Hierarchical)
-example_dict_lossy.update(example_dict_lossy_Table)
-example_dict_lossy.update(example_dict_lossy_Proba)
+    classes = _all_classes("skpro.datatypes")
+    classes = [x[1] for x in classes]
+    classes = [x for x in classes if issubclass(x, BaseExample)]
+    classes = [x for x in classes if not x.__name__.startswith("Base")]
 
-example_dict_metadata = dict()
-example_dict_metadata.update(example_dict_metadata_Series)
-example_dict_metadata.update(example_dict_metadata_Panel)
-example_dict_metadata.update(example_dict_metadata_Hierarchical)
-example_dict_metadata.update(example_dict_metadata_Table)
-example_dict_metadata.update(example_dict_metadata_Proba)
+    # subset only to data types with soft dependencies present
+    if soft_deps == "present":
+        classes = [x for x in classes if _check_estimator_deps(x, severity="none")]
+
+    example_dict = dict()
+    example_dict_lossy = dict()
+    example_dict_metadata = dict()
+    for cls in classes:
+        k = cls()
+        key = k._get_key()
+        key_meta = (key[1], key[2])
+        example_dict[key] = k
+        example_dict_lossy[key] = k.get_class_tags().get("lossy", False)
+        example_dict_metadata[key_meta] = k.get_class_tags().get("metadata", {})
+
+    return example_dict, example_dict_lossy, example_dict_metadata
 
 
 def get_examples(
@@ -99,13 +80,15 @@ def get_examples(
     fixtures: dict with integer keys, elements being
         fixture - example for mtype `mtype`, scitype `as_scitype`
         if return_lossy=True, elements are pairs with fixture and
-        lossy: bool - whether the example is a lossy representation
+            lossy: bool - whether the example is a lossy representation
         if return_metadata=True, elements are triples with fixture, lossy, and
-        metadata: dict - metadata dict that would be returned by check_is_mtype
+            metadata: dict - metadata dict that would be returned by check_is_mtype
     """
     # if as_scitype is None, infer from mtype
     if as_scitype is None:
         as_scitype = mtype_to_scitype(mtype)
+
+    example_dict, example_dict_lossy, example_dict_metadata = generate_example_dicts()
 
     # retrieve all keys that match the query
     exkeys = example_dict.keys()
@@ -116,15 +99,15 @@ def get_examples(
 
     for k in keys:
         if return_lossy:
-            fixtures[k[2]] = (example_dict.get(k), example_dict_lossy.get(k))
+            fixtures[k[2]] = (example_dict.get(k).build(), example_dict_lossy.get(k))
         elif return_metadata:
             fixtures[k[2]] = (
-                example_dict.get(k),
+                example_dict.get(k).build(),
                 example_dict_lossy.get(k),
                 example_dict_metadata.get((k[1], k[2])),
             )
         else:
-            fixtures[k[2]] = example_dict.get(k)
+            fixtures[k[2]] = example_dict.get(k).build()
 
     # deepcopy to avoid side effects
     return deepcopy(fixtures)

--- a/sktime/datatypes/_hierarchical/__init__.py
+++ b/sktime/datatypes/_hierarchical/__init__.py
@@ -4,15 +4,6 @@ from sktime.datatypes._hierarchical._check import check_dict as check_dict_Hiera
 from sktime.datatypes._hierarchical._convert import (
     convert_dict as convert_dict_Hierarchical,
 )
-from sktime.datatypes._hierarchical._examples import (
-    example_dict as example_dict_Hierarchical,
-)
-from sktime.datatypes._hierarchical._examples import (
-    example_dict_lossy as example_dict_lossy_Hierarchical,
-)
-from sktime.datatypes._hierarchical._examples import (
-    example_dict_metadata as example_dict_metadata_Hierarchical,
-)
 from sktime.datatypes._hierarchical._registry import (
     MTYPE_LIST_HIERARCHICAL,
     MTYPE_REGISTER_HIERARCHICAL,
@@ -21,10 +12,6 @@ from sktime.datatypes._hierarchical._registry import (
 __all__ = [
     "check_dict_Hierarchical",
     "convert_dict_Hierarchical",
-    "infer_mtype_dict_Hierarchical",
     "MTYPE_LIST_HIERARCHICAL",
     "MTYPE_REGISTER_HIERARCHICAL",
-    "example_dict_Hierarchical",
-    "example_dict_lossy_Hierarchical",
-    "example_dict_metadata_Hierarchical",
 ]

--- a/sktime/datatypes/_hierarchical/_examples.py
+++ b/sktime/datatypes/_hierarchical/_examples.py
@@ -23,144 +23,141 @@ overall, conversions from non-lossy representations to any other ones
 
 import pandas as pd
 
+from sktime.datatypes._base import BaseExample
 from sktime.datatypes._dtypekind import DtypeKind
-from sktime.utils.dependencies import _check_soft_dependencies
-
-example_dict = dict()
-example_dict_lossy = dict()
-example_dict_metadata = dict()
 
 ###
 # example 0: multivariate, equally sampled
 
-cols = ["foo", "bar", "timepoints"] + [f"var_{i}" for i in range(2)]
 
-Xlist = [
-    pd.DataFrame(
-        [["a", 0, 0, 1, 4], ["a", 0, 1, 2, 5], ["a", 0, 2, 3, 6]], columns=cols
-    ),
-    pd.DataFrame(
-        [["a", 1, 0, 1, 4], ["a", 1, 1, 2, 55], ["a", 1, 2, 3, 6]], columns=cols
-    ),
-    pd.DataFrame(
-        [["a", 2, 0, 1, 42], ["a", 2, 1, 2, 5], ["a", 2, 2, 3, 6]], columns=cols
-    ),
-    pd.DataFrame(
-        [["b", 0, 0, 1, 4], ["b", 0, 1, 2, 5], ["b", 0, 2, 3, 6]], columns=cols
-    ),
-    pd.DataFrame(
-        [["b", 1, 0, 1, 4], ["b", 1, 1, 2, 55], ["b", 1, 2, 3, 6]], columns=cols
-    ),
-    pd.DataFrame(
-        [["b", 2, 0, 1, 42], ["b", 2, 1, 2, 5], ["b", 2, 2, 3, 6]], columns=cols
-    ),
-]
+class _HierMultivEqspl(BaseExample):
+    _tags = {
+        "scitype": "Hierarchical",
+        "index": 0,
+        "metadata": {
+            "is_univariate": False,
+            "is_one_panel": False,
+            "is_one_series": False,
+            "is_equally_spaced": True,
+            "is_equal_length": True,
+            "is_empty": False,
+            "has_nans": False,
+            "n_instances": 6,
+            "n_panels": 2,
+            "n_features": 2,
+            "feature_names": ["var_0", "var_1"],
+            "feature_kind": [DtypeKind.FLOAT, DtypeKind.FLOAT],
+        },
+    }
 
-# Xlist = [
-#     pd.DataFrame(
-#         [["__total", "__total", 0, 6, 100], ["__total", 0, 1, 12, 130],
-#           ["__total", 0, 2, 18, 36]], columns=cols
-#     ),
-#     pd.DataFrame(
-#         [["a", 0, 0, 1, 4], ["a", 0, 1, 2, 5], ["a", 0, 2, 3, 6]], columns=cols
-#     ),
-#     pd.DataFrame(
-#         [["a", 1, 0, 1, 4], ["a", 1, 1, 2, 55], ["a", 1, 2, 3, 6]], columns=cols
-#     ),
-#     pd.DataFrame(
-#         [["a", 2, 0, 1, 42], ["a", 2, 1, 2, 5], ["a", 2, 2, 3, 6]], columns=cols
-#     ),
-#     pd.DataFrame(
-#         [["a", "__total", 0, 3, 50], ["a", "__total", 1, 6, 65],
-#           ["a", "__total", 2, 9, 18]], columns=cols
-#     ),
-#     pd.DataFrame(
-#         [["b", 3, 0, 1, 4], ["b", 3, 1, 2, 5], ["b", 3, 2, 3, 6]], columns=cols
-#     ),
-#     pd.DataFrame(
-#         [["b", 4, 0, 1, 4], ["b", 4, 1, 2, 55], ["b", 4, 2, 3, 6]], columns=cols
-#     ),
-#     pd.DataFrame(
-#         [["b", 5, 0, 1, 42], ["b", 5, 1, 2, 5], ["b", 5, 2, 3, 6]], columns=cols
-#     ),
-#     pd.DataFrame(
-#         [["b", "__total", 0, 3, 50], ["b", "__total", 1, 6, 65],
-#           ["b", "__total", 2, 9, 18]], columns=cols
-#     ),
-# ]
-X = pd.concat(Xlist)
-X = X.set_index(["foo", "bar", "timepoints"])
-# X = X[["var_0"]]
 
-example_dict[("pd_multiindex_hier", "Hierarchical", 0)] = X
-example_dict_lossy[("pd_multiindex_hier", "Hierarchical", 0)] = False
+class _HierMultivEqsplPdMiHier(_HierMultivEqspl):
+    _tags = {
+        "mtype": "pd_multiindex_hier",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-if _check_soft_dependencies("dask", severity="none"):
-    from sktime.datatypes._adapter.dask_to_pd import convert_pandas_to_dask
+    def build(self):
+        cols = ["foo", "bar", "timepoints"] + [f"var_{i}" for i in range(2)]
 
-    df_dask = convert_pandas_to_dask(
-        example_dict[("pd_multiindex_hier", "Hierarchical", 0)], npartitions=1
-    )
+        Xlist = [
+            pd.DataFrame(
+                [["a", 0, 0, 1, 4], ["a", 0, 1, 2, 5], ["a", 0, 2, 3, 6]], columns=cols
+            ),
+            pd.DataFrame(
+                [["a", 1, 0, 1, 4], ["a", 1, 1, 2, 55], ["a", 1, 2, 3, 6]], columns=cols
+            ),
+            pd.DataFrame(
+                [["a", 2, 0, 1, 42], ["a", 2, 1, 2, 5], ["a", 2, 2, 3, 6]], columns=cols
+            ),
+            pd.DataFrame(
+                [["b", 0, 0, 1, 4], ["b", 0, 1, 2, 5], ["b", 0, 2, 3, 6]], columns=cols
+            ),
+            pd.DataFrame(
+                [["b", 1, 0, 1, 4], ["b", 1, 1, 2, 55], ["b", 1, 2, 3, 6]], columns=cols
+            ),
+            pd.DataFrame(
+                [["b", 2, 0, 1, 42], ["b", 2, 1, 2, 5], ["b", 2, 2, 3, 6]], columns=cols
+            ),
+        ]
 
-    example_dict[("dask_hierarchical", "Hierarchical", 0)] = df_dask
-    example_dict_lossy[("dask_hierarchical", "Hierarchical", 0)] = False
+        X = pd.concat(Xlist)
+        X = X.set_index(["foo", "bar", "timepoints"])
+        return X
 
-example_dict_metadata[("Hierarchical", 0)] = {
-    "is_univariate": False,
-    "is_one_panel": False,
-    "is_one_series": False,
-    "is_equally_spaced": True,
-    "is_equal_length": True,
-    "is_empty": False,
-    "has_nans": False,
-    "n_instances": 6,
-    "n_panels": 2,
-    "n_features": 2,
-    "feature_names": ["var_0", "var_1"],
-    "feature_kind": [DtypeKind.FLOAT, DtypeKind.FLOAT],
-}
+
+class _HierMultivEqsplDaskHier(_HierMultivEqspl):
+    _tags = {
+        "mtype": "dask_hierarchical",
+        "python_dependencies": ["dask"],
+        "lossy": False,
+    }
+
+    def build(self):
+        from sktime.datatypes._adapter.dask_to_pd import convert_pandas_to_dask
+
+        X = _HierMultivEqsplPdMiHier().build()
+        return convert_pandas_to_dask(X, npartitions=1)
 
 
 ###
 # example 1: univariate, equally sampled
 
-cols = ["foo", "bar", "timepoints"] + [f"var_{i}" for i in range(1)]
 
-Xlist = [
-    pd.DataFrame([["a", 0, 0, 1], ["a", 0, 1, 2], ["a", 0, 2, 3]], columns=cols),
-    pd.DataFrame([["a", 1, 0, 1], ["a", 1, 1, 2], ["a", 1, 2, 3]], columns=cols),
-    pd.DataFrame([["a", 2, 0, 1], ["a", 2, 1, 2], ["a", 2, 2, 3]], columns=cols),
-    pd.DataFrame([["b", 0, 0, 1], ["b", 0, 1, 2], ["b", 0, 2, 3]], columns=cols),
-    pd.DataFrame([["b", 1, 0, 1], ["b", 1, 1, 2], ["b", 1, 2, 3]], columns=cols),
-    pd.DataFrame([["b", 2, 0, 1], ["b", 2, 1, 2], ["b", 2, 2, 3]], columns=cols),
-]
-X = pd.concat(Xlist)
-X = X.set_index(["foo", "bar", "timepoints"])
+class _HierUnivEqspl(BaseExample):
+    _tags = {
+        "scitype": "Hierarchical",
+        "index": 1,
+        "metadata": {
+            "is_univariate": True,
+            "is_one_panel": False,
+            "is_one_series": False,
+            "is_equally_spaced": True,
+            "is_equal_length": True,
+            "is_empty": False,
+            "has_nans": False,
+            "n_instances": 6,
+            "n_panels": 2,
+            "n_features": 1,
+            "feature_names": ["var_0"],
+            "feature_kind": [DtypeKind.FLOAT],
+        },
+    }
 
-example_dict[("pd_multiindex_hier", "Hierarchical", 1)] = X
-example_dict_lossy[("pd_multiindex_hier", "Hierarchical", 1)] = False
 
-if _check_soft_dependencies("dask", severity="none"):
-    from sktime.datatypes._adapter.dask_to_pd import convert_pandas_to_dask
+class _HierUnivEqsplPdMiHier(_HierUnivEqspl):
+    _tags = {
+        "mtype": "pd_multiindex_hier",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-    df_dask = convert_pandas_to_dask(
-        example_dict[("pd_multiindex_hier", "Hierarchical", 1)], npartitions=1
-    )
+    def build(self):
+        col = ["foo", "bar", "timepoints"] + [f"var_{i}" for i in range(1)]
 
-    example_dict[("dask_hierarchical", "Hierarchical", 1)] = df_dask
-    example_dict_lossy[("dask_hierarchical", "Hierarchical", 1)] = False
+        Xlist = [
+            pd.DataFrame([["a", 0, 0, 1], ["a", 0, 1, 2], ["a", 0, 2, 3]], columns=col),
+            pd.DataFrame([["a", 1, 0, 1], ["a", 1, 1, 2], ["a", 1, 2, 3]], columns=col),
+            pd.DataFrame([["a", 2, 0, 1], ["a", 2, 1, 2], ["a", 2, 2, 3]], columns=col),
+            pd.DataFrame([["b", 0, 0, 1], ["b", 0, 1, 2], ["b", 0, 2, 3]], columns=col),
+            pd.DataFrame([["b", 1, 0, 1], ["b", 1, 1, 2], ["b", 1, 2, 3]], columns=col),
+            pd.DataFrame([["b", 2, 0, 1], ["b", 2, 1, 2], ["b", 2, 2, 3]], columns=col),
+        ]
+        X = pd.concat(Xlist)
+        X = X.set_index(["foo", "bar", "timepoints"])
+        return X
 
-example_dict_metadata[("Hierarchical", 1)] = {
-    "is_univariate": True,
-    "is_one_panel": False,
-    "is_one_series": False,
-    "is_equally_spaced": True,
-    "is_equal_length": True,
-    "is_empty": False,
-    "has_nans": False,
-    "n_instances": 6,
-    "n_panels": 2,
-    "n_features": 1,
-    "feature_names": ["var_0"],
-    "feature_kind": [DtypeKind.FLOAT],
-}
+
+class _HierUnivEqsplDaskHier(_HierUnivEqspl):
+    _tags = {
+        "mtype": "dask_hierarchical",
+        "python_dependencies": ["dask"],
+        "lossy": False,
+    }
+
+    def build(self):
+        from sktime.datatypes._adapter.dask_to_pd import convert_pandas_to_dask
+
+        X = _HierUnivEqsplPdMiHier().build()
+        return convert_pandas_to_dask(X, npartitions=1)

--- a/sktime/datatypes/_hierarchical/_examples.py
+++ b/sktime/datatypes/_hierarchical/_examples.py
@@ -1,24 +1,25 @@
 """Example generation for testing.
 
-Exports dict of examples, useful for testing as fixtures.
+Exports examples of in-memory data containers, useful for testing as fixtures.
 
-example_dict: dict indexed by triple
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are data objects, considered examples for the mtype
-    all examples with same index are considered "same" on scitype content
-    if None, indicates that representation is not possible
+Examples come in clusters, tagged by scitype: str, index: int, and metadata: dict.
 
-example_lossy: dict of bool indexed by pairs of str
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are bool, indicate whether representation has information removed
-    all examples with same index are considered "same" on scitype content
+All examples with the same index are considered "content-wise the same", i.e.,
+representing the same abstract data object. They differ by mtype, i.e.,
+machine type, which is the specific in-memory representation.
 
-overall, conversions from non-lossy representations to any other ones
-    should yield the element exactly, identidally (given same index)
+If an example returns None, it indicates that representation
+with that specific mtype is not possible.
+
+If the tag "lossy" is True, the representation is considered incomplete,
+e.g., metadata such as column names are missing.
+
+Types of tests that can be performed with these examples:
+
+* the mtype and scitype of the example should be correctly inferred by checkers.
+* the metadata of hte example should be correctly inferred by checkers.
+* conversions from non-lossy representations to any other ones
+  should yield the element exactly, identically, for examples of the same index.
 """
 
 import pandas as pd

--- a/sktime/datatypes/_panel/__init__.py
+++ b/sktime/datatypes/_panel/__init__.py
@@ -2,22 +2,11 @@
 
 from sktime.datatypes._panel._check import check_dict as check_dict_Panel
 from sktime.datatypes._panel._convert import convert_dict as convert_dict_Panel
-from sktime.datatypes._panel._examples import example_dict as example_dict_Panel
-from sktime.datatypes._panel._examples import (
-    example_dict_lossy as example_dict_lossy_Panel,
-)
-from sktime.datatypes._panel._examples import (
-    example_dict_metadata as example_dict_metadata_Panel,
-)
 from sktime.datatypes._panel._registry import MTYPE_LIST_PANEL, MTYPE_REGISTER_PANEL
 
 __all__ = [
     "check_dict_Panel",
     "convert_dict_Panel",
-    "infer_mtype_dict_Panel",
     "MTYPE_LIST_PANEL",
     "MTYPE_REGISTER_PANEL",
-    "example_dict_Panel",
-    "example_dict_lossy_Panel",
-    "example_dict_metadata_Panel",
 ]

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -27,7 +27,6 @@ import pandas as pd
 from sktime.datatypes._base import BaseExample
 from sktime.datatypes._dtypekind import DtypeKind
 
-
 ###
 # example 0: multivariate, equally sampled
 

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -24,358 +24,556 @@ overall, conversions from non-lossy representations to any other ones
 import numpy as np
 import pandas as pd
 
+from sktime.datatypes._base import BaseExample
 from sktime.datatypes._dtypekind import DtypeKind
-from sktime.utils.dependencies import _check_soft_dependencies
 
-example_dict = dict()
-example_dict_lossy = dict()
-example_dict_metadata = dict()
 
 ###
 # example 0: multivariate, equally sampled
 
-X = np.array(
-    [[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 55, 6]], [[1, 2, 3], [42, 5, 6]]],
-    dtype=np.int64,
-)
 
-example_dict[("numpy3D", "Panel", 0)] = X
-example_dict_lossy[("numpy3D", "Panel", 0)] = True
+class _PanelMultivEqspl(BaseExample):
+    _tags = {
+        "scitype": "Panel",
+        "index": 0,
+        "metadata": {
+            "is_univariate": False,
+            "is_one_series": False,
+            "n_panels": 1,
+            "is_one_panel": True,
+            "is_equally_spaced": True,
+            "is_equal_length": True,
+            "is_equal_index": True,
+            "is_empty": False,
+            "has_nans": False,
+            "n_instances": 3,
+            "n_features": 2,
+            "feature_names": ["var_0", "var_1"],
+            "feature_kind": [DtypeKind.FLOAT, DtypeKind.FLOAT],
+        },
+    }
 
-example_dict[("numpyflat", "Panel", 0)] = None
-example_dict_lossy[("numpyflat", "Panel", 0)] = True
 
-cols = [f"var_{i}" for i in range(2)]
-Xlist = [
-    pd.DataFrame([[1, 4], [2, 5], [3, 6]], columns=cols),
-    pd.DataFrame([[1, 4], [2, 55], [3, 6]], columns=cols),
-    pd.DataFrame([[1, 42], [2, 5], [3, 6]], columns=cols),
-]
+class _PanelMultivEqsplNumpy3D(_PanelMultivEqspl):
+    _tags = {
+        "mtype": "numpy3D",
+        "python_dependencies": None,
+        "lossy": True,
+    }
 
-example_dict[("df-list", "Panel", 0)] = Xlist
-example_dict_lossy[("df-list", "Panel", 0)] = False
+    def build(self):
+        X = np.array(
+            [[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 55, 6]], [[1, 2, 3], [42, 5, 6]]],
+            dtype=np.int64,
+        )
+        return X
 
-cols = ["instances", "timepoints"] + [f"var_{i}" for i in range(2)]
 
-Xlist = [
-    pd.DataFrame([[0, 0, 1, 4], [0, 1, 2, 5], [0, 2, 3, 6]], columns=cols),
-    pd.DataFrame([[1, 0, 1, 4], [1, 1, 2, 55], [1, 2, 3, 6]], columns=cols),
-    pd.DataFrame([[2, 0, 1, 42], [2, 1, 2, 5], [2, 2, 3, 6]], columns=cols),
-]
-X = pd.concat(Xlist)
-X = X.set_index(["instances", "timepoints"])
+class _PanelMultivEqsplNumpyFlat(_PanelMultivEqspl):
+    _tags = {
+        "mtype": "numpyflat",
+        "python_dependencies": None,
+        "lossy": True,
+    }
 
-example_dict[("pd-multiindex", "Panel", 0)] = X
-example_dict_lossy[("pd-multiindex", "Panel", 0)] = False
+    def build(self):
+        return None
 
-cols = [f"var_{i}" for i in range(2)]
-X = pd.DataFrame(columns=cols, index=pd.RangeIndex(3))
-nestes_series = [
-    pd.Series([1, 2, 3], index=pd.Index([0, 1, 2], name="timepoints")),
-    pd.Series([1, 2, 3], index=pd.Index([0, 1, 2], name="timepoints")),
-    pd.Series([1, 2, 3], index=pd.Index([0, 1, 2], name="timepoints")),
-]
-X["var_0"] = pd.Series(nestes_series)
-nestes_series_2 = [
-    pd.Series([4, 5, 6], index=pd.Index([0, 1, 2], name="timepoints")),
-    pd.Series([4, 55, 6], index=pd.Index([0, 1, 2], name="timepoints")),
-    pd.Series([42, 5, 6], index=pd.Index([0, 1, 2], name="timepoints")),
-]
-X["var_1"] = pd.Series(nestes_series_2)
-X.index.name = "instances"
 
-example_dict[("nested_univ", "Panel", 0)] = X
-example_dict_lossy[("nested_univ", "Panel", 0)] = False
+class _PanelMultivEqsplDfList(_PanelMultivEqspl):
+    _tags = {
+        "mtype": "df-list",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-if _check_soft_dependencies("dask", severity="none"):
-    from sktime.datatypes._adapter.dask_to_pd import convert_pandas_to_dask
+    def build(self):
+        cols = [f"var_{i}" for i in range(2)]
+        Xlist = [
+            pd.DataFrame([[1, 4], [2, 5], [3, 6]], columns=cols),
+            pd.DataFrame([[1, 4], [2, 55], [3, 6]], columns=cols),
+            pd.DataFrame([[1, 42], [2, 5], [3, 6]], columns=cols),
+        ]
+        return Xlist
 
-    df_dask = convert_pandas_to_dask(
-        example_dict[("pd-multiindex", "Panel", 0)], npartitions=1
-    )
 
-    example_dict[("dask_panel", "Panel", 0)] = df_dask
-    example_dict_lossy[("dask_panel", "Panel", 0)] = False
+class _PanelMultivEqsplPdMultiindex(_PanelMultivEqspl):
+    _tags = {
+        "mtype": "pd-multiindex",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-if _check_soft_dependencies("polars", severity="none"):
-    from sktime.datatypes._adapter.polars import convert_pandas_to_polars
+    def build(self):
+        cols = ["instances", "timepoints"] + [f"var_{i}" for i in range(2)]
+        Xlist = [
+            pd.DataFrame([[0, 0, 1, 4], [0, 1, 2, 5], [0, 2, 3, 6]], columns=cols),
+            pd.DataFrame([[1, 0, 1, 4], [1, 1, 2, 55], [1, 2, 3, 6]], columns=cols),
+            pd.DataFrame([[2, 0, 1, 42], [2, 1, 2, 5], [2, 2, 3, 6]], columns=cols),
+        ]
+        X = pd.concat(Xlist)
+        X = X.set_index(["instances", "timepoints"])
+        return X
 
-    pl_frame = convert_pandas_to_polars(example_dict[("pd-multiindex", "Panel", 0)])
 
-    example_dict[("polars_panel", "Panel", 0)] = pl_frame
-    example_dict_lossy[("polars_panel", "Panel", 0)] = False
+class _PanelMultivEqsplNestedUniv(_PanelMultivEqspl):
+    _tags = {
+        "mtype": "nested_univ",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-if _check_soft_dependencies("gluonts", severity="none"):
-    from sktime.datatypes._adapter.gluonts import (
-        convert_pandas_multiindex_to_pandasDataset,
-        convert_pandas_to_listDataset,
-    )
+    def build(self):
+        cols = [f"var_{i}" for i in range(2)]
+        X = pd.DataFrame(columns=cols, index=pd.RangeIndex(3))
+        nestes_series = [
+            pd.Series([1, 2, 3], index=pd.Index([0, 1, 2], name="timepoints")),
+            pd.Series([1, 2, 3], index=pd.Index([0, 1, 2], name="timepoints")),
+            pd.Series([1, 2, 3], index=pd.Index([0, 1, 2], name="timepoints")),
+        ]
+        X["var_0"] = pd.Series(nestes_series)
+        nestes_series_2 = [
+            pd.Series([4, 5, 6], index=pd.Index([0, 1, 2], name="timepoints")),
+            pd.Series([4, 55, 6], index=pd.Index([0, 1, 2], name="timepoints")),
+            pd.Series([42, 5, 6], index=pd.Index([0, 1, 2], name="timepoints")),
+        ]
+        X["var_1"] = pd.Series(nestes_series_2)
+        X.index.name = "instances"
+        return X
 
-    df = example_dict[("pd-multiindex", "Panel", 0)]
 
-    # Updating the DF to have pandas Datetime objects
-    list_dataset = convert_pandas_to_listDataset(df)
+class _PanelMultivEqsplDaskPanel(_PanelMultivEqspl):
+    _tags = {
+        "mtype": "dask_panel",
+        "python_dependencies": ["dask"],
+        "lossy": False,
+    }
 
-    example_dict[("gluonts_ListDataset_panel", "Panel", 0)] = list_dataset
-    example_dict_lossy[("gluonts_ListDataset_panel", "Panel", 0)] = True
+    def build(self):
+        from sktime.datatypes._adapter.dask_to_pd import convert_pandas_to_dask
 
-    # Beginning example tests for PandasDataset
-    df = example_dict[("pd-multiindex", "Panel", 0)]
+        pd_df = _PanelMultivEqsplPdMultiindex().build()
+        df_dask = convert_pandas_to_dask(pd_df, npartitions=1)
+        return df_dask
 
-    pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
-        df, item_id="instances", timepoints="timepoints", target=["var_0", "var_1"]
-    )
 
-    example_dict[("gluonts_PandasDataset_panel", "Panel", 0)] = pandas_dataset
-    example_dict_lossy[("gluonts_PandasDataset_panel", "Panel", 0)] = False
+class _PanelMultivEqsplPolarsPanel(_PanelMultivEqspl):
+    _tags = {
+        "mtype": "polars_panel",
+        "python_dependencies": ["polars"],
+        "lossy": False,
+    }
 
-example_dict_metadata[("Panel", 0)] = {
-    "is_univariate": False,
-    "is_one_series": False,
-    "n_panels": 1,
-    "is_one_panel": True,
-    "is_equally_spaced": True,
-    "is_equal_length": True,
-    "is_equal_index": True,
-    "is_empty": False,
-    "has_nans": False,
-    "n_instances": 3,
-    "n_features": 2,
-    "feature_names": ["var_0", "var_1"],
-    "feature_kind": [DtypeKind.FLOAT, DtypeKind.FLOAT],
-}
+    def build(self):
+        from sktime.datatypes._adapter.polars import convert_pandas_to_polars
+
+        pd_df = _PanelMultivEqsplPdMultiindex().build()
+        pl_frame = convert_pandas_to_polars(pd_df)
+        return pl_frame
+
+
+class _PanelMultivEqsplGluontsListDatasetPanel(_PanelMultivEqspl):
+    _tags = {
+        "mtype": "gluonts_ListDataset_panel",
+        "python_dependencies": ["gluonts"],
+        "lossy": True,
+    }
+
+    def build(self):
+        from sktime.datatypes._adapter.gluonts import convert_pandas_to_listDataset
+
+        pd_df = _PanelMultivEqsplPdMultiindex().build()
+        list_dataset = convert_pandas_to_listDataset(pd_df)
+        return list_dataset
+
+
+class _PanelMultivEqsplGluontsPandasDatasetPanel(_PanelMultivEqspl):
+    _tags = {
+        "mtype": "gluonts_PandasDataset_panel",
+        "python_dependencies": ["gluonts"],
+        "lossy": False,
+    }
+
+    def build(self):
+        from sktime.datatypes._adapter.gluonts import (
+            convert_pandas_multiindex_to_pandasDataset,
+        )
+
+        pd_df = _PanelMultivEqsplPdMultiindex().build()
+        pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
+            pd_df,
+            item_id="instances",
+            timepoints="timepoints",
+            target=["var_0", "var_1"],
+        )
+        return pandas_dataset
+
 
 ###
 # example 1: univariate, equally sampled
 
-X = np.array(
-    [[[4, 5, 6]], [[4, 55, 6]], [[42, 5, 6]]],
-    dtype=np.int64,
-)
 
-example_dict[("numpy3D", "Panel", 1)] = X
-example_dict_lossy[("numpy3D", "Panel", 1)] = True
+class _PanelUnivEqspl(BaseExample):
+    _tags = {
+        "scitype": "Panel",
+        "index": 1,
+        "metadata": {
+            "is_univariate": True,
+            "is_one_series": False,
+            "n_panels": 1,
+            "is_one_panel": True,
+            "is_equally_spaced": True,
+            "is_equal_length": True,
+            "is_equal_index": True,
+            "is_empty": False,
+            "has_nans": False,
+            "n_instances": 3,
+            "n_features": 1,
+            "feature_names": ["var_0"],
+            "feature_kind": [DtypeKind.FLOAT],
+        },
+    }
 
-X = np.array([[4, 5, 6], [4, 55, 6], [42, 5, 6]], dtype=np.int64)
 
-example_dict[("numpyflat", "Panel", 1)] = X
-example_dict_lossy[("numpyflat", "Panel", 1)] = True
+class _PanelUnivEqsplNumpy3D(_PanelUnivEqspl):
+    _tags = {
+        "mtype": "numpy3D",
+        "python_dependencies": None,
+        "lossy": True,
+    }
 
-cols = [f"var_{i}" for i in range(1)]
-Xlist = [
-    pd.DataFrame([[4], [5], [6]], columns=cols),
-    pd.DataFrame([[4], [55], [6]], columns=cols),
-    pd.DataFrame([[42], [5], [6]], columns=cols),
-]
+    def build(self):
+        return np.array([[[4, 5, 6]], [[4, 55, 6]], [[42, 5, 6]]], dtype=np.int64)
 
-example_dict[("df-list", "Panel", 1)] = Xlist
-example_dict_lossy[("df-list", "Panel", 1)] = False
 
-cols = ["instances", "timepoints"] + [f"var_{i}" for i in range(1)]
+class _PanelUnivEqsplNumpyFlat(_PanelUnivEqspl):
+    _tags = {
+        "mtype": "numpyflat",
+        "python_dependencies": None,
+        "lossy": True,
+    }
 
-Xlist = [
-    pd.DataFrame([[0, 0, 4], [0, 1, 5], [0, 2, 6]], columns=cols),
-    pd.DataFrame([[1, 0, 4], [1, 1, 55], [1, 2, 6]], columns=cols),
-    pd.DataFrame([[2, 0, 42], [2, 1, 5], [2, 2, 6]], columns=cols),
-]
-X = pd.concat(Xlist)
-X = X.set_index(["instances", "timepoints"])
+    def build(self):
+        return np.array([[4, 5, 6], [4, 55, 6], [42, 5, 6]], dtype=np.int64)
 
-example_dict[("pd-multiindex", "Panel", 1)] = X
-example_dict_lossy[("pd-multiindex", "Panel", 1)] = False
 
-cols = [f"var_{i}" for i in range(1)]
-X = pd.DataFrame(columns=cols, index=pd.RangeIndex(3))
-data = [
-    pd.Series([4, 5, 6], index=pd.Index([0, 1, 2], name="timepoints")),
-    pd.Series([4, 55, 6], index=pd.Index([0, 1, 2], name="timepoints")),
-    pd.Series([42, 5, 6], index=pd.Index([0, 1, 2], name="timepoints")),
-]
-X["var_0"] = pd.Series(data)
-X.index.name = "instances"
+class _PanelUnivEqsplDfList(_PanelUnivEqspl):
+    _tags = {
+        "mtype": "df-list",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-example_dict[("nested_univ", "Panel", 1)] = X
-example_dict_lossy[("nested_univ", "Panel", 1)] = False
+    def build(self):
+        cols = [f"var_{i}" for i in range(1)]
+        Xlist = [
+            pd.DataFrame([[4], [5], [6]], columns=cols),
+            pd.DataFrame([[4], [55], [6]], columns=cols),
+            pd.DataFrame([[42], [5], [6]], columns=cols),
+        ]
+        return Xlist
 
-if _check_soft_dependencies("dask", severity="none"):
-    from sktime.datatypes._adapter.dask_to_pd import convert_pandas_to_dask
 
-    df_dask = convert_pandas_to_dask(
-        example_dict[("pd-multiindex", "Panel", 1)], npartitions=1
-    )
+class _PanelUnivEqsplPdMultiindex(_PanelUnivEqspl):
+    _tags = {
+        "mtype": "pd-multiindex",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-    example_dict[("dask_panel", "Panel", 1)] = df_dask
-    example_dict_lossy[("dask_panel", "Panel", 1)] = False
+    def build(self):
+        cols = ["instances", "timepoints"] + [f"var_{i}" for i in range(1)]
+        Xlist = [
+            pd.DataFrame([[0, 0, 4], [0, 1, 5], [0, 2, 6]], columns=cols),
+            pd.DataFrame([[1, 0, 4], [1, 1, 55], [1, 2, 6]], columns=cols),
+            pd.DataFrame([[2, 0, 42], [2, 1, 5], [2, 2, 6]], columns=cols),
+        ]
+        X = pd.concat(Xlist)
+        X = X.set_index(["instances", "timepoints"])
+        return X
 
-if _check_soft_dependencies("polars", severity="none"):
-    from sktime.datatypes._adapter.polars import convert_pandas_to_polars
 
-    pl_frame = convert_pandas_to_polars(example_dict[("pd-multiindex", "Panel", 1)])
+class _PanelUnivEqsplNestedUniv(_PanelUnivEqspl):
+    _tags = {
+        "mtype": "nested_univ",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-    example_dict[("polars_panel", "Panel", 1)] = pl_frame
-    example_dict_lossy[("polars_panel", "Panel", 1)] = False
-if _check_soft_dependencies("gluonts", severity="none"):
-    from sktime.datatypes._adapter.gluonts import convert_pandas_to_listDataset
+    def build(self):
+        cols = [f"var_{i}" for i in range(1)]
+        X = pd.DataFrame(columns=cols, index=pd.RangeIndex(3))
+        data = [
+            pd.Series([4, 5, 6], index=pd.Index([0, 1, 2], name="timepoints")),
+            pd.Series([4, 55, 6], index=pd.Index([0, 1, 2], name="timepoints")),
+            pd.Series([42, 5, 6], index=pd.Index([0, 1, 2], name="timepoints")),
+        ]
+        X["var_0"] = pd.Series(data)
+        X.index.name = "instances"
+        return X
 
-    df = example_dict[("pd-multiindex", "Panel", 1)]
 
-    list_dataset = convert_pandas_to_listDataset(df)
+class _PanelUnivEqsplDaskPanel(_PanelUnivEqspl):
+    _tags = {
+        "mtype": "dask_panel",
+        "python_dependencies": ["dask"],
+        "lossy": False,
+    }
 
-    example_dict[("gluonts_ListDataset_panel", "Panel", 1)] = list_dataset
-    example_dict_lossy[("gluonts_ListDataset_panel", "Panel", 1)] = True
+    def build(self):
+        from sktime.datatypes._adapter.dask_to_pd import convert_pandas_to_dask
 
-    # Beginning example tests for PandasDataset
-    df = example_dict[("pd-multiindex", "Panel", 1)]
+        pd_df = _PanelUnivEqsplPdMultiindex().build()
+        df_dask = convert_pandas_to_dask(pd_df, npartitions=1)
+        return df_dask
 
-    pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
-        df, item_id="instances", timepoints="timepoints", target=["var_0"]
-    )
 
-    example_dict[("gluonts_PandasDataset_panel", "Panel", 1)] = pandas_dataset
-    example_dict_lossy[("gluonts_PandasDataset_panel", "Panel", 1)] = False
+class _PanelUnivEqsplPolarsPanel(_PanelUnivEqspl):
+    _tags = {
+        "mtype": "polars_panel",
+        "python_dependencies": ["polars"],
+        "lossy": False,
+    }
 
-example_dict_metadata[("Panel", 1)] = {
-    "is_univariate": True,
-    "is_one_series": False,
-    "n_panels": 1,
-    "is_one_panel": True,
-    "is_equally_spaced": True,
-    "is_equal_length": True,
-    "is_equal_index": True,
-    "is_empty": False,
-    "has_nans": False,
-    "n_instances": 3,
-    "n_features": 1,
-    "feature_names": ["var_0"],
-    "feature_kind": [DtypeKind.FLOAT],
-}
+    def build(self):
+        from sktime.datatypes._adapter.polars import convert_pandas_to_polars
+
+        pd_df = _PanelUnivEqsplPdMultiindex().build()
+        pl_frame = convert_pandas_to_polars(pd_df)
+        return pl_frame
+
+
+class _PanelUnivEqsplGluontsListDatasetPanel(_PanelUnivEqspl):
+    _tags = {
+        "mtype": "gluonts_ListDataset_panel",
+        "python_dependencies": ["gluonts"],
+        "lossy": True,
+    }
+
+    def build(self):
+        from sktime.datatypes._adapter.gluonts import convert_pandas_to_listDataset
+
+        pd_df = _PanelUnivEqsplPdMultiindex().build()
+        list_dataset = convert_pandas_to_listDataset(pd_df)
+        return list_dataset
+
+
+class _PanelUnivEqsplGluontsPandasDatasetPanel(_PanelUnivEqspl):
+    _tags = {
+        "mtype": "gluonts_PandasDataset_panel",
+        "python_dependencies": ["gluonts"],
+        "lossy": False,
+    }
+
+    def build(self):
+        from sktime.datatypes._adapter.gluonts import (
+            convert_pandas_multiindex_to_pandasDataset,
+        )
+
+        pd_df = _PanelUnivEqsplPdMultiindex().build()
+        pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
+            pd_df, item_id="instances", timepoints="timepoints", target=["var_0"]
+        )
+        return pandas_dataset
+
 
 ###
 # example 2: univariate, equally sampled, one series
 
-X = np.array(
-    [[[4, 5, 6]]],
-    dtype=np.int64,
-)
 
-example_dict[("numpy3D", "Panel", 2)] = X
-example_dict_lossy[("numpy3D", "Panel", 2)] = True
+class _PanelUnivEqsplOneSeries(BaseExample):
+    _tags = {
+        "scitype": "Panel",
+        "index": 2,
+        "metadata": {
+            "is_univariate": True,
+            "is_one_series": True,
+            "n_panels": 1,
+            "is_one_panel": True,
+            "is_equally_spaced": True,
+            "is_equal_length": True,
+            "is_equal_index": True,
+            "is_empty": False,
+            "has_nans": False,
+            "n_instances": 1,
+            "n_features": 1,
+            "feature_names": ["var_0"],
+            "feature_kind": [DtypeKind.FLOAT],
+        },
+    }
 
-X = np.array([[4, 5, 6]], dtype=np.int64)
 
-example_dict[("numpyflat", "Panel", 2)] = X
-example_dict_lossy[("numpyflat", "Panel", 2)] = True
+class _PanelUnivEqsplOneSeriesNumpy3D(_PanelUnivEqsplOneSeries):
+    _tags = {
+        "mtype": "numpy3D",
+        "python_dependencies": None,
+        "lossy": True,
+    }
 
-cols = [f"var_{i}" for i in range(1)]
-Xlist = [
-    pd.DataFrame([[4], [5], [6]], columns=cols),
-]
+    def build(self):
+        return np.array([[[4, 5, 6]]], dtype=np.int64)
 
-example_dict[("df-list", "Panel", 2)] = Xlist
-example_dict_lossy[("df-list", "Panel", 2)] = False
 
-cols = ["instances", "timepoints"] + [f"var_{i}" for i in range(1)]
+class _PanelUnivEqsplOneSeriesNumpyFlat(_PanelUnivEqsplOneSeries):
+    _tags = {
+        "mtype": "numpyflat",
+        "python_dependencies": None,
+        "lossy": True,
+    }
 
-Xlist = [
-    pd.DataFrame([[0, 0, 4], [0, 1, 5], [0, 2, 6]], columns=cols),
-]
-X = pd.concat(Xlist)
-X = X.set_index(["instances", "timepoints"])
+    def build(self):
+        return np.array([[4, 5, 6]], dtype=np.int64)
 
-example_dict[("pd-multiindex", "Panel", 2)] = X
-example_dict_lossy[("pd-multiindex", "Panel", 2)] = False
 
-cols = [f"var_{i}" for i in range(1)]
-X = pd.DataFrame(columns=cols, index=pd.RangeIndex(1))
-X["var_0"] = pd.Series(
-    [pd.Series([4, 5, 6], index=pd.Index([0, 1, 2], name="timepoints"))]
-)
-X.index.name = "instances"
+class _PanelUnivEqsplOneSeriesDfList(_PanelUnivEqsplOneSeries):
+    _tags = {
+        "mtype": "df-list",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-example_dict[("nested_univ", "Panel", 2)] = X
-example_dict_lossy[("nested_univ", "Panel", 2)] = False
+    def build(self):
+        cols = [f"var_{i}" for i in range(1)]
+        Xlist = [pd.DataFrame([[4], [5], [6]], columns=cols)]
+        return Xlist
 
-if _check_soft_dependencies("dask", severity="none"):
-    from sktime.datatypes._adapter.dask_to_pd import convert_pandas_to_dask
 
-    df_dask = convert_pandas_to_dask(
-        example_dict[("pd-multiindex", "Panel", 2)], npartitions=1
-    )
+class _PanelUnivEqsplOneSeriesPdMultiindex(_PanelUnivEqsplOneSeries):
+    _tags = {
+        "mtype": "pd-multiindex",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-    example_dict[("dask_panel", "Panel", 2)] = df_dask
-    example_dict_lossy[("dask_panel", "Panel", 2)] = False
+    def build(self):
+        cols = ["instances", "timepoints"] + [f"var_{i}" for i in range(1)]
+        Xlist = [pd.DataFrame([[0, 0, 4], [0, 1, 5], [0, 2, 6]], columns=cols)]
+        X = pd.concat(Xlist)
+        X = X.set_index(["instances", "timepoints"])
+        return X
 
-if _check_soft_dependencies("polars", severity="none"):
-    from sktime.datatypes._adapter.polars import convert_pandas_to_polars
 
-    pl_frame = convert_pandas_to_polars(example_dict[("pd-multiindex", "Panel", 2)])
+class _PanelUnivEqsplOneSeriesNestedUniv(_PanelUnivEqsplOneSeries):
+    _tags = {
+        "mtype": "nested_univ",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-    example_dict[("polars_panel", "Panel", 2)] = pl_frame
-    example_dict_lossy[("polars_panel", "Panel", 2)] = False
+    def build(self):
+        cols = [f"var_{i}" for i in range(1)]
+        X = pd.DataFrame(columns=cols, index=pd.RangeIndex(1))
+        X["var_0"] = pd.Series(
+            [pd.Series([4, 5, 6], index=pd.Index([0, 1, 2], name="timepoints"))]
+        )
+        X.index.name = "instances"
+        return X
 
-if _check_soft_dependencies("gluonts", severity="none"):
-    from sktime.datatypes._adapter.gluonts import convert_pandas_to_listDataset
 
-    df = example_dict[("pd-multiindex", "Panel", 2)]
+class _PanelUnivEqsplOneSeriesDaskPanel(_PanelUnivEqsplOneSeries):
+    _tags = {
+        "mtype": "dask_panel",
+        "python_dependencies": ["dask"],
+        "lossy": False,
+    }
 
-    list_dataset = convert_pandas_to_listDataset(df)
+    def build(self):
+        from sktime.datatypes._adapter.dask_to_pd import convert_pandas_to_dask
 
-    example_dict[("gluonts_ListDataset_panel", "Panel", 2)] = list_dataset
-    example_dict_lossy[("gluonts_ListDataset_panel", "Panel", 2)] = True
+        pd_df = _PanelUnivEqsplOneSeriesPdMultiindex().build()
+        df_dask = convert_pandas_to_dask(pd_df, npartitions=1)
+        return df_dask
 
-    # Beginning example tests for PandasDataset
-    df = example_dict[("pd-multiindex", "Panel", 2)]
 
-    pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
-        df, item_id="instances", timepoints="timepoints", target=["var_0"]
-    )
+class _PanelUnivEqsplOneSeriesPolarsPanel(_PanelUnivEqsplOneSeries):
+    _tags = {
+        "mtype": "polars_panel",
+        "python_dependencies": ["polars"],
+        "lossy": False,
+    }
 
-    example_dict[("gluonts_PandasDataset_panel", "Panel", 2)] = pandas_dataset
-    example_dict_lossy[("gluonts_PandasDataset_panel", "Panel", 2)] = True
+    def build(self):
+        from sktime.datatypes._adapter.polars import convert_pandas_to_polars
 
-example_dict_metadata[("Panel", 2)] = {
-    "is_univariate": True,
-    "is_one_series": True,
-    "n_panels": 1,
-    "is_one_panel": True,
-    "is_equally_spaced": True,
-    "is_equal_length": True,
-    "is_equal_index": True,
-    "is_empty": False,
-    "has_nans": False,
-    "n_instances": 1,
-    "n_features": 1,
-    "feature_names": ["var_0"],
-    "feature_kind": [DtypeKind.FLOAT],
-}
+        pd_df = _PanelUnivEqsplOneSeriesPdMultiindex().build()
+        pl_frame = convert_pandas_to_polars(pd_df)
+        return pl_frame
+
+
+class _PanelUnivEqsplOneSeriesGluontsListDatasetPanel(_PanelUnivEqsplOneSeries):
+    _tags = {
+        "mtype": "gluonts_ListDataset_panel",
+        "python_dependencies": ["gluonts"],
+        "lossy": True,
+    }
+
+    def build(self):
+        from sktime.datatypes._adapter.gluonts import convert_pandas_to_listDataset
+
+        pd_df = _PanelUnivEqsplOneSeriesPdMultiindex().build()
+        list_dataset = convert_pandas_to_listDataset(pd_df)
+        return list_dataset
+
+
+class _PanelUnivEqsplOneSeriesGluontsPandasDatasetPanel(_PanelUnivEqsplOneSeries):
+    _tags = {
+        "mtype": "gluonts_PandasDataset_panel",
+        "python_dependencies": ["gluonts"],
+        "lossy": False,
+    }
+
+    def build(self):
+        from sktime.datatypes._adapter.gluonts import (
+            convert_pandas_multiindex_to_pandasDataset,
+        )
+
+        pd_df = _PanelUnivEqsplOneSeriesPdMultiindex().build()
+        pandas_dataset = convert_pandas_multiindex_to_pandasDataset(
+            pd_df, item_id="instances", timepoints="timepoints", target=["var_0"]
+        )
+        return pandas_dataset
+
 
 ###
 # example 3: univariate, equally sampled, lossy,
 # targets #4299 pd-multiindex panel incorrect is_equally_spaced
 
-X_instances = [0, 0, 0, 1, 1, 1, 2, 2, 2]
-X_timepoints = pd.to_datetime([0, 1, 2, 4, 5, 6, 9, 10, 11], unit="s")
-X_multiindex = pd.MultiIndex.from_arrays(
-    [X_instances, X_timepoints], names=["instances", "timepoints"]
-)
 
-X = pd.DataFrame(index=X_multiindex, data=list(range(0, 9)), columns=["var_0"])
+class _PanelUnivEqsplLossy(BaseExample):
+    _tags = {
+        "scitype": "Panel",
+        "index": 3,
+        "metadata": {
+            "is_univariate": True,
+            "is_one_series": False,
+            "n_panels": 1,
+            "is_one_panel": True,
+            "is_equally_spaced": False,
+            "is_equal_length": True,
+            "is_equal_index": False,
+            "is_empty": False,
+            "has_nans": False,
+            "n_instances": 3,
+            "n_features": 1,
+            "feature_names": ["var_0"],
+            "feature_kind": [DtypeKind.FLOAT],
+        },
+    }
 
-example_dict[("pd-multiindex", "Panel", 3)] = X
-example_dict_lossy[("pd-multiindex", "Panel", 3)] = False
 
-example_dict_metadata[("Panel", 3)] = {
-    "is_univariate": True,
-    "is_one_series": False,
-    "n_panels": 1,
-    "is_one_panel": True,
-    "is_equally_spaced": True,
-    "is_equal_length": True,
-    "is_equal_index": False,
-    "is_empty": False,
-    "has_nans": False,
-    "n_instances": 3,
-    "n_features": 1,
-    "feature_names": ["var_0"],
-    "feature_kind": [DtypeKind.FLOAT],
-}
+class _PanelUnivEqsplLossyPdMultiindex(_PanelUnivEqsplLossy):
+    _tags = {
+        "mtype": "pd-multiindex",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        X_instances = [0, 0, 0, 1, 1, 1, 2, 2, 2]
+        X_timepoints = pd.to_datetime([0, 1, 2, 4, 5, 6, 9, 10, 11], unit="s")
+        X_multiindex = pd.MultiIndex.from_arrays(
+            [X_instances, X_timepoints], names=["instances", "timepoints"]
+        )
+
+        X = pd.DataFrame(index=X_multiindex, data=list(range(0, 9)), columns=["var_0"])
+        return X

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -548,7 +548,7 @@ class _PanelUnivEqsplLossy(BaseExample):
             "is_one_series": False,
             "n_panels": 1,
             "is_one_panel": True,
-            "is_equally_spaced": False,
+            "is_equally_spaced": True,
             "is_equal_length": True,
             "is_equal_index": False,
             "is_empty": False,

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -160,7 +160,7 @@ class _PanelMultivEqsplDaskPanel(_PanelMultivEqspl):
 class _PanelMultivEqsplPolarsPanel(_PanelMultivEqspl):
     _tags = {
         "mtype": "polars_panel",
-        "python_dependencies": ["polars"],
+        "python_dependencies": ["polars", "pyarrow"],
         "lossy": False,
     }
 
@@ -331,7 +331,7 @@ class _PanelUnivEqsplDaskPanel(_PanelUnivEqspl):
 class _PanelUnivEqsplPolarsPanel(_PanelUnivEqspl):
     _tags = {
         "mtype": "polars_panel",
-        "python_dependencies": ["polars"],
+        "python_dependencies": ["polars", "pyarrow"],
         "lossy": False,
     }
 
@@ -488,7 +488,7 @@ class _PanelUnivEqsplOneSeriesDaskPanel(_PanelUnivEqsplOneSeries):
 class _PanelUnivEqsplOneSeriesPolarsPanel(_PanelUnivEqsplOneSeries):
     _tags = {
         "mtype": "polars_panel",
-        "python_dependencies": ["polars"],
+        "python_dependencies": ["polars", "pyarrow"],
         "lossy": False,
     }
 

--- a/sktime/datatypes/_panel/_examples.py
+++ b/sktime/datatypes/_panel/_examples.py
@@ -1,24 +1,25 @@
 """Example generation for testing.
 
-Exports dict of examples, useful for testing as fixtures.
+Exports examples of in-memory data containers, useful for testing as fixtures.
 
-example_dict: dict indexed by triple
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are data objects, considered examples for the mtype
-    all examples with same index are considered "same" on scitype content
-    if None, indicates that representation is not possible
+Examples come in clusters, tagged by scitype: str, index: int, and metadata: dict.
 
-example_lossy: dict of bool indexed by pairs of str
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are bool, indicate whether representation has information removed
-    all examples with same index are considered "same" on scitype content
+All examples with the same index are considered "content-wise the same", i.e.,
+representing the same abstract data object. They differ by mtype, i.e.,
+machine type, which is the specific in-memory representation.
 
-overall, conversions from non-lossy representations to any other ones
-    should yield the element exactly, identidally (given same index)
+If an example returns None, it indicates that representation
+with that specific mtype is not possible.
+
+If the tag "lossy" is True, the representation is considered incomplete,
+e.g., metadata such as column names are missing.
+
+Types of tests that can be performed with these examples:
+
+* the mtype and scitype of the example should be correctly inferred by checkers.
+* the metadata of hte example should be correctly inferred by checkers.
+* conversions from non-lossy representations to any other ones
+  should yield the element exactly, identically, for examples of the same index.
 """
 
 import numpy as np

--- a/sktime/datatypes/_proba/__init__.py
+++ b/sktime/datatypes/_proba/__init__.py
@@ -2,13 +2,6 @@
 
 from sktime.datatypes._proba._check import check_dict as check_dict_Proba
 from sktime.datatypes._proba._convert import convert_dict as convert_dict_Proba
-from sktime.datatypes._proba._examples import example_dict as example_dict_Proba
-from sktime.datatypes._proba._examples import (
-    example_dict_lossy as example_dict_lossy_Proba,
-)
-from sktime.datatypes._proba._examples import (
-    example_dict_metadata as example_dict_metadata_Proba,
-)
 from sktime.datatypes._proba._registry import MTYPE_LIST_PROBA, MTYPE_REGISTER_PROBA
 
 __all__ = [
@@ -16,7 +9,4 @@ __all__ = [
     "convert_dict_Proba",
     "MTYPE_LIST_PROBA",
     "MTYPE_REGISTER_PROBA",
-    "example_dict_Proba",
-    "example_dict_lossy_Proba",
-    "example_dict_metadata_Proba",
 ]

--- a/sktime/datatypes/_proba/_examples.py
+++ b/sktime/datatypes/_proba/_examples.py
@@ -1,94 +1,136 @@
 """Example generation for testing.
 
-Exports dict of examples, useful for testing as fixtures.
+Exports examples of in-memory data containers, useful for testing as fixtures.
 
-example_dict: dict indexed by triple
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are data objects, considered examples for the mtype
-    all examples with same index are considered "same" on scitype content
-    if None, indicates that representation is not possible
+Examples come in clusters, tagged by scitype: str, index: int, and metadata: dict.
 
-example_lossy: dict of bool indexed by triple
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are bool, indicate whether representation has information removed
-    all examples with same index are considered "same" on scitype content
+All examples with the same index are considered "content-wise the same", i.e.,
+representing the same abstract data object. They differ by mtype, i.e.,
+machine type, which is the specific in-memory representation.
 
-example_metadata: dict of metadata dict, indexed by pair
-  1st element = considered as this scitype - str
-  2nd element = int - index of example
-  (there is no "mtype" element, as properties are equal for all mtypes)
-elements are metadata dict, as returned by check_is_mtype
-    used as expected return of check_is_mtype in tests
+If an example returns None, it indicates that representation
+with that specific mtype is not possible.
 
-overall, conversions from non-lossy representations to any other ones
-    should yield the element exactly, identidally (given same index)
+If the tag "lossy" is True, the representation is considered incomplete,
+e.g., metadata such as column names are missing.
+
+Types of tests that can be performed with these examples:
+
+* the mtype and scitype of the example should be correctly inferred by checkers.
+* the metadata of hte example should be correctly inferred by checkers.
+* conversions from non-lossy representations to any other ones
+  should yield the element exactly, identically, for examples of the same index.
 """
 
 import numpy as np
 import pandas as pd
 
-example_dict = dict()
-example_dict_lossy = dict()
-example_dict_metadata = dict()
+from sktime.datatypes._base import BaseExample
 
 ###
 # example 0: univariate
 
-pred_q = pd.DataFrame({0.2: [1, 2, 3], 0.6: [2, 3, 4]})
-pred_q.columns = pd.MultiIndex.from_product([["foobar"], [0.2, 0.6]])
 
-# we need to use this due to numerical inaccuracies from the binary based representation
-pseudo_0_2 = 2 * np.abs(0.6 - 0.5)
-
-example_dict[("pred_quantiles", "Proba", 0)] = pred_q
-example_dict_lossy[("pred_quantiles", "Proba", 0)] = False
-
-pred_int = pd.DataFrame({0.2: [1, 2, 3], 0.6: [2, 3, 4]})
-pred_int.columns = pd.MultiIndex.from_tuples(
-    [("foobar", 0.6, "lower"), ("foobar", pseudo_0_2, "upper")]
-)
-
-example_dict[("pred_interval", "Proba", 0)] = pred_int
-example_dict_lossy[("pred_interval", "Proba", 0)] = False
+class _ProbaUniv(BaseExample):
+    _tags = {
+        "scitype": "Proba",
+        "index": 0,
+        "metadata": {
+            "is_univariate": True,
+            "is_empty": False,
+            "has_nans": False,
+        },
+    }
 
 
-example_dict_metadata[("Proba", 0)] = {
-    "is_univariate": True,
-    "is_empty": False,
-    "has_nans": False,
-}
+class _ProbaUnivPredQ(_ProbaUniv):
+    _tags = {
+        "mtype": "pred_quantiles",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        pred_q = pd.DataFrame({0.2: [1, 2, 3], 0.6: [2, 3, 4]})
+        pred_q.columns = pd.MultiIndex.from_product([["foo"], [0.2, 0.6]])
+
+        return pred_q
+
+
+class _ProbaUnivPredInt(_ProbaUniv):
+    _tags = {
+        "mtype": "pred_interval",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        # we need to use this due to numerical inaccuracies
+        # from the binary based representation
+        pseudo_0_2 = 2 * np.abs(0.6 - 0.5)
+
+        pred_int = pd.DataFrame({0.2: [1, 2, 3], 0.6: [2, 3, 4]})
+        pred_int.columns = pd.MultiIndex.from_tuples(
+            [("foo", 0.6, "lower"), ("foo", pseudo_0_2, "upper")]
+        )
+
+        return pred_int
+
 
 ###
 # example 1: multi
 
-pred_q = pd.DataFrame({0.2: [1, 2, 3], 0.6: [2, 3, 4], 42: [5, 3, -1], 46: [5, 3, -1]})
-pred_q.columns = pd.MultiIndex.from_product([["foo", "bar"], [0.2, 0.6]])
 
-example_dict[("pred_quantiles", "Proba", 1)] = pred_q
-example_dict_lossy[("pred_quantiles", "Proba", 1)] = False
-
-pred_int = pd.DataFrame(
-    {0.2: [1, 2, 3], 0.6: [2, 3, 4], 42: [5, 3, -1], 46: [5, 3, -1]}
-)
-pred_int.columns = pd.MultiIndex.from_tuples(
-    [
-        ("foo", 0.6, "lower"),
-        ("foo", pseudo_0_2, "upper"),
-        ("bar", 0.6, "lower"),
-        ("bar", pseudo_0_2, "upper"),
-    ]
-)
-
-example_dict[("pred_interval", "Proba", 1)] = pred_int
-example_dict_lossy[("pred_interval", "Proba", 1)] = False
+class _ProbaMulti(BaseExample):
+    _tags = {
+        "scitype": "Proba",
+        "index": 1,
+        "metadata": {
+            "is_univariate": False,
+            "is_empty": False,
+            "has_nans": False,
+        },
+    }
 
 
-example_dict_metadata[("Proba", 1)] = {
-    "is_univariate": False,
-    "is_empty": False,
-    "has_nans": False,
-}
+class _ProbaMultiPredQ(_ProbaMulti):
+    _tags = {
+        "mtype": "pred_quantiles",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        pred_q = pd.DataFrame(
+            {0.2: [1, 2, 3], 0.6: [2, 3, 4], 42: [5, 3, -1], 46: [5, 3, -1]}
+        )
+        pred_q.columns = pd.MultiIndex.from_product([["foo", "bar"], [0.2, 0.6]])
+
+        return pred_q
+
+
+class _ProbaMultiPredInt(_ProbaMulti):
+    _tags = {
+        "mtype": "pred_interval",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        # we need to use this due to numerical inaccuracies
+        # from the binary based representation
+        pseudo_0_2 = 2 * np.abs(0.6 - 0.5)
+
+        pred_int = pd.DataFrame(
+            {0.2: [1, 2, 3], 0.6: [2, 3, 4], 42: [5, 3, -1], 46: [5, 3, -1]}
+        )
+        pred_int.columns = pd.MultiIndex.from_tuples(
+            [
+                ("foo", 0.6, "lower"),
+                ("foo", pseudo_0_2, "upper"),
+                ("bar", 0.6, "lower"),
+                ("bar", pseudo_0_2, "upper"),
+            ]
+        )
+
+        return pred_int

--- a/sktime/datatypes/_series/__init__.py
+++ b/sktime/datatypes/_series/__init__.py
@@ -2,13 +2,6 @@
 
 from sktime.datatypes._series._check import check_dict as check_dict_Series
 from sktime.datatypes._series._convert import convert_dict as convert_dict_Series
-from sktime.datatypes._series._examples import example_dict as example_dict_Series
-from sktime.datatypes._series._examples import (
-    example_dict_lossy as example_dict_lossy_Series,
-)
-from sktime.datatypes._series._examples import (
-    example_dict_metadata as example_dict_metadata_Series,
-)
 from sktime.datatypes._series._registry import MTYPE_LIST_SERIES, MTYPE_REGISTER_SERIES
 
 __all__ = [
@@ -16,7 +9,4 @@ __all__ = [
     "convert_dict_Series",
     "MTYPE_LIST_SERIES",
     "MTYPE_REGISTER_SERIES",
-    "example_dict_Series",
-    "example_dict_lossy_Series",
-    "example_dict_metadata_Series",
 ]

--- a/sktime/datatypes/_series/_examples.py
+++ b/sktime/datatypes/_series/_examples.py
@@ -1,31 +1,25 @@
 """Example generation for testing.
 
-Exports dict of examples, useful for testing as fixtures.
+Exports examples of in-memory data containers, useful for testing as fixtures.
 
-example_dict: dict indexed by triple
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are data objects, considered examples for the mtype
-    all examples with same index are considered "same" on scitype content
-    if None, indicates that representation is not possible
+Examples come in clusters, tagged by scitype: str, index: int, and metadata: dict.
 
-example_lossy: dict of bool indexed by triple
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are bool, indicate whether representation has information removed
-    all examples with same index are considered "same" on scitype content
+All examples with the same index are considered "content-wise the same", i.e.,
+representing the same abstract data object. They differ by mtype, i.e.,
+machine type, which is the specific in-memory representation.
 
-example_metadata: dict of metadata dict, indexed by pair
-  1st element = considered as this scitype - str
-  2nd element = int - index of example
-  (there is no "mtype" element, as properties are equal for all mtypes)
-elements are metadata dict, as returned by check_is_mtype
-    used as expected return of check_is_mtype in tests
+If an example returns None, it indicates that representation
+with that specific mtype is not possible.
 
-overall, conversions from non-lossy representations to any other ones
-    should yield the element exactly, identidally (given same index)
+If the tag "lossy" is True, the representation is considered incomplete,
+e.g., metadata such as column names are missing.
+
+Types of tests that can be performed with these examples:
+
+* the mtype and scitype of the example should be correctly inferred by checkers.
+* the metadata of hte example should be correctly inferred by checkers.
+* conversions from non-lossy representations to any other ones
+  should yield the element exactly, identically, for examples of the same index.
 """
 
 import numpy as np

--- a/sktime/datatypes/_series/_examples.py
+++ b/sktime/datatypes/_series/_examples.py
@@ -37,6 +37,7 @@ from sktime.datatypes._dtypekind import DtypeKind
 ###
 # example 0: univariate
 
+
 class _SeriesUniv(BaseExample):
     _tags = {
         "scitype": "Series",
@@ -54,7 +55,6 @@ class _SeriesUniv(BaseExample):
 
 
 class _SeriesUnivPdSeries(_SeriesUniv):
-
     _tags = {
         "mtype": "pd.Series",
         "python_dependencies": None,
@@ -66,7 +66,6 @@ class _SeriesUnivPdSeries(_SeriesUniv):
 
 
 class _SeriesUnivPdDataFrame(_SeriesUniv):
-
     _tags = {
         "mtype": "pd.DataFrame",
         "python_dependencies": None,
@@ -78,7 +77,6 @@ class _SeriesUnivPdDataFrame(_SeriesUniv):
 
 
 class _SeriesUnivNpArray(_SeriesUniv):
-
     _tags = {
         "mtype": "np.ndarray",
         "python_dependencies": None,
@@ -90,7 +88,6 @@ class _SeriesUnivNpArray(_SeriesUniv):
 
 
 class _SeriesUnivXrDataArray(_SeriesUniv):
-
     _tags = {
         "mtype": "xr.DataArray",
         "python_dependencies": "xarray",
@@ -107,7 +104,6 @@ class _SeriesUnivXrDataArray(_SeriesUniv):
 
 
 class _SeriesUnivDaskSeries(_SeriesUniv):
-
     _tags = {
         "mtype": "dask_series",
         "python_dependencies": "dask",
@@ -121,7 +117,6 @@ class _SeriesUnivDaskSeries(_SeriesUniv):
 
 
 class _SeriesUnivPlDataFrame(_SeriesUniv):
-
     _tags = {
         "mtype": "pl.DataFrame",
         "python_dependencies": "polars>=1.0",
@@ -137,7 +132,6 @@ class _SeriesUnivPlDataFrame(_SeriesUniv):
 
 
 class _SeriesUnivGluontsListDataset(_SeriesUniv):
-
     _tags = {
         "mtype": "gluonts_ListDataset_series",
         "python_dependencies": "gluonts",
@@ -171,7 +165,6 @@ class _SeriesMulti(BaseExample):
 
 
 class _SeriesMultiPdSeries(_SeriesMulti):
-
     _tags = {
         "mtype": "pd.Series",
         "python_dependencies": None,
@@ -183,7 +176,6 @@ class _SeriesMultiPdSeries(_SeriesMulti):
 
 
 class _SeriesMultiPdDataFrame(_SeriesMulti):
-
     _tags = {
         "mtype": "pd.DataFrame",
         "python_dependencies": None,
@@ -195,7 +187,6 @@ class _SeriesMultiPdDataFrame(_SeriesMulti):
 
 
 class _SeriesMultiNpArray(_SeriesMulti):
-
     _tags = {
         "mtype": "np.ndarray",
         "python_dependencies": None,
@@ -207,7 +198,6 @@ class _SeriesMultiNpArray(_SeriesMulti):
 
 
 class _SeriesMultiXrDataArray(_SeriesMulti):
-
     _tags = {
         "mtype": "xr.DataArray",
         "python_dependencies": "xarray",
@@ -224,7 +214,6 @@ class _SeriesMultiXrDataArray(_SeriesMulti):
 
 
 class _SeriesMultiDaskSeries(_SeriesMulti):
-
     _tags = {
         "mtype": "dask_series",
         "python_dependencies": "dask",
@@ -239,7 +228,6 @@ class _SeriesMultiDaskSeries(_SeriesMulti):
 
 
 class _SeriesMultiPlDataFrame(_SeriesMulti):
-
     _tags = {
         "mtype": "pl.DataFrame",
         "python_dependencies": "polars>=1.0",
@@ -256,7 +244,6 @@ class _SeriesMultiPlDataFrame(_SeriesMulti):
 
 
 class _SeriesMultiGluontsListDataset(_SeriesMulti):
-
     _tags = {
         "mtype": "gluonts_ListDataset_series",
         "python_dependencies": "gluonts",
@@ -275,7 +262,6 @@ class _SeriesMultiGluontsListDataset(_SeriesMulti):
 
 
 class _SeriesMultiPos(BaseExample):
-
     _tags = {
         "scitype": "Series",
         "index": 2,
@@ -292,7 +278,6 @@ class _SeriesMultiPos(BaseExample):
 
 
 class _SeriesMultiPosPdSeries(_SeriesMultiPos):
-
     _tags = {
         "mtype": "pd.Series",
         "python_dependencies": None,
@@ -304,7 +289,6 @@ class _SeriesMultiPosPdSeries(_SeriesMultiPos):
 
 
 class _SeriesMultiPosPdDataFrame(_SeriesMultiPos):
-
     _tags = {
         "mtype": "pd.DataFrame",
         "python_dependencies": None,
@@ -316,7 +300,6 @@ class _SeriesMultiPosPdDataFrame(_SeriesMultiPos):
 
 
 class _SeriesMultiPosNpArray(_SeriesMultiPos):
-
     _tags = {
         "mtype": "np.ndarray",
         "python_dependencies": None,
@@ -328,7 +311,6 @@ class _SeriesMultiPosNpArray(_SeriesMultiPos):
 
 
 class _SeriesMultiPosXrDataArray(_SeriesMultiPos):
-
     _tags = {
         "mtype": "xr.DataArray",
         "python_dependencies": "xarray",
@@ -345,7 +327,6 @@ class _SeriesMultiPosXrDataArray(_SeriesMultiPos):
 
 
 class _SeriesMultiPosDaskSeries(_SeriesMultiPos):
-
     _tags = {
         "mtype": "dask_series",
         "python_dependencies": "dask",
@@ -360,7 +341,6 @@ class _SeriesMultiPosDaskSeries(_SeriesMultiPos):
 
 
 class _SeriesMultiPosPlDataFrame(_SeriesMultiPos):
-
     _tags = {
         "mtype": "pl.DataFrame",
         "python_dependencies": "polars>=1.0",
@@ -377,7 +357,6 @@ class _SeriesMultiPosPlDataFrame(_SeriesMultiPos):
 
 
 class _SeriesMultiPosGluontsListDataset(_SeriesMultiPos):
-
     _tags = {
         "mtype": "gluonts_ListDataset_series",
         "python_dependencies": "gluonts",
@@ -396,7 +375,6 @@ class _SeriesMultiPosGluontsListDataset(_SeriesMultiPos):
 
 
 class _SeriesUnivPos(BaseExample):
-
     _tags = {
         "scitype": "Series",
         "index": 3,
@@ -413,7 +391,6 @@ class _SeriesUnivPos(BaseExample):
 
 
 class _SeriesUnivPosPdSeries(_SeriesUnivPos):
-
     _tags = {
         "mtype": "pd.Series",
         "python_dependencies": None,
@@ -425,7 +402,6 @@ class _SeriesUnivPosPdSeries(_SeriesUnivPos):
 
 
 class _SeriesUnivPosPdDataFrame(_SeriesUnivPos):
-
     _tags = {
         "mtype": "pd.DataFrame",
         "python_dependencies": None,
@@ -437,7 +413,6 @@ class _SeriesUnivPosPdDataFrame(_SeriesUnivPos):
 
 
 class _SeriesUnivPosNpArray(_SeriesUnivPos):
-
     _tags = {
         "mtype": "np.ndarray",
         "python_dependencies": None,
@@ -449,7 +424,6 @@ class _SeriesUnivPosNpArray(_SeriesUnivPos):
 
 
 class _SeriesUnivPosXrDataArray(_SeriesUnivPos):
-
     _tags = {
         "mtype": "xr.DataArray",
         "python_dependencies": "xarray",
@@ -466,7 +440,6 @@ class _SeriesUnivPosXrDataArray(_SeriesUnivPos):
 
 
 class _SeriesUnivPosPlDataFrame(_SeriesUnivPos):
-
     _tags = {
         "mtype": "pl.DataFrame",
         "python_dependencies": "polars>=1.0",
@@ -482,7 +455,6 @@ class _SeriesUnivPosPlDataFrame(_SeriesUnivPos):
 
 
 class _SeriesUnivPosGluontsListDataset(_SeriesUnivPos):
-
     _tags = {
         "mtype": "gluonts_ListDataset_series",
         "python_dependencies": "gluonts",

--- a/sktime/datatypes/_series/_examples.py
+++ b/sktime/datatypes/_series/_examples.py
@@ -166,7 +166,7 @@ class _SeriesMultiPdSeries(_SeriesMulti):
     }
 
     def build(self):
-        return pd.DataFrame({"a": [1, 4, 0.5, -3], "b": [3, 7, 2, -3 / 7]})
+        return None
 
 
 class _SeriesMultiPdDataFrame(_SeriesMulti):
@@ -279,7 +279,7 @@ class _SeriesMultiPosPdSeries(_SeriesMultiPos):
     }
 
     def build(self):
-        return pd.DataFrame({"a": [1, 4, 0.5, 3], "b": [3, 7, 2, 3 / 7]})
+        return None
 
 
 class _SeriesMultiPosPdDataFrame(_SeriesMultiPos):

--- a/sktime/datatypes/_series/_examples.py
+++ b/sktime/datatypes/_series/_examples.py
@@ -113,7 +113,7 @@ class _SeriesUnivDaskSeries(_SeriesUniv):
 class _SeriesUnivPlDataFrame(_SeriesUniv):
     _tags = {
         "mtype": "pl.DataFrame",
-        "python_dependencies": "polars>=1.0",
+        "python_dependencies": ["polars>=1.0", "pyarrow"],
         "lossy": False,
     }
 
@@ -224,7 +224,7 @@ class _SeriesMultiDaskSeries(_SeriesMulti):
 class _SeriesMultiPlDataFrame(_SeriesMulti):
     _tags = {
         "mtype": "pl.DataFrame",
-        "python_dependencies": "polars>=1.0",
+        "python_dependencies": ["polars>=1.0", "pyarrow"],
         "lossy": False,
     }
 
@@ -337,7 +337,7 @@ class _SeriesMultiPosDaskSeries(_SeriesMultiPos):
 class _SeriesMultiPosPlDataFrame(_SeriesMultiPos):
     _tags = {
         "mtype": "pl.DataFrame",
-        "python_dependencies": "polars>=1.0",
+        "python_dependencies": ["polars>=1.0", "pyarrow"],
         "lossy": False,
     }
 
@@ -436,7 +436,7 @@ class _SeriesUnivPosXrDataArray(_SeriesUnivPos):
 class _SeriesUnivPosPlDataFrame(_SeriesUnivPos):
     _tags = {
         "mtype": "pl.DataFrame",
-        "python_dependencies": "polars>=1.0",
+        "python_dependencies": ["polars>=1.0", "pyarrow"],
         "lossy": False,
     }
 

--- a/sktime/datatypes/_series/_examples.py
+++ b/sktime/datatypes/_series/_examples.py
@@ -107,7 +107,8 @@ class _SeriesUnivDaskSeries(_SeriesUniv):
     def build(self):
         from dask.dataframe import from_pandas
 
-        return from_pandas(self._get_example("pd.DataFrame", 0), npartitions=1)
+        df = _SeriesUnivPdDataFrame().build()
+        return from_pandas(df, npartitions=1)
 
 
 class _SeriesUnivPlDataFrame(_SeriesUniv):
@@ -135,7 +136,8 @@ class _SeriesUnivGluontsListDataset(_SeriesUniv):
     def build(self):
         from sktime.datatypes._adapter.gluonts import convert_pandas_to_listDataset
 
-        return convert_pandas_to_listDataset(self._get_example("pd.DataFrame", 0))
+        df = _SeriesUnivPdDataFrame().build()
+        return convert_pandas_to_listDataset(df)
 
 
 ###

--- a/sktime/datatypes/_table/__init__.py
+++ b/sktime/datatypes/_table/__init__.py
@@ -2,13 +2,6 @@
 
 from sktime.datatypes._table._check import check_dict as check_dict_Table
 from sktime.datatypes._table._convert import convert_dict as convert_dict_Table
-from sktime.datatypes._table._examples import example_dict as example_dict_Table
-from sktime.datatypes._table._examples import (
-    example_dict_lossy as example_dict_lossy_Table,
-)
-from sktime.datatypes._table._examples import (
-    example_dict_metadata as example_dict_metadata_Table,
-)
 from sktime.datatypes._table._registry import MTYPE_LIST_TABLE, MTYPE_REGISTER_TABLE
 
 __all__ = [
@@ -16,7 +9,4 @@ __all__ = [
     "convert_dict_Table",
     "MTYPE_LIST_TABLE",
     "MTYPE_REGISTER_TABLE",
-    "example_dict_Table",
-    "example_dict_lossy_Table",
-    "example_dict_metadata_Table",
 ]

--- a/sktime/datatypes/_table/_examples.py
+++ b/sktime/datatypes/_table/_examples.py
@@ -1,127 +1,239 @@
 """Example generation for testing.
 
-Exports dict of examples, useful for testing as fixtures.
+Exports examples of in-memory data containers, useful for testing as fixtures.
 
-example_dict: dict indexed by triple
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are data objects, considered examples for the mtype
-    all examples with same index are considered "same" on scitype content
-    if None, indicates that representation is not possible
+Examples come in clusters, tagged by scitype: str, index: int, and metadata: dict.
 
-example_lossy: dict of bool indexed by pairs of str
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are bool, indicate whether representation has information removed
-    all examples with same index are considered "same" on scitype content
+All examples with the same index are considered "content-wise the same", i.e.,
+representing the same abstract data object. They differ by mtype, i.e.,
+machine type, which is the specific in-memory representation.
 
-overall, conversions from non-lossy representations to any other ones
-    should yield the element exactly, identidally (given same index)
+If an example returns None, it indicates that representation
+with that specific mtype is not possible.
+
+If the tag "lossy" is True, the representation is considered incomplete,
+e.g., metadata such as column names are missing.
+
+Types of tests that can be performed with these examples:
+
+* the mtype and scitype of the example should be correctly inferred by checkers.
+* the metadata of hte example should be correctly inferred by checkers.
+* conversions from non-lossy representations to any other ones
+  should yield the element exactly, identically, for examples of the same index.
 """
 
 import numpy as np
 import pandas as pd
 
+from sktime.datatypes._base import BaseExample
 from sktime.datatypes._dtypekind import DtypeKind
-from sktime.utils.dependencies import _check_soft_dependencies
-
-example_dict = dict()
-example_dict_lossy = dict()
-example_dict_metadata = dict()
 
 ###
 # example 0: univariate
 
-df = pd.DataFrame({"a": [1, 4, 0.5, -3]})
 
-example_dict[("pd_DataFrame_Table", "Table", 0)] = df
-example_dict_lossy[("pd_DataFrame_Table", "Table", 0)] = False
+class _UnivTable(BaseExample):
+    _tags = {
+        "scitype": "Table",
+        "index": 0,
+        "metadata": {
+            "is_univariate": True,
+            "is_empty": False,
+            "has_nans": False,
+            "n_instances": 4,
+            "n_features": 1,
+            "feature_names": ["a"],
+            "feature_kind": [DtypeKind.FLOAT],
+        },
+    }
 
-arr = np.array([[1], [4], [0.5], [-3]])
 
-example_dict[("numpy2D", "Table", 0)] = arr
-example_dict_lossy[("numpy2D", "Table", 0)] = True
+class _UnivTableDf(_UnivTable):
+    _tags = {
+        "mtype": "pd_DataFrame_Table",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-arr = np.array([1, 4, 0.5, -3])
+    def build(self):
+        return pd.DataFrame({"a": [1, 4, 0.5, -3]})
 
-example_dict[("numpy1D", "Table", 0)] = arr
-example_dict_lossy[("numpy1D", "Table", 0)] = True
 
-series = pd.Series([1, 4, 0.5, -3])
+class _UnivTableNumpy2D(_UnivTable):
+    _tags = {
+        "mtype": "numpy2D",
+        "python_dependencies": None,
+        "lossy": True,
+    }
 
-example_dict[("pd_Series_Table", "Table", 0)] = series
-example_dict_lossy[("pd_Series_Table", "Table", 0)] = True
+    def build(self):
+        return np.array([[1], [4], [0.5], [-3]])
 
-list_of_dict = [{"a": 1.0}, {"a": 4.0}, {"a": 0.5}, {"a": -3.0}]
 
-example_dict[("list_of_dict", "Table", 0)] = list_of_dict
-example_dict_lossy[("list_of_dict", "Table", 0)] = False
+class _UnivTableNumpy1D(_UnivTable):
+    _tags = {
+        "mtype": "numpy1D",
+        "python_dependencies": None,
+        "lossy": True,
+    }
 
-if _check_soft_dependencies(["polars", "pyarrow"], severity="none"):
-    import polars as pl
+    def build(self):
+        return np.array([1, 4, 0.5, -3])
 
-    example_dict[("polars_eager_table", "Table", 0)] = pl.DataFrame(df)
-    example_dict_lossy[("polars_eager_table", "Table", 0)] = False
 
-    example_dict[("polars_lazy_table", "Table", 0)] = pl.LazyFrame(df)
-    example_dict_lossy[("polars_lazy_table", "Table", 0)] = False
+class _UnivTableSeries(_UnivTable):
+    _tags = {
+        "mtype": "pd_Series_Table",
+        "python_dependencies": None,
+        "lossy": True,
+    }
 
-example_dict_metadata[("Table", 0)] = {
-    "is_univariate": True,
-    "is_empty": False,
-    "has_nans": False,
-    "n_instances": 4,
-    "n_features": 1,
-    "feature_names": ["a"],
-    "feature_kind": [DtypeKind.FLOAT],
-}
+    def build(self):
+        return pd.Series([1, 4, 0.5, -3])
+
+
+class _UnivTableListOfDict(_UnivTable):
+    _tags = {
+        "mtype": "list_of_dict",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        return [{"a": 1.0}, {"a": 4.0}, {"a": 0.5}, {"a": -3.0}]
+
+
+class _UnivTablePolarsEager(_UnivTable):
+    _tags = {
+        "mtype": "polars_eager_table",
+        "python_dependencies": ["polars", "pyarrow"],
+        "lossy": False,
+    }
+
+    def build(self):
+        import polars as pl
+
+        df = pd.DataFrame({"a": [1, 4, 0.5, -3]})
+        return pl.DataFrame(df)
+
+
+class _UnivTablePolarsLazy(_UnivTable):
+    _tags = {
+        "mtype": "polars_lazy_table",
+        "python_dependencies": ["polars", "pyarrow"],
+        "lossy": False,
+    }
+
+    def build(self):
+        import polars as pl
+
+        df = pd.DataFrame({"a": [1, 4, 0.5, -3]})
+        return pl.LazyFrame(df)
+
 
 ###
 # example 1: multivariate
 
-example_dict[("numpy1D", "Table", 1)] = None
-example_dict_lossy[("numpy1D", "Table", 1)] = None
 
-df = pd.DataFrame({"a": [1, 4, 0.5, -3], "b": [3, 7, 2, -3 / 7]})
+class _MultivTable(BaseExample):
+    _tags = {
+        "scitype": "Table",
+        "index": 1,
+        "metadata": {
+            "is_univariate": False,
+            "is_empty": False,
+            "has_nans": False,
+            "n_instances": 4,
+            "n_features": 2,
+            "feature_names": ["a", "b"],
+            "feature_kind": [DtypeKind.FLOAT, DtypeKind.FLOAT],
+        },
+    }
 
-example_dict[("d_DataFrame_Table", "Table", 1)] = df
-example_dict_lossy[("pd_DataFrame_Table", "Table", 1)] = False
 
-arr = np.array([[1, 3], [4, 7], [0.5, 2], [-3, -3 / 7]])
+class _MultivTableDf(_MultivTable):
+    _tags = {
+        "mtype": "pd_DataFrame_Table",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-example_dict[("numpy2D", "Table", 1)] = arr
-example_dict_lossy[("numpy2D", "Table", 1)] = True
+    def build(self):
+        return pd.DataFrame({"a": [1, 4, 0.5, -3], "b": [3, 7, 2, -3 / 7]})
 
-example_dict[("pd_Series_Table", "Table", 1)] = None
-example_dict_lossy[("pd_Series_Table", "Table", 1)] = None
 
-list_of_dict = [
-    {"a": 1.0, "b": 3.0},
-    {"a": 4.0, "b": 7.0},
-    {"a": 0.5, "b": 2.0},
-    {"a": -3.0, "b": -3 / 7},
-]
+class _MultivTableNumpy2D(_MultivTable):
+    _tags = {
+        "mtype": "numpy2D",
+        "python_dependencies": None,
+        "lossy": True,
+    }
 
-example_dict[("list_of_dict", "Table", 1)] = list_of_dict
-example_dict_lossy[("list_of_dict", "Table", 1)] = False
+    def build(self):
+        return np.array([[1, 3], [4, 7], [0.5, 2], [-3, -3 / 7]])
 
-if _check_soft_dependencies(["polars", "pyarrow"], severity="none"):
-    import polars as pl
 
-    example_dict[("polars_eager_table", "Table", 1)] = pl.DataFrame(df)
-    example_dict_lossy[("polars_eager_table", "Table", 1)] = False
+class _MultivTableNumpy1D(_MultivTable):
+    _tags = {
+        "mtype": "numpy1D",
+        "python_dependencies": None,
+        "lossy": None,
+    }
 
-    example_dict[("polars_lazy_table", "Table", 1)] = pl.LazyFrame(df)
-    example_dict_lossy[("polars_lazy_table", "Table", 1)] = False
+    def build(self):
+        return None
 
-example_dict_metadata[("Table", 1)] = {
-    "is_univariate": False,
-    "is_empty": False,
-    "has_nans": False,
-    "n_instances": 4,
-    "n_features": 2,
-    "feature_names": ["a", "b"],
-    "feature_kind": [DtypeKind.FLOAT, DtypeKind.FLOAT],
-}
+
+class _MultivTableSeries(_MultivTable):
+    _tags = {
+        "mtype": "pd_Series_Table",
+        "python_dependencies": None,
+        "lossy": None,
+    }
+
+    def build(self):
+        return None
+
+
+class _MultivTableListOfDict(_MultivTable):
+    _tags = {
+        "mtype": "list_of_dict",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        return [
+            {"a": 1.0, "b": 3.0},
+            {"a": 4.0, "b": 7.0},
+            {"a": 0.5, "b": 2.0},
+            {"a": -3.0, "b": -3 / 7},
+        ]
+
+
+class _MultivTablePolarsEager(_MultivTable):
+    _tags = {
+        "mtype": "polars_eager_table",
+        "python_dependencies": ["polars", "pyarrow"],
+        "lossy": False,
+    }
+
+    def build(self):
+        import polars as pl
+
+        df = pd.DataFrame({"a": [1, 4, 0.5, -3], "b": [3, 7, 2, -3 / 7]})
+        return pl.DataFrame(df)
+
+
+class _MultivTablePolarsLazy(_MultivTable):
+    _tags = {
+        "mtype": "polars_lazy_table",
+        "python_dependencies": ["polars", "pyarrow"],
+        "lossy": False,
+    }
+
+    def build(self):
+        import polars as pl
+
+        df = pd.DataFrame({"a": [1, 4, 0.5, -3], "b": [3, 7, 2, -3 / 7]})
+        return pl.LazyFrame(df)

--- a/sktime/utils/retrieval.py
+++ b/sktime/utils/retrieval.py
@@ -86,8 +86,6 @@ def _all_cond(module_name, cond):
 
         # Import the module
         module = importlib.import_module(modname)
-        print(modname)
-        print(inspect.getmembers(module, cond))
 
         # Get all objects from the module
         for name, obj in inspect.getmembers(module, cond):


### PR DESCRIPTION
Refactors the example fixtures in the `datatypes` module along the lines of https://github.com/sktime/skpro/pull/458:

* a base class for datatype examples, `BaseExample`, to replace the more ad-hoc dictionary design
* a complete refactor of all `_example` submodules to this interface
* a full refactor of the public framework module with `get_example` logic, in `datatypes`, to allow extensibility with this design

Beyond the refactor, sets the `polars` requirements for the `polars` data examples to `polars>=1.0`, and adds `pyarrow` as a requirement, consistent with the status quo in `skpro`.

Closes #7128, as it addresses the issue both from an isolation perspective, as well as the missing argument perspective.