### PR TITLE
[ENH] Refactor test class registry to type records

### DIFF
--- a/sktime/registry/_base_classes.py
+++ b/sktime/registry/_base_classes.py
@@ -95,6 +95,7 @@ class object(_BaseScitypeOfObject):
 
         return TestAllObjects
 
+
 class estimator(_BaseScitypeOfObject):
     """Estimator objects, i.e., objects with fit method."""
 

--- a/sktime/registry/_base_classes.py
+++ b/sktime/registry/_base_classes.py
@@ -200,7 +200,9 @@ class early_classifier(_BaseScitypeOfObject):
 
     @classmethod
     def get_test_class(cls):
-        from sktime.classification.early_classification.tests.test_all_early_classifiers import TestAllEarlyClassifiers  # noqa E501
+        from sktime.classification.early_classification.tests.test_all_early_classifiers import (  # noqa E501
+            TestAllEarlyClassifiers,  # noqa E501
+        )  # noqa E501
 
         return TestAllEarlyClassifiers
 
@@ -406,7 +408,9 @@ class transformer(_BaseScitypeOfObject):
 
     @classmethod
     def get_test_class(cls):
-        from sktime.transformations.tests.test_all_transformers import TestAllTransformers  # noqa E501
+        from sktime.transformations.tests.test_all_transformers import (
+            TestAllTransformers,
+        )
 
         return TestAllTransformers
 
@@ -428,7 +432,9 @@ class transformer_pairwise(_BaseScitypeOfObject):
 
     @classmethod
     def get_test_class(cls):
-        from sktime.dists_kernels.tests.test_all_dist_kernels import TestAllPairwiseTransformers  # noqa E501
+        from sktime.dists_kernels.tests.test_all_dist_kernels import (
+            TestAllPairwiseTransformers,
+        )
 
         return TestAllPairwiseTransformers
 
@@ -450,7 +456,9 @@ class transformer_pairwise_panel(_BaseScitypeOfObject):
 
     @classmethod
     def get_test_class(cls):
-        from sktime.dists_kernels.tests.test_all_dist_kernels import TestAllPanelTransformers  # noqa E501
+        from sktime.dists_kernels.tests.test_all_dist_kernels import (
+            TestAllPanelTransformers,
+        )
 
         return TestAllPanelTransformers
 

--- a/sktime/registry/_base_classes.py
+++ b/sktime/registry/_base_classes.py
@@ -69,6 +69,11 @@ class _BaseScitypeOfObject(BaseObject):
         "mixin": False,  # whether this is a mixin, not full scitype
     }
 
+    @classmethod
+    def get_test_class(cls):
+        """Return test class for the scitype."""
+        return None
+
 
 class object(_BaseScitypeOfObject):
     """Universal type for all objects."""
@@ -84,6 +89,11 @@ class object(_BaseScitypeOfObject):
 
         return BaseObject
 
+    @classmethod
+    def get_test_class(cls):
+        from sktime.tests.test_all_estimators import TestAllObjects
+
+        return TestAllObjects
 
 class estimator(_BaseScitypeOfObject):
     """Estimator objects, i.e., objects with fit method."""
@@ -99,6 +109,12 @@ class estimator(_BaseScitypeOfObject):
         from sktime.base import BaseEstimator
 
         return BaseEstimator
+
+    @classmethod
+    def get_test_class(cls):
+        from sktime.tests.test_all_estimators import TestAllEstimators
+
+        return TestAllEstimators
 
 
 class aligner(_BaseScitypeOfObject):
@@ -116,6 +132,12 @@ class aligner(_BaseScitypeOfObject):
 
         return BaseAligner
 
+    @classmethod
+    def get_test_class(cls):
+        from sktime.alignment.tests.test_all_aligners import TestAllAligners
+
+        return TestAllAligners
+
 
 class classifier(_BaseScitypeOfObject):
     """Time series classifier."""
@@ -131,6 +153,12 @@ class classifier(_BaseScitypeOfObject):
         from sktime.classification.base import BaseClassifier
 
         return BaseClassifier
+
+    @classmethod
+    def get_test_class(cls):
+        from sktime.classification.tests.test_all_classifiers import TestAllClassifiers
+
+        return TestAllClassifiers
 
 
 class clusterer(_BaseScitypeOfObject):
@@ -148,6 +176,12 @@ class clusterer(_BaseScitypeOfObject):
 
         return BaseClusterer
 
+    @classmethod
+    def get_test_class(cls):
+        from sktime.clustering.tests.test_all_clusterers import TestAllClusterers
+
+        return TestAllClusterers
+
 
 class early_classifier(_BaseScitypeOfObject):
     """Early time series classifier."""
