### PR TITLE
[MNT] bound `peft<0.14.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,7 +286,7 @@ datasets = [
 dl = [
   'FrEIA; python_version < "3.12"',
   'neuralforecast<1.8.0,>=1.6.4; python_version < "3.11"',
-  'peft>=0.10.0; python_version < "3.12"',
+  'peft>=0.10.0,<0.14.0; python_version < "3.12"',
   'tensorflow<2.17,>=2; python_version < "3.12"',
   'torch; python_version < "3.12"',
   'transformers[torch]<4.41.0; python_version < "3.12"',


### PR DESCRIPTION
It seems that the new minor version of `peft` is causing the problems in https://github.com/sktime/sktime/issues/7492.

This PR adds an upper bound on `peft` that prevents this newer version, 0.14.0, from being installed.

Not a conclusive fix for #7492, but should ensure stability of dependencies until fixed.