### PR TITLE
Fix pandas FutureWarning by replacing inplace fillna with reassignment (#8268)

### DIFF
--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -132,3 +132,4 @@ Estimator Validity Checking
     :template: function.rst
 
     check_estimator
+.. autofunction:: sktime.utils.plot_windows

--- a/sktime/forecasting/base/adapters/_pytorchforecasting.py
+++ b/sktime/forecasting/base/adapters/_pytorchforecasting.py
@@ -506,7 +506,7 @@ class _PytorchForecastingAdapter(_BaseGlobalForecaster):
             time_varying_known_reals = []
             data = deepcopy(y)
         # if fh is not continuous, there will be NaN after extend_y in prediect
-        data["_target_column"].fillna(0, inplace=True)
+        data["_target_column"] = data["_target_column"].fillna(0)
         # add integer time_idx column as pytorch-forecasting requires
         if self._index_len > 1:
             time_idx = (


### PR DESCRIPTION
This PR fixes a pandas FutureWarning triggered by using fillna with inplace=True on a DataFrame slice, which causes chained assignment issues. The fix replaces the inplace call with an explicit assignment to avoid the warning and ensure compatibility with pandas 3.0 and later.

The line:
data["_target_column"].fillna(0, inplace=True)

was changed to:
data["_target_column"] = data["_target_column"].fillna(0)

Why this change?
Eliminates the FutureWarning during runtime
Ensures compatibility with Pandas 3.0+
Prevents chained assignment bugs, improving code safety and clarity