### PR TITLE
[ENH] provide proper mathematical description in docstring `ExpandingCutoffSplitter`

### DIFF
--- a/sktime/split/expandingcutoff.py
+++ b/sktime/split/expandingcutoff.py
@@ -36,7 +36,7 @@ def _validate_cutoff(cutoff):
 
 
 class ExpandingCutoffSplitter(BaseSplitter):
-    """
+    r"""
     Expanding cutoff splitter for time series data.
 
     This splitter combines elements of `ExpandingWindowSplitter` and `CutoffSplitter`
@@ -45,9 +45,24 @@ class ExpandingCutoffSplitter(BaseSplitter):
     starting window for the training set. The training set then expands incrementally
     in each split until it reaches the end of the series.
 
-    The test set is defined by a forecast horizon relative to the last point in the
-    training set, containing as many subsequent indices as specified by the `fh`
-    parameter.
+    The test set is defined by a forecast horizon (`fh`) relative to the last point in the
+    training set, containing the specified number of subsequent indices.
+
+    The traning folds are defined as follows: the training set starts from the beginning of the
+    series and extends up to the `cutoff` index for the first split. In each subsequent split, the
+    training set expands by `step_length`, including all prior data up to the new cutoff.
+
+    .. math::
+        TrainingFolds = \{ [j, \ldots, cutoff + j]\}_{j=0, \ldots, n - cutoff - fh + 1}
+
+    where
+
+    The test folds are defined as follows: The test set consists of the indices immediately following the
+    cutoff in each split, defined by `fh`. The number of test samples in each fold
+    corresponds to the number of indices specified in `fh`.
+
+    .. math::
+        TestFolds = \{ (cutoff + j, \ldots, cutoff + fh + j]\}_{j=0, \ldots, n - cutoff - fh + 1}
 
     The valid types of y-index and cutoff pairings are datelike-datelike, datelike-int,
     and int-int. When a datelike index is combined with an int cutoff, the cutoff
@@ -76,13 +91,15 @@ class ExpandingCutoffSplitter(BaseSplitter):
 
     Parameters
     ----------
-    cutoff (int or pd.Timestamp):
+    cutoff: int or pd.Timestamp
         The initial cutoff point in the series, which marks the beginning of the
         first test set.
-    fh (int, list, or np.array):
+    fh: int, list, or np.array
         Forecasting horizon, determining the size and  indices of the test sets.
-        It can be an integer, a list, or an array.
-    step_length (int):
+        It can be:
+            - An integer: indication how many steps ahead to forecast
+            - A list or array of integers: specifying exact test indices relative to the cutoff
+    step_length: int
         The step length to expand the training set size in each split.
 
     Examples


### PR DESCRIPTION
#### Reference Issues/PRs
Partially solve #7196 


#### What does this implement/fix? Explain your changes.
Provide proper mathematical description in docstring

I should double-check if the mathematical description is correct. But I wanted to know if is that that you had in mind.


#### Any other comments?
I notice that the style of parameters section was different from the one used in `SlidingWindowSplitter`. So I fix it such that the style is equivalent in all the classes.

