### PR TITLE
[ENH] cached `timesfm` instance in case of repeated use - variant with destructor

### DIFF
--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -230,8 +230,11 @@ class TimesFMForecaster(_BaseGlobalForecaster):
     def _get_unique_timesfm_key(self):
         """Get unique key for TimesFM model to use in multiton."""
         repo_id = self.repo_id
+        use_source_package = self.use_source_package
         kwargs = self._get_timesfm_kwargs()
-        kwargs_plus_repo_id = {**kwargs, "repo_id": repo_id}
+        kwargs_plus_repo_id = {
+            **kwargs, "repo_id": repo_id, "use_source_package": use_source_package
+        }
         return str(kwargs_plus_repo_id)
 
     def _predict(self, fh, X, y=None):

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -388,7 +388,6 @@ class _CachedTimesFM:
         self.clients = {}
 
     def load_from_checkpoint(self, client=None):
-
         if client is not None:
             self.clients += {client}
 

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -233,7 +233,9 @@ class TimesFMForecaster(_BaseGlobalForecaster):
         use_source_package = self.use_source_package
         kwargs = self._get_timesfm_kwargs()
         kwargs_plus_repo_id = {
-            **kwargs, "repo_id": repo_id, "use_source_package": use_source_package
+            **kwargs,
+            "repo_id": repo_id,
+            "use_source_package": use_source_package,
         }
         return str(kwargs_plus_repo_id)
 

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -385,11 +385,11 @@ class _CachedTimesFM:
         self.use_source_package = use_source_package
         self.tfm = None
 
-        self.clients = {}
+        self.clients = set()
 
     def load_from_checkpoint(self, client=None):
         if client is not None:
-            self.clients += {client}
+            self.clients = self.clients.union({client})
 
         if self.tfm is None:
             if self.use_source_package:

--- a/sktime/transformations/compose/_logger.py
+++ b/sktime/transformations/compose/_logger.py
@@ -7,6 +7,7 @@ __all__ = ["Logger"]
 
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.compose._common import CORE_MTYPES
+from sktime.utils.singleton import _multiton
 
 
 class Logger(BaseTransformer):
@@ -224,18 +225,6 @@ class Logger(BaseTransformer):
         params3 = {"logger": "foo", "level": logging.DEBUG, "log_methods": "all"}
         params4 = {"logger": "foo", "logger_backend": "datalog", "log_methods": "all"}
         return [params0, params1, params2, params3, params4]
-
-
-def _multiton(cls):
-    """Turn a class into a multiton."""
-    instances = {}
-
-    def get_instance(key, *args, **kwargs):
-        if key not in instances:
-            instances[key] = cls(key, *args, **kwargs)
-        return instances[key]
-
-    return get_instance
 
 
 @_multiton

--- a/sktime/utils/singleton.py
+++ b/sktime/utils/singleton.py
@@ -1,0 +1,28 @@
+"""Utilities for implementing singleton and multiton oop pattern."""
+
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+
+def _singleton(cls):
+    """Turn a class into a singleton."""
+    instance = None
+
+    def get_instance(*args, **kwargs):
+        nonlocal instance
+        if instance is None:
+            instance = cls(*args, **kwargs)
+        return instance
+
+    return get_instance
+
+
+def _multiton(cls):
+    """Turn a class into a multiton."""
+    instances = {}
+
+    def get_instance(key, *args, **kwargs):
+        if key not in instances:
+            instances[key] = cls(key, *args, **kwargs)
+        return instances[key]
+
+    return get_instance

--- a/sktime/utils/tests/test_singleton.py
+++ b/sktime/utils/tests/test_singleton.py
@@ -8,7 +8,7 @@ from sktime.utils.singleton import _multiton, _singleton
 
 
 @_singleton
-class TestSingleton:
+class _TestSingleton:
     def __init__(self, a=0):
         self.a = a
 
@@ -17,7 +17,7 @@ class TestSingleton:
 
 
 @_multiton
-class TestMultiton:
+class _TestMultiton:
     def __init__(self, key, a=0):
         self.key = key
         self.a = a
@@ -32,9 +32,9 @@ class TestMultiton:
 )
 def test_singleton():
     """Test singleton behaviour."""
-    instance1 = TestSingleton(42)
+    instance1 = _TestSingleton(42)
     instance1.set_b(43)
-    instance2 = TestSingleton()
+    instance2 = _TestSingleton()
 
     assert instance1 is instance2
     assert instance1.a == 42
@@ -53,13 +53,13 @@ def test_singleton():
 )
 def test_multiton():
     """Test multiton behaviour."""
-    instance1 = TestMultiton("key1", 42)
+    instance1 = _TestMultiton("key1", 42)
     instance1.set_b(43)
-    instance2 = TestMultiton("key2")
+    instance2 = _TestMultiton("key2")
     instance2.set_b(44)
 
-    instance1b = TestMultiton("key1", 77)
-    instance2b = TestMultiton("key2")
+    instance1b = _TestMultiton("key1", 77)
+    instance2b = _TestMultiton("key2")
 
     assert instance1 is not instance2
     assert instance1 is instance1b

--- a/sktime/utils/tests/test_singleton.py
+++ b/sktime/utils/tests/test_singleton.py
@@ -1,0 +1,71 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for singleton and multiton decorators."""
+
+import pytest
+
+from sktime.tests.test_switch import run_test_for_class
+from sktime.utils.singleton import _multiton, _singleton
+
+
+@_singleton
+class TestSingleton:
+    def __init__(self, a=0):
+        self.a = a
+
+    def set_b(self, b):
+        self.b = b
+
+
+@_multiton
+class TestMultiton:
+    def __init__(self, key, a=0):
+        self.key = key
+        self.a = a
+
+    def set_b(self, b):
+        self.b = b
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(_singleton),
+    reason="run test incrementally (if requested)",
+)
+def test_singleton():
+    """Test singleton behaviour."""
+    instance1 = TestSingleton(42)
+    instance1.set_b(43)
+    instance2 = TestSingleton()
+
+    assert instance1 is instance2
+    assert instance1.a == 42
+    assert instance2.a == 42
+
+    assert instance1.b == 43
+    assert instance2.b == 43
+
+    instance2.set_b(41)
+    assert instance1.b == 41
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(_multiton),
+    reason="run test incrementally (if requested)",
+)
+def test_multiton():
+    """Test multiton behaviour."""
+    instance1 = TestMultiton("key1", 42)
+    instance1.set_b(43)
+    instance2 = TestMultiton("key2")
+    instance2.set_b(44)
+
+    instance1b = TestMultiton("key1", 77)
+    instance2b = TestMultiton("key2")
+
+    assert instance1 is not instance2
+    assert instance1 is instance1b
+    assert instance2 is instance2b
+
+    assert instance1.a == 42
+    assert instance2.a == 0
+    assert instance1b.b == 43
+    assert instance2.b == 44


### PR DESCRIPTION
Variant of https://github.com/sktime/sktime/pull/7204 with a destructor mechanism.

I do not know whether it makes sense to do this - I believe one should, because the reference count of the `_CachedTimesFM` class never reaches zero? Though I am not 100% certain, testing might be needed here.