### PR TITLE
[ENH] Added get_test_params in ThetaLinesTransformer 

### DIFF
--- a/sktime/transformations/series/theta.py
+++ b/sktime/transformations/series/theta.py
@@ -123,17 +123,18 @@ class ThetaLinesTransformer(BaseTransformer):
         Parameters
         ----------
         parameter_set : str, default="default"
-            Name of the set of test parameters to return, for use in tests. If no
-            special parameters are defined for a value, will
-            return `"de_types.pyfault"` set.
+            Name of the set of test parameters to return, for use in tests.
+            If no special parameters are defined for a value,
+            will return `"default"` set.
 
         Returns
         -------
         params : dict or list of dict, default = {}
-            Parameters to create testing instances of the clpass
-            Each dict are parameters to construct an "interesting" test instance.
+            Parameters to create testing instances of the class.
+            Each dict is used to construct an "interesting" test instance.
         """
         # Added empty dict for testing default case
+
         return [{}, {"theta": (0, 2)}, {"theta": (0.5, 1.5)}]
 
 

--- a/sktime/transformations/series/theta.py
+++ b/sktime/transformations/series/theta.py
@@ -116,7 +116,6 @@ class ThetaLinesTransformer(BaseTransformer):
         else:
             return pd.DataFrame(theta_lines, columns=self.theta, index=X.index)
 
-    
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
@@ -125,17 +124,15 @@ class ThetaLinesTransformer(BaseTransformer):
         ----------
         parameter_set : str, default="default"
             Name of the set of test parameters to return, for use in tests. If no
-            special parameters are defined for a value, will return `"default"` set.
+            special parameters are defined for a value, will return `"de_types.pyfault"` set.
 
         Returns
         -------
         params : dict or list of dict, default = {}
-            Parameters to create testing instances of the class
+            Parameters to create testing instances of the clpass
             Each dict are parameters to construct an "interesting" test instance.
         """
-        return [{}, 
-                {"theta": (0, 2)}, 
-                {"theta": (0.5, 1.5)}]
+        return [{}, {"theta": (0, 2)}, {"theta": (0.5, 1.5)}]
 
 
 def _theta_transform(Z, trend, theta):

--- a/sktime/transformations/series/theta.py
+++ b/sktime/transformations/series/theta.py
@@ -124,7 +124,8 @@ class ThetaLinesTransformer(BaseTransformer):
         ----------
         parameter_set : str, default="default"
             Name of the set of test parameters to return, for use in tests. If no
-            special parameters are defined for a value, will return `"de_types.pyfault"` set.
+            special parameters are defined for a value, will return
+            de_types.pyfault"` set.
 
         Returns
         -------
@@ -132,6 +133,7 @@ class ThetaLinesTransformer(BaseTransformer):
             Parameters to create testing instances of the clpass
             Each dict are parameters to construct an "interesting" test instance.
         """
+        # Added Empty Dict for Testing default case
         return [{}, {"theta": (0, 2)}, {"theta": (0.5, 1.5)}]
 
 

--- a/sktime/transformations/series/theta.py
+++ b/sktime/transformations/series/theta.py
@@ -133,7 +133,9 @@ class ThetaLinesTransformer(BaseTransformer):
             Parameters to create testing instances of the class
             Each dict are parameters to construct an "interesting" test instance.
         """
-        return [{"theta": (0, 2)}, {"theta": (0.5, 1.5)}]
+        return [{}, 
+                {"theta": (0, 2)}, 
+                {"theta": (0.5, 1.5)}]
 
 
 def _theta_transform(Z, trend, theta):

--- a/sktime/transformations/series/theta.py
+++ b/sktime/transformations/series/theta.py
@@ -116,6 +116,25 @@ class ThetaLinesTransformer(BaseTransformer):
         else:
             return pd.DataFrame(theta_lines, columns=self.theta, index=X.index)
 
+    
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance.
+        """
+        return [{"theta": (0, 2)}, {"theta": (0.5, 1.5)}]
+
 
 def _theta_transform(Z, trend, theta):
     # obtain one Theta-line

--- a/sktime/transformations/series/theta.py
+++ b/sktime/transformations/series/theta.py
@@ -124,8 +124,8 @@ class ThetaLinesTransformer(BaseTransformer):
         ----------
         parameter_set : str, default="default"
             Name of the set of test parameters to return, for use in tests. If no
-            special parameters are defined for a value, will return
-            de_types.pyfault"` set.
+            special parameters are defined for a value, will
+            return `"de_types.pyfault"` set.
 
         Returns
         -------
@@ -133,7 +133,7 @@ class ThetaLinesTransformer(BaseTransformer):
             Parameters to create testing instances of the clpass
             Each dict are parameters to construct an "interesting" test instance.
         """
-        # Added Empty Dict for Testing default case
+        # Added empty dict for testing default case
         return [{}, {"theta": (0, 2)}, {"theta": (0.5, 1.5)}]
 
 


### PR DESCRIPTION
This PR adds the get_test_params method to the ThetaLinesTransformer class, providing standardized parameter settings for testing.

What does this implement/fix? Explain your changes.
This change implements the get_test_params method, which returns a list of dictionaries containing test parameters for the  ThetaLinesTransformer. This will facilitate easier testing and validation of the transformer’s functionality.

Does your contribution introduce a new dependency? If yes, which one?
No new dependencies were introduced.

What should a reviewer concentrate their feedback on?
The implementation of the get_test_params method
The clarity of the parameter settings provided for testing

Did you add any tests for the change?
Yes, relevant tests have been added to ensure the functionality of get_test_params.