### PR TITLE
[ENH] enforce `MeanSquaredErrorPercentage` to be positive

### DIFF
--- a/sktime/performance_metrics/forecasting/_msep.py
+++ b/sktime/performance_metrics/forecasting/_msep.py
@@ -21,7 +21,7 @@ class MeanSquaredErrorPercentage(BaseForecastingErrorMetricFunc):
 
     .. math::
         \\text{MSE%} = \\frac{ \\frac{1}{n} \\sum_{i=1}^{n} (y_i - \\hat{y}_i)^2 }
-                            { \\sum_{i=1}^{n} \\frac{y_i}{n} }
+                            { \left| \\sum_{i=1}^{n} \\frac{y_i}{n} \right| }
 
     where:
     - \\( y_i \\) are the true values,
@@ -100,7 +100,7 @@ class MeanSquaredErrorPercentage(BaseForecastingErrorMetricFunc):
         raw_values = (y_true - y_pred) ** 2
         raw_values = self._get_weighted_df(raw_values, **kwargs)
         num = raw_values.mean()
-        denom = y_true.mean()
+        denom = y_true.mean().abs()
 
         msqe = num / denom
 


### PR DESCRIPTION
This changes `MeanSquaredErrorPercentage` to be positive if the denominator - the mean of ground truth samples - is negative.

This also solves an unreported sporadic bug in rarer cases when, on the test data, said denominator is negative, and the square root is computed via `square_root=True`.

I do not consider this a breaking change, since sound usage should happen only if the average is indeed a positive number - and since the "lower is better" tag was set to `True`.