### PR TITLE
[ENH] add `_predict_var` in `test_pred_int_tag`

### DIFF
--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -653,14 +653,15 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         #    probabilistic forecasting, this is the condition "pred_int_works" below
 
         # check which methods are implemented
+        implements_var = f._has_implementation_of("_predict_var")
         implements_interval = f._has_implementation_of("_predict_interval")
         implements_quantiles = f._has_implementation_of("_predict_quantiles")
         implements_proba = f._has_implementation_of("_predict_proba")
 
         pred_int_impl = implements_interval or implements_quantiles or implements_proba
+        pred_int_impl = pred_int_impl or implements_var
 
         cls_tag = f.get_class_tag("capability:pred_int", False)
-        obj_tag = f.get_tag("capability:pred_int", False)
 
         if not pred_int_impl and cls_tag:
             raise ValueError(

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -648,13 +648,9 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
             return None
 
         # below, we check the following things:
-        # 1. for forecasters with fixed/non-dynamic tag capability:pred_int,
-        #    its value should be True iff the forecaster implements
-        #    probabilistic forecasting, the condition "pred_int_works"
-        # 2. If the forecaster has a dynamic tag capability:pred_int tag,
-        #    it should be set to True in the class tag, and there must be some
-        #    implementation of probabilistic forecasting methods.
-        #    The reverse implication as in 1 does not need to be true.
+        #    the class value of the tag capability:pred_int,
+        #    should be True iff the forecaster implements
+        #    probabilistic forecasting, this is the condition "pred_int_works" below
 
         # check which methods are implemented
         implements_interval = f._has_implementation_of("_predict_interval")
@@ -665,7 +661,6 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
 
         cls_tag = f.get_class_tag("capability:pred_int", False)
         obj_tag = f.get_tag("capability:pred_int", False)
-        tag_is_dynamic = cls_tag and not obj_tag
 
         if not pred_int_impl and cls_tag:
             raise ValueError(
@@ -674,12 +669,13 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
                 'The flag "capability:pred_int" should instead be set to False.'
             )
 
-        if pred_int_impl and not tag_is_dynamic and not cls_tag:
+        if pred_int_impl and not cls_tag:
             raise ValueError(
                 f"{type(f).__name__} does implement probabilistic forecasting, "
                 'but "capability:pred_int" flag has been set to False incorrectly. '
                 'The flag "capability:pred_int" should instead be set to True.'
             )
+
 
     @pytest.mark.parametrize(
         "fh_int_oos", TEST_OOS_FHS, ids=[f"fh={fh}" for fh in TEST_OOS_FHS]

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -677,7 +677,6 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
                 'The flag "capability:pred_int" should instead be set to True.'
             )
 
-
     @pytest.mark.parametrize(
         "fh_int_oos", TEST_OOS_FHS, ids=[f"fh={fh}" for fh in TEST_OOS_FHS]
     )


### PR DESCRIPTION
Presently, `test_pred_int_tag`, does not take into account `_predict_var` if implemented - this PR adds that to the logic.