### PR TITLE
[BUG] fix `all_estimators` lookup in case a tag is used that is not scitype specific

### DIFF
--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -123,10 +123,14 @@ def all_estimators(
     Returns
     -------
     all_estimators will return one of the following:
-        1. list of estimators, if return_names=False, and return_tags is None
-        2. list of tuples (optional estimator name, class, ~optional estimator
-          tags), if return_names=True or return_tags is not None.
-        3. pandas.DataFrame if as_dataframe = True
+
+        1. list of estimators, if ``return_names=False``, and ``return_tags`` is None
+
+        2. list of tuples (optional estimator name, class, ~ptional estimator
+        tags), if ``return_names=True`` or ``return_tags`` is not ``None``.
+
+        3. ``pandas.DataFrame`` if ``as_dataframe = True``
+
         if list of estimators:
             entries are estimators matching the query,
             in alphabetical order of estimator name
@@ -139,8 +143,7 @@ def all_estimators(
             ``estimator`` is the actual estimator
             ``tags`` are the estimator's values for each tag in return_tags
             and is an optional return.
-        if dataframe:
-            all_estimators will return a pandas.DataFrame.
+        if ``DataFrame``:
             column names represent the attributes contained in each column.
             "estimators" will be the name of the column of estimators, "names"
             will be the name of the column of estimator class names and the string(s)
@@ -194,15 +197,22 @@ def all_estimators(
         estimator_types = [x for y in estimator_types for x in _get_all_descendants(y)]
         estimator_types = list(set(estimator_types))
 
-    if estimator_types is not None and filter_tags is not None:
+    if estimator_types is not None:
+        if filter_tags is None:
+            filter_tags = {}
+        elif isinstance(filter_tags, str):
+            filter_tags = {filter_tags: True}
+        else:
+            filter_tags = filter_tags.copy()
+
         if "object_type" in filter_tags:
             obj_field = filter_tags["object_type"]
             obj_field = _coerce_to_list_of_str(obj_field)
             obj_field = obj_field + estimator_types
-            filter_tags = filter_tags.copy()
-            filter_tags["object_type"] = obj_field
-    elif estimator_types is not None:
-        filter_tags = {"object_type": estimator_types}
+        else:
+            obj_field = estimator_types
+
+        filter_tags["object_type"] = obj_field
 
     result = all_objects(
         object_types=BaseObject,

--- a/sktime/registry/tests/test_lookup.py
+++ b/sktime/registry/tests/test_lookup.py
@@ -216,23 +216,28 @@ def test_all_estimators_return_tags_bad_arg(return_tags):
         _ = all_estimators(return_tags=return_tags)
 
 
-@pytest.mark.parametrize("pred_int", [True, False])
-def test_all_estimators_tag_filter(pred_int):
+@pytest.mark.parametrize("tag_name", ["capability:pred_int", "handles-missing-data"])
+@pytest.mark.parametrize("tag_value", [True, False])
+def test_all_estimators_tag_filter(tag_value, tag_name):
     """Test that tag filtering returns estimators as expected."""
-    NOPROBA_EXAMPLE = "TrendForecaster"
-    PROBA_EXAMPLE = "ARIMA"
+    FALSE_EXAMPLE = "TrendForecaster"  # tag_value known False for both tag_name
+    TRUE_EXAMPLE = "ARIMA"  # tag_value known True for both tag_name
 
-    res = all_estimators("forecaster", filter_tags={"capability:pred_int": pred_int})
+    res = all_estimators("forecaster", filter_tags={tag_name: tag_value})
     names, ests = zip(*res)
 
-    if pred_int:
-        assert PROBA_EXAMPLE in names
-        assert NOPROBA_EXAMPLE not in names
-        assert [est.get_class_tag("capability:pred_int") for est in ests]
+    if tag_value:
+        assert TRUE_EXAMPLE in names
+        assert FALSE_EXAMPLE not in names
+        assert [est.get_class_tag(tag_name) for est in ests]
     else:
-        assert PROBA_EXAMPLE not in names
-        assert NOPROBA_EXAMPLE in names
-        assert [not est.get_class_tag("capability:pred_int") for est in ests]
+        assert TRUE_EXAMPLE not in names
+        assert FALSE_EXAMPLE in names
+        assert [not est.get_class_tag(tag_name) for est in ests]
+
+    for est in ests:  # not done as comprehension to make this easier to read
+        est_type = scitype(est, force_single_scitype=False, coerce_to_list=True)
+        assert "forecaster" in est_type
 
 
 @pytest.mark.parametrize("estimator_scitype", BASE_CLASS_SCITYPE_LIST)


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/7664

The exact failure condition: `all_estimators` would ignore the type specified via `estimator_types` if `filter_tags` was also provided, in a case where all tags filtered for were available in multiple scitypes.

The reason was the internal translation code that translated the `estimator_types` argument to a `filter_tags` argument or `object_types` in `scikit-base` `all_objects`.

This has now been fixed, and a test has been added to cover https://github.com/sktime/sktime/issues/7664.

An existing test for estimator type plus tag filter was present, but it did not trigger the condition as the tag used did not occur outside forecasters. This test has been extended to also use the tag triggering #7664, `handles-missing-data`.

The test framework was also not affected, as the retrieval calls in test collection were not using the `filter_tags` argument.

Also makes formatting improvements to the docstring.