### PR TITLE
[ENH] html display of estimators - tag and consistent handling of via `_steps_attr` in `HeterogenousMetaEstimator` descendants

### DIFF
--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -717,7 +717,10 @@ class _HeterogenousMetaEstimator:
             self.set_tags(**{mid_tag_name: mid_tag_val_not})
 
     def _sk_visual_block_(self):
-        steps = getattr(self, self._steps_attr)
+        if hasattr(self, "is_fitted") and self.is_fitted:
+            steps = getattr(self, self._steps_fitted_attr)
+        else:
+            steps = getattr(self, self._steps_attr)
 
         names, estimators = zip(*steps)
 

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -717,10 +717,7 @@ class _HeterogenousMetaEstimator:
             self.set_tags(**{mid_tag_name: mid_tag_val_not})
 
     def _sk_visual_block_(self):
-        if hasattr(self, "is_fitted") and self.is_fitted:
-            steps = getattr(self, self._steps_fitted_attr)
-        else:
-            steps = getattr(self, self._steps_attr)
+        steps = getattr(self, self._steps_attr)
 
         names, estimators = zip(*steps)
 

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.base import BaseEstimator
+from sktime.utils._estimator_html_repr import _VisualBlock
 
 
 class _HeterogenousMetaEstimator:
@@ -712,6 +713,20 @@ class _HeterogenousMetaEstimator:
             self.set_tags(**{mid_tag_name: mid_tag_val})
         else:
             self.set_tags(**{mid_tag_name: mid_tag_val_not})
+
+    def _sk_visual_block_(self):
+        steps = getattr(self, self._steps_attr)
+
+        names, estimators = zip(*steps)
+
+        name_details = [str(est) for est in estimators]
+        return _VisualBlock(
+            "serial",
+            estimators,
+            names=names,
+            name_details=name_details,
+            dash_wrapped=False,
+        )
 
 
 def flatten(obj):

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -31,6 +31,8 @@ class _HeterogenousMetaEstimator:
     # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_fitted_attr = "steps_"
 
+    _tags = {"visual_block_kind": "serial"}
+
     def get_params(self, deep=True):
         """Get parameters of estimator.
 
@@ -721,7 +723,7 @@ class _HeterogenousMetaEstimator:
 
         name_details = [str(est) for est in estimators]
         return _VisualBlock(
-            "serial",
+            self.get_tag(tag_name="visual_block_kind", tag_value_default="serial"),
             estimators,
             names=names,
             name_details=name_details,

--- a/sktime/classification/compose/_pipeline.py
+++ b/sktime/classification/compose/_pipeline.py
@@ -161,6 +161,16 @@ class ClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
     def _transformers(self, value):
         self.transformers_._steps = value
 
+    @property
+    def _steps(self):
+        return self._check_estimators(self.transformers) + [
+            self._coerce_estimator_tuple(self.classifier)
+        ]
+
+    @property
+    def steps_(self):
+        return self._transformers + [self._coerce_estimator_tuple(self.classifer_)]
+
     def __rmul__(self, other):
         """Magic * method, return concatenated ClassifierPipeline, transformers on left.
 
@@ -472,6 +482,16 @@ class SklearnClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
     @_transformers.setter
     def _transformers(self, value):
         self.transformers_._steps = value
+
+    @property
+    def _steps(self):
+        return self._check_estimators(self.transformers) + [
+            self._coerce_estimator_tuple(self.classifier)
+        ]
+
+    @property
+    def steps_(self):
+        return self._transformers + [self._coerce_estimator_tuple(self.classifer_)]
 
     def __rmul__(self, other):
         """Magic * method, return concatenated ClassifierPipeline, transformers on left.

--- a/sktime/clustering/compose/_pipeline.py
+++ b/sktime/clustering/compose/_pipeline.py
@@ -164,6 +164,16 @@ class ClustererPipeline(_HeterogenousMetaEstimator, BaseClusterer):
     def _transformers(self, value):
         self.transformers_._steps = value
 
+    @property
+    def _steps(self):
+        return self._check_estimators(self.transformers) + [
+            self._coerce_estimator_tuple(self.clusterer)
+        ]
+
+    @property
+    def steps_(self):
+        return self._transformers + [self._coerce_estimator_tuple(self.clusterer_)]
+
     def __rmul__(self, other):
         """Magic * method, return concatenated ClustererPipeline, transformers on left.
 
