### PR TITLE
[MNT] remove top level import of transformers

### DIFF
--- a/sktime/forecasting/hf_transformers_forecaster.py
+++ b/sktime/forecasting/hf_transformers_forecaster.py
@@ -15,10 +15,6 @@ else:
         """Dummy class if torch is unavailable."""
 
 
-if _check_soft_dependencies("transformers", severity="none"):
-    import transformers
-    from transformers import AutoConfig, Trainer, TrainingArguments
-
 from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
 
 __author__ = ["benheid", "geetu040"]
@@ -173,6 +169,8 @@ class HFTransformersForecaster(BaseForecaster):
         self.peft_config = peft_config
 
     def _fit(self, y, X, fh):
+        from transformers import AutoConfig, Trainer, TrainingArguments
+
         # Load model and extract config
         config = AutoConfig.from_pretrained(self.model_path)
 
@@ -305,6 +303,8 @@ class HFTransformersForecaster(BaseForecaster):
         trainer.train()
 
     def _predict(self, fh, X=None):
+        import transformers
+
         if self.deterministic:
             transformers.set_seed(42)
 

--- a/sktime/forecasting/ttm.py
+++ b/sktime/forecasting/ttm.py
@@ -20,10 +20,6 @@ else:
         """Dummy class if torch is unavailable."""
 
 
-if _check_soft_dependencies("transformers", severity="none"):
-    from transformers import Trainer, TrainingArguments
-
-
 class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     """
     TinyTimeMixer Forecaster for Zero-Shot Forecasting of Multivariate Time Series.
@@ -218,6 +214,8 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
         -------
         self : reference to self
         """
+        from transformers import Trainer, TrainingArguments
+
         if self.use_source_package:
             from tsfm_public.models.tinytimemixer import (
                 TinyTimeMixerConfig,


### PR DESCRIPTION
Addressing the CI failures observed in #7488

> RuntimeError: Failed to import transformers.trainer because of the following error (look up to see its traceback): cannot import name 'EncoderDecoderCache' from 'transformers' (/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/transformers/init.py)