### PR TITLE
[BUG] fix `RotationForest` for a custom `base_estimator`

### DIFF
--- a/sktime/classification/sklearn/_rotation_forest.py
+++ b/sktime/classification/sklearn/_rotation_forest.py
@@ -137,6 +137,11 @@ class RotationForest(ClassifierMixin, BaseEstimator):
 
         super().__init__()
 
+        if self.base_estimator is None:
+            self._base_estimator = DecisionTreeClassifier(criterion="entropy")
+        else:
+            self._base_estimator = self.base_estimator
+
     def fit(self, X, y):
         """Fit a forest of trees on cases (X,y), where y is the target variable.
 
@@ -184,9 +189,6 @@ class RotationForest(ClassifierMixin, BaseEstimator):
         time_limit = self.time_limit_in_minutes * 60
         start_time = time.time()
         train_time = 0
-
-        if self.base_estimator is None:
-            self._base_estimator = DecisionTreeClassifier(criterion="entropy")
 
         # remove useless attributes
         self._useful_atts = ~np.all(X[1:] == X[:-1], axis=0)

--- a/sktime/classification/sklearn/tests/test_all_classifiers.py
+++ b/sktime/classification/sklearn/tests/test_all_classifiers.py
@@ -3,6 +3,7 @@
 __author__ = ["MatthewMiddlehurst"]
 
 import pytest
+from sklearn.linear_model import LogisticRegression
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from sktime.classification.sklearn import ContinuousIntervalTree, RotationForest
@@ -10,12 +11,18 @@ from sktime.tests.test_switch import run_test_for_class
 
 ALL_SKLEARN_CLASSIFIERS = [RotationForest, ContinuousIntervalTree]
 
+INSTANCES_TO_TEST = [
+    RotationForest(n_estimators=3),
+    RotationForest(n_estimators=3, base_estimator=LogisticRegression()),
+    ContinuousIntervalTree(),
+]
+
 
 @pytest.mark.skipif(
     not run_test_for_class(ALL_SKLEARN_CLASSIFIERS),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-@parametrize_with_checks([RotationForest(n_estimators=3), ContinuousIntervalTree()])
+@parametrize_with_checks(INSTANCES_TO_TEST)
 def test_sklearn_compatible_estimator(estimator, check):
     """Test that sklearn estimators adhere to sklearn conventions."""
     try:


### PR DESCRIPTION
Fixes https://github.com/sktime/sktime/issues/8265 - the reason was that `base_estimator` was not written to `self._base_estimator` when a non-standard one was provided.

Adds the failure case to the test.