### PR TITLE
[ENH] automatic transformer coercion in explicit forecasting pipeline specification syntax

### DIFF
--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -12,7 +12,7 @@ from sktime.datatypes import ALL_TIME_SERIES_MTYPES
 from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.base._delegate import _DelegatedForecaster
 from sktime.forecasting.base._fh import ForecastingHorizon
-from sktime.registry import is_scitype
+from sktime.registry import is_scitype, scitype
 from sktime.utils.validation.series import check_series
 from sktime.utils.warnings import warn
 
@@ -59,6 +59,8 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
         TypeError if there is not exactly one forecaster in ``estimators``
         TypeError if not allow_postproc and forecaster is not last estimator
         """
+        from sktime.registry._scitype_coercion import all_coercible_to, coerce_scitype
+
         self_name = type(self).__name__
         if not isinstance(estimators, list):
             msg = (
@@ -82,16 +84,24 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
 
         # validate names
         self._check_names(names)
-        if not all([is_scitype(x, ["forecaster", "transformer"]) for x in estimators]):
+
+        ALLOWED_SCITYPES = ["forecaster", "transformer"]
+        COERCIBLE_SCITYPES = all_coercible_to("transformer")
+        COERCIBLE_SCITYPES = set(COERCIBLE_SCITYPES) - set(ALLOWED_SCITYPES)
+        ACCEPTED_SCITYPES = ALLOWED_SCITYPES + list(COERCIBLE_SCITYPES)
+
+        est_scitypes = [scitype(x) for x in estimators]
+
+        if not all([x in ACCEPTED_SCITYPES for x in est_scitypes]):
             raise TypeError(
                 f"estimators passed to {self_name} "
                 f"must be either transformer or forecaster"
             )
-        scitypes = [is_scitype(x, ["forecaster"]) for x in estimators]
-        if sum(scitypes) != 1:
+        forecaster_indicator = [x == "forecaster" for x in est_scitypes]
+        if sum(forecaster_indicator) != 1:
             raise TypeError(
                 f"exactly one forecaster must be contained in the chain, "
-                f"but found {scitypes.count('forecaster')}"
+                f"but found {forecaster_indicator.count('forecaster')}"
             )
 
         forecaster_ind = self._get_forecaster_index(estimator_tuples)
@@ -101,6 +111,18 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                 f"in {self_name}, last estimator must be a forecaster, "
                 f"but found a transformer"
             )
+
+        # coerce to transformer if needed
+
+        def _coerce_to_trafo(x, x_st):
+            if x not in ["forecaster", "transformer"]:
+                return coerce_scitype(x, to_scitype="transformer", from_scitype=x_st)
+            return x
+
+        if not all([x in ALLOWED_SCITYPES for x in est_scitypes]):
+            est_plus_scitype = zip(estimators, est_scitypes)
+            coerced_estimators = [_coerce_to_trafo(*x) for x in est_plus_scitype]
+            estimator_tuples = list(zip(names, coerced_estimators))
 
         # Shallow copy
         return estimator_tuples
@@ -264,6 +286,13 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
         ]
         params1 = {"steps": STEPS1}
 
+        # without TabularToSeriesAdaptor
+        STEPS1_no_adapter = [
+            ("transformer", StandardScaler()),
+            ("forecaster", NaiveForecaster()),
+        ]
+        params4 = {"steps": STEPS1_no_adapter}
+
         # ARIMA has probabilistic methods, ExponentTransformer skips fit
         STEPS2 = [
             ("transformer", ExponentTransformer()),
@@ -273,7 +302,7 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
 
         params3 = {"steps": [Detrender(), YfromX.create_test_instance()]}
 
-        return [params1, params2, params3]
+        return [params1, params2, params3, params4]
 
 
 # we ensure that internally we convert to pd.DataFrame for now
@@ -369,7 +398,7 @@ class ForecastingPipeline(_Pipeline):
         Example 2: without strings
     >>> pipe = ForecastingPipeline([
     ...     Imputer(method="mean"),
-    ...     TabularToSeriesAdaptor(MinMaxScaler()),
+    ...     MinMaxScaler(),
     ...     NaiveForecaster(strategy="drift"),
     ... ])
 

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -33,6 +33,9 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
 
     def _get_forecaster_index(self, estimators):
         """Get the index of the first forecaster in the list."""
+        if hasattr(self, "_forecaster_index"):
+            return self._forecaster_index
+        # fallback logic
         for i, est in enumerate(estimators):
             if is_scitype(est[1], "forecaster"):
                 return i
@@ -104,7 +107,8 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                 f"but found {forecaster_indicator.count('forecaster')}"
             )
 
-        forecaster_ind = self._get_forecaster_index(estimator_tuples)
+        forecaster_index = forecaster_indicator.index(True)
+        self._forecaster_index = forecaster_index
 
         if not allow_postproc and forecaster_ind != len(estimators) - 1:
             TypeError(

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -107,8 +107,8 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                 f"but found {forecaster_indicator.count('forecaster')}"
             )
 
-        forecaster_index = forecaster_indicator.index(True)
-        self._forecaster_index = forecaster_index
+        forecaster_ind = forecaster_indicator.index(True)
+        self._forecaster_index = forecaster_ind
 
         if not allow_postproc and forecaster_ind != len(estimators) - 1:
             TypeError(

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -376,7 +376,6 @@ class ForecastingPipeline(_Pipeline):
     >>> from sktime.datasets import load_longley
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.forecasting.compose import ForecastingPipeline
-    >>> from sktime.transformations.series.adapt import TabularToSeriesAdaptor
     >>> from sktime.transformations.series.impute import Imputer
     >>> from sktime.forecasting.base import ForecastingHorizon
     >>> from sktime.split import temporal_train_test_split
@@ -388,7 +387,7 @@ class ForecastingPipeline(_Pipeline):
         Example 1: string/estimator pairs
     >>> pipe = ForecastingPipeline(steps=[
     ...     ("imputer", Imputer(method="mean")),
-    ...     ("minmaxscaler", TabularToSeriesAdaptor(MinMaxScaler())),
+    ...     ("minmaxscaler", MinMaxScaler()),
     ...     ("forecaster", NaiveForecaster(strategy="drift")),
     ... ])
     >>> pipe.fit(y_train, X_train)

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -1050,8 +1050,6 @@ class TransformedTargetForecaster(_Pipeline):
         -------
         self : returns an instance of self.
         """
