### PR TITLE
[ENH] fix input shape in `CNTCClassifier` and `CNTCRegressor`

### DIFF
--- a/sktime/classification/deep_learning/cntc.py
+++ b/sktime/classification/deep_learning/cntc.py
@@ -116,14 +116,12 @@ class CNTCClassifier(BaseDeepClassifier):
         """Construct a compiled, un-trained, keras model that is ready for training.
 
         In sktime, time series are stored in numpy arrays of shape (d,m), where d
-        is the number of dimensions, m is the series length. Keras/tensorflow assume
-        data is in shape (m,d). This method also assumes (m,d). Transpose should
-        happen in fit.
+        is the number of dimensions, m is the series length.
 
         Parameters
         ----------
         input_shape : tuple
-            The shape of the data fed into the input layer, should be (m,d)
+            The shape of the data fed into the input layer, should be (d,m)
         n_classes: int
             The number of classes, which becomes the size of the output layer
 
@@ -230,8 +228,6 @@ class CNTCClassifier(BaseDeepClassifier):
         if self.callbacks is None:
             self._callbacks = []
         y_onehot = self._convert_y_to_keras(y)
-        # Transpose to conform to Keras input style.
-        X = X.transpose(0, 2, 1)
 
         check_random_state(self.random_state)
         self.input_shape = X.shape[1:]
@@ -275,8 +271,6 @@ class CNTCClassifier(BaseDeepClassifier):
         """
         import numpy as np
 
-        # Transpose to work correctly with keras
-        X = X.transpose((0, 2, 1))
         X2 = self.prepare_input(X)
         probs = self.model_.predict([X2, X, X], self.batch_size, **kwargs)
 

--- a/sktime/regression/deep_learning/cntc.py
+++ b/sktime/regression/deep_learning/cntc.py
@@ -106,14 +106,12 @@ class CNTCRegressor(BaseDeepRegressor):
         """Construct a compiled, un-trained, keras model that is ready for training.
 
         In sktime, time series are stored in numpy arrays of shape (d,m), where d
-        is the number of dimensions, m is the series length. Keras/tensorflow assume
-        data is in shape (m,d). This method also assumes (m,d). Transpose should
-        happen in fit.
+        is the number of dimensions, m is the series length.
 
         Parameters
         ----------
         input_shape : tuple
-            The shape of the data fed into the input layer, should be (m,d)
+            The shape of the data fed into the input layer, should be (d,m)
 
         Returns
         -------
@@ -244,8 +242,6 @@ class CNTCRegressor(BaseDeepRegressor):
         -------
         output : array of shape = [n_instances, n_classes] of probabilities
         """
-        # Transpose to work correctly with keras
-        X = X.transpose((0, 2, 1))
         X2 = self.prepare_input(X)
         preds = self.model_.predict([X2, X, X], self.batch_size, **kwargs)
         return preds

--- a/sktime/regression/deep_learning/cntc.py
+++ b/sktime/regression/deep_learning/cntc.py
@@ -215,8 +215,6 @@ class CNTCRegressor(BaseDeepRegressor):
         """
         if self.callbacks is None:
             self._callbacks = []
-        # Transpose to conform to Keras input style.
-        X = X.transpose(0, 2, 1)
 
         check_random_state(self.random_state)
         self.input_shape = X.shape[1:]

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -42,8 +42,6 @@ EXCLUDE_ESTIMATORS = [
     "FCNRegressor",
     "LSTMFCNRegressor",
     "MACNNRegressor",
-    "CNTCClassifier",
-    "CNTCRegressor",
     # splitters excluded with undiagnosed failures, see #6194
     # these are temporarily skipped to allow merging of the base test framework
     "SameLocSplitter",


### PR DESCRIPTION
Fixed #6467, by fixing input formatting.