### PR TITLE
[ENH] Add temporal global split to evaluate

### DIFF
--- a/sktime/benchmarking/_benchmarking_dataclasses.py
+++ b/sktime/benchmarking/_benchmarking_dataclasses.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from sktime.benchmarking.base import BaseMetric
 from sktime.split.base._base_splitter import BaseSplitter
+from sktime.split.singlewindow import SingleWindowSplitter
 
 
 def _coerce_data_for_evaluate(dataset_loader):
@@ -54,6 +55,13 @@ class TaskObject:
         Splitter used for generating global cross-validation folds.
     error_score: str, optional (default="raise")
         The error score strategy to use.
+    cv_global_temporal:  SingleWindowSplitter, default=None
+        ignored if cv_global is None. If passed, it splits the Panel temporally
+        before the instance split from cv_global is applied. This avoids
+        temporal leakage in the global evaluation across time series.
+        Has to be a SingleWindowSplitter.
+        cv is applied on the test set of the combined application of
+        cv_global and cv_global_temporal.
     """
 
     data: Union[Callable, tuple]
@@ -63,6 +71,7 @@ class TaskObject:
     cv_X = None
     cv_global: Optional[BaseSplitter] = None
     error_score: str = "raise"
+    cv_global_temporal: Optional[SingleWindowSplitter] = None
 
     def get_y_X(self):
         """Get the endogenous and exogenous data."""

--- a/sktime/benchmarking/forecasting.py
+++ b/sktime/benchmarking/forecasting.py
@@ -22,6 +22,7 @@ from sktime.forecasting.base import BaseForecaster
 from sktime.forecasting.model_evaluation import evaluate
 from sktime.performance_metrics.base import BaseMetric
 from sktime.split.base import BaseSplitter
+from sktime.split.singlewindow import SingleWindowSplitter
 from sktime.utils.unique_str import _make_strings_unique
 from sktime.utils.warnings import warn
 
@@ -429,6 +430,7 @@ class ForecastingBenchmark(BaseBenchmark):
         cv_global: Optional[BaseSplitter] = None,
         error_score: str = "raise",
         strategy: str = "refit",
+        cv_global_temporal: Optional[SingleWindowSplitter] = None,
     ):
         """Register a forecasting task to the benchmark.
 
@@ -476,6 +478,13 @@ class ForecastingBenchmark(BaseBenchmark):
             in sequence provided
             "no-update_params" = fit to first training window, re-used without
             fit or update
+        cv_global_temporal:  SingleWindowSplitter, default=None
+            ignored if cv_global is None. If passed, it splits the Panel temporally
+            before the instance split from cv_global is applied. This avoids
+            temporal leakage in the global evaluation across time series.
+            Has to be a SingleWindowSplitter.
+            cv is applied on the test set of the combined application of
+            cv_global and cv_global_temporal.
 
         Returns
         -------
@@ -504,6 +513,7 @@ class ForecastingBenchmark(BaseBenchmark):
             "scorers": scorers,
             "cv_global": cv_global,
             "error_score": error_score,
+            "cv_global_temporal": cv_global_temporal,
         }
         self._add_task(
             task_id,
@@ -572,6 +582,7 @@ class ForecastingBenchmark(BaseBenchmark):
             cv_global=task.cv_global,
             strategy=task.strategy,
             return_model=False,
+            cv_global_temporal=task.cv_global_temporal,
         )
 
         folds = {}

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -366,6 +366,7 @@ def evaluate(
     backend_params: Optional[dict] = None,
     return_model: bool = False,
     cv_global=None,
+    cv_global_temporal=None,
 ):
     r"""Evaluate forecaster using timeseries cross-validation.
 
@@ -540,6 +541,13 @@ def evaluate(
                 forecaster.fit(y=y_train, fh=cv.fh)
                 y_pred = forecaster.predict(y=y_past)
                 metric(y_true, y_pred)
+        cv_global_temporal:  SingleWindowSplitter, default=None
+            ignored if cv_global is None. If passed, it splits the Panel temporally
+            before the instance split from cv_global is applied. This avoids
+            temporal leakage in the global evaluation across time series.
+            Has to be a SingleWindowSplitter.
+            cv is applied on the test set of the combined application of
+            cv_global and cv_global_temporal.
 
     Returns
     -------
@@ -715,7 +723,7 @@ def evaluate(
             for (y_train, y_test), (X_train, X_test) in zip(geny, genx):
                 yield y_train, y_test, X_train, X_test
 
-    def gen_y_X_train_test_global(y, X, cv, cv_X, cv_global):
+    def gen_y_X_train_test_global(y, X, cv, cv_X, cv_global, cv_global_temporal):
         """Generate joint splits of y, X as per cv, cv_X.
 
         If X is None, train/test splits of X are also None.
