### PR TITLE
[BUG] in transformers, do not pass `y` to inner in case of scitype mismatch

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -593,7 +593,7 @@ class BaseTransformer(BaseEstimator):
 
         Explicitly, with examples:
 
-            * if ``X`` is ``Series`` (e.g., ``pd.DataFrame``)´
+            * if ``X`` is ``Series`` (e.g., ``pd.DataFrame``)
             and ``transform-output`` is ``Series``,
             then the return is a single `Series` of the same mtype.
             Example: detrending a single series
@@ -707,7 +707,7 @@ class BaseTransformer(BaseEstimator):
 
         Explicitly, with examples:
 
-            * if ``X`` is ``Series`` (e.g., ``pd.DataFrame``)´
+            * if ``X`` is ``Series`` (e.g., ``pd.DataFrame``)
             and ``transform-output`` is ``Series``,
             then the return is a single `Series` of the same mtype.
             Example: detrending a single series

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -592,19 +592,26 @@ class BaseTransformer(BaseEstimator):
         combinations not in the table are currently not supported
 
         Explicitly, with examples:
-            if `X` is `Series` (e.g., `pd.DataFrame`) and `transform-output` is `Series`
-                then the return is a single `Series` of the same mtype
-                Example: detrending a single series
-            if `X` is `Panel` (e.g., `pd-multiindex`) and `transform-output` is `Series`
-                then the return is `Panel` with same number of instances as `X`
-                    (the transformer is applied to each input Series instance)
-                Example: all series in the panel are detrended individually
-            if `X` is `Series` or `Panel` and `transform-output` is `Primitives`
-                then the return is `pd.DataFrame` with as many rows as instances in `X`
-                Example: i-th row of the return has mean and variance of the i-th series
-            if `X` is `Series` and `transform-output` is `Panel`
-                then the return is a `Panel` object of type `pd-multiindex`
-                Example: i-th instance of the output is the i-th window running over `X`
+
+            * if ``X`` is ``Series`` (e.g., ``pd.DataFrame``)´
+            and ``transform-output`` is ``Series``,
+            then the return is a single `Series` of the same mtype.
+            Example: detrending a single series
+
+            * if ``X`` is ``Panel`` (e.g., ``pd-multiindex``) and ``transform-output``
+            is ``Series``,
+            then the return is `Panel` with same number of instances as ``X``
+            (the transformer is applied to each input Series instance).
+            Example: all series in the panel are detrended individually
+
+            * if ``X`` is ``Series`` or ``Panel`` and ``transform-output`` is
+            ``Primitives``,
+            then the return is ``pd.DataFrame`` with as many rows as instances in ``X``
+            Example: i-th row of the return has mean and variance of the i-th series
+
+            * if ``X`` is ``Series`` and ``transform-output`` is ``Panel``,
+            then the return is a ``Panel`` object of type ``pd-multiindex``.
+            Example: i-th instance of the output is the i-th window running over ``X``
         """
         # check whether is fitted
         self.check_is_fitted()
@@ -699,19 +706,26 @@ class BaseTransformer(BaseEstimator):
         combinations not in the table are currently not supported
 
         Explicitly, with examples:
-            if `X` is `Series` (e.g., `pd.DataFrame`) and `transform-output` is `Series`
-                then the return is a single `Series` of the same mtype
-                Example: detrending a single series
-            if `X` is `Panel` (e.g., `pd-multiindex`) and `transform-output` is `Series`
-                then the return is `Panel` with same number of instances as `X`
-                    (the transformer is applied to each input Series instance)
-                Example: all series in the panel are detrended individually
-            if `X` is `Series` or `Panel` and `transform-output` is `Primitives`
-                then the return is `pd.DataFrame` with as many rows as instances in `X`
-                Example: i-th row of the return has mean and variance of the i-th series
-            if `X` is `Series` and `transform-output` is `Panel`
-                then the return is a `Panel` object of type `pd-multiindex`
-                Example: i-th instance of the output is the i-th window running over `X`
+
+            * if ``X`` is ``Series`` (e.g., ``pd.DataFrame``)´
+            and ``transform-output`` is ``Series``,
+            then the return is a single `Series` of the same mtype.
+            Example: detrending a single series
+
+            * if ``X`` is ``Panel`` (e.g., ``pd-multiindex``) and ``transform-output``
+            is ``Series``,
+            then the return is `Panel` with same number of instances as ``X``
+            (the transformer is applied to each input Series instance).
+            Example: all series in the panel are detrended individually
+
+            * if ``X`` is ``Series`` or ``Panel`` and ``transform-output`` is
+            ``Primitives``,
+            then the return is ``pd.DataFrame`` with as many rows as instances in ``X``
+            Example: i-th row of the return has mean and variance of the i-th series
+
+            * if ``X`` is ``Series`` and ``transform-output`` is ``Panel``,
+            then the return is a ``Panel`` object of type ``pd-multiindex``.
+            Example: i-th instance of the output is the i-th window running over ``X``
         """
         # Non-optimized default implementation; override when a better
         # method is possible for a given algorithm.
