### PR TITLE
[BUG] fix bugs in `MACNNClassifier`, `MACNNRegressor`

### DIFF
--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -131,7 +131,7 @@ class MACNNNetwork(BaseDeepNetwork):
         Parameters
         ----------
         input_shape : tuple
-            The shape of the data(without batch) fed into the input layer
+            The shape of the data (without batch) fed into the input layer
 
         Returns
         -------

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -178,4 +178,3 @@ class MACNNNetwork(BaseDeepNetwork):
         output_layer = keras.layers.GlobalAveragePooling1D()(x)
 
         return input_layer, output_layer
-    

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -85,7 +85,7 @@ class MACNNNetwork(BaseDeepNetwork):
                 filters=kernels, kernel_size=kernel_size, padding=self.padding
             )(x)
             conv_layers.append(conv_layer)
-            
+        
         x1 = keras.layers.Concatenate(axis=2)(conv_layers)
         x1 = keras.layers.BatchNormalization()(x1)
         x1 = keras.layers.Activation("relu")(x1)

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -85,7 +85,7 @@ class MACNNNetwork(BaseDeepNetwork):
                 filters=kernels, kernel_size=kernel_size, padding=self.padding
             )(x)
             conv_layers.append(conv_layer)        
-        
+
         x1 = keras.layers.Concatenate(axis=2)(conv_layers)
         x1 = keras.layers.BatchNormalization()(x1)
         x1 = keras.layers.Activation("relu")(x1)

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -84,7 +84,6 @@ class MACNNNetwork(BaseDeepNetwork):
             conv_layer = keras.layers.Conv1D(
                 filters=kernels, kernel_size=kernel_size, padding=self.padding
             )(x)
-            
             conv_layers.append(conv_layer)        
 
         x1 = keras.layers.Concatenate(axis=2)(conv_layers)

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -100,7 +100,7 @@ class MACNNNetwork(BaseDeepNetwork):
         x2 = keras.layers.RepeatVector(x1.shape[1])(x2)
 
         return keras.layers.Multiply()([x1, x2])
-    
+
     def _stack(self, x, repeats, kernels, reduce):
         """Build MACNN Blocks and stack them.
 
@@ -124,7 +124,7 @@ class MACNNNetwork(BaseDeepNetwork):
         for _ in range(repeats):
             x = self._macnn_block(x, kernels, reduce)
         return x
-    
+
     def build_network(self, input_shape, **kwargs):
         """Construct a network and return its input and output layers.
 

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -148,7 +148,7 @@ class MACNNNetwork(BaseDeepNetwork):
             x=input_layer, 
             repeats=self.repeats, 
             kernels=self.filter_sizes[0], 
-            reduce=self.reduction
+            reduce=self.reduction,
         )
         x = keras.layers.MaxPooling1D(
             pool_size=self.pool_size, strides=self.strides, padding=self.padding
@@ -158,7 +158,7 @@ class MACNNNetwork(BaseDeepNetwork):
             x=x, 
             repeats=self.repeats, 
             kernels=self.filter_sizes[1], 
-            reduce=self.reduction
+            reduce=self.reduction,
         )
         x = keras.layers.MaxPooling1D(
             pool_size=self.pool_size, strides=self.strides, padding=self.padding
@@ -168,8 +168,9 @@ class MACNNNetwork(BaseDeepNetwork):
             x=x, 
             repeats=self.repeats, 
             kernels=self.filter_sizes[2], 
-            reduce=self.reduction
+            reduce=self.reduction,
         )
 
         output_layer = keras.layers.GlobalAveragePooling1D()(x)
+        
         return input_layer, output_layer

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -145,29 +145,33 @@ class MACNNNetwork(BaseDeepNetwork):
         input_layer = keras.layers.Input(shape=input_shape)
 
         x = self._stack(
-            x=input_layer, 
-            repeats=self.repeats, 
-            kernels=self.filter_sizes[0], 
+            x=input_layer,
+            repeats=self.repeats,
+            kernels=self.filter_sizes[0],
             reduce=self.reduction,
         )
         x = keras.layers.MaxPooling1D(
-            pool_size=self.pool_size, strides=self.strides, padding=self.padding
+            pool_size=self.pool_size,
+            strides=self.strides,
+            padding=self.padding,
         )(x)
 
         x = self._stack(
-            x=x, 
-            repeats=self.repeats, 
-            kernels=self.filter_sizes[1], 
+            x=x,
+            repeats=self.repeats,
+            kernels=self.filter_sizes[1],
             reduce=self.reduction,
         )
         x = keras.layers.MaxPooling1D(
-            pool_size=self.pool_size, strides=self.strides, padding=self.padding
+            pool_size=self.pool_size,
+            strides=self.strides,
+            padding=self.padding,
         )(x)
 
         x = self._stack(
-            x=x, 
-            repeats=self.repeats, 
-            kernels=self.filter_sizes[2], 
+            x=x,
+            repeats=self.repeats,
+            kernels=self.filter_sizes[2],
             reduce=self.reduction,
         )
 

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -172,5 +172,6 @@ class MACNNNetwork(BaseDeepNetwork):
         )
 
         output_layer = keras.layers.GlobalAveragePooling1D()(x)
-        
+
         return input_layer, output_layer
