### PR TITLE
[ENH] Implement reconcilers as transformations, and add new non-negative reconciliation

### DIFF
--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -1531,6 +1531,48 @@ class transform_returns_same_time_index(_BaseTag):
     }
 
 
+class hierarchical(_BaseTag):
+    """Property: transformer returns hierarchical series.
+
+    - String name: ``"hierarchical"``
+    - Public property tag
+    - Values: boolean, ``True`` / ``False``
+    - Example: ``True``
+    - Default: ``False``
+
+    This tag applies to transformations that are exclusive to hierarchical series.
+    """
+
+    _tags = {
+        "tag_name": "hierarchical",
+        "parent_type": "transformer",
+        "tag_type": "bool",
+        "short_descr": "does the transformer return hierarchical series?",
+        "user_facing": True,
+    }
+
+
+class hierarchical__reconciliation(_BaseTag):
+    """Property: transformer reconciles hierarchical series.
+
+    - String name: ``"hierarchical:reconciliation"``
+    - Public property tag
+    - Values: boolean, ``True`` / ``False``
+    - Example: ``True``
+    - Default: ``False``
+
+    This tag applies to transformations that reconcile hierarchical series.
+    """
+
+    _tags = {
+        "tag_name": "hierarchical:reconciliation",
+        "parent_type": "transformer",
+        "tag_type": "bool",
+        "short_descr": "does the transformer reconcile hierarchical series?",
+        "user_facing": True,
+    }
+
+
 # Detector tags
 # --------------
 

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -1531,28 +1531,7 @@ class transform_returns_same_time_index(_BaseTag):
     }
 
 
-class hierarchical(_BaseTag):
-    """Property: transformer returns hierarchical series.
-
-    - String name: ``"hierarchical"``
-    - Public property tag
-    - Values: boolean, ``True`` / ``False``
-    - Example: ``True``
-    - Default: ``False``
-
-    This tag applies to transformations that are exclusive to hierarchical series.
-    """
-
-    _tags = {
-        "tag_name": "hierarchical",
-        "parent_type": "transformer",
-        "tag_type": "bool",
-        "short_descr": "does the transformer return hierarchical series?",
-        "user_facing": True,
-    }
-
-
-class hierarchical__reconciliation(_BaseTag):
+class capability__hierarchical_reconciliation(_BaseTag):
     """Property: transformer reconciles hierarchical series.
 
     - String name: ``"hierarchical:reconciliation"``
@@ -1565,7 +1544,7 @@ class hierarchical__reconciliation(_BaseTag):
     """
 
     _tags = {
-        "tag_name": "hierarchical:reconciliation",
+        "tag_name": "capability:hierarchical_reconciliation",
         "parent_type": "transformer",
         "tag_type": "bool",
         "short_descr": "does the transformer reconcile hierarchical series?",

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -137,6 +137,8 @@ class BaseTransformer(BaseEstimator):
         # is transform result always guaranteed to contain no missing values?
         "capability:categorical_in_X": False,
         # does the transformer natively support categorical in exogeneous X?
+        "capability:hierarchical_reconciliation": False,
+        # does the transformer apply hierarchical reconciliation?
         "remember_data": False,  # whether all data seen is remembered as self._X
         "python_version": None,  # PEP 440 python version specifier to limit versions
         "authors": "sktime developers",  # author(s) of the object

--- a/sktime/transformations/hierarchical/aggregate.py
+++ b/sktime/transformations/hierarchical/aggregate.py
@@ -67,8 +67,8 @@ class Aggregator(BaseTransformer):
             "pd_multiindex_hier",
         ],
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
-        "capability:inverse_transform": False,  # does transformer have inverse
-        "skip-inverse-transform": True,  # is inverse-transform skipped when called?
+        "capability:inverse_transform": True,  # does transformer have inverse
+        "skip-inverse-transform": False,  # is inverse-transform skipped when called?
         "univariate-only": False,  # can the transformer handle multivariate X?
         "handles-missing-data": False,  # can estimator handle missing data?
         "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
@@ -185,7 +185,8 @@ class Aggregator(BaseTransformer):
             )
         else:
             for i in range(X.index.nlevels - 1):
-                X = X.drop(index="__total", level=i)
+                # Ignoring since there can be totals in some levels, but not all
+                X = X.drop(index="__total", level=i, errors="ignore")
         return X
 
     @classmethod

--- a/sktime/transformations/hierarchical/reconciliation/__init__.py
+++ b/sktime/transformations/hierarchical/reconciliation/__init__.py
@@ -3,7 +3,7 @@
 from .bottom_up import BottomUpReconciler
 from .forecast_proportions import ForecastProportions
 from .middle_out import MiddleOutReconciler
-from .optimal import FullHierarchyReconciler
+from .optimal import FullHierarchyReconciler, NonNegativeFullHierarchyReconciler
 from .topdown_share import TopdownShareReconciler
 
 __all__ = [
@@ -11,5 +11,6 @@ __all__ = [
     "TopdownShareReconciler",
     "BottomUpReconciler",
     "FullHierarchyReconciler",
+    "NonNegativeFullHierarchyReconciler",
     "ForecastProportions",
 ]

--- a/sktime/transformations/hierarchical/reconciliation/__init__.py
+++ b/sktime/transformations/hierarchical/reconciliation/__init__.py
@@ -1,0 +1,15 @@
+"""Hierarchical reconciliation transformations."""
+
+from .optimal import FullHierarchyReconciler
+from .single_level import (
+    BottomUpReconciler,
+    MiddleOutReconciler,
+    TopdownShareReconciler,
+)
+
+__all__ = [
+    "MiddleOutReconciler",
+    "TopdownShareReconciler",
+    "BottomUpReconciler",
+    "FullHierarchyReconciler",
+]

--- a/sktime/transformations/hierarchical/reconciliation/__init__.py
+++ b/sktime/transformations/hierarchical/reconciliation/__init__.py
@@ -1,15 +1,15 @@
 """Hierarchical reconciliation transformations."""
 
+from .bottom_up import BottomUpReconciler
+from .forecast_proportions import ForecastProportions
+from .middle_out import MiddleOutReconciler
 from .optimal import FullHierarchyReconciler
-from .single_level import (
-    BottomUpReconciler,
-    MiddleOutReconciler,
-    TopdownShareReconciler,
-)
+from .topdown_share import TopdownShareReconciler
 
 __all__ = [
     "MiddleOutReconciler",
     "TopdownShareReconciler",
     "BottomUpReconciler",
     "FullHierarchyReconciler",
+    "ForecastProportions",
 ]

--- a/sktime/transformations/hierarchical/reconciliation/_drop_redundant_hierarchical_levels.py
+++ b/sktime/transformations/hierarchical/reconciliation/_drop_redundant_hierarchical_levels.py
@@ -1,0 +1,104 @@
+from sktime.transformations.base import BaseTransformer
+from sktime.transformations.hierarchical.aggregate import Aggregator
+from sktime.transformations.hierarchical.reconciliation._utils import (
+    _is_hierarchical_dataframe,
+)
+
+__all__ = ["_DropRedundantHierarchicalLevels"]
+
+
+class _DropRedundantHierarchicalLevels(BaseTransformer):
+    """
+    Drop redundant levels from multiindex.
+
+    Sometimes, the multiindex can have redundant levels, for example:
+
+    __total, __total, pd.Period("2020-01-01")
+    stateA, regionA, pd.Period("2020-01-01")
+    stateA, regionB, pd.Period("2020-01-01")
+
+    In this case, stateA is already total at level 0.
+    This transformer will drop the first level, as it is redundant.
+    """
+
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": "felipeangelimvieira",
+        "maintainers": "felipeangelimvieira",
+        # estimator type
+        # --------------
+        "scitype:transform-input": ["Series", "Hierachical"],
+        "scitype:transform-output": ["Series", "Hierarchical", "Panel"],
+        "scitype:transform-labels": "None",
+        # todo instance wise?
+        "scitype:instancewise": True,  # is this an instance-wise transform?
+        "X_inner_mtype": [
+            "pd.Series",
+            "pd.DataFrame",
+            "pd-multiindex",
+            "pd_multiindex_hier",
+        ],
+        "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
+        "capability:inverse_transform": True,  # does transformer have inverse
+        "skip-inverse-transform": False,  # is inverse-transform skipped when called?
+        "univariate-only": False,  # can the transformer handle multivariate X?
+        "handles-missing-data": False,  # can estimator handle missing data?
+        "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
+        "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
+        "transform-returns-same-time-index": False,
+        "capability:hierarchical_reconciliation": False,
+    }
+
+    def _fit(self, X, y):
+        self._no_hierarchy = not _is_hierarchical_dataframe(X)
+        if self._no_hierarchy:
+            return self
+
+        self._aggregator = Aggregator(False)
+        Xt = self._aggregator.fit_transform(X)
+
+        first_level_with_more_than_one_value = X.index.nlevels
+        for level in range(Xt.index.nlevels - 1):
+            nuniques = Xt.index.get_level_values(level).drop("__total").nunique()
+
+            if nuniques > 1:
+                first_level_with_more_than_one_value = level
+                break
+
+        self.levels_to_drop_ = list(range(first_level_with_more_than_one_value))
+
+        self._idx = X.index.droplevel(-1).unique()
+        self._dummy_idx_names = ["dummy" + str(i) for i in range(X.index.nlevels)]
+        self._idx_names = X.index.names
+        return self
+
+    def _transform(self, X, y):
+        if self._no_hierarchy:
+            return X
+
+        return X.droplevel(self.levels_to_drop_)
+
+    def _inverse_transform(self, X, y=None):
+        if self._no_hierarchy:
+            return X
+
+        _X = X.copy()
+
+        # To account for when indexes are unnamed
+        self._dummy_idx_names = ["dummy" + str(i) for i in range(len(self._idx_names))]
+        idx = self._idx.copy()
+        idx.names = self._dummy_idx_names[:-1]
+        _X.index.names = self._dummy_idx_names[len(self.levels_to_drop_) :]
+
+        new_idx = idx.join(_X.index, how="right")
+        _X.index = new_idx
+
+        correct_index_order = list(range(self._idx.nlevels + 1))
+        correct_index_order = (
+            correct_index_order[X.index.nlevels :]
+            + correct_index_order[: X.index.nlevels]
+        )
+        _X = _X.reorder_levels(correct_index_order)
+        _X.index.names = self._idx_names
+        return _X

