### PR TITLE
[ENH] coerce scalar forecasting metric outputs to `float`

### DIFF
--- a/sktime/performance_metrics/forecasting/_coerce.py
+++ b/sktime/performance_metrics/forecasting/_coerce.py
@@ -13,6 +13,8 @@ def _coerce_to_scalar(obj):
     if isinstance(obj, pd.Series):
         assert len(obj) == 1
         return obj.iloc[0]
+    if not isinstance(obj, float):
+        obj = float(obj)
     return obj
 
 


### PR DESCRIPTION
This PR ensures that scalar forecasting metric outputs are coerced to `float`, rather than `np.float64` or `np.int64`.

Important question: what should be the expectation here?
The doctests apparently expect a python float.

For discussion, see https://github.com/sktime/sktime/issues/8075.

Fixes https://github.com/sktime/sktime/issues/8075