### PR TITLE
[BUG] skip `RocketClassifier` expected output test until resolved

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -245,6 +245,8 @@ EXCLUDED_TESTS = {
         "test_inheritance",
         "test_create_test_instance",
     ],
+    # see PR 7921
+    "RocketClassifier": ["test_classifier_on_basic_motions"],
 }
 
 # exclude tests but keyed by test name


### PR DESCRIPTION
Related: https://github.com/sktime/sktime/issues/7921

Skips the failing test until resolved or diagnosed.