@@ -472,6 +482,24 @@ class SklearnClustererPipeline(ClustererPipeline):
             "capability:multithreading": False,
         }
         self.set_tags(**tags_to_set)
+
+    @property
+    def _transformers(self):
+        return self.transformers_._steps
+
+    @_transformers.setter
+    def _transformers(self, value):
+        self.transformers_._steps = value
+
+    @property
+    def _steps(self):
+        return self._check_estimators(self.transformers) + [
+            self._coerce_estimator_tuple(self.clusterer)
+        ]
+
+    @property
+    def steps_(self):
+        return self._transformers + [self._coerce_estimator_tuple(self.clusterer_)]
 
     def __rmul__(self, other):
         """Magic * method, return concatenated ClustererPipeline, transformers on left.

--- a/sktime/dists_kernels/compose.py
+++ b/sktime/dists_kernels/compose.py
@@ -69,6 +69,7 @@ class PwTrafoPanelPipeline(_HeterogenousMetaEstimator, BasePairwiseTransformerPa
 
     def __init__(self, pw_trafo, transformers):
         self.pw_trafo = pw_trafo
+        self.pw_trafo = pw_trafo.clone()
         self.transformers = transformers
         self.transformers_ = TransformerPipeline(transformers)
 
@@ -105,6 +106,15 @@ class PwTrafoPanelPipeline(_HeterogenousMetaEstimator, BasePairwiseTransformerPa
     @_transformers.setter
     def _transformers(self, value):
         self.transformers_._steps = value
+
+    @property
+    def _steps(self):
+        return self._transformers + [self._coerce_estimator_tuple(self.pw_trafo)]
+
+    @property
+    def steps_(self):
+        """Concatenated list of sktime transformers and pairwise panel transformer."""
+        return self._transformers + [self._coerce_estimator_tuple(self.param_est_)]
 
     def __rmul__(self, other):
         """Magic * method, return concatenated PwTrafoPanelPipeline, trafos on left.
@@ -155,10 +165,7 @@ class PwTrafoPanelPipeline(_HeterogenousMetaEstimator, BasePairwiseTransformerPa
         distmat: np.array of shape [n, m]
             (i,j)-th entry contains distance/kernel between X.iloc[i] and X2.iloc[j]
         """
-        trafos = self.transformers_.clone()
-        pw_trafo = self.pw_trafo
-
-        Xt = trafos.fit_transform(X)
+        Xt = self.transformers_.fit_transform(X)
 
         # find out whether we know that the resulting matrix is symmetric
         #   since aligner distances are always symmetric,
@@ -166,9 +173,10 @@ class PwTrafoPanelPipeline(_HeterogenousMetaEstimator, BasePairwiseTransformerPa
         if X2 is None:
             X2t = None
         else:
-            X2t = trafos.fit_transform(X2)
+            X2t = self.transformers_.fit_transform(X2)
 
-        distmat = pw_trafo.transform(Xt, X2t)
+        distmat = self.pw_trafo_.transform(Xt, X2t)
+
         return distmat
 
     def get_params(self, deep=True):

--- a/sktime/dists_kernels/compose.py
+++ b/sktime/dists_kernels/compose.py
@@ -69,7 +69,7 @@ class PwTrafoPanelPipeline(_HeterogenousMetaEstimator, BasePairwiseTransformerPa
 
     def __init__(self, pw_trafo, transformers):
         self.pw_trafo = pw_trafo
-        self.pw_trafo = pw_trafo.clone()
+        self.pw_trafo_ = pw_trafo.clone()
         self.transformers = transformers
         self.transformers_ = TransformerPipeline(transformers)
 
@@ -114,7 +114,7 @@ class PwTrafoPanelPipeline(_HeterogenousMetaEstimator, BasePairwiseTransformerPa
     @property
     def steps_(self):
         """Concatenated list of sktime transformers and pairwise panel transformer."""
-        return self._transformers + [self._coerce_estimator_tuple(self.param_est_)]
+        return self._transformers + [self._coerce_estimator_tuple(self.pw_trafo_)]
 
     def __rmul__(self, other):
         """Magic * method, return concatenated PwTrafoPanelPipeline, trafos on left.

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -227,6 +227,7 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         "authors": ["felipeangelimvieira", "shlok191"],
         "maintainers": ["felipeangelimvieira"],
         "python_version": None,
+        "visual_block_kind": "parallel",
     }
 
     _steps_attr = "_forecasters"

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -230,8 +230,6 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         "visual_block_kind": "parallel",
     }
 
