### PR TITLE
[ENH] refactor `Alignment` and `Proba` datatypes to `scikit-base` records

### DIFF
--- a/sktime/datatypes/_alignment/__init__.py
+++ b/sktime/datatypes/_alignment/__init__.py
@@ -1,13 +1,11 @@
 """Module exports: Alignment type checkers and mtype inference."""
 
-from sktime.datatypes._alignment._check import check_dict as check_dict_Alignment
 from sktime.datatypes._alignment._registry import (
     MTYPE_LIST_ALIGNMENT,
     MTYPE_REGISTER_ALIGNMENT,
 )
 
 __all__ = [
-    "check_dict_Alignment",
     "MTYPE_LIST_ALIGNMENT",
     "MTYPE_REGISTER_ALIGNMENT",
 ]

--- a/sktime/datatypes/_alignment/_base.py
+++ b/sktime/datatypes/_alignment/_base.py
@@ -24,7 +24,7 @@ class ScitypeAlignment(BaseDatatype):
         "python_dependencies": None,
     }
 
-    def __init__(self, is_multiple = None):
+    def __init__(self, is_multiple=None):
         self.is_multiple = is_multiple
 
         super().__init__()

--- a/sktime/datatypes/_alignment/_base.py
+++ b/sktime/datatypes/_alignment/_base.py
@@ -1,0 +1,30 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Base class for data types."""
+
+__author__ = ["fkiraly"]
+
+from sktime.datatypes._base import BaseDatatype
+
+
+class ScitypeAlignment(BaseDatatype):
+    """Alignment data type. Represents an alignment of two or multiple time series.
+
+    Parameters
+    ----------
+    is_multiple : boolean
+        True iff is multiple alignment, i.e., has multiple (3 or more) time series
+    """
+
+    _tags = {
+        "scitype": "Alignment",
+        "name": None,  # any string
+        "name_python": None,  # lower_snake_case
+        "name_aliases": [],
+        "python_version": None,
+        "python_dependencies": None,
+    }
+
+    def __init__(self, is_multiple = None):
+        self.is_multiple = is_multiple
+
+        super().__init__()

--- a/sktime/datatypes/_alignment/_check.py
+++ b/sktime/datatypes/_alignment/_check.py
@@ -113,7 +113,6 @@ def check_align(align_df, name="align_df", index="iloc", return_metadata=False):
             return False, msg
     # no additional restrictions apply if loc or either, so no elif
 
-
     metadata = {}
     if _req("is_multiple", return_metadata):
         metadata["is_multiple"] = n >= 3

--- a/sktime/datatypes/_alignment/_check.py
+++ b/sktime/datatypes/_alignment/_check.py
@@ -27,39 +27,49 @@ msg: str - error message if object is not valid, otherwise None
 metadata: dict - metadata about obj if valid, otherwise None
         returned only if return_metadata is True
     fields:
-        currently none, placeholder
+        is_multiple : boolean, whether align_df has multiple (3 or more) time series
 """
 
 __author__ = ["fkiraly"]
 
-__all__ = ["check_dict"]
-
 import numpy as np
 import pandas as pd
 
-from sktime.datatypes._base._common import _ret
+from sktime.datatypes._alignment._base import ScitypeAlignment
+from sktime.datatypes._base._common import _req, _ret
 
-check_dict = dict()
 
-
-def check_align(align_df, name="align_df", index="iloc"):
+def check_align(align_df, name="align_df", index="iloc", return_metadata=False):
     """Check whether the object is a data frame in alignment format.
 
     Parameters
     ----------
     align_df : any object
         check passes if it follows alignment format, as follows:
-        pandas.DataFrame with column names 'ind'+str(i) for integers i, as follows
-            all integers i between 0 and some natural number n must be present
+
+        pandas.DataFrame with column names 'ind'+str(i) for integers i, as follows:
+        all integers i between 0 and some natural number n must be present
+
     name : string, optional, default="align_df"
         variable name that is printed in ValueError-s
+
     index : string, optional, one of "iloc" (default), "loc", "either"
         whether alignment to check is "loc" or "iloc"
+
+    return_metadata - bool, str, or list of str, optional, default=False
+
+        * if False, returns only ``valid`` return. No metadata is returned.
+        * if True, returns all three return objects. All metadata fields are returned.
+        * if str, list of str, metadata return dict is subset to keys in
+        ``return_metadata``. This allows selective return of metadata fields,
+        to avoid unnecessary computation.
 
     Returns
     -------
     valid : boolean, whether align_df is a valid alignment data frame
     msg : error message if align_df is invalid
+    metadata : dict
+        is_multiple : boolean, whether align_df has multiple (3 or more) time series
     """
     if not isinstance(align_df, pd.DataFrame):
         msg = f"{name} is not a pandas DataFrame"
@@ -103,24 +113,144 @@ def check_align(align_df, name="align_df", index="iloc"):
             return False, msg
     # no additional restrictions apply if loc or either, so no elif
 
