### PR TITLE
[MNT] temporary skip of `pytorch-forecasting` tests until resolution of #7997

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -50,6 +50,11 @@ EXCLUDE_ESTIMATORS = [
     "DartsXGBModel",
     # Large datasets
     "M5Dataset",
+    # ptf global models fail the tests, see #7997
+    "PytorchForecastingTFT",
+    "PytorchForecastingNBeats",
+    "PytorchForecastingNHiTS",
+    "PytorchForecastingDeepAR",
 ]
 
 


### PR DESCRIPTION
This PR skips the `pytorch-forecasting` estimators temporarily until the bug in #7997 is resolved.