### PR TITLE
[MNT] temporary skip of `MCDCNNClassifier` failing tests

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -152,9 +152,6 @@ EXCLUDED_TESTS = {
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
     ],
-    "MCDCNNClassifier": [
-        "test_fit_idempotent",
-    ],
     "MCDCNNRegressor": [
         "test_fit_idempotent",
     ],
@@ -251,6 +248,11 @@ EXCLUDED_TESTS = {
     "MACNNClassifier": [
         "test_multioutput",
         "test_classifier_on_unit_test_data",
+    ],
+    "MCDCNNClassifier": [
+        "test_multioutput",
+        "test_classifier_on_unit_test_data",
+        "test_fit_idempotent",  # not part of bug reports but due to randomness
     ],
 }
 


### PR DESCRIPTION
Skips the failing tests of `MCDCNNClassifier` temporarily until fixed, see #6465 and #7958