### PR TITLE
[ENH] clusterers: improved checking for `X` in `fit` and `predict` in `capability:out_of_sample = False` case, minor improvements to `predict_proba` default

### DIFF
--- a/sktime/clustering/base.py
+++ b/sktime/clustering/base.py
@@ -13,6 +13,7 @@ from sktime.datatypes._dtypekind import DtypeKind
 from sktime.utils.dependencies import _check_estimator_deps
 from sktime.utils.sklearn import is_sklearn_transformer
 from sktime.utils.validation import check_n_jobs
+from sktime.utils.warnings import warn
 
 
 class BaseClusterer(BaseEstimator):
@@ -308,7 +309,9 @@ class BaseClusterer(BaseEstimator):
             n_clusters = max(preds) + 1
         dists = np.zeros((X.shape[0], n_clusters))
         for i in range(n_instances):
-            dists[i, preds[i]] = 1
+            # preds[i] can be -1, in this case there is no cluster for this instance
+            if preds[i] > -1:
+                dists[i, preds[i]] = 1
         return dists
 
     def _score(self, X, y=None):
@@ -428,6 +431,26 @@ class BaseClusterer(BaseEstimator):
         ValueError
             If y or X is invalid input data type, or there is not enough data.
         """
+        # remember hash for determining in predict whether data is the same as in fit
+        # only needed if out_of_sample tag is False, then all X must be the same
+        if not self.get_tag("capability:out_of_sample"):
+            # if first seen in fit: store hash
+            if not hasattr(self, "_X_hash"):
+                self._X_hash = hash(str(X))
+            else:  # in predict: check if hash is the same
+                X_fit_hash = self._X_hash
+                X_predict_hash = hash(str(X))
+                if not X_fit_hash != X_predict_hash:
+                    warn(
+                        f"This instance of {type(self).__name__} does not support "
+                        "different X in fit and predict, "
+                        "but a new X was passed in predict. "
+                        "This may result in an exception, or incorrect results. "
+                        "Please use the same X in fit and predict to avoid this "
+                        "warning, and possible subsequent exceptions.",
+                        obj=self,
+                    )
+
         X = self._initial_conversion(X)
 
         ALLOWED_SCITYPES = [

--- a/sktime/clustering/dbscan.py
+++ b/sktime/clustering/dbscan.py
@@ -2,7 +2,6 @@
 
 __author__ = ["fkiraly"]
 
-import numpy as np
 from sklearn.cluster import DBSCAN
 
 from sktime.clustering.base import BaseClusterer
@@ -175,40 +174,6 @@ class TimeSeriesDBSCAN(BaseClusterer):
                 obj=self,
             )
             return self.clone().fit(all_X).labels_
-
-    def _predict_proba(self, X):
-        """Predicts labels probabilities for sequences in X.
-
-        Default behaviour is to call _predict and set the predicted class probability
-        to 1, other class probabilities to 0. Override if better estimates are
-        obtainable.
-
-        Parameters
-        ----------
-        X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
-            if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_dimensions, series_length]
-            if self.get_tag("X_inner_mtype") = "nested_univ":
-                pd.DataFrame with each column a dimension, each cell a pd.Series
-            for list of other mtypes, see datatypes.SCITYPE_REGISTER
-            for specifications, see examples/AA_datatypes_and_datasets.ipynb
-
-        Returns
-        -------
-        y : 2D array of shape [n_instances, n_classes] - predicted class probabilities
-            1st dimension indices correspond to instance indices in X
-            2nd dimension indices correspond to possible labels (integers)
-            (i, j)-th entry is predictive probability that i-th instance is of class j
-        """
-        preds = self._predict(X)
-        n_instances = len(preds)
-        n_clusters = max(preds) + 1
-        dists = np.zeros((X.shape[0], n_clusters))
-        for i in range(n_instances):
-            # preds[i] can be -1 for DBSCAN
-            if preds[i] > -1:
-                dists[i, preds[i]] = 1
-        return dists
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
This PR improves the checking for `X` in `fit` and `predict` in the `capability:out_of_sample = False` case.

Clusterers with this tag cannot predict labels for `X` other than the one seen in `fit`.

The boilerplate is updated to raise an error message when the `X` is different in that case, by using a print hash of `X` as a proxy to avoid overloading memory (see https://github.com/sktime/sktime/issues/7416 why we do not store `self._X = X`).

The `predict_proba` default is also improved to handle the "-1" case, see `TimeSeriesDBSCAN`.
The logic from `TimeSeriesDBSCAN` dealing with the "-1" case is removed, as it now sits in the base class.

Related: https://github.com/sktime/sktime/issues/7594, https://github.com/sktime/sktime/pull/7592