### PR TITLE
[ENH] New splitter switching from expanding window to sliding window at cutoff point

### DIFF
--- a/sktime/split/base/_base_windowsplitter.py
+++ b/sktime/split/base/_base_windowsplitter.py
@@ -108,6 +108,7 @@ class BaseWindowSplitter(BaseSplitter):
         window_length: ACCEPTED_WINDOW_LENGTH_TYPES,
         step_length: NON_FLOAT_WINDOW_LENGTH_TYPES,
         start_with_window: bool,
+        max_expanding_window_length: ACCEPTED_WINDOW_LENGTH_TYPES = float("inf"),
     ) -> None:
         _check_inputs_for_compatibility(
             [fh, initial_window, window_length, step_length]
@@ -115,6 +116,7 @@ class BaseWindowSplitter(BaseSplitter):
         self.step_length = step_length
         self.start_with_window = start_with_window
         self.initial_window = initial_window
+        self.max_expanding_window_length = max_expanding_window_length
         super().__init__(fh=fh, window_length=window_length)
 
     @property
@@ -221,8 +223,12 @@ class BaseWindowSplitter(BaseSplitter):
             split_points if self._initial_window is None else split_points[1:]
         )
         for split_point in split_points:
+            start = start if expanding else split_point
+            if self.max_expanding_window_length < split_point:
+                start = split_point + window_length - self.max_expanding_window_length
+
             train_start = self._get_train_start(
-                start=start if expanding else split_point,
+                start=start,
                 window_length=window_length,
                 y=y,
             )

