### PR TITLE
[MNT] Remove debugging line from test_check_estimator

### DIFF
--- a/sktime/transformations/tests/test_check_estimator.py
+++ b/sktime/transformations/tests/test_check_estimator.py
@@ -99,5 +99,4 @@ def test_transformation_can_return_new_instances(obj, test_name):
     """
     Test if transformation can change the number of instances.
     """
-    test_name = "test_non_state_changing_method_contract"
     check_estimator(obj, tests_to_run=test_name, raise_exceptions=True)


### PR DESCRIPTION
In a previous PR (#8092), I forgot to remove a line that was forcing the execution of a specific test.

#### Reference Issues/PRs
Related to #8092

#### What does this implement/fix? Explain your changes.
Remove the line that wasn't supposed to be there 
