### PR TITLE
[ENH] `skchange` rename of `Capa` to `CAPA`

### DIFF
--- a/examples/07_detection_anomaly_changepoints.ipynb
+++ b/examples/07_detection_anomaly_changepoints.ipynb
@@ -596,7 +596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "4249c512-6285-4a5a-bce3-1e13c771faee",
    "metadata": {},
    "outputs": [
@@ -613,9 +613,9 @@
     }
    ],
    "source": [
-    "from skchange.anomaly_detectors.capa import Capa\n",
+    "from skchange.anomaly_detectors.capa import CAPA\n",
     "\n",
-    "model = Capa(max_segment_length=350)\n",
+    "model = CAPA(max_segment_length=350)\n",
     "model.fit(df[\"data\"])\n",
     "anomaly_intervals = model.predict(df[\"data\"])\n",
     "anomaly_intervals"


### PR DESCRIPTION
This PR renames `Capa` to `CAPA` in the detection notebook, following the same rename in `skchange`.