@@ -163,6 +197,12 @@ class early_classifier(_BaseScitypeOfObject):
         from sktime.classification.early_classification import BaseEarlyClassifier
 
         return BaseEarlyClassifier
+
+    @classmethod
+    def get_test_class(cls):
+        from sktime.classification.early_classification.tests.test_all_early_classifiers import TestAllEarlyClassifiers  # noqa E501
+
+        return TestAllEarlyClassifiers
 
 
 class forecaster(_BaseScitypeOfObject):
@@ -180,6 +220,12 @@ class forecaster(_BaseScitypeOfObject):
 
         return BaseForecaster
 
+    @classmethod
+    def get_test_class(cls):
+        from sktime.forecasting.tests.test_all_forecasters import TestAllForecasters
+
+        return TestAllForecasters
+
 
 class global_forecaster(_BaseScitypeOfObject):
     """Global time series forecaster."""
@@ -195,6 +241,14 @@ class global_forecaster(_BaseScitypeOfObject):
         from sktime.forecasting.base import _BaseGlobalForecaster
 
         return _BaseGlobalForecaster
+
+    @classmethod
+    def get_test_class(cls):
+        from sktime.forecasting.tests.test_all_forecasters import (
+            TestAllGlobalForecasters,
+        )
+
+        return TestAllGlobalForecasters
 
 
 class metric(_BaseScitypeOfObject):
@@ -262,6 +316,12 @@ class param_est(_BaseScitypeOfObject):
 
         return BaseParamFitter
 
+    @classmethod
+    def get_test_class(cls):
+        from sktime.param_est.tests.test_all_param_est import TestAllParamFitters
+
+        return TestAllParamFitters
+
 
 class regressor(_BaseScitypeOfObject):
     """Time series regressor."""
@@ -277,6 +337,12 @@ class regressor(_BaseScitypeOfObject):
         from sktime.regression.base import BaseRegressor
 
         return BaseRegressor
+
+    @classmethod
+    def get_test_class(cls):
+        from sktime.regression.tests.test_all_regressors import TestAllRegressors
+
+        return TestAllRegressors
 
 
 class detector(_BaseScitypeOfObject):
@@ -294,6 +360,12 @@ class detector(_BaseScitypeOfObject):
 
         return BaseDetector
 
+    @classmethod
+    def get_test_class(cls):
+        from sktime.detection.tests.test_all_detectors import TestAllDetectors
+
+        return TestAllDetectors
+
 
 class splitter(_BaseScitypeOfObject):
     """Time series splitter."""
@@ -309,6 +381,12 @@ class splitter(_BaseScitypeOfObject):
         from sktime.split.base import BaseSplitter
 
         return BaseSplitter
+
+    @classmethod
+    def get_test_class(cls):
+        from sktime.split.tests.test_all_splitters import TestAllSplitters
+
+        return TestAllSplitters
 
 
 class transformer(_BaseScitypeOfObject):
@@ -326,6 +404,12 @@ class transformer(_BaseScitypeOfObject):
 
         return BaseTransformer
 
+    @classmethod
+    def get_test_class(cls):
+        from sktime.transformations.tests.test_all_transformers import TestAllTransformers  # noqa E501
+
+        return TestAllTransformers
+
 
 class transformer_pairwise(_BaseScitypeOfObject):
     """Pairwise transformer for tabular data, distance or kernel."""
@@ -342,6 +426,12 @@ class transformer_pairwise(_BaseScitypeOfObject):
 
         return BasePairwiseTransformer
 
+    @classmethod
+    def get_test_class(cls):
+        from sktime.dists_kernels.tests.test_all_dist_kernels import TestAllPairwiseTransformers  # noqa E501
+
+        return TestAllPairwiseTransformers
+
 
 class transformer_pairwise_panel(_BaseScitypeOfObject):
     """Pairwise transformer for panel data, distance or kernel."""
@@ -357,6 +447,12 @@ class transformer_pairwise_panel(_BaseScitypeOfObject):
         from sktime.dists_kernels.base import BasePairwiseTransformerPanel
 
         return BasePairwiseTransformerPanel
+
+    @classmethod
+    def get_test_class(cls):
+        from sktime.dists_kernels.tests.test_all_dist_kernels import TestAllPanelTransformers  # noqa E501
+
+        return TestAllPanelTransformers
 
 
 class distribution(_BaseScitypeOfObject):
@@ -579,6 +675,12 @@ class series_annotator(_BaseScitypeOfObject):
         from sktime.detection.base import BaseDetector
 
         return BaseDetector
