### PR TITLE
[ENH] Forecasting metrics dispatch of `__call__` to `evaluate` vs `evaluate_by_index`

### DIFF
--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -139,7 +139,7 @@ class BaseForecastingErrorMetric(BaseMetric):
         "lower_is_better": True,
         # "y_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"]
         "inner_implements_multilevel": False,
-        "reserved_params": ["multioutput", "multilevel"],
+        "reserved_params": ["multioutput", "multilevel", "by_index"],
     }
 
     def __init__(

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -820,7 +820,29 @@ class BaseForecastingErrorMetric(BaseMetric):
 
         # else, we expect multioutput to be array-like
         return df.dot(multioutput)
+    
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
 
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            ``MyClass(**params)`` or ``MyClass(**params[i])`` creates a valid test
+            instance.
+            ``create_test_instance`` uses the first (or only) dictionary in ``params``
+        """
+        params1 = {}
+        params2 = {"evaluate_by_timepoints": True}
+        return [params1, params2]
 
 class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
     """Adapter for numpy metrics."""

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -1246,13 +1246,13 @@ class MedianAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFun
         multioutput="uniform_average",
         multilevel="uniform_average",
         sp=1,
-        eval_by_timepoints=False,
+        evaluate_by_timepoints=False,
     ):
         self.sp = sp
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=eval_by_timepoints,
+            evaluate_by_timepoints=evaluate_by_timepoints,
         )
 
     @classmethod
@@ -1375,14 +1375,14 @@ class MeanSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc):
         multilevel="uniform_average",
         sp=1,
         square_root=False,
-        eval_by_timepoints=False,
+        evaluate_by_timepoints=False,
     ):
         self.sp = sp
         self.square_root = square_root
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=eval_by_timepoints,
+            evaluate_by_timepoints=evaluate_by_timepoints,
         )
 
     @classmethod
@@ -1505,14 +1505,14 @@ class MedianSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc
         multilevel="uniform_average",
         sp=1,
         square_root=False,
-        eval_by_timepoints=False,
+        evaluate_by_timepoints=False,
     ):
         self.sp = sp
         self.square_root = square_root
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=eval_by_timepoints,
+            evaluate_by_timepoints=evaluate_by_timepoints,
         )
 
     @classmethod

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -126,8 +126,11 @@ class BaseForecastingErrorMetric(BaseMetric):
         * If 'raw_values', does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
     """
 
     _tags = {
@@ -1072,8 +1075,11 @@ class MeanAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc)
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -1199,10 +1205,12 @@ class MedianAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFun
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -1332,8 +1340,11 @@ class MeanSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -1462,8 +1473,11 @@ class MedianSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -1592,8 +1606,11 @@ class MeanAbsoluteError(BaseForecastingErrorMetric):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -1712,8 +1729,11 @@ class MedianAbsoluteError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -1856,8 +1876,11 @@ class MeanSquaredError(BaseForecastingErrorMetric):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -2073,8 +2096,11 @@ class MeanSquaredErrorPercentage(BaseForecastingErrorMetricFunc):
         If 'uniform_average_time', metric is applied to all data, ignoring level index.
         If 'raw_values', does not average errors across levels, hierarchy is retained.
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
     """
 
     def __init__(
@@ -2252,8 +2278,11 @@ class MedianSquaredError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -2372,8 +2401,11 @@ class GeometricMeanAbsoluteError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -2462,8 +2494,11 @@ class GeometricMeanSquaredError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -2623,8 +2658,11 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -2817,8 +2855,11 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -2949,8 +2990,11 @@ class MeanSquaredPercentageError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -3090,8 +3134,11 @@ class MedianSquaredPercentageError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -3214,8 +3261,11 @@ class MeanRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -3293,8 +3343,11 @@ class MedianRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -3373,8 +3426,11 @@ class GeometricMeanRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -3461,8 +3517,11 @@ class GeometricMeanRelativeSquaredError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -3609,8 +3668,11 @@ class MeanAsymmetricError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -3765,8 +3827,11 @@ class MeanLinexError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     See Also
     --------
@@ -3909,8 +3974,11 @@ class RelativeLoss(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
-        If True, evaluate the metric at each time point.
-        If False, evaluate the metric globally, averaging over all time points.
+
+        * If False, direct call to the metric object averages over time points,
+          equivalent to a call of the``evaluate`` method.
+        * If True, direct call to the metric object evaluates the metric at each
+          time point, equivalent to a call of the ``evaluate_by_index`` method.
 
     References
     ----------

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -820,7 +820,7 @@ class BaseForecastingErrorMetric(BaseMetric):
 
         # else, we expect multioutput to be array-like
         return df.dot(multioutput)
-    
+
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
@@ -843,6 +843,7 @@ class BaseForecastingErrorMetric(BaseMetric):
         params1 = {}
         params2 = {"evaluate_by_timepoints": True}
         return [params1, params2]
+
 
 class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
     """Adapter for numpy metrics."""

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -899,7 +899,9 @@ class _DynamicForecastingErrorMetric(BaseForecastingErrorMetricFunc):
         self.func = func
         self.name = name
         self.lower_is_better = lower_is_better
-        super().__init__(multioutput=multioutput, multilevel=multilevel, by_index=by_index)
+        super().__init__(
+            multioutput=multioutput, multilevel=multilevel, by_index=by_index
+        )
 
         self.set_tags(**{"lower_is_better": lower_is_better})
 
@@ -1124,7 +1126,9 @@ class MeanAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc)
         by_index=False,
     ):
         self.sp = sp
-        super().__init__(multioutput=multioutput, multilevel=multilevel, by_index=by_index)
+        super().__init__(
+            multioutput=multioutput, multilevel=multilevel, by_index=by_index
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -2528,7 +2532,9 @@ class GeometricMeanSquaredError(BaseForecastingErrorMetricFunc):
         by_index=False,
     ):
         self.square_root = square_root
-        super().__init__(multioutput=multioutput, multilevel=multilevel, by_index=by_index)
+        super().__init__(
+            multioutput=multioutput, multilevel=multilevel, by_index=by_index
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -126,6 +126,7 @@ class BaseForecastingErrorMetric(BaseMetric):
         * If 'raw_values', does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -1075,6 +1076,7 @@ class MeanAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc)
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -1206,6 +1208,7 @@ class MedianAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFun
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -1340,6 +1343,7 @@ class MeanSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -1473,6 +1477,7 @@ class MedianSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -1606,6 +1611,7 @@ class MeanAbsoluteError(BaseForecastingErrorMetric):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -1729,6 +1735,7 @@ class MedianAbsoluteError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -1876,6 +1883,7 @@ class MeanSquaredError(BaseForecastingErrorMetric):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -2096,6 +2104,7 @@ class MeanSquaredErrorPercentage(BaseForecastingErrorMetricFunc):
         If 'uniform_average_time', metric is applied to all data, ignoring level index.
         If 'raw_values', does not average errors across levels, hierarchy is retained.
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -2278,6 +2287,7 @@ class MedianSquaredError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -2401,6 +2411,7 @@ class GeometricMeanAbsoluteError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -2494,6 +2505,7 @@ class GeometricMeanSquaredError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -2658,6 +2670,7 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -2855,6 +2868,7 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -2990,6 +3004,7 @@ class MeanSquaredPercentageError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -3134,6 +3149,7 @@ class MedianSquaredPercentageError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -3261,6 +3277,7 @@ class MeanRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -3343,6 +3360,7 @@ class MedianRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -3426,6 +3444,7 @@ class GeometricMeanRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -3517,6 +3536,7 @@ class GeometricMeanRelativeSquaredError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -3668,6 +3688,7 @@ class MeanAsymmetricError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -3827,6 +3848,7 @@ class MeanLinexError(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.
@@ -3974,6 +3996,7 @@ class RelativeLoss(BaseForecastingErrorMetricFunc):
           does not average errors across levels, hierarchy is retained.
 
     by_index : bool, default=False
+        Determines averaging over time points in direct call to metric object.
 
         * If False, direct call to the metric object averages over time points,
           equivalent to a call of the``evaluate`` method.

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -892,13 +892,14 @@ class _DynamicForecastingErrorMetric(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         lower_is_better=True,
+        by_index=False,
     ):
         self.multioutput = multioutput
         self.multilevel = multilevel
         self.func = func
         self.name = name
         self.lower_is_better = lower_is_better
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(multioutput=multioutput, multilevel=multilevel, by_index=by_index)
 
         self.set_tags(**{"lower_is_better": lower_is_better})
 
@@ -1120,9 +1121,10 @@ class MeanAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc)
         multioutput="uniform_average",
         multilevel="uniform_average",
         sp=1,
+        by_index=False,
     ):
         self.sp = sp
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(multioutput=multioutput, multilevel=multilevel, by_index=by_index)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -2523,9 +2525,10 @@ class GeometricMeanSquaredError(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         square_root=False,
+        by_index=False,
     ):
         self.square_root = square_root
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(multioutput=multioutput, multilevel=multilevel, by_index=by_index)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -125,7 +125,7 @@ class BaseForecastingErrorMetric(BaseMetric):
           ignoring level index.
         * If 'raw_values', does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
     """
@@ -146,11 +146,11 @@ class BaseForecastingErrorMetric(BaseMetric):
         self,
         multioutput="uniform_average",
         multilevel="uniform_average",
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.multioutput = multioutput
         self.multilevel = multilevel
-        self.evaluate_by_timepoints = evaluate_by_timepoints
+        self.by_index = by_index
 
         if not hasattr(self, "name") or self.name is None:
             self.name = type(self).__name__
@@ -236,7 +236,7 @@ class BaseForecastingErrorMetric(BaseMetric):
               of shape ``(n_levels, y_true.columns)`` if ``multioutput="raw_values"``.
               metric is applied per level, row averaging (yes/no) as in ``multioutput``.
         """  # noqa: E501
-        if self.evaluate_by_timepoints:
+        if self.by_index:
             return self.evaluate_by_index(y_true, y_pred, **kwargs)
         return self.evaluate(y_true, y_pred, **kwargs)
 
@@ -821,29 +821,6 @@ class BaseForecastingErrorMetric(BaseMetric):
         # else, we expect multioutput to be array-like
         return df.dot(multioutput)
 
-    @classmethod
-    def get_test_params(cls, parameter_set="default"):
-        """Return testing parameter settings for the estimator.
-
-        Parameters
-        ----------
-        parameter_set : str, default="default"
-            Name of the set of test parameters to return, for use in tests. If no
-            special parameters are defined for a value, will return ``"default"`` set.
-
-        Returns
-        -------
-        params : dict or list of dict, default = {}
-            Parameters to create testing instances of the class
-            Each dict are parameters to construct an "interesting" test instance, i.e.,
-            ``MyClass(**params)`` or ``MyClass(**params[i])`` creates a valid test
-            instance.
-            ``create_test_instance`` uses the first (or only) dictionary in ``params``
-        """
-        params1 = {}
-        params2 = {"evaluate_by_timepoints": True}
-        return [params1, params2]
-
 
 class BaseForecastingErrorMetricFunc(BaseForecastingErrorMetric):
     """Adapter for numpy metrics."""
@@ -1091,7 +1068,7 @@ class MeanAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc)
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -1217,7 +1194,7 @@ class MedianAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFun
           does not average errors across levels, hierarchy is retained.
 
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -1269,13 +1246,13 @@ class MedianAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFun
         multioutput="uniform_average",
         multilevel="uniform_average",
         sp=1,
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.sp = sp
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     @classmethod
@@ -1348,7 +1325,7 @@ class MeanSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -1398,14 +1375,14 @@ class MeanSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc):
         multilevel="uniform_average",
         sp=1,
         square_root=False,
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.sp = sp
         self.square_root = square_root
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     @classmethod
@@ -1478,7 +1455,7 @@ class MedianSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -1528,14 +1505,14 @@ class MedianSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc
         multilevel="uniform_average",
         sp=1,
         square_root=False,
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.sp = sp
         self.square_root = square_root
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     @classmethod
@@ -1608,7 +1585,7 @@ class MeanAbsoluteError(BaseForecastingErrorMetric):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -1728,7 +1705,7 @@ class MedianAbsoluteError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -1872,7 +1849,7 @@ class MeanSquaredError(BaseForecastingErrorMetric):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -1922,13 +1899,13 @@ class MeanSquaredError(BaseForecastingErrorMetric):
         multioutput="uniform_average",
         multilevel="uniform_average",
         square_root=False,
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.square_root = square_root
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     def _evaluate(self, y_true, y_pred, **kwargs):
@@ -2089,7 +2066,7 @@ class MeanSquaredErrorPercentage(BaseForecastingErrorMetricFunc):
         If 'uniform_average' (default), errors are mean-averaged across levels.
         If 'uniform_average_time', metric is applied to all data, ignoring level index.
         If 'raw_values', does not average errors across levels, hierarchy is retained.
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
     """
@@ -2099,7 +2076,7 @@ class MeanSquaredErrorPercentage(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         square_root=False,
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.square_root = square_root
         self.multioutput = multioutput
@@ -2107,7 +2084,7 @@ class MeanSquaredErrorPercentage(BaseForecastingErrorMetricFunc):
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     def _evaluate(self, y_true, y_pred, **kwargs):
@@ -2268,7 +2245,7 @@ class MedianSquaredError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -2322,13 +2299,13 @@ class MedianSquaredError(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         square_root=False,
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.square_root = square_root
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     @classmethod
@@ -2388,7 +2365,7 @@ class GeometricMeanAbsoluteError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -2478,7 +2455,7 @@ class GeometricMeanSquaredError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -2636,7 +2613,7 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -2690,13 +2667,13 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         symmetric=False,
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.symmetric = symmetric
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     def _evaluate_by_index(self, y_true, y_pred, **kwargs):
@@ -2830,7 +2807,7 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -2884,13 +2861,13 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         symmetric=False,
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.symmetric = symmetric
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     @classmethod
@@ -2962,7 +2939,7 @@ class MeanSquaredPercentageError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -3020,14 +2997,14 @@ class MeanSquaredPercentageError(BaseForecastingErrorMetricFunc):
         multilevel="uniform_average",
         symmetric=False,
         square_root=False,
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.symmetric = symmetric
         self.square_root = square_root
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     @classmethod
@@ -3103,7 +3080,7 @@ class MedianSquaredPercentageError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -3161,14 +3138,14 @@ class MedianSquaredPercentageError(BaseForecastingErrorMetricFunc):
         multilevel="uniform_average",
         symmetric=False,
         square_root=False,
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.symmetric = symmetric
         self.square_root = square_root
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     @classmethod
@@ -3227,7 +3204,7 @@ class MeanRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -3306,7 +3283,7 @@ class MedianRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -3386,7 +3363,7 @@ class GeometricMeanRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -3474,7 +3451,7 @@ class GeometricMeanRelativeSquaredError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -3526,13 +3503,13 @@ class GeometricMeanRelativeSquaredError(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         square_root=False,
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.square_root = square_root
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     @classmethod
@@ -3622,7 +3599,7 @@ class MeanAsymmetricError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -3685,7 +3662,7 @@ class MeanAsymmetricError(BaseForecastingErrorMetricFunc):
         right_error_function="absolute",
         left_error_penalty=1.0,
         right_error_penalty=1.0,
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.asymmetric_threshold = asymmetric_threshold
         self.left_error_function = left_error_function
@@ -3696,7 +3673,7 @@ class MeanAsymmetricError(BaseForecastingErrorMetricFunc):
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     @classmethod
@@ -3778,7 +3755,7 @@ class MeanLinexError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -3838,14 +3815,14 @@ class MeanLinexError(BaseForecastingErrorMetricFunc):
         b=1.0,
         multioutput="uniform_average",
         multilevel="uniform_average",
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.a = a
         self.b = b
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     @classmethod
@@ -3922,7 +3899,7 @@ class RelativeLoss(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
-    evaluate_by_timepoints : bool, default=False
+    by_index : bool, default=False
         If True, evaluate the metric at each time point.
         If False, evaluate the metric globally, averaging over all time points.
 
@@ -3972,13 +3949,13 @@ class RelativeLoss(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         relative_loss_function=mean_absolute_error,
-        evaluate_by_timepoints=False,
+        by_index=False,
     ):
         self.relative_loss_function = relative_loss_function
         super().__init__(
             multioutput=multioutput,
             multilevel=multilevel,
-            evaluate_by_timepoints=evaluate_by_timepoints,
+            by_index=by_index,
         )
 
     @classmethod

--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -124,6 +124,10 @@ class BaseForecastingErrorMetric(BaseMetric):
         * If 'uniform_average_time', metric is applied to all data,
           ignoring level index.
         * If 'raw_values', does not average errors across levels, hierarchy is retained.
+
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
     """
 
     _tags = {
@@ -142,9 +146,11 @@ class BaseForecastingErrorMetric(BaseMetric):
         self,
         multioutput="uniform_average",
         multilevel="uniform_average",
+        evaluate_by_timepoints=False,
     ):
         self.multioutput = multioutput
         self.multilevel = multilevel
+        self.evaluate_by_timepoints = evaluate_by_timepoints
 
         if not hasattr(self, "name") or self.name is None:
             self.name = type(self).__name__
@@ -230,6 +236,8 @@ class BaseForecastingErrorMetric(BaseMetric):
               of shape ``(n_levels, y_true.columns)`` if ``multioutput="raw_values"``.
               metric is applied per level, row averaging (yes/no) as in ``multioutput``.
         """  # noqa: E501
+        if self.evaluate_by_timepoints:
+            return self.evaluate_by_index(y_true, y_pred, **kwargs)
         return self.evaluate(y_true, y_pred, **kwargs)
 
     def _apply_sample_weight_to_kwargs(self, y_true, y_pred, **kwargs):
@@ -1060,6 +1068,10 @@ class MeanAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc)
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     MedianAbsoluteScaledError
@@ -1181,6 +1193,11 @@ class MedianAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFun
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     MeanAbsoluteScaledError
@@ -1229,9 +1246,14 @@ class MedianAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFun
         multioutput="uniform_average",
         multilevel="uniform_average",
         sp=1,
+        eval_by_timepoints=False,
     ):
         self.sp = sp
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=eval_by_timepoints,
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -1303,6 +1325,10 @@ class MeanSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     MeanAbsoluteScaledError
@@ -1349,10 +1375,15 @@ class MeanSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc):
         multilevel="uniform_average",
         sp=1,
         square_root=False,
+        eval_by_timepoints=False,
     ):
         self.sp = sp
         self.square_root = square_root
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=eval_by_timepoints,
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -1424,6 +1455,10 @@ class MedianSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     MeanAbsoluteScaledError
@@ -1470,10 +1505,15 @@ class MedianSquaredScaledError(_ScaledMetricTags, BaseForecastingErrorMetricFunc
         multilevel="uniform_average",
         sp=1,
         square_root=False,
+        eval_by_timepoints=False,
     ):
         self.sp = sp
         self.square_root = square_root
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=eval_by_timepoints,
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -1544,6 +1584,10 @@ class MeanAbsoluteError(BaseForecastingErrorMetric):
           metric is applied to all data, ignoring level index.
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
+
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
 
     See Also
     --------
@@ -1660,6 +1704,10 @@ class MedianAbsoluteError(BaseForecastingErrorMetricFunc):
           metric is applied to all data, ignoring level index.
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
+
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
 
     See Also
     --------
@@ -1801,6 +1849,10 @@ class MeanSquaredError(BaseForecastingErrorMetric):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     MeanAbsoluteError
@@ -1847,9 +1899,14 @@ class MeanSquaredError(BaseForecastingErrorMetric):
         multioutput="uniform_average",
         multilevel="uniform_average",
         square_root=False,
+        evaluate_by_timepoints=False,
     ):
         self.square_root = square_root
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=evaluate_by_timepoints,
+        )
 
     def _evaluate(self, y_true, y_pred, **kwargs):
         """Evaluate the desired metric on given inputs.
@@ -2009,6 +2066,9 @@ class MeanSquaredErrorPercentage(BaseForecastingErrorMetricFunc):
         If 'uniform_average' (default), errors are mean-averaged across levels.
         If 'uniform_average_time', metric is applied to all data, ignoring level index.
         If 'raw_values', does not average errors across levels, hierarchy is retained.
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
     """
 
     def __init__(
@@ -2016,11 +2076,16 @@ class MeanSquaredErrorPercentage(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         square_root=False,
+        evaluate_by_timepoints=False,
     ):
         self.square_root = square_root
         self.multioutput = multioutput
 
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=evaluate_by_timepoints,
+        )
 
     def _evaluate(self, y_true, y_pred, **kwargs):
         r"""
@@ -2180,6 +2245,10 @@ class MedianSquaredError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     MeanAbsoluteError
@@ -2230,9 +2299,14 @@ class MedianSquaredError(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         square_root=False,
+        evaluate_by_timepoints=False,
     ):
         self.square_root = square_root
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=evaluate_by_timepoints,
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -2290,6 +2364,10 @@ class GeometricMeanAbsoluteError(BaseForecastingErrorMetricFunc):
           metric is applied to all data, ignoring level index.
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
+
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
 
     See Also
     --------
@@ -2376,6 +2454,10 @@ class GeometricMeanSquaredError(BaseForecastingErrorMetricFunc):
           metric is applied to all data, ignoring level index.
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
+
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
 
     See Also
     --------
@@ -2531,6 +2613,10 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     MedianAbsolutePercentageError
@@ -2581,9 +2667,14 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         symmetric=False,
+        evaluate_by_timepoints=False,
     ):
         self.symmetric = symmetric
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=evaluate_by_timepoints,
+        )
 
     def _evaluate_by_index(self, y_true, y_pred, **kwargs):
         """Return the metric evaluated at each time point.
