### PR TITLE
[ENH] handle `BaseForecaster.predict_proba` `skpro` dependency in `TestAllEstimators`

### DIFF
--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -9,7 +9,6 @@ __author__ = ["mloning", "fkiraly", "achieveordie"]
 import numbers
 import os
 import types
-from contextlib import contextmanager
 from copy import deepcopy
 from inspect import getfullargspec, isclass, signature
 from tempfile import TemporaryDirectory
@@ -98,6 +97,7 @@ def subsample_by_version_os(x):
 
 class ValidProbaErrors:
     """Context manager, returns None on valid predict_proba or skpro exception."""
+
     def __enter__(self):
         self.skipped = False
         return self

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -1531,11 +1531,15 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
         if "n_jobs" not in params:
             return None
 
-        # escape predict_proba etc for forecasters if skpro is not available
+        # skip test for predict_proba
+        # this produces a BaseDistribution object, for which no ready
+        # equality check is implemented
         is_forecaster = scitype(estimator_instance) == "forecaster"
-        proba_methods = ["predict_proba", "predict_var"]
+        if is_forecaster and method_nsc == "predict_proba":
+            return None
+        # escape predict_proba etc for forecasters if skpro is not available
         skpro_available = _check_soft_dependencies("skpro", severity="none")
-        if is_forecaster and method_nsc in proba_methods and not skpro_available:
+        if is_forecaster and method_nsc == "predict_var" and not skpro_available:
             return None
 
         # run on a single process


### PR DESCRIPTION
`BaseForecaster.predict_proba` depends on `skpro`, which can cause "`skpro` not present" exceptions in `TestAllEstimators` run on a forecaster when called in an environment that does not contain `skpro`.

In the current CI this happens only in the rare case when forecasters are collected in a non-forecaster CI batch, it still should be handled as these are unexpected failures.