### PR TITLE
[FIX] Fix aggregation function assignment in EnbPI class

### DIFF
--- a/sktime/libs/_aws_fortuna_enbpi/enbpi.py
+++ b/sktime/libs/_aws_fortuna_enbpi/enbpi.py
@@ -27,7 +27,7 @@ class EnbPI:
         if aggregation_fun == "mean":
             self.aggregation_fun = lambda x: np.mean(x, 0)
         elif aggregation_fun == "median":
-            self._aggregation_fun = lambda x: np.median(x, 0)
+            self.aggregation_fun = lambda x: np.median(x, 0)
 
     def conformal_interval(
         self,


### PR DESCRIPTION
I found a bug in the `EnbPI` class that we picked up from fortuna. It was in the `init` by which if a user selected "median" as the aggregation function, this was incorrect assigned to `_aggregation_fun` instead of `aggregation_fun`. The `_aggregation_fun` is never used in the code. See below:

```python
        if aggregation_fun == "mean":
            self.aggregation_fun = lambda x: np.mean(x, 0)
        elif aggregation_fun == "median":
            self._aggregation_fun = lambda x: np.median(x, 0)
```

The obvious quick fix is to drop the leading underscore.