### PR TITLE
[DOC] update core developers on team page, formatting

### DIFF
--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -80,8 +80,6 @@ Core Developers
      - :user:`fnhirwa`
    * - Franz Király
      - :user:`fkiraly`
-   * - Freddy A Boulton
-     - :user:`freddyaboulton`
    * - Hazrul Akmal
      - :user:`hazrulakmal`
    * - Jonathan Bechtel
@@ -98,8 +96,6 @@ Core Developers
      - :user:`pranavvp16`
    * - Sagar Mishra
      - :user:`achieveordie`
-   * - Stanislav Khrapov
-     - :user:`khrapovs`
    * - Svea Marie Meyer
      - :user:`SveaMeyer13`
    * - Ugochukwu Onyeka
@@ -121,6 +117,10 @@ Former Core Developers
      - :user:`TonyBagnall`
    * - Ayushmaan Seth
      - :user:`ayushmaanseth`
+   * - Christopher Holder
+     - :user:`chrisholder`
+   * - Freddy A Boulton
+     - :user:`freddyaboulton`
    * - George Oastler
      - :user:`goastler`
    * - Guzal Bulatova
@@ -151,7 +151,7 @@ Former Core Developers
      - :user:`patrickzib`
    * - Sajaysurya Ganesh
      - :user:`sajaysurya`
-   * - Christopher Holder
-     - :user:`chrisholder`
+   * - Stanislav Khrapov
+     - :user:`khrapovs`
    * - Anonymous upon contributor's request
      - :user:`big-o`

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -70,10 +70,14 @@ Core Developers
      - :user:`Alex-JG3`
    * - Anirban Ray
      - :user:`yarnabrina`
+   * - Armaghan Shakir
+     - :user:`geetu040`
    * - Benedikt Heidrich
      - :user:`benheid`
    * - Daniel Bartling
      - :user:`danbartl`
+   * - Felix Hirwa Nshuti
+     - :user:`fnhirwa`
    * - Franz Király
      - :user:`fkiraly`
    * - Freddy A Boulton
@@ -90,6 +94,8 @@ Core Developers
      - :user:`marrov`
    * - Mirae Parker
      - :user:`miraep8`
+   * - Pranav Prajapati
+     - :user:`pranavvp16`
    * - Sagar Mishra
      - :user:`achieveordie`
    * - Stanislav Khrapov
@@ -98,6 +104,8 @@ Core Developers
      - :user:`SveaMeyer13`
    * - Ugochukwu Onyeka
      - :user:`onyekaugochukwu`
+   * - Xinyu Wu
+     - :user:`XinyuWuu`
 
 Former Core Developers
 ----------------------

--- a/docs/source/get_involved/governance.rst
+++ b/docs/source/get_involved/governance.rst
@@ -183,6 +183,7 @@ Algorithm maintainers that have been unresponsive for a 3 month period automatic
 give up their rights and responsibilities as algorithm maintainers.
 
 Unresponsiveness is defined as:
+
 * not engaging with decision making procedures within the reasonably time frames defined there
 * not reacting to issues or bug reports related to the algorithm, within ten working days
 


### PR DESCRIPTION
This PR adds the four new core developers to the "team" page: @geetu040, @fnhirwa, @pranavvp16, @XinyuWuu.

Also:
* makes some formatting related changes - broken bullet point display, alphabetic ordering
* removes two core developers who have been inactive for a longer time: @chrisholder, @freddyaboulton