### PR TITLE
Fix broken train/test split

### DIFF
--- a/sktime/forecasting/ttm.py
+++ b/sktime/forecasting/ttm.py
@@ -9,11 +9,10 @@ import pandas as pd
 from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import ForecastingHorizon, _BaseGlobalForecaster
-from sktime.split import temporal_train_test_split
 from sktime.utils.warnings import warn
 
 if _check_soft_dependencies("torch", severity="none"):
-    from torch.utils.data import Dataset
+    from torch.utils.data import Dataset, random_split
 else:
 
     class Dataset:
@@ -31,101 +30,41 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     open-sourced by IBM Research. With less than 1 Million parameters, TTM introduces
     the notion of the first-ever "tiny" pre-trained models for Time-Series Forecasting.
 
-    **Zero-shot and Fine-tuning**:
-
-    This model is designed as a versatile foundation model, capable of both
-    zero-shot forecasting and fine-tuning on custom datasets.
-    The choice between zero-shot and fine-tuning is managed internally and
-    is determined by the final configuration used to initialize the model.
-
-    **Initialization Process**:
-
-    1. **Model Path**: The ``model_path`` parameter points to a local folder or
-       huggingface repo that contains both *configuration files*
-       and *pretrained weights*.
-
-    2. **Default Configuration**: The model loads its default configuration from the
-       *configuration files*.
-
-    3. **Custom Configuration**: Users can provide a custom configuration via the
-       ``config`` parameter during model initialization.
-
-    4. **Configuration Override**: If custom configuration is provided,
-       it overrides the default configuration.
-
-    5. **Forecasting Horizon**: If the forecasting horizon (``fh``) specified during
-       ``fit`` exceeds the default ``config.prediction_length``,
-       the configuration is updated to reflect ``max(fh)``.
-
-    6. **Model Architecture**: The final configuration is used to construct the
-       *model architecture*.
-
-    7. **Pretrained Weights**: *pretrained weights* are loded from the ``model_path``,
-       these weights are then aligned and loaded into the *model architechture*.
-
-    8. **Weight Alignment**: However sometimes, *pretrained weights* do not align with
-       the *model architechture*, because the config was changed which created a
-       *model architechture* of different size than the default one.
-       This causes some of the weights in *model architechture* to be reinitialized
-       randomly instead of using the pre-trained weights.
-
-    **Forecasting Modes**:
-
-    - **Zero-shot Forecasting**: When all the *pre-trained weights* are correctly
-      aligned with the *model architechture*, fine-tuing part is bypassed and
-      the model preforms zero-short forecasting.
-
-    - **Fine-tuning**: When not all the *pre-trained weights* are correctly aligned
-      with the *model architechture*, rather some weights are re-initialized,
-      these re-initialized weights are fine-tuned on the provided data.
-
     Parameters
     ----------
     model_path : str, default="ibm/TTM"
         Path to the Huggingface model to use for forecasting.
         This can be either:
-
         - The name of a Huggingface repository (e.g., "ibm/TTM")
-
         - A local path to a folder containing model files in a format supported
           by transformers. In this case, ensure that the directory contains all
           necessary files (e.g., configuration, tokenizer, and model weights).
-
     revision: str, default="main"
         Revision of the model to use:
-
         - "main": For loading model with context_length of 512
           and prediction_length of 96.
-
         - "1024_96_v1": For loading model with context_length of 1024
           and prediction_length of 96.
-
     validation_split : float, default=0.2
         Fraction of the data to use for validation
-
     config : dict, default={}
         Configuration to use for the model. See the ``transformers``
         documentation for details.
-
     training_args : dict, default={}
         Training arguments to use for the model. See ``transformers.TrainingArguments``
         for details.
         Note that the ``output_dir`` argument is required.
-
     compute_metrics : list, default=None
         List of metrics to compute during training. See ``transformers.Trainer``
         for details.
-
     callbacks : list, default=[]
         List of callbacks to use during training. See ``transformers.Trainer``
-
     broadcasting : bool, default=False
         if True, multiindex data input will be broadcasted to single series.
         For each single series, one copy of this forecaster will try to
         fit and predict on it. The broadcasting is happening inside automatically,
         from the outerside api perspective, the input and output are the same,
         only one multiindex output from ``predict``.
