### PR TITLE
[DOC] API reference for detection metrics

### DIFF
--- a/docs/source/api_reference/performance_metrics.rst
+++ b/docs/source/api_reference/performance_metrics.rst
@@ -114,8 +114,48 @@ Distribution forecasts
     SquaredDistrLoss
 
 
-Time series segmentation
-------------------------
+Detection tasks
+---------------
+
+Detection metrics can be applied to compare ground truth events with detected events,
+and ground truth segments with detected segments.
+
+Detection metrics are typically designed for either:
+
+* point events, i.e., annotated time stamps, or
+* segments, i.e., annotated time intervals.
+
+The metrics in ``sktime`` can be used for both types of detection tasks:
+
+* segmentation metrics interpret point events as segment boundaries, separating consecutive segments
+* point event metrics are applied to segments by considering their boundaries as point events
+
+
+Event detection - anomalies, outliers
+-------------------------------------
+
+.. currentmodule:: sktime.performance_metrics.detection
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: function.rst
+
+    DirectedChamfer
+    DirectedHausdorff
+    DetectionCount
+    F1ScoreMargin
+
+Segment detection
+-----------------
+
+.. currentmodule:: sktime.performance_metrics.detection
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: function.rst
+
+    RandIndex
+
 
 .. currentmodule:: sktime.performance_metrics.annotation
 

--- a/docs/source/api_reference/performance_metrics.rst
+++ b/docs/source/api_reference/performance_metrics.rst
@@ -143,7 +143,7 @@ Event detection - anomalies, outliers
     DirectedChamfer
     DirectedHausdorff
     DetectionCount
-    F1ScoreMargin
+    WindowedF1Score
 
 Segment detection
 -----------------

--- a/docs/source/api_reference/performance_metrics.rst
+++ b/docs/source/api_reference/performance_metrics.rst
@@ -157,6 +157,11 @@ Segment detection
     RandIndex
 
 
+Legacy detection metrics
+------------------------
+
+These metrics do not follow the standard API and will be deprecated in the future.
+
 .. currentmodule:: sktime.performance_metrics.annotation
 
 .. autosummary::


### PR DESCRIPTION
This PR adds a proper API reference for the new detection metrics (based on `skbase` class design).

Already includes a link for the windowed F1 score, which will become visible only after merging https://github.com/sktime/sktime/pull/7628.