### PR TITLE
[ENH] Detection metrics - coercion to detection type in boilerplate

### DIFF
--- a/sktime/detection/_datatypes/_convert.py
+++ b/sktime/detection/_datatypes/_convert.py
@@ -11,9 +11,12 @@ def _convert_points_to_segments(points_df, len_X=None, include_labels=False):
     ----------
     points_df : pd.DataFrame
         Points-like output of a detector
-    len_X : int, optional
+    len_X : int, optional, default=None
         Length of the input data.
         If None, the last segment is assumed to be length 1.
+    include_labels : bool, optional, default=False
+        Whether to include labels in the output.
+        If True, labels are RangeIndex of the same length as the segments.
 
     Returns
     -------
@@ -39,3 +42,39 @@ def _convert_points_to_segments(points_df, len_X=None, include_labels=False):
         df_dict["labels"] = labels
 
     return pd.DataFrame(df_dict)
+
+
+def _convert_segments_to_points(seg_df, len_X=None):
+    """Convert points-like output to segments-like output.
+
+    Parameters
+    ----------
+    seg_df : pd.DataFrame
+        Points-like output of a detector
+    len_X : int, optional
+        Length of the input data.
+        If None, the (right point) end of the last segment is omitted.
+
+    Returns
+    -------
+    pd.DataFrame
+        Segments-like output of a detector
+    """
+    if len(seg_df) == 0:
+        return pd.DataFrame(columns=["ilocs"], dtype="int64")
+
+    ix = seg_df.set_index("ilocs").index
+    vals = np.array([ix.left.values, ix.right.values]).transpose().flatten()
+    vals = np.unique(vals)
+
+    if not ix.is_non_overlapping_monotonic:
+        vals = np.sort(vals)
+
+    if vals[0] == 0:
+        vals = vals[1:]
+
+    if len_X is None or vals[-1] == len_X:
+        vals = vals[:-1]
+
+    points_df = pd.DataFrame({"ilocs": vals})
+    return points_df

--- a/sktime/detection/_datatypes/_convert.py
+++ b/sktime/detection/_datatypes/_convert.py
@@ -1,0 +1,41 @@
+"""Utilities to handle checks and conversions between output formats of detectors."""
+
+import numpy as np
+import pandas as pd
+
+
+def _convert_points_to_segments(points_df, len_X=None, include_labels=False):
+    """Convert points-like output to segments-like output.
+
+    Parameters
+    ----------
+    points_df : pd.DataFrame
+        Points-like output of a detector
+    len_X : int, optional
+        Length of the input data.
+        If None, the last segment is assumed to be length 1.
+
+    Returns
+    -------
+    pd.DataFrame
+        Segments-like output of a detector
+    """
+    if len(points_df) == 0:
+        return pd.DataFrame(columns=["ilocs", "labels"], dtype="int64")
+
+    points = points_df.ilocs.values
+    if points[0] != 0:
+        points = np.insert(points, 0, 0)
+    if len_X is None:
+        points = np.append(points, points[-1] + 1)
+    elif points[-1] != len_X:
+        points = np.append(points, len_X)
+
+    ilocs = pd.IntervalIndex.from_breaks(points, closed="left")
+
+    df_dict = {"ilocs": ilocs}
+    if include_labels:
+        labels = pd.RangeIndex(len(ilocs))
+        df_dict["labels"] = labels
+
+    return pd.DataFrame(df_dict)

--- a/sktime/detection/_datatypes/_examples.py
+++ b/sktime/detection/_datatypes/_examples.py
@@ -1,0 +1,47 @@
+"""Utilities to handle checks and conversions between output formats of detectors."""
+
+import pandas as pd
+
+
+def _get_example_segments_0():
+    """Generate example 0 for segmentation output.
+
+    - non-overlapping
+    - non-exhaustive
+    - no labels
+    """
+    segs = pd.IntervalIndex.from_tuples([(1, 2), (3, 6), (7, 10)], "left")
+    return pd.DataFrame({"ilocs": segs})
+
+
+def _get_example_segments_1():
+    """Generate example 1 for segmentation output.
+
+    - non-overlapping
+    - non-exhaustive
+    - labeled
+    """
+    segs = pd.IntervalIndex.from_tuples([(1, 2), (3, 6), (7, 10), (12, 14)], "left")
+    labels = pd.Series([0, 1, 1, 0], index=segs)
+    return pd.DataFrame({"ilocs": segs, "labels": labels})
+
+
+def _get_example_segments_2():
+    """Generate example 2 for segmentation output.
+
+    - non-overlapping
+    - exhaustive
+    - labeled
+    """
+    segs = pd.IntervalIndex.from_tuples([(0, 2), (2, 3), (3, 7), (7, 10)], "left")
+    labels = pd.Series([0, 1, 2, 3])
+    return pd.DataFrame({"ilocs": segs, "labels": labels})
+
+
+def _get_example_points_2():
+    """Generate example 2 for point output.
+
+    Corresponds to example 2 for segmentation output.
+    """
+    points = pd.Series([2, 3, 7], name="ilocs")
+    return pd.DataFrame({"ilocs": points})

