### PR TITLE
[BUG] rectify `ignores-exogeneous-X` tag value in `Croston`

### DIFF
--- a/sktime/forecasting/croston.py
+++ b/sktime/forecasting/croston.py
@@ -77,6 +77,7 @@ class Croston(BaseForecaster):
         # estimator type
         # --------------
         "requires-fh-in-fit": False,  # is forecasting horizon already required in fit?
+        "ignores-exogeneous-X": True,
     }
 
     def __init__(self, smoothing=0.1):


### PR DESCRIPTION
Fixes #6675 

`Croston` does not use exogenous features passed in `X` in different methods, and the value of `ignores-exogeneous-X` tag should be `True`. It was incorrectly set as `False`, and this PR addresses that.