### PR TITLE
[BUG] Fix serialization errors in tests of `MACNNClassifier`

### DIFF
--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -4,11 +4,11 @@ __author__ = ["jnrusson1"]
 
 from sktime.networks.base import BaseDeepNetwork
 from sktime.utils.dependencies import _check_dl_dependencies
+
 if _check_dl_dependencies(severity=None):
     from tensorflow import keras
 else:
     keras = None
-
 
 
 class MACNNNetwork(BaseDeepNetwork):
@@ -82,7 +82,6 @@ class MACNNNetwork(BaseDeepNetwork):
         block_output: An instance of keras.layers.Layer
             Represents the last layer of a MACNN Block, to be used by the next block.
         """
-
         conv_layers = []
         for kernel_size in self.kernel_size:
             conv_layer = keras.layers.Conv1D(

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -5,7 +5,7 @@ __author__ = ["jnrusson1"]
 from sktime.networks.base import BaseDeepNetwork
 from sktime.utils.dependencies import _check_dl_dependencies
 
-if _check_dl_dependencies(severity=None):
+if _check_dl_dependencies(severity="none"):
     from tensorflow import keras
 else:
     keras = None

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -5,11 +5,6 @@ __author__ = ["jnrusson1"]
 from sktime.networks.base import BaseDeepNetwork
 from sktime.utils.dependencies import _check_dl_dependencies
 
-if _check_dl_dependencies(severity="none"):
-    from tensorflow import keras
-else:
-    keras = None
-
 
 class MACNNNetwork(BaseDeepNetwork):
     """Base MACNN Network for MACNNClassifier and MACNNRegressor.
@@ -82,6 +77,8 @@ class MACNNNetwork(BaseDeepNetwork):
         block_output: An instance of keras.layers.Layer
             Represents the last layer of a MACNN Block, to be used by the next block.
         """
+        from tensorflow import keras
+
         conv_layers = []
         for kernel_size in self.kernel_size:
             conv_layer = keras.layers.Conv1D(

--- a/sktime/networks/macnn.py
+++ b/sktime/networks/macnn.py
@@ -4,6 +4,11 @@ __author__ = ["jnrusson1"]
 
 from sktime.networks.base import BaseDeepNetwork
 from sktime.utils.dependencies import _check_dl_dependencies
+if _check_dl_dependencies(severity=None):
+    from tensorflow import keras
+else:
+    keras = None
+
 
 
 class MACNNNetwork(BaseDeepNetwork):
@@ -77,7 +82,6 @@ class MACNNNetwork(BaseDeepNetwork):
         block_output: An instance of keras.layers.Layer
             Represents the last layer of a MACNN Block, to be used by the next block.
         """
-        from tensorflow import keras
 
         conv_layers = []
         for kernel_size in self.kernel_size:
@@ -91,7 +95,7 @@ class MACNNNetwork(BaseDeepNetwork):
         x1 = keras.layers.BatchNormalization()(x1)
         x1 = keras.layers.Activation("relu")(x1)
 
-        x2 = keras.layers.Lambda(lambda y: keras.backend.mean(y, axis=1))(x1)
+        x2 = keras.layers.GlobalAveragePooling1D()(x1)
         x2 = keras.layers.Dense(
             units=int(kernels * 3 / reduce), use_bias=False, activation="relu"
         )(x2)


### PR DESCRIPTION

#### Reference Issues/PRs
See error in CI pipeline: [test_save_estimators_to_file](https://github.com/sktime/sktime/actions/runs/14115519712/job/39553508329?pr=7603)


#### What does this implement/fix? Explain your changes.
Removes the keras module from the pickled objects and replaces backend.mean by AveragePooling
