### PR TITLE
[ENH] refactor `datatypes` registry to `scikit-base` records

### DIFF
--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -29,7 +29,12 @@ import numpy as np
 
 from sktime.datatypes._base import BaseDatatype
 from sktime.datatypes._base._common import _metadata_requested, _ret
-from sktime.datatypes._registry import AMBIGUOUS_MTYPES, SCITYPE_LIST, mtype_to_scitype
+from sktime.datatypes._registry import (
+    AMBIGUOUS_MTYPES,
+    SCITYPE_LIST,
+    generate_scitype_cls_list,
+    mtype_to_scitype,
+)
 
 
 def get_check_dict(soft_deps="present"):
@@ -56,19 +61,7 @@ def get_check_dict(soft_deps="present"):
 @lru_cache(maxsize=1)
 def generate_check_dict(soft_deps="present"):
     """Generate check_dict using lookup."""
-    from skbase.utils.dependencies import _check_estimator_deps
-
-    from sktime.utils.retrieval import _all_classes
-
-    classes = _all_classes("sktime.datatypes")
-    classes = [x[1] for x in classes]
-    classes = [x for x in classes if issubclass(x, BaseDatatype)]
-    classes = [x for x in classes if not x.__name__.startswith("Base")]
-    classes = [x for x in classes if not x.__name__.startswith("Scitype")]
-
-    # subset only to data types with soft dependencies present
-    if soft_deps == "present":
-        classes = [x for x in classes if _check_estimator_deps(x, severity="none")]
+    classes = generate_scitype_cls_list(soft_deps=soft_deps)
 
     check_dict = dict()
     for cls in classes:

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -3,7 +3,6 @@
 import sys
 import warnings
 from functools import lru_cache
-from importlib.metadata import distribution, PackageNotFoundError
 from importlib.util import find_spec
 from inspect import isclass
 

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -3,6 +3,7 @@
 import sys
 import warnings
 from functools import lru_cache
+from importlib.metadata import distribution, PackageNotFoundError
 from importlib.util import find_spec
 from inspect import isclass
 


### PR DESCRIPTION
This PR refactors the `datatypes` registry to the new, programmatic `scikit-base` records, deduplicating the points of extension.

The manually popultated records in the `_registry` folders are removed in favour of the records currently in the `_check` folders.

In a future PR, we may rename `_check` to `_registry`, as these contain the primary records now.