@@ -1134,8 +1148,10 @@ class BaseTransformer(BaseEstimator):
                 var_name="y",
             )
 
+            y_required = self.get_tag("requires_y")
+
             # raise informative error message if y is is in wrong format
-            if not y_valid:
+            if not y_valid and y_required:
                 allowed_msg = (
                     f"Allowed scitypes for y in transformations depend on X passed. "
                     f"Passed X scitype was {X_scitype}, "
@@ -1150,9 +1166,13 @@ class BaseTransformer(BaseEstimator):
                 raise TypeError(
                     "Transformers do not support categorical features in y."
                 )
-
-            y_scitype = y_metadata["scitype"]
-            y_mtype = y_metadata["mtype"]
+            elif not y_valid and not y_required:
+                # if y is wrong type, we do not pass it to inner methods
+                y_scitype = None
+                y_inner_mtype = ["None"]
+            else:  # y_valid, (y_required does not matter then, we pass y)
+                y_scitype = y_metadata["scitype"]
+                y_mtype = y_metadata["mtype"]
 
         else:
             # y_scitype is used below - set to None if y is None

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1162,10 +1162,6 @@ class BaseTransformer(BaseEstimator):
                     msg, var_name=msg_y, allowed_msg=allowed_msg, raise_exception=True
                 )
 
-            if DtypeKind.CATEGORICAL in y_metadata["feature_kind"]:
-                raise TypeError(
-                    "Transformers do not support categorical features in y."
-                )
             elif not y_valid and not y_required:
                 # if y is wrong type, we do not pass it to inner methods
                 y_scitype = None
@@ -1173,6 +1169,11 @@ class BaseTransformer(BaseEstimator):
             else:  # y_valid, (y_required does not matter then, we pass y)
                 y_scitype = y_metadata["scitype"]
                 y_mtype = y_metadata["mtype"]
+
+                if DtypeKind.CATEGORICAL in y_metadata["feature_kind"]:
+                    raise TypeError(
+                        "Transformers do not support categorical features in y."
+                    )
 
         else:
             # y_scitype is used below - set to None if y is None

--- a/sktime/transformations/tests/test_base.py
+++ b/sktime/transformations/tests/test_base.py
@@ -764,16 +764,31 @@ def test_wrong_y_is_not_passed_to_transformer():
         return None
 
     # Define the multi-index
-    index = pd.MultiIndex.from_tuples([
-        (0, datetime.strptime('2024-04-20 18:22:14.877500', '%Y-%m-%d %H:%M:%S.%f')),
-        (0, datetime.strptime('2024-04-20 18:22:14.903000', '%Y-%m-%d %H:%M:%S.%f')),
-        (1, datetime.strptime('2024-04-20 18:24:42.453400', '%Y-%m-%d %H:%M:%S.%f')),
-        (1, datetime.strptime('2024-04-20 18:24:42.478800', '%Y-%m-%d %H:%M:%S.%f'))
-    ], names=['instance', 'Time'])
+    index = pd.MultiIndex.from_tuples(
+        [
+            (
+                0,
+                datetime.strptime("2024-04-20 18:22:14.877500", "%Y-%m-%d %H:%M:%S.%f"),
+            ),
+            (
+                0,
+                datetime.strptime("2024-04-20 18:22:14.903000", "%Y-%m-%d %H:%M:%S.%f"),
+            ),
+            (
+                1,
+                datetime.strptime("2024-04-20 18:24:42.453400", "%Y-%m-%d %H:%M:%S.%f"),
+            ),
+            (
+                1,
+                datetime.strptime("2024-04-20 18:24:42.478800", "%Y-%m-%d %H:%M:%S.%f"),
+            ),
+        ],
+        names=["instance", "Time"],
+    )
 
-    X = pd.DataFrame({
-        'LeftControllerVelocity_0': [-0.01, -0.01, 0.06, 0.06]
-    }, index=index)
+    X = pd.DataFrame(
+        {"LeftControllerVelocity_0": [-0.01, -0.01, 0.06, 0.06]}, index=index
+    )
     y = np.array([1, 0.5])
 
     # noise filter only, this is a reduced MRE

