### PR TITLE
[ENH] Improvements to `EnbPIForecaster`: parallelised fit, fix incompatibilities with some forecasters, add stationarity test for OOB train residuals

### DIFF
--- a/sktime/forecasting/enbpi.py
+++ b/sktime/forecasting/enbpi.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 from sklearn.base import clone
 from sklearn.utils import check_random_state
-from tsbootstrap import MovingBlockBootstrap
 
 from sktime.forecasting.base import BaseForecaster
 from sktime.forecasting.naive import NaiveForecaster
@@ -138,6 +137,8 @@ class EnbPIForecaster(BaseForecaster):
 
         super().__init__()
 
+        from tsbootstrap.block_bootstrap import MovingBlockBootstrap
+
         self.bootstrap_transformer_ = (
             clone(bootstrap_transformer)
             if bootstrap_transformer is not None
@@ -240,9 +241,10 @@ class EnbPIForecaster(BaseForecaster):
 
     def _check_train_residual_stationarity(self, coverage, residuals):
         """
-        Check if the residuals of the training set are stationary. This is important for
-        the EnbPI algorithm to work correctly, as there is an explicit assumption that
-        the train out-of-bag residuals are must be stationary.
+        Check if the residuals of the training set are stationary.
+
+        This is important for the EnbPI algorithm to work correctly, as there is an
+        explicit assumption that the train out-of-bag residuals are must be stationary.
         """
         for i, cov in enumerate(coverage):
             train_residuals = pd.DataFrame(data=residuals[i], index=self._y.index)
@@ -292,7 +294,7 @@ class EnbPIForecaster(BaseForecaster):
         deps = cls.get_class_tag("python_dependencies")
 
         if _check_soft_dependencies(deps, severity="none"):
-            from tsbootstrap import BlockBootstrap
+            from tsbootstrap.block_bootstrap import BlockBootstrap
 
             params = [
                 {},

--- a/sktime/forecasting/enbpi.py
+++ b/sktime/forecasting/enbpi.py
@@ -1,14 +1,18 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Implements EnbPIForecaster."""
 
+import warnings
+
 import numpy as np
 import pandas as pd
 from sklearn.base import clone
 from sklearn.utils import check_random_state
+from tsbootstrap import MovingBlockBootstrap
 
 from sktime.forecasting.base import BaseForecaster
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.libs._aws_fortuna_enbpi.enbpi import EnbPI
+from sktime.param_est.stationarity import StationarityKPSS
 from sktime.utils.parallel import parallelize
 
 __all__ = ["EnbPIForecaster"]
@@ -112,6 +116,7 @@ class EnbPIForecaster(BaseForecaster):
         bootstrap_transformer=None,
         random_state=None,
         aggregation_function="mean",
+        stationarity_estimator=None,
     ):
         self.forecaster = forecaster
         self.forecaster_ = (
@@ -129,15 +134,20 @@ class EnbPIForecaster(BaseForecaster):
                 f"Aggregation function {self.aggregation_function} not supported. "
                 f"Please choose either 'mean' or 'median'."
             )
+        self.stationarity_estimator = stationarity_estimator
 
         super().__init__()
-
-        from tsbootstrap import MovingBlockBootstrap
 
         self.bootstrap_transformer_ = (
             clone(bootstrap_transformer)
             if bootstrap_transformer is not None
             else MovingBlockBootstrap()
+        )
+
+        self.stationarity_estimator_ = (
+            stationarity_estimator.clone()
+            if stationarity_estimator is not None
+            else StationarityKPSS()
         )
 
     def _fit(self, X, y, fh=None):
@@ -202,15 +212,20 @@ class EnbPIForecaster(BaseForecaster):
         train_targets = self._y.copy()
         train_targets.index = pd.RangeIndex(len(train_targets))
         intervals = []
+        residuals = []
         for cov in coverage:
-            conformal_intervals = EnbPI(self.aggregation_function).conformal_interval(
+            conformal_intervals, train_residuals = EnbPI(
+                self.aggregation_function
+            ).conformal_interval(
                 bootstrap_indices=self.indexes,
                 bootstrap_train_preds=np.stack(self._preds),
                 bootstrap_test_preds=np.stack(preds),
                 train_targets=train_targets.values,
                 error=1 - cov,
+                return_residuals=True,
             )
             intervals.append(conformal_intervals.reshape(-1, 2))
+            residuals.append(train_residuals.ravel())
 
         cols = pd.MultiIndex.from_product(
             [self._y.columns, coverage, ["lower", "upper"]]
@@ -219,7 +234,26 @@ class EnbPIForecaster(BaseForecaster):
         pred_int = pd.DataFrame(
             np.concatenate(intervals, axis=1), index=fh_absolute_idx, columns=cols
         )
+        self._check_train_residual_stationarity(coverage, residuals)
+
         return pred_int
+
+    def _check_train_residual_stationarity(self, coverage, residuals):
+        """
+        Check if the residuals of the training set are stationary. This is important for
+        the EnbPI algorithm to work correctly, as there is an explicit assumption that
+        the train out-of-bag residuals are must be stationary.
+        """
+        for i, cov in enumerate(coverage):
+            train_residuals = pd.DataFrame(data=residuals[i], index=self._y.index)
+            param_estimator = self.stationarity_estimator_.clone()
+            param_estimator.fit(train_residuals)
+            is_stationary = param_estimator.stationary_
+            if not is_stationary:
+                warnings.warn(
+                    f"Residuals for the out-of-bag training set are not stationary. "
+                    f"Prediction intervals may be unreliable for coverage {cov}."
+                )
 
     def _update(self, y, X=None, update_params=True):
         """Update cutoff value and, optionally, fitted parameters.


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #8212
Fixes #8216 


#### What does this implement/fix? Explain your changes.
- As described in #8212, as `EnbPIForecaster`'s `fit()` uses a different `fh` than that used to generate the predictions over the original train data (here `fh=y.index()`), this meant the wrapper was incompatible with forecasters that do not support different `fh`s in `fit` and `predict` (e.g. `DirectReductionForecaster`). This PR fixes this by cloning the forecaster and making a `fit_predict` call.
- As described in the "additional issues" section of of #8212, the serial fitting of bootstrapped time series and predicting the whole `y.index()` got really slow with some forecasters (e.g. `DirectReductionForecaster`), so I added a very naive implementation
- As described in #8216, the EnbPI algorithm has an explicit assumption on stationarity of the out-of-bag train residuals. Given that these residuals are easy to extract from the `fortuna` call and the stationarity check is easy to do with `sktime` parameter estimator objects, I included a check for stationarity and warning if not fullfilled.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?
- Validity of the parallelisation: it should probably be optional and give the option to surface some parallel-related params in the init but I was unsure if I was doing this properly.
- If there is a cleaner way to check for stationarity of the OOB train residuals

#### Did you add any tests for the change?

No, but probably should, so I kept this PR as draft