-        self.steps_ = self._get_estimator_tuples(self.steps, clone_ests=True)
-
         # transform pre
         yt = y
         for _, t in self.transformers_pre_:

--- a/sktime/registry/_scitype_coercion.py
+++ b/sktime/registry/_scitype_coercion.py
@@ -124,7 +124,13 @@ def coerce_scitype(
             )
 
     # case 1: detected scitype is not assumed scitype
-    if from_scitype is not None and detected_scitype not in from_scitype:
+    mismatch_raise = (
+        need_detect
+        and from_scitype is not None
+        and detected_scitype not in from_scitype
+    )
+
+    if mismatch_raise:
         # if raise_on_mismatch, raise an error
         if raise_on_mismatch:
             raise TypeError(
@@ -137,6 +143,8 @@ def coerce_scitype(
 
     if from_scitype is None or len(from_scitype) >= 2:
         from_scitype = detected_scitype
+    else:
+        from_scitype = from_scitype[0]
 
     if clone_obj:
         obj = _safe_clone(obj)
@@ -152,3 +160,23 @@ def coerce_scitype(
 
     coerced_obj = coerce_func(obj)
     return coerced_obj
+
+
+def all_coercible_to(to_scitype):
+    """List all scitypes that can be coerced to a given scitype.
+
+    Parameters
+    ----------
+    to_scitype : str
+        scitype to coerce to
+
+    Returns
+    -------
+    coercible_scitypes : list of str
+        list of scitypes that can be coerced to the given scitype, excluding to_scitype
+    """
+    coercible_scitypes = []
+    for (from_scitype, to_scitype_) in _coerce_register.keys():
+        if to_scitype_ == to_scitype and from_scitype != to_scitype:
+            coercible_scitypes.append(from_scitype)
+    return coercible_scitypes

--- a/sktime/registry/_scitype_coercion.py
+++ b/sktime/registry/_scitype_coercion.py
@@ -176,7 +176,7 @@ def all_coercible_to(to_scitype):
         list of scitypes that can be coerced to the given scitype, excluding to_scitype
     """
     coercible_scitypes = []
-    for (from_scitype, to_scitype_) in _coerce_register.keys():
+    for from_scitype, to_scitype_ in _coerce_register.keys():
         if to_scitype_ == to_scitype and from_scitype != to_scitype:
             coercible_scitypes.append(from_scitype)
     return coercible_scitypes


### PR DESCRIPTION
This PR adds automatic transformer coercion in forecasting pipelines, and removes the need for manual transformer coercions such as of `sklearn` estimators through `TabularToTransformAdaptor`.

This is achieved through use of the `registry._scitype_coercion` module, which also has minor updates and bugfixes in this PR.