### PR TITLE
XinyuWuu [MNT] remove ptf install from example notebook

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[all_extras,binder,dev,mlflow]
+          python -m pip install .[all_extras,binder,dev,mlflow,dl]
       - name: Run example notebooks
         run: build_tools/run_examples.sh
         shell: bash

--- a/examples/01c_forecasting_hierarchical_global.ipynb
+++ b/examples/01c_forecasting_hierarchical_global.ipynb
@@ -34,13 +34,7 @@
     "%%capture\n",
     "import warnings\n",
     "\n",
-    "warnings.filterwarnings(\"ignore\")\n",
-    "\n",
-    "import sys\n",
-    "\n",
-    "py_exe = sys.executable\n",
-    "\n",
-    "!{py_exe} -m pip install pytorch-forecasting==1.0.0"
+    "warnings.filterwarnings(\"ignore\")"
    ]
   },
   {


### PR DESCRIPTION
Split part of https://github.com/sktime/sktime/pull/6628, removes `pytorch-forecasting` install from jupyter notebook, instead moves it to the CI.