### PR TITLE
[DOC] add quicklinks at top of README box

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ sktime is a library for time series analysis in Python. It provides a unified in
 
 [scikit-learn]: https://scikit-learn.org/stable/
 
-| Overview | |
+|  | **[Documentation](https://www.sktime.net/en/stable/users.html)** · **[Tutorials](https://www.sktime.net/en/stable/examples.html)** · **[Release Notes](https://www.sktime.net/en/stable/changelog.html)** |
 |---|---|
 | **Open&#160;Source** | [![BSD 3-clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://github.com/sktime/sktime/blob/main/LICENSE) |
 | **Tutorials** | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/sktime/sktime/main?filepath=examples) [![!youtube](https://img.shields.io/static/v1?logo=youtube&label=YouTube&message=tutorials&color=red)](https://www.youtube.com/playlist?list=PLKs3UgGjlWHqNzu0LEOeLKvnjvvest2d0) |


### PR DESCRIPTION
Inspired by the `pytorch-forecasting` box at the top of the README, replaces the wasteful top row which only contained the word "Overview" with three links to key locations on the sktime documentation page - user docs, tutorials, changelog.