### PR TITLE
[DOC] fixes to the mtype API reference

### DIFF
--- a/docs/source/api_reference/data_format.rst
+++ b/docs/source/api_reference/data_format.rst
@@ -76,6 +76,10 @@ The ``Series`` mtype represents a single time series.
 
 .. currentmodule:: sktime.datatypes._series._check
 
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
     SeriesPdDataFrame
     SeriesPdSeries
     SeriesNp2D
@@ -93,6 +97,10 @@ The ``Panel`` mtype represents a flat collection of time series.
 
 .. currentmodule:: sktime.datatypes._panel._check
 
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
     PanelPdMultiIndex
     PanelNp3D
     PanelDfList
@@ -109,6 +117,10 @@ The ``Hierarchical`` mtype represents a hierarchical collection of time series.
 
 .. currentmodule:: sktime.datatypes._hierarchical._check
 
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
     HierarchicalPdMultiIndex
     HierarchicalDask
     HierarchicalPolarsEager
@@ -120,6 +132,10 @@ The ``Hierarchical`` mtype represents a hierarchical collection of time series.
 The ``Table`` mtype represents a (non-temporal) data frame table.
 
 .. currentmodule:: sktime.datatypes._table._check
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
 
     TablePdDataFrame
     TablePdSeries

--- a/sktime/datatypes/_table/_base.py
+++ b/sktime/datatypes/_table/_base.py
@@ -7,7 +7,7 @@ from sktime.datatypes._base import BaseDatatype
 
 
 class ScitypeTable(BaseDatatype):
-    """Base class for Table data types.
+    """Data Frame or Table data type.
 
     Parameters
     ----------

--- a/sktime/datatypes/_table/_base.py
+++ b/sktime/datatypes/_table/_base.py
@@ -6,7 +6,7 @@ __author__ = ["fkiraly"]
 from sktime.datatypes._base import BaseDatatype
 
 
-class BaseTable(BaseDatatype):
+class ScitypeTable(BaseDatatype):
     """Base class for Table data types.
 
     Parameters

--- a/sktime/datatypes/_table/_check.py
+++ b/sktime/datatypes/_table/_check.py
@@ -39,12 +39,12 @@ import pandas as pd
 
 from sktime.datatypes._base._common import _req, _ret
 from sktime.datatypes._dtypekind import _get_feature_kind, _get_table_dtypekind
-from sktime.datatypes._table._base import ScitypeTableTable
+from sktime.datatypes._table._base import BaseTable
 
 PRIMITIVE_TYPES = (float, int, str)
 
 
-class TablePdDataFrame(ScitypeTable):
+class TablePdDataFrame(BaseTable):
     """Data type: pandas.DataFrame based specification of data frame table.
 
     Parameters are inferred by check.
@@ -138,7 +138,7 @@ def _check_pddataframe_table(obj, return_metadata=False, var_name="obj"):
     return _ret(True, None, metadata, return_metadata)
 
 
-class TablePdSeries(ScitypeTable):
+class TablePdSeries(BaseTable):
     """Data type: pandas.Series based specification of data frame table.
 
     Parameters are inferred by check.
@@ -237,7 +237,7 @@ def _check_pdseries_table(obj, return_metadata=False, var_name="obj"):
     return _ret(True, None, metadata, return_metadata)
 
 
-class TableNp1D(ScitypeTable):
+class TableNp1D(BaseTable):
     """Data type: 1D np.ndarray based specification of data frame table.
 
     Parameters are inferred by check.
@@ -336,7 +336,7 @@ def _check_numpy1d_table(obj, return_metadata=False, var_name="obj"):
     return _ret(True, None, metadata, return_metadata)
 
 
-class TableNp2D(ScitypeTable):
+class TableNp2D(BaseTable):
     """Data type: 2D np.ndarray based specification of data frame table.
 
     Parameters are inferred by check.
@@ -434,7 +434,7 @@ def _check_numpy2d_table(obj, return_metadata=False, var_name="obj"):
     return _ret(True, None, metadata, return_metadata)
 
 
-class TableListOfDict(ScitypeTable):
+class TableListOfDict(BaseTable):
     """Data type: list of dict based specification of data frame table.
 
     Parameters are inferred by check.
