### PR TITLE
[ENH] `EnsembleForecaster` option to specify multiple copies of same forecaster easily

### DIFF
--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -342,6 +342,8 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
         self.weights = weights
         super().__init__(forecasters=forecasters, n_jobs=n_jobs)
 
+        print("test")
+
         fc = []
         for forecaster in forecasters:
             if len(forecaster) <= 2:

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -359,8 +359,8 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
                 )
                 raise ValueError(msg)
 
-        self._forecasters = self._check_estimators(fc, clone=False)
-        self.forecasters_ = self._check_estimators(fc, clone=True)
+        self._forecasters = self._check_estimators(fc, clone_ests=False)
+        self.forecasters_ = self._check_estimators(fc, clone_ests=True)
 
         # the ensemble requires fh in fit
         # iff any of the component forecasters require fh in fit

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -436,13 +436,16 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
 
         # univariate case
         FORECASTER = NaiveForecaster()
-        params = [{"forecasters": [("f1", FORECASTER), ("f2", FORECASTER)]}]
+        params0 = {"forecasters": [("f1", FORECASTER), ("f2", FORECASTER)]}
 
         # test multivariate case, i.e., ensembling multiple variables at same time
         FORECASTER = DirectReductionForecaster.create_test_instance()
-        params = params + [{"forecasters": [("f1", FORECASTER), ("f2", FORECASTER)]}]
+        params1 = {"forecasters": [("f1", FORECASTER), ("f2", FORECASTER)]}
 
-        return params
+        # test with multiplicities
+        params2 = {"forecasters": [("f", FORECASTER, 2)]}
+
+        return [params0, params1, params2]
 
 
 def _aggregate(y, aggfunc, weights):

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -338,7 +338,6 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
     _steps_fitted_attr = "forecasters_"
 
     def __init__(self, forecasters, n_jobs=None, aggfunc="mean", weights=None):
-
         self.aggfunc = aggfunc
         self.weights = weights
         super().__init__(forecasters=forecasters, n_jobs=n_jobs)

--- a/sktime/forecasting/online_learning/_online_ensemble.py
+++ b/sktime/forecasting/online_learning/_online_ensemble.py
@@ -16,7 +16,14 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
     Parameters
     ----------
     ensemble_algorithm : ensemble algorithm
-    forecasters : list of (str, estimator) tuples
+
+    forecasters : list of estimator, (str, estimator), or (str, estimator, count) tuples
+        Estimators to apply to the input series.
+
+        * (str, estimator) tuples: the string is a name for the estimator.
+        * estimator without string will be assigned unique name based on class name
+        * (str, estimator, count) tuples: the estimator will be replicated count times.
+
     n_jobs : int or None, optional (default=None)
         The number of jobs to run in parallel for fit. None means 1 unless
         in a joblib.parallel_backend context.
@@ -41,7 +48,7 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
         self.n_jobs = n_jobs
         self.ensemble_algorithm = ensemble_algorithm
 
-        super(EnsembleForecaster, self).__init__(forecasters=forecasters, n_jobs=n_jobs)
+        super().__init__(forecasters=forecasters, n_jobs=n_jobs)
 
     def _fit(self, y, X, fh):
         """Fit to training data.


### PR DESCRIPTION
Resolves #7407. 

A common use case with ML estimators is to create an ensemble estimator with N replicates of the same estimator. This PR facilitates this use case.

Previously, an ensemble forecaster was created via EnsembleForecaster( forecasters, ... ), with forecasters being a list of 2-tuples [(str1, estimator1), ..., (strN, estimatorN)]. This is a bit tedious if many of the estimators are identical.

This PR allows each tuple to be either of the form (str, estimator) (as before) or (str, estimator, count). This latter form says to create count replicates of the estimator.