### PR TITLE
[ENH] Set `context_len` and `horizon_len` per default in `TimesFMForecaster`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3260,10 +3260,10 @@
       ]
     },
     {
-      "login": "TanviPooranmal",
+      "login": "tanvincible",
       "name": "Tanvi Pooranmal Meena",
-      "avatar_url": "https://avatars.githubusercontent.com/TanviPooranmal",
-      "profile": "https://github.com/TanviPooranmal",
+      "avatar_url": "https://avatars.githubusercontent.com/tanvincible",
+      "profile": "https://github.com/tanvincible",
       "contributions": [
         "code",
         "doc"

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -205,6 +205,7 @@ class TimesFMForecaster(_BaseGlobalForecaster):
         self._context_len = None
         self.horizon_len = horizon_len
         self._horizon_len = None
+        self._context_len = None
         self.freq = freq
         self.repo_id = repo_id
         self.input_patch_len = input_patch_len

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -47,7 +47,7 @@ class TimesFMForecaster(_BaseGlobalForecaster):
         and padding or truncation will
         be handled by the model's inference code if necessary.
 
-    horizon_len : int, optional (default=None)
+    horizon_len : int, optional (default=128)
         The length of the forecast horizon.
         If set to None, the forecast horizon is dynamically determined based on the
         provided forecasting horizon `fh`, if available.
@@ -187,7 +187,7 @@ class TimesFMForecaster(_BaseGlobalForecaster):
     def __init__(
         self,
         context_len=None,
-        horizon_len=None,
+        horizon_len=128,
         freq=0,
         repo_id="google/timesfm-1.0-200m",
         input_patch_len=32,
@@ -395,7 +395,7 @@ class TimesFMForecaster(_BaseGlobalForecaster):
         test_params = [
             {
                 "context_len": None,
-                "horizon_len": None,
+                "horizon_len": 128,
                 "freq": 0,
                 "verbose": False,
             },

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -180,8 +180,8 @@ class TimesFMForecaster(_BaseGlobalForecaster):
 
     def __init__(
         self,
-        context_len,
-        horizon_len,
+        context_len=None,
+        horizon_len=None,
         freq=0,
         repo_id="google/timesfm-1.0-200m",
         input_patch_len=32,
@@ -198,6 +198,7 @@ class TimesFMForecaster(_BaseGlobalForecaster):
         self.context_len = context_len
         self.horizon_len = horizon_len
         self._horizon_len = None
+        self._context_len = None
         self.freq = freq
         self.repo_id = repo_id
         self.input_patch_len = input_patch_len
@@ -247,6 +248,13 @@ class TimesFMForecaster(_BaseGlobalForecaster):
             self._horizon_len = max(self.horizon_len, *fh._values.values)
         else:
             self._horizon_len = self.horizon_len
+
+        self._context_len = self.context_len or (
+            ((len(y) // self.input_patch_len) + 1) * self.input_patch_len
+        )
+
+        self.horizon_len_ = self._horizon_len
+        self.context_len_ = self._context_len
 
         self.tfm = _CachedTimesFM(
             key=self._get_unique_timesfm_key(),
@@ -370,6 +378,12 @@ class TimesFMForecaster(_BaseGlobalForecaster):
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
         test_params = [
+            {
+                "context_len": None,
+                "horizon_len": None,
+                "freq": 0,
+                "verbose": False,
+            },
             {
                 "context_len": 64,
                 "horizon_len": 32,

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -268,7 +268,7 @@ class TimesFMForecaster(_BaseGlobalForecaster):
     def _get_timesfm_kwargs(self):
         """Get the kwargs for TimesFM model."""
         return {
-            "context_len": self.context_len,
+            "context_len": self._context_len,
             "horizon_len": self._horizon_len,
             "input_patch_len": self.input_patch_len,
             "output_patch_len": self.output_patch_len,


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs

- Fixes #7209.

#### What does this implement/fix? Explain your changes.

As discussed in #7209, this PR enhances the `TimesFMForecaster` by setting automatic defaults for `context_len` and `horizon_len`:
- `horizon_len`: Defaults to `fh-max` if not explicitly specified.  
- `context_len`: Defaults to the smallest multiple of `input_patch_len` exceeding `len(y)`.  

Explicitly specified values still override these defaults. 
Moreover, calculated values are stored in `self.horizon_len_` and `self.context_len_`.  

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
N/A
<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

Yes, tests have been added in `get_test_params` to cover default and overridden values, including broadcasting.

#### Any other comments?

N/A
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

<!--
Thanks for contributing!
-->
