### PR TITLE
FIX : [BUG] Adding various scorers of the same class in evaluate results in name clashes

### DIFF
--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -60,12 +60,25 @@ def _check_scores(metrics) -> dict:
     metrics_type = {}
     for metric in metrics:
         metric = check_scoring(metric)
-        # collect predict type
+
+        params = metric.get_params()
+        default_metric = metric.__class__()
+        default_params = default_metric.get_params()
+
+        non_default_params = {
+            k: v for k, v in params.items()
+            if k in default_params and v != default_params[k]
+        }
+
+        if non_default_params:
+            param_str = "_".join(f"{k}={v}" for k, v in sorted(non_default_params.items()))
+            metric.name = f"{metric.name}_{param_str}"
+            
         if hasattr(metric, "get_tag"):
             scitype = metric.get_tag(
                 "scitype:y_pred", raise_error=False, tag_value_default="pred"
             )
-        else:  # If no scitype exists then metric is a point forecast type
+        else: 
             scitype = "pred"
         if scitype not in metrics_type.keys():
             metrics_type[scitype] = [metric]

--- a/sktime/forecasting/model_evaluation/tests/test_model_evaluation.py
+++ b/sktime/forecasting/model_evaluation/tests/test_model_evaluation.py
@@ -1,0 +1,92 @@
+import pytest
+import pandas as pd
+from sktime.datasets import load_airline
+from sktime.forecasting.model_evaluation import evaluate
+from sktime.forecasting.naive import NaiveForecaster
+from sktime.split import ExpandingWindowSplitter
+from sktime.performance_metrics.forecasting import (
+    MeanSquaredError,
+    MeanAbsolutePercentageError,
+)
+
+def test_metric_name_clash_resolution():
+    """Test that metrics with different parameters get unique column names."""
+    y = load_airline()[:24]
+    forecaster = NaiveForecaster(strategy="mean", sp=3)
+    cv = ExpandingWindowSplitter(initial_window=12, step_length=6, fh=[1])
+
+    scorers = [
+        MeanSquaredError(square_root=True),  
+        MeanSquaredError(),  
+        MeanAbsolutePercentageError(symmetric=False), 
+    ]
+
+    results = evaluate(
+        forecaster=forecaster,
+        y=y,
+        cv=cv,
+        scoring=scorers,
+    )
+
+    expected_columns = {
+        'test_MeanSquaredError_square_root=True',
+        'test_MeanSquaredError',
+        'test_MeanAbsolutePercentageError_symmetric=False',
+        'fit_time',
+        'pred_time',
+        'len_train_window',
+        'cutoff'
+    }
+    
+    assert set(results.columns) == expected_columns
+    
+    metric_cols = [c for c in results.columns if c.startswith('test_')]
+    assert len(metric_cols) == len(scorers), "Duplicate metric columns detected"
+
+def test_parameter_order_insensitivity():
+    """Test that parameter order doesn't affect metric naming."""
+    scorer1 = MeanAbsolutePercentageError(symmetric=True, multioutput="uniform_average")
+    scorer2 = MeanAbsolutePercentageError(multioutput="uniform_average", symmetric=True)
+    
+    assert scorer1.name == scorer2.name
+
+def test_default_parameters_no_suffix():
+    """Test metrics with default parameters get no parameter suffix."""
+    scorer = MeanSquaredError()
+    assert "_" not in scorer.name, "Default parameters should not add suffix"
+    scorer_modified = MeanSquaredError(square_root=True)
+    assert "_square_root=True" in scorer_modified.name
+
+def test_custom_metric_naming():
+    """Test with custom parameter combinations."""
+    scorer = MeanAbsolutePercentageError(
+        symmetric=True,
+        multioutput="raw_values",
+        horizon_weighting={"weights": [0.5, 0.5]}
+    )
+    
+    expected_suffix = (
+        "horizon_weighting={'weights': [0.5, 0.5]}_"
+        "multioutput=raw_values_"
+        "symmetric=True"
+    )
+    assert expected_suffix in scorer.name
+
+def test_duplicate_metric_configurations():
+    """Test identical metric configurations produce same column name."""
+    y = load_airline()[:24]
+    forecaster = NaiveForecaster(strategy="mean", sp=3)
+    cv = ExpandingWindowSplitter(initial_window=12, step_length=6, fh=[1])
+    
+    scorers = [
+        MeanSquaredError(square_root=True),
+        MeanSquaredError(square_root=True),
+    ]
+
+    with pytest.raises(ValueError, match="Duplicate column names"):
+        evaluate(
+            forecaster=forecaster,
+            y=y,
+            cv=cv,
+            scoring=scorers,
+        )

--- a/sktime/forecasting/model_evaluation/tests/test_model_evaluation.py
+++ b/sktime/forecasting/model_evaluation/tests/test_model_evaluation.py
@@ -1,13 +1,14 @@
 import pytest
