### PR TITLE
[ENH] `_safe_import` to allow multiple inheritance from multiple mock classes

### DIFF
--- a/sktime/utils/_testing/tests/test_safe_import.py
+++ b/sktime/utils/_testing/tests/test_safe_import.py
@@ -59,3 +59,18 @@ def test_import_existing_object():
     from pandas import DataFrame
 
     assert result is DataFrame
+
+
+def test_multiple_inheritance_from_mock():
+    """Test multiple inheritance from dynamic MagicMock."""
+    Class1 = _safe_import("foobar.foo.FooBar")
+    Class2 = _safe_import("barfoobar.BarFooBar")
+
+    class NewClass(Class1, Class2):
+        """This should not trigger an error.
+
+        The class definition would trigger an error if multiple inheritance
+        from Class1 and Class2 does not work, e.g., if it is simply
+        identical to MagicMock.
+        """
+        pass

--- a/sktime/utils/dependencies/_safe_import.py
+++ b/sktime/utils/dependencies/_safe_import.py
@@ -60,6 +60,7 @@ def _safe_import(import_path, pkg_name=None):
 
     if pkg_name is None:
         pkg_name = path_list[0]
+    obj_name = path_list[-1]
 
     if _check_soft_dependencies(pkg_name, severity="none"):
         try:
@@ -71,8 +72,33 @@ def _safe_import(import_path, pkg_name=None):
         except (ImportError, AttributeError):
             return importlib.import_module(import_path)
     else:
-        mock_obj = MagicMock()
+        mock_obj = _create_mock_class(obj_name)
         mock_obj.__str__.return_value = (
             f"Please install {pkg_name} to use this functionality."
         )
         return mock_obj
+
+
+def _create_mock_class(name: str, bases=()):
+    """Create new dynamic mock class similar to MagicMock.
+
+    Parameters
+    ----------
+    name : str
+        The name of the new class.
+    bases : tuple, default=()
+        The base classes of the new class.
+
+    Returns
+    -------
+    a new class that behaves like MagicMock, with name ``name``.
+        Forwards all attribute access to a MagicMock object stored in the instance.
+    """
+    class_dict = {
+        "__init__": lambda self, *args, **kwargs: setattr(self, "_m_o_ck", MagicMock()),
+        "__getattr__": lambda self, name: getattr(self._m_o_ck, name),
+        "__setattr__": lambda self, name, value: setattr(self._m_o_ck, name, value)
+        if name != "_m_o_ck" else object.__setattr__(self, name, value),
+    }
+
+    return type(name, bases, class_dict)


### PR DESCRIPTION
In https://github.com/sktime/sktime/issues/8055 and https://github.com/sktime/sktime/pull/7869, @PranavBhatP reported that `_safe_import` will fail under specific circumsatnces to behave like the imported object if it is not available, namely:

* two classes are safe-imported, and
* another class is defined that inherits from both (directly or indirectly)

This would fail, as the resulting class has `MagicMock` in its inheritance tree.

This PR fixes #8055 by ensuring that classes imported by `_safe_import` are dynamic, with the same behaviour as `MagicMock`, rather than `MagicMock` itself.

A test is added with the minimal failure case of #8055.