### PR TITLE
[DOC] metric docstring fix - `numpy.float64` type print

### DIFF
--- a/sktime/performance_metrics/forecasting/_classes.py
+++ b/sktime/performance_metrics/forecasting/_classes.py
@@ -2772,16 +2772,16 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     >>> y_pred = np.array([2.5, 0.0, 2, 8, 1.25])
     >>> mape = MeanAbsolutePercentageError(symmetric=False)
     >>> mape(y_true, y_pred)
-    np.float64(0.33690476190476193)
+    0.33690476190476193...
     >>> smape = MeanAbsolutePercentageError(symmetric=True)
     >>> smape(y_true, y_pred)
-    np.float64(0.5553379953379953)
+    0.5553379953379953...
     >>> y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
     >>> y_pred = np.array([[0, 2], [-1, 2], [8, -5]])
     >>> mape(y_true, y_pred)
-    np.float64(0.5515873015873016)
+    0.5515873015873016...
     >>> smape(y_true, y_pred)
-    np.float64(0.6080808080808081)
+    0.6080808080808081...
     >>> mape = MeanAbsolutePercentageError(multioutput='raw_values', symmetric=False)
     >>> mape(y_true, y_pred)
     array([0.38095238, 0.72222222])
@@ -2790,10 +2790,10 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     array([0.71111111, 0.50505051])
     >>> mape = MeanAbsolutePercentageError(multioutput=[0.3, 0.7], symmetric=False)
     >>> mape(y_true, y_pred)
-    np.float64(0.6198412698412699)
+    0.6198412698412699...
     >>> smape = MeanAbsolutePercentageError(multioutput=[0.3, 0.7], symmetric=True)
     >>> smape(y_true, y_pred)
-    np.float64(0.5668686868686869)
+    0.5668686868686869...
     """
 
     func = mean_absolute_percentage_error


### PR DESCRIPTION
Attempted fix for the metrics doctests using ellipsis.