### PR TITLE
[DOC] add proper credits to hfawaz and dl-4-tsc in various time series classifiers

### DIFF
--- a/sktime/classification/deep_learning/cnn.py
+++ b/sktime/classification/deep_learning/cnn.py
@@ -15,6 +15,9 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class CNNClassifier(BaseDeepClassifier):
     """Time Convolutional Neural Network (CNN), as described in [1]_.
 
+    Adapted from the implementation from Fawaz et. al
+    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/cnn.py
+
     Parameters
     ----------
     n_epochs       : int, default = 2000
@@ -51,11 +54,6 @@ class CNNClassifier(BaseDeepClassifier):
           ``input_shape[0] < 60`` in the input layer, and ``"valid"`` otherwise.
         - "valid", "same", and other values are passed directly to ``Conv1D``
 
-    Notes
-    -----
-    Adapted from the implementation from Fawaz et. al
-    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/cnn.py
-
     References
     ----------
     .. [1] Zhao et. al, Convolutional neural networks for time series classification,
@@ -75,7 +73,8 @@ class CNNClassifier(BaseDeepClassifier):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["James-Large", "TonyBagnall"],
+        "authors": ["hfawaz", "James-Large"],
+        # hfawaz for dl-4-tsc
         "maintainers": ["James-Large"],
         "python_dependencies": "tensorflow",
         # estimator type handled by parent class

--- a/sktime/classification/deep_learning/cntc.py
+++ b/sktime/classification/deep_learning/cntc.py
@@ -12,6 +12,9 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class CNTCClassifier(BaseDeepClassifier):
     """Contextual Time-series Neural Classifier (CNTC), as described in [1].
 
+    Adapted from the implementation from Fullah et. al
+    https://github.com/AmaduFullah/CNTC_MODEL/blob/master/cntc.ipynb
+
     Parameters
     ----------
     n_epochs       : int, default = 2000
@@ -37,11 +40,6 @@ class CNTCClassifier(BaseDeepClassifier):
         fit parameter for the keras model
     optimizer       : keras.optimizer, default=keras.optimizers.Adam(),
     metrics         : list of strings, default=["accuracy"],
-
-    Notes
-    -----
-    Adapted from the implementation from Fullah et. al
-    https://github.com/AmaduFullah/CNTC_MODEL/blob/master/cntc.ipynb
 
     References
     ----------
@@ -73,7 +71,13 @@ class CNTCClassifier(BaseDeepClassifier):
     """
 
     _tags = {
-        "authors": ["James-Large", "Withington", "TonyBagnall", "AurumnPegasus"],
+        "authors": [
+            "AmaduFullah",
+            "James-Large",
+            "Withington",
+            "TonyBagnall",
+            "AurumnPegasus",
+        ],
         "maintainers": ["James-Large", "Withington", "AurumnPegasus"],
         "python_dependencies": ["tensorflow", "keras-self-attention"],
     }

--- a/sktime/classification/deep_learning/fcn.py
+++ b/sktime/classification/deep_learning/fcn.py
@@ -15,6 +15,9 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class FCNClassifier(BaseDeepClassifier):
     """Fully Connected Neural Network (FCN), as described in [1]_.
 
+    Adapted from the implementation from Fawaz et. al
+    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/fcn.py
+
     Parameters
     ----------
     should inherited fields be listed here?
@@ -39,11 +42,6 @@ class FCNClassifier(BaseDeepClassifier):
     optimizer       : keras.optimizers object, default = Adam(lr=0.01)
         specify the optimizer and the learning rate to be used.
 
-    Notes
-    -----
-    Adapted from the implementation from Fawaz et. al
-    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/fcn.py
-
     References
     ----------
     .. [1] Zhao et. al, Convolutional neural networks for time series classification,
@@ -63,7 +61,8 @@ class FCNClassifier(BaseDeepClassifier):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["James-Large", "AurumnPegasus"],
+        "authors": ["hfawaz", "James-Large", "AurumnPegasus"],
+        # hfawaz for dl-4-tsc
         "maintainers": ["James-Large", "AurumnPegasus"],
         # estimator type handled by parent class
     }

