### PR TITLE
[ENH] remove `numpy 2` dependency handler from `BaseObject`

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -151,59 +151,6 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         """,
     }
 
-    def __init__(self):
-        super().__init__()
-
-        # handle numpy 2 incompatible soft dependencies
-        # for rationale, see _handle_numpy2_softdeps
-        self._handle_numpy2_softdeps()
-
-    # TODO 0.36.0: check list of numpy 2 incompatible soft deps
-    # remove any from NOT_NP2_COMPATIBLE that become compatible
-    def _handle_numpy2_softdeps(self):
-        """Handle tags for soft deps that are not numpy 2 compatible.
-
-        A number of soft dependencies are not numpy 2 compatible yet,
-        but do not set the bound in their setup.py. This method is a patch over
-        those packages' missing bound setting to provide informative
-        errors to users.
-
-        This method does the following:
-
-        * checks if any soft dependencies in the python_dependencies tag
-          are in NOT_NP2_COMPATIBLE, this is a hard-coded
-          list of soft dependencies that are not numpy 2 compatible
-        * if any are found, adds a numpy<2.0 soft dependency to the list,
-          and sets it as a dynamic override of the python_dependencies tag
-        """
-        from packaging.requirements import Requirement
-
-        # pypi package names of soft dependencies that are not numpy 2 compatibleS
-        NOT_NP2_COMPATIBLE = ["pmdarima"]
-
-        softdeps = self.get_class_tag("python_dependencies", [])
-        if softdeps is None:
-            return None
-        if not isinstance(softdeps, list):
-            softdeps = [softdeps]
-        # make copy of list to avoid side effects
-        softdeps = softdeps.copy()
-
-        def _pkg_name(req):
-            """Get package name from requirement string."""
-            return Requirement(req).name
-
-        noncomp = False
-        for softdep in softdeps:
-            # variable: does any softdep string start with one of the non-compatibles
-            noncomp_sd = any([_pkg_name(softdep) == pkg for pkg in NOT_NP2_COMPATIBLE])
-            noncomp = noncomp or noncomp_sd
-
-        if noncomp:
-            softdeps = softdeps + ["numpy<2.0"]
-            self.set_tags(python_dependencies=softdeps)
-        return None
-
     def __eq__(self, other):
         """Equality dunder. Checks equal class and parameters.
 

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -23,7 +23,8 @@ class _PmdArimaAdapter(BaseForecaster):
         "capability:pred_int:insample": True,
         "requires-fh-in-fit": False,
         "handles-missing-data": True,
-        "python_dependencies": "pmdarima",
+        # TODO 0.37.0: check if numpy 2 incompatiblity can be removed
+        "python_dependencies": ["pmdarima", "numpy<2"],
     }
 
     def __init__(self):

--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -24,7 +24,7 @@ class _TbatsAdapter(BaseForecaster):
         "capability:pred_int:insample": True,
         "requires-fh-in-fit": False,
         "handles-missing-data": False,
-        "python_dependencies": "tbats",
+        "python_dependencies": ["tbats", "numpy<2"],
     }
 
     def __init__(

--- a/sktime/registry/tests/test_craft.py
+++ b/sktime/registry/tests/test_craft.py
@@ -102,7 +102,7 @@ def test_deps(spec):
     assert deps(pipe_spec_with_deps) == ["statsmodels"]
 
     # example with two dependencies, should be identified, order does not matter
-    assert set(deps(dunder_spec_with_deps)) == {"statsmodels", "pmdarima"}
+    assert set(deps(dunder_spec_with_deps)) == {"statsmodels", "pmdarima", "numpy<2"}
 
 
 def test_imports():


### PR DESCRIPTION
Half a year ago, we added the method `_handle_numpy2_softdeps` to handle dependencies that were not `numpy 2` compatible, but did not advertise that bound in their package dep bounds. The method was intended to be temporary, until packages move to declare their `numpy` bounds properly, or become compatible with `numpy 2`.

Most soft dependencies have moved to `numpy 2` compatibility, but `pmdarima` has not, and perhaps will not put this in their dependency bounds - it is the only such dependency remaining.

This PR removes the temporary utility and moves the bound into the `pmdarima` adapter.