### PR TITLE
[ENH] cached `timesfm` instance in case of repeated use

### DIFF
--- a/sktime/forecasting/tests/test_timesfm.py
+++ b/sktime/forecasting/tests/test_timesfm.py
@@ -1,0 +1,30 @@
+"""Tests for TimesFMForecaster.
+
+TimesFmForecaster has a very restrictive dependency set,
+which may cancel out with the matrix testing strategy.
+
+Therefore, we call a check_estimator separately.
+"""
+
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+import pytest
+
+from sktime.forecasting.timesfm_forecaster import TimesFMForecaster
+from sktime.tests.test_switch import run_test_for_class
+from sktime.utils import check_estimator
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TimesFMForecaster),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_timesfmforecaster():
+    """Run standard test suite for TimesFMForecaster.
+
+    TimesFmForecaster has a very restrictive dependency set,
+    which may cancel out with the matrix testing strategy.
+
+    Therefore, we call a check_estimator separately.
+    """
+    check_estimator(TimesFMForecaster, raise_exceptions=True)

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -230,8 +230,11 @@ class TimesFMForecaster(_BaseGlobalForecaster):
     def _get_unique_timesfm_key(self):
         """Get unique key for TimesFM model to use in multiton."""
         repo_id = self.repo_id
+        use_source_package = self.use_source_package
         kwargs = self._get_timesfm_kwargs()
-        kwargs_plus_repo_id = {**kwargs, "repo_id": repo_id}
+        kwargs_plus_repo_id = {
+            **kwargs, "repo_id": repo_id, "use_source_package": use_source_package
+        }
         return str(kwargs_plus_repo_id)
 
     def _predict(self, fh, X, y=None):

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -122,6 +122,26 @@ class TimesFMForecaster(_BaseGlobalForecaster):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["rajatsen91", "geetu040"],
+        # rajatsen91 for google-research/timesfm
+        "maintainers": ["geetu040"],
+        # when relaxing deps, check whether the extra test in
+        # test_timesfm.py are still needed
+        "python_version": ">=3.10,<3.11",
+        "python_dependencies": [
+            "tensorflow",
+            "einshape",
+            "jax",
+            "praxis",
+            "huggingface-hub",
+            "paxml",
+            "utilsforecast",
+        ],
+        "env_marker": "sys_platform=='linux'",
+        # estimator type
+        # --------------
         "y_inner_mtype": [
             "pd.Series",
             "pd-multiindex",
@@ -136,21 +156,6 @@ class TimesFMForecaster(_BaseGlobalForecaster):
         "capability:insample": False,
         "capability:pred_int": False,
         "capability:pred_int:insample": False,
-        "authors": ["rajatsen91", "geetu040"],
-        # rajatsen91 for google-research/timesfm
-        "maintainers": ["geetu040"],
-        "python_version": ">=3.10,<3.11",
-        "python_dependencies": [
-            "tensorflow",
-            "einshape",
-            "jax",
-            "praxis",
-            "huggingface-hub",
-            "paxml",
-            "utilsforecast",
-        ],  # when relaxing this, check whether the extra test in
-        # test_timesfm.py are still needed
-        "env_marker": "sys_platform=='linux'",
         "capability:global_forecasting": True,
     }
 

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -237,7 +237,7 @@ class TimesFMForecaster(_BaseGlobalForecaster):
             "repo_id": repo_id,
             "use_source_package": use_source_package,
         }
-        return str(kwargs_plus_repo_id)
+        return str(sorted(kwargs_plus_repo_id.items()))
 
     def _predict(self, fh, X, y=None):
         if fh is None:

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -233,7 +233,9 @@ class TimesFMForecaster(_BaseGlobalForecaster):
         use_source_package = self.use_source_package
         kwargs = self._get_timesfm_kwargs()
         kwargs_plus_repo_id = {
-            **kwargs, "repo_id": repo_id, "use_source_package": use_source_package
+            **kwargs,
+            "repo_id": repo_id,
+            "use_source_package": use_source_package,
         }
         return str(kwargs_plus_repo_id)
 

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -31,19 +31,24 @@ class TimesFMForecaster(_BaseGlobalForecaster):
         The input time series can have any context length,
         and padding or truncation will
         be handled by the model's inference code if necessary.
+
     horizon_len : int
         The length of the forecast horizon. This can be set to any value, although it
         is generally recommended to keep it less than or equal to ``context_len`` for
         optimal performance. The model will still function
         if ``horizon_len`` exceeds ``context_len``.
+
     freq : int, optional (default=0)
         The frequency category of the input time series.
+
         - 0: High frequency, long horizon time series (e.g., daily data and above).
         - 1: Medium frequency time series (e.g., weekly, monthly data).
         - 2: Low frequency, short horizon time series (e.g., quarterly, yearly data).
+
         You can treat this parameter as a free parameter depending
         on your specific use case,
         although it is recommended to follow these guidelines for optimal results.
+
     repo_id : str, optional (default="google/timesfm-1.0-200m")
         The identifier for the model repository.
         The default model is the 200M parameter version.

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -148,7 +148,8 @@ class TimesFMForecaster(_BaseGlobalForecaster):
             "huggingface-hub",
             "paxml",
             "utilsforecast",
-        ],
+        ],  # when relaxing this, check whether the extra test in
+        # test_timesfm.py are still needed
         "env_marker": "sys_platform=='linux'",
         "capability:global_forecasting": True,
     }

