### PR TITLE
[MNT] move release to trusted publishers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Print changed files
         run: |
-          echo "Changed files: $CHANGED_FILES"
+          echo "Changed files:" && echo "$CHANGED_FILES" | tr ' ' '\n'
 
       - name: Run pre-commit on changed files
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -109,3 +109,5 @@ jobs:
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -98,6 +98,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_wheels,test_unix_wheels,test_windows_wheels]
 
+    permissions:
+      id-token: write
+
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -106,6 +109,3 @@ jobs:
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages-dir: wheelhouse/


### PR DESCRIPTION
Moves the release to trusted publishers.

All secrets have been removed from the repo.