### PR TITLE
[MNT] remove `CNTCRegressor` parameter test skip

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -281,7 +281,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "CAPA",
         "CNTCClassifier",
         "CNTCNetwork",
-        "CNTCRegressor",
         "CanonicalIntervalForest",
         "CircularBinarySegmentation",
         "ClaSPTransformer",


### PR DESCRIPTION
Removes the `CNTCRegressor` parameter test skip, after a second set of test parameters has been added.