### PR TITLE
[DOC] clearer install instructions

### DIFF
--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -15,7 +15,7 @@ Welcome to sktime's developer guide!
 New developers should:
 
 * sign up to the developer Discord (see link in README) and say hello in the ``#intro`` channel
-* install a development version of ``sktime``, see :ref:`installation`
+* install a local developer setup of ``sktime``, see :ref:`installation`
 * set up CI tests locally and ensure they know how to check them remotely, see :ref:`continuous_integration`
 * get familiar with the git workflow (:ref:`git_workflow`) and coding standards (:ref:`coding_standards`)
 * feel free, at any point in time, to post questions on Discord, or ask core developers for help (see here for a `list of core developers <https://www.sktime.net/en/latest/about/team.html>`_)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -211,8 +211,8 @@ Virtual environments
 
 Two good options for virtual environment managers are:
 
-* `conda <https://uoa-eresearch.github.io/eresearch-cookbook/recipe/2014/11/20/conda/>`_ (beginner friendly, but may incur license fees for commercial use if using a commercial distribution).
-* `venv <https://realpython.com/python-virtual-environments-a-primer/>`_ (also quite good!).
+* `conda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html>`_ (beginner friendly, but may incur license fees for commercial use if using a commercial distribution).
+* `venv <https://docs.python.org/3/library/venv.html>`_ (also quite good!).
 
 Be sure to link your new virtual environment as the python kernel in whatever IDE you are using.  You can find the instructions for doing so
 in VScode `here <https://code.visualstudio.com/docs/python/environments>`_.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -83,48 +83,32 @@ Note: not all soft dependencies of ``sktime`` are also available on ``conda-forg
 The other soft dependencies can be installed via ``pip``, after ``conda install pip``.
 
 
-Development versions
---------------------
-To install the latest development version of ``sktime``, or earlier versions, the sequence of steps is as follows:
+Development version install
+---------------------------
 
-| Step 1 - ``git`` clone the ``sktime`` repository, the latest version or an earlier version.
-| Step 2 - ensure build requirements are satisfied
-| Step 3 - ``pip`` install the package from a ``git`` clone, with the ``editable`` parameter.
+Development versions of ``sktime`` are installs from static snapshots of the ``sktime`` repository.
 
-Detail instructions for all steps are given below.
-For brevity, we discuss steps 1 and 3 first; step 2 is discussed at the end, as it will depend on the operating system.
+Installing development versions is useful for testing, but not recommended
+for development and contribution. For development and contribution, see the next section
+on full developer setup.
 
-Step 1 - clone the git repository
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``sktime`` repository should be cloned to a local directory, using a graphical user interface, or the command line.
-
-Using the ``git`` command line, the sequence of commands to install the latest version is as follows:
+To install the latest development version of ``sktime``,
+you can use the ``pip`` package manager to install directly from the GitHub repository:
 
 .. code-block:: bash
 
-    git clone https://github.com/sktime/sktime.git
-    cd sktime
-    git checkout main
-    git pull
+    pip install git+https://github.com/sktime/sktime.git
 
 
-To build a previous version, replace line 3 with:
+To install from a specific branch, use the following command:
 
 .. code-block:: bash
 
-    git checkout <VERSION>
+    pip install git+https://github.com/sktime/sktime.git@<branch_name>
 
-This will checkout the code for the version ``<VERSION>``, where ``<VERSION>`` is a valid version string.
-Valid version strings are the repository's ``git`` tags, which can be inspected by running ``git tag``.
+Alternatively, a developer install can be obtained from a local clone of the repository.
 
-You can also `download <https://github.com/sktime/sktime/releases>`_ a zip archive of the version from GitHub.
-
-
-Step 3 - building sktime from source
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To build and install ``sktime`` from source, navigate to the local clone's root directory and type:
+For this, follow Step 1 of the `full developer setup`_ below, and then install the package with:
 
 .. code-block:: bash
 
@@ -132,77 +116,47 @@ To build and install ``sktime`` from source, navigate to the local clone's root 
 
 Alternatively, the ``.`` may be replaced with a full or relative path to the root directory.
 
-For a developer install that updates the package each time the local source code is changed, install ``sktime`` in editable mode, via:
 
-.. code-block:: bash
+Full developer setup for contributors and extension developers
+--------------------------------------------------------------
 
-    pip install --editable '.[dev]'
+To develop ``sktime`` locally, or to contribute to the project, you need to set up:
 
