### PR TITLE
[DOC] remove 2024 elections registration news item

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,12 +6,6 @@ Welcome to sktime
 
 A unified framework for machine learning with time series.
 
-.. topic:: Register as a voter or candidate for the 2024 council elections!
-
-    Represent the community of users and developers,
-    and help shape the future of sktime. Deadline Sep 22.
-    `Register here <https://github.com/sktime/elections>`_
-
 .. topic:: Register as a user!
 
     Prioritized bugfixes, shape the tech roadmap and governance policy.


### PR DESCRIPTION
This removes the 2024 elections registration news item from the landing page, as elections registration for voters and candidates has ended on Sep 22, see https://github.com/sktime/elections