### PR TITLE
[BUG] fix `Series`-to-`Primitives` transformer output index for hierarchical data

### DIFF
--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1401,8 +1401,8 @@ class BaseTransformer(BaseEstimator):
             # which always has the entry 0.
             # in this case, we need to strip this level
             Xt_has_superfluous_zero_level = (
-                X_input_scitype == "Series"
-                and self._is_vectorized
+                X_input_scitype != "Series"
+                and case == "case 3: requires vectorization"
                 and isinstance(Xt, (pd.DataFrame, pd.Series))
             )
             # we ensure the output is pd_DataFrame_Table

--- a/sktime/transformations/tests/test_base.py
+++ b/sktime/transformations/tests/test_base.py
@@ -848,7 +848,7 @@ def test_series_to_primitives_hierarchical():
     from sktime.clustering.dbscan import TimeSeriesDBSCAN
     from sktime.registry import coerce_scitype
 
-    X = _make_hierarchical()
+    # example of Series-to-Primitives supporting Hierarchical
     clust = TimeSeriesDBSCAN.create_test_instance()
     est = coerce_scitype(clust, "transformer")
 
@@ -859,7 +859,9 @@ def test_series_to_primitives_hierarchical():
     assert est.get_tag("scitype:transform-input") == "Series"
     assert est.get_tag("scitype:transform-output") == "Primitives"
 
+    X = _make_hierarchical()
     Xt = est.fit_transform(X)
+    ix = Xt.index
 
     # check that Xt.index is the same as X.index with time level dropped and made unique
     assert (X.index.droplevel(-1).unique() == ix).all()

--- a/sktime/transformations/tests/test_base.py
+++ b/sktime/transformations/tests/test_base.py
@@ -837,7 +837,7 @@ def test_series_to_primitives_hierarchical():
     assert est.get_tag("scitype:transform-input") == "Series"
     assert est.get_tag("scitype:transform-output") == "Primitives"
 
-    X =_make_hierarchical()
+    X = _make_hierarchical()
     Xt = est.fit_transform(X)
     ix = Xt.index
 
@@ -848,10 +848,18 @@ def test_series_to_primitives_hierarchical():
     from sktime.clustering.dbscan import TimeSeriesDBSCAN
     from sktime.registry import coerce_scitype
 
-    X =_make_hierarchical()
-    transformer = TimeSeriesDBSCAN.create_test_instance()
-    transformer = coerce_scitype(transformer, "transformer")
-    Xt = transformer.fit_transform(X)
+    X = _make_hierarchical()
+    clust = TimeSeriesDBSCAN.create_test_instance()
+    est = coerce_scitype(clust, "transformer")
+
+    # ensure est is a good example, if this fails, choose another example
+    #   (if this changes, it may be due to implementing more scitypes)
+    #   (then this is not a failure of est, but we need to choose another example)
+    assert "Hierarchical" in inner_X_scitypes(est)
+    assert est.get_tag("scitype:transform-input") == "Series"
+    assert est.get_tag("scitype:transform-output") == "Primitives"
+
+    Xt = est.fit_transform(X)
 
     # check that Xt.index is the same as X.index with time level dropped and made unique
     assert (X.index.droplevel(-1).unique() == ix).all()


### PR DESCRIPTION
In a combination of cases the `Series`-to-`Primitives` transformer would not correctly handle the output data and drop the last index element unexpectedly. This would happen if:

* a `Series`-to-`Primitives` transformer
* supports `Panel` and `Hierarchical` data natively
* and is passed a hierarchical `pd.DataFrame` to `fit_transform`

This is one of the root causes of https://github.com/sktime/sktime/issues/8012, fixes https://github.com/sktime/sktime/issues/8038

The fix is to catch the condition exactly. The reason for the failure is that we need to deal with two cases separately:

* vectorization causes a new level of "all-zeroes" to appear. This happens exactly if a `Series` is vectorized, because this would result in an abstract "zero-level index", i.e., just a vector without index. `pandas` cannot represent that, so it returns a 1-row-`DataFrame` which has a row index containing the integer 0.
    * in this case, we need to remove the superfluous level after vectorization
* in all other cases - which were erroneously not dealt with (as they did not exist in the code base so far?) there is no superfuous index level to remove.