### PR TITLE
[ENH] private utilities for safe argument passing to function with unknown signature

### DIFF
--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -1202,25 +1202,3 @@ class BaseSeriesAnnotator(BaseDetector):
             "The BaseSeriesAnnotator will be removed in the 0.37.0 release.",
             stacklevel=2,
         )
-
-
-# todo 0.37.0: remove this
-def _method_has_arg(method, arg="y"):
-    """Return if transformer.method has a parameter, and whether it has a default.
-
-    Parameters
-    ----------
-    method : callable
-        method to check
-    arg : str, optional, default="y"
-        parameter name to check
-
-    Returns
-    -------
-    has_param : bool
-        whether the method ``method`` has a parameter with name ``arg``
-    """
-    from inspect import signature
-
-    method_params = list(signature(method).parameters.keys())
-    return arg in method_params

--- a/sktime/detection/base/_base.py
+++ b/sktime/detection/base/_base.py
@@ -28,6 +28,7 @@ import pandas as pd
 
 from sktime.base import BaseEstimator
 from sktime.datatypes import check_is_error_msg, check_is_scitype, convert
+from sktime.utils.adapters._safe_call import _method_has_arg
 from sktime.utils.validation.series import check_series
 from sktime.utils.warnings import warn
 

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -5,13 +5,12 @@
 __author__ = ["mloning", "fkiraly"]
 __all__ = ["TabularToSeriesAdaptor"]
 
-from inspect import signature
-
 import numpy as np
 import pandas as pd
 from sklearn.base import clone
 
 from sktime.transformations.base import BaseTransformer
+from sktime.utils.adapters._safe_call import _method_has_param_and_default
 from sktime.utils.sklearn import prep_skl_df
 
 
@@ -249,14 +248,7 @@ class TabularToSeriesAdaptor(BaseTransformer):
             whether the parameter ``arg`` of method ``method`` has a default value
         """
         method_fun = getattr(self.transformer, method)
-        method_params = list(signature(method_fun).parameters.keys())
-        if arg in method_params:
-            param = signature(self.transformer.fit).parameters[arg]
-            default = param.default
-            has_default = default is not param.empty
-            return True, has_default
-        else:
-            return False, False
+        return _method_has_param_and_default(method_fun, arg)
 
     def _get_args(self, X, y, method="fit"):
         """Get kwargs for method, depending on pass_y and method.

--- a/sktime/utils/adapters/_safe_call.py
+++ b/sktime/utils/adapters/_safe_call.py
@@ -1,0 +1,71 @@
+"""Utilities to safely call functions with varying signature."""
+
+__author__ = ["fkiraly"]
+
+
+from inspect import signature
+
+
+def _safe_call(method, args, kwargs):
+    """Call a method with arguments and keyword arguments.
+
+    Same as calling ``method(*args, **kwargs)`` but not passing keyword arguments
+    in ``kwargs`` that are not in the signature of ``method``.
+
+    Parameters
+    ----------
+    method : callable
+        method to call
+    args : tuple
+        positional arguments to pass to the method
+    kwargs : dict
+        keyword arguments to pass to the method
+    """
+    safe_kwargs = {k: v for k, v in kwargs.items() if _method_has_arg(method, arg=k)}
+    return method(*args, **safe_kwargs)
+
+
+def _method_has_arg(method, arg="y"):
+    """Return if method has a parameter.
+
+    Parameters
+    ----------
+    method : callable
+        method to check
+    arg : str, optional, default="y"
+        parameter name to check
+
+    Returns
+    -------
+    has_param : bool
+        whether the method ``method`` has a parameter with name ``arg``
+    """
+    method_params = list(signature(method).parameters.keys())
+    return arg in method_params
+
+
+def _method_has_param_and_default(method, arg="y"):
+    """Return if transformer.method has a parameter, and whether it has a default.
+
+    Parameters
+    ----------
+    method : callable
+        method to check
+    arg : str, optional, default="y"
+        parameter name to check
+
+    Returns
+    -------
+    has_param : bool
+        whether the method ``method`` has a parameter with name ``arg``
+    has_default : bool
+        whether the parameter ``arg`` of method ``method`` has a default value
+    """
+    has_param = _method_has_arg(method=method, arg=arg)
+    if has_param:
+        param = signature(method).parameters[arg]
+        default = param.default
+        has_default = default is not param.empty
+        return True, has_default
+    else:
+        return False, False

--- a/sktime/utils/tests/test_retrieval.py
+++ b/sktime/utils/tests/test_retrieval.py
@@ -15,7 +15,15 @@ def test_all_functions():
     res = _all_functions("sktime.utils.adapters")
     names = [name for name, _ in res]
 
-    assert {"_clone_fitted_params", "_get_fitted_params_safe"} == set(names)
+    EXPECTED_NAMES = [
+        "_clone_fitted_params",
+        "_get_fitted_params_safe",
+        "_safe_call",
+        "_method_has_arg",
+        "_method_has_param_and_default",
+    ]
+
+    assert EXPECTED_NAMES == set(names)
 
 
 @pytest.mark.skipif(

--- a/sktime/utils/tests/test_retrieval.py
+++ b/sktime/utils/tests/test_retrieval.py
@@ -15,13 +15,13 @@ def test_all_functions():
     res = _all_functions("sktime.utils.adapters")
     names = [name for name, _ in res]
 
-    EXPECTED_NAMES = [
+    EXPECTED_NAMES = {
         "_clone_fitted_params",
         "_get_fitted_params_safe",
         "_safe_call",
         "_method_has_arg",
         "_method_has_param_and_default",
-    ]
+    }
 
     assert EXPECTED_NAMES == set(names)
 


### PR DESCRIPTION
This PR refactors some code for safe argument passing to functions with unknown signature into a new module `sktime.utils.adapter._safe_call`.

The collection of functions is used in two key locations:

* interface contracts with unstable interfaces, e.g., the `sklearn` transformer public API contract
* extension contracts, particularly in the case where we add new arguments to inner extension contracts, for ensuring downwards compatibility (to prior to the added argument), or where we want to have a variable extension contract.

Test coverage for the functions is given through their use through `TabularToSeriesAdaptor`, except `_safe_call` which will be useful in https://github.com/sktime/sktime/pull/7737.