### PR TITLE
[DOC] add docstring example for `PaddingTransformer`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3061,6 +3061,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login":"jan-mue",
+      "name": "Jan Müller",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6440416?v=4",
+      "profile": "https://github.com/jan-mue",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/sktime/transformations/panel/padder.py
+++ b/sktime/transformations/panel/padder.py
@@ -22,6 +22,34 @@ class PaddingTransformer(BaseTransformer):
     ----------
     pad_length : int, optional (default=None) length to pad the series too.
         if None, will find the longest sequence and use instead.
+
+    Example
+    -------
+    >>> import pandas as pd
+    >>> from sktime.transformations.panel.padder import PaddingTransformer
+    >>>
+    >>> # Create a sample nested DataFrame with unequal length time series
+    >>> data = {
+    ...     'feature1': [
+    ...         pd.Series([1, 2, 3]), pd.Series([4, 5]), pd.Series([6, 7, 8, 9])
+    ...     ],
+    ...     'feature2': [
+    ...         pd.Series([10, 11]), pd.Series([12, 13, 14]), pd.Series([15])
+    ...     ]
+    >>> }
+    >>> X = pd.DataFrame(data)
+    >>>
+    >>> # Initialize the PaddingTransformer
+    >>> padder = PaddingTransformer()
+    >>>
+    >>> # Fit the transformer to the data
+    >>> padder.fit(X)
+    >>>
+    >>> # Transform the data
+    >>> Xt = padder.transform(X)
+    >>>
+    >>> # Display the transformed data
+    >>> print(Xt)
     """
 
     _tags = {

--- a/sktime/transformations/panel/padder.py
+++ b/sktime/transformations/panel/padder.py
@@ -36,7 +36,7 @@ class PaddingTransformer(BaseTransformer):
     ...     'feature2': [
     ...         pd.Series([10, 11]), pd.Series([12, 13, 14]), pd.Series([15])
     ...     ]
-    >>> }
+    ... }
     >>> X = pd.DataFrame(data)
     >>>
     >>> # Initialize the PaddingTransformer


### PR DESCRIPTION
This PR adds an example to the docstring of `PaddingTransformer`.

As discussed in #4264.

Initial contribution at PyData Paris 2024 sprint.