### PR TITLE
[ENH] Added support detection for number of clusters, helping with hyperparameter tuning

### DIFF
--- a/sktime/clustering/_tune.py
+++ b/sktime/clustering/_tune.py
@@ -1,0 +1,153 @@
+"""Cluster tuning estimator for time series clustering.
+
+Purpose:
+    Automatically finds the optimal number of clusters for a given clustering algorithm
+    by evaluating different cluster sizes using a specified metric.
+
+This class follows the sktime parameter estimator template.
+
+Mandatory implements:
+    fitting                     - _fit(self, X)
+    fitted parameter inspection - _get_fitted_params()
+
+Optional implements:
+    updating                              - _update(self, X)
+    data conversion and capabilities tags - _tags
+
+Testing - required for sktime test framework and check_estimator usage:
+    get default parameters for test instance(s) - get_test_params()
+
+"""
+
+from sktime.param_est.base import BaseParamFitter
+from sklearn.metrics import silhouette_score
+import numpy as np
+
+class ClusterSupportDetection(BaseParamFitter):
+    """Custom parameter fitter for clustering optimization.
+    
+    Automatically determines the optimal number of clusters using a specified metric.
+
+    Hyper-parameters
+    ----------------
+    estimator : clustering model instance
+        The clustering model to tune, must have a `fit_predict` method.
+    param_range : list or range
+        The range of cluster numbers to evaluate.
+    metric : function, default=None
+        Function to evaluate clustering quality. If None, uses the elbow method.
+    metric_params : dict, optional
+        Additional parameters for the metric function.
+    sample_size : int, optional
+        Number of samples to use if dataset is large.
+    verbose : int, default=0
+        Verbosity level (0 for silent, 1 for progress updates).
+    """
+
+    _tags = {
+        "X_inner_mtype": "pd.DataFrame",
+        "scitype:X": "Panel",
+        "capability:missing_values": False,
+        "capability:multivariate": False,
+        "authors": ["TomatoChocolate12"],
+    }
+
+    def __init__(
+            self,
+            estimator,
+            param_range,
+            metric=None,
+            metric_params=None,
+            sample_size=None,
+            verbose=0
+    ):
+        self.estimator = estimator
+        self.param_range = param_range
+        self.metric = metric
+        self.metric_params = metric_params if metric_params is not None else {}
+        self.sample_size = sample_size
+        self.verbose = verbose
+        
+        super().__init__()
+
+    def _fit(self, X, y=None):
+        """Finds the optimal number of clusters by evaluating different values."""
+        best_score = -np.inf
+        best_param = None
+        scores = {}
+        inertia_values = []
+        
+        for param in self.param_range:
+            if self.verbose:
+                print(f"Evaluating {param} clusters...")
+            
+            estimator = self.estimator.set_params(n_clusters=param)
+            labels = estimator.fit_predict(X)
+            
+            if self.metric:
+                score = self.metric(X, labels, **self.metric_params)
+                scores[param] = score
+            else:
+                inertia = estimator.inertia_
+                inertia_values.append(inertia)
+                scores[param] = -inertia  # Minimizing inertia
+        
+        if not self.metric:
+            # Find the elbow point
+            best_param = self._find_elbow_point(inertia_values)
+            best_score = -inertia_values[best_param - self.param_range[0]]
+        else:
+            best_param = max(scores, key=scores.get)
+            best_score = scores[best_param]
+        
+        self.best_param_ = best_param
+        self.best_score_ = best_score
+        self.scores_ = scores
+        
+        if self.verbose:
+            print(f"Best parameter: {best_param} with score: {best_score}")
+        
+        return self
+    
+    def _find_elbow_point(self, param_range, inertia_values):
+        """Finds the elbow point by detecting when the slope drops below a threshold."""
+        diffs = np.diff(inertia_values)
+        threshold = self.metric_params.get("elbow_threshold", 0.1)
+        for i, diff in enumerate(diffs):
+            if abs(diff) < threshold:
+                return param_range[i]
+        return param_range[-1]
+    
+    def _get_fitted_params(self):
+        """Return the best parameter found."""
+        return {"best_n_clusters": self.best_param_}
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+
+        from sktime.clustering.k_means import TimeSeriesKMeans
+        from sktime.clustering.k_medoids import TimeSeriesKMedoids
+        from sktime.clustering.k_shapes import TimeSeriesKShapes
+        
+        params = {
+            "estimator": TimeSeriesKMeans(),
+            "param_range": range(2, 10),
+            "metric": silhouette_score,
+            "metric_params": None
+        }
+
+        params2 = {
+            "estimator": TimeSeriesKMedoids(),
+            "param_range": range(2, 10),
+            "metric": silhouette_score,
+            "metric_params": {"elbow_threshold": 0.05},
+        }
+
+        params3 = {
+            "estimator": TimeSeriesKShapes(),
+            "param_range": range(2, 10),
+            "metric": None,
+            "metric_params": None,
+        }
+        return [params, params2, params3]

