### PR TITLE
[BUG] fix parameter estimator missing univariate scenario and masked bugs

### DIFF
--- a/sktime/param_est/base.py
+++ b/sktime/param_est/base.py
@@ -160,7 +160,7 @@ class BaseParamFitter(BaseEstimator):
         Parameters
         ----------
         X : time series in sktime compatible data container format
-                Time series to which to fit the forecaster in the update.
+                Time series to which to fit the parameter estimator in the update.
             y can be in one of the following formats, must be same scitype as in fit:
             Series scitype: pd.Series, pd.DataFrame, or np.ndarray (1D or 2D)
             Panel scitype: pd.DataFrame with 2-level row MultiIndex,

--- a/sktime/param_est/compose/_func_fitter.py
+++ b/sktime/param_est/compose/_func_fitter.py
@@ -160,7 +160,15 @@ class FunctionParamFitter(BaseParamFitter):
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
         params = [
-            {"param": "param", "func": lambda X: "foo"},
-            {"param": "param", "func": lambda X, kwarg: "foo", "kw_args": {"kwarg": 1}},
+            {"param": "param", "func": _lambda_test_simple},
+            {"param": "param", "func": _lambda_test_kwarg, "kw_args": {"kwarg": 1}},
         ]
         return params
+
+
+def _lambda_test_simple(X):
+    return "foo"
+
+
+def _lambda_test_kwarg(X, kwarg):
+    return "foo"

--- a/sktime/param_est/lag.py
+++ b/sktime/param_est/lag.py
@@ -25,28 +25,38 @@ class ARLagOrderSelector(BaseParamFitter):
     ----------
     maxlag : int
         Maximum number of lags to consider
+
     ic : str, default="bic"
         Information criterion to use for model selection:
+
         - "aic" : Akaike Information Criterion
         - "bic" : Bayesian Information Criterion (default)
         - "hqic" : Hannan-Quinn Information Criterion
+
     glob : bool, default=False
         If True, searches globally across all lag combinations up to maxlag.
         If False, searches sequentially by adding one lag at a time.
+
     trend : str, default="c"
         Trend to include in the model:
+
         - "n" : No trend
         - "c" : Constant only
         - "t" : Time trend only
         - "ct" : Constant and time trend
+
     seasonal : bool, default=False
         Whether to include seasonal dummies in the model
+
     hold_back : int, optional (default=None)
         Number of initial observations to exclude from the estimation sample
+
     period : int, optional (default=None)
         Period of the data (used only if seasonal=True)
+
     missing : str, default="none"
         How to handle missing values:
+
         - "none" : No handling
         - "drop" : Drop missing observations
         - "raise" : Raise an error
@@ -149,13 +159,6 @@ class ARLagOrderSelector(BaseParamFitter):
         self.ic_value_ = self.results._ics[0][1][key_loc]
 
         return self
-
-    def get_fitted_params(self):
-        """Get fitted parameters."""
-        return {
-            "selected_lags": self.selected_model_,
-            "ic_value": self.ic_value_,
-        }
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -360,15 +360,15 @@ class SeasonalityACFqstat(BaseParamFitter):
         self.pvalues_ = pvalues
 
         if candidate_sp is not None:
-            qstat_cand = qstat[candidate_sp]
-            pvalues_cand = pvalues[candidate_sp]
+            qstat_cand = qstat[candidate_sp - 1]
+            pvalues_cand = pvalues[candidate_sp - 1]
         else:
             qstat_cand = qstat
             pvalues_cand = pvalues
             candidate_sp = range(2, nlags + 1)
 
         self.qstat_cand_ = qstat_cand
-        self.pvalues_cand = pvalues_cand
+        self.pvalues_cand_ = pvalues_cand
 
         if p_adjust != "none":
             reject_cand, pvals_adj, _, _ = multipletests(

--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -360,8 +360,11 @@ class SeasonalityACFqstat(BaseParamFitter):
         self.pvalues_ = pvalues
 
         if candidate_sp is not None:
-            qstat_cand = qstat[candidate_sp - 1]
-            pvalues_cand = pvalues[candidate_sp - 1]
+            if isinstance(candidate_sp, int):
+                candidate_sp = [candidate_sp]
+            csp_ixer = [c-1 for c in candidate_sp]
+            qstat_cand = qstat[csp_ixer]
+            pvalues_cand = pvalues[csp_ixer]
         else:
             qstat_cand = qstat
             pvalues_cand = pvalues

--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -362,7 +362,7 @@ class SeasonalityACFqstat(BaseParamFitter):
         if candidate_sp is not None:
             if isinstance(candidate_sp, int):
                 candidate_sp = [candidate_sp]
-            csp_ixer = [c-1 for c in candidate_sp]
+            csp_ixer = [c - 1 for c in candidate_sp]
             qstat_cand = qstat[csp_ixer]
             pvalues_cand = pvalues[csp_ixer]
         else:

--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -501,12 +501,11 @@ class SeasonalityPeriodogram(BaseParamFitter):
             thresh=self.thresh,
         )
 
