### PR TITLE
[ENH] Validation split fix issue 7644

### DIFF
--- a/sktime/forecasting/hf_transformers_forecaster.py
+++ b/sktime/forecasting/hf_transformers_forecaster.py
@@ -293,14 +293,25 @@ class HFTransformersForecaster(BaseForecaster):
         else:
             raise ValueError("Unknown fit strategy")
 
-        trainer = Trainer(
+        # Get the Trainer
+        if eval_dataset is not None:  # If a test dataset is provided
+            trainer = Trainer(
             model=self.model,
             args=training_args,
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
             compute_metrics=self._compute_metrics,
             callbacks=self._callbacks,
-        )
+            )
+        else:  # If no test dataset (validation_split is None)
+            trainer = Trainer(
+            model=self.model,
+            args=training_args,
+            train_dataset=train_dataset,
+            compute_metrics=self._compute_metrics,
+            callbacks=self._callbacks,
+            )
+
         trainer.train()
 
     def _predict(self, fh, X=None):

--- a/sktime/forecasting/hf_transformers_forecaster.py
+++ b/sktime/forecasting/hf_transformers_forecaster.py
@@ -252,6 +252,7 @@ class HFTransformersForecaster(BaseForecaster):
                 X=X[split:] if X is not None else None,
                 fh=config.prediction_length,
             )
+
         else:
             train_dataset = PyTorchDataset(
                 y,
@@ -260,7 +261,7 @@ class HFTransformersForecaster(BaseForecaster):
                 fh=config.prediction_length,
             )
 
-            eval_dataset = None
+            eval_dataset = None  # No validation dataset
 
         training_args = deepcopy(self.training_args)
         training_args["label_names"] = ["future_values"]

--- a/sktime/forecasting/hf_transformers_forecaster.py
+++ b/sktime/forecasting/hf_transformers_forecaster.py
@@ -252,7 +252,6 @@ class HFTransformersForecaster(BaseForecaster):
                 X=X[split:] if X is not None else None,
                 fh=config.prediction_length,
             )
-
         else:
             train_dataset = PyTorchDataset(
                 y,
@@ -261,7 +260,7 @@ class HFTransformersForecaster(BaseForecaster):
                 fh=config.prediction_length,
             )
 
-            eval_dataset = None  # No validation dataset
+            eval_dataset = None
 
         training_args = deepcopy(self.training_args)
         training_args["label_names"] = ["future_values"]
@@ -293,25 +292,14 @@ class HFTransformersForecaster(BaseForecaster):
         else:
             raise ValueError("Unknown fit strategy")
 
-        # Get the Trainer
-        if eval_dataset is not None:  # If a test dataset is provided
-            trainer = Trainer(
+        trainer = Trainer(
             model=self.model,
             args=training_args,
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
             compute_metrics=self._compute_metrics,
             callbacks=self._callbacks,
-            )
-        else:  # If no test dataset (validation_split is None)
-            trainer = Trainer(
-            model=self.model,
-            args=training_args,
-            train_dataset=train_dataset,
-            compute_metrics=self._compute_metrics,
-            callbacks=self._callbacks,
-            )
-
+        )
         trainer.train()
 
     def _predict(self, fh, X=None):

--- a/sktime/forecasting/ttm.py
+++ b/sktime/forecasting/ttm.py
@@ -388,18 +388,14 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
         training_args = TrainingArguments(**self._training_args)
 
         # Get the Trainer
-        trainer_args = {
-            "model": self.model,
-            "args": training_args,
-            "train_dataset": train,
-            "compute_metrics": self.compute_metrics,
-            "callbacks": self.callbacks,
-        }
-
-        if test is not None:  # Only include eval_dataset if test is provided
-            trainer_args["eval_dataset"] = test
-
-        trainer = Trainer(**trainer_args)
+        trainer = Trainer(
+            model=self.model,
+            args=training_args,
+            train_dataset=train,
+            eval_dataset=test,
+            compute_metrics=self.compute_metrics,
+            callbacks=self.callbacks,
+        )
 
         # Train the model
         trainer.train()

--- a/sktime/forecasting/ttm.py
+++ b/sktime/forecasting/ttm.py
@@ -378,11 +378,14 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
             context_length=config.context_length,
             prediction_length=config.prediction_length,
         )
-        test = PyTorchDataset(
-            y=y_eval,
-            context_length=config.context_length,
-            prediction_length=config.prediction_length,
-        )
+
+        eval = None
+        if self.validation_split is not None:
+            eval = PyTorchDataset(
+                y=y_eval,
+                context_length=config.context_length,
+                prediction_length=config.prediction_length,
+            )
 
         # Get Training Configuration
         training_args = TrainingArguments(**self._training_args)
@@ -392,7 +395,7 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
             model=self.model,
             args=training_args,
             train_dataset=train,
-            eval_dataset=test,
+            eval_dataset=eval,
             compute_metrics=self.compute_metrics,
             callbacks=self.callbacks,
         )


### PR DESCRIPTION
Description:

This update (Fixes #7644) modifies the code to ensure that the y_test dataset is only created when validation_split is not None. If validation_split is None, no y_test dataset is created, and it is not passed to the Trainer. This change optimizes resource usage and eliminates unnecessary processing when validation data is not required.

Key Changes:

Added a conditional check to create y_test only when validation_split is provided.
Ensured that y_test is excluded from being passed to the Trainer when validation_split is None.