+    

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -84,6 +84,7 @@ class MACNNNetwork(BaseDeepNetwork):
             conv_layer = keras.layers.Conv1D(
                 filters=kernels, kernel_size=kernel_size, padding=self.padding
             )(x)
+            
             conv_layers.append(conv_layer)        
 
         x1 = keras.layers.Concatenate(axis=2)(conv_layers)

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -84,7 +84,8 @@ class MACNNNetwork(BaseDeepNetwork):
             conv_layer = keras.layers.Conv1D(
                 filters=kernels, kernel_size=kernel_size, padding=self.padding
             )(x)
-            conv_layers.append(conv_layer)        
+
+            conv_layers.append(conv_layer)
 
         x1 = keras.layers.Concatenate(axis=2)(conv_layers)
         x1 = keras.layers.BatchNormalization()(x1)

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -179,3 +179,38 @@ class MACNNNetwork(BaseDeepNetwork):
         output_layer = keras.layers.GlobalAveragePooling1D()(x)
 
         return input_layer, output_layer
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+            Reserved values for classifiers:
+                "results_comparison" - used for identity testing in some classifiers
+                    should contain parameter settings comparable to "TSC bakeoff"
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            ``MyClass(**params)`` or ``MyClass(**params[i])`` creates a valid test
+            instance.
+            ``create_test_instance`` uses the first (or only) dictionary in ``params``
+        """
+        params1 = {}
+        params2 = {
+            "padding": "valid",
+            "pool_size": 2,
+            "strides": 1,
+            "repeats": 2,
+            "filter_sizes": (64, 128, 256),
+            "kernel_size": (3, 6, 12),
+            "reduction": 16,
+            "random_state": 0,
+        }
+        return [params1, params2]

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -145,26 +145,31 @@ class MACNNNetwork(BaseDeepNetwork):
         input_layer = keras.layers.Input(shape=input_shape)
 
         x = self._stack(
-            x=input_layer, repeats=self.repeats, 
-            kernels=self.filter_sizes[0], reduce=self.reduction
+            x=input_layer, 
+            repeats=self.repeats, 
+            kernels=self.filter_sizes[0], 
+            reduce=self.reduction
         )
         x = keras.layers.MaxPooling1D(
             pool_size=self.pool_size, strides=self.strides, padding=self.padding
         )(x)
 
         x = self._stack(
-            x=x, repeats=self.repeats, 
-            kernels=self.filter_sizes[1], reduce=self.reduction
+            x=x, 
+            repeats=self.repeats, 
+            kernels=self.filter_sizes[1], 
+            reduce=self.reduction
         )
         x = keras.layers.MaxPooling1D(
             pool_size=self.pool_size, strides=self.strides, padding=self.padding
         )(x)
 
         x = self._stack(
-            x=x, repeats=self.repeats, 
-            kernels=self.filter_sizes[2], reduce=self.reduction
+            x=x, 
+            repeats=self.repeats, 
+            kernels=self.filter_sizes[2], 
+            reduce=self.reduction
         )
 
         output_layer = keras.layers.GlobalAveragePooling1D()(x)
-
         return input_layer, output_layer

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -84,7 +84,7 @@ class MACNNNetwork(BaseDeepNetwork):
             conv_layer = keras.layers.Conv1D(
                 filters=kernels, kernel_size=kernel_size, padding=self.padding
             )(x)
-            conv_layers.append(conv_layer)
+            conv_layers.append(conv_layer)        
         
         x1 = keras.layers.Concatenate(axis=2)(conv_layers)
         x1 = keras.layers.BatchNormalization()(x1)

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -165,13 +165,7 @@ EXCLUDED_TESTS = {
     "MCDCNNRegressor": [
         "test_fit_idempotent",
     ],
-    "MACNNClassifier": [
-        "test_fit_idempotent",
-    ],
     "FCNRegressor": [
-        "test_fit_idempotent",
-    ],
-    "MACNNRegressor": [
         "test_fit_idempotent",
     ],
     "InceptionTimeRegressor": [
@@ -323,7 +317,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "LTSFLinearForecaster",
         "LTSFNLinearForecaster",
         "LogTransformer",
-        "MACNNNetwork",
         "MCDCNNClassifier",
         "MCDCNNNetwork",
         "MCDCNNRegressor",

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -29,7 +29,6 @@ EXCLUDE_ESTIMATORS = [
     "LSTMFCNClassifier",  # unknown cause, see bug report #4033
     # DL classifier suspected to cause hangs and memouts, see #4610
     "FCNClassifier",
-    "MACNNClassifier",
     "EditDist",
     "CNNClassifier",
     "FCNClassifier",
@@ -41,7 +40,6 @@ EXCLUDE_ESTIMATORS = [
     "ResNetRegressor",
     "FCNRegressor",
     "LSTMFCNRegressor",
-    "MACNNRegressor",
     # splitters excluded with undiagnosed failures, see #6194
     # these are temporarily skipped to allow merging of the base test framework
     "SameLocSplitter",


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes part of issue #6153
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->


#### What does this implement/fix? Explain your changes.
MACNNClassifier, MACNNRegressor - fail all tests with ValueError: A KerasTensor cannot be used as input to a TensorFlow function.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?
tests
<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?
No, passed all the existing test cases
<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
