### PR TITLE
[BUG] fixing spurious retrieval of fallback `Normal` distribution

### DIFF
--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -172,6 +172,8 @@ def all_estimators(
         "_split",
         "test_split",
         "registry",
+        "normal",
+        "_normal",
     )
 
     ROOT = str(Path(__file__).parent.parent)  # sktime package root directory


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/7716 by excluding the fallback module containing `Normal` from retrieval by `all_estimators`.