### PR TITLE
[DOC] Add Binary Segmentation Estimator to API reference

### DIFF
--- a/docs/source/api_reference/detection.rst
+++ b/docs/source/api_reference/detection.rst
@@ -97,6 +97,14 @@ Time Series Segmentation
 
     ClusterSegmenter
 
+.. currentmodule:: sktime.annotation.bs.BinarySegmentation
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    BinarySegmentation
+
 Time Series Anomaly Detection
 -----------------------------
 


### PR DESCRIPTION

Fixes #7371 






Added Binary Segmentation Estimator in `docs/source/api_reference/detection.rst` 

