### PR TITLE
[ENH] `sklearn 1.6.X` compatibility patch

### DIFF
--- a/sktime/transformations/tests/test_pipeline.py
+++ b/sktime/transformations/tests/test_pipeline.py
@@ -41,7 +41,7 @@ def test_FeatureUnion_pipeline():
         ),
         ("clf", DecisionTreeClassifier()),
     ]
-    clf = make_pipeline(steps)
+    clf = make_pipeline(*steps)
     clf.fit(X_train, y_train)
     y_pred = clf.predict(X_test)
 

--- a/sktime/transformations/tests/test_pipeline.py
+++ b/sktime/transformations/tests/test_pipeline.py
@@ -21,6 +21,7 @@ std_transformer = TabularToSeriesAdaptor(
 )
 
 
+@pytest.mark.xfail(reason="due to changes in sklearn pipelines, use sktime instead")
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.transformations"]),
     reason="test only if anything in sktime.transformations module has changed",

--- a/sktime/transformations/tests/test_pipeline.py
+++ b/sktime/transformations/tests/test_pipeline.py
@@ -3,12 +3,13 @@
 import numpy as np
 import pytest
 from sklearn.model_selection import train_test_split
-from sklearn.pipeline import FeatureUnion, Pipeline
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.tree import DecisionTreeClassifier
 
 from sktime.datasets import load_gunpoint
+from sktime.pipeline import make_pipeline
 from sktime.tests.test_switch import run_test_module_changed
+from sktime.transformations.compose import FeatureUnion
 from sktime.transformations.panel.segment import RandomIntervalSegmenter
 from sktime.transformations.series.adapt import TabularToSeriesAdaptor
 from sktime.utils._testing.panel import make_classification_problem
@@ -40,7 +41,7 @@ def test_FeatureUnion_pipeline():
         ),
         ("clf", DecisionTreeClassifier()),
     ]
-    clf = Pipeline(steps)
+    clf = make_pipeline(steps)
     clf.fit(X_train, y_train)
     y_pred = clf.predict(X_test)
 

--- a/sktime/transformations/tests/test_pipeline.py
+++ b/sktime/transformations/tests/test_pipeline.py
@@ -34,12 +34,9 @@ def test_FeatureUnion_pipeline():
 
     # pipeline with segmentation plus multiple feature extraction
     steps = [
-        ("segment", RandomIntervalSegmenter(n_intervals=1)),
-        (
-            "transform",
-            FeatureUnion([("mean", mean_transformer), ("std", std_transformer)]),
-        ),
-        ("clf", DecisionTreeClassifier()),
+        RandomIntervalSegmenter(n_intervals=1),
+        FeatureUnion([("mean", mean_transformer), ("std", std_transformer)]),
+        DecisionTreeClassifier(),
     ]
     clf = make_pipeline(*steps)
     clf.fit(X_train, y_train)

--- a/sktime/transformations/tests/test_pipeline.py
+++ b/sktime/transformations/tests/test_pipeline.py
@@ -3,13 +3,12 @@
 import numpy as np
 import pytest
 from sklearn.model_selection import train_test_split
+from sklearn.pipeline import FeatureUnion, Pipeline
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.tree import DecisionTreeClassifier
 
 from sktime.datasets import load_gunpoint
-from sktime.pipeline import make_pipeline
 from sktime.tests.test_switch import run_test_module_changed
-from sktime.transformations.compose import FeatureUnion
 from sktime.transformations.panel.segment import RandomIntervalSegmenter
 from sktime.transformations.series.adapt import TabularToSeriesAdaptor
 from sktime.utils._testing.panel import make_classification_problem
@@ -34,11 +33,14 @@ def test_FeatureUnion_pipeline():
 
     # pipeline with segmentation plus multiple feature extraction
     steps = [
-        RandomIntervalSegmenter(n_intervals=1),
-        FeatureUnion([("mean", mean_transformer), ("std", std_transformer)]),
-        DecisionTreeClassifier(),
+        ("segment", RandomIntervalSegmenter(n_intervals=1)),
+        (
+            "transform",
+            FeatureUnion([("mean", mean_transformer), ("std", std_transformer)]),
+        ),
+        ("clf", DecisionTreeClassifier()),
     ]
-    clf = make_pipeline(*steps)
+    clf = Pipeline(steps)
     clf.fit(X_train, y_train)
     y_pred = clf.predict(X_test)
 


### PR DESCRIPTION
Fixes some incompatibilities with `sklearn 1.6.X`:

* `test_FeatureUnion_pipeline` was testing compatibility of classifier pipelines with `sklearn` components. This is no longer supported as `sktime` has transitioned to own components, and `sklearn` made compositors more restrictive with the "metadata routing" mechanism. The test is therefore changed to `xfail` (not removed to have a reference for potential pipeline redesigns).