### PR TITLE
[ENH] Ensure Forecasting Metrics Return `np.float64`

### DIFF
--- a/sktime/performance_metrics/forecasting/_coerce.py
+++ b/sktime/performance_metrics/forecasting/_coerce.py
@@ -1,6 +1,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Output coercion utilities for metric classes."""
 
+import numpy as np
 import pandas as pd
 
 
@@ -13,8 +14,8 @@ def _coerce_to_scalar(obj):
     if isinstance(obj, pd.Series):
         assert len(obj) == 1
         return obj.iloc[0]
-    if not isinstance(obj, float):
-        obj = float(obj)
+    if not isinstance(obj, np.float64):
+        obj = np.float64(obj)
     return obj
 
 

--- a/sktime/performance_metrics/forecasting/tests/test_all_metrics_forecasting.py
+++ b/sktime/performance_metrics/forecasting/tests/test_all_metrics_forecasting.py
@@ -88,7 +88,7 @@ class TestAllForecastingPtMetrics(ForecastingMetricPtFixtureGenerator, QuickTest
         )
 
         if isinstance(multioutput, np.ndarray) or multioutput == "uniform_average":
-            assert all(type(x) is float for x in res.values())
+            assert all(isinstance(x, np.float64) for x in res.values())
         elif multioutput == "raw_values":
             assert all(isinstance(x, np.ndarray) for x in res.values())
             assert all(x.ndim == 1 for x in res.values())

--- a/sktime/performance_metrics/forecasting/tests/test_all_metrics_forecasting.py
+++ b/sktime/performance_metrics/forecasting/tests/test_all_metrics_forecasting.py
@@ -88,7 +88,7 @@ class TestAllForecastingPtMetrics(ForecastingMetricPtFixtureGenerator, QuickTest
         )
 
         if isinstance(multioutput, np.ndarray) or multioutput == "uniform_average":
-            assert all(isinstance(x, float) for x in res.values())
+            assert all(type(x) is float for x in res.values())
         elif multioutput == "raw_values":
             assert all(isinstance(x, np.ndarray) for x in res.values())
             assert all(x.ndim == 1 for x in res.values())

--- a/sktime/performance_metrics/forecasting/tests/test_all_metrics_forecasting.py
+++ b/sktime/performance_metrics/forecasting/tests/test_all_metrics_forecasting.py
@@ -88,7 +88,7 @@ class TestAllForecastingPtMetrics(ForecastingMetricPtFixtureGenerator, QuickTest
         )
 
         if isinstance(multioutput, np.ndarray) or multioutput == "uniform_average":
-            assert all(isinstance(x, np.float64) for x in res.values())
+            assert all(type(x) is np.float64 for x in res.values())
         elif multioutput == "raw_values":
             assert all(isinstance(x, np.ndarray) for x in res.values())
             assert all(x.ndim == 1 for x in res.values())


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/8082

#### **Summary**  
This PR updates the test case in `TestAllForecastingPtMetrics` to strictly check that forecasting metrics return a **Python `np.float64`** instead of allowing any float types (`float`, etc.).  

#### **Changes Made**  
- Updated the assertion in `test_metric_output_direct`:  
  ```python
  if isinstance(multioutput, np.ndarray) or multioutput == "uniform_average":
      assert all(type(x) is np.float64 for x in res.values())  # Ensures strict Python float
  ```

 
