### PR TITLE
[ENH] `is_scitype` utility for scitype checking, improve support of estimators with multiple object types

### DIFF
--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -145,7 +145,7 @@ class BaggingForecaster(BaseForecaster):
         -------
         fresh clone of the transformer to set to self.bootstrap_transformer_
         """
-        from sktime.registry import is_a_scitype
+        from sktime.registry import is_scitype
 
         if transformer is None:
             from sktime.transformations.bootstrap import STLBootstrapTransformer
@@ -163,7 +163,7 @@ class BaggingForecaster(BaseForecaster):
 
         if t_inp != "Series" or t_out != "Panel":
             raise TypeError(msg)
-        if not is_a_scitype(transformer, "transformer"):
+        if not is_scitype(transformer, "transformer"):
             raise TypeError(msg)
 
         if hasattr(transformer, "clone"):
@@ -187,14 +187,14 @@ class BaggingForecaster(BaseForecaster):
         -------
         fresh clone of the forecaster to set to self.forecaster_
         """
-        from sktime.registry import is_a_scitype
+        from sktime.registry import is_scitype
 
         if forecaster is None:
             from sktime.forecasting.ets import AutoETS
 
             return AutoETS(sp=self.sp, random_state=self.random_state)
 
-        if not is_a_scitype(forecaster, "forecaster"):
+        if not is_scitype(forecaster, "forecaster"):
             raise TypeError(
                 "Error in BaggingForecaster: "
                 "forecaster in BaggingForecaster should be an sktime forecaster"

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -145,7 +145,7 @@ class BaggingForecaster(BaseForecaster):
         -------
         fresh clone of the transformer to set to self.bootstrap_transformer_
         """
-        from sktime.registry import scitype
+        from sktime.registry import is_a_scitype
 
         if transformer is None:
             from sktime.transformations.bootstrap import STLBootstrapTransformer
@@ -163,7 +163,7 @@ class BaggingForecaster(BaseForecaster):
 
         if t_inp != "Series" or t_out != "Panel":
             raise TypeError(msg)
-        if scitype(transformer) != "transformer":
+        if not is_a_scitype(transformer, "transformer"):
             raise TypeError(msg)
 
         if hasattr(transformer, "clone"):
@@ -187,14 +187,14 @@ class BaggingForecaster(BaseForecaster):
         -------
         fresh clone of the forecaster to set to self.forecaster_
         """
-        from sktime.registry import scitype
+        from sktime.registry import is_a_scitype
 
         if forecaster is None:
             from sktime.forecasting.ets import AutoETS
 
             return AutoETS(sp=self.sp, random_state=self.random_state)
 
-        if not scitype(forecaster) == "forecaster":
+        if not is_a_scitype(forecaster, "forecaster"):
             raise TypeError(
                 "Error in BaggingForecaster: "
                 "forecaster in BaggingForecaster should be an sktime forecaster"

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -12,7 +12,7 @@ from sktime.datatypes import ALL_TIME_SERIES_MTYPES
 from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.base._delegate import _DelegatedForecaster
 from sktime.forecasting.base._fh import ForecastingHorizon
-from sktime.registry import scitype
+from sktime.registry import is_a_scitype
 from sktime.utils._estimator_html_repr import _VisualBlock
 from sktime.utils.validation.series import check_series
 from sktime.utils.warnings import warn
@@ -32,13 +32,11 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
     # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_fitted_attr = "steps_"
 
-    def _get_pipeline_scitypes(self, estimators):
-        """Get list of scityes (str) from names/estimator list."""
-        return [scitype(x[1], raise_on_unknown=False) for x in estimators]
-
     def _get_forecaster_index(self, estimators):
         """Get the index of the first forecaster in the list."""
-        return self._get_pipeline_scitypes(estimators).index("forecaster")
+        for i, est in enumerate(estimators):
+            if is_a_scitype(est[1], "forecaster"):
+                return i
 
     def _check_steps(self, estimators, allow_postproc=False):
         """Check Steps.
@@ -85,14 +83,15 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
 
         # validate names
         self._check_names(names)
-
-        scitypes = self._get_pipeline_scitypes(estimator_tuples)
-        if not set(scitypes).issubset(["forecaster", "transformer"]):
+        if not all(
+            [is_a_scitype(x, ["forecaster", "transformer"]) for x in estimators]
+        ):
             raise TypeError(
                 f"estimators passed to {self_name} "
                 f"must be either transformer or forecaster"
             )
-        if scitypes.count("forecaster") != 1:
+        scitypes = [is_a_scitype(x, ["forecaster"]) for x in estimators]
+        if sum(scitypes) != 1:
             raise TypeError(
                 f"exactly one forecaster must be contained in the chain, "
                 f"but found {scitypes.count('forecaster')}"

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -12,7 +12,7 @@ from sktime.datatypes import ALL_TIME_SERIES_MTYPES
 from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.base._delegate import _DelegatedForecaster
 from sktime.forecasting.base._fh import ForecastingHorizon
-from sktime.registry import is_a_scitype
+from sktime.registry import is_scitype
 from sktime.utils._estimator_html_repr import _VisualBlock
 from sktime.utils.validation.series import check_series
 from sktime.utils.warnings import warn
@@ -35,7 +35,7 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
     def _get_forecaster_index(self, estimators):
         """Get the index of the first forecaster in the list."""
         for i, est in enumerate(estimators):
-            if is_a_scitype(est[1], "forecaster"):
+            if is_scitype(est[1], "forecaster"):
                 return i
 
     def _check_steps(self, estimators, allow_postproc=False):
@@ -83,14 +83,12 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
 
         # validate names
         self._check_names(names)
-        if not all(
-            [is_a_scitype(x, ["forecaster", "transformer"]) for x in estimators]
-        ):
+        if not all([is_scitype(x, ["forecaster", "transformer"]) for x in estimators]):
             raise TypeError(
                 f"estimators passed to {self_name} "
                 f"must be either transformer or forecaster"
             )
-        scitypes = [is_a_scitype(x, ["forecaster"]) for x in estimators]
+        scitypes = [is_scitype(x, ["forecaster"]) for x in estimators]
         if sum(scitypes) != 1:
             raise TypeError(
                 f"exactly one forecaster must be contained in the chain, "

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -36,7 +36,7 @@ from sktime.datatypes._utilities import get_time_index
 from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
 from sktime.forecasting.base._fh import _index_range
 from sktime.forecasting.base._sktime import _BaseWindowForecaster
-from sktime.registry import scitype
+from sktime.registry import scitype, is_a_scitype
 from sktime.transformations.compose import FeatureUnion
 from sktime.transformations.series.summarize import WindowSummarizer
 from sktime.utils.datetime import _shift
@@ -1631,13 +1631,12 @@ def _infer_scitype(estimator):
     if is_sklearn_estimator(estimator):
         return f"tabular-{sklearn_scitype(estimator)}"
     else:
-        inferred_skt_scitype = scitype(estimator, raise_on_unknown=False)
-        if inferred_skt_scitype in ["object", "estimator"]:
+        if is_a_scitype(estimator, ["object", "estimator"]):
             return "tabular-regressor"
-        if inferred_skt_scitype == "regressor":
+        if is_a_scitype(estimator, "regressor"):
             return "time-series-regressor"
         else:
-            return inferred_skt_scitype
+            return scitype(estimator, raise_on_unknown=False)
 
 
 def _check_strategy(strategy):

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -36,7 +36,7 @@ from sktime.datatypes._utilities import get_time_index
 from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
 from sktime.forecasting.base._fh import _index_range
 from sktime.forecasting.base._sktime import _BaseWindowForecaster
-from sktime.registry import scitype, is_a_scitype
+from sktime.registry import is_a_scitype, scitype
 from sktime.transformations.compose import FeatureUnion
 from sktime.transformations.series.summarize import WindowSummarizer
 from sktime.utils.datetime import _shift

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -36,7 +36,7 @@ from sktime.datatypes._utilities import get_time_index
 from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
 from sktime.forecasting.base._fh import _index_range
 from sktime.forecasting.base._sktime import _BaseWindowForecaster
-from sktime.registry import is_a_scitype, scitype
+from sktime.registry import is_scitype, scitype
 from sktime.transformations.compose import FeatureUnion
 from sktime.transformations.series.summarize import WindowSummarizer
 from sktime.utils.datetime import _shift
@@ -1631,9 +1631,9 @@ def _infer_scitype(estimator):
     if is_sklearn_estimator(estimator):
         return f"tabular-{sklearn_scitype(estimator)}"
     else:
-        if is_a_scitype(estimator, ["object", "estimator"]):
+        if is_scitype(estimator, ["object", "estimator"]):
             return "tabular-regressor"
-        if is_a_scitype(estimator, "regressor"):
+        if is_scitype(estimator, "regressor"):
             return "time-series-regressor"
         else:
             return scitype(estimator, raise_on_unknown=False)

--- a/sktime/registry/__init__.py
+++ b/sktime/registry/__init__.py
@@ -10,7 +10,7 @@ from sktime.registry._base_classes import (
 )
 from sktime.registry._craft import craft, deps, imports
 from sktime.registry._lookup import all_estimators, all_tags
-from sktime.registry._scitype import is_a_scitype, scitype
+from sktime.registry._scitype import is_scitype, scitype
 from sktime.registry._scitype_coercion import coerce_scitype
 from sktime.registry._tags import (
     ESTIMATOR_TAG_LIST,
@@ -26,7 +26,7 @@ __all__ = [
     "craft",
     "deps",
     "imports",
-    "is_a_scitype",
+    "is_scitype",
     "resolve_alias",
     "scitype",
     "ALIAS_DICT",

--- a/sktime/registry/__init__.py
+++ b/sktime/registry/__init__.py
@@ -10,7 +10,7 @@ from sktime.registry._base_classes import (
 )
 from sktime.registry._craft import craft, deps, imports
 from sktime.registry._lookup import all_estimators, all_tags
-from sktime.registry._scitype import scitype
+from sktime.registry._scitype import is_a_scitype, scitype
 from sktime.registry._scitype_coercion import coerce_scitype
 from sktime.registry._tags import (
     ESTIMATOR_TAG_LIST,
@@ -26,6 +26,7 @@ __all__ = [
     "craft",
     "deps",
     "imports",
+    "is_a_scitype",
     "resolve_alias",
     "scitype",
     "ALIAS_DICT",

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -7,25 +7,28 @@ from inspect import isclass
 from sktime.registry._base_classes import get_base_class_register
 
 
-def is_scitype(obj, desired_scitype):
+def is_scitype(obj, scitypes):
     """Check if obj is of desired scitype.
 
     Parameters
     ----------
-    obj : class or object
-    desired_scitype : str or list of str
+    obj : class or object, must be an skbase BaseObject descendant
+    scitypes : str or iterable of str
+        scitype(s) to check, each str must be a valid scitype string
 
     Returns
     -------
     is_scitype : bool
-        True if obj is of desired scitype, False otherwise
+        True if obj tag ``object_type``, or inferred scitype via ``registry.scitype``,
+        contains at least one of the scitype strings in ``scitypes``.
     """
-    scitypes = scitype(
+    obj_scitypes = scitype(
         obj, force_single_scitype=False, coerce_to_list=True, raise_on_unknown=False
     )
-    if isinstance(desired_scitype, str):
-        desired_scitype = [desired_scitype]
-    return len(desired_scitype.intersection(scitypes)) > 0
+    if isinstance(scitypes, str):
+        scitypes = [scitypes]
+    scitypes = set(scitypes)
+    return len(scitypes.intersection(obj_scitypes)) > 0
 
 
 def scitype(

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -7,6 +7,13 @@ from inspect import isclass
 from sktime.registry._base_classes import get_base_class_register
 
 
+def is_a_scitype(obj, desired_scitype):
+    scitypes = scitype(obj, force_single_scitype=False, coerce_to_list=True)
+    if isinstance(desired_scitype, str):
+        desired_scitype = [desired_scitype]
+    return any([scitype in desired_scitype for scitype in scitypes])
+
+
 def scitype(
     obj, force_single_scitype=True, coerce_to_list=False, raise_on_unknown=True
 ):

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -7,13 +7,25 @@ from inspect import isclass
 from sktime.registry._base_classes import get_base_class_register
 
 
-def is_a_scitype(obj, desired_scitype):
+def is_scitype(obj, desired_scitype):
+    """Check if obj is of desired scitype.
+
+    Parameters
+    ----------
+    obj : class or object
+    desired_scitype : str or list of str
+
+    Returns
+    -------
+    is_scitype : bool
+        True if obj is of desired scitype, False otherwise
+    """
     scitypes = scitype(
         obj, force_single_scitype=False, coerce_to_list=True, raise_on_unknown=False
     )
     if isinstance(desired_scitype, str):
         desired_scitype = [desired_scitype]
-    return any([scitype in desired_scitype for scitype in scitypes])
+    return len(desired_scitype.intersection(scitypes)) > 0
 
 
 def scitype(

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -8,7 +8,9 @@ from sktime.registry._base_classes import get_base_class_register
 
 
 def is_a_scitype(obj, desired_scitype):
-    scitypes = scitype(obj, force_single_scitype=False, coerce_to_list=True, raise_on_unknown=False)
+    scitypes = scitype(
+        obj, force_single_scitype=False, coerce_to_list=True, raise_on_unknown=False
+    )
     if isinstance(desired_scitype, str):
         desired_scitype = [desired_scitype]
     return any([scitype in desired_scitype for scitype in scitypes])

--- a/sktime/registry/_scitype.py
+++ b/sktime/registry/_scitype.py
@@ -8,7 +8,7 @@ from sktime.registry._base_classes import get_base_class_register
 
 
 def is_a_scitype(obj, desired_scitype):
-    scitypes = scitype(obj, force_single_scitype=False, coerce_to_list=True)
+    scitypes = scitype(obj, force_single_scitype=False, coerce_to_list=True, raise_on_unknown=False)
     if isinstance(desired_scitype, str):
         desired_scitype = [desired_scitype]
     return any([scitype in desired_scitype for scitype in scitypes])

--- a/sktime/registry/tests/test_scitype.py
+++ b/sktime/registry/tests/test_scitype.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from sktime.registry._scitype import scitype
+from sktime.registry._scitype import is_scitype, scitype
 
 
 @pytest.mark.parametrize("coerce_to_list", [True, False])
@@ -92,3 +92,15 @@ def test_scitype_generic(force_single_scitype, coerce_to_list):
         expected = "foo"
 
     assert scitype_inferred == expected
+
+
+def test_is_scitype():
+    """Test that is_scitype is correctly checking the scitypes."""
+    from sktime.base import BaseObject
+
+    class _DummyClass(BaseObject):
+        _tags = {"object_type": ["foo", "bar"]}
+
+    assert is_scitype(_DummyClass, "foo")
+    assert is_scitype(_DummyClass, "bar")
+    assert not is_scitype(_DummyClass, "baz")

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -225,9 +225,9 @@ class BaseTransformer(BaseEstimator):
         other : object
             object to check
         """
-        from sktime.registry import is_a_scitype
+        from sktime.registry import is_scitype
 
-        is_sktime_transformr = is_a_scitype(other, "transformer")
+        is_sktime_transformr = is_scitype(other, "transformer")
         return is_sklearn_transformer(other) or is_sktime_transformr
 
     def __mul__(self, other):

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -225,9 +225,9 @@ class BaseTransformer(BaseEstimator):
         other : object
             object to check
         """
-        from sktime.registry import scitype
+        from sktime.registry import is_a_scitype
 
-        is_sktime_transformr = scitype(other, raise_on_unknown=False) == "transformer"
+        is_sktime_transformr = is_a_scitype(other, "transformer")
         return is_sklearn_transformer(other) or is_sktime_transformr
 
     def __mul__(self, other):

--- a/sktime/transformations/compose/_transformif.py
+++ b/sktime/transformations/compose/_transformif.py
@@ -205,13 +205,13 @@ class TransformIf(_DelegatedTransformer):
         -------
         self : a fitted instance of the estimator
         """
-        from sktime.registry import is_a_scitype
+        from sktime.registry import is_scitype
 
         if_estimator_ = self.if_estimator.clone()
 
-        if is_a_scitype(if_estimator_, "forecaster"):
+        if is_scitype(if_estimator_, "forecaster"):
             self.if_estimator_ = if_estimator_.fit(y=X, X=y)
-        elif is_a_scitype(if_estimator_, "transformer"):
+        elif is_scitype(if_estimator_, "transformer"):
             self.if_estimator_ = if_estimator_.fit(X=X, y=y)
         else:
             try:

--- a/sktime/transformations/compose/_transformif.py
+++ b/sktime/transformations/compose/_transformif.py
@@ -205,13 +205,13 @@ class TransformIf(_DelegatedTransformer):
         -------
         self : a fitted instance of the estimator
         """
-        from sktime.registry import scitype
+        from sktime.registry import is_a_scitype
 
         if_estimator_ = self.if_estimator.clone()
 
-        if scitype(if_estimator_) == "forecaster":
+        if is_a_scitype(if_estimator_, "forecaster"):
             self.if_estimator_ = if_estimator_.fit(y=X, X=y)
-        elif scitype(if_estimator_) == "transformer":
+        elif is_a_scitype(if_estimator_, "transformer"):
             self.if_estimator_ = if_estimator_.fit(X=X, y=y)
         else:
             try:

--- a/sktime/utils/_testing/estimator_checks.py
+++ b/sktime/utils/_testing/estimator_checks.py
@@ -16,7 +16,7 @@ from sktime.classification.base import BaseClassifier
 from sktime.classification.early_classification import BaseEarlyClassifier
 from sktime.clustering.base import BaseClusterer
 from sktime.datatypes._panel._check import is_nested_dataframe
-from sktime.registry import scitype
+from sktime.registry import is_a_scitype
 
 
 def _list_required_methods(est_scitype, is_est=True):
@@ -203,11 +203,8 @@ def _has_capability(est, method: str) -> bool:
             return True
         return get_tag(est, "capability:pred_int", False)
     # skip transform for forecasters that have it - pipelines
-    if method == "transform" and scitype(est) in (
-        "classifier",
-        "forecaster",
-    ):
+    if method == "transform" and is_a_scitype(est, ["classifier", "forecaster"]):
         return False
-    if method == "predict" and scitype(est) == "transformer":
+    if method == "predict" and is_a_scitype(est, "transformer"):
         return False
     return True

--- a/sktime/utils/_testing/estimator_checks.py
+++ b/sktime/utils/_testing/estimator_checks.py
@@ -16,7 +16,7 @@ from sktime.classification.base import BaseClassifier
 from sktime.classification.early_classification import BaseEarlyClassifier
 from sktime.clustering.base import BaseClusterer
 from sktime.datatypes._panel._check import is_nested_dataframe
-from sktime.registry import is_a_scitype
+from sktime.registry import is_scitype
 
 
 def _list_required_methods(est_scitype, is_est=True):
@@ -203,8 +203,8 @@ def _has_capability(est, method: str) -> bool:
             return True
         return get_tag(est, "capability:pred_int", False)
     # skip transform for forecasters that have it - pipelines
-    if method == "transform" and is_a_scitype(est, ["classifier", "forecaster"]):
+    if method == "transform" and is_scitype(est, ["classifier", "forecaster"]):
         return False
-    if method == "predict" and is_a_scitype(est, "transformer"):
+    if method == "predict" and is_scitype(est, "transformer"):
         return False
     return True

--- a/sktime/utils/_testing/scenarios_classification.py
+++ b/sktime/utils/_testing/scenarios_classification.py
@@ -14,7 +14,7 @@ __all__ = [
 from inspect import isclass
 
 from sktime.base import BaseObject
-from sktime.registry import is_a_scitype
+from sktime.registry import is_scitype
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import (
     _make_classification_y,
@@ -76,7 +76,7 @@ class ClassifierTestScenario(TestScenario, BaseObject):
         # applicable only if obj inherits from BaseClassifier, BaseEarlyClassifier or
         #   BaseRegressor. currently we test both classifiers and regressors using these
         #   scenarios
-        if is_a_scitype(obj, ["classifier", "early_classifier", "regressor"]):
+        if is_scitype(obj, ["classifier", "early_classifier", "regressor"]):
             return False
 
         # if X is multivariate, applicable only if can handle multivariate

--- a/sktime/utils/_testing/scenarios_classification.py
+++ b/sktime/utils/_testing/scenarios_classification.py
@@ -14,7 +14,7 @@ __all__ = [
 from inspect import isclass
 
 from sktime.base import BaseObject
-from sktime.registry import scitype
+from sktime.registry import is_a_scitype
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import (
     _make_classification_y,
@@ -76,11 +76,7 @@ class ClassifierTestScenario(TestScenario, BaseObject):
         # applicable only if obj inherits from BaseClassifier, BaseEarlyClassifier or
         #   BaseRegressor. currently we test both classifiers and regressors using these
         #   scenarios
-        if scitype(obj) not in (
-            "classifier",
-            "early_classifier",
-            "regressor",
-        ):
+        if is_a_scitype(obj, ["classifier", "early_classifier", "regressor"]):
             return False
 
         # if X is multivariate, applicable only if can handle multivariate

--- a/sktime/utils/_testing/scenarios_clustering.py
+++ b/sktime/utils/_testing/scenarios_clustering.py
@@ -10,7 +10,7 @@ __all__ = ["scenarios_clustering"]
 from inspect import isclass
 
 from sktime.base import BaseObject
-from sktime.registry import is_a_scitype
+from sktime.registry import is_scitype
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_panel_X, make_clustering_problem
 from sktime.utils._testing.scenarios import TestScenario
@@ -69,7 +69,7 @@ class ClustererTestScenario(TestScenario, BaseObject):
         # applicable only if obj inherits from BaseClassifier, BaseEarlyClassifier or
         #   BaseRegressor. currently we test both classifiers and regressors using these
         #   scenarios
-        if is_a_scitype(obj, "clusterer"):
+        if is_scitype(obj, "clusterer"):
             return False
 
         # if X is multivariate, applicable only if can handle multivariate

--- a/sktime/utils/_testing/scenarios_clustering.py
+++ b/sktime/utils/_testing/scenarios_clustering.py
@@ -10,7 +10,7 @@ __all__ = ["scenarios_clustering"]
 from inspect import isclass
 
 from sktime.base import BaseObject
-from sktime.registry import scitype
+from sktime.registry import is_a_scitype
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_panel_X, make_clustering_problem
 from sktime.utils._testing.scenarios import TestScenario
@@ -69,7 +69,7 @@ class ClustererTestScenario(TestScenario, BaseObject):
         # applicable only if obj inherits from BaseClassifier, BaseEarlyClassifier or
         #   BaseRegressor. currently we test both classifiers and regressors using these
         #   scenarios
-        if scitype(obj) != "clusterer":
+        if is_a_scitype(obj, "clusterer"):
             return False
 
         # if X is multivariate, applicable only if can handle multivariate

--- a/sktime/utils/_testing/scenarios_forecasting.py
+++ b/sktime/utils/_testing/scenarios_forecasting.py
@@ -18,7 +18,7 @@ import pandas as pd
 
 from sktime.base import BaseObject
 from sktime.datatypes import mtype_to_scitype
-from sktime.registry import is_a_scitype
+from sktime.registry import is_scitype
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_panel_X
 from sktime.utils._testing.scenarios import TestScenario
@@ -49,7 +49,7 @@ class ForecasterTestScenario(TestScenario, BaseObject):
                 return obj.get_tag(tag_name)
 
         # applicable only if obj inherits from BaseForecaster
-        if is_a_scitype(obj, "forecaster"):
+        if is_scitype(obj, "forecaster"):
             return False
 
         # applicable only if number of variables in y complies with scitype:y

--- a/sktime/utils/_testing/scenarios_forecasting.py
+++ b/sktime/utils/_testing/scenarios_forecasting.py
@@ -18,7 +18,7 @@ import pandas as pd
 
 from sktime.base import BaseObject
 from sktime.datatypes import mtype_to_scitype
-from sktime.registry import scitype
+from sktime.registry import is_a_scitype
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_panel_X
 from sktime.utils._testing.scenarios import TestScenario
@@ -49,7 +49,7 @@ class ForecasterTestScenario(TestScenario, BaseObject):
                 return obj.get_tag(tag_name)
 
         # applicable only if obj inherits from BaseForecaster
-        if scitype(obj) != "forecaster":
+        if is_a_scitype(obj, "forecaster"):
             return False
 
         # applicable only if number of variables in y complies with scitype:y


### PR DESCRIPTION
#### Reference Issues/PRs

Alternative to #7137 #7136 #7135

#### What does this implement/fix? Explain your changes.
Introduces a new method `is_scitype`, which checks if an estimator has the same scitype as at least one of the elements from a list of strings, `scitypes`


#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

Are the missing instances where `is_scitype` should be used

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
