### PR TITLE
[DOC] update enbpi docstrings

### DIFF
--- a/sktime/forecasting/enbpi.py
+++ b/sktime/forecasting/enbpi.py
@@ -62,16 +62,18 @@ class EnbPIForecaster(BaseForecaster):
     Examples
     --------
     >>> from tsbootstrap import MovingBlockBootstrap
-    >>> from sktime.forecasting.compose import EnbPIForecaster
+    >>> from sktime.forecasting.enbpi import EnbPIForecaster
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.datasets import load_airline
     >>> from sktime.transformations.series.difference import Differencer
     >>> from sktime.transformations.series.detrend import Deseasonalizer
+    >>> from sktime.forecasting.base import ForecastingHorizon
     >>> y = load_airline()
     >>> forecaster = Differencer(lags=[1]) * Deseasonalizer(sp=12) * EnbPIForecaster(
     ...    forecaster=NaiveForecaster(sp=12),
     ...    bootstrap_transformer=MovingBlockBootstrap(n_bootstraps=10))
-    >>> forecaster.fit(y, fh=range(12))
+    >>> fh = ForecastingHorizon(np.arange(1, 13))
+    >>> forecaster.fit(y, fh=fh)
     >>> res = forecaster.predict()
     >>> res_int = forecaster.predict_interval(coverage=[0.5])
 


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/7645

A simple fix in the example docstrings of EnbPIForecaster
Solves :
- Module Import error
- Specifies the range for the Forcasting Horizon

The example provided in the [Docs](https://www.sktime.net/en/latest/api_reference/auto_generated/sktime.forecasting.enbpi.EnbPIForecaster.html) would produce errors.

@fkiraly Kindly review this PR, thanks!!