--- a/sktime/transformations/hierarchical/reconciliation/_utils.py
+++ b/sktime/transformations/hierarchical/reconciliation/_utils.py
@@ -1,0 +1,121 @@
+import pandas as pd
+
+
+def loc_series_idxs(y, idxs):
+    return y.loc[y.index.droplevel(-1).isin(idxs)]
+
+
+def get_bottom_level_idxs(y):
+    idx = y.index
+    idx = idx.droplevel(-1).unique()
+    return idx[idx.get_level_values(-1) != "__total"]
+
+
+def get_bottom_series(y):
+    bottom_idx = get_bottom_level_idxs(y)
+    return loc_series_idxs(y, bottom_idx)
+
+
+def get_total_level_idxs(y):
+    nlevels = y.index.droplevel(-1).nlevels
+    return pd.Index([tuple(["__total"] * nlevels)])
+
+
+def get_total_series(y):
+    total_idx = get_total_level_idxs(y)
+    return loc_series_idxs(y, total_idx)
+
+
+def get_middle_level_series(y, middle_level):
+    idx = y.index
+    idx = idx.droplevel(-1).unique()
+    idx_middle_level = idx.get_level_values(middle_level)
+    idx_below_middle_level = idx.get_level_values(middle_level + 1)
+    is_middle_level_mask = (idx_below_middle_level == "__total") & (
+        idx_middle_level != "__total"
+    )
+    return idx[is_middle_level_mask]
+
+
+def split_middle_levels(y, middle_level):
+    """Return two series: middle level and above, and middle level and below."""
+    idx = y.index
+    idx = idx.droplevel(-1).unique()
+    idx_middle_level = idx.get_level_values(middle_level)
+    idx_below_middle_level = idx.get_level_values(middle_level + 1)
+    is_middle_or_above_mask = idx_below_middle_level == "__total"
+    is_middle_or_below_mask = idx_middle_level != "__total"
+
+    return loc_series_idxs(y, idx[is_middle_or_above_mask]), loc_series_idxs(
+        y, idx[is_middle_or_below_mask]
+    )
+
+
+def is_ancestor(agg_node, node):
+    """Return True if agg_node is an ancestor of node."""
+    return all(a == b or a == "__total" for a, b in zip(agg_node, node))
+
+
+def filter_descendants(X, aggregator_node):
+    """
+    Get descendants of aggregator_node from X.
+
+    Returns a sub-DataFrame/Series of X containing only rows whose
+    droplevel(-1) is a descendant of 'aggregator_node' at the given 'middle_level'.
+
+    aggregator_node is a tuple like ('CA', 'CA_1', '__total', '__total')
+    or ('regionA', 'storeA', '__total', '__total'), etc.
+    """
+    # We'll operate on the "higher-level" portion of the index
+    # (i.e., the index after dropping the time or final level).
+    idx_upper = X.index.droplevel(-1)  # e.g. (region, store, cat, dept)
+    nodes = idx_upper.unique()
+
+    # We only want to keep those which are descendants of aggregator_node,
+    # i.e., aggregator_node is an ancestor of that node.
+    # Because aggregator_node is "at" middle_level,
+    # but it may also have __total at deeper levels.
+    descendant_mask = [is_ancestor(aggregator_node, n) for n in nodes]
+    descendant_nodes = nodes[descendant_mask]
+
+    # Now filter X by these nodes
+    return X.loc[idx_upper.isin(descendant_nodes)]
+
+
+def _is_hierarchical_dataframe(X):
+    if not X.index.nlevels > 1:
+        return False
+    has_total = False
+    for i in range(X.index.nlevels - 1):
+        if "__total" in X.index.get_level_values(i):
+            has_total = True
+            break
+    return has_total or X.index.nlevels > 2
+
+
+def get_middle_level_aggregators(X, middle_level):
+    """
+    Get middle level aggregators from the index of X.
+
+    Identify aggregator nodes at the specified middle_level, i.e.
+    those for which the next level is '__total'.
+
+    Example:
+      If middle_level=1, then for a node= (region, store, cat, dept),
+      we check node[middle_level+1] == '__total'.
+      The node itself must not be __total at middle_level
+      (otherwise it's above or not a well-defined middle node).
+    """
+    idx = X.index.droplevel(-1).unique()
+    if middle_level + 1 >= idx.nlevels:
+        # If the user picks a middle_level at the last level, there's no "next" level
+        return []
+
+    # The aggregator condition:
+    #   * the next level's value is '__total'
+    #   * the middle level's value != '__total'
+    next_level_vals = idx.get_level_values(middle_level + 1)
+    this_level_vals = idx.get_level_values(middle_level)
+
+    is_agg = (next_level_vals == "__total") & (this_level_vals != "__total")
+    return idx[is_agg]

--- a/sktime/transformations/hierarchical/reconciliation/bottom_up.py
+++ b/sktime/transformations/hierarchical/reconciliation/bottom_up.py
@@ -1,0 +1,97 @@
+"""Single-level reconciliation."""
+
+from sktime.transformations.base import BaseTransformer
+from sktime.transformations.hierarchical.aggregate import Aggregator
+from sktime.transformations.hierarchical.reconciliation._utils import (
+    _is_hierarchical_dataframe,
+    get_bottom_level_idxs,
+    loc_series_idxs,
+)
+
+__all__ = [
+    "BottomUpReconciler",
+]
+
+
+class BottomUpReconciler(BaseTransformer):
+    """
+    Bottom-up reconciliation for hierarchical time series data.
+
+    It aggregates the data to the bottom level and then transforms it back
+    to the original hierarchy.
+
+    Attributes
+    ----------
+    _tags : dict
+        Common tags for the transformer.
+    _no_hierarchy : bool
+        Indicates if the data has no hierarchy (single level).
+    _original_series : pd.Index
+        The original series index before transformation.
+    _aggregator : Aggregator
+        An instance of the Aggregator class used for aggregation.
+    _bottom_series : pd.Index
+        The index of the bottom level series.
+    """
+
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": "felipeangelimvieira",
+        "maintainers": "felipeangelimvieira",
+        # estimator type
+        # --------------
+        "scitype:transform-input": "Series",
+        "scitype:transform-output": "Series",
+        "scitype:transform-labels": "None",
+        # todo instance wise?
+        "scitype:instancewise": True,  # is this an instance-wise transform?
+        "X_inner_mtype": [
+            "pd.Series",
+            "pd.DataFrame",
+            "pd-multiindex",
+            "pd_multiindex_hier",
+        ],
+        "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
+        "capability:inverse_transform": True,  # does transformer have inverse
+        "skip-inverse-transform": False,  # is inverse-transform skipped when called?
+        "univariate-only": False,  # can the transformer handle multivariate X?
+        "handles-missing-data": False,  # can estimator handle missing data?
+        "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
+        "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
+        "transform-returns-same-time-index": False,
+        "capability:hierarchical_reconciliation": True,
+    }
+
+    def _fit(self, X, y):
+        self._no_hierarchy = not _is_hierarchical_dataframe(X)
+
+        if self._no_hierarchy:
+            return self
+
+        self._original_series = X.index.droplevel(-1).unique()
+        self._aggregator = Aggregator()
+        self._aggregator.fit(X)
+        X = self._aggregator.transform(X)
+
+        self._bottom_series = get_bottom_level_idxs(X)
+
+        return self
+
+    def _transform(self, X, y=None):
+        if self._no_hierarchy:
+            return X
+
+        X = self._aggregator.transform(X)
+        X_bottom = loc_series_idxs(X, self._bottom_series)
+
+        return X_bottom
+
+    def _inverse_transform(self, X, y=None):
+        if self._no_hierarchy:
+            return X
+
+        X = self._aggregator.transform(X)
+        X = loc_series_idxs(X, self._original_series).sort_index()
+
+        return X

