### PR TITLE
[ENH] minor improvements to `BaseDetector`

### DIFF
--- a/sktime/annotation/bs.py
+++ b/sktime/annotation/bs.py
@@ -156,10 +156,6 @@ class BinarySegmentation(BaseDetector):
 
         return change_points
 
-    def _fit(self, X, Y=None):
-        """Fit method for compatibitility with sklearn-type interface."""
-        return self
-
     def _predict(self, X, Y=None):
         """Find the change points on 'X'.
 

--- a/sktime/annotation/hmm_learn/base.py
+++ b/sktime/annotation/hmm_learn/base.py
@@ -20,8 +20,9 @@ class BaseHMMLearn(BaseDetector):
     """Base class for all HMM wrappers, handles required overlap between packages."""
 
     _tags = {
+        "capability:multivariate": False,
         "univariate-only": True,
-        "fit_is_empty": True,
+        "fit_is_empty": False,
         "python_dependencies": "hmmlearn",
         "task": "segmentation",
         "learning_type": "unsupervised",

--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -68,12 +68,15 @@ class BaseDetector(BaseEstimator):
         # todo 0.37.0 switch order of series-annotator and detector
         # todo 1.0.0 - remove series-annotator
         "object_type": ["series-annotator", "detector"],  # type of object
-        "learning_type": "None",  # Tag to determine test in test_all_annotators
-        "task": "None",  # Tag to determine test in test_all_annotators
+        "learning_type": "None",  # supervised, unsupervised
+        "task": "None",  # anomaly_detection, change_point_detection, segmentation
+        "capability:multivariate": False,
+        "capability:missing_values": False,
+        "capability:update": False,
         #
-        # todo: distribution_type? we may have to refactor this, seems very soecufuc
-        "distribution_type": "None",  # Tag to determine test in test_all_annotators
-        "X_inner_mtype": "pd.DataFrame",  # Tag to determine test in test_all_annotators
+        # todo: distribution_type does not seem to be used - refactor or remove
+        "distribution_type": "None",
+        "X_inner_mtype": "pd.DataFrame",
     }
 
     def __init__(self):
@@ -143,6 +146,13 @@ class BaseDetector(BaseEstimator):
         _is_fitted flag to True.
         """
         X_inner = self._check_X(X)
+
+        # skip inner _fit if fit is empty
+        # we also do not need to memorize data, since we do same in _update
+        # basic checks (above) are still needed
+        if self.get_tag("fit_is_empty", False):
+            self._is_fitted = True
+            return self
 
         if Y is not None:
             warn(
@@ -301,6 +311,10 @@ class BaseDetector(BaseEstimator):
         self.check_is_fitted()
 
         X_inner = self._check_X(X)
+
+        # no update needed if fit is empty
+        if self.get_tag("fit_is_empty", False):
+            return self
 
         if Y is not None:
             warn(

--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -77,6 +77,7 @@ class BaseDetector(BaseEstimator):
         # todo: distribution_type does not seem to be used - refactor or remove
         "distribution_type": "None",
         "X_inner_mtype": "pd.DataFrame",
+        "fit_is_empty": False,
     }
 
     def __init__(self):

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -1531,6 +1531,48 @@ class transform_returns_same_time_index(_BaseTag):
     }
 
 
+# Detectors
+# ---------
+
+
+class capability__update(_BaseTag):
+    """Capability: whether the estimator can be run in stream or on-line mode.
+
+    - String name: ``"capability:update"``
+    - Public capability tag
+    - Values: boolean, ``True`` / ``False``
+    - Example: ``True``
+    - Default: ``False``
+
+    The tag specifies whether the estimator can be run in stream or on-line mode,
+    with an ``update`` method. Depending on the estimator type, literature
+    may refer to this as on-line learning, incremental learning, or stream learning.
+
+    If the tag is ``True``, the ``update`` method is implemented and can be used
+    to update the estimator with new data, without re-fitting the entire model.
+
+    If the tag is ``False``, behaviour depends on the estimator type,
+    two common cases are:
+
+    * ``update`` will raise an exception. Compositors may be available
+      to add on-line learning capabilities, these are typically listed in the
+      exception message.
+    * ``update`` will not raise an exception but carry out a reasonable default,
+      such as a full re-fit, or discard the new data.
+
+    For the exact behaviour, users should consult the documentation of the
+    respective ``update`` method.
+    """
+
+    _tags = {
+        "tag_name": "capability:update",
+        "parent_type": ["transformer", "detector"],
+        "tag_type": "bool",
+        "short_descr": "does the estimator provied stream/on-line capabilities via the update method?",  # noqa: E501
+        "user_facing": True,
+    }
+
+
 # Developer tags
 # --------------
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -1159,12 +1159,14 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
     def test_valid_estimator_class_tags(self, estimator_class):
         """Check that Estimator class tags are in VALID_ESTIMATOR_TAGS."""
         for tag in estimator_class.get_class_tags().keys():
-            assert tag in VALID_ESTIMATOR_TAGS
+            msg = "Found invalid tag: %s" % tag
+            assert tag in VALID_ESTIMATOR_TAGS, msg
 
     def test_valid_estimator_tags(self, estimator_instance):
         """Check that Estimator tags are in VALID_ESTIMATOR_TAGS."""
         for tag in estimator_instance.get_tags().keys():
-            assert tag in VALID_ESTIMATOR_TAGS
+            msg = "Found invalid tag: %s" % tag
+            assert tag in VALID_ESTIMATOR_TAGS, msg
 
 
 class TestAllEstimators(BaseFixtureGenerator, QuickTester):


### PR DESCRIPTION
This PR makes minor improvements to the `BaseDetector` class:

* extension of existing capability tags to detector
* addition of `capability:update` tag for offline vs online detection
* boilerplate code to skip `_fit` and `_update` if `fit_is_empty` tag is set
* fix incorrect value of `fit_is_empty` tag in `hmmlearn` estimators

Besides the above, an explicit error message is added in `TestAllEstimators`, closely related to testing tag vailidity of tags such as the above.