### PR TITLE
[ENH] sync dependency checkers with `scikit-base`

### DIFF
--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -83,9 +83,7 @@ def is_soft_dep_missing_message(msg):
     missing_version_msg = "to be present in the python environment, with version"
     cond1 = missing_version_msg in msg
     # message if dependency is missing entirely
-    missing_dep_entirely_msg = (
-        "is a soft dependency and not included in the base sktime installation"
-    )
+    missing_dep_entirely_msg = "requires package"
     cond2 = missing_dep_entirely_msg in msg
     # special message for deep learning dependencies
     error_msg_dl = "required for deep learning"

--- a/sktime/utils/_testing/tests/test_check_imports.py
+++ b/sktime/utils/_testing/tests/test_check_imports.py
@@ -5,8 +5,9 @@ from sktime.utils.dependencies import _check_soft_dependencies
 
 def test_check_soft_dependencies_raises_error():
     """Test the _check_soft_dependencies() function."""
-    with pytest.raises(ModuleNotFoundError, match=r".* soft dependency .*"):
-        _check_soft_dependencies("unavailable_module")
+    MODULE = "unavailable_module"
+    with pytest.raises(ModuleNotFoundError, match=r".* requires package .*"):
+        _check_soft_dependencies(MODULE)
 
-    with pytest.raises(ModuleNotFoundError, match=r".* soft dependency .*"):
-        _check_soft_dependencies("unavailable_module_1", "unavailable_module_2")
+    with pytest.raises(ModuleNotFoundError, match=r".* requires package .*"):
+        _check_soft_dependencies(MODULE + "_1", MODULE + "_2")

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -141,7 +141,7 @@ def _check_soft_dependencies(
                 )
             msg = msg + (
                 f"To install the requirement {package!r}, please run: "
-                "pip install {package}` "
+                f"pip install {package}` "
             )
             # if msg is not None, none of the above is executed,
             # so if msg is passed it overrides the default messages

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -1,7 +1,5 @@
 """Utility to check soft dependency imports, and raise warnings or errors."""
 
-__author__ = ["fkiraly", "mloning"]
-
 import sys
 import warnings
 from functools import lru_cache
@@ -131,23 +129,20 @@ def _check_soft_dependencies(
         if pkg_env_version is None:
             if obj is None and msg is None:
                 msg = (
-                    f"{package!r} not found. "
-                    f"{package!r} is a soft dependency and not included in the "
-                    f"base sktime installation. Please run: `pip install {package}` to "
-                    f"install the {package} package. "
-                    f"To install all soft dependencies, run: `pip install "
-                    f"sktime[all_extras]`"
+                    f"{class_name} requires package {package!r} to be present "
+                    f"in the python environment, but {package!r} was not found. "
                 )
             elif msg is None:  # obj is not None, msg is None
                 msg = (
                     f"{class_name} requires package {package!r} to be present "
                     f"in the python environment, but {package!r} was not found. "
-                    f"{package!r} is a soft dependency and not included in the base "
-                    f"sktime installation. Please run: `pip install {package}` to "
-                    f"install the {package} package. "
-                    f"To install all soft dependencies, run: `pip install "
-                    f"sktime[all_extras]`"
+                    f"{package!r} is a dependency of {class_name} and required "
+                    f"to construct it. "
                 )
+            msg = msg + (
+                f"Please run: `pip install {package}` to "
+                f"install the {package!r} package. "
+            )
             # if msg is not None, none of the above is executed,
             # so if msg is passed it overrides the default messages
 
@@ -221,10 +216,10 @@ def _check_mlflow_dependencies(msg=None, severity="error"):
     Parameters
     ----------
     msg: str, optional, default= default message (msg below)
-        error message to be returned when `ModuleNotFoundError` is raised.
+        error message to be returned when ``ModuleNotFoundError`` is raised.
     severity: str, either of "error", "warning" or "none"
         behaviour for raising errors or warnings
-        "error" - raises a `ModuleNotFound` if mlflow-related packages are not found.
+        "error" - raises a ``ModuleNotFound`` if mlflow-related packages are not found.
         "warning" - raises a warning message if any mlflow-related package is not
             installed also returns False. In case all packages are present,
             returns True.

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -140,8 +140,8 @@ def _check_soft_dependencies(
                     f"to construct it. "
                 )
             msg = msg + (
-                f"Please run: `pip install {package}` to "
-                f"install {package!r}. "
+                f"To install the requirement {package!r}, please run: "
+                "pip install {package}` "
             )
             # if msg is not None, none of the above is executed,
             # so if msg is passed it overrides the default messages

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -141,7 +141,7 @@ def _check_soft_dependencies(
                 )
             msg = msg + (
                 f"Please run: `pip install {package}` to "
-                f"install the {package!r} package. "
+                f"install {package!r}. "
             )
             # if msg is not None, none of the above is executed,
             # so if msg is passed it overrides the default messages


### PR DESCRIPTION
Syncs the dependency checker utilities with `scikit-base`, in anticipation of a refactor deduplication.