### PR TITLE
[MNT] CI: Add ubuntu-22.04-arm runners to enhance arm aarch64 architecture testing and maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,7 +293,7 @@ jobs:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -34,6 +34,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
+          - ubuntu-22.04-arm
           - windows-latest
     runs-on: ${{ matrix.operating-system }}
     steps:
@@ -61,6 +62,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
+          - ubuntu-22.04-arm
           - windows-latest
         sktime-component:
           - alignment
@@ -99,6 +101,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
+          - ubuntu-22.04-arm
           - windows-latest
     runs-on: ${{ matrix.operating-system }}
     steps:

--- a/.github/workflows/test_base.yml
+++ b/.github/workflows/test_base.yml
@@ -34,6 +34,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
+          - ubuntu-22.04-arm
           - windows-latest
     runs-on: ${{ matrix.operating-system }}
     steps:

--- a/.github/workflows/test_datasets.yml
+++ b/.github/workflows/test_datasets.yml
@@ -19,6 +19,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
+          - ubuntu-22.04-arm
           - windows-latest
     runs-on: ${{ matrix.operating-system }}
     steps:
@@ -55,6 +56,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
+          - ubuntu-22.04-arm
           - windows-latest
     runs-on: ${{ matrix.operating-system }}
     steps:

--- a/.github/workflows/test_module.yml
+++ b/.github/workflows/test_module.yml
@@ -66,6 +66,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
+          - ubuntu-22.04-arm
           - windows-latest
         sktime-component: ${{ fromJSON(needs.detect.outputs.module_changes) }}
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/test_other.yml
+++ b/.github/workflows/test_other.yml
@@ -47,6 +47,7 @@ jobs:
         operating-system:
           - macos-13
           - ubuntu-latest
+          - ubuntu-22.04-arm
           - windows-latest
     runs-on: ${{ matrix.operating-system }}
     steps:


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
This PR implements ARM64 architecture support across all GitHub Actions workflow files by adding `ubuntu-22.04-arm` runners. The change enables testing on ARM-based infrastructure providing comprehensive platform coverage for sktime's CI pipeline.

Modified workflow files:
- test.yml
- test_all.yml
- test_base.yml
- test_datasets.yml
- test_module.yml
- test_other.yml
#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies are introduced. This change only affects the CI infrastructure by adding ARM-based runners to existing workflows.

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?
Reviewers should focus on:
- Impact on overall CI execution time across all workflows 
- Verification that all tests pass consistently on ARM architecture
- Assessment of any potential increase in resource usage [**Check** [**Usage Limit**](https://github.com/sktime/sktime/pull/7695)]

The key metrics to evaluate are:
1. Total CI pipeline execution time before and after the ARM runner addition
2. Resource utilization patterns

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?
No additional tests were required as this change focuses on CI infrastructure. The existing test suite will run on the new ARM runners, providing architecture-specific validation.
<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->
Assessment suggests minimal impact on overall CI execution time and PyPI package size. The addition of ARM architecture testing provides valuable coverage for users deploying sktime on ARM-based systems, including popular platforms like AWS Graviton instances. If the metrics remain stable (CI timing and PyPI size), this enhancement will significantly improve our cross-architecture testing capabilities without introducing substantial overhead.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
