### PR TITLE
[ENH] refactor forecasting metric tests prep - object_type tag `metric_forecasting`

### DIFF
--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -127,6 +127,7 @@ class BaseForecastingErrorMetric(BaseMetric):
     """
 
     _tags = {
+        "object_type": ["metric_forecasting", "metric"],
         "requires-y-train": False,
         "requires-y-pred-benchmark": False,
         "univariate-only": False,

--- a/sktime/registry/_base_classes.py
+++ b/sktime/registry/_base_classes.py
@@ -213,6 +213,24 @@ class metric(_BaseScitypeOfObject):
         return BaseMetric
 
 
+class metric_forecasting(_BaseScitypeOfObject):
+    """Performance metric for time series forecasting."""
+
+    _tags = {
+        "scitype_name": "metric_forecasting",
+        "short_descr": "performance metric for forecasting",
+        "parent_scitype": "metric",
+    }
+
+    @classmethod
+    def get_base_class(cls):
+        from sktime.performance_metrics.forecasting._classes import (
+            BaseForecastingMetric,
+        )
+
+        return BaseForecastingMetric
+
+
 class network(_BaseScitypeOfObject):
     """Deep learning network for time series."""
 


### PR DESCRIPTION
Step 1 in a refactor of tests for forecasting metrics towards an `skbase` idiomatic design.

This PR adds a specific object type for forecasting performance metrics, which can be used later in writing a "test all" class and `check_estimator` integration.