### PR TITLE
[BUG] fix `_HeterogenousEnsembleForecaster` parameter inspection

### DIFF
--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -112,7 +112,8 @@ class _HeterogenousMetaEstimator:
         if deep and hasattr(self, attr):
             estimators = getattr(self, attr)
             estimators = [(x[0], x[1]) for x in estimators]
-            out.update(estimators)
+            estimator_dict = {name: estimator for name, estimator in estimators}
+            out.update(estimator_dict)
             for name, estimator in estimators:
                 # checks estimator has the method we want to call
                 cond1 = hasattr(estimator, public_method)

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -26,7 +26,6 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
     _steps_fitted_attr = "forecasters_"
 
     def __init__(self, forecasters, n_jobs=None, fc_alt=None):
-
         if forecasters is not None:
             self.forecasters = forecasters
         self.n_jobs = n_jobs

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -27,8 +27,6 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
 
     def __init__(self, forecasters, n_jobs=None):
         self.forecasters = forecasters
-        if not isinstance(forecasters, (list, tuple)):
-            forecasters = [forecasters]
         self.forecasters_ = self._check_forecasters_init(forecasters)
         self.n_jobs = n_jobs
         super().__init__()
@@ -67,13 +65,8 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
         TypeError if not allow_postproc and forecaster is not last estimator
         """
         self_name = type(self).__name__
-        if not isinstance(estimators, list) or len(self.forecasters) == 0:
-            msg = (
-                f"steps in {self_name} must be list of estimators, "
-                f"or (string, estimator) pairs, "
-                f"the two can be mixed; but, found steps of type {type(estimators)}"
-            )
-            raise TypeError(msg)
+        if not isinstance(estimators, (list, tuple)):
+            estimators = [estimators]
 
         estimator_tuples = self._get_estimator_tuples(estimators, clone_ests=True)
         names, estimators = zip(*estimator_tuples)

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -35,7 +35,8 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
         else:
             fc = forecasters
 
-        self._initialize_forecaster_tuples(fc)
+        if forecasters is not None:
+            self._initialize_forecaster_tuples(fc)
 
     def _initialize_forecaster_tuples(self, forecasters):
         """Initialize estimator tuple attributes, default.

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -26,7 +26,9 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
     _steps_fitted_attr = "forecasters_"
 
     def __init__(self, forecasters, n_jobs=None, fc_alt=None):
-        self.forecasters = forecasters
+
+        if forecasters is not None:
+            self.forecasters = forecasters
         self.n_jobs = n_jobs
         super().__init__()
 

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -68,19 +68,16 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
         # validate names
         self._check_names(names)
         if not all([is_scitype(x, "forecaster") for x in estimators]):
-            raise TypeError(
-                f"estimators passed to {self_name} "
-                f"must be forecasters"
-            )
+            raise TypeError(f"estimators passed to {self_name} must be forecasters")
 
-        has_estimator = any(est not in (None, "drop") for est in estimatorss)
+        has_estimator = any(est not in (None, "drop") for est in estimators)
         if not has_estimator:
             raise ValueError(
                 "All estimators are dropped. At least one is required "
                 "to be an estimator."
             )
 
-        return estimator_tuples 
+        return estimator_tuples
 
     def _fit_forecasters(self, forecasters, y, X, fh):
         """Fit all forecasters in parallel."""

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -36,7 +36,7 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
         else:
             fc = forecasters
 
-        if forecasters is not None:
+        if fc is not None:
             self._initialize_forecaster_tuples(fc)
 
     def _initialize_forecaster_tuples(self, forecasters):
