### PR TITLE
[ENH] forecasting `evaluate`: new `return_model` parameter to return fitted estimator states

### DIFF
--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -340,11 +340,11 @@ def evaluate(
     strategy: str = "refit",
     scoring: Optional[Union[callable, list[callable]]] = None,
     return_data: bool = False,
-    return_model: bool = False,
     error_score: Union[str, int, float] = np.nan,
     backend: Optional[str] = None,
     cv_X=None,
     backend_params: Optional[dict] = None,
+    return_model: bool = False,
 ):
     r"""Evaluate forecaster using timeseries cross-validation.
 

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -7,6 +7,7 @@ __all__ = ["evaluate"]
 
 import time
 import warnings
+from copy import deepcopy
 from typing import Optional, Union
 
 import numpy as np
@@ -310,7 +311,7 @@ def _evaluate_window(x, meta):
         temp_result["y_test"] = [y_test]
         temp_result.update(y_preds_cache)
     if return_model:
-        temp_result["fitted_forecaster"] = [forecaster]
+        temp_result["fitted_forecaster"] = [deepcopy(forecaster)]
     result = pd.DataFrame(temp_result)
     result = result.astype({"len_train_window": int, "cutoff": cutoff_dtype})
     if old_naming:

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -74,8 +74,11 @@ def _check_scores(metrics) -> dict:
 
 
 def _get_column_order_and_datatype(
-    metric_types: dict, return_data: bool = True, cutoff_dtype=None, old_naming=True,
-    return_model: bool = False
+    metric_types: dict,
+    return_data: bool = True,
+    cutoff_dtype=None,
+    old_naming=True,
+    return_model: bool = False,
 ) -> dict:
     """Get the ordered column name and input datatype of results."""
     others_metadata = {
@@ -313,7 +316,11 @@ def _evaluate_window(x, meta):
     if old_naming:
         result = result.rename(columns=old_name_mapping)
     column_order = _get_column_order_and_datatype(
-        scoring, return_data, cutoff_dtype, old_naming=old_naming, return_model=return_model
+        scoring,
+        return_data,
+        cutoff_dtype,
+        old_naming=old_naming,
+        return_model=return_model,
     )
     result = result.reindex(columns=column_order.keys())
 
@@ -637,7 +644,9 @@ def evaluate(
     if backend in ["dask", "dask_lazy"] and not not_parallel:
         import dask.dataframe as dd
 
-        metadata = _get_column_order_and_datatype(scoring, return_data, cutoff_dtype, return_model=return_model)
+        metadata = _get_column_order_and_datatype(
+            scoring, return_data, cutoff_dtype, return_model=return_model
+        )
 
         results = dd.from_delayed(results, meta=metadata)
         if backend == "dask":

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -478,16 +478,17 @@ def evaluate(
         - pred_time: (float) Time in sec to ``predict`` from fitted estimator.
         - len_train_window: (int) Length of train window.
         - cutoff: (int, pd.Timestamp, pd.Period) cutoff = last time index in train fold.
-        - y_train: (pd.Series) only present if see ``return_data=True``
+
+        - y_train: (pd.Series) only present if ``return_data=True``,
         train fold of the i-th split in ``cv``, used to fit/update the forecaster.
 
-        - y_pred: (pd.Series) present if see ``return_data=True``
+        - y_pred: (pd.Series) present if ``return_data=True``,
         forecasts from fitted forecaster for the i-th test fold indices of ``cv``.
 
-        - y_test: (pd.Series) present if see ``return_data=True``
+        - y_test: (pd.Series) present if ``return_data=True``,
         testing fold of the i-th split in ``cv``, used to compute the metric.
 
-        - fitted_forecaster: (BaseForecaster) present if see ``return_model=True``
+        - fitted_forecaster: (BaseForecaster) present if ``return_model=True``,
         fitted forecaster for the i-th split in ``cv``.
 
     Examples

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -317,9 +317,9 @@ def _evaluate_window(x, meta):
     if old_naming:
         result = result.rename(columns=old_name_mapping)
     column_order = _get_column_order_and_datatype(
-        scoring,
-        return_data,
-        cutoff_dtype,
+        metric_types=scoring,
+        return_data=return_data,
+        cutoff_dtype=cutoff_dtype,
         old_naming=old_naming,
         return_model=return_model,
     )

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -526,7 +526,17 @@ def evaluate(
     ...     scoring=[MeanSquaredError(square_root=True), MeanAbsoluteError()],
     ... )
 
-    To get the fitted models for each fold, set return_model=True:
+    An example of an interval metric is the ``PinballLoss``.
+    It can be used with all probabilistic forecasters.
+
+    >>> from sktime.forecasting.naive import NaiveVariance
+    >>> from sktime.performance_metrics.forecasting.probabilistic import PinballLoss
+    >>> loss = PinballLoss()
+    >>> forecaster = NaiveForecaster(strategy="drift")
+    >>> results = evaluate(forecaster=NaiveVariance(forecaster),
+    ... y=y, cv=cv, scoring=loss)
+
+    To return fitted models for each fold, set ``return_model=True``:
 
     >>> results = evaluate(
     ...     forecaster=forecaster,

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -533,7 +533,7 @@ def evaluate(
     ...     scoring=loss,
     ...     return_model=True
     ... )
-    >>> fitted_forecaster = results.iloc[0]["fitted_forecaster"]  # get first fold's model
+    >>> fitted_forecaster = results.iloc[0]["fitted_forecaster"]
     """
     if backend in ["dask", "dask_lazy"]:
         if not _check_soft_dependencies("dask", severity="none"):

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -71,7 +71,9 @@ def _check_evaluate_output(out, cv, y, scoring, return_data, return_model):
     assert isinstance(out, pd.DataFrame)
     # Check column names.
     scoring = _check_scores(scoring)
