### PR TITLE
[BUG] Fix `DartsLinearRegression` failing instead of giving a warning

### DIFF
--- a/sktime/forecasting/darts.py
+++ b/sktime/forecasting/darts.py
@@ -366,7 +366,7 @@ class DartsXGBModel(_DartsRegressionModelsAdapter):
         kwargs = self.kwargs or {}
         if self.quantiles is not None and self.multi_models:
             warn(
-                message=(
+                (
                     "Setting multi_models=True with quantile regression may"
                     " cause issues. Consider using multi_models=False."
                 ),
@@ -592,7 +592,7 @@ class DartsLinearRegressionModel(_DartsRegressionModelsAdapter):
         kwargs = self.kwargs or {}
         if self.quantiles is not None and self.multi_models:
             warn(
-                message=(
+                (
                     "Setting multi_models=True with quantile regression may"
                     " cause issues. Consider using multi_models=False."
                 ),

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -60,6 +60,7 @@ EXCLUDE_ESTIMATORS = [
     "SARIMAX",
     "StatsModelsARIMA",
     "ShapeletLearningClassifierTslearn",
+    "DartsXGBModel",
 ]
 
 


### PR DESCRIPTION
this pr fixes the failure of the `DartsLinearRegression` which was failing instead of raising a warning.
it adds `message` to be passed correctly instead of using `message` as a keyword argument.
Also skipping tests for `DartsXGBModel` as it causes timeout errors as reported in https://github.com/sktime/sktime/pull/7110

fixes https://github.com/sktime/sktime/issues/7224