@@ -555,7 +555,7 @@ def _check_list_of_dict_table(obj, return_metadata=False, var_name="obj"):
     return _ret(True, None, metadata, return_metadata)
 
 
-class TablePolarsEager(ScitypeTable):
+class TablePolarsEager(BaseTable):
     """Data type: eager polars DataFrame based specification of data frame table.
 
     Parameters are inferred by check.
@@ -620,7 +620,7 @@ class TablePolarsEager(ScitypeTable):
         return check_polars_frame(obj, return_metadata, var_name, lazy=False)
 
 
-class TablePolarsLazy(ScitypeTable):
+class TablePolarsLazy(BaseTable):
     """Data type: lazy polars DataFrame based specification of data frame table.
 
     Parameters are inferred by check.

--- a/sktime/datatypes/_table/_check.py
+++ b/sktime/datatypes/_table/_check.py
@@ -39,7 +39,7 @@ import pandas as pd
 
 from sktime.datatypes._base._common import _req, _ret
 from sktime.datatypes._dtypekind import _get_feature_kind, _get_table_dtypekind
-from sktime.datatypes._table._base import ScitypeTableTable
+from sktime.datatypes._table._base import ScitypeTable
 
 PRIMITIVE_TYPES = (float, int, str)
 

--- a/sktime/datatypes/_table/_check.py
+++ b/sktime/datatypes/_table/_check.py
@@ -39,12 +39,12 @@ import pandas as pd
 
 from sktime.datatypes._base._common import _req, _ret
 from sktime.datatypes._dtypekind import _get_feature_kind, _get_table_dtypekind
-from sktime.datatypes._table._base import BaseTable
+from sktime.datatypes._table._base import ScitypeTableTable
 
 PRIMITIVE_TYPES = (float, int, str)
 
 
-class TablePdDataFrame(BaseTable):
+class TablePdDataFrame(ScitypeTable):
     """Data type: pandas.DataFrame based specification of data frame table.
 
     Parameters are inferred by check.
@@ -138,7 +138,7 @@ def _check_pddataframe_table(obj, return_metadata=False, var_name="obj"):
     return _ret(True, None, metadata, return_metadata)
 
 
-class TablePdSeries(BaseTable):
+class TablePdSeries(ScitypeTable):
     """Data type: pandas.Series based specification of data frame table.
 
     Parameters are inferred by check.
@@ -237,7 +237,7 @@ def _check_pdseries_table(obj, return_metadata=False, var_name="obj"):
     return _ret(True, None, metadata, return_metadata)
 
 
-class TableNp1D(BaseTable):
+class TableNp1D(ScitypeTable):
     """Data type: 1D np.ndarray based specification of data frame table.
 
     Parameters are inferred by check.
@@ -336,7 +336,7 @@ def _check_numpy1d_table(obj, return_metadata=False, var_name="obj"):
     return _ret(True, None, metadata, return_metadata)
 
 
-class TableNp2D(BaseTable):
+class TableNp2D(ScitypeTable):
     """Data type: 2D np.ndarray based specification of data frame table.
 
     Parameters are inferred by check.
@@ -434,7 +434,7 @@ def _check_numpy2d_table(obj, return_metadata=False, var_name="obj"):
     return _ret(True, None, metadata, return_metadata)
 
 
-class TableListOfDict(BaseTable):
+class TableListOfDict(ScitypeTable):
     """Data type: list of dict based specification of data frame table.
 
     Parameters are inferred by check.
@@ -555,7 +555,7 @@ def _check_list_of_dict_table(obj, return_metadata=False, var_name="obj"):
     return _ret(True, None, metadata, return_metadata)
 
 
-class TablePolarsEager(BaseTable):
+class TablePolarsEager(ScitypeTable):
     """Data type: eager polars DataFrame based specification of data frame table.
 
     Parameters are inferred by check.
@@ -620,7 +620,7 @@ class TablePolarsEager(BaseTable):
         return check_polars_frame(obj, return_metadata, var_name, lazy=False)
 
 
-class TablePolarsLazy(BaseTable):
+class TablePolarsLazy(ScitypeTable):
     """Data type: lazy polars DataFrame based specification of data frame table.
 
     Parameters are inferred by check.


### PR DESCRIPTION
Fixes some issues with the new API reference for data formats:

* adds missing `Table` scitype - broken link
* fixes missing mtype entries