### PR TITLE
[MNT] temporary skip `SCINetForecaster`

### DIFF
--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -72,6 +72,7 @@ EXCLUDE_ESTIMATORS = [
     # multiple timeouts and sporadic failures reported related to VARMAX
     # 2997, 3176, 7985
     "VARMAX",
+    "SCINetForecaster",  # known bug #7871
 ]
 
 


### PR DESCRIPTION
temporary skip for `SCINetForecaster` until https://github.com/sktime/sktime/issues/7871 is resolved