### PR TITLE
[MNT] update `PyKANForecaster` dependency set

### DIFF
--- a/sktime/forecasting/pykan_forecaster.py
+++ b/sktime/forecasting/pykan_forecaster.py
@@ -59,7 +59,7 @@ class PyKANForecaster(BaseForecaster):
         # --------------
         "authors": ["benheid"],
         "maintainers": ["benheid"],
-        "python_dependencies": ["pykan", "torch"],
+        "python_dependencies": ["pykan", "torch", "matplotlib"],
         # estimator type
         # --------------
         "y_inner_mtype": "pd.Series",


### PR DESCRIPTION
The `PyKANForecaster` seems to require `matplotlib` now as one of its dependencies, see failure below:

```
 FAILED sktime/tests/test_all_estimators.py::TestAllEstimators::test_fit_idempotent[PyKANForecaster-2-ForecasterFitPredictMultivariateNoX-predict] - ModuleNotFoundError: No module named 'matplotlib'
```

This is likely bad dependency management on the part of the package maintainers - `matplotlib` is a plotting and not a modelling package - but it cannot be helped as the import is somewhere on module level, so it is a de-facto dependency now.

We need to keep track and add the dependency requirement, or the estimator will break for users.