### PR TITLE
[MNT] temporary skip of `VARMAX` tests due to timeout

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -184,6 +184,8 @@ EXCLUDED_TESTS = {
     "VARMAX": [
         "test_update_predict_single",  # see 2997, sporadic failure, unknown cause
         "test__y_when_refitting",  # see 3176
+        "test_update_predict_predicted_index",  # see 7985, timeout
+        "test_hierarchical_with_exogeneous",  # see 7985, timeout
     ],
     "InformationGainSegmentation": [
         "test_inheritance",


### PR DESCRIPTION
Temporary skip of `VARMAX` tests due to sporadic timeout, see #7965