### PR TITLE
[MNT] Temporarily remove RecursiveReductionForecaster from unit tests

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -57,6 +57,8 @@ EXCLUDE_ESTIMATORS = [
     "PytorchForecastingDeepAR",
     # STDBSCAN is not API compliant, see #7994
     "STDBSCAN",
+    # Temporarily remove RRF from tests, while #7380 is not merged
+    "RecursiveReductionForecaster",
 ]
 
 


### PR DESCRIPTION
PR to temporarily remove RecursiveReductionForecaster (RRF) from unit tests

#### Reference Issues/PRs
This will be fixed in #7380 but, since the RRF is causing time-out errors in CIs, this is kind of urgent at the moment. #7380 should re-add this estimator to the tests.