@@ -2716,6 +2807,10 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     MeanAbsolutePercentageError
@@ -2766,9 +2861,14 @@ class MedianAbsolutePercentageError(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         symmetric=False,
+        evaluate_by_timepoints=False,
     ):
         self.symmetric = symmetric
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=evaluate_by_timepoints,
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -2839,6 +2939,10 @@ class MeanSquaredPercentageError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     MeanAbsolutePercentageError
@@ -2893,10 +2997,15 @@ class MeanSquaredPercentageError(BaseForecastingErrorMetricFunc):
         multilevel="uniform_average",
         symmetric=False,
         square_root=False,
+        evaluate_by_timepoints=False,
     ):
         self.symmetric = symmetric
         self.square_root = square_root
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=evaluate_by_timepoints,
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -2971,6 +3080,10 @@ class MedianSquaredPercentageError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     MeanAbsolutePercentageError
@@ -3025,10 +3138,15 @@ class MedianSquaredPercentageError(BaseForecastingErrorMetricFunc):
         multilevel="uniform_average",
         symmetric=False,
         square_root=False,
+        evaluate_by_timepoints=False,
     ):
         self.symmetric = symmetric
         self.square_root = square_root
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=evaluate_by_timepoints,
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -3085,6 +3203,10 @@ class MeanRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
           metric is applied to all data, ignoring level index.
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
+
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
 
     See Also
     --------
