### PR TITLE
[BUG] skip the test `load_fpp3` if rdata is not installed

### DIFF
--- a/sktime/datasets/tests/test_datadownload.py
+++ b/sktime/datasets/tests/test_datadownload.py
@@ -1,12 +1,10 @@
 """Test data loaders that download from external sources."""
 
-import sys
 from urllib.request import Request, urlopen
 
 import numpy as np
 import pandas as pd
 import pytest
-from packaging.specifiers import SpecifierSet
 
 from sktime.datasets import (
     load_forecastingdata,
@@ -105,9 +103,8 @@ def test_load_forecasting_data_invalid_name(name):
 
 
 @pytest.mark.skipif(
-    sys.version.split(" ")[0] in SpecifierSet("<3.9")
-    or not _check_soft_dependencies("rdata", severity="none"),
-    reason="rdata loader does not work on python 3.8; run test only if it is installed",
+    _check_soft_dependencies("rdata", severity="none"),
+    reason="run test only if the soft dependency rdata is installed",
 )
 @pytest.mark.datadownload
 def test_load_fpp3():

--- a/sktime/datasets/tests/test_datadownload.py
+++ b/sktime/datasets/tests/test_datadownload.py
@@ -17,6 +17,7 @@ from sktime.datasets import (
 )
 from sktime.datasets.tsf_dataset_names import tsf_all, tsf_all_datasets
 from sktime.datatypes import check_is_mtype, check_raise
+from sktime.utils.dependencies import _check_soft_dependencies
 
 # test tsf download only on a random uniform subsample of datasets
 N_TSF_SUBSAMPLE = 3
@@ -104,8 +105,9 @@ def test_load_forecasting_data_invalid_name(name):
 
 
 @pytest.mark.skipif(
-    sys.version.split(" ")[0] in SpecifierSet("<3.9"),
-    reason="rdata loader does not work on python 3.8",
+    sys.version.split(" ")[0] in SpecifierSet("<3.9")
+    or not _check_soft_dependencies("rdata", severity="none"),
+    reason="rdata loader does not work on python 3.8; run test only if it is installed",
 )
 @pytest.mark.datadownload
 def test_load_fpp3():

--- a/sktime/datasets/tests/test_datadownload.py
+++ b/sktime/datasets/tests/test_datadownload.py
@@ -103,7 +103,7 @@ def test_load_forecasting_data_invalid_name(name):
 
 
 @pytest.mark.skipif(
-    _check_soft_dependencies("rdata", severity="none"),
+    not _check_soft_dependencies("rdata", severity="none"),
     reason="run test only if the soft dependency rdata is installed",
 )
 @pytest.mark.datadownload


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs

Addresses the isolation in #7177, but does not resolve the testing issue.

#### What does this implement/fix? Explain your changes.
Skip the test `load_fpp3` if the package `rdata` is not installed