### PR TITLE
[DOC] full API reference for `polars` based mtypes for time series, panels, and hierarchical data

### DIFF
--- a/sktime/datatypes/_hierarchical/_check.py
+++ b/sktime/datatypes/_hierarchical/_check.py
@@ -308,6 +308,51 @@ class HierarchicalDask(ScitypeHierarchical):
 class HierarchicalPolarsEager(ScitypeHierarchical):
     """Data type: polars DataFrame frame based specification of hierarchical series.
 
+    Name: ``"polars_hierarchical"``
+
+    Short description:
+
+    a ``polars.DataFrame``,
+    where instance index and time index are columns starting with ``__index__``,
+    having exactly two such columns.
+    The last, rightmost column is interpreted as a time index,
+    and the other ``__index__`` columns are interpreted as hierarchy indices.
+    The other cols are the variables.
+
+    Long description:
+
+    The ``"polars_hierarchical"`` :term:`mtype` is a concrete specification
+    that implements the ``Hierarchical`` :term:`scitype`, i.e., the abstract
+    type of a hierarchically indexed collection of time series.
+
+    An object ``obj: polars.DataFrame`` follows the specification iff
+
+    * structure convention: ``obj`` must be a ``polars.DataFrame``,
+      with three or more columns starting with ``__index__``.
+      The last, rightmost ``__index__`` column is interpreted as a time index.
+      Its values must be monotonically increasing with rows,
+      for rows with the same values of other index columns.
+    * hierarchy level: rows with the same non-time index values correspond to the
+      same hierarchy unit; rows with different non-time index combination
+      correspond to different hierarchy unit.
+    * hierarchy: the non-time indices are interpreted as hierarchy identifying index.
+    * time index: the values in the last column starting with
+      ``__index__`` are interpreted as a time index.
+    * time points: rows of ``obj`` with the same time index index correspond
+      to the same time point; rows of ``obj`` with different time index
+      correspond to the different time points.
+    * variables: all columns not starting with ``__index__``
+      are interpreted as variables.
+    * variable names: column names of ``obj`` which do not start with ``__index__``.
+
+    Capabilities:
+
+    * can represent multivariate hierarchical series
+    * can represent unequally spaced hierarchical series
+    * can represent unequally supported hierarchical series
+    * cannot represent hierarchical series with different sets of variables
+    * can represent missing values
+
     Parameters
     ----------
     is_univariate: bool

--- a/sktime/datatypes/_panel/_check.py
+++ b/sktime/datatypes/_panel/_check.py
@@ -1061,6 +1061,48 @@ class PanelDask(ScitypePanel):
 class PanelPolarsEager(ScitypePanel):
     """Data type: polars.DataFrame based specification of panel of time series.
 
+    Name: ``"polars_panel"``
+
+    Short description:
+
+    a ``polars.DataFrame``,
+    where instance index and time index are columns starting with ``__index__``,
+    having exactly two such columns.
+    The first (leftmost) column is the instance index,
+    the second (rightmost) column is the time index.
+    The other cols are the variables.
+
+    Long description:
+
+    The ``"polars_panel"`` :term:`mtype` is a concrete specification
+    that implements the ``Panel`` :term:`scitype`, i.e., the abstract
+    type of a collection of time series.
+
+    An object ``obj: polars.DataFrame`` follows the specification iff:
+
+    * structure convention: ``obj`` must be a ``polars.DataFrame``,
+      with exactly two columns starting with ``__index__``.
+      The values of the last, rightmost index must be monotonically increasing
+      with rows,
+      for rows with the same values of the first, leftmost index column.
+    * instances: the first column starting with ``__index__`` is interpreted
+      as an instance index. All rows with the same instance index value
+      correspond to the same instance.
+    * instance index: The values in the first column starting with ``__index__``.
+    * time points: the second column starting with ``__index__`` is interpreted
+      as a time index.
+    * time index: The values in the second column starting with ``__index__``.
+    * variables: all other columns are interpreted as variables.
+    * variable names: column names of ``obj`` which do not start with ``__index__``.
+
+    Capabilities:
+
+    * can represent panels of multivariate series
+    * can represent unequally spaced series
+    * can represent panels of unequally supported series
+    * cannot represent panels of series with different sets of variables
+    * can represent missing values
+
     Parameters
     ----------
     is_univariate: bool

--- a/sktime/datatypes/_series/_check.py
+++ b/sktime/datatypes/_series/_check.py
@@ -813,6 +813,39 @@ class SeriesDask(ScitypeSeries):
 class SeriesPolarsEager(ScitypeSeries):
     """Data type: polars.DataFrame based specification of single time series.
 
+    Name: ``"pl.DataFrame"``
+
+    Short description:
+
+    a ``polars.DataFrame`` where rows are interpred as temporally ordered.
+    Optionally, a time index can be present as a single column starting with
+    ``__index__``, e.g., ``__index__0`` or ``__index__time``, or ``__index__``.
+
+    Long description:
+
+    The ``"polars.DataFrame"`` :term:`mtype` is a concrete specification
+    that implements the ``Series`` :term:`scitype`, i.e., the abstract
+    type of a single time series.
+
+    An object ``obj: polars.DataFrame`` follows the specification iff:
+
+    * structure convention: if an ``__index__`` column is present,
+      its values must increase monotonically by row. Otherwise, no
+      additional structure is required.
+    * variables: columns of ``obj`` correspond to different variables,
+      with exception of the ``__index__`` column if present.
+    * variable names: column names ``obj.columns``
+    * time points: rows of ``obj`` correspond to different, distinct time points
+    * time index: if an ``__index__`` column is present,
+      its values are interpreted as time index. If not, the index is
+      interpreted to be a zero-indexed integer index.
+
+    Capabilities:
+
+    * can represent multivariate series
+    * can represent unequally spaced series
+    * can represent missing values
+
     Parameters
     ----------
     is_univariate: bool


### PR DESCRIPTION
This PR adds a full API reference for `polars` based mtypes for time series, panels, and hierarchical data.

Towards https://github.com/sktime/sktime/issues/7386