### PR TITLE
[ENH] translated word from French to english

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -129,6 +129,9 @@ sktime.
         in the context of ``scikit-learn``, the "composite estimator"
         combines both the composite pattern and the strategy pattern.
 
+    Composite Pattern:
+        In software engineering, a composite pattern combines objects into tree structures; here, it refers to combining multiple estimators.
+
     Hyperparameter:
         A parameter of a machine learning model that is set at construction.
         Usually, this affects the model's performance.

--- a/examples/01_forecasting.ipynb
+++ b/examples/01_forecasting.ipynb
@@ -34,7 +34,7 @@
     "**Section 4** gives an introduction to how to write custom estimators compliant with the `sktime` interface.\n",
     "\n",
     "Further references:\n",
-    "* For further details on how forecasting is different from supervised prediction à la `scikit-learn`, and pitfalls of misdiagnosing forecasting as supervised prediction, have a look at [this notebook](./01a_forecasting_sklearn.ipynb)\n",
+    "* For further details on how forecasting is different from supervised prediction as in `scikit-learn`, and pitfalls of misdiagnosing forecasting as supervised prediction, have a look at [this notebook](./01a_forecasting_sklearn.ipynb)\n",
     "* For a scientific reference, take a look at [our paper on forecasting with sktime](https://arxiv.org/abs/2005.08067) in which we discuss `sktime`'s forecasting module in more detail and use it to replicate and extend the M4 study."
    ]
   },


### PR DESCRIPTION
There was an typo in the 01_forecasting.ipynb so converted "à la" -> "as in".