### PR TITLE
[MNT] remove `TimeSeriesAUPRC` from exports and docs

### DIFF
--- a/sktime/performance_metrics/detection/__init__.py
+++ b/sktime/performance_metrics/detection/__init__.py
@@ -5,7 +5,6 @@ from sktime.performance_metrics.detection._count import DetectionCount
 from sktime.performance_metrics.detection._f1score import WindowedF1Score
 from sktime.performance_metrics.detection._hausdorff import DirectedHausdorff
 from sktime.performance_metrics.detection._randindex import RandIndex
-from sktime.performance_metrics.detection._ts_auprc import TimeSeriesAUPRC
 
 __all__ = [
     "DirectedChamfer",
@@ -13,5 +12,4 @@ __all__ = [
     "DetectionCount",
     "WindowedF1Score",
     "RandIndex",
-    "TimeSeriesAUPRC",
 ]

--- a/sktime/performance_metrics/detection/_ts_auprc.py
+++ b/sktime/performance_metrics/detection/_ts_auprc.py
@@ -101,10 +101,10 @@ class TimeSeriesAUPRC(BaseDetectionMetric):
     --------
     >>> import numpy as np
     >>> from sktime.performance_metrics.detection import TimeSeriesAUPRC
-    >>> ts_auprc=TimeSeriesAUPRC(with_scores=True)
+    >>> ts_auprc = TimeSeriesAUPRC(with_scores=True)
     >>> y_true = np.array([0, 0, 1, 1, 0, 0, 1])
     >>> y_pred = np.array([0.1, 0.3, 0.7, 0.8, 0.2, 0.0, 0.9])
-    >>> area=ts_auprc.evaluate(y_true, y_pred)
+    >>> area = ts_auprc.evaluate(y_true, y_pred)  # doctest: +SKIP
     """
 
     _tags = {


### PR DESCRIPTION
The class is not working and failing tests. It is removed for now, from public exports