### PR TITLE
[DOC] add docstring example to `Filter` transformer

### DIFF
--- a/sktime/transformations/series/filter.py
+++ b/sktime/transformations/series/filter.py
@@ -36,7 +36,7 @@ class Filter(BaseTransformer):
     -------
     >>> from sktime.transformations.series.filter import Filter
     >>> from sktime.datasets import load_arrow_head
-    >>> X, y = load_arrow_head(return_X_y=True)
+    >>> X, y = load_arrow_head(return_X_y=True, return_type="pd-multiindex")
     >>> transformer = Filter(sfreq=128, l_freq=0.5, h_freq=40)
     >>> X_filtered = transformer.fit_transform(X)
     """

--- a/sktime/transformations/series/filter.py
+++ b/sktime/transformations/series/filter.py
@@ -31,6 +31,14 @@ class Filter(BaseTransformer):
         Additional parameters passed on to ``mne.filter.filter_data``.
         See ``mne.filter.filter_data``
         documentation for a detailed description of all options.
+
+    Example
+    -------
+    >>> from sktime.transformations.series.filter import Filter
+    >>> from sktime.datasets import load_arrow_head
+    >>> X, y = load_arrow_head(return_X_y=True)
+    >>> transformer = Filter(sfreq=128, l_freq=0.5, h_freq=40)
+    >>> X_filtered = transformer.fit_transform(X)
     """
 
     # default tag values for "Series-to-Series"


### PR DESCRIPTION
This Pr adds a docstring example to the `Filter` transformer.

Towards #4264.

Demo issue for pydata Paris 2024.