### PR TITLE
[BUG] Exclude `alignment` mtypes during `GlobalForecasterTest`

### DIFF
--- a/sktime/forecasting/tests/test_all_forecasters.py
+++ b/sktime/forecasting/tests/test_all_forecasters.py
@@ -1306,7 +1306,10 @@ class TestAllGlobalForecasters(BaseFixtureGenerator, QuickTester):
             assert isinstance(y_pred, pd.DataFrame)
             assert check_is_mtype(
                 y_pred,
-                mtype(y_test, exclude_mtypes=["pd_DataFrame_Table"]),
+                mtype(
+                    y_test,
+                    exclude_mtypes=["pd_DataFrame_Table", "alignment", "alignment_loc"],
+                ),
                 msg_return_dict="list",
             )
             msg = (


### PR DESCRIPTION

#### Reference Issues/PRs
Avoids unnecessary tests against certain mtypes during testing 