-    columns = _get_column_order_and_datatype(scoring, return_data, return_model)
+    columns = _get_column_order_and_datatype(
+        metric_types=scoring, return_data=return_data, return_model=return_model
+    )
     assert set(out.columns) == columns.keys(), "Columns are not identical"
 
     # Check number of rows against number of splits.
@@ -146,7 +148,9 @@ def test_evaluate_common_configs(
         scoring=scoring,
         **backend,
     )
-    _check_evaluate_output(out, cv, y, scoring, False, False)
+    _check_evaluate_output(
+        out=out, cv=cv, y=y, scoring=scoring, return_data=False, return_model=False
+    )
 
     # check scoring
     actual = out.loc[:, f"test_{scoring.name}"]
@@ -182,7 +186,14 @@ def test_scoring_list(return_data, return_model, scores):
         return_data=return_data,
         return_model=return_model,
     )
-    _check_evaluate_output(out, cv, y, scores, return_data, return_model)
+    _check_evaluate_output(
+        out=out,
+        cv=cv,
+        y=y,
+        scoring=scores,
+        return_data=return_data,
+        return_model=return_model,
+    )
 
 
 @pytest.mark.skipif(
@@ -200,7 +211,9 @@ def test_evaluate_initial_window():
     out = evaluate(
         forecaster=forecaster, y=y, cv=cv, strategy="update", scoring=scoring
     )
-    _check_evaluate_output(out, cv, y, scoring, False, False)
+    _check_evaluate_output(
+        out=out, cv=cv, y=y, scoring=scoring, return_data=False, return_model=False
+    )
     assert out.loc[0, "len_train_window"] == initial_window
 
     # check scoring

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -23,6 +23,7 @@ from sktime.datasets import load_airline, load_longley
 # from sktime.exceptions import FitFailedWarning
 # commented out until bugs are resolved, see test_evaluate_error_score
 from sktime.forecasting.arima import ARIMA, AutoARIMA
+from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.compose._reduce import DirectReductionForecaster
 from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 from sktime.forecasting.model_evaluation import evaluate
@@ -66,11 +67,11 @@ INTERVAL_METRICS_WITH_PARAMS = [
 BACKENDS = _get_parallel_test_fixtures("estimator")
 
 
-def _check_evaluate_output(out, cv, y, scoring, return_data):
+def _check_evaluate_output(out, cv, y, scoring, return_data, return_model):
     assert isinstance(out, pd.DataFrame)
     # Check column names.
     scoring = _check_scores(scoring)
-    columns = _get_column_order_and_datatype(scoring, return_data)
+    columns = _get_column_order_and_datatype(scoring, return_data, return_model)
     assert set(out.columns) == columns.keys(), "Columns are not identical"
 
     # Check number of rows against number of splits.
@@ -102,6 +103,14 @@ def _check_evaluate_output(out, cv, y, scoring, return_data):
 
     else:
         assert np.all(out.loc[:, "len_train_window"] == cv.window_length)
+
+    # Check fitted models
+    if return_model:
+        assert "fitted_forecaster" in out.columns
+        assert all(
+            isinstance(f, (BaseForecaster, type(None)))
+            for f in out["fitted_forecaster"].values
+        )
 
 
 @pytest.mark.skipif(
@@ -137,7 +146,7 @@ def test_evaluate_common_configs(
         scoring=scoring,
         **backend,
     )
-    _check_evaluate_output(out, cv, y, scoring, False)
+    _check_evaluate_output(out, cv, y, scoring, False, False)
 
     # check scoring
     actual = out.loc[:, f"test_{scoring.name}"]
@@ -158,8 +167,9 @@ def test_evaluate_common_configs(
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 @pytest.mark.parametrize("return_data", [True, False])
+@pytest.mark.parametrize("return_model", [True, False])
 @pytest.mark.parametrize("scores", [METRICS, PROBA_METRICS, METRICS + PROBA_METRICS])
-def test_scoring_list(return_data, scores):
+def test_scoring_list(return_data, return_model, scores):
     y = make_forecasting_problem(n_timepoints=30, index_type="int")
     forecaster = NaiveForecaster()
     cv = SlidingWindowSplitter(fh=[1, 2, 3], initial_window=15, step_length=5)
@@ -170,8 +180,9 @@ def test_scoring_list(return_data, scores):
         cv=cv,
         scoring=scores,
         return_data=return_data,
+        return_model=return_model,
     )
-    _check_evaluate_output(out, cv, y, scores, return_data)
+    _check_evaluate_output(out, cv, y, scores, return_data, return_model)
 
 
 @pytest.mark.skipif(
@@ -189,7 +200,7 @@ def test_evaluate_initial_window():
     out = evaluate(
         forecaster=forecaster, y=y, cv=cv, strategy="update", scoring=scoring
     )
-    _check_evaluate_output(out, cv, y, scoring, False)
+    _check_evaluate_output(out, cv, y, scoring, False, False)
     assert out.loc[0, "len_train_window"] == initial_window
 
     # check scoring
@@ -229,10 +240,13 @@ def test_evaluate_no_exog_against_with_exog():
 )
 @pytest.mark.parametrize("error_score", [np.nan, "raise", 1000])
 @pytest.mark.parametrize("return_data", [True, False])
+@pytest.mark.parametrize("return_model", [True, False])
 @pytest.mark.parametrize("strategy", ["refit", "update", "no-update_params"])
 @pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("scores", [[MeanAbsolutePercentageError()], METRICS])
-def test_evaluate_error_score(error_score, return_data, strategy, backend, scores):
+def test_evaluate_error_score(
+    error_score, return_data, return_model, strategy, backend, scores
+):
     """Test evaluate to raise warnings and exceptions according to error_score value."""
     forecaster = ExponentialSmoothing(sp=12)
     y = load_airline()
@@ -248,6 +262,7 @@ def test_evaluate_error_score(error_score, return_data, strategy, backend, score
         "cv": cv,
         "scoring": scores,
         "return_data": return_data,
+        "return_model": return_model,
         "error_score": error_score,
         "strategy": strategy,
     }


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #7636 

#### What does this implement/fix? Explain your changes.

This draft PR enhances the `evaluate` function in sktime to optionally return fitted models for each fold in the cross-validation. This is implemented through a new `return_model` parameter which, when set to `True`, adds a `fitted_forecaster` column to the results DataFrame containing the fitted forecaster for each fold.

The enhancement is useful for:
- Analyzing model behavior across different folds
- Reusing fitted models from specific folds for further analysis or prediction
- Debugging model performance variations between folds

Changes made:
1. Added `return_model` parameter to `evaluate` function (default=False)
2. Modified `_get_column_order_and_datatype` to include fitted model column
3. Updated `_evaluate_window` to store fitted models in results
4. Added documentation for the new parameter and return value
5. Added example usage in docstring
6. Increased coverage of current tests to account for the new feature

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies were introduced.

#### What should a reviewer concentrate their feedback on?

* [] Correctness of model storage and retrieval in parallel execution modes
* [] Memory implications of storing fitted models
* [] Documentation clarity and completeness
* [] Handling of fitted models in error cases
* [] Review updated tests

#### Did you add any tests for the change?

Yes but they could benefit from some review.

#### Any other comments?

The implementation maintains backward compatibility as the `return_model` parameter defaults to False. When using parallel backends (especially dask), users should be aware of potential memory implications when storing fitted models for many folds.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with [ENH] as this is a feature enhancement