### PR TITLE
[MNT] increase `pytorch-forecasting` bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,7 +293,7 @@ dl = [
   'torch; python_version < "3.12"',
   'transformers[torch]<4.41.0; python_version < "3.12"',
   'pykan>=0.2.1,<0.2.9; python_version > "3.9.7"',
-  'pytorch-forecasting>=1.0.0,<1.2.0; python_version < "3.13"',
+  'pytorch-forecasting>=1.0.0,<1.4.0',
   'lightning>=2.0; python_version < "3.12"',
   'gluonts>=0.14.3; python_version < "3.12"',
   'einops>0.7.0; python_version < "3.12"',


### PR DESCRIPTION
`pytorch-forecasting` 1.3.0 has been released recently, with 3.13 support and bugfixes. We should increase the bound and merge after tests pass.