-    _steps_attr = "_forecasters"
-
     def __init__(
         self,
         forecasters,

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -321,6 +321,14 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
             self._predict_var = _predict_var
             self._predict_proba = _predict_proba
 
+    @property
+    def _steps(self):
+        return [self._coerce_estimator_tuple(self.transformer)] + self._forecasters
+
+    @property
+    def steps_(self):
+        return [self._coerce_estimator_tuple(self.transformer_)] + self._forecasters
+
     def _fit(self, y, X=None, fh=None):
         """Fit forecaster to training data.
 

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -579,8 +579,7 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
             fallback forecaster with the category: "fallback_forecaster"
         """
         return list(self.forecasters.items()) + [
-            "fallback_forecaster",
-            self.fallback_forecaster,
+            ("fallback_forecaster", self.fallback_forecaster)
         ]
 
     @_forecasters.setter

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -1902,6 +1902,7 @@ class Permute(_DelegatedForecaster, BaseForecaster, _HeterogenousMetaEstimator):
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
         "X-y-must-have-same-index": False,
+        "visual_block_kind": "serial",
     }
 
     _delegate_name = "estimator_"
@@ -1916,6 +1917,14 @@ class Permute(_DelegatedForecaster, BaseForecaster, _HeterogenousMetaEstimator):
         self._set_delegated_tags(estimator)
 
         self._set_permuted_estimator()
+
+    @property
+    def _steps(self):
+        return getattr(self.estimator_, self.steps_arg)
+
+    @property
+    def steps_(self):
+        return getattr(self.estimator_, self.steps_arg)
 
     def _set_permuted_estimator(self):
         """Set self.estimator_ based on permutation arg."""

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -13,7 +13,6 @@ from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.base._delegate import _DelegatedForecaster
 from sktime.forecasting.base._fh import ForecastingHorizon
 from sktime.registry import is_scitype
-from sktime.utils._estimator_html_repr import _VisualBlock
 from sktime.utils.validation.series import check_series
 from sktime.utils.warnings import warn
 
@@ -275,18 +274,6 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
         params3 = {"steps": [Detrender(), YfromX.create_test_instance()]}
 
         return [params1, params2, params3]
-
-    def _sk_visual_block_(self):
-        names, estimators = zip(*self._steps)
-
-        name_details = [str(est) for est in estimators]
-        return _VisualBlock(
-            "serial",
-            estimators,
-            names=names,
-            name_details=name_details,
-            dash_wrapped=False,
-        )
 
 
 # we ensure that internally we convert to pd.DataFrame for now

