### PR TITLE
added docstring to the PanelPolarsEager class

### DIFF
--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -1045,6 +1045,37 @@ class PanelDask(ScitypePanel):
 class PanelPolarsEager(ScitypePanel):
     """Data type: polars.DataFrame based specification of panel of time series.
 
+    Name: ``"polars_panel"``
+
+    Short description:
+    A ``polars.DataFrame`` with a specific structure for panel data, where each row
+    represents a time point and columns represent variables.
+
+    Long description:
+    The ``"polars_panel"`` :term:`mtype` is a concrete specification of the
+    ``Panel`` :term:`scitype`, which represents a collection of time series data for
+    multiple instances.
+    An object ``obj: polars.DataFrame`` follows the specification iff:
+    * structure convention: ``obj`` must be a Polars DataFrame with a specific
+    structure.
+    * instance level: rows with the same instance identifier correspond to the same
+    instance; different instance identifiers correspond to different instances.
+    * time index: one of the columns in ``obj`` must be a time index, which can be of
+    type ``Int64``, ``Range``, ``Datetime``, or ``Period``, and must be monotonic.
+    * time points: rows of ``obj`` with the same time index correspond to the same time
+    point; rows of ``obj`` with different time indices correspond to different time
+    points.
+    * variables: columns of ``obj`` (excluding the time index and instance identifier)
+    correspond to variables.
+    * variable names: column names are taken from ``obj.columns``.
+
+    Capabilities:
+    * can represent multivariate panel data.
+    * can represent unequally spaced time series.
+    * can represent missing values.
+    * cannot represent panel data with different sets of variables for different
+    instances.
+
     Parameters
     ----------
     is_univariate: bool


### PR DESCRIPTION
Towards fixing issue [#7386](https://github.com/sktime/sktime/issues/7386) 

#### What does this implement/fix? Explain your changes.
<!--
Implements a docstring for the PanelPolarsEager class.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
None
-->

#### What should a reviewer concentrate their feedback on?

<!-- - -->

#### Did you add any tests for the change?

<!-- No, It wasn't required.
-->

#### Any other comments?
<!--
-->

#### PR checklist
<!--
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [DOC ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--

-->
