### PR TITLE
[BUG] Stop Importing Modules if Raised an Exception in `_safe_import`

### DIFF
--- a/sktime/utils/dependencies/_safe_import.py
+++ b/sktime/utils/dependencies/_safe_import.py
@@ -72,10 +72,10 @@ def _safe_import(import_path, pkg_name=None):
             module = importlib.import_module(module_name)
             return getattr(module, attr_name)
         except (ImportError, AttributeError):
-            return importlib.import_module(import_path)
-    else:
-        mock_obj = _create_mock_class(obj_name)
-        return mock_obj
+            pass
+
+    mock_obj = _create_mock_class(obj_name)
+    return mock_obj
 
 
 class CommonMagicMeta(type):

--- a/sktime/utils/dependencies/tests/test_safe_import.py
+++ b/sktime/utils/dependencies/tests/test_safe_import.py
@@ -1,4 +1,4 @@
-__author__ = ["jgyasu"]
+__author__ = ["jgyasu", "fkiraly"]
 
 from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
 
@@ -71,3 +71,14 @@ def test_multiple_inheritance_from_mock():
         """
 
         pass
+
+
+def test_soft_dependency_chains():
+    """Test soft dependency chains.
+
+    This test checks if a module can be imported safely even if it is
+    dependent on another soft dependency, e.g., gluonts.torch.PyTorchPredictor
+    depends on lightning.
+    """
+    result = _safe_import("gluonts.torch.PyTorchPredictor")
+    assert result is not None


### PR DESCRIPTION
Fixes #8181 

This PR allows `_safe_import` to create mock objects if it encounters an `ImportError` or `AttributeError` exception.