### PR TITLE
[BUG] fix accidental failure in fixture generating utility `_get_parallel_test_fixtures`,

### DIFF
--- a/sktime/utils/parallel.py
+++ b/sktime/utils/parallel.py
@@ -282,7 +282,7 @@ def _get_parallel_test_fixtures(naming="estimator"):
             }
         )
 
-    fixtures = [x in fixtures for x in fixtures if x["backend"] not in SKIP_FIXTURES]
+    fixtures = [x for x in fixtures if x["backend"] not in SKIP_FIXTURES]
     # remove backends in SKIP_FIXTURES from fixtures
 
     return fixtures


### PR DESCRIPTION
https://github.com/sktime/sktime/pull/8188 accidentally introduced a failure in the test fixture generating utility `_get_parallel_test_fixtures`, which leads to failures in all parallelization backend related tests.

This PR fixes that.

Since this is purely in the test framework, I do not think we need to release a hotfix.