### PR TITLE
[ENH] fix `check_estimator` integration for `TestAllGlobalForecasters`

### DIFF
--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -940,7 +940,7 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
         _assert_correct_columns(y_pred, y_train)
 
 
-class TestAllGlobalForecasters(BaseFixtureGenerator):
+class TestAllGlobalForecasters(BaseFixtureGenerator, QuickTester):
     """Module level tests for all global forecasters."""
 
     estimator_type_filter = "global_forecaster"


### PR DESCRIPTION
This PR fixes check_estimator` integration for `TestAllGlobalForecasters`, which broke through the fix https://github.com/sktime/sktime/pull/7789