### PR TITLE
[MNT] bound `SignatureTransformer` to `numpy<2`

### DIFF
--- a/sktime/transformations/panel/signature_based/_signature_method.py
+++ b/sktime/transformations/panel/signature_based/_signature_method.py
@@ -61,7 +61,7 @@ class SignatureTransformer(BaseTransformer):
         # --------------
         "authors": "jambo6",
         "maintainers": "jambo6",
-        "python_dependencies": "esig",
+        "python_dependencies": ["esig", "numpy<2.0"],
         "python_version": "<3.10",
         # estimator type
         # --------------


### PR DESCRIPTION
From `test-all`, `SignatureTransformer` is incompatible with `numpy 2`, this PR restricts it to `numpy<2`, similar to `SignatureClassifier` which uses it under the hood.

Closes #7023, as it is seems the `esig` package is no longer maintained.