### PR TITLE
[BUG] Coerce pd.Series' names to string in _StatsModelsAdapter

### DIFF
--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -100,6 +100,11 @@ class _StatsModelsAdapter(BaseForecaster):
                 )
                 if index_diff.isin(y.index).all():
                     y = y.loc[index_diff]
+
+                if isinstance(y, pd.Series):
+                    y = y.copy()
+                    y.name = str(y.name)
+
                 self._fitted_forecaster = self._fitted_forecaster.append(y)
 
     def _predict(self, fh, X):

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -66,6 +66,14 @@ class _StatsModelsAdapter(BaseForecaster):
         # so we coerce them here to pd.RangeIndex
         if isinstance(y, pd.Series) and pd.api.types.is_integer_dtype(y.index):
             y, X = _coerce_int_to_range_index(y, X)
+
+        if isinstance(y, pd.Series):
+            # Statsmodels, internally, add suffixes to the endog feature
+            # name. If the series name is not a string, an exception can
+            # be raised. We convert the name to a string to avoid this.
+            y = y.copy()
+            y.name = str(y.name)
+
         self._fit_forecaster(y, X)
         return self
 


### PR DESCRIPTION


#### Reference Issues/PRs
Fixes #7934, #7930 


#### What does this implement/fix? Explain your changes.
This PR coerces the name of the series to string before calling statsmodels


#### What should a reviewer concentrate their feedback on?

Is this the correct fix? Should `BaseForecaster` avoid passing non-string column names and series names to inner methods?

