### PR TITLE
[ENH] add clusterer use to `GroupByCategoryForecaster` and docstrings

### DIFF
--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -9,12 +9,8 @@ from sktime.base._meta import _HeterogenousMetaEstimator
 from sktime.datatypes import ALL_TIME_SERIES_MTYPES, mtype_to_scitype
 from sktime.forecasting.base import BaseForecaster
 from sktime.forecasting.base._delegate import _DelegatedForecaster
-from sktime.forecasting.croston import Croston
-from sktime.forecasting.naive import NaiveForecaster
-from sktime.forecasting.trend import PolynomialTrendForecaster
 from sktime.registry import coerce_scitype
 from sktime.transformations.base import BaseTransformer
-from sktime.transformations.series.adi_cv import ADICVTransformer
 
 __author__ = ["fkiraly", "felipeangelimvieira"]
 __all__ = ["ForecastByLevel", "GroupbyCategoryForecaster"]
@@ -249,6 +245,8 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
             self.transformer = transformer
 
         else:
+            from sktime.transformations.series.adi_cv import ADICVTransformer
+
             self.transformer = ADICVTransformer(features=["class"])
 
         self.forecasters = forecasters
@@ -512,6 +510,12 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+        from sktime.clustering.dbscan import TimeSeriesDBSCAN
+        from sktime.forecasting.croston import Croston
+        from sktime.forecasting.naive import NaiveForecaster
+        from sktime.forecasting.trend import PolynomialTrendForecaster
+        from sktime.transformations.series.adi_cv import ADICVTransformer
+
         param1 = {
             "forecasters": {
                 "smooth": NaiveForecaster(),
@@ -530,7 +534,14 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
             "fallback_forecaster": Croston(),
         }
 
-        params = [param1, param2]
+        # use with clusterer
+        param3 = {
+            "forecasters": {},
+            "transformer": TimeSeriesDBSCAN.create_test_instance(),
+            "fallback_forecaster": Croston(),
+        }
+
+        params = [param1, param2, param3]
         return params
 
     def _iterate_predict_method_over_categories(

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -12,6 +12,7 @@ from sktime.forecasting.base._delegate import _DelegatedForecaster
 from sktime.forecasting.croston import Croston
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.forecasting.trend import PolynomialTrendForecaster
+from sktime.registry import coerce_scitype
 from sktime.transformations.base import BaseTransformer
 from sktime.transformations.series.adi_cv import ADICVTransformer
 
@@ -155,9 +156,12 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         dict of forecasters with the key corresponding to categories generated
         by the given transformer and the value corresponding to a sktime forecaster.
 
-    transformer : sktime transformer, default = ADICVTransformer()
-        A series-to-primitives sk-time transformer that generates a value
+    transformer : sktime transformer or clusterer, default = ADICVTransformer()
+        A series-to-primitives sktime transformer that generates a value
         which can be used to quantify a choice of forecaster for the time series.
+
+        If a clusterer is used, it must suport cluster assignment,
+        i.e, have the ``capability:predict`` tag.
 
         Note: To ensure correct functionality, the transformer must store the
         generated category in the first column of the returned values when
@@ -250,7 +254,7 @@ class GroupbyCategoryForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         self.forecasters = forecasters
         self.fallback_forecaster = fallback_forecaster
 
-        self.transformer_ = self.transformer.clone()
+        self.transformer_ = coerce_scitype(self.transformer, "transformer").clone()
 
         super().__init__()
 

--- a/sktime/forecasting/compose/_transform_select_forecaster.py
+++ b/sktime/forecasting/compose/_transform_select_forecaster.py
@@ -29,9 +29,12 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         dict of forecasters with the key corresponding to categories generated
         by the given transformer and the value corresponding to a sktime forecaster.
 
-    transformer : sktime transformer, default = ADICVTransformer()
+    transformer : sktime transformer or clusterer, default = ADICVTransformer()
         A series-to-primitives sk-time transformer that generates a value
         which can be used to quantify a choice of forecaster for the time series.
+
+        If a clusterer is used, it must suport cluster assignment,
+        i.e, have the ``capability:predict`` tag.
 
         Note: To ensure correct functionality, the transformer must store the
         generated category in the first column of the returned values when
@@ -42,6 +45,9 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         the transformer does not match any of the given forecasters.
 
     pooling : str, optional, default = "local", one of {"local", "global"}
+        The pooling strategy to use for the forecasters. If "local", the forecasters
+        are fit and predicted independently for each category. If "global", the
+        forecasters are fit and predicted on the entire dataset.
 
     Raises
     ------


### PR DESCRIPTION
This PR adds the possibility to pass a clusterer to `GroupByCategoryForecaster`.

It also looks like the `GroupByCategoryForecaster` is mostly a copy of `TransformSelectForecaster`, so I do not quite understand what happened here.

In any case, I've tried to sync the classes as much as possible, with various features that have since been added to `TransformSelectForecaster`.