### PR TITLE
Fix : Added Link for skbase in intersphinx_mapping

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -621,6 +621,7 @@ intersphinx_mapping = {
     "joblib": ("https://joblib.readthedocs.io/en/stable/", None),
     "scikit-learn": ("https://scikit-learn.org/stable/", None),
     "statsmodels": ("https://www.statsmodels.org/stable/", None),
+    "skbase": ("https://skbase.readthedocs.io/en/latest/", None),
 }
 
 # -- Options for _todo extension ----------------------------------------------


### PR DESCRIPTION
Fixes #7655 

The source links for various methods, such as [`check_is_fitted`](https://www.sktime.net/en/latest/api_reference/auto_generated/sktime.forecasting.enbpi.EnbPIForecaster.html#sktime.forecasting.enbpi.EnbPIForecaster.check_is_fitted), [`clone`](https://www.sktime.net/en/latest/api_reference/auto_generated/sktime.forecasting.enbpi.EnbPIForecaster.html#sktime.forecasting.enbpi.EnbPIForecaster.clone), etc., were previously leading to an invalid location [(sktime/skbase/base/_base.py/)](https://github.com/sktime/sktime/blob/main/skbase/base/_base.py#L1499-L1530)  instead of the correct path [(skbase/skbase/base/_base.py)](https://github.com/sktime/skbase/blob/main/skbase/base/_base.py).

Fixes:

Added the correct ReadTheDocs link for `skbase `in the `intersphinx_mapping` section of the [`sktime/docs/source/conf.py`](https://github.com/sktime/sktime/blob/main/docs/source/conf.py) file. This change should hopefully now correctly point to the skbase repository, fixing the broken links issue.