### PR TITLE
[DOC] Add reference documentation for AutoEnsembleForecaster weighting methods

### DIFF
--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -84,6 +84,20 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
         The weights based on either ``regressor.feature_importances_`` or
         ``regressor.coef_`` values.
 
+    Notes
+    _____
+    The feature-importance weighting method implements an approach inspired by
+    Caruana et al.'s ensemble selection methodology, which selects and weights
+    models based on their performance characteristics.
+
+    References
+    __________
+    .. [1] Caruana, R., Niculescu-Mizil, A., Crew, G., & Ksikes, A. (2004).
+           "Ensemble Selection from Libraries of Models."
+           Proceedings of the 21st International Conference on Machine Learning (ICML).
+           https://www.cs.cornell.edu/~caruana/ctp/ct.papers/caruana.icml04.icdm06long.pdf
+
+
     See Also
     --------
     EnsembleForecaster
@@ -147,6 +161,19 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
         Returns
         -------
         self : returns an instance of self.
+
+        Notes
+        _____
+        For the "feature-importance" method, the weighting approach follows principles
+        from Caruana et al. (2004), using either feature importances or coefficients
+        from the meta-model to determine ensemble weights. For the "inverse-variance"
+        method, weights are computed based on the prediction error variance on a
+        held-out test set.
+
+        References
+        __________
+        .. [1] Caruana, R., et al. (2004). "Ensemble Selection from Libraries of Models."
+           ICML '04. https://www.cs.cornell.edu/~caruana/ctp/ct.papers/caruana.icml04.icdm06long.pdf
         """
         forecasters = [x[1] for x in self.forecasters_]
 


### PR DESCRIPTION
Fixes #8184 

#### What does this implement/fix? Explain your changes.
This PR enhances the documentation of the AutoEnsembleForecaster by adding clear references to the theoretical foundation of its weighting methods, addressing issue #[issue_number]. Specifically:

- Adds citation and link to Caruana et al. (2004) paper which inspired the "feature-importance" weighting method
- Enhances both class and _fit method docstrings with detailed explanations of weighting methodologies
- Clarifies the theoretical basis for both "feature-importance" and "inverse-variance" weighting approaches
- Maintains consistency with sktime's documentation standards

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies were introduced.

#### What should a reviewer concentrate their feedback on?
- Accuracy and completeness of the academic reference
- Clarity and usefulness of the added documentation
- Consistency with sktime's documentation style
- Whether the explanation of weighting methods is sufficiently detailed for users

#### Did you add any tests for the change?
As this is a documentation-only change, no new tests were added. The existing docstring tests should continue to pass.

#### PR checklist
- [x] PR title starts with [DOC] for documentation changes
- [x] Documentation follows sktime's style guide
- [x] Added complete citation with accessible link
- [x] Documentation is clear and informative for users