@@ -3161,6 +3283,10 @@ class MedianRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     MeanRelativeAbsoluteError
@@ -3236,6 +3362,10 @@ class GeometricMeanRelativeAbsoluteError(BaseForecastingErrorMetricFunc):
           metric is applied to all data, ignoring level index.
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
+
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
 
     See Also
     --------
@@ -3321,6 +3451,10 @@ class GeometricMeanRelativeSquaredError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     MeanRelativeAbsoluteError
@@ -3369,9 +3503,14 @@ class GeometricMeanRelativeSquaredError(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         square_root=False,
+        evaluate_by_timepoints=False,
     ):
         self.square_root = square_root
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=evaluate_by_timepoints,
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -3460,6 +3599,10 @@ class MeanAsymmetricError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     mean_linex_error
@@ -3519,6 +3662,7 @@ class MeanAsymmetricError(BaseForecastingErrorMetricFunc):
         right_error_function="absolute",
         left_error_penalty=1.0,
         right_error_penalty=1.0,
+        evaluate_by_timepoints=False,
     ):
         self.asymmetric_threshold = asymmetric_threshold
         self.left_error_function = left_error_function
@@ -3526,7 +3670,11 @@ class MeanAsymmetricError(BaseForecastingErrorMetricFunc):
         self.left_error_penalty = left_error_penalty
         self.right_error_penalty = right_error_penalty
 
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=evaluate_by_timepoints,
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -3607,6 +3755,10 @@ class MeanLinexError(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     See Also
     --------
     mean_asymmetric_error
@@ -3663,10 +3815,15 @@ class MeanLinexError(BaseForecastingErrorMetricFunc):
         b=1.0,
         multioutput="uniform_average",
         multilevel="uniform_average",
+        evaluate_by_timepoints=False,
     ):
         self.a = a
         self.b = b
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=evaluate_by_timepoints,
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -3742,6 +3899,10 @@ class RelativeLoss(BaseForecastingErrorMetricFunc):
         * If ``'raw_values'``,
           does not average errors across levels, hierarchy is retained.
 
