### PR TITLE
[ENH] forecasters - reduce memory usage and decouple from remembered data

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -1604,6 +1604,7 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
             y_scitype = y_metadata["scitype"]
             self._y_metadata = y_metadata
             self._y_mtype_last_seen = y_metadata["mtype"]
+            self.feature_names_in_ = y_metadata["feature_names"]
 
             req_vec_because_rows = y_scitype not in y_inner_scitype
             req_vec_because_cols = (
@@ -1796,6 +1797,7 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
             else:
                 self._y = update_data(self._y, y)
 
+        if y is not None:
             # set cutoff to the end of the observation horizon
             self._set_cutoff_from_y(y)
 

--- a/sktime/forecasting/base/adapters/_pytorch.py
+++ b/sktime/forecasting/base/adapters/_pytorch.py
@@ -141,8 +141,10 @@ class BaseDeepNetworkPyTorch(BaseForecaster):
             y_pred.append(self.network(x).detach())
         y_pred = cat(y_pred, dim=0).view(-1, y_pred[0].shape[-1]).numpy()
         y_pred = y_pred[fh._values.values - 1]
+
+        feature_names = self._y_metadata["feature_names"]
         y_pred = pd.DataFrame(
-            y_pred, columns=self._y.columns, index=fh.to_absolute_index(self.cutoff)
+            y_pred, columns=feature_names, index=fh.to_absolute_index(self.cutoff)
         )
 
         return y_pred

--- a/sktime/forecasting/dummy.py
+++ b/sktime/forecasting/dummy.py
@@ -154,8 +154,9 @@ class ForecastKnownValues(BaseForecaster):
         fh_abs = fh.to_absolute_index(self.cutoff)
 
         try:
+            feature_names = self._y_metadata["feature_names"]
             y_pred = self._y_known.reindex(fh_abs, **reindex_params)
-            y_pred = y_pred.reindex(self._y.columns, axis=1, **reindex_params)
+            y_pred = y_pred.reindex(feature_names, axis=1, **reindex_params)
         # TypeError happens if indices are incompatible types
         except TypeError:
             if self.fill_value is None:

--- a/sktime/forecasting/dummy.py
+++ b/sktime/forecasting/dummy.py
@@ -153,18 +153,16 @@ class ForecastKnownValues(BaseForecaster):
 
         fh_abs = fh.to_absolute_index(self.cutoff)
 
+        feat_names = self._y_metadata["feature_names"]
         try:
-            feature_names = self._y_metadata["feature_names"]
             y_pred = self._y_known.reindex(fh_abs, **reindex_params)
-            y_pred = y_pred.reindex(feature_names, axis=1, **reindex_params)
+            y_pred = y_pred.reindex(feat_names, axis=1, **reindex_params)
         # TypeError happens if indices are incompatible types
         except TypeError:
             if self.fill_value is None:
-                y_pred = pd.DataFrame(index=fh_abs, columns=self._y.columns)
+                y_pred = pd.DataFrame(index=fh_abs, columns=feat_names)
             else:
-                y_pred = pd.DataFrame(
-                    self.fill_value, index=fh_abs, columns=self._y.columns
-                )
+                y_pred = pd.DataFrame(self.fill_value, index=fh_abs, columns=feat_names)
 
         return y_pred
 

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -742,10 +742,14 @@ class TestAllForecasters(
         actual = y_pred.index
         np.testing.assert_array_equal(actual, expected)
 
-    def test__y_and_cutoff(self, estimator_instance, n_columns):
+    @pytest.mark.parametrize("remember_data", [True, False])
+    def test__y_and_cutoff(self, estimator_instance, n_columns, remember_data):
         """Check cutoff and _y."""
         # check _y and cutoff is None after construction
-        f = estimator_instance
+        f = estimator_instance.clone()
+
+        if remember_data:
+            f.set_config(remember_data=True)
 
         y = _make_series(n_columns=n_columns)
         y_train, y_test = temporal_train_test_split(y, train_size=0.75)
@@ -760,8 +764,12 @@ class TestAllForecasters(
         # action:uncomments the line above
         # why: fails for multivariates cause they are DataFrames
         # solution: look for a general solution for Series and DataFrames
-        assert len(f._y) > 0
         assert f.cutoff == y_train.index[-1]
+
+        if not remember_data:
+            return None
+
+        assert len(f._y) > 0
 
         # check data pointers
         np.testing.assert_array_equal(f._y.index, y_train.index)

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -783,6 +783,7 @@ class TestAllForecasters(
 
     def test__y_when_refitting(self, estimator_instance, n_columns):
         """Test that _y is updated when forecaster is refitted."""
+        estimator_instance = estimator_instance.clone().set_config(remember_data=True)
         y_train = _make_series(n_columns=n_columns)
         estimator_instance.fit(y_train, fh=FH0)
         estimator_instance.fit(y_train[3:], fh=FH0)

--- a/sktime/utils/estimators/_forecasters.py
+++ b/sktime/utils/estimators/_forecasters.py
@@ -282,9 +282,8 @@ class MockForecaster(BaseForecaster):
             Point predictions
         """
         index = fh.to_absolute_index(self.cutoff)
-        return pd.DataFrame(
-            self.prediction_constant, index=index, columns=self._y.columns
-        )
+        columns = self._y_metadata["feature_names"]
+        return pd.DataFrame(self.prediction_constant, index=index, columns=columns)
 
     def _update(self, y, X=None, update_params=True):
         """Update time series to incremental training data.


### PR DESCRIPTION
This PR decouples base classes and some individual classes from the remembered `_y` and `_X`.

This is towards https://github.com/sktime/sktime/issues/7416 for the more general topic of being memory aware.