### PR TITLE
[ENH] refactor checks for detector outputs into separate module

### DIFF
--- a/sktime/detection/_datatypes/__init__.py
+++ b/sktime/detection/_datatypes/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities to handle checks and conversions between output formats of detectors."""

--- a/sktime/detection/_datatypes/_check.py
+++ b/sktime/detection/_datatypes/_check.py
@@ -1,0 +1,59 @@
+"""Utilities to handle checks and conversions between output formats of detectors."""
+
+import pandas as pd
+
+
+def _is_valid_detection(obj, type="points"):
+    """Check if the input is valid common output format.
+
+    Parameters
+    ----------
+    obj : pd.DataFrame
+        Output of a detector to check for validity
+    type : str {"points", "segments"}
+        Type of output to check for validity
+    """
+    if not isinstance(obj, pd.DataFrame):
+        return False
+    if not isinstance(obj.index, pd.RangeIndex):
+        return False
+    if "ilocs" not in obj.columns:
+        return False
+
+    if type == "points":
+        return _is_points_like(obj)
+    elif type == "segments":
+        return _is_valid_segments_like(obj)
+
+    return False
+
+
+def _is_points_like(obj):
+    """Check if the input is points-like.
+
+    Assumes validity of input is checked elsewhere.
+
+    Parameters
+    ----------
+    obj : pd.DataFrame
+        Output of a detector to check
+    """
+    return pd.api.types.is_integer_dtype(obj.ilocs.dtype)
+
+
+def _is_valid_segments_like(obj):
+    """Check if the input is valid segments-like.
+
+    Assumes validity of input is checked elsewhere.
+
+    Parameters
+    ----------
+    obj : pd.DataFrame
+        Output of a detector to check
+    """
+    ilocs_dtype = obj.ilocs.dtype
+    if not (isinstance(ilocs_dtype, pd.IntervalDtype) or len(obj) == 0):
+        return False
+    if not len(obj) == 0:
+        return pd.api.types.is_integer_dtype(ilocs_dtype.subtype)
+    return True

--- a/sktime/detection/_datatypes/_check.py
+++ b/sktime/detection/_datatypes/_check.py
@@ -21,14 +21,14 @@ def _is_valid_detection(obj, type="points"):
         return False
 
     if type == "points":
-        return _is_points_like(obj)
+        return _is_points_dtype(obj)
     elif type == "segments":
-        return _is_valid_segments_like(obj)
+        return _is_segments_dtype(obj)
 
     return False
 
 
-def _is_points_like(obj):
+def _is_points_dtype(obj):
     """Check if the input is points-like.
 
     Assumes validity of input is checked elsewhere.
@@ -41,7 +41,7 @@ def _is_points_like(obj):
     return pd.api.types.is_integer_dtype(obj.ilocs.dtype)
 
 
-def _is_valid_segments_like(obj):
+def _is_segments_dtype(obj):
     """Check if the input is valid segments-like.
 
     Assumes validity of input is checked elsewhere.

--- a/sktime/detection/tests/test_all_detectors.py
+++ b/sktime/detection/tests/test_all_detectors.py
@@ -5,6 +5,7 @@ __all__ = []
 
 import pandas as pd
 
+from sktime.detection._datatypes._check import _is_valid_detection
 from sktime.tests.test_all_estimators import BaseFixtureGenerator, QuickTester
 from sktime.utils._testing.detection import make_detection_problem
 from sktime.utils.validation.detection import check_learning_type, check_task
@@ -54,9 +55,21 @@ class TestAllDetectors(DetectorFixtureGenerator, QuickTester):
         X_test = make_detection_problem(
             n_timepoints=10, estimator_type=estimator.get_tag("distribution_type")
         )
-        y_test = estimator.predict(X_test)
-        assert isinstance(y_test, pd.DataFrame)
-        assert isinstance(y_test.index, pd.RangeIndex)
+        y_pred = estimator.predict(X_test)
+
+        detector_type = estimator.get_tag("task")
+        if detector_type in ["anomaly_detection", "change_point_detection"]
+            expected_y_pred_type = "points"
+        elif detector_type == "segmentation":
+            expected_y_pred_type = "segments"
+        else:
+            raise ValueError(
+                f"Unknown task tag of {estimator_instance}: {detector_type}, "
+                "expected one of ['anomaly_detection', 'change_point_detection', "
+                f"'segmentation'], but found {detector_type}"
+            )
+
+        assert _is_valid_detection(y_pred, type=expected_y_pred_type), y_pred
 
     def test_transform_output_type(self, estimator_instance):
         """Test output type for the transform method."""
@@ -84,10 +97,7 @@ class TestAllDetectors(DetectorFixtureGenerator, QuickTester):
             estimator_type=estimator_instance.get_tag("distribution_type"),
         )
         y_pred = estimator_instance.predict_points(X_test)
-        assert isinstance(y_pred, pd.DataFrame)
-        assert isinstance(y_pred.index, pd.RangeIndex)
-        assert "ilocs" in y_pred.columns
-        assert pd.api.types.is_integer_dtype(y_pred["ilocs"].dtype), y_pred
+        assert _is_valid_detection(y_pred, type="points"), y_pred
 
     def test_predict_segments(self, estimator_instance):
         X_train = make_detection_problem(
@@ -101,13 +111,7 @@ class TestAllDetectors(DetectorFixtureGenerator, QuickTester):
             estimator_type=estimator_instance.get_tag("distribution_type"),
         )
         y_pred = estimator_instance.predict_segments(X_test)
-        assert isinstance(y_pred, pd.DataFrame)
-        assert isinstance(y_pred.index, pd.RangeIndex)
-        assert "ilocs" in y_pred.columns
-        ilocs_dtype = y_pred["ilocs"].dtype
-        assert isinstance(y_pred["ilocs"].dtype, pd.IntervalDtype) or len(y_pred) == 0
-        if not len(y_pred) == 0:
-            assert pd.api.types.is_integer_dtype(ilocs_dtype.subtype)
+        assert _is_valid_detection(y_pred, type="segments"), y_pred
 
     def test_detector_tags(self, estimator_class):
         """Check the learning_type and task tags are valid."""

--- a/sktime/detection/tests/test_all_detectors.py
+++ b/sktime/detection/tests/test_all_detectors.py
@@ -58,7 +58,7 @@ class TestAllDetectors(DetectorFixtureGenerator, QuickTester):
         y_pred = estimator.predict(X_test)
 
         detector_type = estimator.get_tag("task")
-        if detector_type in ["anomaly_detection", "change_point_detection"]
+        if detector_type in ["anomaly_detection", "change_point_detection"]:
             expected_y_pred_type = "points"
         elif detector_type == "segmentation":
             expected_y_pred_type = "segments"


### PR DESCRIPTION
This PR refactors the checks for detector outputs from `TestAllDetectors` to a separate module, `detection._datatypes`.

This is in order to introduce a data checker layer similra to `datatypes`, without fully integrating with the `datatypes` machinery yet - as we will probably reuse the utilities inside `BaseDetector` before that.