### PR TITLE
[BUG] Update `DistanceFeatures` to handle hierarchical data

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -61,8 +61,6 @@ EXCLUDE_ESTIMATORS = [
     "STDBSCAN",
     # Temporarily remove RRF from tests, while #7380 is not merged
     "RecursiveReductionForecaster",
-    # DistanceFeatures does ont work for hierarchical data, see #8077
-    "DistanceFeatures",
     # TimeSeriesKvisibility is not API compliant, see #8026 and #8072
     "TimeSeriesKvisibility",
 ]
@@ -296,7 +294,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "DirRecTimeSeriesRegressionForecaster",
         "DirectTimeSeriesRegressionForecaster",
         "DistFromAligner",
-        "DistanceFeatures",
         "DontUpdate",
         "DummyRegressor",
         "ElasticEnsemble",


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #8077. See also the `DistanceFeatures` test failures tracked in #8026.

#### What does this implement/fix? Explain your changes.
`DistanceFeatures` has been updated to handle hierarchical input correctly. The previous implementation dropped index levels when coercing the input to Panel, but this led to non unique indices.
The new implementation utilises `flatten_multiindex` to instead combine the instance indices.
The option flatten_hierarchy was also failing when panel data was passed in, as `flatten_multiindex` assumes that a multiindex is passed in. This PR adds a check to confirm that the index is a multiindex before attempting to flatten it.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
I am also tempted to flatten the column indices if `flatten_hierarchy` is set to `True`. i.e.
```diff

        if self.flatten_hierarchy and X.index.nlevels > 1:
            X_ind = flatten_multiindex(X_ind)

+       if self.flatten_hierarchy and X_train.index.nlevels > 1:
+           X_train_ind = flatten_multiindex(X_train_ind)
+
        Xt = pd.DataFrame(distmat, columns=X_train_ind, index=X_ind)
```

#### Did you add any tests for the change?
Reinstated the tests for `DistanceFeatures`. Also removed the skip for `test_get_test_params_coverage`.

#### Any other comments?

#### PR checklist

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).

