### PR TITLE
[BUG] Deplace `stateless` tag by `requires_fit` in `adapt.py`

### DIFF
--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -184,7 +184,7 @@ class TabularToSeriesAdaptor(BaseTransformer):
 
         # sklearn transformers that are known to fit in transform do not need fit
         if hasattr(transformer, "_get_tags"):
-            trafo_fit_in_transform = transformer._get_tags()["stateless"]
+            trafo_fit_in_transform = not transformer._get_tags()["requires_fit"]
         else:
             trafo_fit_in_transform = False
 


### PR DESCRIPTION

#### Reference Issues/PRs
Fixes #7803 


#### What does this implement/fix? Explain your changes.
Replaces the tag, since requires_fit should be used according to https://github.com/scikit-learn/scikit-learn/issues/30840. 

 
#### Does your contribution introduce a new dependency? If yes, which one?
No
#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

When we set scikit-learn lower bound to 1.6.0, we could use also `get_tags` method, which would be prettier.