-    return True, ""
+
+    metadata = {}
+    if _req("is_multiple", return_metadata):
+        metadata["is_multiple"] = n >= 3
+
+    return True, "", metadata
 
 
-def check_alignment_alignment(obj, return_metadata=False, var_name="obj"):
-    """Check whether object has mtype `alignment` for scitype `Alignment`."""
-    valid, msg = check_align(obj, name=var_name, index="iloc")
+class AlignmentIloc(ScitypeAlignment):
+    """Data type: pandas.DataFrame based specification of an alignment, iloc references.
 
-    return _ret(valid, msg, {}, return_metadata)
+    Name: ``"alignment"``
+
+    Short description:
+
+    ``pandas.DataFrame``, with cols = aligned series, entries = iloc references,
+    rows = ordered alignment pairs/tuples
+
+    Long description:
+
+    The ``"alignment"`` :term:`mtype` is a concrete specification
+    that implements the ``Alignment`` :term:`scitype`, i.e., the abstract
+    type of an alignment of two or more time series.
+
+    An object ``obj: pandas.DataFrame`` follows the specification iff:
+
+    * structure convention: ``obj.index`` must be ``RangeIndex``
+    * column names must be strings of the form ``"ind0"``, ``"ind1"``, ..., ``"indn"``,
+        where ``n`` is the number of columns
+    * column types must be integers, either numpy or pandas nullable integer types
+    * all columns must be monotonic increasing, not necessarily strictly, or by 1
+
+    Parameters
+    ----------
+    is_multiple : boolean
+        True iff is multiple alignment, i.e., between 3 or more time series
+    """
+
+    _tags = {
+        "scitype": "Alignment",
+        "name": "alignment",  # any string
+        "name_python": "alignment_iloc",  # lower_snake_case
+        "name_aliases": [],
+        "python_version": None,
+        "python_dependencies": "pandas",
+    }
+
+    def _check(self, obj, return_metadata=False, var_name="obj"):
+        """Check if obj is of this data type.
+
+        Parameters
+        ----------
+        obj : any
+            Object to check.
+        return_metadata : bool, optional (default=False)
+            Whether to return metadata.
+        var_name : str, optional (default="obj")
+            Name of the variable to check, for use in error messages.
+
+        Returns
+        -------
+        valid : bool
+            Whether obj is of this data type.
+        msg : str, only returned if return_metadata is True.
+            Error message if obj is not of this data type.
+        metadata : dict, only returned if return_metadata is True.
+            Metadata dictionary.
+        """
+        valid, msg, metadata = check_align(
+            obj, name=var_name, index="iloc", return_metadata=return_metadata
+        )
+
+        return _ret(valid, msg, metadata, return_metadata)
 
 
-check_dict[("alignment", "Alignment")] = check_alignment_alignment
+class AlignmentLoc(ScitypeAlignment):
+    """Data type: pandas.DataFrame based specification of an alignment, loc references.
 
+    Name: ``"alignment_loc"``
 
-def check_alignment_loc_alignment(obj, return_metadata=False, var_name="obj"):
-    """Check whether object has mtype `alignment_loc` for scitype `Alignment`."""
-    valid, msg = check_align(obj, name=var_name, index="loc")
+    Short description:
 
-    return _ret(valid, msg, {}, return_metadata)
+    ``pandas.DataFrame``, with cols = aligned series, entries = loc references,
+    rows = ordered alignment pairs/tuples
 
+    Long description:
 
-check_dict[("alignment_loc", "Alignment")] = check_alignment_loc_alignment
+    The ``"alignment"`` :term:`mtype` is a concrete specification
+    that implements the ``Alignment`` :term:`scitype`, i.e., the abstract
+    type of an alignment of two or more time series.
+
+    An object ``obj: pandas.DataFrame`` follows the specification iff:
+
+    * structure convention: ``obj.index`` must be ``RangeIndex``
+    * column names must be strings of the form ``"ind0"``, ``"ind1"``, ..., ``"indn"``,
+        where ``n`` is the number of columns
+    * column types must be valid vor loc indexing into
+    ``Int64Index``, ``RangeIndex``, ``DatetimeIndex``, or ``PeriodIndex``.
+    * all columns must be monotonic increasing, not necessarily strictly, or regulraly
+
+    Parameters
+    ----------
+    is_multiple : boolean
+        True iff is multiple alignment, i.e., between 3 or more time series
+    """
+
+    _tags = {
+        "scitype": "Alignment",
+        "name": "alignment_loc",  # any string
+        "name_python": "alignment_loc",  # lower_snake_case
+        "name_aliases": [],
+        "python_version": None,
+        "python_dependencies": "pandas",
+    }
+
+    def _check(self, obj, return_metadata=False, var_name="obj"):
+        """Check if obj is of this data type.
+
+        Parameters
+        ----------
+        obj : any
+            Object to check.
+        return_metadata : bool, optional (default=False)
+            Whether to return metadata.
+        var_name : str, optional (default="obj")
+            Name of the variable to check, for use in error messages.
+
+        Returns
+        -------
+        valid : bool
+            Whether obj is of this data type.
+        msg : str, only returned if return_metadata is True.
+            Error message if obj is not of this data type.
+        metadata : dict, only returned if return_metadata is True.
+            Metadata dictionary.
+        """
+        valid, msg, metadata = check_align(
+            obj, name=var_name, index="loc", return_metadata=return_metadata
+        )
+
+        return _ret(valid, msg, metadata, return_metadata)

