### PR TITLE
[ENH] enable `Imputer` for hierarchical data

### DIFF
--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -100,7 +100,7 @@ class Imputer(BaseTransformer):
         "scitype:transform-output": "Series",
         # what scitype is returned: Primitives, Series, Panel
         "scitype:instancewise": True,  # is this an instance-wise transform?
-        "X_inner_mtype": ["pd.DataFrame"],
+        "X_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for y?
         "fit_is_empty": False,


### PR DESCRIPTION
The `Imputer` had logic for hierarchical data internally, but hierarchical data was never passed.

This is likely a mistake - this PR changes the tags so hierarchical data is passed.

This may well uncover some bugs, which then will need fixing.