### PR TITLE
[DOC] categories for clustering algorithms in API reference

### DIFF
--- a/docs/source/api_reference/clustering.rst
+++ b/docs/source/api_reference/clustering.rst
@@ -15,8 +15,8 @@ A full table with tag based search is also available on the
 (select "clustering" in the "Estimator type" dropdown).
 
 
-Clustering models
------------------
+Partitioning based
+------------------
 
 .. currentmodule:: sktime.clustering.k_means
 
@@ -43,6 +43,9 @@ Clustering models
 
     TimeSeriesKShapes
 
+Spectral and kernel clustering
+------------------------------
+
 .. currentmodule:: sktime.clustering.kernel_k_means
 
 .. autosummary::
@@ -50,6 +53,17 @@ Clustering models
     :template: class.rst
 
     TimeSeriesKernelKMeans
+
+Density-based
+-------------
+
+.. currentmodule:: sktime.clustering.dbscan
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    TimeSeriesDBSCAN
 
 Base
 ----


### PR DESCRIPTION
This PR adds a sub-division of the existing categories in the API reference for clustering, and the missing DBSCAN algorithm.