### PR TITLE
DIAGNOSTIC: forecasters with `remember_data=False` config

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -120,7 +120,7 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         #  "joblib": uses custom joblib backend, set via `joblib_backend` tag
         #  "dask": uses `dask`, requires `dask` package in environment
         "backend:parallel:params": None,  # params for parallelization backend
-        "remember_data": True,  # whether to remember data in fit - self._X, self._y
+        "remember_data": False,  # whether to remember data in fit - self._X, self._y
     }
 
     _config_doc = {


### PR DESCRIPTION
Diagnostic towards https://github.com/sktime/sktime/issues/7416 for the more general topic of being memory aware.

Changes the default `remember_data` config to `False`, preventing memorization of `_X`, `_y` attributes.

