### PR TITLE
[MNT] add upper bound to skforecast autoreg adapter

### DIFF
--- a/sktime/forecasting/compose/_skforecast_reduce.py
+++ b/sktime/forecasting/compose/_skforecast_reduce.py
@@ -132,7 +132,7 @@ class SkforecastAutoreg(BaseForecaster):
         "capability:pred_int:insample": False,
         "capability:categorical_in_X": True,
         "python_version": ">=3.8,<3.13",
-        "python_dependencies": ["skforecast>=0.12.1"],
+        "python_dependencies": ["skforecast<0.14,>=0.12.1"],
     }
 
     def __init__(


### PR DESCRIPTION
Towards #7451

As outlined in https://github.com/sktime/sktime/issues/7451#issuecomment-2506334247, this PR restricts `SkforecastAutoreg` to `skforecast<0.14`. There will be no user visible changes for the time being since skforecast is bounded in pyproject.toml similarly so far.