### PR TITLE
[ENH] in tests, handle soft dependency in `BaseForecaster.predict_proba` on `skpro`

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -911,6 +911,7 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
                 "think this estimator should have the capability, please open "
                 "an issue on sktime."
             )
+        self.check_is_fitted()
 
         if hasattr(self, "_is_vectorized") and self._is_vectorized:
             raise NotImplementedError(
@@ -936,8 +937,6 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
 
         if non_default_pred_proba and not skpro_present:
             raise ImportError(msg)
-
-        self.check_is_fitted()
 
         # input checks and conversions
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -1334,6 +1334,11 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
                 scenario.run(estimator, method_sequence=[method_nsc])
             except NotImplementedError:
                 return None
+            except ImportError as e:
+                if "skpro" in str(e):
+                    return None
+                else:
+                    raise e
 
         # dict_after = dictionary of estimator after predict and fit
         output = scenario.run(estimator, method_sequence=[method_nsc])
@@ -1393,6 +1398,11 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
                 scenario.run(estimator, method_sequence=[method_nsc])
             except NotImplementedError:
                 return None
+            except ImportError as e:
+                if "skpro" in str(e):
+                    return None
+                else:
+                    raise e
 
         # Fit the model, get args before and after
         _, args_after = scenario.run(


### PR DESCRIPTION
In the "by-module" tests, the following condition could lead to unexpected failure:

something changes in two top level modules, and one of them is a `forecasting` estimator with a valid, non-standard `predict_proba` method - or one of the framework module.

The problem is that this combined change will lead to `TestAllEstimators` being executed in the non-forecasting cluster of tests, attempting to call `predict_proba` of the forecaster.

This requires `skpro` for representation of distributions, which is not installed in the non-forecasting test VM, producing an exception.

The change ensures that the test for `predict_proba` is not run if `skpro` is not present - it is present in the forecasting tests which will always run.