### PR TITLE
[ENH] change `imports` utility to produce public import paths

### DIFF
--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -163,7 +163,8 @@ def imports(spec):
             )
         cls = register[x]
 
-        import_str = f"from {cls.__module__} import {x}"
+        import_module = _get_public_import(cls.__module__)
+        import_str = f"from {import_module} import {x}"
         import_strs += [import_str]
 
     if len(import_strs) == 0:
@@ -172,3 +173,15 @@ def imports(spec):
         imports_str = "\n".join(sorted(import_strs))
 
     return imports_str
+
+
+def _get_public_import(module_path: str) -> str:
+    """Get the public import path from full import path.
+
+    Removes everything from the first private submodule (starting with '_') onwards.
+    """
+    parts = module_path.split(".")
+    for i, part in enumerate(parts):
+        if part.startswith("_"):
+            return ".".join(parts[:i])  # Keep only part before first private submodule
+    return module_path  # Return the original path if no private submodules are found

--- a/sktime/registry/tests/test_craft.py
+++ b/sktime/registry/tests/test_craft.py
@@ -111,9 +111,9 @@ def test_imports():
     assert imports(simple_spec) == simple_spec_imports
 
     pipe_imports = (
-        "from sktime.forecasting.compose._pipeline import TransformedTargetForecast"
+        "from sktime.forecasting.compose import TransformedTargetForecast"
         "er\nfrom sktime.forecasting.exp_smoothing import ExponentialSmoothing\nfrom"
-        " sktime.forecasting.model_selection._tune import ForecastingGridSearch"
+        " sktime.forecasting.model_selection import ForecastingGridSearch"
         "CV\nfrom sktime.forecasting.naive import NaiveForecaster\nfrom sktime.fore"
         "casting.naive import NaiveForecaster\nfrom sktime.forecasting.theta impor"
         "t ThetaForecaster\nfrom sktime.split.expandingwindow import "


### PR DESCRIPTION
The `imports` utility currently produces the full import path, including private folders.

This PR improves it to produce the lowest public import path instead.