### PR TITLE
[ENH] Adds test params for `ComposableTimeSeriesForestRegressor`

### DIFF
--- a/sktime/regression/compose/_ensemble.py
+++ b/sktime/regression/compose/_ensemble.py
@@ -412,4 +412,7 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
-        return {"n_estimators": 3}
+        param1 = {"n_estimators": 3}
+        param2 = {"n_estimators": 5,"max_depth":5,"min_samples_split":4,"random_state":42}
+        param3 = {"n_estimators": 10,"max_depth":7,"min_samples_split":3.2}
+        return [param1,param2,param3]


### PR DESCRIPTION


#### Reference Issues/PRs
<!--
Example: Fixes #3429 
-->


#### What does this implement/fix? Explain your changes.
<!--
Added 2 new test parameters for the `ComposableTimeSeriesForestRegressor`. One of the parameters sets out a simpler version of the model, and the other two tests a more sophisticated model with one with seed (random_state = 42) and other with float value for (min_samples_split = 3.2).
-->