--- a/sktime/transformations/hierarchical/reconciliation/forecast_proportions.py
+++ b/sktime/transformations/hierarchical/reconciliation/forecast_proportions.py
@@ -1,0 +1,139 @@
+"""Forecast-proportions reconciliation."""
+
+from sktime.transformations.base import BaseTransformer
+from sktime.transformations.hierarchical.aggregate import Aggregator
+from sktime.transformations.hierarchical.reconciliation._drop_redundant_hierarchical_levels import (  # noqa: E501
+    _DropRedundantHierarchicalLevels,
+)
+from sktime.transformations.hierarchical.reconciliation._utils import (
+    _is_hierarchical_dataframe,
+    _promote_hierarchical_indexes_and_keep_timeindex,
+    _recursively_propagate_topdown,
+    get_bottom_level_idxs,
+    get_total_level_idxs,
+    loc_series_idxs,
+)
+
+__all__ = ["ForecastProportions"]
+
+
+class ForecastProportions(BaseTransformer):
+    """
+    Apply forecast proportions to hierarchical time series.
+
+    Forecast proportions keep the original series during `transform`,
+    and propagate the "proportions" of each forecast with respect to its
+    total during `inverse_transform`.
+
+    For more information, see "Single level approaches" in [1].
+
+    References
+    ----------
+    .. [1] Hyndman, R. J., & Athanasopoulos, G. (2018). Forecasting:
+       principles and practice. OTexts.
+
+    """
+
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": "felipeangelimvieira",
+        "maintainers": "felipeangelimvieira",
+        # estimator type
+        # --------------
+        "scitype:transform-input": "Series",
+        "scitype:transform-output": "Series",
+        "scitype:transform-labels": "None",
+        # todo instance wise?
+        "scitype:instancewise": True,  # is this an instance-wise transform?
+        "X_inner_mtype": [
+            "pd.Series",
+            "pd.DataFrame",
+            "pd-multiindex",
+            "pd_multiindex_hier",
+        ],
+        "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
+        "capability:inverse_transform": True,  # does transformer have inverse
+        "skip-inverse-transform": False,  # is inverse-transform skipped when called?
+        "univariate-only": False,  # can the transformer handle multivariate X?
+        "handles-missing-data": False,  # can estimator handle missing data?
+        "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
+        "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
+        "transform-returns-same-time-index": False,
+        "capability:hierarchical_reconciliation": True,
+    }
+
+    def __init__(self):
+        super().__init__()
+
+    def _fit(self, X, y):
+        self._no_hierarchy = not _is_hierarchical_dataframe(X)
+
+        if self._no_hierarchy:
+            return self
+
+        self._original_series = X.index.droplevel(-1).unique()
+        self._aggregator = Aggregator()
+        self._aggregator.fit(X)
+        X = self._aggregator.transform(X)
+
+        self._drop_redundant_levels = _DropRedundantHierarchicalLevels()
+        self._drop_redundant_levels.fit(X)
+        X = self._drop_redundant_levels.transform(X)
+
+        self._total_series = get_total_level_idxs(X)
+        self._bottom_series = get_bottom_level_idxs(X)
+
+        return self
+
+    def _transform(self, X, y):
+        if self._no_hierarchy:
+            return X
+        X = self._drop_redundant_levels.transform(X)
+        return X
+
+    def _inverse_transform(self, X, y):
+        if self._no_hierarchy:
+            return X
+
+        # In forecast proportions, we have to recursively apply
+        # the ratio between the total forecast yhat/sum(yhat_lower)
+        # to the bottom level series
+
+        # To do this, we will create a dataframe with this ratio for each
+        # series and timesteps
+
+        # Map each series to its total series
+
+        idx_map_parents = X.index.map(_promote_hierarchical_indexes_and_keep_timeindex)
+        idx = X.index
+
+        # Df mapping each value to its parent
+        X_parents = X.copy()
+        # Set total to 0 because of the operations below
+        # which would account for it twice
+        X_parents.loc[X_parents.index.isin(self._total_series)] = 0
+        X_parents.index = idx_map_parents
+
+        # The parent sum according to direct children
+        X_parents_bu = X_parents.groupby(
+            level=[i for i in range(X.index.nlevels)]
+        ).sum()
+        X_parents_bu = X_parents_bu.loc[idx_map_parents]
+        X_parents_bu.index = idx
+
+        # The forecasted parent total
+        X_parents_total = X.loc[idx_map_parents]
+        X_parents_total.index = idx
+
+        X_ratios = X_parents_total / X_parents_bu
+        X_ratios.index = X.index
+
+        # Now, multiply the ratio down to the bottom level, recursively
+
+        X_ratios_propagated = _recursively_propagate_topdown(X_ratios)
+        _X = X_ratios_propagated * X
+
+        _X = self._drop_redundant_levels.inverse_transform(_X)
+        _X = loc_series_idxs(_X, self._original_series).sort_index()
+        return _X

--- a/sktime/transformations/hierarchical/reconciliation/middle_out.py
+++ b/sktime/transformations/hierarchical/reconciliation/middle_out.py
@@ -3,190 +3,13 @@
 import pandas as pd
 
 from sktime.transformations.base import BaseTransformer
-from sktime.transformations.hierarchical.aggregate import Aggregator
 from sktime.transformations.hierarchical.reconciliation._utils import (
     _is_hierarchical_dataframe,
     filter_descendants,
-    get_bottom_level_idxs,
     get_middle_level_aggregators,
-    get_total_level_idxs,
-    loc_series_idxs,
 )
 
-__all__ = ["TopdownShareReconciler", "BottomUpReconciler", "MiddleOutReconciler"]
-
-
-_COMMON_TAGS = {
-    # packaging info
-    # --------------
-    "authors": "felipeangelimvieira",
-    "maintainers": "felipeangelimvieira",
-    # estimator type
-    # --------------
-    "scitype:transform-input": "Series",
-    "scitype:transform-output": "Series",
-    "scitype:transform-labels": "None",
-    # todo instance wise?
-    "scitype:instancewise": True,  # is this an instance-wise transform?
-    "X_inner_mtype": [
-        "pd.Series",
-        "pd.DataFrame",
-        "pd-multiindex",
-        "pd_multiindex_hier",
-    ],
-    "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
-    "capability:inverse_transform": True,  # does transformer have inverse
-    "skip-inverse-transform": False,  # is inverse-transform skipped when called?
-    "univariate-only": False,  # can the transformer handle multivariate X?
-    "handles-missing-data": False,  # can estimator handle missing data?
-    "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
-    "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
-    "transform-returns-same-time-index": False,
-    "hierarchical": True,
-    "hierarchical:reconciliation": True,
-}
-
-
-class TopdownShareReconciler(BaseTransformer):
-    """
-    Topdown reconciliation.
-
-    TopdownReconciler is a transformer for hierarchical time series reconciliation
-    using the top-down approach.
-
-    Attributes
-    ----------
-    _tags : dict
-        Common tags for the transformer.
-    _no_hierarchy : bool
-        Indicates if the input series has no hierarchy.
-    _original_series : pd.Index
-        Original series index without the bottom level.
-    _aggregator : Aggregator
-        Aggregator instance to aggregate the series.
-    _total_series : pd.Index
-        Index of the total level series.
-    _bottom_series : pd.Index
-        Index of the bottom level series.
-    """
-
-    _tags = _COMMON_TAGS
-
-    def _fit(self, X, y):
-        self._no_hierarchy = not _is_hierarchical_dataframe(X)
-
-        if self._no_hierarchy:
-            return self
-
-        self._original_series = X.index.droplevel(-1).unique()
-        self._aggregator = Aggregator()
-        self._aggregator.fit(X)
-        X = self._aggregator.transform(X)
-
-        self._total_series = get_total_level_idxs(X)
-        self._bottom_series = get_bottom_level_idxs(X)
-
-        return self
-
-    def _transform(self, X, y):
-        if self._no_hierarchy:
-            return X
-
-        X = self._aggregator.transform(X)
-        X_total = loc_series_idxs(X, self._total_series)
-        X_bottom = loc_series_idxs(X, self._bottom_series)
-
-        X_total.index = X_total.index.get_level_values(-1)
-
-        X_total_expanded = X_total.reindex(X_bottom.index.get_level_values(-1))
-        X_total_expanded.index = X_bottom.index
-
-        shares = X_bottom / X_total_expanded
-
-        _X = pd.concat([loc_series_idxs(X, self._total_series), shares], axis=0)
-        _X = loc_series_idxs(_X, self._original_series).sort_index()
-
-        return _X
-
-    def _inverse_transform(self, X, y):
-        if self._no_hierarchy:
-            return X
-
-        X_total = loc_series_idxs(X, self._total_series)
-        X_bottom = loc_series_idxs(X, self._bottom_series)
-
-        # Keep only timeindex of total series
-        X_total.index = X_total.index.get_level_values(-1)
-
-        # Reindex total series to match bottom series
-        X_total_expanded = X_total.reindex(X_bottom.index.get_level_values(-1))
-        X_total_expanded.index = X_bottom.index
-
-        forecasts_from_shares = X_bottom * X_total_expanded
-        _X = pd.concat(
-            [loc_series_idxs(X, self._original_series), forecasts_from_shares], axis=0
-        )
-
-        _X = self._aggregator.transform(_X)
-        _X = loc_series_idxs(_X, self._original_series).sort_index()
-        return _X
-
-
-class BottomUpReconciler(BaseTransformer):
-    """
-    Bottom-up reconciliation for hierarchical time series data.
-
-    It aggregates the data to the bottom level and then transforms it back
-    to the original hierarchy.
-
-    Attributes
-    ----------
-    _tags : dict
-        Common tags for the transformer.
-    _no_hierarchy : bool
-        Indicates if the data has no hierarchy (single level).
-    _original_series : pd.Index
-        The original series index before transformation.
-    _aggregator : Aggregator
-        An instance of the Aggregator class used for aggregation.
-    _bottom_series : pd.Index
-        The index of the bottom level series.
-    """
-
-    _tags = _COMMON_TAGS
-
-    def _fit(self, X, y):
-        self._no_hierarchy = not _is_hierarchical_dataframe(X)
-
-        if self._no_hierarchy:
-            return self
-
-        self._original_series = X.index.droplevel(-1).unique()
-        self._aggregator = Aggregator()
-        self._aggregator.fit(X)
-        X = self._aggregator.transform(X)
-
-        self._bottom_series = get_bottom_level_idxs(X)
-
-        return self
-
-    def _transform(self, X, y=None):
-        if self._no_hierarchy:
-            return X
-
-        X = self._aggregator.transform(X)
-        X_bottom = loc_series_idxs(X, self._bottom_series)
-
-        return X_bottom
-
-    def _inverse_transform(self, X, y=None):
-        if self._no_hierarchy:
-            return X
-
-        X = self._aggregator.transform(X)
-        X = loc_series_idxs(X, self._original_series).sort_index()
-
-        return X
+__all__ = ["MiddleOutReconciler"]
 
 
 class MiddleOutReconciler(BaseTransformer):
