### PR TITLE
[ENH] fix `test_excluded_tests_by_test` for `HFTransformersForecaster`

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -362,6 +362,7 @@ EXCLUDED_TESTS_BY_TEST = {
         "EnbPIForecaster",
         "FittedParamExtractor",
         "ForecastingOptunaSearchCV",
+    "HFTransformersForecaster",
         "HolidayFeatures",
         "ParamFitterPipeline",
         "PluginParamsForecaster",

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -382,6 +382,7 @@ EXCLUDE_SOFT_DEPS = [
     "EnbPIForecaster",
     "FittedParamExtractor",
     "ForecastingOptunaSearchCV",
+    "HFTransformersForecaster",
     "HolidayFeatures",
     "ParamFitterPipeline",
     "PluginParamsForecaster",


### PR DESCRIPTION
This PR fixes fix `test_excluded_tests_by_test` for the `HFTransformersForecaster`.

The reason for the failure is parallel PRs which changed test parameters of `HFTransformersForecaster`.