### PR TITLE
[ENH] homogenization of sktime and skchange detection API - `predict`, `predict_points`, `predict_segments`

### DIFF
--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -242,13 +242,15 @@ class BaseDetector(BaseEstimator):
             * ``"label"`` - if the task, by tags, is supervised or semi-supervised
               segmentation, or segment clustering.
 
-            The meaning of segments in the ``"ilocs"`` column and ``"labels"``
+            The meaning of entries in the ``"ilocs"`` column and ``"labels"``
             column is as follows:
 
             * If ``task`` is ``"anomaly_detection"`` or ``"change_point_detection"``,
-              the intervals are intervals between changepoints/anomalies, and
-              potential labels are consecutive integers starting from 0.
-            * If ``task`` is ``"segmentation"``, the values are segmentation labels.
+              ``"ilocs"`` contains the iloc index of the event, and
+              labels (if present) signify types of events.
+            * If ``task`` is ``"segmentation"``, ``"ilocs"`` contains left-closed
+              intervals of iloc based segments, and labels (if present)
+              are types of segments.
         """
         self.check_is_fitted()
 

--- a/sktime/detection/dummy/_dummy_regular_an.py
+++ b/sktime/detection/dummy/_dummy_regular_an.py
@@ -25,7 +25,7 @@ class DummyRegularAnomalies(BaseDetector):
     >>> from sktime.detection.dummy import DummyRegularAnomalies
     >>> y = pd.Series([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     >>> d = DummyRegularAnomalies(step_size=3)
-    >>> d.fit_transform(y)
+    >>> yt = d.fit_transform(y)
     """
 
     _tags = {
@@ -61,7 +61,10 @@ class DummyRegularAnomalies(BaseDetector):
         self :
             Reference to self.
         """
-        self.first_index_ = X.index[0]
+        X_index = X.index
+        if isinstance(X_index, pd.DatetimeIndex):
+            X_index = pd.PeriodIndex(X_index)
+        self.first_index_ = X_index[0]
         return self
 
     def _predict(self, X):
@@ -87,6 +90,9 @@ class DummyRegularAnomalies(BaseDetector):
         step_size = self.step_size
 
         X_index = X.index
+        if isinstance(X_index, pd.DatetimeIndex):
+            X_index = pd.PeriodIndex(X_index)
+
         first_index = self.first_index_
 
         offset = X_index - first_index
@@ -97,8 +103,10 @@ class DummyRegularAnomalies(BaseDetector):
             offset = pd.Index(offset)
 
         change_point_indicator = offset % step_size == step_size - 1
-        X_ix_cp = X_index[change_point_indicator]
-        change_points = pd.Series(X_ix_cp)
+
+        X_range = pd.RangeIndex(len(X))
+        X_ix_cp = X_range[change_point_indicator]
+        change_points = pd.Series(X_ix_cp, dtype="int64")
         return change_points
 
     @classmethod

--- a/sktime/detection/dummy/_dummy_regular_cp.py
+++ b/sktime/detection/dummy/_dummy_regular_cp.py
@@ -23,7 +23,7 @@ class DummyRegularChangePoints(DummyRegularAnomalies):
     >>> from sktime.detection.dummy import DummyRegularChangePoints
     >>> y = pd.Series([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     >>> d = DummyRegularChangePoints(step_size=3)
-    >>> d.fit_transform(y)
+    >>> yt = d.fit_transform(y)
     """
 
     # same code except the tag

--- a/sktime/detection/tests/test_all_detectors.py
+++ b/sktime/detection/tests/test_all_detectors.py
@@ -83,7 +83,10 @@ class TestAllDetectors(DetectorFixtureGenerator, QuickTester):
             estimator_type=estimator_instance.get_tag("distribution_type"),
         )
         y_pred = estimator_instance.predict_points(X_test)
-        assert isinstance(y_pred, pd.Series)
+        assert isinstance(y_pred, pd.DataFrame)
+        assert isinstance(y_pred.index, pd.RangeIndex)
+        assert "ilocs" in y_pred.columns
+        assert pd.api.types.is_integer_dtype(y_pred["ilocs"].dtype), y_pred
 
     def test_predict_segments(self, estimator_instance):
         X_train = make_detection_problem(
@@ -96,10 +99,13 @@ class TestAllDetectors(DetectorFixtureGenerator, QuickTester):
             n_timepoints=10,
             estimator_type=estimator_instance.get_tag("distribution_type"),
         )
-        y_test = estimator_instance.predict_segments(X_test)
-        assert isinstance(y_test, pd.Series)
-        assert isinstance(y_test.index.dtype, pd.IntervalDtype)
-        assert pd.api.types.is_integer_dtype(y_test)
+        y_pred = estimator_instance.predict_segments(X_test)
+        assert isinstance(y_pred, pd.DataFrame)
+        assert isinstance(y_pred.index, pd.RangeIndex)
+        assert "ilocs" in y_pred.columns
+        ilocs_dtype = y_pred["ilocs"].dtype
+        assert isinstance(y_pred["ilocs"].dtype, pd.IntervalDtype)
+        assert pd.api.types.is_integer_dtype(ilocs_dtype.subtype)
 
     def test_detector_tags(self, estimator_class):
         """Check the learning_type and task tags are valid."""


### PR DESCRIPTION
This PR carries out some remaining steps of interface homogenization with `skchange`:

* index of returns of `predict`, `predict_points`, `predict_segments` is now always a `RangeIndex` - no key information requires index manipulation anymore.
* return of `predict_points`, `predict_segments` is now always a `pd.DataFrame`, with one column `"ilocs"` for the event indices, and additional potential columns in supervised and semi-supervised cases
* return of `predict` is `pd.Series` in the unsupervised case, otherwise also `pd.DataFrame`, and identical with one of `predict_points` or `predict_segments` in the supervised and semi-supervised case

Also updates some estimators to function as expected:

* existing estimators through coercions to the desired output
* dummy estimators