### PR TITLE
[BUG] Standardize variable name 

### DIFF
--- a/sktime/datatypes/_convert_utils/_coerce.py
+++ b/sktime/datatypes/_convert_utils/_coerce.py
@@ -38,3 +38,35 @@ def _coerce_df_dtypes(obj):
         return obj
 
     return obj
+
+
+def _coerce_variable_name(obj: pd.Series | pd.DataFrame, prefix=""):
+    if isinstance(obj, pd.Series):
+        old_names = [obj.name]
+        obj.name = prefix + "var0"
+        new_names = [obj.name]
+    elif isinstance(obj, pd.DataFrame):
+        old_names = list(obj.columns)
+        obj.columns = [prefix + "var" + str(i) for i in range(len(obj.columns))]
+        new_names = list(obj.columns)
+    else:
+        return obj, [], []
+    return obj, old_names, new_names
+
+
+def _restore_variable_name(
+    obj: pd.Series | pd.DataFrame, old_names: list, new_names: list
+):
+    if isinstance(obj, pd.Series):
+        assert (
+            obj.name == new_names[0]
+        ), f"Series name: {obj.name} not match with new_names: {new_names}"
+        assert len(old_names) == 1, "len(old_names) must equal to 1 for series"
+        obj.name = old_names[0]
+    elif isinstance(obj, pd.DataFrame):
+        assert (
+            list(obj.columns) == new_names
+        ), f"DataFrame name(s): {obj.columns} not match with new_names: {new_names}"
+        obj.columns = old_names
+
+    return obj

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -92,7 +92,7 @@ def convert_MvS_to_UvS_as_Series(obj: pd.DataFrame, store=None) -> pd.Series:
         store["columns"] = obj.columns[[0]]
 
     y = obj[obj.columns[0]]
-
+    y.name = obj.index.name
     if (
         isinstance(store, dict) and "name" in store.keys()
     ):  ## column name becomes attr name

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -65,7 +65,7 @@ def convert_UvS_to_MvS_as_Series(obj: pd.Series, store=None) -> pd.DataFrame:
         store["name"] = obj.name
 
     res = pd.DataFrame(obj)
