### PR TITLE
[DOC] fix duplications of the word "correspond"

### DIFF
--- a/examples/01c_forecasting_hierarchical_global.ipynb
+++ b/examples/01c_forecasting_hierarchical_global.ipynb
@@ -279,7 +279,7 @@
     "* instance index: the first element of pairs in `obj.index` is interpreted as an instance index. \n",
     "* variables: columns of `obj` correspond to different variables\n",
     "* variable names: column names `obj.columns`\n",
-    "* time points: rows of `obj` with the same `\"timepoints\"` index correspond correspond to the same time point; rows of `obj` with different `\"timepoints\"` index correspond correspond to the different time points.\n",
+    "* time points: rows of `obj` with the same `\"timepoints\"` index correspond to the same time point; rows of `obj` with different `\"timepoints\"` index correspond to the different time points.\n",
     "* time index: the second element of pairs in `obj.index` is interpreted as a time index. \n",
     "* capabilities: can represent panels of multivariate series; can represent unequally spaced series; can represent panels of unequally supported series; cannot represent panels of series with different sets of variables."
    ]
@@ -416,7 +416,7 @@
     "* hierarchy: the non-time-like indices in `obj.index` are interpreted as a hierarchy identifying index. \n",
     "* variables: columns of `obj` correspond to different variables\n",
     "* variable names: column names `obj.columns`\n",
-    "* time points: rows of `obj` with the same `\"timepoints\"` index correspond correspond to the same time point; rows of `obj` with different `\"timepoints\"` index correspond correspond to the different time points.\n",
+    "* time points: rows of `obj` with the same `\"timepoints\"` index correspond to the same time point; rows of `obj` with different `\"timepoints\"` index correspond to the different time points.\n",
     "* time index: the last element of tuples in `obj.index` is interpreted as a time index. \n",
     "* capabilities: can represent hierarchical series; can represent unequally spaced series; can represent unequally supported hierarchical series; cannot represent hierarchical series with different sets of variables."
    ]

--- a/examples/AA_datatypes_and_datasets.ipynb
+++ b/examples/AA_datatypes_and_datasets.ipynb
@@ -479,7 +479,7 @@
     "* instance index: the first element of pairs in `obj.index` (0-th level value) is interpreted as an instance index, we call it \"instance index\" below.\n",
     "* instances: rows with the same \"instance index\" index value correspond to the same instance; rows with different \"instance index\" values correspond to different instances. \n",
     "* time index: the second element of pairs in `obj.index` (1-st level value) is interpreted as a time index, we call it \"time index\" below. \n",
-    "* time points: rows of `obj` with the same \"time index\" value correspond correspond to the same time point; rows of `obj` with different \"time index\" index correspond correspond to the different time points.\n",
+    "* time points: rows of `obj` with the same \"time index\" value correspond to the same time point; rows of `obj` with different \"time index\" index correspond to the different time points.\n",
     "* variables: columns of `obj` correspond to different variables\n",
     "* variable names: column names `obj.columns`\n",
     "* capabilities: can represent panels of multivariate series; can represent unequally spaced series; can represent panels of unequally supported series; cannot represent panels of series with different sets of variables."
@@ -759,7 +759,7 @@
     "* hierarchy level: rows with the same non-time-like index values correspond to the same hierarchy unit; rows with different non-time-like index combination correspond to different hierarchy unit.\n",
     "* hierarchy: the non-time-like indices in `obj.index` are interpreted as a hierarchy identifying index. \n",
     "* time index: the last element of tuples in `obj.index` is interpreted as a time index. \n",
-    "* time points: rows of `obj` with the same `\"timepoints\"` index correspond correspond to the same time point; rows of `obj` with different `\"timepoints\"` index correspond correspond to the different time points.\n",
+    "* time points: rows of `obj` with the same `\"timepoints\"` index correspond to the same time point; rows of `obj` with different `\"timepoints\"` index correspond to the different time points.\n",
     "* variables: columns of `obj` correspond to different variables\n",
     "* variable names: column names `obj.columns`\n",
     "* capabilities: can represent hierarchical series; can represent unequally spaced series; can represent unequally supported hierarchical series; cannot represent hierarchical series with different sets of variables."

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -427,7 +427,7 @@ class PanelPdMultiIndex(ScitypePanel):
       is interpreted as a time index, we call it "time index" below.
     * time points: rows of ``obj`` with the same "time index" value correspond
       correspond to the same time point; rows of `obj` with different "time index"
-      index correspond correspond to the different time points.
+      index correspond to the different time points.
     * variables: columns of ``obj`` correspond to different variables
     * variable names: column names ``obj.columns``
 


### PR DESCRIPTION
This PR fixes multiple duplications of the word "correspond", replacing "correspond correspond" by simply "correspond".

I am surprised there were so many in the code base (nine), perhaps this is case of copy-paste proliferation.