### PR TITLE
[ENH]  Added the pre-commit hook of pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,9 @@ repos:
     hooks:
       - id: shellcheck
         name: shellcheck
+
+  - repo: https://github.com/PyCQA/pylint
+    rev: v3.0.2  # Use the latest version
+    hooks:
+      - id: pylint
+        args: ["--load-plugins=pylint.extensions.docparams", "--disable=too-few-public-methods", "--disable=C0111"]


### PR DESCRIPTION
Fixes #7728 

This PR introduces a pre-commit hook configuration for Pylint in the repo. The following changes were made:

- Pylint Hook Addition:

          Added the latest version of the Pylint hook (v3.0.2) to the pre-commit configuration.

- Plugin Loading:

       pylint.extensions.docparams plugin is loaded to enforce proper parameter documentation in docstrings.

- Disabling Specific Pylint Warnings:

       Disabled the warning for too few public methods (too-few-public-methods).
       Disabled the warning for missing module docstring (C0111).