--- a/sktime/detection/_datatypes/_examples.py
+++ b/sktime/detection/_datatypes/_examples.py
@@ -45,3 +45,24 @@ def _get_example_points_2():
     """
     points = pd.Series([2, 3, 7], name="ilocs")
     return pd.DataFrame({"ilocs": points})
+
+
+def _get_example_segments_3():
+    """Generate example 3 for segmentation output.
+
+    - overlapping
+    - exhaustive
+    - labeled
+    """
+    segs = pd.IntervalIndex.from_tuples([(0, 3), (2, 5), (3, 7), (7, 10)], "left")
+    labels = pd.Series([0, 1, 2, 3])
+    return pd.DataFrame({"ilocs": segs, "labels": labels})
+
+
+def _get_example_points_3():
+    """Generate example 3 as points only.
+
+    Corresponds to example 3 for point output.
+    """
+    pts = [2, 3, 5, 7]
+    return pd.DataFrame({"ilocs": pts})

--- a/sktime/detection/_datatypes/test/__init__.py
+++ b/sktime/detection/_datatypes/test/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for utilities for checks and conversions for detection outputs."""

--- a/sktime/detection/_datatypes/test/test_convert.py
+++ b/sktime/detection/_datatypes/test/test_convert.py
@@ -1,0 +1,29 @@
+"""Tests for detection output converters."""
+
+import pandas as pd
+import pytest
+
+from sktime.detection._datatypes._convert import _convert_points_to_segments
+from sktime.detection._datatypes._examples import (
+    _get_example_points_2,
+    _get_example_segments_2,
+)
+from sktime.tests.test_switch import run_test_module_changed
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.detection._datatypes"),
+    reason="Test only runs when module changed",
+)
+def test_convert_points_to_segments():
+    """Test _convert_points_to_segments on an example."""
+    points_df = _get_example_points_2()
+    segments_df_no_lab = _convert_points_to_segments(points_df, len_X=10)
+    segments_df_w_lab = _convert_points_to_segments(
+        points_df, len_X=10, include_labels=True
+    )
+    expected_segments_df_w_lab = _get_example_segments_2()
+    expected_segments_df_no_lab = expected_segments_df_w_lab.drop(columns=["labels"])
+
+    pd.testing.assert_frame_equal(segments_df_no_lab, expected_segments_df_no_lab)
+    pd.testing.assert_frame_equal(segments_df_w_lab, expected_segments_df_w_lab)

--- a/sktime/detection/_datatypes/test/test_convert.py
+++ b/sktime/detection/_datatypes/test/test_convert.py
@@ -3,10 +3,15 @@
 import pandas as pd
 import pytest
 
-from sktime.detection._datatypes._convert import _convert_points_to_segments
+from sktime.detection._datatypes._convert import (
+    _convert_points_to_segments,
+    _convert_segments_to_points,
+)
 from sktime.detection._datatypes._examples import (
     _get_example_points_2,
+    _get_example_points_3,
     _get_example_segments_2,
+    _get_example_segments_3,
 )
 from sktime.tests.test_switch import run_test_module_changed
 
@@ -27,3 +32,16 @@ def test_convert_points_to_segments():
 
     pd.testing.assert_frame_equal(segments_df_no_lab, expected_segments_df_no_lab)
     pd.testing.assert_frame_equal(segments_df_w_lab, expected_segments_df_w_lab)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.detection._datatypes"),
+    reason="Test only runs when module changed",
+)
+def test_convert_segments_to_points():
+    """Test _convert_points_to_segments on an example."""
+    seg_df = _get_example_segments_3()
+    points_df_expected = _get_example_points_3()
+    points_df = _convert_segments_to_points(seg_df, len_X=10)
+
+    pd.testing.assert_frame_equal(points_df, points_df_expected)

--- a/sktime/performance_metrics/detection/_base.py
+++ b/sktime/performance_metrics/detection/_base.py
@@ -153,13 +153,16 @@ class BaseDetectionMetric(BaseMetric):
         X = _coerce_to_df(X, var_name="X", allow_none=allow_none_X)
 
         # coerce to detection type
-        y_true = self._coerce_to_detection_type(y_true, X)
+        y_true = self._coerce_to_detection_type(y_true, X, allow_none=allow_none_y_true)
         y_pred = self._coerce_to_detection_type(y_pred, X)
 
         return y_true, y_pred, X
 
-    def _coerce_to_detection_type(self, y, X):
+    def _coerce_to_detection_type(self, y, X, allow_none=False):
         """Coerce input to detection type."""
