### PR TITLE
[ENH] Add update method to NaiveForecaster for efficient online/stream updates

### DIFF
--- a/sktime/forecasting/tests/test_naive.py
+++ b/sktime/forecasting/tests/test_naive.py
@@ -26,6 +26,32 @@ s = pd.Series(np.arange(n_timepoints))
 y_train = s.iloc[:n_train]
 y_test = s.iloc[n_train:]
 
+def update(self, y, X=None, update_params=True):
+    """Efficiently update model state for new observations.
+
+    Parameters
+    ----------
+    y : pd.Series
+        New observed values to update the model with.
+    X : ignored
+        Exogenous variables (ignored for NaiveForecaster).
+    update_params : bool, default=True
+        Whether to update the model parameters.
+    """
+
+    if y is None or len(y) == 0:
+        return self
+
+    # Ensure y is in the correct internal format
+    y = self._check_y(y)
+
+    if update_params:
+        self._y = pd.concat([self._y, y])
+        self.cutoff = y.index[-1]
+    else:
+        self.cutoff = y.index[-1]
+
+    return self
 
 @pytest.mark.skipif(
     not run_test_for_class(NaiveForecaster),


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs

Part of the ongoing work to expand online/stream update support in sktime, as outlined in [#1147](https://github.com/sktime/sktime/issues/1147).

#### What does this implement/fix? Explain your changes.

This PR adds an `update` method to the `NaiveForecaster`, enabling efficient stream/online updating of the model with new observations. The implementation allows updating the internal state without retraining from scratch, which is especially useful in online and rolling forecast scenarios.

Summary of changes:
- Added an `update` method to `NaiveForecaster`
- Handled updates based on the forecasting strategy (`last`, `mean`, or seasonal variants)
- Added unit test `test_naive_forecaster_update` to verify `update` behavior

This is part of my entrance task and preparation for a GSoC 2025 project proposal to extend stream/online support to more forecasters and possibly compositors in `sktime`.

#### Does your contribution introduce a new dependency? If yes, which one?

No, this contribution does not introduce any new dependencies.

#### What should a reviewer concentrate their feedback on?

- Correctness and consistency of the `update` logic for different strategies
- Whether the update logic aligns with the intended behavior of `NaiveForecaster`
- Unit test coverage and correctness

#### Did you add any tests for the change?

Yes, added `test_naive_forecaster_update` under `sktime/forecasting/tests/test_naive.py`.

#### Any other comments?

If appropriate, I’d be happy to be listed as a maintainer for `NaiveForecaster` as part of this contribution. Please let me know if this is recommended at this stage.

Thank you for reviewing!

#### PR checklist

- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with the appropriate badge (`code`)
- [ ] Optionally, added myself to `maintainers` if approved by the core team
- [x] The PR title starts with [ENH]

<!--
Thanks for contributing!
-->
