### PR TITLE
[ENH] `_placeholder_record` to allow mirroring of multiple locations, update of `skchange` import locations

### DIFF
--- a/sktime/detection/skchange_aseg/capa.py
+++ b/sktime/detection/skchange_aseg/capa.py
@@ -4,7 +4,7 @@ from sktime.detection.base import BaseDetector
 from sktime.utils.dependencies import _placeholder_record
 
 
-@_placeholder_record("skchange.anomaly_detectors.capa")
+@_placeholder_record(["skchange.anomaly_detectors", "skchange.anomaly_detectors.capa"])
 class CAPA(BaseDetector):
     """CAPA = Collective and point anomaly detection, from skchange.
 

--- a/sktime/detection/skchange_aseg/circular_binseg.py
+++ b/sktime/detection/skchange_aseg/circular_binseg.py
@@ -4,7 +4,9 @@ from sktime.detection.base import BaseDetector
 from sktime.utils.dependencies import _placeholder_record
 
 
-@_placeholder_record("skchange.anomaly_detectors.circular_binseg")
+@_placeholder_record(
+    ["skchange.anomaly_detectors", "skchange.anomaly_detectors.circular_binseg"]
+)
 class CircularBinarySegmentation(BaseDetector):
     """Circular binary segmentation algorithm for anomalous segment detection, skchange.
 

--- a/sktime/detection/skchange_aseg/mvcapa.py
+++ b/sktime/detection/skchange_aseg/mvcapa.py
@@ -4,7 +4,7 @@ from sktime.detection.base import BaseDetector
 from sktime.utils.dependencies import _placeholder_record
 
 
-@_placeholder_record("skchange.anomaly_detectors.capa")
+@_placeholder_record(["skchange.anomaly_detectors", "skchange.anomaly_detectors.capa"])
 class MVCAPA(BaseDetector):
     """MVCAPA = Multivariate collective and point anomaly detection, from skchange.
 

--- a/sktime/detection/skchange_aseg/statthreshold.py
+++ b/sktime/detection/skchange_aseg/statthreshold.py
@@ -6,7 +6,9 @@ from sktime.detection.base import BaseDetector
 from sktime.utils.dependencies import _placeholder_record
 
 
-@_placeholder_record("skchange.anomaly_detectors.anomalisers")
+@_placeholder_record(
+    ["skchange.anomaly_detectors", "skchange.anomaly_detectors.anomalisers"]
+)
 class StatThresholdAnomaliser(BaseDetector):
     """Anomaly detection based on thresholding values of segment statistics, skchange.
 

--- a/sktime/detection/skchange_cp/moving_window.py
+++ b/sktime/detection/skchange_cp/moving_window.py
@@ -4,7 +4,9 @@ from sktime.detection.base import BaseDetector
 from sktime.utils.dependencies import _placeholder_record
 
 
-@_placeholder_record("skchange.change_detectors.moving_window")
+@_placeholder_record(
+    ["skchange.change_detectors", "skchange.change_detectors.moving_window"]
+)
 class MovingWindow(BaseDetector):
     """Moving window algorithm for multiple changepoint detection, from skchange.
 

--- a/sktime/detection/skchange_cp/pelt.py
+++ b/sktime/detection/skchange_cp/pelt.py
@@ -4,7 +4,7 @@ from sktime.detection.base import BaseDetector
 from sktime.utils.dependencies import _placeholder_record
 
 
-@_placeholder_record("skchange.change_detectors.pelt")
+@_placeholder_record(["skchange.change_detectors", "skchange.change_detectors.pelt"])
 class PELT(BaseDetector):
     """Pruned exact linear time changepoint detection, from skchange.
 

--- a/sktime/detection/skchange_cp/seeded_binseg.py
+++ b/sktime/detection/skchange_cp/seeded_binseg.py
@@ -4,7 +4,9 @@ from sktime.detection.base import BaseDetector
 from sktime.utils.dependencies import _placeholder_record
 
 
-@_placeholder_record("skchange.change_detectors.seeded_binseg")
+@_placeholder_record(
+    ["skchange.change_detectors", "skchange.change_detectors.seeded_binseg"]
+)
 class SeededBinarySegmentation(BaseDetector):
     """Seeded binary segmentation algorithm for changepoint detection, from skchange.
 

--- a/sktime/utils/dependencies/_placeholder.py
+++ b/sktime/utils/dependencies/_placeholder.py
@@ -62,7 +62,8 @@ def _placeholder_record(module_name, obj_name=None, dependencies=None, condition
         if not load_condition:
             return cls
 
-        if isinstance(module_name, str):
+        if isinstance(module_name, str):  # noqa: F823
+            # false positive for flake8, does not understand decorators
             module_name = [module_name]
 
         for module in module_name:

--- a/sktime/utils/dependencies/_placeholder.py
+++ b/sktime/utils/dependencies/_placeholder.py
@@ -46,7 +46,8 @@ def _placeholder_record(module_name, obj_name=None, dependencies=None, condition
             _obj_name = cls.__name__
         else:
             _obj_name = obj_name
-
+        # same for module_name and condition
+        _module_name = module_name
         load_condition = condition
 
         deps_satisfied = _check_estimator_deps(cls, severity="none")
@@ -62,11 +63,10 @@ def _placeholder_record(module_name, obj_name=None, dependencies=None, condition
         if not load_condition:
             return cls
 
-        if isinstance(module_name, str):  # noqa: F823
-            # false positive for flake8, does not understand decorators
-            module_name = [module_name]
+        if isinstance(_module_name, str):
+            _module_name = [_module_name]
 
-        for module in module_name:
+        for module in _module_name:
             # attempt to import the object from the module
             imported_cls = _attempt_import(module, _obj_name)
 


### PR DESCRIPTION
This PR updates `_placeholder_record` to allow mirroring of mulitple upstream locations, which are checked in sequence.

The direct use case is recent breaking changes of import locations in `skchange`, moving public import locations of individual estimators one level up.

In order to maintain compatibility with both newer and older locations, the new `_placeholder_record` is used with the pattern `[new_location, old_location]`.

FYI @tveten, are these the correct new import locations? Also, for your convenience, here is the deprecation/change policy we are using:
https://www.sktime.net/en/stable/developer_guide/deprecation.html

It would be great if you would add some testing for integrity of the import locations in `skchange`!