### PR TITLE
[BUG] fix `get_fitted_params` access to wrapped estimators in `_HeterogenousEnsembleForecaster` descendants

### DIFF
--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -18,6 +18,12 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
     # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_attr = "forecasters"
 
+    # if the estimator is fittable, _HeterogenousMetaEstimator also
+    # provides an override for get_fitted_params for params from the fitted estimators
+    # the fitted estimators should be in a different attribute, _steps_fitted_attr
+    # this must be an iterable of (name: str, estimator, ...) tuples for the default
+    _steps_fitted_attr = "forecasters_"
+
     def __init__(self, forecasters, n_jobs=None):
         self.forecasters = forecasters
         self.forecasters_ = None

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -61,19 +61,20 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
     >>> from sktime.forecasting.trend import PolynomialTrendForecaster, TrendForecaster
     >>> from sktime.utils._testing.hierarchical import _bottom_hier_datagen
     >>> y = _bottom_hier_datagen(
-    ...         no_bottom_nodes=7,
-    ...         no_levels=2,
-    ...         random_seed=123
+    ...     no_bottom_nodes=7,
+    ...     no_levels=2,
+    ...     random_seed=123,
     ... )
 
     >>> # Example of by = 'level'
     >>> forecasters = [
     ...     ('naive', NaiveForecaster(), 0),
-    ...     ('trend', TrendForecaster(), 1)
+    ...     ('trend', TrendForecaster(), 1),
     ... ]
     >>> forecaster = HierarchyEnsembleForecaster(
-    ...                 forecasters=forecasters,
-    ...                 by='level', default = PolynomialTrendForecaster(degree=2)
+    ...     forecasters=forecasters,
+    ...     by='level',
+    ...     default=PolynomialTrendForecaster(degree=2),
     ... )
     >>> forecaster.fit(y, fh=[1, 2, 3])
     HierarchyEnsembleForecaster(...)

--- a/sktime/forecasting/compose/tests/test_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/tests/test_hierarchy_ensemble.py
@@ -212,3 +212,34 @@ def test_level_one_data(forecasters, default):
         def_pred = def_frcstr.predict()
         msg = "Node default predictions do not match"
         assert np.all(actual_pred.loc[def_pred.index] == def_pred), msg
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(HierarchyEnsembleForecaster),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_get_fitted_params():
+    """Tests that get_fitted_params works as expected.
+
+    Checks absence of bug #7418.
+    """
+    from sktime.forecasting.compose import HierarchyEnsembleForecaster
+    from sktime.forecasting.naive import NaiveForecaster
+    from sktime.forecasting.trend import PolynomialTrendForecaster, TrendForecaster
+    from sktime.utils._testing.hierarchical import _bottom_hier_datagen
+
+    y = _bottom_hier_datagen(no_bottom_nodes=7, no_levels=2, random_seed=123)
+
+    forecasters = [
+        ('naive', NaiveForecaster(), 0),
+        ('trend', TrendForecaster(), 1),
+    ]
+    forecaster = HierarchyEnsembleForecaster(
+        forecasters=forecasters,
+        by='level',
+        default=PolynomialTrendForecaster(degree=2),
+    )
+    forecaster.fit(y, fh=[1, 2, 3])
+
+    assert forecaster.get_fitted_params()["naive"].is_fitted
+    assert forecaster.get_fitted_params()["trend"].is_fitted

--- a/sktime/forecasting/compose/tests/test_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/tests/test_hierarchy_ensemble.py
@@ -231,12 +231,12 @@ def test_get_fitted_params():
     y = _bottom_hier_datagen(no_bottom_nodes=7, no_levels=2, random_seed=123)
 
     forecasters = [
-        ('naive', NaiveForecaster(), 0),
-        ('trend', TrendForecaster(), 1),
+        ("naive", NaiveForecaster(), 0),
+        ("trend", TrendForecaster(), 1),
     ]
     forecaster = HierarchyEnsembleForecaster(
         forecasters=forecasters,
-        by='level',
+        by="level",
         default=PolynomialTrendForecaster(degree=2),
     )
     forecaster.fit(y, fh=[1, 2, 3])


### PR DESCRIPTION
This PR fixes the `get_fitted_params` not yielding access to component forecasters in some descendants of `_HeterogenousEnsembleForecaster` descendants.

The reason was that the `_steps_fitted_attr` was not set, likely because `get_fitted_params` was introduced after some of the affected forecasters.

This is now fixed - also fixes https://github.com/sktime/sktime/issues/7418