### PR TITLE
[BUG] safer context manager for `pandas 2.2` warning suppression

### DIFF
--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -170,7 +170,7 @@ def _check_freq(obj):
     elif isinstance(obj, (pd.Period, pd.Index)):
         return _extract_freq_from_cutoff(obj)
     elif isinstance(obj, str) or obj is None:
-        with _suppress_pd22_warning:
+        with _suppress_pd22_warning():
             offset = to_offset(obj)
         return offset
     else:
@@ -400,7 +400,7 @@ class ForecastingHorizon:
             freq_from_self = None
 
         if freq_from_self is not None and freq_from_obj is not None:
-            with _suppress_pd22_warning:
+            with _suppress_pd22_warning():
                 freqs_unequal = freq_from_self != freq_from_obj
             if freqs_unequal:
                 raise ValueError(

--- a/sktime/utils/datetime.py
+++ b/sktime/utils/datetime.py
@@ -71,7 +71,7 @@ def _get_intervals_count_and_unit(freq: str) -> tuple[int, str]:
     if freq is None:
         raise ValueError("frequency is missing")
     else:
-        with _suppress_pd22_warning:
+        with _suppress_pd22_warning():
             offset = pd.tseries.frequencies.to_offset(freq)
         count, unit = offset.n, offset.base.freqstr
         return count, unit

--- a/sktime/utils/warnings.py
+++ b/sktime/utils/warnings.py
@@ -76,7 +76,8 @@ class _SuppressWarningPattern:
             self.original_showwarning(message, category, filename, lineno, file, line)
 
 
-_suppress_pd22_warning = _SuppressWarningPattern(
-    FutureWarning,
-    r"'[A-Z]+' is deprecated and will be removed in a future version, please use '[A-Z]+' instead",  # noqa
-)
+def _suppress_pd22_warning():
+    return _SuppressWarningPattern(
+        FutureWarning,
+        r"'[A-Z]+' is deprecated and will be removed in a future version, please use '[A-Z]+' instead",  # noqa
+    )


### PR DESCRIPTION
Ensures a new context manager is generated each time for use, for the `pandas 2.2` related warning context manager used in https://github.com/sktime/sktime/issues/7906

Does not solve the race condition, but makes the context manager safer.