### PR TITLE
[ENH] parity of `_HeterogenousMetaEstimator._check_estimator` with `skbase` and fixes in `EnsembleForecaster.__init__`

### DIFF
--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -287,8 +287,10 @@ class _HeterogenousMetaEstimator:
         if (
             estimators is None
             or (not allow_empty and len(estimators) == 0)
-            or not (isinstance(estimators, list)
-            or (allow_dict and isinstance(estimators, dict)))
+            or not (
+                isinstance(estimators, list)
+                or (allow_dict and isinstance(estimators, dict))
+            )
         ):
             raise TypeError(msg)
 

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -287,8 +287,8 @@ class _HeterogenousMetaEstimator:
         if (
             estimators is None
             or (not allow_empty and len(estimators) == 0)
-            or not isinstance(estimators, list)
-            or (not allow_dict and isinstance(estimators, dict))
+            or not (isinstance(estimators, list)
+            or (allow_dict and isinstance(estimators, dict)))
         ):
             raise TypeError(msg)
 

--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -233,7 +233,9 @@ class _HeterogenousMetaEstimator:
         estimators,
         attr_name="steps",
         cls_type=None,
+        allow_dict=False,
         allow_mix=True,
+        allow_empty=False,
         clone_ests=True,
     ):
         """Check that estimators is a list of estimators or list of str/est tuples.
@@ -247,9 +249,13 @@ class _HeterogenousMetaEstimator:
             Name of checked attribute in error messages
         cls_type : class or tuple of class, optional. Default = BaseEstimator.
             class(es) that all estimators are checked to be an instance of
+        allow_dict : bool, default=False
+            Whether `objs` can be a dictionary mapping str names to objects.
         allow_mix : boolean, optional. Default = True.
             whether mix of estimator and (str, estimator) is allowed in `estimators`
-        clone_ests : boolean, optional. Default = True.
+        allow_empty : boolean, optional. Default = False
+            whether empty list of estimators is allowed
+        clone_ests : boolean, optional. Default = True
             whether estimators in return are cloned (True) or references (False).
 
         Returns
@@ -280,8 +286,9 @@ class _HeterogenousMetaEstimator:
 
         if (
             estimators is None
-            or len(estimators) == 0
+            or (not allow_empty and len(estimators) == 0)
             or not isinstance(estimators, list)
+            or (not allow_dict and isinstance(estimators, dict))
         ):
             raise TypeError(msg)
 
@@ -292,7 +299,15 @@ class _HeterogenousMetaEstimator:
 
             return is_est, is_tuple
 
-        if not all(any(is_est_is_tuple(x)) for x in estimators):
+        # We've already guarded against objs being dict when allow_dict is False
+        # So here we can just check dictionary elements
+        if isinstance(estimators, dict) and not all(
+            isinstance(name, str) and isinstance(obj, cls_type)
+            for name, obj in estimators.items()
+        ):
+            raise TypeError(msg)
+
+        elif not all(any(is_est_is_tuple(x)) for x in estimators):
             raise TypeError(msg)
 
         msg_no_mix = (

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -342,8 +342,6 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
         self.weights = weights
         super().__init__(forecasters=forecasters, n_jobs=n_jobs)
 
-        print("test")
-
         fc = []
         for forecaster in forecasters:
             if len(forecaster) <= 2:
@@ -361,8 +359,12 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
                 )
                 raise ValueError(msg)
 
-        self._forecasters = self._check_estimators(fc, clone_ests=False)
-        self.forecasters_ = self._check_estimators(fc, clone_ests=True)
+        self._forecasters = self._check_estimators(
+            fc, clone_ests=False, allow_empty=True
+        )
+        self.forecasters_ = self._check_estimators(
+            fc, clone_ests=True, allow_empty=True
+        )
 
         # the ensemble requires fh in fit
         # iff any of the component forecasters require fh in fit


### PR DESCRIPTION
This PR combines a refactor with a fix:

* brings `_HeterogeousMetaEstimator._check_estimator` to parity with `scikit-base`
* fixes issues with `EnsembleForecaster.__init__` introduced in https://github.com/sktime/sktime/pull/7424

The two are combined due to small footprint and dependency.