### PR TITLE
[MNT] fix some faulty instances of dependency handling

### DIFF
--- a/sktime/forecasting/moirai_forecaster.py
+++ b/sktime/forecasting/moirai_forecaster.py
@@ -10,11 +10,7 @@ if _check_soft_dependencies("lightning", severity="none"):
 
 from sktime.forecasting.base import _BaseGlobalForecaster
 
-if _check_soft_dependencies(
-    "huggingface-hub",
-    severity="none",
-    package_import_alias={"huggingface-hub": "huggingface_hub"},
-):
+if _check_soft_dependencies("huggingface-hub", severity="none"):
     from huggingface_hub import hf_hub_download
 
 
@@ -113,11 +109,6 @@ class MOIRAIForecaster(_BaseGlobalForecaster):
         "authors": ["gorold", "chenghaoliu89", "liu-jc", "benheid", "pranavvp16"],
         # gorold, chenghaoliu89, liu-jc are from SalesforceAIResearch/uni2ts
         "maintainers": ["pranavvp16"],
-        "python_dependencies_alias": {
-            "salesforce-uni2ts": "uni2ts",
-            "huggingface-hub": "huggingface_hub",
-            "hydra-core": "hydra",
-        },
     }
 
     def __init__(
@@ -159,11 +150,7 @@ class MOIRAIForecaster(_BaseGlobalForecaster):
             )
 
     # Apply a patch for redirecting imports to sktime.libs.uni2ts
-    if _check_soft_dependencies(
-        ["lightning", "huggingface-hub"],
-        severity="none",
-        package_import_alias={"huggingface-hub": "huggingface_hub"},
-    ):
+    if _check_soft_dependencies(["lightning", "huggingface-hub"], severity="none"):
         from sktime.libs.uni2ts.forecast import MoiraiForecast
 
         @patch.dict("sys.modules", {"uni2ts": sktime.libs.uni2ts})

--- a/sktime/forecasting/rbf_forecaster.py
+++ b/sktime/forecasting/rbf_forecaster.py
@@ -10,7 +10,7 @@ from sktime.forecasting.base.adapters._pytorch import BaseDeepNetworkPyTorch
 from sktime.utils.dependencies._dependencies import _check_soft_dependencies
 from sktime.utils.warnings import warn
 
-if _check_soft_dependencies("torch", severity="warning"):
+if _check_soft_dependencies("torch", severity="none"):
     import torch
     import torch.nn as nn
 

--- a/sktime/libs/uni2ts/moirai_module.py
+++ b/sktime/libs/uni2ts/moirai_module.py
@@ -26,11 +26,7 @@ else:
         pass
 
 
-if _check_soft_dependencies(
-    "huggingface-hub",
-    severity="none",
-    package_import_alias={"huggingface-hub": "huggingface_hub"},
-):
+if _check_soft_dependencies("huggingface-hub", severity="none"):
     from huggingface_hub import PyTorchModelHubMixin
 else:
     # Create Dummy class

--- a/sktime/transformations/series/subsequence_extraction.py
+++ b/sktime/transformations/series/subsequence_extraction.py
@@ -11,7 +11,6 @@ from functools import partial
 
 import numpy as np
 import pandas as pd
-from numpy._core._multiarray_umath import _ArrayFunctionDispatcher
 
 from sktime.transformations.base import BaseTransformer
 
@@ -114,11 +113,6 @@ class SubsequenceExtractionTransformer(BaseTransformer):
             raise ValueError(
                 f"Subsequence length parameter ({self.subseq_len}) is not less \
                 than or equal to the minimum sequence length of X ({len(X)})."
-            )
-
-        if not (isinstance(self.aggregate_fn, _ArrayFunctionDispatcher)):
-            raise ValueError(
-                f"{self.aggregate_fn} is not supported for parameter aggregate_fn"
             )
 
         if self.selector not in ["max", "min"]:


### PR DESCRIPTION
This PR fixes some faulty instances of core and soft dependency handling.

* Use of deprecated `package_import_alias`
* `warning` raised in `rbf_forecaster.py`
* private import in `subsequence_extraction.py`