### PR TITLE
[ENH] fix API incompatibility of `SubLOF` detector

### DIFF
--- a/sktime/detection/compose/_pipeline.py
+++ b/sktime/detection/compose/_pipeline.py
@@ -369,7 +369,7 @@ class DetectorPipeline(_HeterogenousMetaEstimator, BaseDetector):
 
         from sklearn.preprocessing import StandardScaler
 
-        from sktime.annotation.lof import SubLOF
+        from sktime.detection.lof import SubLOF
         from sktime.transformations.series.adapt import TabularToSeriesAdaptor
         from sktime.transformations.series.detrend import Detrender
         from sktime.transformations.series.exponent import ExponentTransformer

--- a/sktime/detection/lof.py
+++ b/sktime/detection/lof.py
@@ -224,6 +224,7 @@ class SubLOF(BaseDetector):
         """
         if isinstance(X, pd.Series):
             X = X.to_frame()
+        X["__id"] = pd.RangeIndex(len(X))
 
         y_all = []
         for interval, model in self.models.items():
@@ -232,8 +233,8 @@ class SubLOF(BaseDetector):
             if len(X_subset) == 0:
                 continue
 
-            y_subset = model.predict(X_subset)
-            anomaly_indexes = np.where(y_subset == -1)[0]
+            y_subset = model.predict(X_subset.iloc[:, [0]])
+            anomaly_indexes = np.where(y_subset == -1)[0] + X_subset["__id"].iloc[0]
             y_all.append(pd.Series(anomaly_indexes))
 
         if len(y_all) == 0:

--- a/sktime/detection/lof.py
+++ b/sktime/detection/lof.py
@@ -227,8 +227,6 @@ class SubLOF(BaseDetector):
 
         y_all = []
         for interval, model in self.models.items():
-            print(X.index)
-            print(interval)
             X_subset = X.loc[(X.index >= interval.left) & (X.index < interval.right)]
 
             if len(X_subset) == 0:

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -301,11 +301,6 @@ EXCLUDED_TESTS = {
         "test_predict_segments",
         "test_transform_output_type",
     ],
-    "SubLOF": [
-        "test_predict_points",
-        "test_predict_segments",
-        "test_transform_output_type",
-    ],
 }
 
 # exclude tests but keyed by test name

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -269,11 +269,6 @@ EXCLUDED_TESTS = {
         "test_predict_segments",
         "test_transform_output_type",
     ],
-    "DetectorPipeline": [
-        "test_predict_points",
-        "test_predict_segments",
-        "test_transform_output_type",
-    ],
     "BinarySegmentation": [
         "test_predict_segments",
         "test_transform_output_type",
@@ -411,7 +406,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "SlidingWindowSegmenter",
         "SlopeTransformer",
         "StackingForecaster",
-        "SubLOF",
         "SummaryClassifier",
         "SupervisedIntervals",
         "SupervisedTimeSeriesForest",


### PR DESCRIPTION
This PR fixes the API incompatibility of the `SubLOF` detector - this is crucial as it was used as a component in other detector test casess such as the `DetectorPipeline`.

Consequently, this PR re-enables tests of `SubLOF` and also `DetectorPipeline`. Fixes #7415.