### PR TITLE
[ENH] Added basic usage example for TimeSeriesKShapes

### DIFF
--- a/sktime/clustering/k_shapes.py
+++ b/sktime/clustering/k_shapes.py
@@ -48,6 +48,15 @@ class TimeSeriesKShapes(_TslearnAdapter, BaseClusterer):
         the sample weights if provided.
     n_iter_: int
         Number of iterations run.
+    
+    Examples
+    --------
+    >>> from sktime.clustering.k_shapes import TimeSeriesKShapes
+    >>> from sktime.datasets import load_basic_motions
+    >>> X_train, _ = load_basic_motions(split="train", return_X_y=True)
+    >>> model = TimeSeriesKShapes(n_clusters=3, max_iter=50, tol=1e-4, random_state=42)
+    >>> model.fit(X_train)
+    >>> y_pred = model.predict(X_train)
     """
 
     _tags = {


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
Fixes #4264 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Added basic usage example for TimeSeriesKShapes


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ENH] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
