### PR TITLE
Introducing SKTIME Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ Questions and feedback are extremely welcome! We strongly believe in the value o
 | :speech_balloon: **General Discussion**        | [GitHub Discussions] |
 | :factory: **Contribution & Development** | `dev-chat` channel · [Discord] |
 | :globe_with_meridians: **Meet-ups and collaboration sessions** | [Discord] - Fridays 13 UTC, dev/meet-ups channel |
+| :robot: **Ask SKTIME Guru** | [Gurubase]                                  |
 
 [github issue tracker]: https://github.com/sktime/sktime/issues
 [github discussions]: https://github.com/sktime/sktime/discussions
 [stack overflow]: https://stackoverflow.com/questions/tagged/sktime
 [discord]: https://discord.com/invite/54ACzaFsn7
+[gurubase]: https://gurubase.io/g/sktime
 
 ## :dizzy: Features
 Our objective is to enhance the interoperability and usability of the time series analysis ecosystem in its entirety. sktime provides a __unified interface for distinct but related time series learning tasks__. It features [__dedicated time series algorithms__](https://www.sktime.net/en/stable/estimator_overview.html) and __tools for composite model building__,  such as pipelining, ensembling, tuning, and reduction, empowering users to apply algorithms designed for one task to another.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [SKTIME Guru](https://gurubase.io/g/sktime) to Gurubase. SKTIME Guru uses the data from this repo and data from the [docs](https://www.sktime.net/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "SKTIME Guru", which highlights that SKTIME now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable SKTIME Guru in Gurubase, just let me know that's totally fine.