### PR TITLE
[ENH] Remove `gluonts dependency` in `gluonts_ListDataset_panel` mtype

### DIFF
--- a/sktime/datatypes/_adapter/tests/test_gluonts.py
+++ b/sktime/datatypes/_adapter/tests/test_gluonts.py
@@ -55,6 +55,29 @@ def test_pandas_to_ListDataset(pandas_df):
         np.testing.assert_allclose(group_data.values, generated_list[idx]["target"])
         idx += 1
 
+    try:
+        from gluonts.dataset.common import ListDataset
+        from gluonts.dataset.field_names import FieldName
+
+        gluon_dataset = []
+        for entry in generated_list:
+            gluon_dataset.append(
+                {
+                    FieldName.START: entry["start"],
+                    FieldName.TARGET: entry["target"],
+                }
+            )
+
+        # Attempt to create ListDataset object
+        list_dataset = ListDataset(gluon_dataset, freq="D", one_dim_target=False)
+
+        first_item = next(iter(list_dataset))
+        assert "start" in first_item
+        assert "target" in first_item
+        np.testing.assert_allclose(first_item["target"], generated_list[0]["target"])
+    except ImportError:
+        pytest.skip("GluonTS not available for compatibility test")
+
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("gluonts", severity="none"),

--- a/sktime/datatypes/_adapter/tests/test_gluonts.py
+++ b/sktime/datatypes/_adapter/tests/test_gluonts.py
@@ -55,28 +55,25 @@ def test_pandas_to_ListDataset(pandas_df):
         np.testing.assert_allclose(group_data.values, generated_list[idx]["target"])
         idx += 1
 
-    try:
-        from gluonts.dataset.common import ListDataset
-        from gluonts.dataset.field_names import FieldName
+    from gluonts.dataset.common import ListDataset
+    from gluonts.dataset.field_names import FieldName
 
-        gluon_dataset = []
-        for entry in generated_list:
-            gluon_dataset.append(
-                {
-                    FieldName.START: entry["start"],
-                    FieldName.TARGET: entry["target"],
-                }
-            )
+    gluon_dataset = []
+    for entry in generated_list:
+        gluon_dataset.append(
+            {
+                FieldName.START: entry["start"],
+                FieldName.TARGET: entry["target"],
+            }
+        )
 
-        # Attempt to create ListDataset object
-        list_dataset = ListDataset(gluon_dataset, freq="D", one_dim_target=False)
+    # Attempt to create ListDataset object
+    list_dataset = ListDataset(gluon_dataset, freq="D", one_dim_target=False)
 
-        first_item = next(iter(list_dataset))
-        assert "start" in first_item
-        assert "target" in first_item
-        np.testing.assert_allclose(first_item["target"], generated_list[0]["target"])
-    except ImportError:
-        pytest.skip("GluonTS not available for compatibility test")
+    first_item = next(iter(list_dataset))
+    assert "start" in first_item
+    assert "target" in first_item
+    np.testing.assert_allclose(first_item["target"], generated_list[0]["target"])
 
 
 @pytest.mark.skipif(

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -1271,7 +1271,7 @@ class PanelGluontsList(ScitypePanel):
         "name_python": "panel_gluonts_list",  # lower_snake_case
         "name_aliases": [],
         "python_version": None,
-        "python_dependencies": "gluonts",
+        "python_dependencies": None,
         "capability:multivariate": True,
         "capability:unequally_spaced": True,
         "capability:missing_values": True,
@@ -1302,13 +1302,24 @@ class PanelGluontsList(ScitypePanel):
 
         metadata = dict()
 
+        if not isinstance(obj, list):
+            msg = f"{var_name} must be a list, found {type(obj)}"
+            return _ret(False, msg, None, return_metadata)
+
+        # Check for 'dictionary' type and 'target' key
+        if not isinstance(obj[0], dict) or "target" not in obj[0]:
+            msg = (
+                f"{var_name} must be list of dict with 'target' key, got {type(obj[0])}"
+            )
+            return _ret(False, msg, None, return_metadata)
+
         if (
-            not isinstance(obj, list)
-            or not isinstance(obj[0], dict)
-            or "target" not in obj[0]
+            not isinstance(obj[0]["target"], (pd.DataFrame, pd.Series))
             or len(obj[0]["target"]) <= 1
         ):
-            msg = f"{var_name} must be a gluonts.ListDataset, found {type(obj)}"
+            msg = f"""Each 'target' must be a Pandas DataFrame or Series with more than
+                    one entry, found {type(obj[0]['target'])}
+                    """
             return _ret(False, msg, None, return_metadata)
 
         # Check if there are no time series in the ListDataset

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -1302,24 +1302,13 @@ class PanelGluontsList(ScitypePanel):
 
         metadata = dict()
 
-        if not isinstance(obj, list):
-            msg = f"{var_name} must be a list, found {type(obj)}"
-            return _ret(False, msg, None, return_metadata)
-
-        # Check for 'dictionary' type and 'target' key
-        if not isinstance(obj[0], dict) or "target" not in obj[0]:
-            msg = (
-                f"{var_name} must be list of dict with 'target' key, got {type(obj[0])}"
-            )
-            return _ret(False, msg, None, return_metadata)
-
         if (
-            not isinstance(obj[0]["target"], (pd.DataFrame, pd.Series))
+            not isinstance(obj, list)
+            or not isinstance(obj[0], dict)
+            or "target" not in obj[0]
             or len(obj[0]["target"]) <= 1
         ):
-            msg = f"""Each 'target' must be a Pandas DataFrame or Series with more than
-                    one entry, found {type(obj[0]['target'])}
-                    """
+            msg = f"{var_name} must be a listDataset, found {type(obj)}"
             return _ret(False, msg, None, return_metadata)
 
         # Check if there are no time series in the ListDataset


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
Fix #7551 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
I've added a general set of checks  under `_check` function for the `PanelGluontsList` class. Have not updated the docstring if this is required.
#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
Feedback on the general implementation of code and any other requirements.
#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
