### PR TITLE
[MNT] skip `test_transformation_can_return_new_instances` until resolution of #8084

### DIFF
--- a/sktime/transformations/tests/test_check_estimator.py
+++ b/sktime/transformations/tests/test_check_estimator.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from sktime.tests.test_switch import run_test_module_changed
 from sktime.transformations.base import BaseTransformer
 from sktime.utils.estimator_checks import check_estimator, parametrize_with_checks
 
@@ -87,6 +88,10 @@ class _TransformChangeNInstances(BaseTransformer):
 
 
 @pytest.mark.xfail
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.transformations.base"),
+    reason="run test only if transformations base class has changed",
+)
 @parametrize_with_checks([_TransformChangeNInstances])
 def test_transformation_can_return_new_instances(obj, test_name):
     """

--- a/sktime/transformations/tests/test_check_estimator.py
+++ b/sktime/transformations/tests/test_check_estimator.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from sktime.transformations.base import BaseTransformer
 from sktime.utils.estimator_checks import check_estimator, parametrize_with_checks
@@ -85,6 +86,7 @@ class _TransformChangeNInstances(BaseTransformer):
         ]
 
 
+@pytest.mark.xfail
 @parametrize_with_checks([_TransformChangeNInstances])
 def test_transformation_can_return_new_instances(obj, test_name):
     """


### PR DESCRIPTION
Temporary skip for `test_transformation_can_return_new_instances` until https://github.com/sktime/sktime/issues/8084 is resolved.