### PR TITLE
[MNT] temporary skip of `STDBSCAN` clusterer

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -55,6 +55,8 @@ EXCLUDE_ESTIMATORS = [
     "PytorchForecastingNBeats",
     "PytorchForecastingNHiTS",
     "PytorchForecastingDeepAR",
+    # STDBSCAN is not API compliant, see #7994
+    "STDBSCAN",
 ]
 
 


### PR DESCRIPTION
Temporarily skips `STDBSCAN` clusterer, until #7994 is resolved.