-
+    res.columns.name = obj.name
     if (
         isinstance(store, dict)
         and "columns" in store.keys()

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -92,7 +92,7 @@ def convert_MvS_to_UvS_as_Series(obj: pd.DataFrame, store=None) -> pd.Series:
         store["columns"] = obj.columns[[0]]
 
     y = obj[obj.columns[0]]
-    y.name = obj.index.name
+    y.name = obj.columns.name
     if (
         isinstance(store, dict) and "name" in store.keys()
     ):  ## column name becomes attr name

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -65,7 +65,7 @@ def convert_UvS_to_MvS_as_Series(obj: pd.Series, store=None) -> pd.DataFrame:
         store["name"] = obj.name
 
     res = pd.DataFrame(obj)
-    res.columns.names = [obj.name]
+    res.columns = [obj.name]
     if (
         isinstance(store, dict)
         and "columns" in store.keys()
@@ -92,7 +92,7 @@ def convert_MvS_to_UvS_as_Series(obj: pd.DataFrame, store=None) -> pd.Series:
         store["columns"] = obj.columns[[0]]
 
     y = obj[obj.columns[0]]
-    y.name = obj.columns.names[0]
+    y.name = obj.columns[0]
     if (
         isinstance(store, dict) and "name" in store.keys()
     ):  ## column name becomes attr name

--- a/sktime/datatypes/_series/_convert.py
+++ b/sktime/datatypes/_series/_convert.py
@@ -65,7 +65,7 @@ def convert_UvS_to_MvS_as_Series(obj: pd.Series, store=None) -> pd.DataFrame:
         store["name"] = obj.name
 
     res = pd.DataFrame(obj)
-    res.columns.name = obj.name
+    res.columns.names = [obj.name]
     if (
         isinstance(store, dict)
         and "columns" in store.keys()
@@ -92,7 +92,7 @@ def convert_MvS_to_UvS_as_Series(obj: pd.DataFrame, store=None) -> pd.Series:
         store["columns"] = obj.columns[[0]]
 
     y = obj[obj.columns[0]]
-    y.name = obj.columns.name
+    y.name = obj.columns.names[0]
     if (
         isinstance(store, dict) and "name" in store.keys()
     ):  ## column name becomes attr name

--- a/sktime/datatypes/tests/test_convert_bugfixes.py
+++ b/sktime/datatypes/tests/test_convert_bugfixes.py
@@ -36,6 +36,6 @@ def test_convert_MvS_UvS_as_Series():
     """Checks that column name in MvS is preserved as attr name in UvS"""
     y = load_airline()
     z = convert_UvS_to_MvS_as_Series(y)
-    assert y.name == z.columns.name
+    assert y.name == z.columns.names[0]
     w = convert_MvS_to_UvS_as_Series(z)
     assert y.name == w.name

--- a/sktime/datatypes/tests/test_convert_bugfixes.py
+++ b/sktime/datatypes/tests/test_convert_bugfixes.py
@@ -5,7 +5,10 @@ __author__ = ["fkiraly", "ericjb"]
 import pytest
 
 from sktime.datasets import load_airline
-from sktime.datatypes._series._convert import convert_MvS_to_UvS_as_Series
+from sktime.datatypes._series._convert import (
+    convert_MvS_to_UvS_as_Series,
+    convert_UvS_to_MvS_as_Series,
+)
 from sktime.tests.test_switch import run_test_module_changed
 
 
@@ -29,10 +32,10 @@ def test_multiindex_to_df_list_large_level_values():
     convert_to(X1, "df-list")
 
 
-def test_convert_MvS_to_UvS_as_Series():
+def test_convert_MvS_UvS_as_Series():
     """Checks that column name in MvS is preserved as attr name in UvS"""
     y = load_airline()
-    z = y.to_frame()
+    z = convert_UvS_to_MvS_as_Series(y)
+    assert y.name == z.columns.name
     w = convert_MvS_to_UvS_as_Series(z)
-
     assert y.name == w.name

--- a/sktime/datatypes/tests/test_convert_bugfixes.py
+++ b/sktime/datatypes/tests/test_convert_bugfixes.py
@@ -36,6 +36,6 @@ def test_convert_MvS_UvS_as_Series():
     """Checks that column name in MvS is preserved as attr name in UvS"""
     y = load_airline()
     z = convert_UvS_to_MvS_as_Series(y)
-    assert y.name == z.columns.names[0]
+    assert y.name == z.columns[0]
     w = convert_MvS_to_UvS_as_Series(z)
     assert y.name == w.name

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -6,9 +6,15 @@ __author__ = ["fkiraly", "mloning"]
 
 __all__ = ["ColumnEnsembleTransformer", "ColumnwiseTransformer"]
 
+from copy import deepcopy
+
 import pandas as pd
 
 from sktime.base._meta import _ColumnEstimator, _HeterogenousMetaEstimator
+from sktime.datatypes._convert_utils._coerce import (
+    _coerce_variable_name,
+    _restore_variable_name,
+)
 from sktime.transformations.base import BaseTransformer
 from sktime.utils._estimator_html_repr import _VisualBlock
 from sktime.utils.multiindex import rename_multiindex
@@ -271,6 +277,15 @@ class ColumnEnsembleTransformer(
 
         return transformers
 
+    def fit(self, X, y=None):
+        X, self._Xoldnames, self._Xnewnames = _coerce_variable_name(
+            deepcopy(X), prefix="X"
+        )
+        y, self._yoldnames, self._ynewnames = _coerce_variable_name(
+            deepcopy(y), prefix="y"
+        )
+        return super().fit(X, y)
+
     def _fit(self, X, y=None):
         """Fit transformer to X and y.
 
@@ -300,6 +315,17 @@ class ColumnEnsembleTransformer(
             self.transformers_.append((name, transformer_, index))
 
         return self
+
+    def transform(self, X, y=None):
+        X, self._Xoldnames, self._Xnewnames = _coerce_variable_name(
+            deepcopy(X), prefix="X"
+        )
+        y, self._yoldnames, self._ynewnames = _coerce_variable_name(
+            deepcopy(y), prefix="y"
+        )
+        X_out = super().transform(X, y)
+        X_out = _restore_variable_name(X_out, self._Xoldnames, self._Xnewnames)
+        return X_out
 
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.


### PR DESCRIPTION
fix https://github.com/sktime/sktime/issues/7948

This PR standardizes the variable name(s) for pd.Series and pd.DataFrame before passing it to `fit` and  `transform` and restore the original name(s) after `transform`.