@@ -203,7 +26,34 @@ class MiddleOutReconciler(BaseTransformer):
         The transformer to use for each subtree below the middle-level totals.
     """
 
-    _tags = _COMMON_TAGS
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": "felipeangelimvieira",
+        "maintainers": "felipeangelimvieira",
+        # estimator type
+        # --------------
+        "scitype:transform-input": "Series",
+        "scitype:transform-output": "Series",
+        "scitype:transform-labels": "None",
+        # todo instance wise?
+        "scitype:instancewise": True,  # is this an instance-wise transform?
+        "X_inner_mtype": [
+            "pd.Series",
+            "pd.DataFrame",
+            "pd-multiindex",
+            "pd_multiindex_hier",
+        ],
+        "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
+        "capability:inverse_transform": True,  # does transformer have inverse
+        "skip-inverse-transform": False,  # is inverse-transform skipped when called?
+        "univariate-only": False,  # can the transformer handle multivariate X?
+        "handles-missing-data": False,  # can estimator handle missing data?
+        "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
+        "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
+        "transform-returns-same-time-index": False,
+        "capability:hierarchical_reconciliation": True,
+    }
 
     def __init__(
         self,
@@ -349,6 +199,13 @@ class MiddleOutReconciler(BaseTransformer):
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Get test params."""
+        from sktime.transformations.hierarchical.reconciliation.bottom_up import (
+            BottomUpReconciler,
+        )
+        from sktime.transformations.hierarchical.reconciliation.topdown_share import (
+            TopdownShareReconciler,
+        )
+
         return [
             {
                 "middle_level": 1,

--- a/sktime/transformations/hierarchical/reconciliation/optimal.py
+++ b/sktime/transformations/hierarchical/reconciliation/optimal.py
@@ -1,11 +1,123 @@
 import pandas as pd
 
 from sktime.transformations.base import BaseTransformer
+from sktime.transformations.hierarchical.aggregate import Aggregator
 
-# Add engine for non-constrained reconciliation and for non-negative
+# TODO(felipeangelimvieira): Add summing matrix from series function
+# TODO(felipeangelimvieira): Compute non-constrained reconciliation
+# TODO(felipeangelimvieira): Compute non-negative reconciliation
+# TODO(felipeangelimvieira): Immutable series reconciliation: should this be a separate class?
+
+_COMMON_TAGS = {
+    # packaging info
+    # --------------
+    "authors": "felipeangelimvieira",
+    "maintainers": "felipeangelimvieira",
+    # estimator type
+    # --------------
+    "scitype:transform-input": "Series",
+    "scitype:transform-output": "Series",
+    "scitype:transform-labels": "None",
+    # todo instance wise?
+    "scitype:instancewise": True,  # is this an instance-wise transform?
+    "X_inner_mtype": [
+        "pd.Series",
+        "pd.DataFrame",
+        "pd-multiindex",
+        "pd_multiindex_hier",
+    ],
+    "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
+    "capability:inverse_transform": False,  # does transformer have inverse
+    "skip-inverse-transform": True,  # is inverse-transform skipped when called?
+    "univariate-only": False,  # can the transformer handle multivariate X?
+    "handles-missing-data": False,  # can estimator handle missing data?
+    "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
+    "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
+    "transform-returns-same-time-index": False,
+}
 
 
-class OptimalReconciler(BaseTransformer):
+class FullHierarchyReconciler(BaseTransformer):
+
+    _tags = _COMMON_TAGS
+
     def __init__(self, error_covariance_matrix: pd.DataFrame = None):
         self.error_covariance_matrix = error_covariance_matrix
         super().__init__()
+
+    def _fit(self, X, y):
+        self.aggregator_ = Aggregator()
+        self.aggregator_.fit(X)
+        self.unique_series_ = X.index.droplevel(-1).unique()
+        self.S_ = create_summing_matrix_from_index(self.unique_series_)
+
+        self._sigma = self.error_covariance_matrix.copy()
+        if self.error_covariance_matrix is None:
+            self._sigma = np.eye(len(self.unique_series_))
+            self._sigma = pd.DataFrame(
+                self._sigma,
+                index=self.S_.index,
+                columns=self.S_.index,
+            )
+
+    def _transform(self, X, y):
+
+        X = self.aggregator_.transform(X)
+        return X
+
+    def _inverse_transform(self, X, y=None): ...
+
+
+class NonNegativeHierarchyReconciler(BaseTransformer):
+    _tags = _COMMON_TAGS
+
+    def __init__(self, error_covariance_matrix: pd.DataFrame = None):
+        self.error_covariance_matrix = error_covariance_matrix
+        super().__init__()
+
+
+import pandas as pd
+import numpy as np
+
+
+def create_summing_matrix_from_index(hier_index):
+    """
+    Given a MultiIndex 'hier_index' of a hierarchical time series
+    (following an sktime-like convention), return a summation matrix S
+    as a DataFrame. Each row corresponds to a node in the hierarchy,
+    and each column corresponds to a bottom (leaf) node.
+    The entry S[i, j] = 1 if row i (an aggregator node) is an ancestor
+    of column j (a bottom node), else 0.
+    """
+
+    # Convert index to list of tuples for convenience
+    all_nodes = list(hier_index)
+
+    # Identify bottom nodes (leaf series): those with no '__total' in their tuple
+    bottom_nodes = [node for node in all_nodes if "__total" not in node]
+
+    # Initialize an (N x M) matrix: N = total nodes, M = bottom nodes
+    N = len(all_nodes)
+    M = len(bottom_nodes)
+    S = np.zeros((N, M), dtype=int)
+
+    # Helper function: check if 'agg' is an ancestor of 'bot'
+    # Ancestor means that for each level `a_level` in agg and `b_level` in bot:
+    #    a_level == '__total' OR a_level == b_level
+    def is_ancestor(agg, bot):
+        return all(a == b or a == "__total" for a, b in zip(agg, bot))
+
+    # Populate the summation matrix
+    for i, agg_node in enumerate(all_nodes):
+        for j, bottom_node in enumerate(bottom_nodes):
+            if is_ancestor(agg_node, bottom_node):
+                S[i, j] = 1
+
+    # Create a DataFrame with the same row index and MultiIndex columns
+    S_df = pd.DataFrame(
+        S,
+        index=pd.MultiIndex.from_tuples(all_nodes, names=hier_index.names),
+        columns=pd.MultiIndex.from_tuples(bottom_nodes, names=hier_index.names),
+    )
+
+    return S_df

--- a/sktime/transformations/hierarchical/reconciliation/optimal.py
+++ b/sktime/transformations/hierarchical/reconciliation/optimal.py
@@ -38,7 +38,6 @@ _COMMON_TAGS = {
 
 
 class FullHierarchyReconciler(BaseTransformer):
-
     _tags = _COMMON_TAGS
 
     def __init__(self, error_covariance_matrix: pd.DataFrame = None):
@@ -61,7 +60,6 @@ class FullHierarchyReconciler(BaseTransformer):
             )
 
     def _transform(self, X, y):
-
         X = self.aggregator_.transform(X)
         return X
 
@@ -76,8 +74,8 @@ class NonNegativeHierarchyReconciler(BaseTransformer):
         super().__init__()
 
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 
 def create_summing_matrix_from_index(hier_index):
@@ -89,7 +87,6 @@ def create_summing_matrix_from_index(hier_index):
     The entry S[i, j] = 1 if row i (an aggregator node) is an ancestor
     of column j (a bottom node), else 0.
     """
-
     # Convert index to list of tuples for convenience
     all_nodes = list(hier_index)
 

--- a/sktime/transformations/hierarchical/reconciliation/optimal.py
+++ b/sktime/transformations/hierarchical/reconciliation/optimal.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+from sktime.transformations.base import BaseTransformer
+
+# Add engine for non-constrained reconciliation and for non-negative
+
+
+class OptimalReconciler(BaseTransformer):
+    def __init__(self, error_covariance_matrix: pd.DataFrame = None):
+        self.error_covariance_matrix = error_covariance_matrix
+        super().__init__()

--- a/sktime/transformations/hierarchical/reconciliation/single_level.py
+++ b/sktime/transformations/hierarchical/reconciliation/single_level.py
@@ -1,0 +1,304 @@
+"""Single-level reconciliation."""
+
+import pandas as pd
+
+from sktime.transformations.base import BaseTransformer
+from sktime.transformations.hierarchical.aggregate import Aggregator
+
+__all__ = ["TopdownReconciler", "BottomUpReconciler", "MiddleOutReconciler"]
+
+
+def loc_series_idxs(y, idxs):
+    return y.loc[y.index.droplevel(-1).isin(idxs)]
+
+
+def get_bottom_level_idxs(y):
+    idx = y.index
+    idx = idx.droplevel(-1).unique()
+    return idx[idx.get_level_values(-1) != "__total"]
+
+
+def get_bottom_series(y):
+    bottom_idx = get_bottom_level_idxs(y)
+    return loc_series_idxs(y, bottom_idx)
+
+
+def get_total_level_idxs(y):
+    nlevels = y.index.droplevel(-1).nlevels
+    return pd.Index([tuple(["__total"] * nlevels)])
+
+
+def get_total_series(y):
+    total_idx = get_total_level_idxs(y)
+    return loc_series_idxs(y, total_idx)
+
+
+def get_middle_level_series(y, middle_level):
+    idx = y.index
+    idx = idx.droplevel(-1).unique()
+    idx_middle_level = idx.get_level_values(middle_level)
+    idx_below_middle_level = idx.get_level_values(middle_level + 1)
+    is_middle_level_mask = (idx_below_middle_level == "__total") & (
+        idx_middle_level != "__total"
+    )
+    return idx[is_middle_level_mask]
+
+
+def split_middle_levels(y, middle_level):
+    """
+    Return two series: middle level and above, and middle level and below.
+    """
+    idx = y.index
+    idx = idx.droplevel(-1).unique()
+    idx_middle_level = idx.get_level_values(middle_level)
+    idx_below_middle_level = idx.get_level_values(middle_level + 1)
+    is_middle_or_above_mask = idx_below_middle_level == "__total"
+    is_middle_or_below_mask = idx_middle_level != "__total"
+
+    return loc_series_idxs(y, idx[is_middle_or_above_mask]), loc_series_idxs(
+        y, idx[is_middle_or_below_mask]
+    )
+
+
+_COMMON_TAGS = {
+    # packaging info
+    # --------------
+    "authors": "felipeangelimvieira",
+    "maintainers": "felipeangelimvieira",
+    # estimator type
+    # --------------
+    "scitype:transform-input": "Series",
+    "scitype:transform-output": "Series",
+    "scitype:transform-labels": "None",
+    # todo instance wise?
+    "scitype:instancewise": True,  # is this an instance-wise transform?
+    "X_inner_mtype": [
+        "pd.Series",
+        "pd.DataFrame",
+        "pd-multiindex",
+        "pd_multiindex_hier",
+    ],
+    "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
+    "capability:inverse_transform": False,  # does transformer have inverse
+    "skip-inverse-transform": True,  # is inverse-transform skipped when called?
+    "univariate-only": False,  # can the transformer handle multivariate X?
+    "handles-missing-data": False,  # can estimator handle missing data?
+    "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
+    "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
+    "transform-returns-same-time-index": False,
+}
+
+
+class TopdownReconciler(BaseTransformer):
+    """
+    Topdown reconciliation.
+
+    TopdownReconciler is a transformer for hierarchical time series reconciliation
+    using the top-down approach.
+
+    Attributes
+    ----------
+    _tags : dict
+        Common tags for the transformer.
+    _no_hierarchy : bool
+        Indicates if the input series has no hierarchy.
+    _original_series : pd.Index
+        Original series index without the bottom level.
+    _aggregator : Aggregator
+        Aggregator instance to aggregate the series.
+    _total_series : pd.Index
+        Index of the total level series.
+    _bottom_series : pd.Index
+        Index of the bottom level series.
+    """
+
+    _tags = _COMMON_TAGS
+
+    def _fit(self, X, y):
+        self._no_hierarchy = X.index.nlevels == 1
+
+        if self._no_hierarchy:
+            return self
+
+        self._original_series = X.index.droplevel(-1).unique()
+        self._aggregator = Aggregator()
+        self._aggregator.fit(X)
+        X = self._aggregator.transform(X)
+
+        self._total_series = get_total_level_idxs(X)
+        self._bottom_series = get_bottom_level_idxs(X)
+
+        return self
+
+    def _transform(self, X, y):
+        if self._no_hierarchy:
+            return X
+
+        X = self._aggregator.transform(X)
+        X_total = loc_series_idxs(X, self._total_series)
+        X_bottom = loc_series_idxs(X, self._bottom_series)
+
+        X_total.index = X_total.index.get_level_values(-1)
+
+        X_total_expanded = X_total.reindex(X_bottom.index.get_level_values(-1))
+        X_total_expanded.index = X_bottom.index
+
+        shares = X_bottom / X_total_expanded
+
+        _X = pd.concat([loc_series_idxs(X, self._total_series), shares], axis=0)
+        _X = loc_series_idxs(_X, self._original_series).sort_index()
+
+        return _X
+
+    def _inverse_transform(self, X, y):
+        if self._no_hierarchy:
+            return X
+
+        X_total = loc_series_idxs(X, self._total_series)
+        X_bottom = loc_series_idxs(X, self._bottom_series)
+
+        # Keep only timeindex of total series
+        X_total.index = X_total.index.get_level_values(-1)
+
+        # Reindex total series to match bottom series
+        X_total_expanded = X_total.reindex(X_bottom.index.get_level_values(-1))
+        X_total_expanded.index = X_bottom.index
+
+        forecasts_from_shares = X_bottom * X_total_expanded
+        _X = pd.concat(
+            [loc_series_idxs(X, self._original_series), forecasts_from_shares], axis=0
+        )
+
+        _X = self._aggregator.transform(_X)
+        _X = loc_series_idxs(_X, self._original_series).sort_index()
+        return _X
+
+
+class BottomUpReconciler(BaseTransformer):
+    """
+    Bottom-up reconciliation for hierarchical time series data.
+
+    It aggregates the data to the bottom level and then transforms it back
+    to the original hierarchy.
+
+    Attributes
+    ----------
+    _tags : dict
+        Common tags for the transformer.
+    _no_hierarchy : bool
+        Indicates if the data has no hierarchy (single level).
+    _original_series : pd.Index
+        The original series index before transformation.
+    _aggregator : Aggregator
+        An instance of the Aggregator class used for aggregation.
+    _bottom_series : pd.Index
+        The index of the bottom level series.
+    """
+
+    _tags = _COMMON_TAGS
+
+    def _fit(self, X, y):
+        self._no_hierarchy = X.index.nlevels == 1
+
+        if self._no_hierarchy:
+            return self
+
+        self._original_series = X.index.droplevel(-1).unique()
+        self._aggregator = Aggregator()
+        self._aggregator.fit(X)
+        X = self._aggregator.transform(X)
+
+        self._bottom_series = get_bottom_level_idxs(X)
+
+        return self
+
+    def _transform(self, X, y=None):
+        if self._no_hierarchy:
+            return X
+
+        X = self._aggregator.transform(X)
+        X_bottom = loc_series_idxs(X, self._bottom_series)
+
+        return X_bottom
+
+    def _inverse_transform(self, X, y=None):
+        if self._no_hierarchy:
+            return X
+
+        X = self._aggregator.transform(X)
+        X = loc_series_idxs(X, self._original_series).sort_index()
+
+        return X
+
+
+class MiddleOutReconciler(BaseTransformer):
+    """
+    Reconciliation using a middle-out approach.
+
+    Parameters
+    ----------
+    middle_level : int
+        The level at which to split the hierarchy for reconciliation.
+    middle_top_reconciler : BaseTransformer
+        The transformer to use for the top part of the hierarchy.
+    middle_bottom_reconciler : BaseTransformer
+        The transformer to use for the bottom part of the hierarchy.
+    """
+
+    def __init__(
+        self,
+        middle_level: int,
+        middle_top_reconciler: BaseTransformer,
+        middle_bottom_reconciler: BaseTransformer,
+    ):
+        self.middle_level = middle_level
+        self.middle_top_reconciler = middle_top_reconciler
+        self.middle_bottom_reconciler = middle_bottom_reconciler
+
+        super().__init__()
+
+    def _fit(self, X, y):
+        self._no_hierarchy = X.index.nlevels == 1
+
+        if self._no_hierarchy:
+            # TODO(fangelim): Should we raise a warning here?
+            return self
+
+        X_middle_top, X_middle_bottom = split_middle_levels(X, self.middle_level)
+
+        self.middle_top_reconciler.fit(X=X_middle_top, y=y)
+        self.middle_bottom_reconciler.fit(X=X_middle_bottom, y=y)
+
+        return self
+
+    def _transform(self, X, y=None):
+        if self._no_hierarchy:
+            return X
+
+        X_middle_top, X_middle_bottom = split_middle_levels(X, self.middle_level)
+
+        X_middle_top = self.middle_top_reconciler.transform(X_middle_top)
+        X_middle_bottom = self.middle_bottom_reconciler.transform(X_middle_bottom)
+
+        _X = pd.concat([X_middle_top, X_middle_bottom], axis=0).sort_index()
+
+        # Remove middle level duplicates
+        _X = _X[~_X.index.duplicated(keep="first")]
+        return _X
+
+    def _inverse_transform(self, X, y=None):
+        if self._no_hierarchy:
+            return X
+
+        X_middle_top, X_middle_bottom = split_middle_levels(X, self.middle_level)
+
+        X_middle_top = self.middle_top_reconciler.inverse_transform(X_middle_top)
+        X_middle_bottom = self.middle_bottom_reconciler.inverse_transform(
+            X_middle_bottom
+        )
+
+        _X = pd.concat([X_middle_top, X_middle_bottom], axis=0).sort_index()
+
+        # Remove middle level duplicates
+        _X = _X[~_X.index.duplicated(keep="first")]
+        return _X

--- a/sktime/transformations/hierarchical/reconciliation/single_level.py
+++ b/sktime/transformations/hierarchical/reconciliation/single_level.py
@@ -4,60 +4,16 @@ import pandas as pd
 
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.hierarchical.aggregate import Aggregator
+from sktime.transformations.hierarchical.reconciliation._utils import (
+    _is_hierarchical_dataframe,
+    filter_descendants,
+    get_bottom_level_idxs,
+    get_middle_level_aggregators,
+    get_total_level_idxs,
+    loc_series_idxs,
+)
 
 __all__ = ["TopdownShareReconciler", "BottomUpReconciler", "MiddleOutReconciler"]
-
-
-def loc_series_idxs(y, idxs):
-    return y.loc[y.index.droplevel(-1).isin(idxs)]
-
-
-def get_bottom_level_idxs(y):
-    idx = y.index
-    idx = idx.droplevel(-1).unique()
-    return idx[idx.get_level_values(-1) != "__total"]
-
-
-def get_bottom_series(y):
-    bottom_idx = get_bottom_level_idxs(y)
-    return loc_series_idxs(y, bottom_idx)
-
-
-def get_total_level_idxs(y):
-    nlevels = y.index.droplevel(-1).nlevels
-    return pd.Index([tuple(["__total"] * nlevels)])
-
-
-def get_total_series(y):
-    total_idx = get_total_level_idxs(y)
-    return loc_series_idxs(y, total_idx)
-
-
-def get_middle_level_series(y, middle_level):
-    idx = y.index
-    idx = idx.droplevel(-1).unique()
-    idx_middle_level = idx.get_level_values(middle_level)
-    idx_below_middle_level = idx.get_level_values(middle_level + 1)
-    is_middle_level_mask = (idx_below_middle_level == "__total") & (
-        idx_middle_level != "__total"
-    )
-    return idx[is_middle_level_mask]
-
-
-def split_middle_levels(y, middle_level):
-    """
-    Return two series: middle level and above, and middle level and below.
-    """
-    idx = y.index
-    idx = idx.droplevel(-1).unique()
-    idx_middle_level = idx.get_level_values(middle_level)
-    idx_below_middle_level = idx.get_level_values(middle_level + 1)
-    is_middle_or_above_mask = idx_below_middle_level == "__total"
-    is_middle_or_below_mask = idx_middle_level != "__total"
-
-    return loc_series_idxs(y, idx[is_middle_or_above_mask]), loc_series_idxs(
-        y, idx[is_middle_or_below_mask]
-    )
 
 
 _COMMON_TAGS = {
@@ -79,13 +35,15 @@ _COMMON_TAGS = {
         "pd_multiindex_hier",
     ],
     "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
-    "capability:inverse_transform": False,  # does transformer have inverse
-    "skip-inverse-transform": True,  # is inverse-transform skipped when called?
+    "capability:inverse_transform": True,  # does transformer have inverse
+    "skip-inverse-transform": False,  # is inverse-transform skipped when called?
     "univariate-only": False,  # can the transformer handle multivariate X?
     "handles-missing-data": False,  # can estimator handle missing data?
     "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
     "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
     "transform-returns-same-time-index": False,
+    "hierarchical": True,
+    "hierarchical:reconciliation": True,
 }
 
 
@@ -115,7 +73,7 @@ class TopdownShareReconciler(BaseTransformer):
     _tags = _COMMON_TAGS
 
     def _fit(self, X, y):
-        self._no_hierarchy = X.index.nlevels == 1
+        self._no_hierarchy = not _is_hierarchical_dataframe(X)
 
         if self._no_hierarchy:
             return self
@@ -198,7 +156,7 @@ class BottomUpReconciler(BaseTransformer):
     _tags = _COMMON_TAGS
 
     def _fit(self, X, y):
-        self._no_hierarchy = X.index.nlevels == 1
+        self._no_hierarchy = not _is_hierarchical_dataframe(X)
 
         if self._no_hierarchy:
             return self
@@ -231,37 +189,6 @@ class BottomUpReconciler(BaseTransformer):
         return X
 
 
-from sktime.transformations.base import BaseTransformer
-
-# other imports as needed
-
-
-def get_middle_level_aggregators(X, middle_level):
-    """
-    Identify aggregator nodes at the specified middle_level, i.e.
-    those for which the next level is '__total'.
-
-    Example:
-      If middle_level=1, then for a node= (region, store, cat, dept),
-      we check node[middle_level+1] == '__total'.
-      The node itself must not be __total at middle_level
-      (otherwise it's above or not a well-defined middle node).
-    """
-    idx = X.index.droplevel(-1).unique()
-    if middle_level + 1 >= idx.nlevels:
-        # If the user picks a middle_level at the last level, there's no "next" level
-        return []
-
-    # The aggregator condition:
-    #   * the next level's value is '__total'
-    #   * the middle level's value != '__total'
-    next_level_vals = idx.get_level_values(middle_level + 1)
-    this_level_vals = idx.get_level_values(middle_level)
-
-    is_agg = (next_level_vals == "__total") & (this_level_vals != "__total")
-    return idx[is_agg]
-
-
 class MiddleOutReconciler(BaseTransformer):
     """
     Reconciliation using a middle-out approach.
@@ -276,6 +203,8 @@ class MiddleOutReconciler(BaseTransformer):
         The transformer to use for each subtree below the middle-level totals.
     """
 
+    _tags = _COMMON_TAGS
+
     def __init__(
         self,
         middle_level: int,
@@ -288,7 +217,7 @@ class MiddleOutReconciler(BaseTransformer):
         super().__init__()
 
     def _fit(self, X, y):
-        self._no_hierarchy = X.index.nlevels == 1
+        self._no_hierarchy = not _is_hierarchical_dataframe(X)
         if self._no_hierarchy:
             return self
 
@@ -417,31 +346,18 @@ class MiddleOutReconciler(BaseTransformer):
         _X = _X[~_X.index.duplicated(keep="first")]
         return _X
 
-
-def is_ancestor(agg_node, node):
-    """Returns True if agg_node is an ancestor of node."""
-    return all(a == b or a == "__total" for a, b in zip(agg_node, node))
-
-
-def filter_descendants(X, aggregator_node):
-    """
-    Returns a sub-DataFrame/Series of X containing only rows whose
-    droplevel(-1) is a descendant of 'aggregator_node' at the given 'middle_level'.
-
-    aggregator_node is a tuple like ('CA', 'CA_1', '__total', '__total')
-    or ('regionA', 'storeA', '__total', '__total'), etc.
-    """
-    # We'll operate on the "higher-level" portion of the index
-    # (i.e., the index after dropping the time or final level).
-    idx_upper = X.index.droplevel(-1)  # e.g. (region, store, cat, dept)
-    nodes = idx_upper.unique()
-
-    # We only want to keep those which are descendants of aggregator_node,
-    # i.e., aggregator_node is an ancestor of that node.
-    # Because aggregator_node is "at" middle_level,
-    # but it may also have __total at deeper levels.
-    descendant_mask = [is_ancestor(aggregator_node, n) for n in nodes]
-    descendant_nodes = nodes[descendant_mask]
-
-    # Now filter X by these nodes
-    return X.loc[idx_upper.isin(descendant_nodes)]
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Get test params."""
+        return [
+            {
+                "middle_level": 1,
+                "middle_top_reconciler": TopdownShareReconciler(),
+                "middle_bottom_reconciler": BottomUpReconciler(),
+            },
+            {
+                "middle_level": 2,
+                "middle_top_reconciler": TopdownShareReconciler(),
+                "middle_bottom_reconciler": BottomUpReconciler(),
+            },
+        ]

--- a/sktime/transformations/hierarchical/reconciliation/topdown_share.py
+++ b/sktime/transformations/hierarchical/reconciliation/topdown_share.py
@@ -1,0 +1,126 @@
+"""Topdown hierarchical reconciliation transformer."""
+
+import pandas as pd
+
+from sktime.transformations.base import BaseTransformer
+from sktime.transformations.hierarchical.aggregate import Aggregator
+from sktime.transformations.hierarchical.reconciliation._utils import (
+    _is_hierarchical_dataframe,
+    get_bottom_level_idxs,
+    get_total_level_idxs,
+    loc_series_idxs,
+)
+
+__all__ = ["TopdownShareReconciler"]
+
+
+class TopdownShareReconciler(BaseTransformer):
+    """
+    Topdown reconciliation.
+
+    TopdownReconciler is a transformer for hierarchical time series reconciliation
+    using the top-down approach.
+
+    Attributes
+    ----------
+    _tags : dict
+        Common tags for the transformer.
+    _no_hierarchy : bool
+        Indicates if the input series has no hierarchy.
+    _original_series : pd.Index
+        Original series index without the bottom level.
+    _aggregator : Aggregator
+        Aggregator instance to aggregate the series.
+    _total_series : pd.Index
+        Index of the total level series.
+    _bottom_series : pd.Index
+        Index of the bottom level series.
+    """
+
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": "felipeangelimvieira",
+        "maintainers": "felipeangelimvieira",
+        # estimator type
+        # --------------
+        "scitype:transform-input": "Series",
+        "scitype:transform-output": "Series",
+        "scitype:transform-labels": "None",
+        # todo instance wise?
+        "scitype:instancewise": True,  # is this an instance-wise transform?
+        "X_inner_mtype": [
+            "pd.Series",
+            "pd.DataFrame",
+            "pd-multiindex",
+            "pd_multiindex_hier",
+        ],
+        "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
+        "capability:inverse_transform": True,  # does transformer have inverse
+        "skip-inverse-transform": False,  # is inverse-transform skipped when called?
+        "univariate-only": False,  # can the transformer handle multivariate X?
+        "handles-missing-data": False,  # can estimator handle missing data?
+        "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
+        "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
+        "transform-returns-same-time-index": False,
+        "capability:hierarchical_reconciliation": True,
+    }
+
+    def _fit(self, X, y):
+        self._no_hierarchy = not _is_hierarchical_dataframe(X)
+
+        if self._no_hierarchy:
+            return self
+
+        self._original_series = X.index.droplevel(-1).unique()
+        self._aggregator = Aggregator()
+        self._aggregator.fit(X)
+        X = self._aggregator.transform(X)
+
+        self._total_series = get_total_level_idxs(X)
+        self._bottom_series = get_bottom_level_idxs(X)
+
+        return self
+
+    def _transform(self, X, y):
+        if self._no_hierarchy:
+            return X
+
+        X = self._aggregator.transform(X)
+        X_total = loc_series_idxs(X, self._total_series)
+        X_bottom = loc_series_idxs(X, self._bottom_series)
+
+        X_total.index = X_total.index.get_level_values(-1)
+
+        X_total_expanded = X_total.reindex(X_bottom.index.get_level_values(-1))
+        X_total_expanded.index = X_bottom.index
+
+        shares = X_bottom / X_total_expanded
+
+        _X = pd.concat([loc_series_idxs(X, self._total_series), shares], axis=0)
+        _X = loc_series_idxs(_X, self._original_series).sort_index()
+
+        return _X
+
+    def _inverse_transform(self, X, y):
+        if self._no_hierarchy:
+            return X
+
+        X_total = loc_series_idxs(X, self._total_series)
+        X_bottom = loc_series_idxs(X, self._bottom_series)
+
+        # Keep only timeindex of total series
+        X_total.index = X_total.index.get_level_values(-1)
+
+        # Reindex total series to match bottom series
+        X_total_expanded = X_total.reindex(X_bottom.index.get_level_values(-1))
+        X_total_expanded.index = X_bottom.index
+
+        forecasts_from_shares = X_bottom * X_total_expanded
+        _X = pd.concat(
+            [loc_series_idxs(X, self._original_series), forecasts_from_shares], axis=0
+        )
+
+        _X = self._aggregator.transform(_X)
+        _X = loc_series_idxs(_X, self._original_series).sort_index()
+        return _X

--- a/sktime/transformations/hierarchical/tests/reconciliation/test_drop_redundant_hierarchical_levels.py
+++ b/sktime/transformations/hierarchical/tests/reconciliation/test_drop_redundant_hierarchical_levels.py
@@ -1,0 +1,69 @@
+import pandas as pd
+import pytest
+
+from sktime.transformations.hierarchical.reconciliation.forecast_proportions import (
+    _DropRedundantHierarchicalLevels,
+)
+
+
+@pytest.fixture
+def hierarchical_data():
+    """Fixture for a sample hierarchical DataFrame with redundant levels."""
+    index = pd.MultiIndex.from_tuples(
+        [
+            ("__total", "__total", pd.Period("2020-01-01")),
+            ("stateA", "regionA", pd.Period("2020-01-01")),
+            ("stateA", "regionB", pd.Period("2020-01-01")),
+            ("stateA", "regionC", pd.Period("2020-01-01")),
+        ],
+        names=["level_0", "level_1", "time"],
+    )
+    data = pd.DataFrame({"value": [100, 40, 30, 30]}, index=index)
+    return data
+
+
+def test_fit(hierarchical_data):
+    """Test the `_fit` method to ensure it detects levels to drop."""
+    transformer = _DropRedundantHierarchicalLevels()
+    transformer.fit(hierarchical_data)
+
+    assert hasattr(transformer, "levels_to_drop_")
+    assert transformer.levels_to_drop_ == [0], "Expected to drop the first level."
+
+
+def test_transform(hierarchical_data):
+    """Test the `_transform` method to ensure it drops redundant levels."""
+    transformer = _DropRedundantHierarchicalLevels()
+    transformer.fit(hierarchical_data)
+    transformed = transformer.transform(hierarchical_data, None)
+
+    assert (
+        transformed.index.nlevels == 2
+    ), "Expected the transformed index to have 2 levels."
+    assert (
+        "level_0" not in transformed.index.names
+    ), "The redundant level was not removed."
+
+
+def test_inverse_transform(hierarchical_data):
+    """Test the `_inverse_transform`, to ensure it reconstructs the index."""
+    transformer = _DropRedundantHierarchicalLevels()
+    transformer.fit(hierarchical_data)
+    transformed = transformer.transform(hierarchical_data, None)
+    inversed = transformer.inverse_transform(transformed, None)
+
+    pd.testing.assert_frame_equal(hierarchical_data, inversed)
+    assert (
+        inversed.index.nlevels == hierarchical_data.index.nlevels
+    ), "Expected the index to match the original."
+
+
+def test_no_hierarchy_handling():
+    """Test the transformer with a non-hierarchical DataFrame."""
+    non_hierarchical_data = pd.DataFrame({"value": [1, 2, 3]}, index=[0, 1, 2])
+    transformer = _DropRedundantHierarchicalLevels()
+    transformer.fit(non_hierarchical_data)
+
+    assert transformer._no_hierarchy is True, "Expected `_no_hierarchy` to be True."
+    transformed = transformer.transform(non_hierarchical_data)
+    pd.testing.assert_frame_equal(non_hierarchical_data, transformed)

--- a/sktime/transformations/hierarchical/tests/reconciliation/test_optimal.py
+++ b/sktime/transformations/hierarchical/tests/reconciliation/test_optimal.py
@@ -1,0 +1,121 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from sktime.transformations.hierarchical.reconciliation.optimal import (
+    create_summing_matrix_from_index,
+)
+
+
+###############################
+# The function under test (for reference here).
+# Remove or comment this out if you already import it from your_module.
+###############################
+def create_summing_matrix_from_index(hier_index):
+    """
+    Given a MultiIndex 'hier_index' of a hierarchical time series
+    (following an sktime-like convention), return a summation matrix S
+    as a DataFrame. Each row corresponds to a node in the hierarchy,
+    and each column corresponds to a bottom (leaf) node.
+    The entry S[i, j] = 1 if row i (an aggregator node) is an ancestor
+    of column j (a bottom node), else 0.
+    """
+    import numpy as np
+
+    all_nodes = list(hier_index)
+    # Bottom nodes: those with no '__total'
+    bottom_nodes = [node for node in all_nodes if "__total" not in node]
+
+    N = len(all_nodes)
+    M = len(bottom_nodes)
+    S = np.zeros((N, M), dtype=int)
+
+    def is_ancestor(agg, bot):
+        return all(a == b or a == "__total" for a, b in zip(agg, bot))
+
+    for i, agg_node in enumerate(all_nodes):
+        for j, bottom_node in enumerate(bottom_nodes):
+            if is_ancestor(agg_node, bottom_node):
+                S[i, j] = 1
+
+    S_df = pd.DataFrame(
+        S,
+        index=pd.MultiIndex.from_tuples(all_nodes, names=hier_index.names),
+        columns=pd.MultiIndex.from_tuples(bottom_nodes, names=hier_index.names),
+    )
+    return S_df
+
+
+@pytest.fixture
+def small_hier_index():
+    """
+    A small MultiIndex hierarchy for testing.
+    We'll have a few aggregator levels and a few bottom (leaf) series.
+    """
+    tuples = [
+        # bottom-level nodes (no '__total')
+        ("regionA", "storeA", "catA", "deptA"),
+        ("regionA", "storeA", "catA", "deptB"),
+        ("regionA", "storeA", "catB", "deptC"),
+        ("regionB", "storeC", "catA", "deptA"),
+        # aggregator nodes
+        ("regionA", "storeA", "catA", "__total"),
+        ("regionA", "storeA", "catB", "__total"),
+        ("regionA", "storeA", "__total", "__total"),
+        ("regionB", "storeC", "__total", "__total"),
+        ("__total", "__total", "__total", "__total"),
+    ]
+    names = ["region", "store", "category", "department"]
+    return pd.MultiIndex.from_tuples(tuples, names=names)
+
+
+def test_create_summing_matrix_from_index(small_hier_index):
+    # Given our small index, let's compute the summation matrix
+    S_df = create_summing_matrix_from_index(small_hier_index)
+
+    # --- 1) Basic checks ---
+    # We expect:
+    #   N = total nodes = 9
+    #   M = bottom nodes (no '__total') = 4
+    assert S_df.shape == (9, 4), "Summation matrix shape should be (9 x 4)."
+
+    # --- 2) Check that each aggregator row sums to the number of bottom nodes it covers ---
+    # Let's pick a known aggregator: ('regionA', 'storeA', 'catA', '__total')
+    # This should be an ancestor of the bottom nodes that start with ('regionA', 'storeA', 'catA', ...)
+    row_agg = ("regionA", "storeA", "catA", "__total")
+    # The corresponding bottom nodes are:
+    # ('regionA', 'storeA', 'catA', 'deptA') and ('regionA', 'storeA', 'catA', 'deptB')
+    # so we expect 2 ones in that row
+    expected_sum = 2
+    actual_sum = S_df.loc[row_agg].sum()
+    assert (
+        actual_sum == expected_sum
+    ), f"Row for {row_agg} should sum to {expected_sum}, got {actual_sum}"
+
+    # --- 3) Check that a fully aggregated node has 1 for all bottom nodes ---
+    # e.g., the global aggregator ('__total', '__total', '__total', '__total')
+    global_agg = ("__total", "__total", "__total", "__total")
+    # Should be ancestor of all 4 bottom-level nodes
+    global_sum_expected = 4
+    global_sum_actual = S_df.loc[global_agg].sum()
+    assert (
+        global_sum_actual == global_sum_expected
+    ), f"Global aggregator row should sum to {global_sum_expected}, got {global_sum_actual}"
+
+    # --- 4) Check that bottom-level rows (leaf series) have a 1 only in their own column ---
+    # For example, ('regionA', 'storeA', 'catA', 'deptA') should have a 1 in column
+    # ('regionA', 'storeA', 'catA', 'deptA') and 0 elsewhere.
+    leaf_node = ("regionA", "storeA", "catA", "deptA")
+    row_values = S_df.loc[leaf_node].values
+    # Expect exactly one "1" in the matching column, and zeros elsewhere
+    assert (
+        np.count_nonzero(row_values) == 1
+    ), f"Leaf node {leaf_node} should have exactly 1 in its row, got {np.count_nonzero(row_values)}"
+    # Check that the position of the 1 is exactly the matching column
+    leaf_node_col_index = S_df.columns.tolist().index(leaf_node)
+    assert (
+        row_values[leaf_node_col_index] == 1
+    ), "Leaf node row should have a 1 in its own column."
+
+    # If all assertions pass, the test passes
+    print("All tests passed for create_summing_matrix_from_index!")

--- a/sktime/transformations/hierarchical/tests/reconciliation/test_utils.py
+++ b/sktime/transformations/hierarchical/tests/reconciliation/test_utils.py
@@ -1,0 +1,120 @@
+import pandas as pd
+import pytest
+
+from sktime.transformations.hierarchical.reconciliation._utils import (
+    _promote_hierarchical_indexes,
+    _recursively_propagate_topdown,
+)
+
+
+@pytest.mark.parametrize(
+    "idx_tuple, expected_result",
+    [
+        # Case 1: No "__total" in the tuple, add it to the last level
+        (("region", "store", "product"), ("region", "store", "__total")),
+        # Case 2: "__total" already present at the last level, move up one level
+        (("region", "store", "__total"), ("region", "__total", "__total")),
+        # Case 3: "__total" at the first level, keep unchanged
+        (("__total", "__total", "__total"), ("__total", "__total", "__total")),
+        # Case 5: "__total" in the middle of the tuple
+        (("region", "__total", "__total"), ("__total", "__total", "__total")),
+    ],
+)
+def test_walk_up_hierarchical_levels(idx_tuple, expected_result):
+    result = _promote_hierarchical_indexes(idx_tuple)
+    assert result == expected_result, f"Failed for input: {idx_tuple}"
+
+
+def example_data_for_topdown_all_ones():
+    """3-level MultiIndex, all values = 1.0 (should remain unchanged)."""
+    index = pd.MultiIndex.from_tuples(
+        [
+            ("__total", "__total", "__total", pd.Period("2020-01-01")),
+            ("regionA", "__total", "__total", pd.Period("2020-01-01")),
+            ("regionA", "storeB", "__total", pd.Period("2020-01-01")),
+            ("regionA", "storeB", "p1", pd.Period("2020-01-01")),
+            ("regionA", "storeB", "p2", pd.Period("2020-01-01")),
+            ("regionB", "__total", "__total", pd.Period("2020-01-01")),
+            ("regionB", "storeA", "__total", pd.Period("2020-01-01")),
+            ("regionB", "storeA", "p1", pd.Period("2020-01-01")),
+            ("regionB", "storeA", "p2", pd.Period("2020-01-01")),
+        ],
+        names=["region", "store", "product", "period"],
+    )
+    X = pd.Series(1.0, index=index)
+    return X, X
+
+
+def example_data_for_topdown_varied():
+    """3-level MultiIndex, varied values for more thorough test."""
+    index = pd.MultiIndex.from_tuples(
+        [
+            ("__total", "__total", "__total", pd.Period("2020-01-01")),
+            ("regionA", "__total", "__total", pd.Period("2020-01-01")),
+            ("regionA", "storeB", "__total", pd.Period("2020-01-01")),
+            ("regionA", "storeB", "p1", pd.Period("2020-01-01")),
+            ("regionA", "storeB", "p2", pd.Period("2020-01-01")),
+            ("regionB", "__total", "__total", pd.Period("2020-01-01")),
+            ("regionB", "storeA", "__total", pd.Period("2020-01-01")),
+            ("regionB", "storeA", "p1", pd.Period("2020-01-01")),
+            ("regionB", "storeA", "p2", pd.Period("2020-01-01")),
+        ],
+        names=["region", "store", "product", "period"],
+    )
+
+    T = 1
+    A = 0.9
+    AB = 0.8
+    AB1 = 0.81
+    AB2 = 0.72
+    B = 0.7
+    BA = 0.63
+    BA1 = 0.56
+    BA2 = 0.5
+
+    data = [T, A, AB, AB1, AB2, B, BA, BA1, BA2]
+    X = pd.Series(data, index=index)
+
+    # Expected outcome:
+
+    data = [
+        T,
+        A * T,
+        AB * A * T,
+        AB1 * AB * A * T,
+        AB2 * AB * A * T,
+        B * T,
+        BA * B * T,
+        BA1 * BA * B * T,
+        BA2 * BA * B * T,
+    ]
+    expected = pd.Series(data, index=index)
+    return X, expected
+
+
+@pytest.mark.parametrize(
+    "example_func", [example_data_for_topdown_all_ones, example_data_for_topdown_varied]
+)
+def test_recursively_propagate_topdown(example_func):
+    """Basic functional test for _recursively_propagate_topdown."""
+    X, expected = example_func()  # create the sample data
+    X_propagated = _recursively_propagate_topdown(X)
+
+    # Sanity check #1: same shape, same index
+    assert X_propagated.shape == X.shape
+    pd.testing.assert_index_equal(X_propagated.index, X.index)
+
+    # If all ones, they should remain unchanged
+    if (X == 1.0).all():
+        pd.testing.assert_series_equal(X, X_propagated)
+
+    pd.testing.assert_series_equal(X_propagated, expected)
+    # Otherwise, do a broader check
+    # e.g. check that no NaNs introduced, or compare numeric ranges:
+    assert not X_propagated.isna().any(), "Should not introduce NaNs."
+    assert X_propagated.min() >= 0, "Ratios should stay non-negative (example logic)."
+
+    # If you know the exact numeric outcome for the varied case,
+    # you can define a reference 'expected' Series and compare:
+    # expected = ...
+    # pd.testing.assert_series_equal(X_propagated, expected)

--- a/sktime/transformations/tests/test_all_transformers.py
+++ b/sktime/transformations/tests/test_all_transformers.py
@@ -251,12 +251,13 @@ class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
     def test_hierarchical_transformations(self, estimator_instance, no_levels):
         """Test that hierarchical transformers can handle hierarchical data."""
         # skip this test if the estimator is not hierarchical
+        import numpy as np
         from pandas.testing import assert_frame_equal
 
         from sktime.forecasting.exp_smoothing import ExponentialSmoothing
 
         if not estimator_instance.get_tag(
-            "hierarchical:reconciliation", False, raise_error=False
+            "capability:hierarchical_reconciliation", False, raise_error=False
         ):
             return None
 
@@ -275,6 +276,7 @@ class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
         forecaster = ExponentialSmoothing(trend="add", seasonal="additive", sp=12)
         prds = forecaster.fit(X).predict(fh)
 
+        prds += np.random.normal(0, 0.1, prds.shape)
         # reconcile forecasts
         reconciler = estimator_instance
         prds_recon = reconciler.fit_transform(prds)


### PR DESCRIPTION
This PR adds new reconciliation methods and revisits the current reconciliation API.

Currently, the reconciliation is done at `transform`. However, to be able to have all reconciliation strategies under the same 
API, we should notice that there are two important steps:

1. `transform`: Pre-process the original timeseries, by converting them to shares (in Topdown-share), by keeping just the relevant ones (bottom-levels, in bottom-up approach), or by doing nothing (optimal reconciliation).
2. `inverse_transform`: Reconcile the base forecasts

In this PR, the zero-constrained representation was used because it is more efficient and more versatile.

#### Reference Issues/PRs

Add some of the methods mentioned in #7609 

#### What does this implement/fix? Explain your changes.

- Add Topdown (share) reconciliation
- Add optimal non-negative reconciliation (using cvxpy to solve quadratic programming problem)
- Add middle-out reconciliation
- Add forecast proportions and optimal reconciliation (called "FullHierarchyReconciliation") as a transformations
- Add new tag `capability:hierarchical_reconciliation` so that tailored unit tests can be executed

#### Does your contribution introduce a new dependency? If yes, which one?

Yes, optinal `cvxpy` to solve quadratic programming problem in non-negative reconciliation


#### What should a reviewer concentrate their feedback on?

- The new API design proposal
- The directory name, and we should discuss on how to handle deprecation and fix tutorials
- The new tag

#### Did you add any tests for the change?

Yes, added tests for some utilities and for hierarchical reconciliation

#### Any other comments?

With these transformations implemented, it is easy to create or extend the current ReconcileForecaster to account for these new possibilities.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [x] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