--- a/sktime/forecasting/compose/_transform_select_forecaster.py
+++ b/sktime/forecasting/compose/_transform_select_forecaster.py
@@ -400,8 +400,7 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
             fallback forecaster with the category: "fallback_forecaster"
         """
         return list(self.forecasters.items()) + [
-            "fallback_forecaster",
-            self.fallback_forecaster,
+            ("fallback_forecaster", self.fallback_forecaster)
         ]
 
     @_forecasters.setter

--- a/sktime/forecasting/compose/_transform_select_forecaster.py
+++ b/sktime/forecasting/compose/_transform_select_forecaster.py
@@ -111,13 +111,13 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
 
         # saving arguments to object storage
         if transformer is not None:
-            transformer_ = transformer
+            self.transformer = transformer
         else:
             from sktime.transformations.series.adi_cv import ADICVTransformer
 
-            transformer_ = ADICVTransformer(features=["class"])
+            self.transformer = ADICVTransformer(features=["class"])
 
-        self.transformer_ = coerce_scitype(transformer_, "transformer")
+        self.transformer_ = coerce_scitype(self.transformer, "transformer").clone()
 
         for forecaster in forecasters.values():
             assert isinstance(forecaster, BaseForecaster)

--- a/sktime/forecasting/compose/_transform_select_forecaster.py
+++ b/sktime/forecasting/compose/_transform_select_forecaster.py
@@ -188,6 +188,14 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
             self._predict_var = _predict_var
             self._predict_proba = _predict_proba
 
+    @property
+    def _steps(self):
+        return [self._coerce_estimator_tuple(self.transformer)] + self._forecasters
+
+    @property
+    def steps_(self):
+        return [self._coerce_estimator_tuple(self.transformer_)] + self._forecasters
+
     def _fit(self, y, X=None, fh=None):
         """Fit forecaster to training data.
 

--- a/sktime/forecasting/compose/_transform_select_forecaster.py
+++ b/sktime/forecasting/compose/_transform_select_forecaster.py
@@ -93,9 +93,8 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         "authors": ["shlok191"],
         "maintainers": ["shlok191"],
         "python_version": None,
+        "visual_block_kind": "parallel",
     }
