### PR TITLE
[BUG] ensure `BaseDetector.transform` uses `iloc` indexing

### DIFF
--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -250,7 +250,7 @@ class BaseDetector(BaseEstimator):
               segments. Possible labels are integers starting from 0.
         """
         y = self.predict(X)
-        return self.sparse_to_dense(y, X.index)
+        return self.sparse_to_dense(y, pd.RangeIndex(len(X)))
 
     def transform_scores(self, X):
         """Return scores for predicted labels on test/deployment data.


### PR DESCRIPTION
This PR ensures that `BaseDetector.transform` uses `iloc` indexing.

Currently, it appears that the conversions still use `loc` indexing, which will be wrong in cases where `loc` and `iloc` diverge, e.g., for datetime-like indices.