### PR TITLE
[ENH] trigger differential tests if core framework modules change

### DIFF
--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -24,7 +24,7 @@ def run_test_for_class(cls, return_reason=False):
        If yes, behaviour depends on ONLY_CHANGED_MODULES setting:
        if off (False), always runs the test (return True);
        if on (True), runs test if and only if
-       at least one of conditions 2, 3, 4 below are met.
+       at least one of conditions 2, 3, 4, 5 below are met.
 
     2. Condition 2:
 
@@ -43,13 +43,19 @@ def run_test_for_class(cls, return_reason=False):
       for any of its dependencies have changed in ``pyproject.toml``,
       condition 4 is met.
 
+    5. Condition 5:
+
+      If the object is an sktime ``BaseObject``,
+      and one of the core framework modules ``datatypes``, ``tests``, ``utils``
+      have changed, then condition 5 is met.
+
     cls can also be a list of classes or functions,
     in this case the test is run if and only if both of the following are True:
 
     * all required soft dependencies are present
     * if ``ONLY_CHANGED_MODULES`` is True, additionally,
       if any of the estimators in the list should be tested by
-      at least one of criteria 2-4 above.
+      at least one of criteria 2-5 above.
       If ``ONLY_CHANGED_MODULES`` is False, this condition is always True.
 
     Also checks whether the class or function is on the exclude override list,
@@ -76,6 +82,7 @@ def run_test_for_class(cls, return_reason=False):
         * "True_pyproject_change" - run reason, dep(s) in ``pyproject.toml`` changed
         * "True_changed_tests" - run reason, test(s) covering class have changed
         * "True_changed_class" - run reason, module(s) containing class changed
+        * "True_changed_framework" - run reason, core framework modules changed
 
         If multiple reasons are present, the first one in the above list is returned.
 
@@ -118,6 +125,7 @@ def run_test_for_class(cls, return_reason=False):
             "True_pyproject_change",
             "True_changed_tests",
             "True_changed_class",
+            "True_changed_framework",
         ]
         for pos_reason in POS_REASONS:
             if any(reason == pos_reason for reason in reasons):
@@ -159,12 +167,17 @@ def _run_test_for_class(cls):
         * "True_pyproject_change" - run reason, dep(s) in ``pyproject.toml`` changed
         * "True_changed_tests" - run reason, test(s) covering class have changed
         * "True_changed_class" - run reason, module(s) containing class changed
+        * "True_changed_framework" - run reason, core framework modules changed
 
         If multiple reasons are present, the first one in the above list is returned.
     """
     from sktime.tests.test_all_estimators import ONLY_CHANGED_MODULES
     from sktime.utils.dependencies import _check_estimator_deps
-    from sktime.utils.git_diff import get_packages_with_changed_specs, is_class_changed
+    from sktime.utils.git_diff import(
+        get_packages_with_changed_specs,
+        is_class_changed,
+        is_module_changed,
+    )
 
     PACKAGE_REQ_CHANGED = get_packages_with_changed_specs()
 
@@ -244,6 +257,15 @@ def _run_test_for_class(cls):
     cond2 = _is_class_changed_or_local_parents(cls)
     if cond2:
         return True, "True_changed_class"
+
+    # Condition 5:
+    # if the object is an sktime BaseObject, and one of the core framework modules
+    # datatypes, tests, utils have changed, then run the test
+    datatypes_changed = is_module_changed("sktime.datatypes")
+    tests_changed = is_module_changed("sktime.tests")
+    utils_changed = is_module_changed("sktime.utils")
+    if any([datatypes_changed, tests_changed, utils_changed]):
+        return True, "True_changed_framework"
 
     # if none of the conditions are met, do not run the test
     # reason is that there was no change

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -173,7 +173,7 @@ def _run_test_for_class(cls):
     """
     from sktime.tests.test_all_estimators import ONLY_CHANGED_MODULES
     from sktime.utils.dependencies import _check_estimator_deps
-    from sktime.utils.git_diff import(
+    from sktime.utils.git_diff import (
         get_packages_with_changed_specs,
         is_class_changed,
         is_module_changed,

--- a/sktime/tests/tests/test_test_utils.py
+++ b/sktime/tests/tests/test_test_utils.py
@@ -97,7 +97,12 @@ def test_run_test_for_class():
     assert isinstance(run_nodep, bool)
     assert isinstance(reason_nodep, str)
 
-    POS_REASONS = ["True_pyproject_change", "True_changed_class", "True_changed_tests"]
+    POS_REASONS = [
+        "True_pyproject_change",
+        "True_changed_class",
+        "True_changed_tests",
+        "True_changed_framework",
+    ]
 
     if not ONLY_CHANGED_MODULES:
         assert run_nodep


### PR DESCRIPTION
This PR tries to cover some blind spots in the testing framework.

It triggers differential tests for estimators and object where previously they would not have been triggered, namely if one of the three key framework modules changes: `datatypes`, `tests`, and `utils`.

This condition is added to the `run_test_for_class` switch.