### PR TITLE
[BUG] fix wrong return of fit in doc tests of `MoiraiForecaster` and `TimeLLM`

### DIFF
--- a/sktime/forecasting/moirai_forecaster.py
+++ b/sktime/forecasting/moirai_forecaster.py
@@ -69,6 +69,7 @@ class MOIRAIForecaster(_BaseGlobalForecaster):
     >>> y = pd.DataFrame(y, index=index)
     >>> X = pd.DataFrame(X, columns=["x1", "x2"], index=index)
     >>> morai_forecaster.fit(y, X=X)
+    MOIRAIForecaster(checkpoint_path='sktime/moirai-1.0-R-small')
     >>> X_test = pd.DataFrame(np.random.normal(0, 1, (10, 2)),
     ...                      columns=["x1", "x2"],
     ...                      index=pd.date_range("2020-01-31", periods=10, freq="D"),

--- a/sktime/forecasting/time_llm.py
+++ b/sktime/forecasting/time_llm.py
@@ -71,7 +71,7 @@ class TimeLLMForecaster(BaseForecaster):
     ...     llm_model='GPT2'
     ... )
     >>> forecaster.fit(y, fh=[1])
-    TimeLLMForecaster(pred_len=1)
+    TimeLLMForecaster(pred_len=36)
     >>> y_pred = forecaster.predict(fh=[1])
     """
 


### PR DESCRIPTION


#### What does this implement/fix? Explain your changes.
Fix return type of MoiraiForecaster and TimeLLLM
