### PR TITLE
[DOC] Fix Docstring Example of Distance Based Classifiers

### DIFF
--- a/sktime/classification/distance_based/_time_series_neighbors_pyts.py
+++ b/sktime/classification/distance_based/_time_series_neighbors_pyts.py
@@ -75,8 +75,8 @@ class KNeighborsTimeSeriesClassifierPyts(_PytsAdapter, BaseClassifier):
 
     Examples
     --------
-    >>> import sktime.classification.distance_based as clf_db  # doctest: +SKIP
-    >>> from clf_db import KNeighborsTimeSeriesClassifierPyts  # doctest: +SKIP
+    >>> from sktime.classification.distance_based import (  # doctest: +SKIP
+    ...     KNeighborsTimeSeriesClassifierPyts)  # doctest: +SKIP
     >>> from sktime.datasets import load_unit_test  # doctest: +SKIP
     >>> X_train, y_train = load_unit_test(split="train")  # doctest: +SKIP
     >>> X_test, y_test = load_unit_test(split="test")  # doctest: +SKIP

--- a/sktime/classification/distance_based/_time_series_neighbors_tslearn.py
+++ b/sktime/classification/distance_based/_time_series_neighbors_tslearn.py
@@ -59,8 +59,8 @@ class KNeighborsTimeSeriesClassifierTslearn(_TslearnAdapter, BaseClassifier):
 
     Examples
     --------
-    >>> import sktime.classification.distance_based as db_clf  # doctest: +SKIP
-    >>> from db_clf import KNeighborsTimeSeriesClassifierTslearn  # doctest: +SKIP
+    >>> from sktime.classification.distance_based import ( # doctest: +SKIP
+    ...    KNeighborsTimeSeriesClassifierTslearn) # doctest: +SKIP
     >>> from sktime.datasets import load_unit_test  # doctest: +SKIP
     >>> X_train, y_train = load_unit_test(split="train")  # doctest: +SKIP
     >>> X_test, y_test = load_unit_test(split="test")  # doctest: +SKIP


### PR DESCRIPTION
Fixes #8312 

This PR corrects the doctest example of two distance based classifiers. They were giving a `ModuleNotFound` error because of how they were getting imported. 