### PR TITLE
[BUG] `TimeSeriesKVisibility` - fix missing `python_dependencies` tag

### DIFF
--- a/sktime/clustering/kvisibility.py
+++ b/sktime/clustering/kvisibility.py
@@ -65,6 +65,7 @@ class TimeSeriesKvisibility(BaseClusterer):
         # --------------
         "authors": "seigpe",
         "maintainers": ["seigpe", "acoxonante"],
+        "python_dependencies": ["networkx", "ts2vg"],
         # estimator type
         # --------------
         "capability:multivariate": False,


### PR DESCRIPTION
Fixes the missing `python_dependencies` tag in `TimeSeriesKVisibility`.

Previoulsly masked due to the bug fixed in https://github.com/sktime/sktime/pull/7971.