### PR TITLE
[MNT] temporary skip for `TimeSeriesKvisibility` until fix of known failures

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -61,6 +61,8 @@ EXCLUDE_ESTIMATORS = [
     "STDBSCAN",
     # DistanceFeatures does ont work for hierarchical data, see #8077
     "DistanceFeatures",
+    # TimeSeriesKvisibility is not API compliant, see #8026 and #8072
+    "TimeSeriesKvisibility",
 ]
 
 


### PR DESCRIPTION
This PR adds a temporary skip for `TimeSeriesKvisibility` until known failures are fixed. See #8026 and #8072