### PR TITLE
[MNT] skip tests with `ray` parallelization fixtures

### DIFF
--- a/sktime/utils/parallel.py
+++ b/sktime/utils/parallel.py
@@ -218,6 +218,12 @@ def _parallelize_ray(fun, iter, meta, backend, backend_params):
 para_dict["ray"] = _parallelize_ray
 
 
+# list of backends where we skip tests during CI
+SKIP_FIXTURES = [
+    "ray",  # unstable, sporadic crashes in CI
+]
+
+
 def _get_parallel_test_fixtures(naming="estimator"):
     """Return fixtures for parallelization tests.
 
@@ -275,5 +281,8 @@ def _get_parallel_test_fixtures(naming="estimator"):
                 },
             }
         )
+
+    fixtures = [x in fixtures for x in fixtures if x["backend"] not in SKIP_FIXTURES]
+    # remove backends in SKIP_FIXTURES from fixtures
 
     return fixtures

--- a/sktime/utils/parallel.py
+++ b/sktime/utils/parallel.py
@@ -220,7 +220,7 @@ para_dict["ray"] = _parallelize_ray
 
 # list of backends where we skip tests during CI
 SKIP_FIXTURES = [
-    "ray",  # unstable, sporadic crashes in CI
+    "ray",  # unstable, sporadic crashes in CI, see bug 8149
 ]
 
 


### PR DESCRIPTION
Skips the `ray` parallelization fixtures until https://github.com/sktime/sktime/issues/8149 is resolved.