### PR TITLE
[ENH] improvements to clusterer base class and tests

### DIFF
--- a/sktime/clustering/base.py
+++ b/sktime/clustering/base.py
@@ -44,7 +44,12 @@ class BaseClusterer(BaseEstimator):
         self.fit_time_ = 0
         self._class_dictionary = {}
         self._threads_to_use = 1
-        self.n_clusters = n_clusters
+
+        # defensive programming in case subclass does set n_clusters
+        # but does not pass it to super().__init__
+        if not hasattr(self, "n_clusters"):
+            self.n_clusters = n_clusters
+
         super().__init__()
         _check_estimator_deps(self)
 

--- a/sktime/clustering/tests/test_all_clusterers.py
+++ b/sktime/clustering/tests/test_all_clusterers.py
@@ -41,7 +41,7 @@ class TestAllClusterers(ClustererFixtureGenerator, QuickTester):
         if estimator_instance.get_tag("capability:multivariate"):
             return None
 
-        error_msg = "multivariate series"
+        error_msg = "multivariate"
 
         scenario = ClustererFitPredictMultivariate()
 


### PR DESCRIPTION
This PR makes minor improvements to the clusterer base class:

* the base class is modified to not override the `n_clusters` attribute if it was already set in the child class - this could lead to hard-to-diagnose errors, especially since this is not described in the extension guide.
* the pytest regex to check univariate clustering algorithms was incorrect - this did not cause issues until now as all clusterers were multivariate.