### PR TITLE
[MNT] Enhancing CI to ignore tests on estimators that require large computing time, controlled by a separate tag to include such estimators

### DIFF
--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -341,6 +341,39 @@ class env_marker(_BaseTag):
     }
 
 
+class test_only_estimator(_BaseTag):
+    """Tag to determine test execution strategy of estimator in sktime CI.
+
+    Part of packaging metadata for the object, used only in ``sktime`` CI.
+
+    ``sktime``'s CI framework regularly tests various estimators in pull requests,
+    along with the estimator that is being implemented or modified. If the base
+    module has been modified, then all estimators that inherit from the
+    base module are also tested.
+
+    The `test_only_estimator` tag is used to indicate whether the tests for the
+    estimator should only be run when the estimator itself is modified.
+    Therefore pull requests that do not modify the estimator will not trigger
+    tests for the estimator, including base classes that the estimator
+    inherits from.
+
+    This tag should be set to ``True`` if you would like tests for the estimator to
+    not be triggered unless the estimator/class itself is modified in a pull
+    request. This tag is primarily used for estimators that use high amounts of
+    resources to complete estimator tests, such as time series models built on
+    top of large language models that contain many parameters.
+    This tag should be used sparingly, as it can lead to reduced test coverage.
+    """
+
+    _tags = {
+        "tag_name": "test_only_estimator",
+        "parent_type": "object",
+        "tag_type": "bool",
+        "short_descr": "whether or not the estimator should only be tested when itself has changed",  # noqa: E501
+        "user_facing": False,
+    }
+
+
 class requires_cython(_BaseTag):
     """Whether the object requires a C compiler present, such as libomp, gcc.
 


### PR DESCRIPTION
As we continue to include more LLM based time series models into the library, the new estimators being implemented are beginning to slow down CI runs, impacting both new pull requests and GHA workflows in general. For example, #8234 is a known issue where the `TimeLLM` model was crashing various CI workflows. These failures will impact other pull requests, and prevents new code from being verified if it successfully pass estimator tests.

This PR aims to address this issue by adding a new tag that ensures the tests for an estimator that requires large computing time to only be tested if the module itself has changed as suggested in https://github.com/sktime/sktime/pull/7087#issuecomment-2918774302

Note that the estimator will still be requires to pass its respective estimator tests on the CI, we'll just be ignoring running them again when other PRs unrelated to such estimators to prevent any potential crashes and or slow CI running times.

Also relates to #7087 and #8331 as this pr will likely go after this one as it requires the utility `_get_all_changed_classes` along with the new ci workflows

