### PR TITLE
[DOC] Add unified forecasting usage example notebook

### DIFF
--- a/examples/01d_forecasting_unified_example.ipynb
+++ b/examples/01d_forecasting_unified_example.ipynb
@@ -1,0 +1,68 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9abfd11c-1ea3-4a2b-9e97-d1bfb38f3725",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sktime.datasets import load_airline\n",
+    "from sktime.forecasting.model_selection import temporal_train_test_split\n",
+    "from sktime.forecasting.naive import NaiveForecaster\n",
+    "from sktime.forecasting.arima import AutoARIMA\n",
+    "from sktime.forecasting.exp_smoothing import ExponentialSmoothing\n",
+    "from sktime.forecasting.theta import ThetaForecaster\n",
+    "from sktime.forecasting.base import ForecastingHorizon\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Load data\n",
+    "y = load_airline()\n",
+    "y_train, y_test = temporal_train_test_split(y, test_size=36)\n",
+    "fh = ForecastingHorizon(y_test.index, is_relative=False)\n",
+    "\n",
+    "# Models to compare\n",
+    "models = {\n",
+    "    \"Naive\": NaiveForecaster(strategy=\"last\"),\n",
+    "    \"AutoARIMA\": AutoARIMA(),\n",
+    "    \"ExpSmoothing\": ExponentialSmoothing(),\n",
+    "    \"Theta\": ThetaForecaster()\n",
+    "}\n",
+    "\n",
+    "# Plot forecasts\n",
+    "plt.figure(figsize=(12, 6))\n",
+    "plt.plot(y, label=\"True\")\n",
+    "\n",
+    "for name, model in models.items():\n",
+    "    model.fit(y_train)\n",
+    "    y_pred = model.predict(fh)\n",
+    "    plt.plot(y_pred, label=name)\n",
+    "\n",
+    "plt.title(\"Unified Forecasting Example\")\n",
+    "plt.legend()\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a new example notebook `01d_forecasting_unified_example.ipynb` under the `examples/` folder.

The notebook demonstrates consistent and unified usage of forecasting models in `sktime` using:
- A common dataset
- Consistent structure across models
- Plots for model comparison

This addresses issue #8283 to improve documentation clarity for users exploring forecasting APIs.
