### PR TITLE
[DOC] improved docstring for grouped/clustering forecaster compositors

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -53,10 +53,10 @@ Pipelines can also be constructed using ``*``, ``**``, ``+``, and ``|`` dunders.
     MultiplexForecaster
     ForecastX
     ForecastByLevel
-    GroupbyCategoryForecaster
-    Permute
-    HierarchyEnsembleForecaster
     TransformSelectForecaster
+    GroupbyCategoryForecaster
+    HierarchyEnsembleForecaster
+    Permute
     FhPlexForecaster
     IgnoreX
     FallbackForecaster

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -136,13 +136,17 @@ class ForecastByLevel(_DelegatedForecaster):
 
 
 class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
-    """Compositor that utilizes varying forecasters based on inferred category.
+    """Choosing a global forecaster based on category or cluster of time series.
+
+    Programmatic generalization of "cluster then apply forecaster" approach,
+    or the Syntetos/Boylan heuristic to apply forecaster by categories
+    smooth, erratic, intermittent, lumpy.
 
     Applies a series-to-primitives transformer on a given time series. Series are
     grouped by the generated value from the transformer, and the corresponding
     forecaster is used to predict the time series.
 
-    Differently from `TransformSelectForecaster`, this compositor passes all timeseries
+    Different from ``TransformSelectForecaster``, this compositor passes all timeseries
     of a given category to the forecaster, instead of passing only one at a time.
 
     Parameters
@@ -172,7 +176,7 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
     --------
     This example showcases how the GroupbyCategoryForecaster can be utilized to select
     appropriate forecasters on the basis of the time series category determined by
-    the ADICVTransformer!
+    the ADICVTransformer:
 
     >>> from sktime.forecasting.compose import GroupbyCategoryForecaster
     >>> from sktime.forecasting.croston import Croston
@@ -180,13 +184,13 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.transformations.series.adi_cv import ADICVTransformer
 
-    # Importing the methods which can generate data of specific categories
+    Importing the methods which can generate data of specific categories
     depending on their variance and average demand intervals.
 
     >>> from sktime.transformations.series.tests.test_adi_cv import (
     ...     _generate_erratic_series)
 
-    # The forecaster is defined which accepts a dictionary of forecasters,
+    The forecaster is defined which accepts a dictionary of forecasters,
     a transformer and optionally a fallback_forecaster
 
     >>> group_forecaster = GroupbyCategoryForecaster(
@@ -198,9 +202,9 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
 
     >>> generated_data = _generate_erratic_series()
 
-    # The fit function firstly passes the data through the given transformer
-    # to generate a given category. This category can be seen by the variable
-    # self.category_.
+    The fit function firstly passes the data through the given transformer
+    to generate a given category. This category can be seen by the variable
+    self.category_.
 
     >>> group_forecaster = group_forecaster.fit(generated_data, fh=50)
     >>> #print(f"The chosen category is: {group_forecaster.category}")

--- a/sktime/forecasting/compose/_transform_select_forecaster.py
+++ b/sktime/forecasting/compose/_transform_select_forecaster.py
@@ -9,12 +9,19 @@ from sktime.registry import coerce_scitype
 
 
 class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
-    """Compositor that utilizes varying forecasters by time series data's nature.
+    """Choosing a forecaster based on category or cluster of time series.
+
+    Programmatic generalization of "cluster then apply forecaster" approach,
+    or the Syntetos/Boylan heuristic to apply forecaster by categories
+    smooth, erratic, intermittent, lumpy.
 
     Applies a series-to-primitives transformer on a given time series. Based on the
     generated value from the transformer, one of multiple forecasters provided by
     the user in the form of a dictionary (key => category, value => forecaster) is
     selected. Finally, the chosen forecaster is fit to the data for future predictions.
+
+    To apply a global forecaster per category, use the ``GroupbyCategoryForecaster``
+    compositor instead.
 
     Parameters
     ----------


### PR DESCRIPTION
This improves the summary and docstring for the grouped/clustering forecaster compositors, in order to enhance clarity about what they are doing, and findability given that it also clarifies the one-sentence summary in the API docs.