### PR TITLE
[BUG] fix `statsmodels` adapter variable name for `pd.Series`

### DIFF
--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -53,9 +53,10 @@ class _StatsModelsAdapter(BaseForecaster):
         -------
         self : returns an instance of self.
         """
-        # save info needed for _predict: should these be saved to self._y_metdata?
+        # save info needed for _predict: should these be saved to self._y_metadata?
         self._y_len = len(y)
         self._y_first_index = y.index[0]
+        self._y_name = y.name
         self._set_cutoff_from_y(y)
 
         # statsmodels does not support the pd.Int64Index as required,
@@ -135,7 +136,7 @@ class _StatsModelsAdapter(BaseForecaster):
         y_pred = y_pred.iloc[fh_int]
         # ensure that name is not added nor removed
         # otherwise this may upset conversion to pd.DataFrame
-        y_pred.name = self._get_varnames()[0]
+        y_pred.name = self._y_name
         return y_pred
 
     @staticmethod

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -56,8 +56,11 @@ class _StatsModelsAdapter(BaseForecaster):
         # save info needed for _predict: should these be saved to self._y_metadata?
         self._y_len = len(y)
         self._y_first_index = y.index[0]
-        self._y_was_series_without_name = hasattr(y, "name") and y.name is None
         self._set_cutoff_from_y(y)
+
+        self._y_was_series = isinstance(y, pd.Series)
+        if isinstance(y, pd.Series):
+            self._y_name = y.name
 
         # statsmodels does not support the pd.Int64Index as required,
         # so we coerce them here to pd.RangeIndex
@@ -136,8 +139,8 @@ class _StatsModelsAdapter(BaseForecaster):
         y_pred = y_pred.iloc[fh_int]
         # ensure that name is not added nor removed
         # otherwise this may upset conversion to pd.DataFrame
-        if isinstance(y_pred, pd.Series) and self._y_was_series_without_name:
-            y_pred.name = None
+        if self._y_was_series:
+            y_pred.name = self._y_name
         return y_pred
 
     @staticmethod

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -56,7 +56,7 @@ class _StatsModelsAdapter(BaseForecaster):
         # save info needed for _predict: should these be saved to self._y_metadata?
         self._y_len = len(y)
         self._y_first_index = y.index[0]
-        self._y_name = y.name
+        self._y_was_series_without_name = hasattr(y, "name") and y.name is None
         self._set_cutoff_from_y(y)
 
         # statsmodels does not support the pd.Int64Index as required,
@@ -136,7 +136,8 @@ class _StatsModelsAdapter(BaseForecaster):
         y_pred = y_pred.iloc[fh_int]
         # ensure that name is not added nor removed
         # otherwise this may upset conversion to pd.DataFrame
-        y_pred.name = self._y_name
+        if isinstance(y_pred, pd.Series) and self._y_was_series_without_name:
+            y_pred.name = None
         return y_pred
 
     @staticmethod


### PR DESCRIPTION
This PR fixes the inconsistency in variable `name` for the `statsmodels` adapter.

The reason for the inconsistency was that the metadata `varnames` was replacing `None` `name` with `0`, so playing back the latter in `_predict` would change the `name` attribute of the `pd.Series`.

The fix plays back the name as seen in `_fit`, after remembering it.

Fixes #7825