-        seasons = [x[0] for x in seasons]
-
         if seasons is None or len(seasons) == 0:
             self.sp_ = 1
             self.sp_significant_ = []
         else:
+            seasons = [x[0] for x in seasons]
             self.sp_significant_ = seasons
             self.sp_ = self.sp_significant_[0]
 

--- a/sktime/param_est/stationarity/_arch.py
+++ b/sktime/param_est/stationarity/_arch.py
@@ -758,8 +758,7 @@ class StationarityZivotAndrews(BaseParamFitter):
         """
         params1 = {}
         params2 = {
-            "lags": 2,
-            "trend": "t",
+            "trend": "ct",
             "trim": 0.1,
             "max_lags": 5,
             "method": "t-stat",

--- a/sktime/param_est/stationarity/_arch.py
+++ b/sktime/param_est/stationarity/_arch.py
@@ -758,10 +758,10 @@ class StationarityZivotAndrews(BaseParamFitter):
         """
         params1 = {}
         params2 = {
-            "lags": 5,
+            "lags": 2,
             "trend": "ct",
             "trim": 0.1,
-            "max_lags": 10,
+            "max_lags": 3,
             "method": "t-stat",
             "p_threshold": 0.1,
         }

--- a/sktime/param_est/stationarity/_arch.py
+++ b/sktime/param_est/stationarity/_arch.py
@@ -759,9 +759,9 @@ class StationarityZivotAndrews(BaseParamFitter):
         params1 = {}
         params2 = {
             "lags": 2,
-            "trend": "ct",
+            "trend": "t",
             "trim": 0.1,
-            "max_lags": 3,
+            "max_lags": 5,
             "method": "t-stat",
             "p_threshold": 0.1,
         }

--- a/sktime/param_est/stationarity/_statsmodels.py
+++ b/sktime/param_est/stationarity/_statsmodels.py
@@ -169,13 +169,12 @@ class StationarityKPSS(BaseParamFitter):
     ----------
     p_threshold : float, optional, default=0.05
         significance threshold to apply in testing for stationarity
+
     regression : str, one of {"c","ct","ctt","n"}, optional, default="c"
         Constant and trend order to include in regression.
 
         * "c" : constant only (default).
         * "ct" : constant and trend.
-        * "ctt" : constant, and linear and quadratic trend.
-        * "n" : no constant, no trend.
 
     nlags : str or int, optional, default="auto". If int, must be positive.
         Indicates the number of lags to be used internally in ``kpss``.
@@ -286,6 +285,6 @@ class StationarityKPSS(BaseParamFitter):
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
         params1 = {}
-        params2 = {"p_threshold": 0.1, "regression": "ctt", "nlags": 5}
+        params2 = {"p_threshold": 0.1, "regression": "ct", "nlags": 5}
 
         return [params1, params2]

--- a/sktime/utils/_testing/scenarios_param_est.py
+++ b/sktime/utils/_testing/scenarios_param_est.py
@@ -53,7 +53,7 @@ class ParamFitterTestScenario(TestScenario, BaseObject):
 class ParamFitterUnivariate(ParamFitterTestScenario):
     """Estimate parameters on a univariate series."""
 
-    _tags = {"X_univariate": False, "is_enabled": True}
+    _tags = {"X_univariate": True, "is_enabled": True}
 
     @property
     def args(self):

--- a/sktime/utils/_testing/scenarios_param_est.py
+++ b/sktime/utils/_testing/scenarios_param_est.py
@@ -59,7 +59,7 @@ class ParamFitterUnivariate(ParamFitterTestScenario):
     def args(self):
         return {
             "fit": {
-                "X": _make_series(n_timepoints=20, n_columns=1, random_state=RAND_SEED)
+                "X": _make_series(n_timepoints=30, n_columns=1, random_state=RAND_SEED)
             },
         }
 
@@ -75,7 +75,7 @@ class ParamFitterMultivariate(ParamFitterTestScenario):
     def args(self):
         return {
             "fit": {
-                "X": _make_series(n_timepoints=20, n_columns=2, random_state=RAND_SEED)
+                "X": _make_series(n_timepoints=30, n_columns=2, random_state=RAND_SEED)
             },
         }
 


### PR DESCRIPTION
As an unreported bug in the test framework, one of the data scenarios was not passed to parameter estimators.

This masked a number of bugs which this PR also fixes:

* `StationarityZivotAndrews` test examples had too large parameters for the test data
* `StationarityKPSS` docstring claimed `regression` options which did not exist
* `FunctionParamFitter` pickling tests would not work for lambda expressions - tests have been replaced by bound functions
* `SeasonalityACFqstat` had an indexing bug (1 vs 0 based indexing)
* `SeasonalityPeriodogram` would break if it found no seasonality
* `ARLagOrderSelector` overrode the wrong fitted parameter method, `get_fitted_params` (rather than the private one)