-
     use_source_package : bool, default=False
         If True, the model and configuration will be loaded directly from the source
         package ``tsfm_public.models.tinytimemixer``. This is useful if you
@@ -140,9 +79,9 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     ----------
     .. [1] https://github.com/ibm-granite/granite-tsfm/tree/main/tsfm_public/models/tinytimemixer
     .. [2] Ekambaram, V., Jati, A., Dayama, P., Mukherjee, S.,
-           Nguyen, N.H., Gifford, W.M., Reddy, C. and Kalagnanam, J., 2024.
-           Tiny Time Mixers (TTMs): Fast Pre-trained Models for Enhanced
-           Zero/Few-Shot Forecasting of Multivariate Time Series. CoRR.
+    Nguyen, N.H., Gifford, W.M., Reddy, C. and Kalagnanam, J., 2024.
+    Tiny Time Mixers (TTMs): Fast Pre-trained Models for Enhanced
+    Zero/Few-Shot Forecasting of Multivariate Time Series. CoRR.
     .. [3] https://github.com/ibm-granite/granite-tsfm/blob/main/notebooks/tutorial/ttm_tutorial.ipynb
     .. [4] https://github.com/ibm-granite/granite-tsfm/tree/ttm
 
@@ -152,7 +91,6 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     >>> from sktime.datasets import load_airline
     >>> y = load_airline()
     >>> forecaster = TinyTimeMixerForecaster() # doctest: +SKIP
-    >>> # performs zero-shot forecasting, as default config (unchanged) is used
     >>> forecaster.fit(y, fh=[1, 2, 3]) # doctest: +SKIP
     >>> y_pred = forecaster.predict() # doctest: +SKIP
 
@@ -179,7 +117,7 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     ...     },
     ... ) # doctest: +SKIP
     >>>
-    >>> # model is fine-tuned, as a config different from default is provided.
+    >>> # train and predict
     >>> forecaster.fit(y, fh=[1, 2, 3]) # doctest: +SKIP
     >>> y_pred = forecaster.predict() # doctest: +SKIP
     """
@@ -365,27 +303,17 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
                 _model = getattr(_model, attr_name)
             _model.weight.requires_grad = True
 
-        if self.validation_split is not None:
-            y_train, y_eval = temporal_train_test_split(
-                y, test_size=self.validation_split
-            )
-        else:
-            y_train = y
-            y_eval = None
 
-        train = PyTorchDataset(
-            y=y_train,
+        dataset = PyTorchDataset(
+            y=y,
             context_length=config.context_length,
             prediction_length=config.prediction_length,
         )
+        train, test = random_split(dataset, [1 - self.validation_split, self.validation_split])
 
-        eval = None
-        if self.validation_split is not None:
-            eval = PyTorchDataset(
-                y=y_eval,
-                context_length=config.context_length,
-                prediction_length=config.prediction_length,
-            )
+        if train.__len__() <= 0 or test.__len__() <= 0:
+            raise ValueError("Training or Test dataset is empty, either provide longer series" + 
+                             "or reduce the context_length and prediction_length")
 
         # Get Training Configuration
         training_args = TrainingArguments(**self._training_args)
@@ -395,7 +323,7 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
             model=self.model,
             args=training_args,
             train_dataset=train,
-            eval_dataset=eval,
+            eval_dataset=test,
             compute_metrics=self.compute_metrics,
             callbacks=self.callbacks,
         )
@@ -541,7 +469,7 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
                 "model_path": "ibm/TTM",
                 "revision": "main",
                 "config": {
-                    "context_length": 8,
+                    "context_length": 5,
                     "prediction_length": 2,
                 },
                 "validation_split": 0.2,


### PR DESCRIPTION

#### Reference Issues/PRs
fixes #7829 


#### What does this implement/fix? Explain your changes.
Makes the train/test split more robust by using the torch functionality directly on the dataset. Improves the error message in case the train or test set is empty.


#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set. There
are also further specific instructions to follow for soft dependencies.
See here for handling dependencies in sktime: https://www.sktime.net/en/latest/developer_guide/dependencies.html
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

<!--
Thanks for contributing!
-->
