### PR TITLE
[MNT] 0.34.0 deprecations and change actions

### DIFF
--- a/sktime/annotation/base/_base.py
+++ b/sktime/annotation/base/_base.py
@@ -81,12 +81,7 @@ class BaseSeriesAnnotator(BaseEstimator):
 
         super().__init__()
 
-        # hacky workaround to ensure task and learning_type are set
-        # TODO 0.34.0: remove the self.task and self.learning_type attributes
-        # if possible, check downwards compatibility
         self.set_tags(**{"task": task, "learning_type": learning_type})
-        self.task = task
-        self.learning_type = learning_type
 
     def __rmul__(self, other):
         """Magic * method, return (left) concatenated AnnotatorPipeline.

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -151,36 +151,8 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         """,
     }
 
-    # TODO 0.34.0: check whether python 3.8 has reached EoL.
-    # If so, remove warning altogether
     def __init__(self):
         super().__init__()
-
-        import sys
-
-        from packaging.specifiers import SpecifierSet
-
-        from sktime.utils.warnings import warn
-
-        py39_or_higher = SpecifierSet(">=3.9")
-        sys_version = sys.version.split(" ")[0]
-
-        # todo 0.34.0 - check whether python 3.8 eol is reached.
-        # If yes, remove this msg.
-        if sys_version not in py39_or_higher:
-            warn(
-                f"From sktime 0.30.0, sktime requires Python version >=3.9, "
-                f"but found {sys_version}. "
-                "The package can still be installed, until 3.8 end of life "
-                "is reached, "
-                "but some functionality may not work as test coverage is dropped."
-                "Kindly note for context: python 3.8 will reach end of life "
-                "in October 2024, and multiple sktime core dependencies, "
-                "including scikit-learn, have already dropped support for 3.8. ",
-                category=DeprecationWarning,
-                obj=self,
-                stacklevel=2,
-            )
 
         # handle numpy 2 incompatible soft dependencies
         # for rationale, see _handle_numpy2_softdeps

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -158,7 +158,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         # for rationale, see _handle_numpy2_softdeps
         self._handle_numpy2_softdeps()
 
-    # TODO 0.34.0: check list of numpy 2 incompatible soft deps
+    # TODO 0.35.0: check list of numpy 2 incompatible soft deps
     # remove any from NOT_NP2_COMPATIBLE that become compatible
     def _handle_numpy2_softdeps(self):
         """Handle tags for soft deps that are not numpy 2 compatible.

--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -20,7 +20,7 @@ from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.utils.validation.panel import check_X
 
 
-# TODO: fix this in 0.34.0
+# TODO: fix this in 0.35.0
 # base class should have been changed to BaseEarlyClassifier
 class ProbabilityThresholdEarlyClassifier(BaseClassifier):
     """Probability Threshold Early Classifier.

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -964,8 +964,8 @@ def _index_range(relative, cutoff):
 
 def _is_pandas_arithmetic_bug_fixed():
     """Check if pandas supports correct arithmetic without a workaround."""
-    # TODO: 0.34.0:
-    # Check at every minor release whether lower pandas bound >=0.15.0
+    # TODO: 0.35.0:
+    # Check at every minor release whether lower pandas bound >=1.5.0
     # if yes, can remove the workaround in the "else" condition and the check
     #
     # context:

--- a/sktime/forecasting/base/tests/test_fh.py
+++ b/sktime/forecasting/base/tests/test_fh.py
@@ -745,7 +745,7 @@ def test_exponential_smoothing_case_with_naive():
 
 
 # TODO: Replace this long running test with fast unit test
-# todo 0.34.0: check whether numpy 2 bound is still necessary
+# todo 0.35.0: check whether numpy 2 bound is still necessary
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
     or not _check_estimator_deps(AutoARIMA, severity="none")

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -160,7 +160,7 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                         if len(levels) == 1:
                             levels = levels[0]
                         yt[ix] = y.xs(ix, level=levels, axis=1)
-                        # todo 0.34.0 - check why this cannot be easily removed
+                        # todo 0.35.0 - check why this cannot be easily removed
                         # in theory, we should get rid of the "Coverage" case treatment
                         # (the legacy naming convention was removed in 0.23.0)
                         # deal with the "Coverage" case, we need to get rid of this
@@ -1813,7 +1813,7 @@ class ForecastX(BaseForecaster):
         params1 = {"forecaster_X": fx, "forecaster_y": fy}
 
         # example with probabilistic capability
-        # todo 0.34.0: check if numpy<2 is still needed
+        # todo 0.35.0: check if numpy<2 is still needed
         if _check_soft_dependencies(["pmdarima", "numpy<2"], severity="none"):
             fy_proba = ARIMA()
         else:

--- a/sktime/forecasting/model_selection/__init__.py
+++ b/sktime/forecasting/model_selection/__init__.py
@@ -20,7 +20,7 @@ from sktime.forecasting.model_selection._tune import (
 )
 
 
-# todo 0.34.0 - check whether we should remove, otherwise bump
+# todo 0.35.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def temporal_train_test_split(
     y, X=None, test_size=None, train_size=None, fh=None, anchor="start"
@@ -47,7 +47,7 @@ def temporal_train_test_split(
     )
 
 
-# todo 0.34.0 - check whether we should remove, otherwise bump
+# todo 0.35.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
     """Legacy export of Expanding window splitter.
@@ -70,7 +70,7 @@ def ExpandingWindowSplitter(fh=1, initial_window=10, step_length=1):
     return _EWSplitter(fh=fh, initial_window=initial_window, step_length=step_length)
 
 
-# todo 0.34.0 - check whether we should remove, otherwise bump
+# todo 0.35.0 - check whether we should remove, otherwise bump
 # still used in blog posts and old tutorials
 def SlidingWindowSplitter(
     fh=1, window_length=10, step_length=1, initial_window=None, start_with_window=True

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -84,7 +84,7 @@ class BaseGridSearch(_DelegatedForecaster):
         if tune_by_variable:
             self.set_tags(**{"scitype:y": "univariate"})
 
-        # todo 0.34.0: check if this is still necessary
+        # todo 0.35.0: check if this is still necessary
         # n_jobs is deprecated, left due to use in tutorials, books, blog posts
         if n_jobs != "deprecated":
             warn(


### PR DESCRIPTION
Carries out deprecations and change actions scheduled for 0.34.0:

* remove internal `self.task` and `self.learning_type` from `BaseSeriesAnnotator`
* remove python 3.8 EOL warnings, as python 3.8 has now reached EOL
* bump deprecation/change checks scheduled for 0.33.0 to 0.34.0