### PR TITLE
[MNT] Make grid search parameters configurable to enable faster testing

### DIFF
--- a/sktime/classification/distance_based/_shape_dtw.py
+++ b/sktime/classification/distance_based/_shape_dtw.py
@@ -103,6 +103,13 @@ class ShapeDTW(BaseClassifier):
     metric_params               : dictionary for metric parameters
                                   (default = None).
 
+
+    n_splits                : int, number of splits for cross-validation
+                              (default = 10). Used for finding  the
+                              weighting_factor if 'shape_descriptor_function'
+                              is set to 'compound' and weighting_factor is
+                              not given in 'metric_params'.
+
     Notes
     -----
     .. [1] Jiaping Zhao and Laurent Itti, "shapeDTW: Shape Dynamic Time Warping",
@@ -144,8 +151,10 @@ class ShapeDTW(BaseClassifier):
         shape_descriptor_function="raw",
         shape_descriptor_functions=None,
         metric_params=None,
+        n_splits=10,
     ):
         self.n_neighbors = n_neighbors
+        self.n_splits = n_splits
         self.subsequence_length = subsequence_length
         self.shape_descriptor_function = shape_descriptor_function
         self.shape_descriptor_functions = shape_descriptor_functions
@@ -222,25 +231,30 @@ class ShapeDTW(BaseClassifier):
         self.metric_params = {k.lower(): v for k, v in self.metric_params.items()}
 
         # Get the weighting_factor if one is provided
-        if self.metric_params.get("weighting_factor") is not None:
+        if isinstance(self.metric_params.get("weighting_factor"), float):
             self.weighting_factor = self.metric_params.get("weighting_factor")
         else:
-            # Tune it otherwise
-            self._param_matrix = {
-                "metric_params": [
-                    {"weighting_factor": 0.1},
-                    {"weighting_factor": 0.125},
-                    {"weighting_factor": (1 / 6)},
-                    {"weighting_factor": 0.25},
-                    {"weighting_factor": 0.5},
-                    {"weighting_factor": 1},
-                    {"weighting_factor": 2},
-                    {"weighting_factor": 4},
-                    {"weighting_factor": 6},
-                    {"weighting_factor": 8},
-                    {"weighting_factor": 10},
-                ]
-            }
+            if isinstance(self.metric_params.get("weighting_factor"), list):
+                self._param_matrix = {
+                    "metric_params": self.metric_params.get("weighting_factor")
+                }
+            else:
+                # Tune it otherwise
+                self._param_matrix = {
+                    "metric_params": [
+                        {"weighting_factor": 0.1},
+                        {"weighting_factor": 0.125},
+                        {"weighting_factor": (1 / 6)},
+                        {"weighting_factor": 0.25},
+                        {"weighting_factor": 0.5},
+                        {"weighting_factor": 1},
+                        {"weighting_factor": 2},
+                        {"weighting_factor": 4},
+                        {"weighting_factor": 6},
+                        {"weighting_factor": 8},
+                        {"weighting_factor": 10},
+                    ]
+                }
 
             n = self.n_neighbors
             sl = self.subsequence_length
@@ -263,7 +277,7 @@ class ShapeDTW(BaseClassifier):
                     metric_params=mp,
                 ),
                 param_grid=self._param_matrix,
-                cv=KFold(n_splits=10, shuffle=True),
+                cv=KFold(n_splits=self.n_splits, shuffle=True),
                 scoring="accuracy",
             )
             grid.fit(X, y)
@@ -546,5 +560,6 @@ class ShapeDTW(BaseClassifier):
             "n_neighbors": 3,
             "shape_descriptor_function": "compound",
             "shape_descriptor_functions": ["paa", "dwt"],
+            "n_splits": 2,
         }
         return [params1, params2]


### PR DESCRIPTION


#### Reference Issues/PRs
Fixes #8323



#### What does this implement/fix? Explain your changes.

I make the n_splits and the weighting_factor configurable. Making them configurable enables us to reduce the number of parameters that need to be tested in the params set 2. 


#### Improvements on local machine:

* Original Params 2 take 114.19 seconds
* Setting the n_split to 2 take 26.51 seconds
* Setting n_split to 2 and testing only two configurations takes 8.27 seconds

