### PR TITLE
[BUG] Fix `fh` handling in greedy splitters

### DIFF
--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -84,7 +84,7 @@ class ExpandingGreedySplitter(BaseSplitter):
         test_size = self.test_size
 
         if isinstance(test_size, float):
-            _test_size = np.ceil(len(y) * test_size)
+            _test_size = int(np.ceil(len(y) * test_size))
             self.fh = np.arange(_test_size) + 1
         else:
             _test_size = test_size

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -10,6 +10,7 @@ __all__ = [
 __author__ = ["davidgilbertson"]
 
 from typing import Optional, Union
+
 import numpy as np
 import pandas as pd
 

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -9,6 +9,7 @@ __all__ = [
 ]
 __author__ = ["davidgilbertson"]
 
+from typing import Optional, Union
 import numpy as np
 import pandas as pd
 
@@ -62,12 +63,17 @@ class ExpandingGreedySplitter(BaseSplitter):
 
     _tags = {"split_hierarchical": True}
 
-    def __init__(self, test_size: int, folds: int = 5, step_length: int = None):
+    def __init__(
+        self,
+        test_size: Union[int, float],
+        folds: int = 5,
+        step_length: Optional[int] = None,
+    ):
         super().__init__()
         self.test_size = test_size
         self.folds = folds
         self.step_length = step_length
-        self.fh = np.arange(test_size) + 1
+        self.fh = np.arange(test_size) + 1 if isinstance(test_size, int) else None
 
         # no algorithm implemented that is faster for float than naive iteration
         if isinstance(test_size, float):
@@ -78,6 +84,7 @@ class ExpandingGreedySplitter(BaseSplitter):
 
         if isinstance(test_size, float):
             _test_size = np.ceil(len(y) * test_size)
+            self.fh = np.arange(_test_size) + 1
         else:
             _test_size = test_size
 

--- a/sktime/split/slidinggreedy.py
+++ b/sktime/split/slidinggreedy.py
@@ -78,6 +78,7 @@ class SlidingGreedySplitter(BaseSplitter):
         self.test_size = test_size
         self.folds = folds
         self.step_length = step_length
+        self.fh = np.arange(test_size) + 1 if isinstance(test_size, int) else None
 
         if isinstance(train_size, float) or isinstance(test_size, float):
             self.set_tags(**{"split_hierarchical": False})

--- a/sktime/split/slidinggreedy.py
+++ b/sktime/split/slidinggreedy.py
@@ -94,6 +94,7 @@ class SlidingGreedySplitter(BaseSplitter):
 
         if isinstance(test_size, float):
             _test_size = int(np.ceil(len(y) * test_size))
+            self.fh = np.arange(_test_size) + 1
         else:
             _test_size = test_size
 

--- a/sktime/split/tests/test_expandinggreedy.py
+++ b/sktime/split/tests/test_expandinggreedy.py
@@ -117,7 +117,7 @@ def test_expanding_greedy_splitter_consecutive():
     not run_test_for_class(ExpandingGreedySplitter),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-def test_sliding_greedy_expanding_forecast_horizon():
+def test_expanding_greedy_splitter_forecast_horizon():
     """Test that ExpandingGreedySplitter's forecast horizon is properly handled."""
     ts = np.arange(10)
 

--- a/sktime/split/tests/test_expandinggreedy.py
+++ b/sktime/split/tests/test_expandinggreedy.py
@@ -111,3 +111,26 @@ def test_expanding_greedy_splitter_consecutive():
     )
 
     assert has_consecutive_index.all()
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ExpandingGreedySplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_sliding_greedy_expanding_forecast_horizon():
+    """Test that ExpandingGreedySplitter's forecast horizon is properly handled."""
+    ts = np.arange(10)
+
+    # Test with integer test_size
+    cv_int_test = ExpandingGreedySplitter(test_size=2, folds=3)
+    assert len(cv_int_test.fh) == 2
+    assert all(cv_int_test.fh == np.array([1, 2]))
+    _ = list(cv_int_test.split(ts))  # Call to split should not affect fh initialization
+    assert len(cv_int_test.fh) == 2
+
+    # Test with float test_size
+    cv_float_test = ExpandingGreedySplitter(test_size=0.2, folds=2)
+    assert cv_float_test.fh is None
+    _ = list(cv_float_test.split(ts))  # Call split to should initialize fh
+    assert len(cv_float_test.fh) == 2
+    assert all(cv_float_test.fh == np.array([1, 2]))

--- a/sktime/split/tests/test_slidinggreedy.py
+++ b/sktime/split/tests/test_slidinggreedy.py
@@ -28,6 +28,29 @@ def test_sliding_greedy_splitter_lengths():
     not run_test_for_class(SlidingGreedySplitter),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
+def test_sliding_greedy_splitter_forecast_horizon():
+    """Test that SlidingGreedySplitter's forecast horizon is properly handled."""
+    ts = np.arange(10)
+
+    # Test with integer test_size
+    cv_int_test = SlidingGreedySplitter(train_size=4, test_size=2, folds=3)
+    assert len(cv_int_test.fh) == 2
+    assert all(cv_int_test.fh == np.array([1, 2]))
+    _ = list(cv_int_test.split(ts))  # Call to split should not affect fh initialization
+    assert len(cv_int_test.fh) == 2
+
+    # Test with float test_size
+    cv_float_test = SlidingGreedySplitter(train_size=0.5, test_size=0.2, folds=2)
+    assert cv_float_test.fh is None
+    _ = list(cv_float_test.split(ts))  # Call split to should initialize fh
+    assert len(cv_float_test.fh) == 2
+    assert all(cv_float_test.fh == np.array([1, 2]))
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SlidingGreedySplitter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_sliding_greedy_splitter_indices():
     """Test that SlidingGreedySplitter returns the correct indices."""
     y = np.arange(10)


### PR DESCRIPTION
#### Reference Issues/PRs:
Fixes #8198 and fixes #8199 

#### What does this implement/fix? Explain your changes.
This PR adds:
- Missing `fh` init in SlidingGreedySplittter
- Proper `fh` handling when `test_size` is `float` for both greedy splitters
- Fixes inexact type hints in ExpandingGreedySplitter
- Adds tests for `fh` handling in both splitters

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
- If the side-effect of setting `fh` on `split()` is a bad pattern
- If initialising `fh` differently based on the type of `test_size` is a bad pattern
- The correctness of the tests

#### Did you add any tests for the change?
Yes, previously the greedy splitters did not check `fh` handling and now both have a test to cover this.