### PR TITLE
Update code format & add backend and backend_params and utilize sktime.utils instead of joblib 

### DIFF
--- a/sktime/utils/parallel.py
+++ b/sktime/utils/parallel.py
@@ -89,7 +89,7 @@ para_dict = {}
 
 def _parallelize_none(fun, iter, meta, backend, backend_params):
     """Execute loop via simple sequential list comprehension."""
-    ret = [fun(x, meta=meta) for x in iter]
+    ret = [fun(x, y=None, X=None, fh=None, meta=meta) for x in iter]
     return ret
 
 


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/7427

- Added `backend` and `backend_params` to `_HeterogenousEnsembleForecaster` for improved parallelization flexibility.
- Deprecated `n_jobs` with a **warning**, following the deprecation policy.
Modified parallelization from joblib to `sktime.utils.parallel`