### PR TITLE
[BUG] Make _TransformChangeNInstances capable of handling hierarchical test scenarios

### DIFF
--- a/sktime/transformations/tests/test_check_estimator.py
+++ b/sktime/transformations/tests/test_check_estimator.py
@@ -72,12 +72,15 @@ class _TransformChangeNInstances(BaseTransformer):
 
         rng = np.random.default_rng(self.random_state)
         # series names
-        instances = X.index.droplevel(-1).unique()
+        instances_idx = X.index.droplevel(-1).unique()
         # Sample self.n_instances at random
 
-        n = min(self.n, len(instances))
-        instances = rng.choice(instances, n, replace=False)
-        return X.loc[instances].sort_index()
+        n = min(self.n, len(instances_idx))
+        selected_instances_idx = rng.choice(
+            list(range(len(instances_idx))), n, replace=False
+        )
+        instances = instances_idx[selected_instances_idx]
+        return X.loc[X.index.droplevel(-1).isin(instances)].sort_index()
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -87,7 +90,6 @@ class _TransformChangeNInstances(BaseTransformer):
         ]
 
 
-@pytest.mark.xfail
 @pytest.mark.skipif(
     not run_test_module_changed("sktime.transformations.base"),
     reason="run test only if transformations base class has changed",
@@ -97,4 +99,5 @@ def test_transformation_can_return_new_instances(obj, test_name):
     """
     Test if transformation can change the number of instances.
     """
+    test_name = "test_non_state_changing_method_contract"
     check_estimator(obj, tests_to_run=test_name, raise_exceptions=True)


### PR DESCRIPTION
The estimator _TransformChangeNInstances, which was created for test purposes, was not correctly handling hierarchical scenarious that were just re-activated.

#### Reference Issues/PRs
Fixes #8084 