--- a/sktime/classification/deep_learning/lstmfcn.py
+++ b/sktime/classification/deep_learning/lstmfcn.py
@@ -15,10 +15,8 @@ from sktime.networks.lstmfcn import LSTMFCNNetwork
 class LSTMFCNClassifier(BaseDeepClassifier):
     """Implementation of LSTMFCNClassifier from Karim et al (2019) [1].
 
-    Overview
-    --------
-     Combines an LSTM arm with a CNN arm. Optionally uses an attention mechanism in the
-     LSTM which the author indicates provides improved performance.
+    Combines an LSTM arm with a CNN arm. Optionally uses an attention mechanism in the
+    LSTM which the author indicates provides improved performance.
 
     Parameters
     ----------

--- a/sktime/classification/deep_learning/mcdcnn.py
+++ b/sktime/classification/deep_learning/mcdcnn.py
@@ -15,6 +15,9 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class MCDCNNClassifier(BaseDeepClassifier):
     """Multi Channel Deep Convolutional Neural Classifier, as described in [1]_.
 
+    Adapted from the implementation of Fawaz et. al
+    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/mcdcnn.py
+
     Parameters
     ----------
     n_epochs : int, optional (default=120)
@@ -57,11 +60,6 @@ class MCDCNNClassifier(BaseDeepClassifier):
     random_state : int, optional (default=0)
         The seed to any random action.
 
-    Notes
-    -----
-    Adapted from the implementation of Fawaz et. al
-    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/mcdcnn.py
-
     References
     ----------
     .. [1] Zheng et. al, Time series classification using multi-channels deep
@@ -81,7 +79,7 @@ class MCDCNNClassifier(BaseDeepClassifier):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["james-large"],
+        "authors": ["hfawaz", "james-large"],
         "maintainers": ["james-large"],
         "python_dependencies": "tensorflow",
         # estimator type handled by parent class

--- a/sktime/classification/deep_learning/mlp.py
+++ b/sktime/classification/deep_learning/mlp.py
@@ -15,6 +15,9 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class MLPClassifier(BaseDeepClassifier):
     """Multi Layer Perceptron Network (MLP), as described in [1]_.
 
+    Adapted from the implementation from source code
+    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/mlp.py
+
     Parameters
     ----------
     should inherited fields be listed here?
@@ -39,11 +42,6 @@ class MLPClassifier(BaseDeepClassifier):
     optimizer       : keras.optimizers object, default = Adam(lr=0.01)
         specify the optimizer and the learning rate to be used.
 
-    Notes
-    -----
-    Adapted from the implementation from source code
-    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/mlp.py
-
     References
     ----------
     .. [1] Wang et. al, Time series classification from
@@ -63,7 +61,8 @@ class MLPClassifier(BaseDeepClassifier):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["James-Large", "AurumnPegasus"],
+        "authors": ["hfawaz", "James-Large", "AurumnPegasus"],
+        # hfawaz for dl-4-tsc
         "maintainers": ["James-Large", "AurumnPegasus"],
         # estimator type handled by parent class
     }

--- a/sktime/classification/deep_learning/resnet.py
+++ b/sktime/classification/deep_learning/resnet.py
@@ -15,6 +15,9 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class ResNetClassifier(BaseDeepClassifier):
     """Residual Neural Network as described in [1].
 
+    Adapted from the implementation from source code
+    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/resnet.py
+
     Parameters
     ----------
     n_epochs       : int, default = 1500
@@ -38,12 +41,6 @@ class ResNetClassifier(BaseDeepClassifier):
     optimizer       : keras.optimizers object, default = Adam(lr=0.01)
         specify the optimizer and the learning rate to be used.
 
-
-    Notes
-    -----
-    Adapted from the implementation from source code
-    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/resnet.py
-
     References
     ----------
         .. [1] Wang et. al, Time series classification from
@@ -63,7 +60,8 @@ class ResNetClassifier(BaseDeepClassifier):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["James-Large", "AurumnPegasus", "nilesh05apr"],
+        "authors": ["hfawaz", "James-Large", "AurumnPegasus", "nilesh05apr"],
+        # hfawaz for dl-4-tsc
         "maintainers": ["James-Large", "AurumnPegasus", "nilesh05apr"],
         "python_dependencies": ["tensorflow"],
         # estimator type handled by parent class

--- a/sktime/networks/cnn.py
+++ b/sktime/networks/cnn.py
@@ -9,7 +9,7 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class CNNNetwork(BaseDeepNetwork):
     """Establish the network structure for a CNN.
 
-    Adapted from the implementation used in [1]
+    Adapted from the implementation used in [1]_.
 
     Parameters
     ----------
@@ -31,18 +31,18 @@ class CNNNetwork(BaseDeepNetwork):
     random_state    : int, default = 0
         seed to any needed random actions
 
-    Notes
-    -----
-    Adapted from source code
-    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/cnn.py
-
     References
     ----------
     .. [1] Zhao et al. Convolutional neural networks for time series classification,
     Journal of Systems Engineering and Electronics 28(1), 162--169, 2017
     """
 
