### PR TITLE
[ENH] Fix polars `PerformanceWarning` when object is of type `polars.LazyFrame`

### DIFF
--- a/sktime/datatypes/_adapter/polars.py
+++ b/sktime/datatypes/_adapter/polars.py
@@ -226,22 +226,31 @@ def check_polars_frame(
 
     # columns in polars are unique, no check required
 
+    if lazy:
+        width = obj.collect_schema().len()
+        columns = obj.collect_schema().names()
+        dtypes = obj.collect_schema().dtypes()
+    else:
+        width = obj.width
+        columns = obj.columns
+        dtypes = obj.dtypes
+
     if _req("is_empty", return_metadata):
-        metadata["is_empty"] = obj.width < 1
+        metadata["is_empty"] = width < 1
     if _req("is_univariate", return_metadata):
-        metadata["is_univariate"] = obj.width - len(index_cols) == 1
+        metadata["is_univariate"] = width - len(index_cols) == 1
     if _req("n_features", return_metadata):
-        metadata["n_features"] = len(obj.collect_schema()) - len(index_cols)
+        metadata["n_features"] = width - len(index_cols)
     if _req("feature_names", return_metadata):
-        feature_columns = [x for x in obj.columns if x not in index_cols]
+        feature_columns = [x for x in columns if x not in index_cols]
         metadata["feature_names"] = feature_columns
     if _req("dtypekind_dfip", return_metadata):
         index_cols_count = len(index_cols)
-        dtype_list = obj.dtypes[index_cols_count:]
+        dtype_list = dtypes[index_cols_count:]
         metadata["dtypekind_dfip"] = _polars_dtype_to_kind(dtype_list)
     if _req("feature_kind", return_metadata):
         index_cols_count = len(index_cols)
-        dtype_list = obj.dtypes[index_cols_count:]
+        dtype_list = dtypes[index_cols_count:]
         dtype_kind = _polars_dtype_to_kind(dtype_list)
         metadata["feature_kind"] = _get_feature_kind(dtype_kind)
 

--- a/sktime/datatypes/_adapter/polars.py
+++ b/sktime/datatypes/_adapter/polars.py
@@ -231,7 +231,7 @@ def check_polars_frame(
     if _req("is_univariate", return_metadata):
         metadata["is_univariate"] = obj.width - len(index_cols) == 1
     if _req("n_features", return_metadata):
-        metadata["n_features"] = obj.width - len(index_cols)
+        metadata["n_features"] = len(obj.collect_schema()) - len(index_cols)
     if _req("feature_names", return_metadata):
         feature_columns = [x for x in obj.columns if x not in index_cols]
         metadata["feature_names"] = feature_columns


### PR DESCRIPTION
Changed the way to calculate the number of actual features to solve performance issues #7134

<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes #7134 


#### What does this implement/fix? Explain your changes.
I have updated the way to calculate the number of actual features in the LazyFrame to improve performance. The previous method raised performance warnings during execution, particularly when determining the width of a LazyFrame. I have replaced the line:
```python
metadata["n_features"] = obj.width - len(index_cols)
metadata["n_features"] = obj.collect_schema().len() - len(index_cols)
```

This change avoids the costly operation of resolving the schema and thus addresses the performance warnings.

#### Does your contribution introduce a new dependency? If yes, which one?
No, this change does not introduce any new dependencies.

#### What should a reviewer concentrate their feedback on?
The effectiveness of the new method for calculating the number of features.
Ensure that performance warnings no longer occur when running the tests in sktime/datatypes/tests/test_check.py.
Code clarity and any potential edge cases that may not be covered.

#### Did you add any tests for the change?\
I have verified that existing tests cover the functionality affected by this change. The tests in sktime/datatypes/tests/test_check.py will help ensure that the performance warnings are resolved.
