### PR TITLE
[ENH] address some `pandas` deprecation warnings

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -51,7 +51,7 @@ Highlights
 * MAPA forecaster (:pr:`7620`) :user:`phoeenniixx`
 * Interface to ``skforecast.recursive.ForecasterRecursive`` (:pr:`7554`) :user:`yarnabrina`
 * Native reducers (2nd generation) now support arbitrary imputation strategies (:pr:`7535`, :pr:`7646`) :user:`lenaklosik`
-* New detection metrics: RAND Index, windows F1-score (:pr:`7533`, :pr:`7628`) :user:`gavinkatz001`
+* New detection metrics: RAND Index, windowed F1-score (:pr:`7533`, :pr:`7628`) :user:`gavinkatz001`
 * forecasting ``evaluate`` now allows returning fitted estimators via ``return_model`` parameter (:pr:`7637`) :user:`marrov`
 * Tags and object API for Datasets (:pr:`7398`) :user:`felipeangelimvieira`
 * K-visibility clustering algorithm (:pr:`7592`) :user:`seigpe`

--- a/sktime/performance_metrics/detection/_randindex.py
+++ b/sktime/performance_metrics/detection/_randindex.py
@@ -245,7 +245,7 @@ class RandIndex(BaseDetectionMetric):
         # Case 2/3: user-provided 'ilocs'
         if "ilocs" in y.columns:
             col_dtype = y["ilocs"].dtype
-            if pd.api.types.is_interval_dtype(col_dtype):
+            if isinstance(col_dtype, pd.IntervalDtype):
                 for i, row in y.iterrows():
                     interval = row["ilocs"]
                     seg_start, seg_end = interval.left, interval.right

--- a/sktime/transformations/series/outlier_detection.py
+++ b/sktime/transformations/series/outlier_detection.py
@@ -193,7 +193,8 @@ def _hampel_filter(Z, cv, n_sigma, half_window_length, k):
             idx_range = [cv_window[0] + half_window_length]
 
         for idx in idx_range:
-            Z.iloc[idx] = _compare(
+            loc_idx = Z.index[idx]  # convert to loc to avoid write on copy
+            Z.loc[loc_idx] = _compare(
                 value=Z.iloc[idx],
                 cv_median=cv_median,
                 cv_sigma=cv_sigma,


### PR DESCRIPTION
This PR addresses the following deprecation warnings from `pandas`:

* deprecation of `is_interval_dtype`
* deprecation of certain write-on-slice cases