### PR TITLE
[ENH] improve condition and error message in `test_excluded_tests_by_test`

### DIFF
--- a/sktime/tests/tests/test_test_utils.py
+++ b/sktime/tests/tests/test_test_utils.py
@@ -29,12 +29,13 @@ def test_excluded_tests_by_test():
         )
     ]
     excluded_estimators = EXCLUDED_TESTS_BY_TEST["test_get_test_params_coverage"]
-    assert set(excluded_estimators) - set(EXCLUDE_SOFT_DEPS) == set(
+    assert set(excluded_estimators) - set(EXCLUDE_SOFT_DEPS) <= set(
         filtered_estimators
     ) - set(EXCLUDE_SOFT_DEPS), (
-        "Assertion failed: The sets of excluded and filtered estimators "
-        "do not match. Please remove the estimator you have added "
-        "test parameters to from EXCLUDED_TESTS_BY_TEST or EXCLUDE_SOFT_DEPS."
+        "If this PR adds test parameters to an estimator's get_test_params: "
+        "Please ensure to remove this estimator "
+        "from EXCLUDED_TESTS_BY_TEST and EXCLUDE_SOFT_DEPS "
+        "in sktime.tests._config, if it is present there."
     )
 
 


### PR DESCRIPTION
This PR improves, and fixes, the test `test_excluded_tests_by_test`, whose sole purpose it is to remind contributors actioning one of the estimtaors in https://github.com/sktime/sktime/issues/3429 to remove the test skip from the estimator.

* the condition is changed so the test triggers only in this scenario, and not when a new estimator is added that does not have enough test parameter sets. Currently the intended condition and the latter as well trigger a failure, and these triggers correspond to the two "subset" relationships of the set equality. Removing one removes the undesired trigger condition.
* The error message is updated to be clearer and more actionable to contributors.