+        if allow_none and y is None:
+            return None
+
         detection_type = self.get_tag("scitype:y")
 
         if _is_points_dtype(y) and detection_type == "segments":

--- a/sktime/performance_metrics/detection/_base.py
+++ b/sktime/performance_metrics/detection/_base.py
@@ -173,5 +173,4 @@ class BaseDetectionMetric(BaseMetric):
             y = _convert_points_to_segments(y, len_X=len_X)
         elif _is_segments_dtype(y) and detection_type == "points":
             y = _convert_segments_to_points(y, len_X=len_X)
-        else:
-            return y
+        return y

--- a/sktime/performance_metrics/detection/_base.py
+++ b/sktime/performance_metrics/detection/_base.py
@@ -2,6 +2,14 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 from sktime.datatypes import check_is_scitype, convert_to
+from sktime.detection._datatypes._check import (
+    _is_points_dtype,
+    _is_segments_dtype,
+)
+from sktime.detection._datatypes._convert import (
+    _convert_points_to_segments,
+    _convert_segments_to_points,
+)
 from sktime.performance_metrics.base import BaseMetric
 
 
@@ -144,4 +152,19 @@ class BaseDetectionMetric(BaseMetric):
         y_pred = _coerce_to_df(y_pred, var_name="y_pred")
         X = _coerce_to_df(X, var_name="X", allow_none=allow_none_X)
 
+        # coerce to detection type
+        y_true = self._coerce_to_detection_type(y_true, X)
+        y_pred = self._coerce_to_detection_type(y_pred, X)
+
         return y_true, y_pred, X
+
+    def _coerce_to_detection_type(self, y, X):
+        """Coerce input to detection type."""
+        detection_type = self.get_tag("scitype:y")
+
+        if _is_points_dtype(y) and detection_type == "segments":
+            y = _convert_points_to_segments(y, len_X=len(X))
+        elif _is_segments_dtype(y) and detection_type == "points":
+            y = _convert_segments_to_points(y, len_X=len(X))
+        else:
+            return y

--- a/sktime/performance_metrics/detection/_base.py
+++ b/sktime/performance_metrics/detection/_base.py
@@ -164,10 +164,14 @@ class BaseDetectionMetric(BaseMetric):
             return None
 
         detection_type = self.get_tag("scitype:y")
+        if X is None:
+            len_X = None
+        else:
+            len_X = len(X)
 
         if _is_points_dtype(y) and detection_type == "segments":
-            y = _convert_points_to_segments(y, len_X=len(X))
+            y = _convert_points_to_segments(y, len_X=len_X)
         elif _is_segments_dtype(y) and detection_type == "points":
-            y = _convert_segments_to_points(y, len_X=len(X))
+            y = _convert_segments_to_points(y, len_X=len_X)
         else:
             return y

--- a/sktime/performance_metrics/detection/tests/test_base.py
+++ b/sktime/performance_metrics/detection/tests/test_base.py
@@ -1,0 +1,38 @@
+"""Tests for base class boilerplate."""
+
+import pandas as pd
+import pytest
+
+from sktime.detection._datatypes._examples import (
+    _get_example_points_2,
+    _get_example_points_3,
+    _get_example_segments_2,
+    _get_example_segments_3,
+)
+from sktime.performance_metrics.detection._chamfer import DirectedChamfer
+from sktime.tests.test_switch import run_test_module_changed
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.performance_metrics.detection"),
+    reason="run test only if detection module changed",
+)
+def test_input_coercions():
+    """Test that segments are coerced for point metrics."""
+    y_pred_seg = _get_example_segments_2()
+    y_true_seg = _get_example_segments_3()
+
+    y_pred_pts = _get_example_points_2()
+    y_true_pts = _get_example_points_3()
+
+    metric = DirectedChamfer()
+
+    loss_seg = metric(y_true_seg, y_pred_seg)
+    loss_pts = metric(y_true_pts, y_pred_pts)
+    assert loss_seg == loss_pts
+
+    X = pd.DataFrame({"range10": range(10)})
+
+    loss_seg_X = metric(y_true_seg, y_pred_seg, X)
+    loss_pts_X = metric(y_true_pts, y_pred_pts, X)
+    assert loss_seg_X == loss_pts_X


### PR DESCRIPTION
Currently, detection metrics can accept segments or point event detections, as determined by the `"scitype:y"` tag.

Currently, if a metric is given the other type, it fails.

This PR adds conversion between the two types with, in my opinion, sensible choices to use in detection metrics - so all metrics can now be provided with point or segment detections.

Under the hood, this uses new `datatypes`-like functionality in the `detection` module - optimally, mid-term this gets refactored to deduplicate with the converters in `BaseDetector`, or moved to `sktime.datatypes` as an mtype.

However, for the time being, it seemed more sensible to add new code, as the conversions required for metrics are not exactly those in the base class.