### PR TITLE
[ENH] added test parameter set for ColumnTransformer

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -321,7 +321,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "ClustererPipeline",
         "ColumnConcatenator",
         "ColumnEnsembleClassifier",
-        "ColumnTransformer",
         "ColumnwiseTransformer",
         "ComposableTimeSeriesForestRegressor",
         "ContractableBOSS",

--- a/sktime/transformations/panel/compose.py
+++ b/sktime/transformations/panel/compose.py
@@ -212,16 +212,32 @@ class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
+        from sktime.transformations.series.detrend import Detrender
         from sktime.transformations.series.exponent import ExponentTransformer
 
-        TRANSFORMERS = [
-            ("transformer1", ExponentTransformer()),
-            ("transformer2", ExponentTransformer()),
+        TRANSFORMERS_1 = [
+            ("transformer1", ExponentTransformer(power=2)),
+            ("transformer2", ExponentTransformer(power=3)),
+        ]
+        TRANSFORMERS_2 = [
+            ("transformer1", ExponentTransformer(power=1)),
+            ("transformer2", Detrender()),
         ]
 
-        return {
-            "transformers": [(name, estimator, [0]) for name, estimator in TRANSFORMERS]
-        }
+        return [
+            {
+                "transformers": [
+                    (name, estimator, [0]) for name, estimator in TRANSFORMERS_1
+                ]
+            },
+            {
+                "transformers": [
+                    (name, estimator, [0]) for name, estimator in TRANSFORMERS_2
+                ],
+                "remainder": "passthrough",
+                "preserve_dataframe": False,
+            },
+        ]
 
     def fit(self, X, y=None):
         """Fit the transformer."""


### PR DESCRIPTION
In accordance with issue #7431, I have updated `get_test_params` method for `ColumnTransformer` to ensure 2 parameter tests sets.