### PR TITLE
[DOC] Added docstrings for PanelDask class #7563

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3313,6 +3313,16 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "manu042k",
+      "name": "Manoj Manjunatha",
+      "avatar_url": "https://avatars.githubusercontent.com/u/60233628?v=4",
+      "profile": "https://github.com/manu042k",
+      "contributions": [
+        "doc"
+      ]
     }
+
   ]
 }

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -970,6 +970,7 @@ def _check_numpyflat_Panel(obj, return_metadata=False, var_name="obj"):
 
 class PanelDask(ScitypePanel):
     """Data type: dask data frame based specification of panel of time series.
+    
     Name: ``"dask_panel"``
 
     Short description:

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -970,6 +970,37 @@ def _check_numpyflat_Panel(obj, return_metadata=False, var_name="obj"):
 
 class PanelDask(ScitypePanel):
     """Data type: dask data frame based specification of panel of time series.
+    Name: ``"dask_panel"``
+
+    Short description:
+
+    A ``dask.dataframe.DataFrame``,with rows = instances, columns = variables.
+
+    Long description:
+
+    The ``"dask_panel"`` :term:`mtype` is a concrete specification
+    that implements the ``Panel`` :term:`scitype`, i.e., the abstract
+    type of a collection of time series.
+
+    An object ``obj: dask.dataframe.DataFrame`` follows the specification iff:
+
+    * structure convention: ``obj`` must be a ``dask.dataframe.DataFrame``.
+    * instances: instances correspond to different rows of ``obj``.
+    * instance index: the instance index of an instance is the row index at which
+      it is located in ``obj``. That is, the data at ``obj.loc[i]``
+      correspond to observations of the instance with index ``i``.
+    * variables: columns of ``obj`` correspond to different variables available
+      for each instance.
+    * variable names: column names ``obj.columns`` are the names of variables
+      available for each instance.
+
+    Capabilities:
+
+    * can represent panels of multivariate series
+    * can represent unequally spaced series
+    * can represent panels of unequally supported series
+    * can represent panels of series with different sets of variables
+    * can represent missing values
 
     Parameters
     ----------


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes #7386


#### What does this implement/fix? Explain your changes.
Added doc strings for PanelDask class.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?

#### Did you add any tests for the change?
No

#### Any other comments?

#### PR checklist


##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