@@ -51,8 +51,8 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
         ----------
         forecasters : list of estimators, or list of (name, estimator) pairs
         """
-        self.forecasters_ = self._check_forecasters_init(forecasters)
-        self._forecasters = self._check_estimators(
+        self._forecasters = self._check_forecasters_init(forecasters)
+        self.forecasters_ = self._check_estimators(
             forecasters, clone_ests=True, allow_empty=True
         )
 

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -28,6 +28,7 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
     def __init__(self, forecasters, n_jobs=None):
         self.forecasters = forecasters
         self._forecasters = self._check_forecasters(forecasters)
+        self.forecasters_ = [(name, f.clone()) for name, f in self._forecasters]
         self.n_jobs = n_jobs
         super().__init__()
 

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -25,22 +25,34 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
     # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _steps_fitted_attr = "forecasters_"
 
-    def __init__(self, forecasters, n_jobs=None):
+    def __init__(self, forecasters, n_jobs=None, fc_alt=None):
         self.forecasters = forecasters
-        self.forecasters_ = self._check_forecasters_init(forecasters)
         self.n_jobs = n_jobs
         super().__init__()
 
-    @property
-    def _forecasters(self):
-        """Make internal list of forecasters.
+        if fc_alt is not None:
+            fc = fc_alt
+        else:
+            fc = forecasters
 
-        The list only contains the name and forecasters. This is for the implementation
-        of get_params via _HeterogenousMetaEstimator._get_params which expects lists of
-        tuples of len 2.
+        self._initialize_forecaster_tuples(fc)
+
+    def _initialize_forecaster_tuples(self, forecasters):
+        """Initialize estimator tuple attributes, default.
+
+        Initializes:
+
+        - self.forecasters_ from self.forecasters, this is coerced to a list of tuples
+        - self._forecasters from self.forecasters, same as above but also cloned
+
+        Parameters
+        ----------
+        forecasters : list of estimators, or list of (name, estimator) pairs
         """
-        forecasters = self.forecasters_
-        return [(name, forecaster) for name, forecaster in forecasters]
+        self.forecasters_ = self._check_forecasters_init(forecasters)
+        self._forecasters = self._check_estimators(
+            forecasters, clone_ests=True, allow_empty=True
+        )
 
     def _check_forecasters_init(self, estimators):
         """Check Steps.
@@ -68,20 +80,15 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
         if not isinstance(estimators, (list, tuple)):
             estimators = [estimators]
 
-        estimator_tuples = self._get_estimator_tuples(estimators, clone_ests=True)
-        names, estimators = zip(*estimator_tuples)
+        estimator_tuples = self._get_estimator_tuples(
+            estimators, clone_ests=False, allow_empty=True
+        )
+
+        estimators = [x[1] for x in estimator_tuples]
 
         # validate names
-        self._check_names(names)
         if not all([is_scitype(x, "forecaster") for x in estimators]):
             raise TypeError(f"estimators passed to {self_name} must be forecasters")
-
-        has_estimator = any(est not in (None, "drop") for est in estimators)
-        if not has_estimator:
-            raise ValueError(
-                "All estimators are dropped. At least one is required "
-                "to be an estimator."
-            )
 
         return estimator_tuples
 

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -27,12 +27,24 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
 
     def __init__(self, forecasters, n_jobs=None):
         self.forecasters = forecasters
-        self._forecasters = self._check_forecasters(forecasters)
-        self.forecasters_ = [(name, f.clone()) for name, f in self._forecasters]
+        if not isinstance(forecasters, (list, tuple)):
+            forecasters = [forecasters]
+        self.forecasters_ = self._check_forecasters_init(forecasters)
         self.n_jobs = n_jobs
         super().__init__()
 
-    def _check_forecasters(self, estimators):
+    @property
+    def _forecasters(self):
+        """Make internal list of forecasters.
+
+        The list only contains the name and forecasters. This is for the implementation
+        of get_params via _HeterogenousMetaEstimator._get_params which expects lists of
+        tuples of len 2.
+        """
+        forecasters = self.forecasters_
+        return [(name, forecaster) for name, forecaster in forecasters]
+
+    def _check_forecasters_init(self, estimators):
         """Check Steps.
 
         Parameters

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -80,9 +80,7 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
         if not isinstance(estimators, (list, tuple)):
             estimators = [estimators]
 