--- a/sktime/transformations/compose/_logger.py
+++ b/sktime/transformations/compose/_logger.py
@@ -7,6 +7,7 @@ __all__ = ["Logger"]
 
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.compose._common import CORE_MTYPES
+from sktime.utils.singleton import _multiton
 
 
 class Logger(BaseTransformer):
@@ -224,18 +225,6 @@ class Logger(BaseTransformer):
         params3 = {"logger": "foo", "level": logging.DEBUG, "log_methods": "all"}
         params4 = {"logger": "foo", "logger_backend": "datalog", "log_methods": "all"}
         return [params0, params1, params2, params3, params4]
-
-
-def _multiton(cls):
-    """Turn a class into a multiton."""
-    instances = {}
-
-    def get_instance(key, *args, **kwargs):
-        if key not in instances:
-            instances[key] = cls(key, *args, **kwargs)
-        return instances[key]
-
-    return get_instance
 
 
 @_multiton

--- a/sktime/utils/singleton.py
+++ b/sktime/utils/singleton.py
@@ -1,0 +1,28 @@
+"""Utilities for implementing singleton and multiton oop pattern."""
+
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+
+def _singleton(cls):
+    """Turn a class into a singleton."""
+    instance = None
+
+    def get_instance(*args, **kwargs):
+        nonlocal instance
+        if instance is None:
+            instance = cls(*args, **kwargs)
+        return instance
+
+    return get_instance
+
+
+def _multiton(cls):
+    """Turn a class into a multiton."""
+    instances = {}
+
+    def get_instance(key, *args, **kwargs):
+        if key not in instances:
+            instances[key] = cls(key, *args, **kwargs)
+        return instances[key]
+
+    return get_instance

--- a/sktime/utils/tests/test_singleton.py
+++ b/sktime/utils/tests/test_singleton.py
@@ -8,7 +8,7 @@ from sktime.utils.singleton import _multiton, _singleton
 
 
 @_singleton
-class TestSingleton:
+class _TestSingleton:
     def __init__(self, a=0):
         self.a = a
 
@@ -17,7 +17,7 @@ class TestSingleton:
 
 
 @_multiton
-class TestMultiton:
+class _TestMultiton:
     def __init__(self, key, a=0):
         self.key = key
         self.a = a
@@ -32,9 +32,9 @@ class TestMultiton:
 )
 def test_singleton():
     """Test singleton behaviour."""
-    instance1 = TestSingleton(42)
+    instance1 = _TestSingleton(42)
     instance1.set_b(43)
-    instance2 = TestSingleton()
+    instance2 = _TestSingleton()
 
     assert instance1 is instance2
     assert instance1.a == 42
@@ -53,13 +53,13 @@ def test_singleton():
 )
 def test_multiton():
     """Test multiton behaviour."""
-    instance1 = TestMultiton("key1", 42)
+    instance1 = _TestMultiton("key1", 42)
     instance1.set_b(43)
-    instance2 = TestMultiton("key2")
+    instance2 = _TestMultiton("key2")
     instance2.set_b(44)
 
-    instance1b = TestMultiton("key1", 77)
-    instance2b = TestMultiton("key2")
+    instance1b = _TestMultiton("key1", 77)
+    instance2b = _TestMultiton("key2")
 
     assert instance1 is not instance2
     assert instance1 is instance1b

--- a/sktime/utils/tests/test_singleton.py
+++ b/sktime/utils/tests/test_singleton.py
@@ -1,0 +1,71 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for singleton and multiton decorators."""
+
+import pytest
+
+from sktime.tests.test_switch import run_test_for_class
+from sktime.utils.singleton import _multiton, _singleton
+
+
+@_singleton
+class TestSingleton:
+    def __init__(self, a=0):
+        self.a = a
+
+    def set_b(self, b):
+        self.b = b
+
+
+@_multiton
+class TestMultiton:
+    def __init__(self, key, a=0):
+        self.key = key
+        self.a = a
+
+    def set_b(self, b):
+        self.b = b
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(_singleton),
+    reason="run test incrementally (if requested)",
+)
+def test_singleton():
+    """Test singleton behaviour."""
+    instance1 = TestSingleton(42)
+    instance1.set_b(43)
+    instance2 = TestSingleton()
+
+    assert instance1 is instance2
+    assert instance1.a == 42
+    assert instance2.a == 42
+
+    assert instance1.b == 43
+    assert instance2.b == 43
+
+    instance2.set_b(41)
+    assert instance1.b == 41
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(_multiton),
+    reason="run test incrementally (if requested)",
+)
+def test_multiton():
+    """Test multiton behaviour."""
+    instance1 = TestMultiton("key1", 42)
+    instance1.set_b(43)
+    instance2 = TestMultiton("key2")
+    instance2.set_b(44)
+
+    instance1b = TestMultiton("key1", 77)
+    instance2b = TestMultiton("key2")
+
+    assert instance1 is not instance2
+    assert instance1 is instance1b
+    assert instance2 is instance2b
+
+    assert instance1.a == 42
+    assert instance2.a == 0
+    assert instance1b.b == 43
+    assert instance2.b == 44


### PR DESCRIPTION
This PR ensures that `timesfm` zero-shot model instances are not repeatedly loaded into memory for same configurations and repo IDs.

This is ensured by wrapping the `timesfm` package facing constructor in a multiton pattern, with key uniquely determined by configuration and repo ID.

Depends on the multiton pattern decorator refactor in #7203.

Closes #7201.

Also adds a test that ensures that the tests on `TimesFMForecaster` are run in the linux/3.10 combination.