### PR TITLE
[BUG] fix ForecastingHorizon `to_absolute` wiht multiple frequencies

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -806,29 +806,7 @@ def _to_relative(fh: ForecastingHorizon, cutoff=None) -> ForecastingHorizon:
             absolute = _coerce_to_period(absolute, freq=fh._freq)
             cutoff = _coerce_to_period(cutoff, freq=fh._freq)
 
-        # TODO: 0.34.0:
-        # Check at every minor release whether lower pandas bound >=0.15.0
-        # if yes, can remove the workaround in the "else" condition and the check
-        #
-        # context:
-        # there is a bug in pandas
-        # that requires a workaround when computing index diff below
-        # bug report: https://github.com/pandas-dev/pandas/issues/45999
-        # fix, present from 1.5.0 on: https://github.com/pandas-dev/pandas/pull/46006
-        #
-        # example with bug and workaround:
-        # periods = pd.period_range(start="2021-01-01", periods=3, freq="2H")
-        # periods - periods[0]
-        # Out: Index([<0 * Hours>, <4 * Hours>, <8 * Hours>], dtype = 'object')
-        # [v - periods[0] for v in periods]
-        # Out: Index([<0 * Hours>, <2 * Hours>, <4 * Hours>], dtype='object')
-        #
-        # Below checks pandas version
-        # "if" branch has code that is expected to work
-        # "else" has the workaround for versions strictly lower than pandas 1.5.0
-        pandas_version_with_bugfix = _check_soft_dependencies(
-            "pandas>=1.5.0", severity="none"
-        )
+        pandas_version_with_bugfix = _is_pandas_arithmetic_bug_fixed()
         if pandas_version_with_bugfix:
             relative = absolute - cutoff
         else:
@@ -880,11 +858,17 @@ def _to_absolute(fh: ForecastingHorizon, cutoff) -> ForecastingHorizon:
             # coerce to pd.Period for reliable arithmetic operations and
             # computations of time deltas
             cutoff = _coerce_to_period(cutoff, freq=fh._freq)
-
         if isinstance(cutoff, pd.Index):
             cutoff = cutoff[[0] * len(relative)]
 
-        absolute = cutoff + relative
+        # pandas bugfix
+        pandas_version_with_bugfix = _is_pandas_arithmetic_bug_fixed()
+        if not pandas_version_with_bugfix and isinstance(cutoff, pd.PeriodIndex):
+            absolute = pd.PeriodIndex(cutoff.to_list() + relative, freq=fh._freq)
+        elif not pandas_version_with_bugfix and isinstance(cutoff, pd.DatetimeIndex):
+            absolute = pd.DatetimeIndex(cutoff.to_list() + relative, freq=fh._freq)
+        else:
+            absolute = cutoff + relative
 
         if is_timestamp:
             # coerce back to DatetimeIndex after operation
@@ -976,3 +960,28 @@ def _index_range(relative, cutoff):
         # coerce back to DatetimeIndex after operation
         absolute = absolute.to_timestamp(cutoff.freqstr)
     return absolute
+
+
+def _is_pandas_arithmetic_bug_fixed():
+    """Check if pandas supports correct arithmetic without a workaround."""
+    # TODO: 0.34.0:
+    # Check at every minor release whether lower pandas bound >=0.15.0
+    # if yes, can remove the workaround in the "else" condition and the check
+    #
+    # context:
+    # there is a bug in pandas
+    # that requires a workaround when computing index diff below
+    # bug report: https://github.com/pandas-dev/pandas/issues/45999
+    # fix, present from 1.5.0 on: https://github.com/pandas-dev/pandas/pull/46006
+    #
+    # example with bug and workaround:
+    # periods = pd.period_range(start="2021-01-01", periods=3, freq="2H")
+    # periods - periods[0]
+    # Out: Index([<0 * Hours>, <4 * Hours>, <8 * Hours>], dtype = 'object')
+    # [v - periods[0] for v in periods]
+    # Out: Index([<0 * Hours>, <2 * Hours>, <4 * Hours>], dtype='object')
+    #
+    # Below checks pandas version
+    # "True" represents that is expected to work
+    # "False" has the workaround for versions strictly lower than pandas 1.5.0
+    return _check_soft_dependencies("pandas>=1.5.0", severity="none")

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -571,6 +571,18 @@ def test_to_absolute_int_fh_with_freq(idx: int, freq: str):
     assert_array_equal(fh + idx, absolute_int)
 
 
+@pytest.mark.parametrize("freq", FREQUENCY_STRINGS)
+def test_to_absolute_with_multiple_freq(freq: str):
+    """Test to_absolute with multiple freq"""
+    fh = ForecastingHorizon([0, 1, 2, 3, 4], is_relative=True)
+    start = "2024-09-26 17:24"
+    cutoff = pd.PeriodIndex([start], freq=freq)
+    absolute = fh.to_absolute(cutoff)
+    date_range = pd.date_range(start=start, freq=freq, periods=5)
+    period_index = date_range.to_period(freq)
+    assert_array_equal(period_index.to_numpy(), absolute.to_numpy())
+
+
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"]),
     reason="run only if base module has changed or datatypes module has changed",


### PR DESCRIPTION

<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->

Fixes #7170 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Use `Period` instead of `PeriodIndex` for performing mathematical operations

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->
no

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
add a unit test 

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
