### PR TITLE
DIAGNOSTIC: test differential testing 2

### DIFF
--- a/sktime/forecasting/naive.py
+++ b/sktime/forecasting/naive.py
@@ -31,7 +31,7 @@ from sktime.utils.validation.forecasting import check_sp
 from sktime.utils.warnings import warn
 
 
-class NaiveForecaster(_BaseWindowForecaster):
+class NaiveForecaster(_BaseWindowForecaster):  # foo
     """Forecast based on naive assumptions about past trends continuing.
 
     NaiveForecaster is a forecaster that makes forecasts using simple

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -262,9 +262,8 @@ def _run_test_for_class(cls):
     # if the object is an sktime BaseObject, and one of the core framework modules
     # datatypes, tests, utils have changed, then run the test
     datatypes_changed = is_module_changed("sktime.datatypes")
-    tests_changed = is_module_changed("sktime.tests")
     utils_changed = is_module_changed("sktime.utils")
-    if any([datatypes_changed, tests_changed, utils_changed]):
+    if any([datatypes_changed, utils_changed]):
         return True, "True_changed_framework"
 
     # if none of the conditions are met, do not run the test


### PR DESCRIPTION
Diagnostic for checking the differential testing logic.

This PR should test only the `Padder`.

The condition "`sktime.tests` has changed" is removed.