### PR TITLE
[ENH] remove accidental `univariate-only` tags from forecasters

### DIFF
--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -420,7 +420,7 @@ class ThetaModularForecaster(BaseForecaster):
 
     _tags = {
         "authors": ["GuzalBulatova", "fkiraly"],
-        "univariate-only": False,
+        "scitype:y": "both",
         "y_inner_mtype": "pd.Series",
         "requires-fh-in-fit": False,
         "handles-missing-data": False,

--- a/sktime/forecasting/var.py
+++ b/sktime/forecasting/var.py
@@ -93,7 +93,6 @@ class VAR(_StatsModelsAdapter):
         "scitype:y": "multivariate",
         "y_inner_mtype": "pd.DataFrame",
         "requires-fh-in-fit": False,
-        "univariate-only": False,
         "ignores-exogeneous-X": True,
         "capability:pred_int": True,
         "capability:pred_int:insample": False,

--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -98,7 +98,6 @@ class VECM(_StatsModelsAdapter):
         "y_inner_mtype": "pd.DataFrame",
         "X_inner_mtype": "pd.DataFrame",
         "requires-fh-in-fit": False,
-        "univariate-only": False,
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,
         "capability:pred_int:insample": False,


### PR DESCRIPTION
This PR removes a few accidental `univariate-only` tags from forecasters - this tag was never used in forecasterse and was probably added by accident.