+
+    @classmethod
+    def get_test_class(cls):
+        from sktime.detection.tests.test_all_detectors import TestAllDetectors
+
+        return TestAllDetectors
 
 
 class transformer_series_to_primitives(_BaseScitypeOfObject):

--- a/sktime/registry/_base_classes.py
+++ b/sktime/registry/_base_classes.py
@@ -177,12 +177,6 @@ class clusterer(_BaseScitypeOfObject):
 
         return BaseClusterer
 
-    @classmethod
-    def get_test_class(cls):
-        from sktime.clustering.tests.test_all_clusterers import TestAllClusterers
-
-        return TestAllClusterers
-
 
 class early_classifier(_BaseScitypeOfObject):
     """Early time series classifier."""

--- a/sktime/tests/test_class_register.py
+++ b/sktime/tests/test_class_register.py
@@ -27,7 +27,7 @@ def get_test_class_registry():
     testclass_dict = {}
 
     for base_class in base_classes:
-        scitype_str = base_class.get_tag("scitype_name")
+        scitype_str = base_class.get_class_tag("scitype_name")
         test_class = base_class.get_test_class()
 
         if test_class is not None:

--- a/sktime/tests/test_class_register.py
+++ b/sktime/tests/test_class_register.py
@@ -20,51 +20,18 @@ def get_test_class_registry():
         test class registry
         keys are scitypes, values are test classes TestAll[Scitype]
     """
-    from sktime.alignment.tests.test_all_aligners import TestAllAligners
-    from sktime.classification.early_classification.tests.test_all_early_classifiers import (  # noqa E501
-        TestAllEarlyClassifiers,
-    )
-    from sktime.classification.tests.test_all_classifiers import TestAllClassifiers
-    from sktime.detection.tests.test_all_detectors import TestAllDetectors
-    from sktime.dists_kernels.tests.test_all_dist_kernels import (
-        TestAllPairwiseTransformers,
-        TestAllPanelTransformers,
-    )
-    from sktime.forecasting.tests.test_all_forecasters import (
-        TestAllForecasters,
-        TestAllGlobalForecasters,
-    )
-    from sktime.param_est.tests.test_all_param_est import TestAllParamFitters
-    from sktime.regression.tests.test_all_regressors import TestAllRegressors
-    from sktime.split.tests.test_all_splitters import TestAllSplitters
-    from sktime.tests.test_all_estimators import TestAllEstimators, TestAllObjects
-    from sktime.transformations.tests.test_all_transformers import TestAllTransformers
+    from sktime.registry._base_classes import _get_base_classes
 
-    testclass_dict = dict()
-    # every object in sktime inherits from BaseObject
-    # "object" tests are run for all objects
-    testclass_dict["object"] = TestAllObjects
-    # fittable objects inherit from BaseEstimator
-    # "estimator" tests are run for all estimators
-    # estimators are also objects
-    testclass_dict["estimator"] = TestAllEstimators
-    # more specific base classes
-    # these inherit either from BaseEstimator or BaseObject,
-    # so also imply estimator and object tests, or only object tests
-    testclass_dict["aligner"] = TestAllAligners
-    testclass_dict["classifier"] = TestAllClassifiers
-    testclass_dict["detector"] = TestAllDetectors
-    testclass_dict["early_classifier"] = TestAllEarlyClassifiers
-    testclass_dict["forecaster"] = TestAllForecasters
-    testclass_dict["global_forecaster"] = TestAllGlobalForecasters
-    testclass_dict["param_est"] = TestAllParamFitters
-    testclass_dict["regressor"] = TestAllRegressors
-    # todo 1.0.0 - remove series-annotator
-    testclass_dict["series-annotator"] = TestAllDetectors
-    testclass_dict["splitter"] = TestAllSplitters
-    testclass_dict["transformer"] = TestAllTransformers
-    testclass_dict["transformer-pairwise"] = TestAllPairwiseTransformers
-    testclass_dict["transformer-pairwise-panel"] = TestAllPanelTransformers
+    base_classes = _get_base_classes()
+
+    testclass_dict = {}
+
+    for base_class in base_classes:
+        scitype_str = base_class.get_tag("scitype_name")
+        test_class = base_class.get_test_class()
+
+        if test_class is not None:
+            testclass_dict[scitype_str] = test_class
 
     return testclass_dict
 


### PR DESCRIPTION
This PR moves the test class registry to the type registry, reducing the number of extension points by one if a new scitype is added.

Fixes https://github.com/sktime/sktime/issues/7493.

As a side effect, also reduces the number of deprecation points for defunct scitypes such as `series-annotator` by one - the release manager notes have been updated to take this into account as well.