### PR TITLE
[DOC] in docstring, rename `Example`  to `Examples` sections

### DIFF
--- a/sktime/alignment/utils/utils_align.py
+++ b/sktime/alignment/utils/utils_align.py
@@ -25,8 +25,8 @@ def reindex_iloc(df, inds, copy=True):
         out of bound indices will result in np.nan values
         entries are references to original DataFrame if copy=False
 
-    Example
-    -------
+    Examples
+    --------
     >>> X = pd.DataFrame({'a' : [1,2,3,4]}, index=[-4,7,11,14])
     >>> reindex_iloc(X, [1, 2, 6])
          a
@@ -56,8 +56,8 @@ def convert_align_to_align_loc(align, X, align_name="align", df_name="X", copy=T
     pd.DataFrame in alignment format, with columns 'ind'+str(i) for integer i
         cols contain loc index of X[i] mapped to alignment coordinate for alignment
 
-    Example
-    -------
+    Examples
+    --------
     align_df = pd.DataFrame({'ind0' : [1,2,3], 'ind1' : [0,2,4]})
     X = [pd.DataFrame({'a' : [1,2,3,4]}, index=[-4,7,11,14]),
             pd.DataFrame({'a' : [1,2,3,5,6]}, index=[4,8,12,16,20])

--- a/sktime/annotation/igts.py
+++ b/sktime/annotation/igts.py
@@ -152,8 +152,8 @@ class IGTS:
     activities.", Pervasive and Mobile Computing, 38, 92-109, (2017).
     https://www.sciencedirect.com/science/article/abs/pii/S1574119217300081
 
-    Example
-    -------
+    Examples
+    --------
     >>> from sktime.annotation.datagen import piecewise_normal_multivariate
     >>> from sklearn.preprocessing import MinMaxScaler
     >>> X = piecewise_normal_multivariate(lengths=[10, 10, 10, 10],

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -726,8 +726,8 @@ def flatten(obj):
     list or tuple, tuple if obj was tuple, list otherwise
         flat iterable, containing non-list/tuple elements in obj in same order as in obj
 
-    Example
-    -------
+    Examples
+    --------
     >>> flatten([1, 2, [3, (4, 5)], 6])
     [1, 2, 3, 4, 5, 6]
     """
@@ -752,8 +752,8 @@ def unflatten(obj, template):
         has element bracketing exactly as `template`
             and elements in sequence exactly as `obj`
 
-    Example
-    -------
+    Examples
+    --------
     >>> unflatten([1, 2, 3, 4, 5, 6], [6, 3, [5, (2, 4)], 1])
     [1, 2, [3, (4, 5)], 6]
     """

--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -1543,8 +1543,8 @@ def load_m5(
     - dept_id
     - date
 
-    Example
-    -------
+    Examples
+    --------
     >>> data = load_m5()
     >>> data.head()
     """

--- a/sktime/datatypes/_adapter/gluonts.py
+++ b/sktime/datatypes/_adapter/gluonts.py
@@ -14,8 +14,8 @@ def convert_pandas_to_listDataset(pd_dataframe: pd.DataFrame):
     gluonts.dataset.common.ListDataset
         A gluonTS ListDataset formed from `pd_dataframe`
 
-    Example
-    --------
+    Examples
+    ---------
     >>> import pandas as pd
     >>> cols = ["instances", "timepoints"] + [f"var_{i}" for i in range(2)]
     >>> Xlist = [

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -2634,8 +2634,8 @@ class YfromX(BaseForecaster, _ReducerMixin):
         if there are 2 or less levels, "global" and "panel" result in the same
         if there is only 1 level (single time series), all three settings agree
 
-    Example
-    -------
+    Examples
+    --------
     >>> from sktime.datasets import load_longley
     >>> from sktime.split import temporal_train_test_split
     >>> from sktime.forecasting.compose import YfromX

--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -62,8 +62,8 @@ class VECM(_StatsModelsAdapter):
         2D ndarray/pd.DataFrame of size (any, neqs)
         Forecasted value of exog_coint
 
-    Example
-    -------
+    Examples
+    --------
     >>> from sktime.forecasting.vecm import VECM
     >>> from sktime.split import temporal_train_test_split
     >>> from sktime.forecasting.base import ForecastingHorizon

--- a/sktime/proba/_empirical.py
+++ b/sktime/proba/_empirical.py
@@ -25,8 +25,8 @@ class Empirical(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> import pandas as pd
     >>> from sktime.proba.empirical import Empirical
 

--- a/sktime/proba/_laplace.py
+++ b/sktime/proba/_laplace.py
@@ -21,8 +21,8 @@ class Laplace(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from sktime.proba.laplace import Laplace
 
     >>> n = Laplace(mu=[[0, 1], [2, 3], [4, 5]], scale=1)

--- a/sktime/proba/_mixture.py
+++ b/sktime/proba/_mixture.py
@@ -23,8 +23,8 @@ class Mixture(_HeterogenousMetaEstimator, BaseDistribution):
     index : pd.Index, optional, default = inferred from component distributions
     columns : pd.Index, optional, default = inferred from component distributions
 
-    Example
-    -------
+    Examples
+    --------
     >>> from sktime.proba.mixture import Mixture
     >>> from sktime.proba.normal import Normal
     >>>

--- a/sktime/proba/_normal.py
+++ b/sktime/proba/_normal.py
@@ -22,8 +22,8 @@ class Normal(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from sktime.proba.normal import Normal
 
     >>> n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)

--- a/sktime/proba/_t.py
+++ b/sktime/proba/_t.py
@@ -24,8 +24,8 @@ class TDistribution(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from sktime.proba.t import TDistribution
 
     >>> n = TDistribution(mu=[[0, 1], [2, 3], [4, 5]], sigma=1, df=10)

--- a/sktime/proba/tfp.py
+++ b/sktime/proba/tfp.py
@@ -22,8 +22,8 @@ class TFNormal(_BaseTFDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from sktime.proba.tfp import TFNormal  # doctest: +SKIP
 
     >>> n = TFNormal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)  # doctest: +SKIP

--- a/sktime/transformations/panel/dwt.py
+++ b/sktime/transformations/panel/dwt.py
@@ -21,8 +21,8 @@ class DWTTransformer(BaseTransformer):
     num_levels : int, number of levels to perform the Haar wavelet
         transformation.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from sktime.transformations.panel.dwt import DWTTransformer
     >>> from sktime.datasets import load_airline
     >>> from sktime.datatypes import convert

--- a/sktime/transformations/panel/hog1d.py
+++ b/sktime/transformations/panel/hog1d.py
@@ -42,8 +42,8 @@ class HOG1DTransformer(BaseTransformer):
     scaling_factor : float, default=0.1
         a constant that is multiplied to modify the distribution.
 
-    Example
-    ----------
+    Examples
+    -----------
     >>> from sktime.transformations.panel.hog1d import HOG1DTransformer
     >>> from sktime.datasets import load_arrow_head
     >>>

--- a/sktime/transformations/panel/padder.py
+++ b/sktime/transformations/panel/padder.py
@@ -23,8 +23,8 @@ class PaddingTransformer(BaseTransformer):
     pad_length : int, optional (default=None) length to pad the series too.
         if None, will find the longest sequence and use instead.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import pandas as pd
     >>> from sktime.transformations.panel.padder import PaddingTransformer
     >>>

--- a/sktime/transformations/series/binning.py
+++ b/sktime/transformations/series/binning.py
@@ -44,8 +44,8 @@ class TimeBinAggregate(BaseTransformer):
         "bin_mid" = transformed pd.DataFrame will be indexed by bin midpoints
         "bin" = transformed pd.DataFrame will have ``bins`` as ``IntervalIndex``
 
-    Example
-    -------
+    Examples
+    --------
     from sktime.datatypes import get_examples
     from sktime.transformations.series.binning import TimeBinAggregate
 

--- a/sktime/transformations/series/dilation_mapping.py
+++ b/sktime/transformations/series/dilation_mapping.py
@@ -47,8 +47,8 @@ class DilationMappingTransformer(BaseTransformer):
        Accurate and Memory Constrained Time Series Classification", 2023,
        arXiv preprint arXiv:2301.10194.
 
-    Example
-    ----------
+    Examples
+    -----------
     >>> from sktime.transformations.series.dilation_mapping import \
     ...     DilationMappingTransformer
     >>> from sktime.datasets import load_airline

--- a/sktime/transformations/series/filter.py
+++ b/sktime/transformations/series/filter.py
@@ -32,8 +32,8 @@ class Filter(BaseTransformer):
         See ``mne.filter.filter_data``
         documentation for a detailed description of all options.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from sktime.transformations.series.filter import Filter
     >>> from sktime.datasets import load_arrow_head
     >>> X, y = load_arrow_head(return_X_y=True, return_type="pd-multiindex")

--- a/sktime/transformations/series/kinematic.py
+++ b/sktime/transformations/series/kinematic.py
@@ -49,8 +49,8 @@ class KinematicFeatures(BaseTransformer):
         * "a_abs" - absolute acceleration
         * "curv" - curvature
 
-    Example
-    -------
+    Examples
+    --------
     >>> import numpy as np
     >>> import pandas as pd
     >>> from sktime.transformations.series.kinematic import KinematicFeatures


### PR DESCRIPTION
It seems that examples on a section with title `Example` are not displayes by sphinx, the name needs to be `Examples`.

This PR corrects the section header in a number of docstrings.