--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -183,6 +183,42 @@ class HierarchicalPdMultiIndex(ScitypeHierarchical):
 class HierarchicalDask(ScitypeHierarchical):
     """Data type: dask frame based specification of hierarchical series.
 
+    Name: ``"dask_hierarchical"``
+
+    Short description:
+    A ``dask.DataFrame`` with hierarchical indices, where the last index level represents
+    time and earlier levels represent the hierarchy.cols = variables.
+
+    Long description:
+    The ``"dask_hierarchical"`` :term:`mtype` is a concrete specification of the 
+    ``Hierarchical`` :term:`scitype`, which represents a hierarchically indexed 
+    collection of time series.
+
+    An object ``obj: dask.DataFrame`` follows the specification iff:
+
+    * structure convention: ``obj.index`` must be a multi-level index of type 
+      ``(Index, ..., Index, t)``, where ``t`` is one of ``Int64Index``, 
+      ``RangeIndex``, ``DatetimeIndex``, ``PeriodIndex``, and monotonic.
+      The last index is interpreted as time-like.
+    * hierarchy level: rows with the same non-time-like index values correspond 
+      to the same hierarchy unit; different non-time-like index combinations 
+      correspond to different hierarchy units.
+    * hierarchy: the non-time-like indices in ``obj.index`` identify the 
+      hierarchy structure.
+    * time index: the last element of tuples in ``obj.index`` is interpreted
+      as a time index.
+    * time points: rows of ``obj`` with the same ``"timepoints"`` index correspond
+      to the same time point; rows of ``obj`` with different ``"timepoints"`` index
+    * variables: columns of ``obj`` correspond to variables.
+    * variable names: column names are taken from ``obj.columns``.
+
+    Capabilities:
+    * can represent multivariate hierarchical series.
+    * can represent unequally spaced hierarchical series.
+    * can represent unequally supported hierarchical series.
+    * cannot represent hierarchical series with different sets of variables.
+    * can represent missing values.
+
     Parameters
     ----------
     is_univariate: bool

--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -186,30 +186,31 @@ class HierarchicalDask(ScitypeHierarchical):
     Name: ``"dask_hierarchical"``
 
     Short description:
-    A ``dask.DataFrame`` with hierarchical indices, where the last index level represents
-    time and earlier levels represent the hierarchy.cols = variables.
+    A ``dask.DataFrame`` where hierarchy is represented using explicit columns 
+    instead of a traditional index, and time is recorded in a dedicated column.
 
     Long description:
     The ``"dask_hierarchical"`` :term:`mtype` is a concrete specification of the 
-    ``Hierarchical`` :term:`scitype`, which represents a hierarchically indexed 
+    ``Hierarchical`` :term:`scitype`, which represents a hierarchically structured 
     collection of time series.
 
     An object ``obj: dask.DataFrame`` follows the specification iff:
 
-    * structure convention: ``obj.index`` must be a multi-level index of type 
-      ``(Index, ..., Index, t)``, where ``t`` is one of ``Int64Index``, 
-      ``RangeIndex``, ``DatetimeIndex``, ``PeriodIndex``, and monotonic.
-      The last index is interpreted as time-like.
-    * hierarchy level: rows with the same non-time-like index values correspond 
-      to the same hierarchy unit; different non-time-like index combinations 
-      correspond to different hierarchy units.
-    * hierarchy: the non-time-like indices in ``obj.index`` identify the 
-      hierarchy structure.
-    * time index: the last element of tuples in ``obj.index`` is interpreted
-      as a time index.
-    * time points: rows of ``obj`` with the same ``"timepoints"`` index correspond
-      to the same time point; rows of ``obj`` with different ``"timepoints"`` index
-    * variables: columns of ``obj`` correspond to variables.
+    * structure convention: ``obj`` must have at least three index columns, where:
+      - The first ``n-1`` index columns define the hierarchy.
+      - The last index column represents time.
+    * hierarchy level: rows with the same values in the hierarchy columns belong 
+      to the same hierarchy unit, while different hierarchy values correspond to 
+      different hierarchy units.
+    * hierarchy: the hierarchy structure is explicitly encoded in columns rather 
+      than an index.
+    * time index: the last column in the index set is interpreted as a time column.
+      It must be one of ``Int64``, ``RangeIndex``, ``DatetimeIndex``, or ``PeriodIndex``, 
+      and must be monotonically increasing.
+    * time points: rows with the same value in the time column correspond to 
+      the same time point.
+    * variables: columns excluding the hierarchy and time columns correspond 
+      to variables.
     * variable names: column names are taken from ``obj.columns``.
 
     Capabilities:
@@ -252,6 +253,7 @@ class HierarchicalDask(ScitypeHierarchical):
         list of feature kind strings for each feature in the panel,
         coerced to FLOAT or CATEGORICAL type
     """
+
 
     _tags = {
         "scitype": "Hierarchical",


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
Resolves #7781 .

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
I have tried to implement a class called `ClusterSupportDetection` within a new file called `_tune.py` to help with hyperparameter tuning with clustering methods. Two support detection techniques, using *silhouette score* and the *elbow method* have been implemented. Some liberty has been taken with the implementation of the elbow method technique, wherein, the user can choose to use a threshold to ensure that the elbow chosen (optimal number of clusters) would have a slope lesser than the specified threshold.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->
I have used the external libraries of `numpy` and `sklearn.metric` for this task. I do not think these would cause any dependancy issues.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
Yes, I have added tests with some of the previously implemented clusterers.

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
