### PR TITLE
[Bug] Column name changed in convert_MvS_to_UvS_as_Series

### DIFF
--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -92,7 +92,7 @@ def convert_MvS_to_UvS_as_Series(obj: pd.DataFrame, store=None) -> pd.Series:
         store["columns"] = obj.columns[[0]]
 
     y = obj[obj.columns[0]]
-
+    y.name = obj.index.name
     if (
         isinstance(store, dict) and "name" in store.keys()
     ):  ## column name becomes attr name


### PR DESCRIPTION
```py
import pandas

from sktime.datatypes._series._convert import convert_MvS_to_UvS_as_Series

df = pandas.DataFrame([0, 1, 2])

series = convert_MvS_to_UvS_as_Series(df)

print("before:")
print(df)
print("after:")
print(series)
```
```py
before:
   0
0  0
1  1
2  2
after:
0    0
1    1
2    2
Name: 0, dtype: int64
```

CI test failure: https://github.com/sktime/sktime/actions/runs/13559190428/job/37899406116?pr=6868