### PR TITLE
[MNT] `detection` module - move CI from `annotation` module

### DIFF
--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -64,9 +64,9 @@ jobs:
           - windows-latest
         sktime-component:
           - alignment
-          - annotation
           - classification
           - clustering
+          - detection
           - forecasting
           - networks
           - param_est
@@ -128,6 +128,7 @@ jobs:
           --ignore sktime/annotation
           --ignore sktime/classification
           --ignore sktime/clustering
+          --ignore sktime/detection
           --ignore sktime/forecasting
           --ignore sktime/networks
           --ignore sktime/param_est

--- a/.github/workflows/test_module.yml
+++ b/.github/workflows/test_module.yml
@@ -19,10 +19,6 @@ jobs:
               - pyproject.toml
               - sktime/base/**
               - sktime/alignment/**
-            annotation:
-              - pyproject.toml
-              - sktime/base/**
-              - sktime/annotation/**
             classification:
               - pyproject.toml
               - sktime/base/**
@@ -31,6 +27,10 @@ jobs:
               - pyproject.toml
               - sktime/base/**
               - sktime/clustering/**
+            detection:
+              - pyproject.toml
+              - sktime/base/**
+              - sktime/detection/**
             forecasting:
               - pyproject.toml
               - sktime/base/**

--- a/.github/workflows/test_other.yml
+++ b/.github/workflows/test_other.yml
@@ -77,6 +77,7 @@ jobs:
           --ignore sktime/annotation
           --ignore sktime/classification
           --ignore sktime/clustering
+          --ignore sktime/detection
           --ignore sktime/forecasting
           --ignore sktime/networks
           --ignore sktime/param_est


### PR DESCRIPTION
With the full transfer of tests from `annotation` to `detection`, the CI for the `detection` alias `annotation` module should be pointed to the `detection` module.

This PR carries out that change of pointer.