### PR TITLE
[ENH] remove "only multivariate" forecaster property

### DIFF
--- a/sktime/forecasting/dynamic_factor.py
+++ b/sktime/forecasting/dynamic_factor.py
@@ -130,7 +130,7 @@ class DynamicFactor(_StatsModelsAdapter):
         # python_dependencies: "statsmodels" - inherited from _StatsModelsAdapter
         # estimator type
         # --------------
-        "scitype:y": "multivariate",
+        "scitype:y": "both",
         "ignores-exogeneous-X": False,
         "capability:missing_values": True,
         "y_inner_mtype": "pd.DataFrame",

--- a/sktime/forecasting/var.py
+++ b/sktime/forecasting/var.py
@@ -90,7 +90,7 @@ class VAR(_StatsModelsAdapter):
         # "python_dependencies": "statsmodels" - inherited from _StatsModelsAdapter
         # estimator type
         # --------------
-        "scitype:y": "multivariate",
+        "scitype:y": "both",
         "y_inner_mtype": "pd.DataFrame",
         "requires-fh-in-fit": False,
         "ignores-exogeneous-X": True,

--- a/sktime/forecasting/varmax.py
+++ b/sktime/forecasting/varmax.py
@@ -216,7 +216,7 @@ class VARMAX(_StatsModelsAdapter):
         # "python_dependencies": "statsmodels" - inherited from _StatsModelsAdapter
         # estimator type
         # --------------
-        "scitype:y": "multivariate",
+        "scitype:y": "both",
         "ignores-exogeneous-X": False,
         "capability:missing_values": False,
         "y_inner_mtype": "pd.DataFrame",

--- a/sktime/forecasting/vecm.py
+++ b/sktime/forecasting/vecm.py
@@ -94,7 +94,7 @@ class VECM(_StatsModelsAdapter):
         # "python_dependencies": "statsmodels" - inherited from _StatsModelsAdapter
         # estimator type
         # --------------
-        "scitype:y": "multivariate",
+        "scitype:y": "both",
         "y_inner_mtype": "pd.DataFrame",
         "X_inner_mtype": "pd.DataFrame",
         "requires-fh-in-fit": False,

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -73,7 +73,6 @@ EXCLUDE_ESTIMATORS = [
     "FreshPRINCE",
     # multiple timeouts and sporadic failures reported related to VARMAX
     # 2997, 3176, 7985
-    "VARMAX",
     "SARIMAX",
     "SCINetForecaster",  # known bug #7871
     "MAPAForecaster",  # known bug #8039


### PR DESCRIPTION
This PR aims to remove the special treatment of forecasters which can deal with multivariate endogenous data but not with univariate endogenous data - by turning them into forecasters that can deal with both.

This property has proven rare and confusing to users, resulting in a `scitype:y` tag where the value `"both"` indicates the case where a forecaster can deal with univariate and multivariate data, which is >95% of forecasters that can deal with multivariate data.

Ultimately, I would propose to change the tag into a `capability:multivariate` tag that can be True or False, and the two cases are "univariate ok, multivariate is broadcast", and "univariate and multivariate are both ok", though this does not happen in this PR.

WiP - for now this PR simply changes the `"multivariate"` valued tags to `"both"`, to see what fails and/or if the tag value is just an erroneous confusion on developr side - or whether the "univariate does not work" property is truly implied.

