### PR TITLE
[BUG] Exclude pytest from running `datadownload` test by default

### DIFF
--- a/sktime/datasets/tests/test_datadownload.py
+++ b/sktime/datasets/tests/test_datadownload.py
@@ -17,6 +17,8 @@ from sktime.datasets.tsf_dataset_names import tsf_all, tsf_all_datasets
 from sktime.datatypes import check_is_mtype, check_raise
 from sktime.utils.dependencies import _check_soft_dependencies
 
+pytestmark = pytest.mark.skip
+
 # test tsf download only on a random uniform subsample of datasets
 N_TSF_SUBSAMPLE = 3
 TSF_SUBSAMPLE = np.random.choice(tsf_all_datasets, N_TSF_SUBSAMPLE)


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs

Fixes #7607 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Exclude pytest from running `datadownload` test by default by adding a skip pytestmark variable 


