### PR TITLE
[BUG] fix sporadic out-of-bounds error in `ProximityStump` and WDTW

### DIFF
--- a/sktime/distances/_wdtw_numba.py
+++ b/sktime/distances/_wdtw_numba.py
@@ -46,8 +46,9 @@ def _weighted_cost_matrix(
     cost_matrix = np.full((x_size + 1, y_size + 1), np.inf)
     cost_matrix[0, 0] = 0.0
 
+    wv_len = max(x_size, y_size)
     weight_vector = np.array(
-        [1 / (1 + np.exp(-g * (i - x_size / 2))) for i in range(0, x_size)]
+        [1 / (1 + np.exp(-g * (i - wv_len / 2))) for i in range(0, wv_len)]
     )
 
     for i in range(x_size):


### PR DESCRIPTION
This PR fixes an out-of-bounds error in `ProximityStump` and WDTW.

The error is due to a sporadic out-of-bounds where, in the WDTW distance, weights of form w(abs(i-j)) are copmuted, with w a pre-allocated weight vector. The pre-allocation size takes only the possible range of i into account, but not the range of j.

This is fixed.