### PR TITLE
[BUG] slice `X` in `pmdARIMA._predict_interval` and fix the type of the returned dataframe

### DIFF
--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -281,6 +281,13 @@ class _PmdArimaAdapter(BaseForecaster):
                 Upper/lower interval end forecasts are equivalent to
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
+        fh_abs = fh.to_absolute(self.cutoff).to_pandas()
+        fh_abs_int = fh.to_absolute_int(fh_abs[0], self.cutoff).to_pandas()
+        end_int = fh_abs_int[-1] + 2
+        if X is not None:
+            X = get_slice(X, start=self.cutoff[0], start_inclusive=False)
+            X = X.iloc[:end_int]
+            
         # initializing cutoff and fh related info
         cutoff = self.cutoff
         fh_oos = fh.to_out_of_sample(cutoff)
@@ -321,7 +328,7 @@ class _PmdArimaAdapter(BaseForecaster):
             pred_int[(var_name, a, "lower")] = pd.concat([ins_int, oos_int])["lower"]
             pred_int[(var_name, a, "upper")] = pd.concat([ins_int, oos_int])["upper"]
 
-        return pred_int
+        return pred_int.astype(float)
 
     def _get_fitted_params(self):
         """Get fitted parameters.


### PR DESCRIPTION
There were two bugs in the ARIMA model: 
* exogenous features where not correctly sliced.
* the type of the returned dataframe was wrong.


<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Towards #7849


#### What does this implement/fix? Explain your changes.
Use the same logic as _predict to slice exogenous features
Set the correct type for the returned dataframe

#### Any other comments?
@fkiraly is there a test missing that checks the dtype of the returned prediction?

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
