### PR TITLE
[ENH] `TransformedTargetForecaster` to support polymorphic forecasters

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -38,7 +38,16 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
 
     def _get_forecaster_index(self, estimators):
         """Get the index of the first forecaster in the list."""
-        return self._get_pipeline_scitypes(estimators).index("forecaster")
+        pipe_scitypes = [
+            scitype(
+                x[1],
+                raise_on_unknown=False,
+                force_single_scitype=False,
+                coerce_to_list=True,
+            ) for x in estimators
+        ]
+        is_fcst = ["forecaster" in s for s in pipe_scitypes]
+        return is_fcst.index(True)
 
     def _check_steps(self, estimators, allow_postproc=False):
         """Check Steps.


### PR DESCRIPTION
This updates `TransformedTargetForecaster` to support polymorphic forecasters, i.e., estimators where `"forecaster"` is just one of multiple scitypes.

Alternative to https://github.com/sktime/sktime/pull/7135/files