+    evaluate_by_timepoints : bool, default=False
+        If True, evaluate the metric at each time point.
+        If False, evaluate the metric globally, averaging over all time points.
+
     References
     ----------
     Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of
@@ -3788,9 +3949,14 @@ class RelativeLoss(BaseForecastingErrorMetricFunc):
         multioutput="uniform_average",
         multilevel="uniform_average",
         relative_loss_function=mean_absolute_error,
+        evaluate_by_timepoints=False,
     ):
         self.relative_loss_function = relative_loss_function
-        super().__init__(multioutput=multioutput, multilevel=multilevel)
+        super().__init__(
+            multioutput=multioutput,
+            multilevel=multilevel,
+            evaluate_by_timepoints=evaluate_by_timepoints,
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/performance_metrics/forecasting/tests/test_all_metrics_forecasting.py
+++ b/sktime/performance_metrics/forecasting/tests/test_all_metrics_forecasting.py
@@ -186,3 +186,25 @@ class TestAllForecastingPtMetrics(ForecastingMetricPtFixtureGenerator, QuickTest
         # wt_metr = metric(sample_weight=wts)
         # res_wt = wt_metr(y_true, y_pred)
         # assert np.allclose(res_wt, metric_obj(y_true, y_pred, sample_weight=wts))
+
+    def test_evaluate_by_index(self, estimator_instance):
+        """Test that by_index parameter returns temporally calculated error metrics."""
+        metric_obj = estimator_instance
+        metric_obj.set_params(by_index=True)
+        metric = type(metric_obj)
+
+        y_true = np.array([3, -0.5, 2, 7, 2])
+        y_pred = np.array([2.5, 0.5, 2, 8, 2.25])
+
+        y_kwargs = {
+            "y_true": y_true,
+            "y_pred": y_pred,
+            "y_pred_benchmark": y_true,
+            "y_train": y_true,
+        }
+
+        # skip for private metrics such as dynamic error metrics
+        if metric.__name__.startswith("_"):
+            return None
+
+        assert len(metric_obj(**y_kwargs)) == len(y_true)

--- a/sktime/performance_metrics/forecasting/tests/test_all_metrics_forecasting.py
+++ b/sktime/performance_metrics/forecasting/tests/test_all_metrics_forecasting.py
@@ -134,6 +134,21 @@ class TestAllForecastingPtMetrics(ForecastingMetricPtFixtureGenerator, QuickTest
 
         assert (res.index == y_true.index).all()
 
+        metric = metric.clone()
+
+        metric.set_params(by_index=True)
+
+        res_call = metric(
+            y_true=y_true,
+            y_pred=y_pred,
+            y_pred_benchmark=y_pred,
+            y_train=y_true,
+        )
+        if isinstance(multioutput, str) and multioutput == "raw_values":
+            pd.testing.assert_frame_equal(res, res_call)
+        else:
+            pd.testing.assert_series_equal(res, res_call)
+
     def test_uniform_average_time(self, estimator_instance):
         """Tests that uniform_average_time indeed ignores index."""
         metric_obj = estimator_instance.set_params(multilevel="uniform_average_time")
@@ -186,25 +201,3 @@ class TestAllForecastingPtMetrics(ForecastingMetricPtFixtureGenerator, QuickTest
         # wt_metr = metric(sample_weight=wts)
         # res_wt = wt_metr(y_true, y_pred)
         # assert np.allclose(res_wt, metric_obj(y_true, y_pred, sample_weight=wts))
-
-    def test_evaluate_by_index(self, estimator_instance):
-        """Test that by_index parameter returns temporally calculated error metrics."""
-        metric_obj = estimator_instance
-        metric_obj.set_params(by_index=True)
-        metric = type(metric_obj)
-
-        y_true = np.array([3, -0.5, 2, 7, 2])
-        y_pred = np.array([2.5, 0.5, 2, 8, 2.25])
-
-        y_kwargs = {
-            "y_true": y_true,
-            "y_pred": y_pred,
-            "y_pred_benchmark": y_true,
-            "y_train": y_true,
-        }
-
-        # skip for private metrics such as dynamic error metrics
-        if metric.__name__.startswith("_"):
-            return None
-
-        assert len(metric_obj(**y_kwargs)) == len(y_true)


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Closes #6813 

#### What does this implement/fix? Explain your changes.
Adds a class parameter to dispatch between `evaluate` and `evaluate_by_index`, if `__call__` is called.


#### Did you add any tests for the change?


#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