@@ -737,34 +745,43 @@ def evaluate(
         if not isinstance(cv_global, InstanceSplitter):
             cv_global = InstanceSplitter(cv_global)
 
-        if cv_X is not None:
-            assert isinstance(cv_X, SingleWindowSplitter), (
-                "cv_X must be an instance of sktime.split.SingleWindowSplitter"
-            )
-        assert isinstance(cv, SingleWindowSplitter), (
-            "cv must be an instance of sktime.split.SingleWindowSplitter"
-        )
+        if cv_global_temporal is not None:
+            assert isinstance(cv_global_temporal, SingleWindowSplitter)
 
         geny = cv_global.split_series(y)
         if X is None:
             for y_train, y_test in geny:
-                y_hist, y_true = next(cv.split_series(y_test))
-                yield y_train, y_hist, y_true, None, None
+                if cv_global_temporal is not None:
+                    y_train, _ = next(cv_global_temporal.split_series(y_train))
+                    _, y_test = next(cv_global_temporal.split_series(y_test))
+                for y_hist, y_true in cv.split_series(y_test):
+                    yield y_train, y_hist, y_true, None, None
         else:
-            if cv_X is None:
-                from sktime.split import SameLocSplitter
-
-                cv_X = SameLocSplitter(cv, y)
+            from sktime.split import SameLocSplitter, TestPlusTrainSplitter
 
             genx = SameLocSplitter(cv_global, y).split_series(X)
 
             for (y_train, y_test), (X_train, X_test) in zip(geny, genx):
-                y_hist, y_true = next(cv.split_series(y_test))
-                yield y_train, y_hist, y_true, X_train, X_test
+                if cv_global_temporal is not None:
+                    y_train, _ = next(cv_global_temporal.split_series(y_train))
+                    X_train, _ = next(cv_global_temporal.split_series(X_train))
+                    _, y_test = next(cv_global_temporal.split_series(y_test))
+                    _, X_test = next(cv_global_temporal.split_series(X_test))
+                if cv_X is None:
+                    _cv_X = TestPlusTrainSplitter(SameLocSplitter(cv, y_test))
+                else:
+                    _cv_X = cv_X
+                for (y_hist, y_true), (_, X_future) in zip(
+                    cv.split_series(y_test), _cv_X.split_series(X_test)
+                ):
+                    # X_hist is not used in the evaluation
+                    yield y_train, y_hist, y_true, X_train, X_future
 
     # generator for y and X splits to iterate over below
     if cv_global is not None:
-        yx_splits = gen_y_X_train_test_global(y, X, cv, cv_X, cv_global=cv_global)
+        yx_splits = gen_y_X_train_test_global(
+            y, X, cv, cv_X, cv_global=cv_global, cv_global_temporal=cv_global_temporal
+        )
     else:
         yx_splits = gen_y_X_train_test(y, X, cv, cv_X)
 


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Towards #8063 


#### What does this implement/fix? Explain your changes.
* Enables the usage of SlidingWindowSplitter etc. as cv when being in global mode.
* Enables the usage of Temporal splitting the instance split that is used for testing. This avoids temporal data leakage across different time series.
* Add test for testing the behaviour of the temporal splitting


The interface is a bit complicated. Not sure, how this can be solved, or if someone has a better idea.