### PR TITLE
[BUG] fix `check_estimator` test in case of failure

### DIFF
--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -57,7 +57,7 @@ def _check_none_failed_and_only_few_skipped(result):
         * If any tests failed, i.e., return is not "PASSED".
         * If more than 10% of tests were skipped, i.e., return is "SKIP".
     """
-    assert not any(x == "FAILED" for x in result.values())
+    assert all(isinstance(x, str) for x in result.values())
 
     # Check less than 10% are skipped.
     skip_ratio = sum([x[:4] == "SKIP" for x in result.values()])

--- a/sktime/utils/tests/test_check_estimator.py
+++ b/sktime/utils/tests/test_check_estimator.py
@@ -54,9 +54,11 @@ def _check_none_failed_and_only_few_skipped(result):
     ------
     AssertionError
 
-        * If any tests failed, i.e., return is not "PASSED".
+        * If the input is not a dict.
+        * If any tests failed, i.e., return is not "PASSED" or a skip-related string.
         * If more than 10% of tests were skipped, i.e., return is "SKIP".
     """
+    assert isinstance(result, dict)
     assert all(isinstance(x, str) for x in result.values())
 
     # Check less than 10% are skipped.


### PR DESCRIPTION
The tests for `check_estimator` would fail with uninformative error, as the dict would contain `Exception` descendants in case of failure and not - as a subroutine assumed - strings starting with `FAIL` or similar.

This PR fixes this failure case and ensures the failure condition is clearly handled.