### PR TITLE
[ENH] Draft PR for `PeftTuner` class

### DIFF
--- a/sktime/forecasting/pefttuner.py
+++ b/sktime/forecasting/pefttuner.py
@@ -39,3 +39,9 @@ class PeftTuner(BaseTuner):
 
         trainer.train()
         return peft_model
+
+
+# keep in mind to investigate: help the user figure out how target_modules
+# fix html representation for peft
+# global forecaster can be recursively called on the previous one
+# drawback - investigations of how to integrate peft library methods to this design

--- a/sktime/forecasting/pefttuner.py
+++ b/sktime/forecasting/pefttuner.py
@@ -1,0 +1,41 @@
+"""Tuner module for global forecasters."""
+
+from peft import get_peft_model
+from transformers import Trainer
+
+
+class BaseTuner:
+    """Base class for the tuner methods."""
+
+    pass
+
+
+class PeftTuner(BaseTuner):
+    """Peft Tuner implementation."""
+
+    def __init__(self, peft_config):
+        self.peft_config = peft_config
+
+    def train(
+        self,
+        model,
+        train_dataset,
+        eval_dataset,
+        training_args,
+        compute_metrics=None,
+        callbacks=None,
+    ):
+        """Train method for the PeftTuner."""
+        peft_model = get_peft_model(model, self.peft_config)
+
+        trainer = Trainer(
+            peft_model,
+            training_args,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            compute_metrics=compute_metrics,
+            callbacks=callbacks,
+        )
+
+        trainer.train()
+        return peft_model

--- a/sktime/forecasting/ttm.py
+++ b/sktime/forecasting/ttm.py
@@ -182,7 +182,7 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
         self.use_source_package = use_source_package
         self.sktime_model = sktime_model
         self.tuner = tuner
-
+        # self._tuner = self.tuner if self.tuner else DefaultTuner()
         if self.broadcasting:
             self.set_tags(
                 **{
@@ -292,7 +292,8 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
         # Get the Model
         # self.model, info = PatchTSTForPrediction.from_pretrained(
         # "ibm-granite/granite-timeseries-patchtst",
-
+        # if not self._model:
+        # self._model instead of self.model
         self.model, info = TinyTimeMixerForPrediction.from_pretrained(
             self.model_path,
             revision=self.revision,


### PR DESCRIPTION
@benHeid This is the draft pr for the `PeftTuner` that we discussed synchronously on 10/09/2024

You can always make a fork to play around with it if you wish :)

relates to #7086 #6968 and #7077 

Topics for further refinement and discussion

- keep in mind to investigate: help the user figure out how target_modules
- fix html representation for peft
- allowing global forecaster can be recursively called on the previous one
- drawback - investigations of how to integrate `peft` library methods to this design
- Making all global forecasters have a tuner and model parameter inside 
- Designing ideas for `DefaultTuner`, `NoTuning` or `FullFineTuner` etc...
- - Default Tuner should be used if no particular tuner is defined
