### PR TITLE
[DOC] add docstring example for `DropNA`

### DIFF
--- a/sktime/transformations/series/dropna.py
+++ b/sktime/transformations/series/dropna.py
@@ -40,6 +40,19 @@ class DropNA(BaseTransformer):
         If True, drops the same rows/columns in transform as in fit. If false,
         drops rows/columns according to the NAs seen in transform (equivalent
         to PandasTransformAdaptor(method="dropna")).
+
+    Examples
+    --------
+    >>> from sktime.transformations.series.dropna import DropNA
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> X = pd.DataFrame({'a': [1, 2, np.nan, 4], 'b': [5, np.nan, 7, 8]})
+    >>> transformer = DropNA(axis=0, how='any')
+    >>> X_transformed = transformer.fit_transform(X)
+    >>> print(X_transformed)
+       a    b
+    0  1.0  5.0
+    3  4.0  8.0
     """
 
     _tags = {


### PR DESCRIPTION
#### Reference Issues/PRs
This PR fixes some part of issue #4400 

#### What does this implement/fix? Explain your changes.
This PR adds an example to the docstring of the `DropNA` class in `sktime/transformations/series/dropna.py`. The example demonstrates how to use the `DropNA` transformer, including necessary imports and a sample usage scenario.

#### Does your contribution introduce a new dependency? If yes, which one?
No, this change does not introduce any new dependencies.

#### What should a reviewer concentrate their feedback on?
- The clarity and correctness of the added example in the docstring
- Whether the example adequately demonstrates the usage of the `DropNA` transformer

#### Did you add any tests for the change?
No new tests were added as this is a documentation change.

#### Any other comments?
This change aims to improve the usability of the `DropNA` transformer by providing a clear, executable example in its docstring.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with the `doc` badge for improving documentation.
- [ ] The PR title starts with [DOC] to indicate it's a documentation improvement.

##### For new estimators
- Not applicable as this is not a new estimator.

<!--
Thanks for contributing!
-->