### PR TITLE
[DOC] Add missing space to `Pipeline` constructor warning

### DIFF
--- a/sktime/pipeline/pipeline.py
+++ b/sktime/pipeline/pipeline.py
@@ -165,7 +165,7 @@ class Pipeline(BaseEstimator):
             "such as TransformedTargetForecaster, ForecastingPipeline, "
             "ClassificationPipeline, etc., see for instance "
             "notebooks 01_forecasting.ipynb and "
-            "02_classification.ipynb at"
+            "02_classification.ipynb at "
             "https://github.com/sktime/sktime/blob/main/examples/.",
             stacklevel=1,
         )


### PR DESCRIPTION
There's a typo in `Pipeline`'s constructor in a multi-line string leading to this:

<img width="1022" alt="Typo" src="https://github.com/user-attachments/assets/3cb679b1-ae5a-4aaf-9933-29c8b711f41d" />

This PR fixes it, making formatting of that line consistent with how spaces are enabled in adjacent lines.