### PR TITLE
Fix TSFreshClassifier multiprocessing idempotency by enforcing consistent feature ordering (Issue #8150)

### DIFF
--- a/sktime/classification/feature_based/_tsfresh_classifier.py
+++ b/sktime/classification/feature_based/_tsfresh_classifier.py
@@ -228,12 +228,13 @@ class TSFreshClassifier(BaseClassifier):
             return dists
 
         m = getattr(self._estimator, "predict_proba", None)
+        X_t = self._transformer.transform(X)
+        if hasattr(self, "_Xt_colnames"):
+            X_t = X_t.reindex(self._Xt_colnames, axis=1, fill_value=0)
         if callable(m):
-            return self._estimator.predict_proba(self._transformer.transform(X))
+            return self._estimator.predict_proba(X_t)
         else:
             dists = np.zeros((X.shape[0], self.n_classes_))
-            X_t = self._transformer.transform(X)
-            X_t = X_t.reindex(self._Xt_colnames, axis=1, fill_value=0)
             preds = self._estimator.predict(X_t)
             for i in range(0, X.shape[0]):
                 dists[i, self._class_dictionary[preds[i]]] = 1


### PR DESCRIPTION
This pull request addresses an issue raised in the TSFreshClassifier where different feature names are passed to the internal estimator during multiprocessing (when running with [n_jobs=-1]
The underlying problem was that the transformed data generated during prediction did not strictly follow the same column ordering as seen during fitting. This resulted in a ValueError from the estimator.

**Changes:*
*
* In the [_fit]method, the transformer’s output column order is stored in [self._Xt_colnames] and later used during prediction.
* In both [_predict] and [_predict_proba], after transforming [X], the resulting DataFrame is reindexed with [self._Xt_colnames] to ensure the column order is consistent with that of the training data.
