### PR TITLE
[BUG] fix singular matrices in `test_reconcilerforecaster_return_totals`

### DIFF
--- a/sktime/forecasting/reconcile.py
+++ b/sktime/forecasting/reconcile.py
@@ -41,13 +41,14 @@ class ReconcilerForecaster(BaseForecaster):
     method : {"mint_cov", "mint_shrink", "ols", "wls_var", "wls_str", \
             "bu", "td_fcst"}, default="mint_shrink"
         The reconciliation approach applied to the forecasts based on:
-            * "mint_cov" - sample covariance
-            * "mint_shrink" - covariance with shrinkage
-            * "ols" - ordinary least squares
-            * "wls_var" - weighted least squares (variance)
-            * "wls_str" - weighted least squares (structural)
-            * "bu" - bottom-up
-            * "td_fcst" - top down based on forecast proportions
+
+            * ``"mint_cov"`` - sample covariance
+            * ``"mint_shrink"`` - covariance with shrinkage
+            * ``"ols"`` - ordinary least squares
+            * ``"wls_var"`` - weighted least squares (variance)
+            * ``"wls_str"`` - weighted least squares (structural)
+            * ``"bu"`` - bottom-up
+            * ``"td_fcst"`` - top down based on forecast proportions
 
     return_totals : bool
         Whether the predictions returned by ``predict`` and predict-like methods

--- a/sktime/forecasting/reconcile.py
+++ b/sktime/forecasting/reconcile.py
@@ -48,9 +48,14 @@ class ReconcilerForecaster(BaseForecaster):
             * "wls_str" - weighted least squares (structural)
             * "bu" - bottom-up
             * "td_fcst" - top down based on forecast proportions
+
     return_totals : bool
-        If True, returns the dataframe with __total values
-        If False, returns the dataframe without __total values
+        Whether the predictions returned by ``predict`` and predict-like methods
+        should include the total values in the hierarchy, stored at the ``__total``
+        index levels.
+
+        * If True, prediction data frames include total values at ``__total`` levels
+        * If False, prediction data frames are returned without ``__total`` levels
 
     See Also
     --------

--- a/sktime/forecasting/tests/test_reconcile.py
+++ b/sktime/forecasting/tests/test_reconcile.py
@@ -133,7 +133,7 @@ def test_reconcilerforecaster_return_totals(method, return_totals):
     from sktime.forecasting.reconcile import ReconcilerForecaster
 
     y = _make_hierarchical(
-        hierarchy_levels=(4, 3),  # (m, n) = (4, 3)
+        hierarchy_levels=(2, 2),  # (m, n) = (4, 3)
         n_columns=1,
         min_timepoints=12,
         max_timepoints=12,
@@ -143,7 +143,7 @@ def test_reconcilerforecaster_return_totals(method, return_totals):
     y_test = get_window(y, window_length=2)
 
     X = _make_hierarchical(
-        hierarchy_levels=(4, 3),
+        hierarchy_levels=(2, 2),
         n_columns=2,
         min_timepoints=12,
         max_timepoints=12,

--- a/sktime/forecasting/tests/test_reconcile.py
+++ b/sktime/forecasting/tests/test_reconcile.py
@@ -124,6 +124,10 @@ def test_reconcilerforecaster_exog(n_columns):
     estimator_instance.update(y=y_test, X=X_test)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(ReconcilerForecaster),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 @pytest.mark.parametrize("method", METHOD_LIST)
 @pytest.mark.parametrize("return_totals", [True, False])
 def test_reconcilerforecaster_return_totals(method, return_totals):

--- a/sktime/forecasting/tests/test_reconcile.py
+++ b/sktime/forecasting/tests/test_reconcile.py
@@ -136,8 +136,11 @@ def test_reconcilerforecaster_return_totals(method, return_totals):
     from sktime.forecasting.compose import YfromX
     from sktime.forecasting.reconcile import ReconcilerForecaster
 
+    m = 2
+    n = 2
+
     y = _make_hierarchical(
-        hierarchy_levels=(2, 2),  # (m, n) = (2, 2)
+        hierarchy_levels=(m, n),
         n_columns=1,
         min_timepoints=12,
         max_timepoints=12,
@@ -147,7 +150,7 @@ def test_reconcilerforecaster_return_totals(method, return_totals):
     y_test = get_window(y, window_length=2)
 
     X = _make_hierarchical(
-        hierarchy_levels=(2, 2),
+        hierarchy_levels=(m, n),
         n_columns=2,
         min_timepoints=12,
         max_timepoints=12,
@@ -166,7 +169,7 @@ def test_reconcilerforecaster_return_totals(method, return_totals):
     y_pred = estimator_instance.predict(X=X_test)
     if return_totals:
         # for hierarchy_levels=(m, n), len(y_pred) = len(y_test) + (1 + m) * 2
-        assert len(y_pred) == (len(y_test) + (1 + 4) * 2)
+        assert len(y_pred) == (len(y_test) + (1 + m) * 2)
     else:
         assert len(y_test) == len(y_pred)
         assert y_test.index.equals(y_pred.index)

--- a/sktime/forecasting/tests/test_reconcile.py
+++ b/sktime/forecasting/tests/test_reconcile.py
@@ -133,7 +133,7 @@ def test_reconcilerforecaster_return_totals(method, return_totals):
     from sktime.forecasting.reconcile import ReconcilerForecaster
 
     y = _make_hierarchical(
-        hierarchy_levels=(2, 2),  # (m, n) = (4, 3)
+        hierarchy_levels=(2, 2),  # (m, n) = (2, 2)
         n_columns=1,
         min_timepoints=12,
         max_timepoints=12,


### PR DESCRIPTION
The test `test_reconcilerforecaster_return_totals` would sporadically fail due to singular matrices.

This is due to the length of the time series - 12 - being equal to the number of time series, which can result in near-singular matrices due to the random generation.

Reducing the number of time series should substantially lower the probability of this, as done in this PR.