### PR TITLE
[BUG] Fix infinite recursion in `_SuppressWarningPattern` and `LossySetitemError` in `SummaryTransformer`

### DIFF
--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -296,7 +296,7 @@ class WindowSummarizer(BaseTransformer):
         lags = func_dict["summarizer"] == "lag"
         # Convert lags to default list notation with window_length 1
         boost_lag = func_dict.loc[lags, "window"].apply(lambda x: [int(x), 1])
-        func_dict.loc[:, "window"] = func_dict["window"].astype("object")
+        func_dict["window"] = func_dict["window"].astype("object", copy=False)
         func_dict.loc[lags, "window"] = boost_lag
         self.truncate_start = func_dict["window"].apply(lambda x: x[0] + x[1] - 1).max()
         self._func_dict = func_dict

--- a/sktime/transformations/series/tests/test_summarize.py
+++ b/sktime/transformations/series/tests/test_summarize.py
@@ -115,3 +115,15 @@ def test_summary_transformer_incorrect_quantile_raises_error(quantile_arg):
             summary_function="mean", quantiles=quantile_arg
         )
         transformer.fit_transform(_make_test_data(0))
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SummaryTransformer),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_summarize_no_lossy_setitem():
+    """Test that SummaryTransformer.fit does not raise LossySetitemError."""
+    data = pd.Series(range(12, 0, -1))
+    transformer = SummaryTransformer()
+    transformer.fit(data)
+    assert True  # Reaching here means no LossySetitemError was raised

--- a/sktime/utils/tests/test_warnings.py
+++ b/sktime/utils/tests/test_warnings.py
@@ -1,0 +1,22 @@
+import warnings
+
+from sktime.utils.warnings import _SuppressWarningPattern
+
+
+def test_custom_showwarning_no_recursion():
+    """Test that _custom_showwarning does not cause infinite recursion."""
+    # Instantiate the class with a test pattern
+    suppressor = _SuppressWarningPattern(FutureWarning, r"Test.*")
+
+    # Monkey-patch temporário para usar o _custom_showwarning
+    original_showwarning = warnings.showwarning
+    warnings.showwarning = suppressor._custom_showwarning
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.filterwarnings("always", category=FutureWarning)
+        warnings.warn("Test warning", FutureWarning)
+        assert len(w) == 1, "Warning should be emitted exactly once"
+        assert "Test warning" in str(w[0].message)
+
+    # Restore the original handler
+    warnings.showwarning = original_showwarning

--- a/sktime/utils/tests/test_warnings.py
+++ b/sktime/utils/tests/test_warnings.py
@@ -8,15 +8,13 @@ def test_custom_showwarning_no_recursion():
     # Instantiate the class with a test pattern
     suppressor = _SuppressWarningPattern(FutureWarning, r"Test.*")
 
-    # Monkey-patch temporário para usar o _custom_showwarning
-    original_showwarning = warnings.showwarning
-    warnings.showwarning = suppressor._custom_showwarning
-
     with warnings.catch_warnings(record=True) as w:
         warnings.filterwarnings("always", category=FutureWarning)
         warnings.warn("Test warning", FutureWarning)
         assert len(w) == 1, "Warning should be emitted exactly once"
         assert "Test warning" in str(w[0].message)
 
-    # Restore the original handler
-    warnings.showwarning = original_showwarning
+    with suppressor:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.warn("Test warning", FutureWarning)
+            assert len(w) == 0, "Warning should be suppressed"

--- a/sktime/utils/warnings.py
+++ b/sktime/utils/warnings.py
@@ -55,29 +55,15 @@ class _SuppressWarningPattern:
 
     def __init__(self, warning_type, message_pattern):
         self.warning_type = warning_type
-        self.message_pattern = re.compile(message_pattern)
+        self.message_pattern = message_pattern
 
     def __enter__(self):
-        self.original_filters = warnings.filters[:]
-        warnings.simplefilter("default", self.warning_type)
-        self.original_showwarning = warnings.showwarning
-        warnings.showwarning = self._custom_showwarning
+        warnings.filterwarnings(
+            "ignore", category=self.warning_type, message=self.message_pattern
+        )
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        warnings.filters = self.original_filters
-        warnings.showwarning = self.original_showwarning
-
-    def _custom_showwarning(
-        self, message, category, filename, lineno, file=None, line=None
-    ):
-        if not hasattr(self, "_in_warning"):
-            self._in_warning = True
-            try:
-                self.original_showwarning(
-                    message, category, filename, lineno, file, line
-                )
-            finally:
-                del self._in_warning
+        warnings.filterwarnings("default", category=self.warning_type)
 
 
 _suppress_pd22_warning = _SuppressWarningPattern(

--- a/sktime/utils/warnings.py
+++ b/sktime/utils/warnings.py
@@ -2,7 +2,6 @@
 
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-import re
 import warnings
 from warnings import warn as _warn
 

--- a/sktime/utils/warnings.py
+++ b/sktime/utils/warnings.py
@@ -70,10 +70,14 @@ class _SuppressWarningPattern:
     def _custom_showwarning(
         self, message, category, filename, lineno, file=None, line=None
     ):
-        right_type = issubclass(category, self.warning_type)
-        fits_pattern = self.message_pattern.search(str(message))
-        if not (right_type and fits_pattern):
-            self.original_showwarning(message, category, filename, lineno, file, line)
+        if not hasattr(self, "_in_warning"):
+            self._in_warning = True
+            try:
+                self.original_showwarning(
+                    message, category, filename, lineno, file, line
+                )
+            finally:
+                del self._in_warning
 
 
 _suppress_pd22_warning = _SuppressWarningPattern(


### PR DESCRIPTION
### Issue
The `_custom_showwarning` method in `sktime/utils/warnings.py` causes infinite recursion when handling certain warnings (e.g., pandas `LossySetitemError`), resulting in a `RecursionError: maximum recursion depth exceeded`. Additionally, in `sktime/transformations/series/summarize.py`, the line `func_dict.loc[:, "window"] = func_dict["window"].astype("object")` throws a `LossySetitemError` in pandas 2.x due to incompatible type coercion.

This issue was identified while using PyCaret with sktime, where tests failed with a crash in a joblib worker due to a `PicklingError` caused by excessive recursion.

### Solution
- Modified the `_custom_showwarning` method in the `_SuppressWarningPattern` class to add a guard against recursion using an `_in_warning` flag, while preserving delegation to `original_showwarning`.
- Fixed `SummaryTransformer` to use a type-safe conversion with `func_dict["window"] = func_dict["window"].astype("object", copy=False)`, avoiding the `LossySetitemError`.

### Changes
- `sktime/utils/warnings.py`: Added protection against infinite recursion in the `_custom_showwarning` method of `_SuppressWarningPattern` using an `_in_warning` flag.
- `sktime/transformations/series/summarize.py`: Replaced the problematic assignment with an explicit conversion of the `"window"` column to `object` using `copy=False` for greater efficiency.
- `sktime/utils/tests/test_warnings.py`: Added a new test file to verify that `_custom_showwarning` in `_SuppressWarningPattern` emits warnings without recursion.
- `sktime/transformations/series/tests/test_summarize.py`: Added a new test `test_summarize_no_lossy_setitem` to confirm that `SummaryTransformer.fit` does not raise `LossySetitemError`.

### Related
- Investigated in PyCaret PR [#4150](https://github.com/pycaret/pycaret/pull/4150)

### Verification
Tested locally with PyCaret and sktime, resolving the crash in the `test_blend_model_predict` test. The change in `summarize.py` ensures compatibility with pandas 2.x while maintaining efficiency with `copy=False`.