### PR TITLE
Fix #5073: Add optional transformer to ytox transformer

### DIFF
--- a/sktime/transformations/compose/_ytox.py
+++ b/sktime/transformations/compose/_ytox.py
@@ -130,9 +130,9 @@ class YtoX(BaseTransformer):
         "requires_y": True,
     }
 
-    def __init__(self, subset_index=False):
+    def __init__(self, subset_index=False, transformer=None):
         self.subset_index = subset_index
-
+        self.transformer = transformer
         super().__init__()
 
     def _transform(self, X, y=None):
@@ -152,9 +152,15 @@ class YtoX(BaseTransformer):
         y, as a transformed version of X
         """
         if self.subset_index:
-            return y.loc[X.index.intersection(y.index)]
+            y_transformed = y.loc[X.index.intersection(y.index)]
         else:
-            return y
+            y_transformed = y
+
+        # Apply the transformer if provided
+        if self.transformer is not None:
+            y_transformed = self.transformer.fit_transform(y_transformed)
+
+        return y_transformed
 
     def _inverse_transform(self, X, y=None):
         """Inverse transform, inverse operation to transform.

--- a/sktime/transformations/tests/test_ytox.py
+++ b/sktime/transformations/tests/test_ytox.py
@@ -1,0 +1,142 @@
+import pytest
+import pandas as pd
+import numpy as np
+from sktime.datasets import load_airline
+from sktime.transformations.compose import YtoX
+from sktime.transformations.series.exponent import ExponentTransformer
+from sktime.transformations.series.boxcox import BoxCoxTransformer
+
+
+@pytest.fixture
+def y_data():
+    """Fixture to create a sample dataset."""
+    y = load_airline()
+    return y
+
+
+def get_test_params():
+    """Provide test parameters for the YtoX class."""
+    # Return instances with different parameters
+    return [
+        {"ytox": YtoX(subset_index=False), "description": "YtoX without subset_index"},
+        {"ytox": YtoX(subset_index=True), "description": "YtoX with subset_index"},
+        {"ytox": YtoX(subset_index=False, transformer=ExponentTransformer(power=2)), "description": "YtoX with ExponentTransformer"},
+        {"ytox": YtoX(subset_index=False, transformer=BoxCoxTransformer()), "description": "YtoX with BoxCoxTransformer"},
+    ]
+
+
+def ensure_dataframe(output):
+    """Ensure the output is a DataFrame."""
+    if isinstance(output, pd.Series):
+        return output.to_frame()
+    return output
+
+
+@pytest.mark.parametrize("params", get_test_params())
+def test_ytox(params, y_data):
+    """Test YtoX with different parameters."""
+    ytox = params["ytox"]
+    description = params["description"]
+
+    X = pd.DataFrame(np.random.randn(len(y_data), 2), index=y_data.index)  # Example exogenous data
+
+    # Call fit first
+    ytox.fit(X, y_data)
+
+    transformed_y = ensure_dataframe(ytox.transform(X, y_data))
+
+    # Ensure both are DataFrames
+    if ytox.transformer is not None:
+        expected_y = ensure_dataframe(ytox.transformer.fit_transform(y_data))
+    else:
+        expected_y = ensure_dataframe(y_data)
+
+    try:
+        # Check if transformed data is the same as the original `y`
+        pd.testing.assert_frame_equal(transformed_y, expected_y)
+    except AssertionError as e:
+        print(f"\nError in {description}:")
+        print("\nTransformed y:\n", transformed_y.head())
+        print("\nExpected y:\n", expected_y.head())
+        print("\nError:\n", e)
+
+        # Perform a detailed comparison to find exact differences
+        diff = transformed_y.compare(expected_y)
+        print("\nDifferences between transformed and expected:\n", diff)
+
+        raise
+
+
+def test_ytox_with_transformer(y_data):
+    """Test YtoX with a transformer applied, ensuring the result is the same as applying transformer directly to `y`."""
+    X = pd.DataFrame(np.random.randn(len(y_data), 2), index=y_data.index)  # Example exogenous data
+
+    # Use an example transformer, e.g., an exponent transformer
+    transformer = ExponentTransformer(power=2)
+
+    # Apply the transformer directly to y
+    transformed_y_direct = ensure_dataframe(transformer.fit_transform(y_data))
+
+    # Create a YtoX transformer with the provided transformer
+    ytox = YtoX(transformer=transformer)
+
+    # Fit YtoX first
+    ytox.fit(X, y_data)
+
+    # Apply the YtoX transformation
+    transformed_y_via_ytox = ensure_dataframe(ytox.transform(X, y_data))
+
+    try:
+        # Check if the results are the same as applying the transformer directly to y
+        pd.testing.assert_frame_equal(transformed_y_direct, transformed_y_via_ytox)
+    except AssertionError as e:
+        print("\nTransformed y via YtoX:\n", transformed_y_via_ytox.head())
+        print("\nDirectly Transformed y:\n", transformed_y_direct.head())
+        print("\nError:\n", e)
+
+        # Perform a detailed comparison to find exact differences
+        diff = transformed_y_via_ytox.compare(transformed_y_direct)
+        print("\nDifferences between transformed via YtoX and directly transformed:\n", diff)
+
+        raise
+
+
+@pytest.mark.parametrize("params", get_test_params())
+def test_ytox_subset_index(params, y_data):
+    """Test the subset_index option of YtoX."""
+    ytox = params["ytox"]
+    description = params["description"]
+
+    # Ensure the YtoX transformer behaves as expected with subset_index=True
+    X = pd.DataFrame(np.random.randn(len(y_data), 2), index=y_data.index)  # Example exogenous data
+
+    # Subset the X to a smaller index
+    X_subset = X.iloc[:-5]
+
+    # Call fit first
+    ytox.fit(X_subset, y_data.iloc[:-5])
+
+    transformed_y = ensure_dataframe(ytox.transform(X_subset, y_data.iloc[:-5]))
+
+    # Ensure both are DataFrames
+    if ytox.transformer is not None:
+        expected_y = ensure_dataframe(ytox.transformer.fit_transform(y_data.iloc[:-5]))
+    else:
+        expected_y = ensure_dataframe(y_data.iloc[:-5])
+
+    try:
+        # Check if transformed data is the same as the original `y`
+        transformed_y.reset_index(drop=True, inplace=True)
+        expected_y.reset_index(drop=True, inplace=True)
+        pd.testing.assert_frame_equal(transformed_y, expected_y)
+    except AssertionError as e:
+        print(f"\nError in {description}:")
+        print("\nTransformed y:\n", transformed_y.head())
+        print("\nExpected y:\n", expected_y.head())
+        print("\nError:\n", e)
+
+        # Perform a detailed comparison to find exact differences
+        diff = transformed_y.compare(expected_y)
+        print("\nDifferences between transformed and expected:\n", diff)
+
+        raise


### PR DESCRIPTION
- Enhanced the ytox transformer to accept an optional transformer argument.
- Applied the specified transformer to the output, providing more flexibility.

This update resolves the issue by implementing the requested functionality and ensuring it behaves as expected.

<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
