### PR TITLE
[ENH] detection module rework - populate author and maintainer tags

### DIFF
--- a/sktime/detection/adapters/_pyod.py
+++ b/sktime/detection/adapters/_pyod.py
@@ -34,6 +34,12 @@ class PyODDetector(BaseDetector):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["mloning", "satya-pattnaik", "fkiraly"],
+        "maintainers": "satya-pattnaik",
+        # estimator type
+        # --------------
         "python_dependencies": "pyod",
         "task": "anomaly_detection",
         "learning_type": "unsupervised",

--- a/sktime/detection/bs.py
+++ b/sktime/detection/bs.py
@@ -53,6 +53,12 @@ class BinarySegmentation(BaseDetector):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": "Alex-JG3",
+        "maintainers": "Alex-JG3",
+        # estimator type
+        # --------------
         "fit_is_empty": True,
         "univariate-only": True,
         "task": "change_point_detection",

--- a/sktime/detection/clasp.py
+++ b/sktime/detection/clasp.py
@@ -215,6 +215,12 @@ class ClaSPSegmentation(BaseDetector):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["ermshaua", "patrickzib"],
+        "maintainers": "ermshaua",
+        # estimator type
+        # --------------
         "task": "change_point_detection",
         "learning_type": "unsupervised",
         "univariate-only": True,

--- a/sktime/detection/clust.py
+++ b/sktime/detection/clust.py
@@ -38,6 +38,12 @@ class ClusterSegmenter(BaseDetector):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": "Ankit-1204",
+        "maintainers": "Ankit-1204",
+        # estimator type
+        # --------------
         "task": "segmentation",
         "learning_type": "unsupervised",
     }

--- a/sktime/detection/compose/_pipeline.py
+++ b/sktime/detection/compose/_pipeline.py
@@ -41,8 +41,14 @@ class DetectorPipeline(_HeterogenousMetaEstimator, BaseDetector):
     >>> y_hat = pipeline.transform(x)
     """
 
-    # Change the `task` and `learning_type` as needed
-    _tags = {"learning_type": "unsupervised"}
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": "fkiraly",
+        # estimator type
+        # --------------
+        "learning_type": "unsupervised",
+    }
 
     # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self

--- a/sktime/detection/eagglo.py
+++ b/sktime/detection/eagglo.py
@@ -81,6 +81,12 @@ class EAgglo(BaseTransformer):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": "KatieBuc",
+        "maintainers": "KatieBuc",
+        # estimator type
+        # --------------
         "fit_is_empty": False,
     }
 

--- a/sktime/detection/ggs.py
+++ b/sktime/detection/ggs.py
@@ -425,6 +425,11 @@ class GreedyGaussianSegmentation(BaseDetector):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": "lmmentel",
+        # estimator type
+        # --------------
         "fit_is_empty": True,
         "task": "segmentation",
         "learning_type": "unsupervised",

--- a/sktime/detection/hmm.py
+++ b/sktime/detection/hmm.py
@@ -129,6 +129,12 @@ class HMM(BaseDetector):
 
     # plan to update to make multivariate.
     _tags = {
+        # packaging info
+        # --------------
+        "authors": "miraep8",
+        "maintainers": "miraep8",
+        # estimator type
+        # --------------
         "univariate-only": True,
         "fit_is_empty": True,
         "task": "segmentation",

--- a/sktime/detection/hmm_learn/base.py
+++ b/sktime/detection/hmm_learn/base.py
@@ -20,6 +20,12 @@ class BaseHMMLearn(BaseDetector):
     """Base class for all HMM wrappers, handles required overlap between packages."""
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": "miraep8",
+        "maintainers": "miraep8",
+        # estimator type
+        # --------------
         "capability:multivariate": False,
         "univariate-only": True,
         "fit_is_empty": False,

--- a/sktime/detection/lof.py
+++ b/sktime/detection/lof.py
@@ -125,6 +125,12 @@ class SubLOF(BaseDetector):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": "Alex-JG3",
+        "maintainers": "Alex-JG3",
+        # estimator type
+        # --------------
         "task": "anomaly_detection",
         "learning_type": "unsupervised",
         "univariate-only": False,

--- a/sktime/detection/stray.py
+++ b/sktime/detection/stray.py
@@ -76,6 +76,12 @@ class STRAY(BaseTransformer):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": "KatieBuc",
+        "maintainers": "KatieBuc",
+        # estimator type
+        # --------------
         "handles-missing-data": True,
         "X_inner_mtype": "np.ndarray",
         "fit_is_empty": False,


### PR DESCRIPTION
This PR populates the author and maintainer tags of estimators in the detection module that predate the major rework - these did not have the tags properly populated.

Tags are populated from commit history and/or author fields on module level.