### PR TITLE
DIAGNOSTIC: suspected test coverage gap for `EnsembleForecaster`

### DIFF
--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -386,6 +386,8 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
         -------
         self : returns an instance of self.
         """
+        raise RuntimeError("testing")
+
         names, forecasters = self._check_forecasters()
         self._fit_forecasters(forecasters, y, X, fh)
         return self

--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -31,11 +31,7 @@ from sktime.split import (
     SlidingWindowSplitter,
     temporal_train_test_split,
 )
-from sktime.tests.test_all_estimators import (
-    BaseFixtureGenerator,
-    QuickTester,
-    TestAllObjects,
-)
+from sktime.tests.test_all_estimators import BaseFixtureGenerator, QuickTester
 from sktime.utils._testing.forecasting import (
     _assert_correct_columns,
     _assert_correct_pred_time_index,
@@ -947,7 +943,7 @@ class TestAllForecasters(
         _assert_correct_columns(y_pred, y_train)
 
 
-class TestAllGlobalForecasters(TestAllObjects, _ProbalisticPredictionCheck):
+class TestAllGlobalForecasters(_ProbalisticPredictionCheck):
     """Module level tests for all global forecasters."""
 
     estimator_type_filter = "global_forecaster"


### PR DESCRIPTION
The test framework seems not to have covered a failing `check_estimator` for `EnsembleForecaster`, see https://github.com/sktime/sktime/issues/7784 and #7787

This PR tries to diagnose why, by inserting a `raise` in `_fit`.