### PR TITLE
[BUG] fix `_HeterogenousMetaForecaster` handling of `forecasters_`

### DIFF
--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -96,6 +96,10 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
         """Return list of forecasters."""
         return [x[1] for x in self.forecasters_]
 
+    def _get_forecaster_names(self):
+        """Return list of forecaster names."""
+        return [x[0] for x in self.forecasters_]
+
     def _fit_forecasters(self, forecasters, y, X, fh):
         """Fit all forecasters in parallel.
 
@@ -110,11 +114,15 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
             """Fit single forecaster."""
             return forecaster.fit(y, X, fh)
 
+        if forecasters is None:
+            forecasters = self._get_forecaster_list()
+
         fitted_fcst = Parallel(n_jobs=self.n_jobs)(
             delayed(_fit_forecaster)(forecaster.clone(), y, X, fh)
             for forecaster in forecasters
         )
-        self.forecasters_ = list(zip(self._get_forecaster_list(), fitted_fcst))
+        fcst_names = self._get_forecaster_names()
+        self.forecasters_ = list(zip(fcst_names, fitted_fcst))
 
     def _predict_forecasters(self, fh=None, X=None, forecasters=None):
         """Collect results from forecaster.predict() calls."""

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -93,14 +93,20 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
         return estimator_tuples
 
     def _fit_forecasters(self, forecasters, y, X, fh):
-        """Fit all forecasters in parallel."""
+        """Fit all forecasters in parallel.
+
+        Returns
+        -------
+        list of references to fitted forecasters
+            in same order as forecasters
+        """
         from joblib import Parallel, delayed
 
         def _fit_forecaster(forecaster, y, X, fh):
             """Fit single forecaster."""
             return forecaster.fit(y, X, fh)
 
-        self.forecasters_ = Parallel(n_jobs=self.n_jobs)(
+        return Parallel(n_jobs=self.n_jobs)(
             delayed(_fit_forecaster)(forecaster.clone(), y, X, fh)
             for forecaster in forecasters
         )

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -112,7 +112,7 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
         )
         self.forecasters_ = list(zip([x[0] for x in self.forecasters_], fitted_fcst))
 
-    def _predict_forecasters(self, forecasters=None, fh=None, X=None):
+    def _predict_forecasters(self, fh=None, X=None, forecasters=None):
         """Collect results from forecaster.predict() calls."""
         if forecasters is None:
             forecasters = [x[1] for x in self.forecasters_]

--- a/sktime/forecasting/base/_meta.py
+++ b/sktime/forecasting/base/_meta.py
@@ -92,6 +92,10 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
 
         return estimator_tuples
 
+    def _get_forecaster_list(self):
+        """Return list of forecasters."""
+        return [x[1] for x in self.forecasters_]
+
     def _fit_forecasters(self, forecasters, y, X, fh):
         """Fit all forecasters in parallel.
 
@@ -110,12 +114,12 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
             delayed(_fit_forecaster)(forecaster.clone(), y, X, fh)
             for forecaster in forecasters
         )
-        self.forecasters_ = list(zip([x[0] for x in self.forecasters_], fitted_fcst))
+        self.forecasters_ = list(zip(self._get_forecaster_list(), fitted_fcst))
 
     def _predict_forecasters(self, fh=None, X=None, forecasters=None):
         """Collect results from forecaster.predict() calls."""
         if forecasters is None:
-            forecasters = [x[1] for x in self.forecasters_]
+            forecasters = self._get_forecaster_list()
         return [forecaster.predict(fh=fh, X=X) for forecaster in forecasters]
 
     def _update(self, y, X=None, update_params=True):
@@ -131,6 +135,6 @@ class _HeterogenousEnsembleForecaster(_HeterogenousMetaEstimator, BaseForecaster
         -------
         self : an instance of self.
         """
-        for forecaster in self.forecasters_:
+        for forecaster in self._get_forecaster_list():
             forecaster.update(y, X, update_params=update_params)
         return self

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -328,18 +328,6 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
         "scitype:y": "both",
     }
 
-    # for default get_params/set_params from _HeterogenousMetaEstimator
-    # _steps_attr points to the attribute of self
-    # which contains the heterogeneous set of estimators
-    # this must be an iterable of (name: str, estimator, ...) tuples for the default
-    _steps_attr = "_forecasters"
-
-    # if the estimator is fittable, _HeterogenousMetaEstimator also
-    # provides an override for get_fitted_params for params from the fitted estimators
-    # the fitted estimators should be in a different attribute, _steps_fitted_attr
-    # this must be an iterable of (name: str, estimator, ...) tuples for the default
-    _steps_fitted_attr = "forecasters_"
-
     def __init__(self, forecasters, n_jobs=None, aggfunc="mean", weights=None):
         self.aggfunc = aggfunc
         self.weights = weights
@@ -391,8 +379,7 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
         -------
         self : returns an instance of self.
         """
-        forecasters = [f[1] for f in self._forecasters]
-        self._fit_forecasters(forecasters, y, X, fh)
+        self._fit_forecasters(None, y, X, fh)
         return self
 
     def _predict(self, fh, X):

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -143,7 +143,7 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
         """
         if update_params:
             warn("Updating `final regressor is not implemented", obj=self)
-        for forecaster in self.forecasters_:
+        for forecaster in self._get_forecaster_list():
             forecaster.update(y, X, update_params=update_params)
         return self
 

--- a/sktime/forecasting/online_learning/_online_ensemble.py
+++ b/sktime/forecasting/online_learning/_online_ensemble.py
@@ -107,7 +107,7 @@ class OnlineEnsembleForecaster(EnsembleForecaster):
         if len(y) >= 1 and self.ensemble_algorithm is not None:
             self._fit_ensemble(y, X)
 
-        for forecaster in self.forecasters_:
+        for forecaster in self._get_forecaster_list():
             forecaster.update(y, X, update_params=update_params)
 
         return self


### PR DESCRIPTION
`_HeterogenousMetaForecaster` descendants would have a bug where the `forecasters_` attribute was populated by `_fit_forecasters` with a list of forecasters, not with the expected list of (name, estimator) pairs.

This impacted `get_fitted_params` and general usage, this should now be fixed.