### PR TITLE
[ENH] change `all_estimators` retrieval to be entirely tag based

### DIFF
--- a/sktime/registry/_base_classes.py
+++ b/sktime/registry/_base_classes.py
@@ -543,7 +543,7 @@ def _construct_child_tree(mode="class"):
     dict: keys = classes/strings, value = tuple of child classes/strings
         dict of child classes or scitype strings, according to parent_scitype tag
     """
-    return _construct_child_tree_cached(mode=mode).copy
+    return _construct_child_tree_cached(mode=mode).copy()
 
 
 @lru_cache

--- a/sktime/registry/_base_classes.py
+++ b/sktime/registry/_base_classes.py
@@ -440,7 +440,7 @@ class transformer_pairwise(_BaseScitypeOfObject):
     _tags = {
         "scitype_name": "transformer-pairwise",
         "short_descr": "pairwise transformer for tabular data, distance or kernel",
-        "parent_scitype": "transformer",
+        "parent_scitype": "estimator",
     }
 
     @classmethod
@@ -464,7 +464,7 @@ class transformer_pairwise_panel(_BaseScitypeOfObject):
     _tags = {
         "scitype_name": "transformer-pairwise-panel",
         "short_descr": "pairwise transformer for panel data, distance or kernel",
-        "parent_scitype": "transformer",
+        "parent_scitype": "estimator",
     }
 
     @classmethod
@@ -797,7 +797,7 @@ class transformer_series_to_primitives(_BaseScitypeOfObject):
     _tags = {
         "scitype_name": "series-to-primitives-trafo",
         "short_descr": "time series to primitives transformer",
-        "parent_scitype": "transformer",
+        "parent_scitype": "estimator",
         "mixin": True,
     }
 
@@ -814,7 +814,7 @@ class transformer_series_to_series(_BaseScitypeOfObject):
     _tags = {
         "scitype_name": "series-to-series-trafo",
         "short_descr": "time series to time series transformer",
-        "parent_scitype": "transformer",
+        "parent_scitype": "estimator",
         "mixin": True,
     }
 
@@ -831,7 +831,7 @@ class transformer_panel_to_tabular(_BaseScitypeOfObject):
     _tags = {
         "scitype_name": "panel-to-tabular-trafo",
         "short_descr": "panel to tabular transformer",
-        "parent_scitype": "transformer",
+        "parent_scitype": "estimator",
         "mixin": True,
     }
 
@@ -848,7 +848,7 @@ class transformer_panel_to_panel(_BaseScitypeOfObject):
     _tags = {
         "scitype_name": "panel-to-panel-trafo",
         "short_descr": "panel to panel transformer",
-        "parent_scitype": "transformer",
+        "parent_scitype": "estimator",
         "mixin": True,
     }
 

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -23,6 +23,7 @@ import pandas as pd
 from skbase.lookup import all_objects
 
 from sktime.registry._base_classes import (
+    _get_all_descendants,
     get_base_class_for_str,
     get_obj_scitype_list,
 )
@@ -188,6 +189,8 @@ def all_estimators(
         return obj
 
     estimator_types = _coerce_to_list_of_str(estimator_types)
+    estimator_types = [x for y in _get_all_descendants(estimator_types) for x in y]
+    estimator_types = list(set(estimator_types))
 
     if estimator_types is not None and filter_tags is not None:
         if "object_type" in filter_tags:

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -188,9 +188,10 @@ def all_estimators(
             return [obj]
         return obj
 
-    estimator_types = _coerce_to_list_of_str(estimator_types)
-    estimator_types = [x for y in estimator_types for x in _get_all_descendants(y)]
-    estimator_types = list(set(estimator_types))
+    if estimator_types is not None:
+        estimator_types = _coerce_to_list_of_str(estimator_types)
+        estimator_types = [x for y in estimator_types for x in _get_all_descendants(y)]
+        estimator_types = list(set(estimator_types))
 
     if estimator_types is not None and filter_tags is not None:
         if "object_type" in filter_tags:

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -174,13 +174,17 @@ def all_estimators(
 
     ROOT = str(Path(__file__).parent.parent)  # sktime package root directory
 
-    def _coerce_to_list_of_str(obj):
+    def _coerce_to_str(obj):
         if isinstance(obj, (list, tuple)):
-            return [_coerce_to_list_of_str(o) for o in obj]
+            return [_coerce_to_str(o) for o in obj]
         if isclass(obj):
             obj = obj.get_tag("object_type")
-        if not isinstance(obj, list):
-            obj = [obj]
+        return obj
+
+    def _coerce_to_list_of_str(obj):
+        obj = _coerce_to_str(obj)
+        if isinstance(obj, str):
+            return [obj]
         return obj
 
     estimator_types = _coerce_to_list_of_str(estimator_types)

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -189,7 +189,7 @@ def all_estimators(
         return obj
 
     estimator_types = _coerce_to_list_of_str(estimator_types)
-    estimator_types = [x for y in _get_all_descendants(estimator_types) for x in y]
+    estimator_types = [x for y in estimator_types for x in _get_all_descendants(y)]
     estimator_types = list(set(estimator_types))
 
     if estimator_types is not None and filter_tags is not None:

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import pandas as pd
 from skbase.lookup import all_objects
 
+from sktime.base import BaseObject
 from sktime.registry._base_classes import (
     _get_all_descendants,
     get_base_class_for_str,
@@ -204,7 +205,7 @@ def all_estimators(
         filter_tags = {"object_type": estimator_types}
 
     result = all_objects(
-        object_types=None,
+        object_types=BaseObject,
         filter_tags=filter_tags,
         exclude_objects=exclude_estimators,
         return_names=return_names,


### PR DESCRIPTION
This PR changes `all_estimators` retrieval to be entierly tag based.

Previously, retrieval and indexing used class inheritance to determine the type of an estimator. This has now been completely changed to using tag based retrieval, via the `object_type` tag that all estimators in `sktime` possess.

Advantages:

* more idiomatic, minimizing API points for retrieval
* there are less cached lists of retrieved classes internally

