### PR TITLE
added 'object_type':'forecaster' in estimator type  of __PytorchForecastingAdapter(_BaseGlobalForecaster) class

### DIFF
--- a/sktime/forecasting/base/adapters/_pytorchforecasting.py
+++ b/sktime/forecasting/base/adapters/_pytorchforecasting.py
@@ -64,6 +64,7 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
         ],
         # estimator type
         # --------------
+        "object_type": "forecaster",
         "y_inner_mtype": [
             "pd-multiindex",
             "pd_multiindex_hier",


### PR DESCRIPTION
Fix this issue: #8218 