-
-    _steps_attr = "_forecasters"
 
     def __init__(
         self,

--- a/sktime/param_est/compose/_pipeline.py
+++ b/sktime/param_est/compose/_pipeline.py
@@ -138,6 +138,16 @@ class ParamFitterPipeline(_HeterogenousMetaEstimator, BaseParamFitter):
     def _transformers(self, value):
         self.transformers_._steps = value
 
+    @property
+    def _steps(self):
+        return self._check_estimators(self.transformers) + [
+            self._coerce_estimator_tuple(self.param_est)
+        ]
+
+    @property
+    def steps_(self):
+        return self._transformers + [self._coerce_estimator_tuple(self.param_est_)]
+
     def __rmul__(self, other):
         """Magic * method, return concatenated ParamFitterPipeline, trafos on left.
 

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -1971,6 +1971,12 @@ ESTIMATOR_TAG_REGISTER = [
         "dict",
         "deprecated tag for dependency import aliases",
     ),
+    (
+        "visual_block_kind",
+        "estimator",
+        ("str", ["single", "serial", "parallel"]),
+        "how to display html represantation of a meta-estimator in jupyter notebook",
+    ),
 ]
 
 # construct the tag register from all classes in this module

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -150,6 +150,16 @@ class RegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
     def _transformers(self, value):
         self.transformers_._steps = value
 
+    @property
+    def _steps(self):
+        return self._check_estimators(self.transformers) + [
+            self._coerce_estimator_tuple(self.regressor)
+        ]
+
+    @property
+    def steps_(self):
+        return self._transformers + [self._coerce_estimator_tuple(self.regressor_)]
+
     def __rmul__(self, other):
         """Magic * method, return concatenated RegressorPipeline, transformers on left.
 
@@ -433,6 +443,16 @@ class SklearnRegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
     @_transformers.setter
     def _transformers(self, value):
         self.transformers_._steps = value
+
+    @property
+    def _steps(self):
+        return self._check_estimators(self.transformers) + [
+            self._coerce_estimator_tuple(self.regressor)
+        ]
+
+    @property
+    def steps_(self):
+        return self._transformers + [self._coerce_estimator_tuple(self.regressor_)]
 
     def __rmul__(self, other):
         """Magic * method, return concatenated RegressorPipeline, transformers on left.

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -210,7 +210,7 @@ class ColumnEnsembleTransformer(
         for the implementation of get_params via _HeterogenousMetaEstimator._get_params
         which expects lists of tuples of len 2.
         """
-        transformers = self._check_transformers(self.transformers)
+        transformers = self.transformers
         if isinstance(transformers, BaseTransformer):
             return [("transformers", transformers)]
         else:

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -218,7 +218,7 @@ class ColumnEnsembleTransformer(
 
     @_transformers.setter
     def _transformers(self, value):
-        if len(value) == 1 and isinstance(value, BaseTransformer):
+        if isinstance(value, BaseTransformer):
             self.transformers = value
         elif len(value) == 1 and isinstance(value, list):
             self.transformers = value[0][1]

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from sktime.base._meta import _ColumnEstimator, _HeterogenousMetaEstimator
 from sktime.transformations.base import BaseTransformer
+from sktime.utils._estimator_html_repr import _VisualBlock
 from sktime.utils.multiindex import rename_multiindex
 from sktime.utils.validation.series import check_series
 
@@ -370,6 +371,14 @@ class ColumnEnsembleTransformer(
         }
 
         return [params1, params2, params3]
+
+    def _sk_visual_block_(self):
+        transformers = self._transformers + [("remainder", self.remainder)]
+
+        names, transformers = zip(*transformers)
+        return _VisualBlock(
+            self.get_tag(tag_name="visual_block_kind"), transformers, names=names
+        )
 
 
 class ColumnwiseTransformer(BaseTransformer):

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -134,7 +134,7 @@ class ColumnEnsembleTransformer(
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
     # this must be an iterable of (name: str, estimator, ...) tuples for the default
-    _steps_attr = "_transformers"
+    _steps_attr = "transformers"
     # if the estimator is fittable, _HeterogenousMetaEstimator also
     # provides an override for get_fitted_params for params from the fitted estimators
     # the fitted estimators should be in a different attribute, _steps_fitted_attr
@@ -210,7 +210,7 @@ class ColumnEnsembleTransformer(
         for the implementation of get_params via _HeterogenousMetaEstimator._get_params
         which expects lists of tuples of len 2.
         """
-        transformers = self.transformers
+        transformers = self._check_transformers(self.transformers)
         if isinstance(transformers, BaseTransformer):
             return [("transformers", transformers)]
         else:

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -127,13 +127,14 @@ class ColumnEnsembleTransformer(
         "fit_is_empty": False,
         "capability:unequal_length": True,
         "handles-missing-data": True,
+        "visual_block_kind": "parallel",
     }
 
     # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self
     # which contains the heterogeneous set of estimators
     # this must be an iterable of (name: str, estimator, ...) tuples for the default
-    _steps_attr = "transformers"
+    _steps_attr = "_transformers"
     # if the estimator is fittable, _HeterogenousMetaEstimator also
     # provides an override for get_fitted_params for params from the fitted estimators
     # the fitted estimators should be in a different attribute, _steps_fitted_attr

--- a/sktime/transformations/compose/_featureunion.py
+++ b/sktime/transformations/compose/_featureunion.py
@@ -58,6 +58,7 @@ class FeatureUnion(_HeterogenousMetaEstimator, BaseTransformer):
         "transform-returns-same-time-index": False,
         "skip-inverse-transform": False,
         "capability:inverse_transform": False,
+        "visual_block_kind": "parallel",
         # unclear what inverse transform should be, since multiple inverse_transform
         #   would have to inverse transform to one
     }


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
Implements #7222 
Fixes #7152 


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
- update `sk_visual_block` method of `_HeterogenousMetaestimator` to be based on the `visual_block_kind` tag
- add `visual_block_kind` to tags registry
- add new `_steps` and `steps_` properties to:
     - `ParamFitterPipeline`
     - `PwTrafoPanelPipeline`
     - `RegressorPipeline`
     - `ClassifierPipeline`
     - `ClustererPipeline`
     - `PwTrafoPanelPipeline`
     - `GroupbyCategoryForecaster` 
     - `Permute`
- change `FeatureUnion`'s visual_block_kind tag to parallel and update `_steps_attr` to correct format (an iterable of (name: str, estimator) tuples)
- update `_steps_attr` of `GroupbyCategoryForecaster` and `TransformSelectForecaster` to point to default (the steps properties). Change their `visual_block_kind` tag to parallel.
- update `_steps_attr` of ColumnEnsembleTransformer from "transformers" to "_transformers" which has a correct format (an iterable of (name: str, estimator) tuples) instead of (name: str, estimator, column). Update its `visual_block_kind` tag to parallel.

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
