### PR TITLE
[DOC] added missing import statements in ReverseAugmenter docstring example

### DIFF
--- a/sktime/transformations/series/augmenter.py
+++ b/sktime/transformations/series/augmenter.py
@@ -111,6 +111,8 @@ class ReverseAugmenter(_AugmenterTags, BaseTransformer):
 
     Examples
     --------
+    >>> import pandas as pd
+    >>> from sktime.transformations.series.augmenter import ReverseAugmenter
     >>> X = pd.Series([1,2,3,4,5])
     >>> augmenter = ReverseAugmenter()
     >>> Xt = augmenter.fit_transform(X)


### PR DESCRIPTION
I have added the missing import statements in ReverseAugmenter docstring example to make it easy for user to quickly copy and paste the example to test it out. This fix was in accordance with the issue #4400.