### PR TITLE
[ENH] Add `predict_proba` tag for classifier to estimator overview table

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -420,7 +420,7 @@ def _make_estimator_overview(app):
         ],
         "classifier": [
             "capability:multivariate",
-            "capability: predict_proba",
+            "capability:predict_proba",
             "capability:multioutput",
             "capability:unequal_length",
             "capability:missing_values",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -420,6 +420,7 @@ def _make_estimator_overview(app):
         ],
         "classifier": [
             "capability:multivariate",
+            "capability: predict_proba",
             "capability:multioutput",
             "capability:unequal_length",
             "capability:missing_values",


### PR DESCRIPTION
The table on [Estimator Overview](https://www.sktime.net/en/stable/estimator_overview.html) page does not have the filter for `"capability:predict_proba"` currently. This PR adds it.

<img width="1021" alt="Screenshot 2025-06-04 at 3 53 16 PM" src="https://github.com/user-attachments/assets/535be3fe-aed8-4f43-a13a-3350b622cf77" />