-import pandas as pd
+
 from sktime.datasets import load_airline
 from sktime.forecasting.model_evaluation import evaluate
 from sktime.forecasting.naive import NaiveForecaster
-from sktime.split import ExpandingWindowSplitter
 from sktime.performance_metrics.forecasting import (
-    MeanSquaredError,
     MeanAbsolutePercentageError,
+    MeanSquaredError,
 )
+from sktime.split import ExpandingWindowSplitter
+
 
 def test_metric_name_clash_resolution():
     """Test that metrics with different parameters get unique column names."""
@@ -16,9 +17,9 @@ def test_metric_name_clash_resolution():
     cv = ExpandingWindowSplitter(initial_window=12, step_length=6, fh=[1])
 
     scorers = [
-        MeanSquaredError(square_root=True),  
-        MeanSquaredError(),  
-        MeanAbsolutePercentageError(symmetric=False), 
+        MeanSquaredError(square_root=True),
+        MeanSquaredError(),
+        MeanAbsolutePercentageError(symmetric=False),
     ]
 
     results = evaluate(
@@ -29,26 +30,28 @@ def test_metric_name_clash_resolution():
     )
 
     expected_columns = {
-        'test_MeanSquaredError_square_root=True',
-        'test_MeanSquaredError',
-        'test_MeanAbsolutePercentageError_symmetric=False',
-        'fit_time',
-        'pred_time',
-        'len_train_window',
-        'cutoff'
+        "test_MeanSquaredError_square_root=True",
+        "test_MeanSquaredError",
+        "test_MeanAbsolutePercentageError_symmetric=False",
+        "fit_time",
+        "pred_time",
+        "len_train_window",
+        "cutoff",
     }
-    
+
     assert set(results.columns) == expected_columns
-    
-    metric_cols = [c for c in results.columns if c.startswith('test_')]
+
+    metric_cols = [c for c in results.columns if c.startswith("test_")]
     assert len(metric_cols) == len(scorers), "Duplicate metric columns detected"
+
 
 def test_parameter_order_insensitivity():
     """Test that parameter order doesn't affect metric naming."""
     scorer1 = MeanAbsolutePercentageError(symmetric=True, multioutput="uniform_average")
     scorer2 = MeanAbsolutePercentageError(multioutput="uniform_average", symmetric=True)
-    
+
     assert scorer1.name == scorer2.name
+
 
 def test_default_parameters_no_suffix():
     """Test metrics with default parameters get no parameter suffix."""
@@ -57,14 +60,15 @@ def test_default_parameters_no_suffix():
     scorer_modified = MeanSquaredError(square_root=True)
     assert "_square_root=True" in scorer_modified.name
 
+
 def test_custom_metric_naming():
     """Test with custom parameter combinations."""
     scorer = MeanAbsolutePercentageError(
         symmetric=True,
         multioutput="raw_values",
-        horizon_weighting={"weights": [0.5, 0.5]}
+        horizon_weighting={"weights": [0.5, 0.5]},
     )
-    
+
     expected_suffix = (
         "horizon_weighting={'weights': [0.5, 0.5]}_"
         "multioutput=raw_values_"
@@ -72,12 +76,13 @@ def test_custom_metric_naming():
     )
     assert expected_suffix in scorer.name
 
+
 def test_duplicate_metric_configurations():
     """Test identical metric configurations produce same column name."""
     y = load_airline()[:24]
     forecaster = NaiveForecaster(strategy="mean", sp=3)
     cv = ExpandingWindowSplitter(initial_window=12, step_length=6, fh=[1])
-    
+
     scorers = [
         MeanSquaredError(square_root=True),
         MeanSquaredError(square_root=True),


### PR DESCRIPTION
**Describe the bug**
 If I add multiple instances of the same scorer class in evaluate, name clashes happens #8052

**To Reproduce:**

```
from sktime.datasets import load_airline
from sktime.forecasting.model_evaluation import evaluate
from sktime.split import ExpandingWindowSplitter
from sktime.forecasting.naive import NaiveForecaster
from sktime.performance_metrics.forecasting import MeanSquaredError

# Load example data
y = load_airline()[:24]

# Define forecaster
forecaster = NaiveForecaster(strategy="mean", sp=3)

# Define cross-validation splitter
cv = ExpandingWindowSplitter(initial_window=12, step_length=6, fh=[1, 2, 3])

# Define scorers with different parameters
scorer1 = MeanSquaredError(square_root=True)  # RMSE
scorer2 = MeanSquaredError()  # MSE

# Evaluate forecaster with multiple scorers
results = evaluate(
    forecaster=forecaster,
    y=y,
    cv=cv,
    scoring=[scorer1, scorer2],
)

# Print the resulting columns to observe the name clash
print(results.columns)
```
![image](https://github.com/user-attachments/assets/2f1434ea-a6fc-42ca-ba14-1073da9dfb0d)


After Fixing Bug we get:
![image](https://github.com/user-attachments/assets/0aa892ab-c10f-4415-aa7f-c0dbd7e48d2f)