--- a/sktime/datatypes/_alignment/_examples.py
+++ b/sktime/datatypes/_alignment/_examples.py
@@ -42,6 +42,7 @@ class _AlignmentSimpleAlignment(_AlignmentSimple):
         "mtype": "alignment",
         "python_dependencies": None,
         "lossy": False,
+        "metadata": {"is_multiple": False},
     }
 
     def build(self):
@@ -53,6 +54,7 @@ class _AlignmentSimpleAlignmentLoc(_AlignmentSimple):
         "mtype": "alignment_loc",
         "python_dependencies": None,
         "lossy": False,
+        "metadata": {"is_multiple": False},
     }
 
     def build(self):

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -178,7 +178,8 @@ def check_is_mtype(
         list or dict type is controlled via ``msg_return_dict`` argument
 
         * if str: error message for tested mtype
-        * it list: list of len(mtype) with message per mtype if list, same order as mtype
+        * it list: list of len(mtype) with message per mtype if list,
+        same order as in ``mtype`` parameter
         * if dict: dict with mtype as key and error message for mtype as value
         * returned only if return_metadata is True or str, list of str
 

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -138,68 +138,95 @@ def check_is_mtype(
 ):
     """Check object for compliance with mtype specification, return metadata.
 
+    See glossary for explanations of :glossary:`mtype` and :glossary:`scitype`.
+
     Parameters
     ----------
     obj - object to check
+
     mtype: str or list of str, mtype to check obj as
         valid mtype strings are in datatypes.MTYPE_REGISTER (1st column)
+
     scitype: str, optional, scitype to check obj as; default = inferred from mtype
         if inferred from mtype, list elements of mtype need not have same scitype
         valid mtype strings are in datatypes.SCITYPE_REGISTER (1st column)
+
     return_metadata - bool, str, or list of str, optional, default=False
-        if False, returns only "valid" return
-        if True, returns all three return objects
-        if str, list of str, metadata return dict is subset to keys in return_metadata
+
+        * if False, returns only ``valid`` return. No metadata is returned.
+        * if True, returns all three return objects. All metadata fields are returned.
+        * if str, list of str, metadata return dict is subset to keys in
+        ``return_metadata``. This allows selective return of metadata fields,
+        to avoid unnecessary computation.
+
     var_name: str, optional, default="obj"
         name of input in error messages
+
     msg_return_dict: str, one of ``"list"`` or ``"dict"``, optional, default="dict"
         whether returned msg, if returned, is a str, dict or list
 
         * if ``msg_return_dict="list"``,
-          returned ``msg`` is ``str`` if ``mtype`` is ``str``,
-          returned ``msg`` is ``list`` of ``str`` if ``mtype`` is ``list``
+        returned ``msg`` is ``str`` if ``mtype`` is ``str``,
+        returned ``msg`` is ``list`` of ``str`` if ``mtype`` is ``list``
 
         * if ``msg_return_dict="dict"``,
-          returned ``msg`` is ``str`` if ``mtype`` is ``str``,
-          returned ``msg`` is ``dict`` of ``str`` if ``mtype`` is ``list``.
-          If ``dict``, has str in ``mtype`` as key,
-          and error message for mtype as value.
+        returned ``msg`` is ``str`` if ``mtype`` is ``str``,
+        returned ``msg`` is ``dict`` of ``str`` if ``mtype`` is ``list``.
+        If ``dict``, has str in ``mtype`` as key,
+        and error message for mtype as value.
 
     Returns
     -------
-    valid: bool - whether obj is a valid object of mtype/scitype
-    msg: str or list/dict of str - error messages if object is not valid, otherwise None
-        list or dict type is controlled via msg_return_dict
-        if str: error message for tested mtype
-        it list: list of len(mtype) with message per mtype if list, same order as mtype
-        if dict: dict with mtype as key and error message for mtype as value
-        returned only if return_metadata is True or str, list of str
+    valid: bool
+        whether obj is a valid object of mtype/scitype
+
+    msg: str or list/dict of str
+        error messages if object is not valid, otherwise None
+
+        list or dict type is controlled via ``msg_return_dict`` argument
+
+        * if str: error message for tested mtype
+        * it list: list of len(mtype) with message per mtype if list, same order as mtype
+        * if dict: dict with mtype as key and error message for mtype as value
+        * returned only if return_metadata is True or str, list of str
+
     metadata: dict - metadata about obj if valid, otherwise None
-            returned only if return_metadata is True or str, list of str
+        returned only if ``return_metadata`` is True or str, list of str
+
         Keys populated depend on (assumed, otherwise identified) scitype of obj.
+
         Always returned:
-            "mtype": str, mtype of obj (assumed or inferred)
-            "scitype": str, scitype of obj (assumed or inferred)
+
+            * "mtype": str, mtype of obj (assumed or inferred)
+            * "scitype": str, scitype of obj (assumed or inferred)
+
         For scitype "Series":
-            "is_univariate": bool, True iff series has one variable
-            "is_equally_spaced": bool, True iff series index is equally spaced
-            "is_empty": bool, True iff series has no variables or no instances
-            "has_nans": bool, True iff the series contains NaN values
+
+            * "is_univariate": bool, True iff series has one variable
+            * "is_equally_spaced": bool, True iff series index is equally spaced
+            * "is_empty": bool, True iff series has no variables or no instances
+            * "has_nans": bool, True iff the series contains NaN values
+
         For scitype "Panel":
-            "is_univariate": bool, True iff all series in panel have one variable
-            "is_equally_spaced": bool, True iff all series indices are equally spaced
-            "is_equal_length": bool, True iff all series in panel are of equal length
-            "is_empty": bool, True iff one or more of the series in the panel are empty
-            "is_one_series": bool, True iff there is only one series in the panel
-            "has_nans": bool, True iff the panel contains NaN values
-            "n_instances": int, number of instances in the panel
+
+            * "is_univariate": bool, True iff all series in panel have one variable
+            * "is_equally_spaced": bool, True iff all series indices are equally spaced
+            * "is_equal_length": bool, True iff all series in panel are of equal length
+            * "is_empty": bool, True iff one or more series in the panel are empty
+            * "is_one_series": bool, True iff there is only one series in the panel
+            * "has_nans": bool, True iff the panel contains NaN values
+            * "n_instances": int, number of instances in the panel
+
         For scitype "Table":
-            "is_univariate": bool, True iff table has one variable
-            "is_empty": bool, True iff table has no variables or no instances
-            "has_nans": bool, True iff the panel contains NaN values
-            "n_instances": int, number of instances/rows in the table
+
+            * "is_univariate": bool, True iff table has one variable
+            * "is_empty": bool, True iff table has no variables or no instances
+            * "has_nans": bool, True iff the panel contains NaN values
+            * "n_instances": int, number of instances/rows in the table
+
         For scitype "Alignment":
-            currently none
+
+            * "is_multiple" : bool, True iff multiple alignment of (3 or more) series
 
     Raises
     ------
@@ -283,15 +310,25 @@ def check_is_mtype(
 def check_raise(obj, mtype: str, scitype: str = None, var_name: str = "input"):
     """Check object for compliance with mtype specification, raise errors.
 
+    See glossary for explanations of :glossary:`mtype` and :glossary:`scitype`.
+
     Parameters
     ----------
-    obj - object to check
+    obj
+        object to check
+
     mtype: str or list of str, mtype to check obj as
         valid mtype strings are in datatypes.MTYPE_REGISTER (1st column)
-    scitype: str, optional, scitype to check obj as; default = inferred from mtype
+
+    scitype: str, optional; default = inferred from mtype
+        scitype to check obj against
+
         if inferred from mtype, list elements of mtype need not have same scitype
-        valid mtype strings are in datatypes.SCITYPE_REGISTER (1st column)
-    var_name: str, optional, default="input" - name of input in error messages
+
+        valid mtype strings are can be found in :ref:`data_format`
+
+    var_name: str, optional, default="input" 
+        name of input in error messages
 
     Returns
     -------
@@ -332,11 +369,16 @@ def mtype(
     ----------
     obj : object to infer type of - any type, should comply with some mtype spec
         if as_scitype is provided, this needs to be mtype belonging to scitype
+
     as_scitype : str, list of str, or None, optional, default=None
         name of scitype(s) the object "obj" is considered as, finds mtype for that
+
         if None (default), does not assume a specific as_scitype and tests all mtypes
-            generally, as_scitype should be provided for maximum efficiency
+
+        generally, as_scitype should be provided for maximum efficiency
+
         valid scitype type strings are in datatypes.SCITYPE_REGISTER (1st column)
+
     exclude_mtypes : list of str, default = AMBIGUOUS_MTYPES
         which mtypes to ignore in inferring mtype, default = ambiguous ones
 
@@ -413,52 +455,74 @@ def check_is_scitype(
 ):
     """Check object for compliance with scitype specification, return metadata.
 
+    See glossary for explanations of :glossary:`mtype` and :glossary:`scitype`.
+
     Parameters
     ----------
-    obj - object to check
+    obj
+        object to check
+
     scitype: str or list of str, scitype to check obj as
         valid mtype strings are in datatypes.SCITYPE_REGISTER
-    return_metadata - bool, optional, default=False
-        if False, returns only "valid" return
-        if True, returns all three return objects
-        if str, list of str, metadata return dict is subset to keys in return_metadata
+
+    return_metadata - bool, str, or list of str, optional, default=False
+
+        * if False, returns only ``valid`` return. No metadata is returned.
+        * if True, returns all three return objects. All metadata fields are returned.
+        * if str, list of str, metadata return dict is subset to keys in
+        ``return_metadata``. This allows selective return of metadata fields,
+        to avoid unnecessary computation.
+
     var_name: str, optional, default="obj" - name of input in error messages
+
     exclude_mtypes : list of str, default = AMBIGUOUS_MTYPES
         which mtypes to ignore in inferring mtype, default = ambiguous ones
 
     Returns
     -------
     valid: bool - whether obj is a valid object of mtype/scitype
+
     msg: dict[str, str] or None
-        error messages if object is not valid, otherwise None
+        error messages if object is not valid, otherwise None.
         keys are all mtypes tested, value for key is error message for that key
+
     metadata: dict - metadata about obj if valid, otherwise None
-            returned only if return_metadata is True
-        Fields depend on scitpe.
+        returned only if ``return_metadata`` is True or str, list of str
+
+        Keys populated depend on (assumed, otherwise identified) scitype of obj.
+
         Always returned:
-            "mtype": str, mtype of obj (assumed or inferred)
-                mtype strings with explanation are in datatypes.MTYPE_REGISTER
-            "scitype": str, scitype of obj (assumed or inferred)
-                scitype strings with explanation are in datatypes.SCITYPE_REGISTER
+
+            * "mtype": str, mtype of obj (assumed or inferred)
+            * "scitype": str, scitype of obj (assumed or inferred)
+
         For scitype "Series":
-            "is_univariate": bool, True iff series has one variable
-            "is_equally_spaced": bool, True iff series index is equally spaced
-            "is_empty": bool, True iff series has no variables or no instances
-            "has_nans": bool, True iff the series contains NaN values
+
+            * "is_univariate": bool, True iff series has one variable
+            * "is_equally_spaced": bool, True iff series index is equally spaced
+            * "is_empty": bool, True iff series has no variables or no instances
+            * "has_nans": bool, True iff the series contains NaN values
+
         For scitype "Panel":
-            "is_univariate": bool, True iff all series in panel have one variable
-            "is_equally_spaced": bool, True iff all series indices are equally spaced
-            "is_equal_length": bool, True iff all series in panel are of equal length
-            "is_empty": bool, True iff one or more of the series in the panel are empty
-            "is_one_series": bool, True iff there is only one series in the panel
-            "has_nans": bool, True iff the panel contains NaN values
-            "n_instances": int, number of instances in the panel
+
+            * "is_univariate": bool, True iff all series in panel have one variable
+            * "is_equally_spaced": bool, True iff all series indices are equally spaced
+            * "is_equal_length": bool, True iff all series in panel are of equal length
+            * "is_empty": bool, True iff one or more series in the panel are empty
+            * "is_one_series": bool, True iff there is only one series in the panel
+            * "has_nans": bool, True iff the panel contains NaN values
+            * "n_instances": int, number of instances in the panel
+
         For scitype "Table":
-            "is_univariate": bool, True iff table has one variable
-            "is_empty": bool, True iff table has no variables or no instances
-            "has_nans": bool, True iff the panel contains NaN values
+
+            * "is_univariate": bool, True iff table has one variable
+            * "is_empty": bool, True iff table has no variables or no instances
+            * "has_nans": bool, True iff the panel contains NaN values
+            * "n_instances": int, number of instances/rows in the table
+
         For scitype "Alignment":
-            currently none
+
+            * "is_multiple" : bool, True iff multiple alignment of (3 or more) series
 
     Raises
     ------
@@ -560,12 +624,16 @@ def check_is_error_msg(msg, var_name="obj", allowed_msg=None, raise_exception=Fa
 def scitype(obj, candidate_scitypes=SCITYPE_LIST, exclude_mtypes=AMBIGUOUS_MTYPES):
     """Infer the scitype of an object.
 
+    See glossary for explanations of :glossary:`mtype` and :glossary:`scitype`.
+
     Parameters
     ----------
     obj : object to infer type of - any type, should comply with some mtype spec
         if as_scitype is provided, this needs to be mtype belonging to scitype
+
     candidate_scitypes: str or list of str, scitypes to pick from
         valid scitype strings are in datatypes.SCITYPE_REGISTER
+
     exclude_mtypes : list of str, default = AMBIGUOUS_MTYPES
         which mtypes to ignore in inferring mtype, default = ambiguous ones
         valid mtype strings are in datatypes.MTYPE_REGISTER

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -76,12 +76,6 @@ def generate_check_dict(soft_deps="present"):
         key = k._get_key()
         check_dict[key] = k
 
-    # temporary while refactoring
-    from sktime.datatypes._proba import check_dict_Proba
-
-    # pool convert_dict-s
-    check_dict.update(check_dict_Proba)
-
     return check_dict
 
 

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -319,7 +319,7 @@ def check_raise(obj, mtype: str, scitype: str = None, var_name: str = "input"):
 
         valid mtype strings are can be found in :ref:`data_format`
 
-    var_name: str, optional, default="input" 
+    var_name: str, optional, default="input"
         name of input in error messages
 
     Returns

--- a/sktime/datatypes/_check.py
+++ b/sktime/datatypes/_check.py
@@ -77,11 +77,9 @@ def generate_check_dict(soft_deps="present"):
         check_dict[key] = k
 
     # temporary while refactoring
-    from sktime.datatypes._alignment import check_dict_Alignment
     from sktime.datatypes._proba import check_dict_Proba
 
     # pool convert_dict-s
-    check_dict.update(check_dict_Alignment)
     check_dict.update(check_dict_Proba)
 
     return check_dict

--- a/sktime/datatypes/_proba/__init__.py
+++ b/sktime/datatypes/_proba/__init__.py
@@ -1,11 +1,9 @@
 """Type checkers, converters and mtype inference for probabilistic return types."""
 
-from sktime.datatypes._proba._check import check_dict as check_dict_Proba
 from sktime.datatypes._proba._convert import convert_dict as convert_dict_Proba
 from sktime.datatypes._proba._registry import MTYPE_LIST_PROBA, MTYPE_REGISTER_PROBA
 
 __all__ = [
-    "check_dict_Proba",
     "convert_dict_Proba",
     "MTYPE_LIST_PROBA",
     "MTYPE_REGISTER_PROBA",

--- a/sktime/datatypes/_proba/_base.py
+++ b/sktime/datatypes/_proba/_base.py
@@ -1,0 +1,36 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Base class for data types."""
+
+__author__ = ["fkiraly"]
+
+from sktime.datatypes._base import BaseDatatype
+
+
+class ScitypeProba(BaseDatatype):
+    """Probabilistic forecast data type.
+
+    Parameters
+    ----------
+    is_univariate: bool
+        True iff series has one variable
+    is_empty: bool
+        True iff series has no variables or no instances
+    has_nans: bool
+        True iff the series contains NaN values
+    """
+
+    _tags = {
+        "scitype": "Alignment",
+        "name": None,  # any string
+        "name_python": None,  # lower_snake_case
+        "name_aliases": [],
+        "python_version": None,
+        "python_dependencies": None,
+    }
+
+    def __init__(self, is_univariate=None, is_empty=None, has_nans=None):
+        self.is_univariate = is_univariate
+        self.is_empty = is_empty
+        self.has_nans = has_nans
+
+        super().__init__()

--- a/sktime/datatypes/_proba/_check.py
+++ b/sktime/datatypes/_proba/_check.py
@@ -1,6 +1,6 @@
-"""Machine type checkers for Series scitype.
+"""Machine type checkers for Proba scitype.
 
-Exports checkers for Series scitype:
+Exports checkers for Proba scitype:
 
 check_dict: dict indexed by pairs of str
   1st element = mtype - str
@@ -34,141 +34,230 @@ metadata: dict - metadata about obj if valid, otherwise None
 
 __author__ = ["fkiraly"]
 
-__all__ = ["check_dict"]
-
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
 from sktime.datatypes._base._common import _req
 from sktime.datatypes._base._common import _ret as ret
+from sktime.datatypes._proba._base import ScitypeProba
 
-check_dict = dict()
 
+class ProbaPredQuantiles(ScitypeProba):
+    """Data type: pandas.DataFrame based specification of predictive quantiles.
 
-def check_pred_quantiles_proba(obj, return_metadata=False, var_name="obj"):
-    metadata = dict()
+    Name: ``"pred_quantiles"``
 
-    # check if the input is a dataframe
-    if not isinstance(obj, pd.DataFrame):
-        msg = f"{var_name} should be a pd.DataFrame"
-        return ret(False, msg, None, return_metadata)
+    Short description:
 
-    # we now know obj is a pd.DataFrame
-    index = obj.index
-    if _req("is_empty", return_metadata):
-        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
+    ``pandas.DataFrame``, with cols = variable name and quantile point,
+    rows = time index
 
-    # check that column indices are unique
-    if not len(set(obj.columns)) == len(obj.columns):
-        msg = "column indices must be unique"
-        return ret(False, msg, None, return_metadata)
+    Parameters
+    ----------
+    is_univariate: bool
+        True iff series has one variable
+    is_empty: bool
+        True iff series has no variables or no instances
+    has_nans: bool
+        True iff the series contains NaN values
+    """
 
-    # check that all cols are numeric
-    if not np.all([is_numeric_dtype(obj[c]) for c in obj.columns]):
+    _tags = {
+        "scitype": "Proba",
+        "name": "pred_quantiles",  # any string
+        "name_python": "proba_pred_quantiles",  # lower_snake_case
+        "name_aliases": [],
+        "python_version": None,
+        "python_dependencies": "pandas",
+    }
+
+    def _check(self, obj, return_metadata=False, var_name="obj"):
+        """Check if obj is of this data type.
+
+        Parameters
+        ----------
+        obj : any
+            Object to check.
+        return_metadata : bool, optional (default=False)
+            Whether to return metadata.
+        var_name : str, optional (default="obj")
+            Name of the variable to check, for use in error messages.
+
+        Returns
+        -------
+        valid : bool
+            Whether obj is of this data type.
+        msg : str, only returned if return_metadata is True.
+            Error message if obj is not of this data type.
+        metadata : dict, only returned if return_metadata is True.
+            Metadata dictionary.
+        """
+        metadata = dict()
+
+        # check if the input is a dataframe
+        if not isinstance(obj, pd.DataFrame):
+            msg = f"{var_name} should be a pd.DataFrame"
+            return ret(False, msg, None, return_metadata)
+
+        # we now know obj is a pd.DataFrame
+        index = obj.index
+        if _req("is_empty", return_metadata):
+            metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
+
+        # check that column indices are unique
+        if not len(set(obj.columns)) == len(obj.columns):
+            msg = "column indices must be unique"
+            return ret(False, msg, None, return_metadata)
+
+        # check that all cols are numeric
+        if not np.all([is_numeric_dtype(obj[c]) for c in obj.columns]):
+            msg = (
+                f"{var_name} should only have numeric dtype columns, "
+                f"but found dtypes {obj.dtypes}"
+            )
+            return ret(False, msg, None, return_metadata)
+
+        # Check time index is ordered in time
+        if not index.is_monotonic_increasing:
+            msg = (
+                f"The (time) index of {var_name} must be sorted monotonically "
+                f"increasing, but found: {index}"
+            )
+            return ret(False, msg, None, return_metadata)
+
+        # check column multiindex
+        colidx = obj.columns
         msg = (
-            f"{var_name} should only have numeric dtype columns, "
-            f"but found dtypes {obj.dtypes}"
+            f"column of {var_name} must be pd.MultiIndex, with two levels."
+            "first level is variable name, "
+            "second level are (numeric) alpha values between 0 and 1."
         )
-        return ret(False, msg, None, return_metadata)
 
-    # Check time index is ordered in time
-    if not index.is_monotonic_increasing:
+        if not isinstance(colidx, pd.MultiIndex) or not colidx.nlevels == 2:
+            return ret(False, msg, None, return_metadata)
+        alphas = colidx.get_level_values(1)
+        if not is_numeric_dtype(alphas):
+            return ret(False, msg, None, return_metadata)
+        if not (alphas <= 1).all() or not (alphas >= 0).all():
+            return ret(False, msg, None, return_metadata)
+
+        # compute more metadata, only if needed
+        if _req("has_nans", return_metadata):
+            metadata["has_nans"] = obj.isna().values.any()
+        if _req("is_univariate", return_metadata):
+            metadata["is_univariate"] = len(colidx.get_level_values(0).unique()) == 1
+
+        return ret(True, None, metadata, return_metadata)
+
+
+class ProbaPredInterval(ScitypeProba):
+    """Data type: pandas.DataFrame based specification of predictive intervals.
+
+    Name: ``"pred_interval"``
+
+    Short description:
+
+    ``pandas.DataFrame``, with cols = variable name, coverage, and lower/upper;
+    rows = time index
+
+    Parameters
+    ----------
+    is_univariate: bool
+        True iff series has one variable
+    is_empty: bool
+        True iff series has no variables or no instances
+    has_nans: bool
+        True iff the series contains NaN values
+    """
+
+    _tags = {
+        "scitype": "Proba",
+        "name": "pred_interval",  # any string
+        "name_python": "proba_pred_interval",  # lower_snake_case
+        "name_aliases": [],
+        "python_version": None,
+        "python_dependencies": "pandas",
+    }
+
+    def _check(self, obj, return_metadata=False, var_name="obj"):
+        """Check if obj is of this data type.
+
+        Parameters
+        ----------
+        obj : any
+            Object to check.
+        return_metadata : bool, optional (default=False)
+            Whether to return metadata.
+        var_name : str, optional (default="obj")
+            Name of the variable to check, for use in error messages.
+
+        Returns
+        -------
+        valid : bool
+            Whether obj is of this data type.
+        msg : str, only returned if return_metadata is True.
+            Error message if obj is not of this data type.
+        metadata : dict, only returned if return_metadata is True.
+            Metadata dictionary.
+        """
+        metadata = dict()
+
+        # check if the input is a dataframe
+        if not isinstance(obj, pd.DataFrame):
+            msg = f"{var_name} should be a pd.DataFrame"
+            return ret(False, msg, None, return_metadata)
+
+        # we now know obj is a pd.DataFrame
+        index = obj.index
+        if _req("is_empty", return_metadata):
+            metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
+
+        # check that column indices are unique
+        if not len(set(obj.columns)) == len(obj.columns):
+            msg = "column indices must be unique"
+            return ret(False, msg, None, return_metadata)
+
+        # check that all cols are numeric
+        if not np.all([is_numeric_dtype(obj[c]) for c in obj.columns]):
+            msg = (
+                f"{var_name} should only have numeric dtype columns, "
+                f"but found dtypes {obj.dtypes}"
+            )
+            return ret(False, msg, None, return_metadata)
+
+        # Check time index is ordered in time
+        if not index.is_monotonic_increasing:
+            msg = (
+                f"The (time) index of {var_name} must be sorted monotonically "
+                f"increasing, but found: {index}"
+            )
+            return ret(False, msg, None, return_metadata)
+
+        # check column multiindex
+        colidx = obj.columns
         msg = (
-            f"The (time) index of {var_name} must be sorted monotonically increasing, "
-            f"but found: {index}"
+            f"Column of {var_name} must be pd.MultiIndex, with three levels. "
+            "First level is variable name, "
+            "second level are (numeric) coverage values between 0 and 1, "
+            'third level is string "lower" or "upper", for lower/upper interval end.'
         )
-        return ret(False, msg, None, return_metadata)
 
-    # check column multiindex
-    colidx = obj.columns
-    msg = (
-        f"column of {var_name} must be pd.MultiIndex, with two levels."
-        "first level is variable name, "
-        "second level are (numeric) alpha values between 0 and 1."
-    )
+        if not isinstance(colidx, pd.MultiIndex) or not colidx.nlevels == 3:
+            return ret(False, msg, None, return_metadata)
+        coverages = colidx.get_level_values(1)
+        if not is_numeric_dtype(coverages):
+            return ret(False, msg, None, return_metadata)
+        if not (coverages <= 1).all() or not (coverages >= 0).all():
+            return ret(False, msg, None, return_metadata)
+        upper_lower = colidx.get_level_values(2)
+        if not upper_lower.isin(["upper", "lower"]).all():
+            return ret(False, msg, None, return_metadata)
 
-    if not isinstance(colidx, pd.MultiIndex) or not colidx.nlevels == 2:
-        return ret(False, msg, None, return_metadata)
-    alphas = colidx.get_level_values(1)
-    if not is_numeric_dtype(alphas):
-        return ret(False, msg, None, return_metadata)
-    if not (alphas <= 1).all() or not (alphas >= 0).all():
-        return ret(False, msg, None, return_metadata)
+        # compute more metadata, only if needed
+        if _req("has_nans", return_metadata):
+            metadata["has_nans"] = obj.isna().values.any()
+        if _req("is_univariate", return_metadata):
+            metadata["is_univariate"] = len(colidx.get_level_values(0).unique()) == 1
 
-    # compute more metadata, only if needed
-    if _req("has_nans", return_metadata):
-        metadata["has_nans"] = obj.isna().values.any()
-    if _req("is_univariate", return_metadata):
-        metadata["is_univariate"] = len(colidx.get_level_values(0).unique()) == 1
-
-    return ret(True, None, metadata, return_metadata)
-
-
-check_dict[("pred_quantiles", "Proba")] = check_pred_quantiles_proba
-
-
-def check_pred_interval_proba(obj, return_metadata=False, var_name="obj"):
-    metadata = dict()
-
-    # check if the input is a dataframe
-    if not isinstance(obj, pd.DataFrame):
-        msg = f"{var_name} should be a pd.DataFrame"
-        return ret(False, msg, None, return_metadata)
-
-    # we now know obj is a pd.DataFrame
-    index = obj.index
-    if _req("is_empty", return_metadata):
-        metadata["is_empty"] = len(index) < 1 or len(obj.columns) < 1
-
-    # check that column indices are unique
-    if not len(set(obj.columns)) == len(obj.columns):
-        msg = "column indices must be unique"
-        return ret(False, msg, None, return_metadata)
-
-    # check that all cols are numeric
-    if not np.all([is_numeric_dtype(obj[c]) for c in obj.columns]):
-        msg = (
-            f"{var_name} should only have numeric dtype columns, "
-            f"but found dtypes {obj.dtypes}"
-        )
-        return ret(False, msg, None, return_metadata)
-
-    # Check time index is ordered in time
-    if not index.is_monotonic_increasing:
-        msg = (
-            f"The (time) index of {var_name} must be sorted monotonically increasing, "
-            f"but found: {index}"
-        )
-        return ret(False, msg, None, return_metadata)
-
-    # check column multiindex
-    colidx = obj.columns
-    msg = (
-        f"Column of {var_name} must be pd.MultiIndex, with three levels. "
-        "First level is variable name, "
-        "second level are (numeric) coverage values between 0 and 1, "
-        'third level is string "lower" or "upper", for lower/upper interval end.'
-    )
-
-    if not isinstance(colidx, pd.MultiIndex) or not colidx.nlevels == 3:
-        return ret(False, msg, None, return_metadata)
-    coverages = colidx.get_level_values(1)
-    if not is_numeric_dtype(coverages):
-        return ret(False, msg, None, return_metadata)
-    if not (coverages <= 1).all() or not (coverages >= 0).all():
-        return ret(False, msg, None, return_metadata)
-    upper_lower = colidx.get_level_values(2)
-    if not upper_lower.isin(["upper", "lower"]).all():
-        return ret(False, msg, None, return_metadata)
-
-    # compute more metadata, only if needed
-    if _req("has_nans", return_metadata):
-        metadata["has_nans"] = obj.isna().values.any()
-    if _req("is_univariate", return_metadata):
-        metadata["is_univariate"] = len(colidx.get_level_values(0).unique()) == 1
-
-    return ret(True, None, metadata, return_metadata)
-
-
-check_dict[("pred_interval", "Proba")] = check_pred_interval_proba
+        return ret(True, None, metadata, return_metadata)


### PR DESCRIPTION
Completes the refactor of `datatypes` `_check` modules by refactoring the `Alignment` and `Proba` modules completely to the `scikit-base` patterns.

Also reformats the docstrings of public methods in the `datatypes` libary to render correctly.