### PR TITLE
Enhance HTML representation of ColumnEnsembleTransformer

### DIFF
--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -201,6 +201,13 @@ class ColumnEnsembleTransformer(
             tags_to_clone = ["scitype:transform-output", "scitype:transform-labels"]
             self.clone_tags(transformers[0][1], tags_to_clone)
 
+    def _sk_visual_block_(self):
+        """Return visual block for HTML representation."""
+        from sklearn.utils import _visual_block
+
+        names, transformers, columns = zip(*self.transformers)
+        return _visual_block("parallel", transformers, names=names, columns=columns)
+
     @property
     def _transformers(self):
         """Make internal list of transformers.

--- a/sktime/transformations/tests/test_column_ensemble_transformer.py
+++ b/sktime/transformations/tests/test_column_ensemble_transformer.py
@@ -1,0 +1,23 @@
+import pandas as pd
+
+from sktime.transformations.compose import ColumnEnsembleTransformer
+from sktime.transformations.series.detrend import Detrender
+from sktime.transformations.series.difference import Differencer
+
+
+def test_column_ensemble_transformer_html_representation():
+    """Test HTML representation of ColumnEnsembleTransformer includes column names."""
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    transformer = ColumnEnsembleTransformer(
+        [("foo", Differencer(), "a"), ("bar", Detrender(), "b")]
+    )
+    transformer.fit(df)
+    html_repr = transformer._repr_html_()
+
+    assert "foo" in html_repr
+    assert "bar" in html_repr
+    assert "a" in html_repr
+    assert "b" in html_repr
+    assert "Differencer" in html_repr
+    assert "Detrender" in html_repr
+    assert "ColumnEnsembleTransformer" in html_repr


### PR DESCRIPTION
I've made changes as per the issue #7438 suggested, added a new method `_sk_visual_block_` to the `ColumnEnsembleTransformer `class. It returns a visual block for the HTML representation using the `_visual_block` function from `sklearn.utils` and wrote a test to check the changes
