### PR TITLE
[DOC] add clear reference to `ReconcilerForecaster` in `Reconciler` documentation

### DIFF
--- a/sktime/transformations/hierarchical/reconcile.py
+++ b/sktime/transformations/hierarchical/reconcile.py
@@ -30,16 +30,20 @@ class Reconciler(BaseTransformer):
     after prediction. However they are general and can be used to transform
     hierarchical time-series data.
 
-    Please refer to [1]_ for further information
+    For reconciliation methods that require historical values in addition to the
+    forecasts, such as MinT, see the ``ReconcilerForecaster`` class.
+
+    For further information on the methods, see [1]_.
 
     Parameters
     ----------
     method : {"bu", "ols", "wls_str", "td_fcst"}, default="bu"
         The reconciliation approach applied to the forecasts
-            "bu" - bottom-up
-            "ols" - ordinary least squares
-            "wls_str" - weighted least squares (structural)
-            "td_fcst" - top down based on (forecast) proportions
+
+        * ``"bu"`` - bottom-up
+        * ``"ols"`` - ordinary least squares
+        * ``"wls_str"`` - weighted least squares (structural)
+        * ``"td_fcst"`` - top down based on (forecast) proportions
 
     See Also
     --------


### PR DESCRIPTION
This PR adds a clear reference to `ReconcilerForecaster` in the `Reconciler` documentation, and also solves some formatting issues.