-    _tags = {"python_dependencies": "tensorflow"}
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": ["hfawaz"],
+        "python_dependencies": "tensorflow",
+    }
 
     def __init__(
         self,

--- a/sktime/networks/fcn.py
+++ b/sktime/networks/fcn.py
@@ -9,17 +9,15 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class FCNNetwork(BaseDeepNetwork):
     """Establish the network structure for a FCN.
 
-    Adapted from the implementation used in [1]
+    Adapted from the implementation of Fawaz et. al
+    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/fcn.py
+
+    Implements network in [1]_.
 
     Parameters
     ----------
-    random_state    : int, default = 0
+    random_states : int, default = 0
         seed to any needed random actions
-
-    Notes
-    -----
-    Adapted from the implementation from Fawaz et. al
-    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/fcn.py
 
     References
     ----------

--- a/sktime/networks/inceptiontime.py
+++ b/sktime/networks/inceptiontime.py
@@ -24,7 +24,10 @@ class InceptionTimeNetwork(BaseDeepNetwork):
                     ArXiv}, Year                     = {2019} }
     """
 
-    _tags = {"python_dependencies": "tensorflow"}
+    _tags = {
+        "authors": ["hfawaz", "JamesLarge", "Withington"],
+        "python_dependencies": "tensorflow",
+    }
 
     def __init__(
         self,

--- a/sktime/networks/mcdcnn.py
+++ b/sktime/networks/mcdcnn.py
@@ -1,6 +1,6 @@
 """Multi Channel Deep Convolution Neural Network (MCDCNN)."""
 
-__author__ = ["James Large", "Withington"]
+__author__ = ["James-Large", "Withington"]
 
 from sktime.networks.base import BaseDeepNetwork
 from sktime.utils.dependencies import _check_dl_dependencies
@@ -10,7 +10,7 @@ class MCDCNNNetwork(BaseDeepNetwork):
     """
     Multi Channel Deep Convolutional Neural Network (MCDCNN).
 
-    Adapted from the implementation from Fawaz et. al:
+    Adapted from the implementation of Fawaz et. al:
     https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/mcdcnn.py
 
     Parameters
@@ -35,7 +35,10 @@ class MCDCNNNetwork(BaseDeepNetwork):
         The seed to any random action.
     """
 
-    _tags = {"python_dependencies": "tensorflow"}
+    _tags = {
+        "authors": ["hfawaz", "James-Large", "Withington"],
+        "python_dependencies": "tensorflow",
+    }
 
     def __init__(
         self,

--- a/sktime/networks/mlp.py
+++ b/sktime/networks/mlp.py
@@ -9,17 +9,15 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class MLPNetwork(BaseDeepNetwork):
     """Establish the network structure for a MLP.
 
-    Adapted from the implementation used in [1]
+    Adapted from the implementation from source code
+    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/mlp.py
+
+    Implements a simple MLP network, as in [1]_.
 
     Parameters
     ----------
     random_state    : int, default = 0
         seed to any needed random actions
-
-    Notes
-    -----
-    Adapted from the implementation from source code
-    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/mlp.py
 
     References
     ----------
@@ -31,7 +29,10 @@ class MLPNetwork(BaseDeepNetwork):
     1578--1585}, year={2017}, organization={IEEE} }
     """
 
-    _tags = {"python_dependencies": "tensorflow"}
+    _tags = {
+        "authors": ["hfawaz", "James-Large", "Withington", "AurumnPegasus"],
+        "python_dependencies": "tensorflow",
+    }
 
     def __init__(
         self,

--- a/sktime/networks/resnet.py
+++ b/sktime/networks/resnet.py
@@ -1,6 +1,6 @@
 """Residual Network (ResNet) (minus the final output layer)."""
 
-__author__ = ["James Large", "Withington", "nilesh05apr"]
+__author__ = ["James-Large", "Withington", "nilesh05apr"]
 
 from sktime.networks.base import BaseDeepNetwork
 from sktime.utils.dependencies import _check_dl_dependencies
@@ -9,17 +9,13 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class ResNetNetwork(BaseDeepNetwork):
     """Establish the network structure for a ResNet.
 
-    Adapted from the implementations used in [1]
+    Adapted from the implementation in
+    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/resnet.py
 
     Parameters
     ----------
     random_state : int, optional (default = 0)
         The random seed to use random activities.
-
-    Notes
-    -----
-    Adapted from the implementation source code
-    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/resnet.py
 
     References
     ----------
@@ -34,7 +30,10 @@ class ResNetNetwork(BaseDeepNetwork):
     1578--1585}, year={2017}, organization={IEEE} }
     """
 
-    _tags = {"python_dependencies": ["tensorflow", "keras-self-attention"]}
+    _tags = {
+        "authors": ["hfawaz", "James-Large", "Withington", "nilesh05apr"],
+        "python_dependencies": ["tensorflow", "keras-self-attention"],
+    }
 
     def __init__(self, random_state=0):
         _check_dl_dependencies(severity="error")

--- a/sktime/regression/deep_learning/cnn.py
+++ b/sktime/regression/deep_learning/cnn.py
@@ -15,6 +15,9 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class CNNRegressor(BaseDeepRegressor):
     """Time Series Convolutional Neural Network (CNN), as described in [1].
 
+    Adapted from the implementation from Fawaz et. al
+    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/cnn.py
+
     Parameters
     ----------
     n_epochs       : int, default = 2000
@@ -77,7 +80,8 @@ class CNNRegressor(BaseDeepRegressor):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["AurumnPegasus", "achieveordie"],
+        "authors": ["hfawaz", "AurumnPegasus", "achieveordie"],
+        # hfawaz for dl-4-tsc
         "maintainers": ["AurumnPegasus", "achieveordie"],
         "python_dependencies": "tensorflow",
         # estimator type handled by parent class

--- a/sktime/regression/deep_learning/cntc.py
+++ b/sktime/regression/deep_learning/cntc.py
@@ -12,6 +12,9 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class CNTCRegressor(BaseDeepRegressor):
     """Contextual Time-series Neural Regressor (CNTC), as described in [1].
 
+    Adapted from the implementation from Fullah et. al
+    https://github.com/AmaduFullah/CNTC_MODEL/blob/master/cntc.ipynb
+
     Parameters
     ----------
     n_epochs       : int, default = 2000
@@ -38,11 +41,6 @@ class CNTCRegressor(BaseDeepRegressor):
     optimizer       : keras.optimizer, default=keras.optimizers.Adam(),
     metrics         : list of strings, default=["accuracy"],
 
-    Notes
-    -----
-    Adapted from the implementation from Fullah et. al
-    https://github.com/AmaduFullah/CNTC_MODEL/blob/master/cntc.ipynb
-
     References
     ----------
     .. [1] Network originally defined in:
@@ -63,7 +61,12 @@ class CNTCRegressor(BaseDeepRegressor):
     """
 
     _tags = {
-        "authors": ["James-Large", "Withington", "TonyBagnall", "AurumnPegasus"],
+        "authors": [
+            "AmaduFullah",
+            "James-Large",
+            "Withington",
+            "AurumnPegasus",
+        ],
         "maintainers": ["James-Large", "Withington", "AurumnPegasus", "nilesh05apr"],
         "python_dependencies": ["tensorflow", "keras-self-attention"],
     }

--- a/sktime/regression/deep_learning/fcn.py
+++ b/sktime/regression/deep_learning/fcn.py
@@ -15,6 +15,9 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class FCNRegressor(BaseDeepRegressor):
     """Fully Connected Neural Network (FCN), as described in [1]_.
 
+    Adapted from the implementation from Fawaz et. al
+    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/fcn.py
+
     Parameters
     ----------
     should inherited fields be listed here?
@@ -38,11 +41,6 @@ class FCNRegressor(BaseDeepRegressor):
     optimizer       : keras.optimizers object, default = Adam(lr=0.01)
         specify the optimizer and the learning rate to be used.
 
-    Notes
-    -----
-    Adapted from the implementation from Fawaz et. al
-    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/fcn.py
-
     References
     ----------
     .. [1] Zhao et. al, Convolutional neural networks for time series classification,
@@ -52,7 +50,7 @@ class FCNRegressor(BaseDeepRegressor):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["James-Large", "AurumnPegasus"],
+        "authors": ["hfawaz", "James-Large", "AurumnPegasus"],
         "maintainers": ["James-Large", "AurumnPegasus", "nilesh05apr"],
         # estimator type handled by parent class
     }

--- a/sktime/regression/deep_learning/inceptiontime.py
+++ b/sktime/regression/deep_learning/inceptiontime.py
@@ -15,6 +15,9 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class InceptionTimeRegressor(BaseDeepRegressor):
     """InceptionTime Deep Learning Regressor.
 
+    Adapted from the implementation of Fawaz et. al
+    https://github.com/hfawaz/InceptionTime/blob/master/classifiers/inception.py
+
     Parameters
     ----------
     n_epochs : int, default=1500
@@ -39,15 +42,12 @@ class InceptionTimeRegressor(BaseDeepRegressor):
     -----
     ..[1] Fawaz et. al, InceptionTime: Finding AlexNet for Time Series
     Classification, Data Mining and Knowledge Discovery, 34, 2020
-
-    Adapted from the implementation from Fawaz et. al
-    https://github.com/hfawaz/InceptionTime/blob/master/classifiers/inception.py
     """
 
     _tags = {
         # packaging info
         # --------------
-        "authors": ["james-large"],
+        "authors": ["hfawaz", "james-large"],
         "maintainers": ["james-large", "niles05apr"],
         # estimator type handled by parent class
     }

--- a/sktime/regression/deep_learning/mcdcnn.py
+++ b/sktime/regression/deep_learning/mcdcnn.py
@@ -15,6 +15,9 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class MCDCNNRegressor(BaseDeepRegressor):
     """Multi Channel Deep Convolutional Neural Regressor, adopted from [1]_.
 
+    Adapted from the implementation of Fawaz et. al
+    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/mcdcnn.py
+
     Parameters
     ----------
     n_epochs : int, optional (default=120)
@@ -56,11 +59,6 @@ class MCDCNNRegressor(BaseDeepRegressor):
     random_state : int, optional (default=0)
         The seed to any random action.
 
-    Notes
-    -----
-    Adapted from the implementation of Fawaz et. al
-    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/mcdcnn.py
-
     References
     ----------
     .. [1] Zheng et. al, Time series classification using multi-channels deep
@@ -80,7 +78,7 @@ class MCDCNNRegressor(BaseDeepRegressor):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["James-Large"],
+        "authors": ["hfawaz", "James-Large"],
         "python_dependencies": "tensorflow",
         # estimator type handled by parent class
     }

--- a/sktime/regression/deep_learning/mlp.py
+++ b/sktime/regression/deep_learning/mlp.py
@@ -15,6 +15,9 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class MLPRegressor(BaseDeepRegressor):
     """Multi Layer Perceptron Network (MLP), as described in [1]_.
 
+    Adapted from the implementation by hfawaz in
+    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/mlp.py
+
     Parameters
     ----------
     should inherited fields be listed here?
@@ -38,11 +41,6 @@ class MLPRegressor(BaseDeepRegressor):
     optimizer       : keras.optimizers object, default = Adam(lr=0.01)
         specify the optimizer and the learning rate to be used.
 
-    Notes
-    -----
-    Adapted from the implementation from source code
-    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/mlp.py
-
     References
     ----------
     .. [1] Wang et. al, Time series classification from
@@ -64,7 +62,7 @@ class MLPRegressor(BaseDeepRegressor):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["James-Large", "AurumnPegasus"],
+        "authors": ["hfawaz", "James-Large", "AurumnPegasus"],
         "maintainers": ["James-Large", "AurumnPegasus", "nilesh05apr"],
         # estimator type handled by parent class
     }

--- a/sktime/regression/deep_learning/resnet.py
+++ b/sktime/regression/deep_learning/resnet.py
@@ -14,6 +14,9 @@ from sktime.utils.dependencies import _check_dl_dependencies
 class ResNetRegressor(BaseDeepRegressor):
     """Residual Neural Network Regressor adopted from [1].
 
+    Adapted from the implementation by hfawaz in
+    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/resnet.py
+
     Parameters
     ----------
     n_epochs       : int, default = 1500
@@ -37,12 +40,6 @@ class ResNetRegressor(BaseDeepRegressor):
     optimizer       : keras.optimizers object, default = Adam(lr=0.01)
         specify the optimizer and the learning rate to be used.
 
-
-    Notes
-    -----
-    Adapted from the implementation from source code
-    https://github.com/hfawaz/dl-4-tsc/blob/master/classifiers/resnet.py
-
     References
     ----------
         .. [1] Wang et. al, Time series classification from
@@ -62,7 +59,8 @@ class ResNetRegressor(BaseDeepRegressor):
     _tags = {
         # packaging info
         # --------------
-        "authors": ["James-Large", "Withington"],
+        "authors": ["hfawaz", "James-Large", "Withington"],
+        # hfawaz for dl-4-tsc
         "maintainers": ["Withington"],
         "python_dependencies": "tensorflow",
         # estimator type handled by parent class


### PR DESCRIPTION
Upon reviewing https://github.com/sktime/sktime/issues/7453, I noticed that a lot of code in the TSC module was copied from dl-4-tsc - without giving clear credit to @hfawaz, e.g., not mentioning them in the authors tag fields.

This has been rectified by:

* adding @hfawaz as the first author to the `authors` tag
* moving the reference to dl-4-tsc to the top of the estimator card

FYI @skinan