-This allows editing and extending the code in-place. See also
-`pip reference on editable installs <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_).
+* a local clone of the ``sktime`` repository.
+* a virtual environment with an editable install of ``sktime`` and its developer dependencies.
 
-.. note::
-
-    You will have to re-run:
-
-    .. code-block:: bash
-
-        pip install --editable .
-
-    every time the source code of a compiled extension is changed (for
-    instance when switching branches or pulling changes from upstream).
-
-Step 2 - Building binary packages and installers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``.whl`` package and ``.exe`` installers can be built with:
-
-.. code-block:: bash
-
-    pip install build
-    python -m build --wheel
-
-The resulting packages are generated in the ``dist/`` folder.
-
-Contributor or 3rd party extension developer setup
---------------------------------------------------
+The following steps guide you through the process:
 
 1. Follow the Git workflow: Fork and clone the repository as described in [Git and GitHub workflow](https://www.sktime.net/en/stable/developer_guide/git_workflow.html)
 
 2. Set up a new virtual environment. Our instructions will go through the commands to set up a ``conda`` environment which is recommended for sktime development.
-This relies on an `anaconda installation <https://www.anaconda.com/products/individual#windows>`_. The process will be similar for ``venv`` or other virtual environment managers.
+The process will be similar for ``venv`` or other virtual environment managers.
 
-In the ``anaconda prompt`` terminal:
+  .. warning::
+       Using ``conda`` via one of the commercial distributions such as Anaconda
+       is in general not free for commercial use and may incur significant costs or liabilities.
+       Consider using free distributions and channels for package management,
+       and be aware of applicable terms and conditions.
+
+In the ``conda`` terminal:
 
 3. Navigate to your local sktime folder, :code:`cd sktime` or similar
 
-4. Create a new environment with a supported python version: :code:`conda create -n sktime-dev python=3.8` (or :code:`python=3.11` etc)
+4. Create a new environment with a supported python version: :code:`conda create -n sktime-dev python=3.11` (or :code:`python=3.12` etc)
 
    .. warning::
-       If you already have an environment called "sktime-dev" from a previous attempt you will first need to remove this.
+       If you already have an environment called ``sktime-dev`` from a previous attempt you will first need to remove this.
 
 5. Activate the environment: :code:`conda activate sktime-dev`
 
 6. Build an editable version of sktime.
-In order to install only the dev dependencies, :code:`pip install -e .[dev]`
+In order to install only the dev dependencies, :code:`pip install -e ".[dev]"`
 If you also want to install soft dependencies, install them individually, after the above,
-or instead use: :code:`pip install -e .[all_extras,dev]` to install all of them.
+or instead use: :code:`pip install -e ".[all_extras,dev]"` to install all of them.
 
-    .. note::
-
-        If this step results in a "no matches found" error, it may be due to how your shell handles special characters.
-
-        - Possible solution: use quotation marks:
-
-            .. code-block:: bash
-
-                pip install -e ."[dev]"
-
-7. If everything has worked you should see message "successfully installed sktime"
+7. If everything has worked, you should see message "successfully installed sktime"
 
 Some users have experienced issues when installing NumPy, particularly version 1.19.4.
-
-
 
 .. note::
 
@@ -228,7 +182,7 @@ Notebooks, follow `these instructions <https://janakiev.com/blog/jupyter-virtual
 adding your virtual environment as a new kernel for your notebook.
 
 Installing ``all_extras`` on mac with ARM processor
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If you are using a mac with an ARM processor, you may encounter an error when installing
 ``sktime[all_extras]``.  This is due to the fact that some libraries included in ``all_extras``
 are not compatible with ARM-based processors.
@@ -257,7 +211,7 @@ Virtual environments
 
 Two good options for virtual environment managers are:
 
-* `conda <https://uoa-eresearch.github.io/eresearch-cookbook/recipe/2014/11/20/conda/>`_ (many sktime community members us this)
+* `conda <https://uoa-eresearch.github.io/eresearch-cookbook/recipe/2014/11/20/conda/>`_ (beginner friendly, but may incur license fees for commercial use if using a commercial distribution).
 * `venv <https://realpython.com/python-virtual-environments-a-primer/>`_ (also quite good!).
 
 Be sure to link your new virtual environment as the python kernel in whatever IDE you are using.  You can find the instructions for doing so


### PR DESCRIPTION
This PR deduplicates and clarifies the install instructions for `sktime`.

* deduplicates the instructions with the Git setup page
* deduplicates two sections on developer install
* removes ambiguous instrutions that lead to a non-editable install
* adds quotation marks for all install commands to ensure compatibility with all OS
* adds warning on liability or cost when using commercial conda distributions like Anaconda