### PR TITLE
[BUG] Fix codec error on traditional Chinese Windows systems

### DIFF
--- a/sktime/utils/_estimator_html_repr.py
+++ b/sktime/utils/_estimator_html_repr.py
@@ -185,7 +185,9 @@ def _write_base_object_html(
         )
 
 
-with open(Path(__file__).parent / "_estimator_html_repr.css") as style_file:
+with open(
+    Path(__file__).parent / "_estimator_html_repr.css", encoding="utf-8"
+) as style_file:
     # use the style defined in the css file
     _STYLE = style_file.read()
 


### PR DESCRIPTION
This PR addresses the issue raised about encoding scheme when parsing html files on traditional Chinese windows systems, we are supposed to pass the `encoding` argument  to the open function to enforce `ute-8`

closes https://github.com/sktime/sktime/issues/7479
