### PR TITLE
[MNT] skip early classifier `TEASER` in `test_multiprocessing_idempotent`

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -192,6 +192,7 @@ EXCLUDED_TESTS = {
     "TEASER": [
         "test_non_state_changing_method_contract",
         "test_fit_idempotent",
+        "test_multiprocessing_idempotent",
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
     ],


### PR DESCRIPTION
The early classifier `TEASER` fails `test_multiprocessing_idempotent` with the error below - this is due to different output API.

The test is skipped until the tests have been adapted, the skip is added to the existing skips of this nature.

```
FAILED sktime/tests/test_all_estimators.py::TestAllEstimators::test_multiprocessing_idempotent[TEASER-ClassifierFitPredictThreeClasses-predict_proba] - ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 2 dimensions. The detected shape was (2, 5) + inhomogeneous part.
```