### PR TITLE
[ENH] decorators for singleton and multiton oop pattern

### DIFF
--- a/sktime/transformations/compose/_logger.py
+++ b/sktime/transformations/compose/_logger.py
@@ -7,6 +7,7 @@ __all__ = ["Logger"]
 
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.compose._common import CORE_MTYPES
+from sktime.utils.singleton import _multiton
 
 
 class Logger(BaseTransformer):
@@ -224,18 +225,6 @@ class Logger(BaseTransformer):
         params3 = {"logger": "foo", "level": logging.DEBUG, "log_methods": "all"}
         params4 = {"logger": "foo", "logger_backend": "datalog", "log_methods": "all"}
         return [params0, params1, params2, params3, params4]
-
-
-def _multiton(cls):
-    """Turn a class into a multiton."""
-    instances = {}
-
-    def get_instance(key, *args, **kwargs):
-        if key not in instances:
-            instances[key] = cls(key, *args, **kwargs)
-        return instances[key]
-
-    return get_instance
 
 
 @_multiton

--- a/sktime/utils/singleton.py
+++ b/sktime/utils/singleton.py
@@ -1,0 +1,28 @@
+"""Utilities for implementing singleton and multiton oop pattern."""
+
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+
+def _singleton(cls):
+    """Turn a class into a singleton."""
+    instance = None
+
+    def get_instance(*args, **kwargs):
+        nonlocal instance
+        if instance is None:
+            instance = cls(*args, **kwargs)
+        return instance
+
+    return get_instance
+
+
+def _multiton(cls):
+    """Turn a class into a multiton."""
+    instances = {}
+
+    def get_instance(key, *args, **kwargs):
+        if key not in instances:
+            instances[key] = cls(key, *args, **kwargs)
+        return instances[key]
+
+    return get_instance


### PR DESCRIPTION
This PR adds decorators implementing the singleton and multiton oop pattern to `sktime.utils.singleton`.

The `_multiton` decorator is moved from the `Logger` transformer to the `utils` module, and now imported from there.

This PR anticipates that we may need these patterns in more than one internal use case, for instance:

* more general logging
* caching immutable instances of zero-shot founcation models loaded into memory, see https://github.com/sktime/sktime/issues/7201

FYI @j-adamczyk