### PR TITLE
[ENH] homogenization of sktime and skchange detection API - base class `predict_scores` return type

### DIFF
--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -295,8 +295,9 @@ class BaseDetector(BaseEstimator):
         self.check_is_fitted()
 
         X_inner = self._check_X(X)
+        scores = self._predict_scores(X_inner)
 
-        return self._predict_scores(X_inner)
+        return pd.DataFrame(scores)
 
     def update(self, X, y=None, Y=None):
         """Update model with new data and optional ground truth labels.

--- a/sktime/detection/tests/test_clasp.py
+++ b/sktime/detection/tests/test_clasp.py
@@ -30,7 +30,7 @@ def test_clasp_sparse():
     scores = clasp.predict_scores(ts)
 
     assert len(found_cps) == 1 and found_cps[0] == 893
-    assert len(scores) == 1 and scores[0] > 0.74
+    assert len(scores) == 1 and scores.iloc[0, 0] > 0.74
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->

This change is part of the ongoing effort to homogenize the base class detection module and ensure compliance across the BaseDetector hierarchy, as listed in #7323.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

- Updates the `predict_scores` method of the `BaseDetector` class to ensure its return type complies with the updated contract, as described in the class docstring. Specifically, the `predict_scores` method now guarantees that its return type is always a `pd.DataFrame` with the same index as `predict`'s return type of `pd.Series`.
- Updates `test_clasp_sparse` in the `test_clasp` suite to expect a `pd.DataFrame` return type and appropriately index into it

<!--
Thanks for contributing!
-->