-        estimator_tuples = self._get_estimator_tuples(
-            estimators, clone_ests=False, allow_empty=True
-        )
+        estimator_tuples = self._get_estimator_tuples(estimators, clone_ests=False)
 
         estimators = [x[1] for x in estimator_tuples]
 

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -176,7 +176,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
         -------
         self : returns an instance of self.
         """
-        forecasters = [x[1] for x in self._forecasters]
+        forecasters = self._check_forecasters(y)
 
         self.forecasters_ = []
         self.y_columns = list(y.columns)

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -175,7 +175,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
         -------
         self : returns an instance of self.
         """
-        forecasters = self._check_forecasters(y)
+        forecasters = [x[1] for x in self._forecasters]
 
         self.forecasters_ = []
         self.y_columns = list(y.columns)

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -114,7 +114,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
     def __init__(self, forecasters):
         self.forecasters = forecasters
 
-        super().__init__(forecasters=forecasters)
+        super().__init__(forecasters=None)
 
         # set requires-fh-in-fit depending on forecasters
         if isinstance(forecasters, BaseForecaster):

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -113,6 +113,7 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
 
     def __init__(self, forecasters):
         self.forecasters = forecasters
+
         super().__init__(forecasters=forecasters)
 
         # set requires-fh-in-fit depending on forecasters

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -47,6 +47,7 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
     ----------
     forecasters : list of (str, estimator) tuples
         Estimators to apply to the input series.
+
     method : str, optional, default="feature-importance"
         Strategy used to compute weights. Available choices:
 
@@ -57,6 +58,7 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
             use the inverse variance of the forecasting error
             (based on the internal train-test-split) to compute optimal
             weights, a given ``regressor`` will be omitted.
+
     regressor : sklearn-like regressor, optional, default=None.
         Used to infer optimal weights from coefficients (linear models) or from
         feature importance scores (decision tree-based models). If None, then

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -147,7 +147,7 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
         -------
         self : returns an instance of self.
         """
-        _, forecasters = self._check_forecasters()
+        forecasters = [x[1] for x in self.forecasters_]
 
         # get training data for meta-model
         if X is not None:

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -114,9 +114,7 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
         self.by = by
         self.default = default
 
-        super().__init__(forecasters=forecasters)
-
-        self._initialize_forecaster_tuples(forecasters)
+        super().__init__(forecasters=None)
 
         if isinstance(forecasters, BaseForecaster):
             tags_to_clone = [

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -113,7 +113,10 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
         self.forecasters = forecasters
         self.by = by
         self.default = default
+
         super().__init__(forecasters=forecasters)
+
+        self._initialize_forecaster_tuples(forecasters)
 
         if isinstance(forecasters, BaseForecaster):
             tags_to_clone = [

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -93,7 +93,7 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
         -------
         self : returns an instance of self.
         """
-        _, forecasters = self._check_forecasters()
+        forecasters = [x[1] for x in self.forecasters_]
         self.regressor_ = check_regressor(
             regressor=self.regressor, random_state=self.random_state
         )

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -69,9 +69,10 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
     }
 
     def __init__(self, forecasters, regressor=None, random_state=None, n_jobs=None):
-        super().__init__(forecasters=forecasters, n_jobs=n_jobs)
         self.regressor = regressor
         self.random_state = random_state
+
+        super().__init__(forecasters=forecasters, n_jobs=n_jobs)
 
         self._anytagis_then_set("ignores-exogeneous-X", False, True, forecasters)
         self._anytagis_then_set("handles-missing-data", False, True, forecasters)

--- a/sktime/forecasting/online_learning/_online_ensemble.py
+++ b/sktime/forecasting/online_learning/_online_ensemble.py
@@ -66,7 +66,7 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
         -------
         self : returns an instance of self.
         """
-        names, forecasters = self._check_forecasters()
+        forecasters = [x[1] for x in self.forecasters_]
         self.weights = np.ones(len(forecasters)) / len(forecasters)
         self._fit_forecasters(forecasters, y, X, fh)
         return self


### PR DESCRIPTION
`_HeterogenousEnsembleForecaster` parameter inspection did not work as intended as the initial coercion to name/estimator pairs was buggy. This is fixed