--- a/sktime/split/expandingslidingwindow.py
+++ b/sktime/split/expandingslidingwindow.py
@@ -1,0 +1,156 @@
+import pandas as pd
+from sktime.split.base import BaseWindowSplitter
+from sktime.split.base._common import (
+    DEFAULT_FH,
+    DEFAULT_STEP_LENGTH,
+    DEFAULT_WINDOW_LENGTH,
+    FORECASTING_HORIZON_TYPES,
+    SPLIT_GENERATOR_TYPE,
+)
+from sktime.utils.validation import (
+    ACCEPTED_WINDOW_LENGTH_TYPES,
+    NON_FLOAT_WINDOW_LENGTH_TYPES,
+)
+
+
+class ExpandingSlidingWindowSplitter(BaseWindowSplitter):
+    r"""Combined Expanding and Sliding Window Splitter.
+
+    This splitter starts as an expanding window splitter until a specified
+    maximum window length is reached, then transitions to a sliding window splitter.
+
+    For example, with ``initial_window = 1``, ``window_length = 2``, ``step_length = 1``,
+    ``fh = [1, 2]``,, and ``max_expanding_window_length = 8``
+
+    |--------------------|
+    | * x x - - - - - - -| Expanding (initial_window = 1)
+    | * * x x - - - - - -| Expanding
+    | * * * x x - - - - -| Expanding
+    | * * * * x x - - - -| Expanding
+    | * * * * * x x - - -| Expanding
+    | - * * * * * x x - -| Sliding (switched)
+    | - - * * * * * x x -| Sliding
+    | - - - * * * * * x x| Sliding
+    |--------------------|
+      0 1 2 3 4 5 6 7 8 9
+                ^
+                |_ maximum expanding window size reached
+
+    ``*`` = training fold
+    ``x`` = test fold
+    ``-`` = unused observations
+
+    Parameters
+    ----------
+    fh : int, list or np.array, optional (default=1)
+        Forecasting horizon
+    initial_window : int or timedelta or pd.DateOffset, optional (default=10)
+        Initial window length for the expanding window phase
+    step_length : int or timedelta or pd.DateOffset, optional (default=1)
+        Step length between windows
+    max_expanding_window_length : int, optional (default=float('inf'))
+        Maximum window length. If none is passed in, it will keep expanding indefinitely.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.split import SlidingWindowSplitter
+    >>> ts = np.arange(10)
+    >>> splitter = ExpandingSlidingWindowSplitter(fh=[1, 2], step_length=3, initial_window=2, max_expanding_window_length=5)
+    >>> list(splitter.split(ts)) # doctest: +SKIP
+    [(array([0, 1]), array([2, 3])), (array([0, 1, 2, 3, 4]), array([5, 6])), (array([3, 4, 5, 6, 7]), array([8, 9]))]
+    """
+
+    def __init__(
+        self,
+        fh: FORECASTING_HORIZON_TYPES = DEFAULT_FH,
+        step_length: NON_FLOAT_WINDOW_LENGTH_TYPES = DEFAULT_STEP_LENGTH,
+        initial_window: ACCEPTED_WINDOW_LENGTH_TYPES = DEFAULT_WINDOW_LENGTH,
+        max_expanding_window_length: ACCEPTED_WINDOW_LENGTH_TYPES = float("inf"),
+    ) -> None:
+        start_with_window = initial_window != 0
+
+        super().__init__(
+            fh=fh,
+            window_length=initial_window,
+            initial_window=None,
+            step_length=step_length,
+            start_with_window=start_with_window,
+        )
+
+        # initial_window needs to be written to self for sklearn compatibility
+        self.initial_window = initial_window
+        # this class still acts as if it were overwritten with None,
+        # via the _initial_window property that is read everywhere
+
+        # Defines the maximum length of the expanding window before switching to the sliding window
+        self.max_expanding_window_length = max_expanding_window_length
+
+    @property
+    def _initial_window(self):
+        return None
+
+    def _split_windows(self, **kwargs) -> SPLIT_GENERATOR_TYPE:
+        return self._split_windows_generic(expanding=True, **kwargs)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the splitter."""
+        params1 = {"fg": [1, 2], "step_length": 3, "initial_window": 2, "max_expanding_window_length": 5}
+
+        return [params1]
+
+
+# Test cases
+def test_combined_window_splitter():
+    import numpy as np
+
+    # Test case 1: Basic functionality
+    ts = np.arange(1, 20 + 1)
+    splitter = CombinedWindowSplitter(
+        fh=[1, 2], step_length=1, initial_window=2, max_expanding_window_length=5
+    )
+    splits = list(splitter.split(ts))
+    for i, split in enumerate(splits):
+        print(f"Split {i}: {split}")
+
+    assert len(splits) == 7, f"Expected 7 splits, got {len(splits)}"
+    assert np.array_equal(
+        splits[0][0], np.array([0, 1, 2, 3, 4])
+    ), "First split train window incorrect"
+    assert np.array_equal(
+        splits[0][1], np.array([5, 6])
+    ), "First split test window incorrect"
+    assert np.array_equal(
+        splits[3][0], np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    ), "Transition split incorrect"
+    assert np.array_equal(
+        splits[-1][0], np.array([6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    ), "Last split train window incorrect"
+
+    # Test case 2: Without max_window_length
+    splitter = CombinedWindowSplitter(fh=[1], initial_window=3, step_length=1)
+    splits = list(splitter.split(ts))
+
+    assert len(splits) == 16, f"Expected 16 splits, got {len(splits)}"
+    assert np.array_equal(
+        splits[-1][0], np.array(range(18))
+    ), "Last split should include all but last point"
+
+    # Test case 3: Edge case with short time series
+    ts_short = np.arange(5)
+    splitter = CombinedWindowSplitter(
+        fh=[1], initial_window=3, step_length=1, max_expanding_window_length=4
+    )
+    splits = list(splitter.split(ts_short))
+
+    assert len(splits) == 1, f"Expected 1 split for short series, got {len(splits)}"
+    assert np.array_equal(
+        splits[0][0], np.array([0, 1, 2])
+    ), "Short series split incorrect"
+
+    print("All tests passed!")
+
+
+# Run the tests
+test_combined_window_splitter()


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->

Fixes #7191 - Combining expanding and sliding window splitter in one


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

This PR implements a combination of the sliding window splitter and expanding window splitter. It will by default behave as the expanding window splitter up to a point. After the maximum expanded window size is reached, the splitter continues as a sliding window splitter.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- Potential issues with this approach?
- Should we extend the existing splitters with this argument or have it as a new class?

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