--- a/sktime/transformations/tests/test_base.py
+++ b/sktime/transformations/tests/test_base.py
@@ -737,3 +737,49 @@ def test_vectorize_reconstruct_correct_hierarchy():
 
     # check that Xt.index is the same as X.index with time level dropped and made unique
     assert (X.index.droplevel(-1).unique() == Xt.index).all()
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.transformations"),
+    reason="run test only if anything in sktime.transformations module has changed",
+)
+def test_wrong_y_is_not_passed_to_transformer():
+    """Tests that y incompatible with internal type is not passed to transformer.
+
+    Failure case of bug #6417.
+    """
+    from datetime import datetime
+
+    import numpy as np
+    import pandas as pd
+
+    from sktime.pipeline import make_pipeline
+    from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor
+    from sktime.transformations.compose import FitInTransform
+    from sktime.transformations.panel.interpolate import TSInterpolator
+    from sktime.transformations.series.kalman_filter import KalmanFilterTransformerPK
+
+    # this test requires the KalmanFilterTransformerPK to be runnable
+    if not _check_estimator_deps(KalmanFilterTransformerPK, severity="none"):
+        return None
+
+    # Define the multi-index
+    index = pd.MultiIndex.from_tuples([
+        (0, datetime.strptime('2024-04-20 18:22:14.877500', '%Y-%m-%d %H:%M:%S.%f')),
+        (0, datetime.strptime('2024-04-20 18:22:14.903000', '%Y-%m-%d %H:%M:%S.%f')),
+        (1, datetime.strptime('2024-04-20 18:24:42.453400', '%Y-%m-%d %H:%M:%S.%f')),
+        (1, datetime.strptime('2024-04-20 18:24:42.478800', '%Y-%m-%d %H:%M:%S.%f'))
+    ], names=['instance', 'Time'])
+
+    X = pd.DataFrame({
+        'LeftControllerVelocity_0': [-0.01, -0.01, 0.06, 0.06]
+    }, index=index)
+    y = np.array([1,0.5])
+
+
+    noise_filter = FitInTransform(KalmanFilterTransformerPK(1, denoising=True))
+    interpolator = TSInterpolator(4000)
+    regressor = KNeighborsTimeSeriesRegressor()
+
+    model = make_pipeline(noise_filter, interpolator, regressor)
+    model.fit(X, y)

--- a/sktime/transformations/tests/test_base.py
+++ b/sktime/transformations/tests/test_base.py
@@ -757,10 +757,10 @@ def test_wrong_y_is_not_passed_to_transformer():
     from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor
     from sktime.transformations.compose import FitInTransform
     from sktime.transformations.panel.interpolate import TSInterpolator
-    from sktime.transformations.series.kalman_filter import KalmanFilterTransformerPK
+    from sktime.transformations.series.kalman_filter import KalmanFilterTransformerFP
 
-    # this test requires the KalmanFilterTransformerPK to be runnable
-    if not _check_estimator_deps(KalmanFilterTransformerPK, severity="none"):
+    # this test requires the KalmanFilterTransformerFP to be runnable
+    if not _check_estimator_deps(KalmanFilterTransformerFP, severity="none"):
         return None
 
     # Define the multi-index
@@ -774,10 +774,14 @@ def test_wrong_y_is_not_passed_to_transformer():
     X = pd.DataFrame({
         'LeftControllerVelocity_0': [-0.01, -0.01, 0.06, 0.06]
     }, index=index)
-    y = np.array([1,0.5])
+    y = np.array([1, 0.5])
 
+    # noise filter only, this is a reduced MRE
+    noise_filter_only = FitInTransform(KalmanFilterTransformerFP(1, denoising=True))
+    noise_filter_only.fit(X, y)
 
-    noise_filter = FitInTransform(KalmanFilterTransformerPK(1, denoising=True))
+    # in pipeline, this is the full MRE from bug #6417
+    noise_filter = FitInTransform(KalmanFilterTransformerFP(1, denoising=True))
     interpolator = TSInterpolator(4000)
     regressor = KNeighborsTimeSeriesRegressor()
 


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/6417.

The fix is not passing a `y` of mismatching scitype to the inner methods of transformations.

The reason for the bug #6417 was that, in classification or regression pipelines, a `Table` `y` would be passed on to sensible choices of transformers in a pipeline that could optionally take a `Series` `y`, causing an exception, while the user expectation would be that that `y` is not used.

The case where there is this mismatch with user expectation is a quite specialized combination case:

* a transformation is used that can use `y` but does not need to
* that `y`, when passed, must have scitype `Series`
* that is, equivalently in terms of tags: `requires_y = False` and `scitype:transform-labels = Series`
* the transformation is used in a classifier or regressor pipeline, which assumes `y` of `Table` scitype throughout

The pipeline then attempts to plug in the `Table` `y` into the transformation, which used to fail.

This PR resolves this by the internal checker discarding a mismatched `y`, instead of raising the exception.

The downside is that mismatch may also be due to incorrect input, but due to the above case it feels like it is better to err on the side of permissiveness, otherwise it would be much more involved to resolve the bug.

On a side note, the condition may seems to be a bit specialized, and few transformers satisfy it - however, the `filterpy` Kalman filter interface is one of them, ad filtering prior to classification or regression is a common pre-processing step.

This PR also contains a minor improvement to the docstrings, the docstring changes are exclusively formatting, to ensure they render correctly.