### PR TITLE
[ENH] Wrap tsai TST and InceptionTime classifiers for use in sktime

### DIFF
--- a/sktime/tsai_integration/__init__.py
+++ b/sktime/tsai_integration/__init__.py
@@ -1,0 +1,8 @@
+"""
+tsai_integration
+================
+Thin wrappers that let you call tsai’s deep-learning models from sktime’s API.
+"""
+from .delegated_classifier import TsaiTSTClassifier, TsaiInceptionTimeClassifier
+
+__all__ = ["TsaiTSTClassifier", "TsaiInceptionTimeClassifier"]

--- a/sktime/tsai_integration/delegated_classifier.py
+++ b/sktime/tsai_integration/delegated_classifier.py
@@ -1,0 +1,126 @@
+"""Wrappers for tsai deep-learning classifiers exposed through sktime."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from sktime.classification.base import BaseClassifier
+from sktime.datatypes._panel._convert import from_nested_to_3d_numpy
+# from sktime.utils.validation._dependencies import _check_soft_dependencies
+
+import torch          # ← required for the custom loss
+
+__author__ = ["timeseriesAI (oguiza)", "estiern", "AlexThomasMa"]
+
+
+# -------------------------------------------------------------------------
+# custom loss: CrossEntropy that always sees integer targets
+# -------------------------------------------------------------------------
+_ce = torch.nn.CrossEntropyLoss()
+
+def _loss(pred, targ):
+    """Wrapper around torch.nn.CrossEntropyLoss that casts targets to long."""
+    return _ce(pred, targ.long())
+# -------------------------------------------------------------------------
+
+
+class _TsaiBaseClassifier(BaseClassifier):
+    """Shared logic for any tsai network used as a classifier in sktime."""
+
+    _tags = {
+        "scitype:instancewise": True,
+        "requires_y": True,
+        "handles-tabular_X": False,
+        "python_dependencies": "tsai",
+    }
+
+    def __init__(self, tsai_model_cls, n_epochs=5, bs=64, lr=1e-3, **fit_kwargs):
+        self.tsai_model_cls = tsai_model_cls
+        self.n_epochs = n_epochs
+        self.bs = bs
+        self.lr = lr
+        self.fit_kwargs = fit_kwargs
+
+        self._learn = None          # fastai Learner (tsai learner)
+        self._classes = None        # np.ndarray of class labels
+
+        super().__init__()
+
+    # ------------------------------------------------------------------ #
+    # fitting
+    # ------------------------------------------------------------------ #
+    def fit(self, X: pd.DataFrame, y: pd.Series):
+        # _check_soft_dependencies("tsai", severity="error")
+        from tsai.all import get_ts_dls, ts_learner
+
+        # 1) Convert nested DataFrame -> 3-D NumPy array of shape (N, C, L)
+        X_np = from_nested_to_3d_numpy(X)
+
+        # 2) Encode y labels to integer indices
+        classes, y_int = np.unique(y, return_inverse=True)
+        self._classes = classes
+        y_int = y_int.astype(np.int64)            # CrossEntropyLoss expects int64
+
+        # 3) Build tsai DataLoaders
+        dls = get_ts_dls(X_np, y_int, bs=self.bs, classification=True)
+
+        # 4) Instantiate tsai model & fastai Learner
+        n_classes = len(self._classes)
+        model = self.tsai_model_cls(dls.vars, n_classes, dls.len)
+        self._learn = ts_learner(dls, model, loss_func=_loss)
+        self._learn.fit_one_cycle(self.n_epochs, self.lr, **self.fit_kwargs)
+
+        return self
+
+    # inference (direct model forward - no fastai helpers)
+    # ------------------------------------------------------------------ #
+    def _forward(self, X_np: np.ndarray):
+        """
+        Run a batch (N,C,L) through the tsai model and return
+        soft-max probabilities – completely avoiding fastai’s
+        `test_dl` / `Learner.predict` code-path.
+        """
+        import torch
+
+        mdl      = self._learn.model.eval()
+        device   = self._learn.dls.device
+        xb       = torch.from_numpy(X_np).to(device).float()      # (N,C,L)
+        with torch.no_grad():
+            logits = mdl(xb)                                      # (N,C)
+            probs  = torch.softmax(logits, dim=1).cpu().numpy()
+        return probs                                              # (N,C)
+
+    def predict(self, X: pd.DataFrame):
+        X_np  = from_nested_to_3d_numpy(X)        # (N,C,L)
+        probs = self._forward(X_np)               # (N,C)
+        idx   = probs.argmax(axis=1)              # (N,)
+        return self._classes[idx]
+
+    def predict_proba(self, X: pd.DataFrame):
+        X_np  = from_nested_to_3d_numpy(X)
+        return self._forward(X_np)
+    # ------------------------------------------------------------------ #
+    # ------------------------------------------------------------------ #
+
+
+def _safe_import_tsai_model(path: str, name: str):
+    """Internal helper so the import only happens if tsai is present."""
+    import importlib
+    return getattr(importlib.import_module(path), name)
+
+
+class TsaiTSTClassifier(_TsaiBaseClassifier):
+    """tsai Temporal Self-Attention (TST) classifier wrapped for sktime."""
+
+    def __init__(self, **kwargs):
+        TST = _safe_import_tsai_model("tsai.models.TST", "TST")  # noqa: N806
+        super().__init__(TST, **kwargs)
+
+
+class TsaiInceptionTimeClassifier(_TsaiBaseClassifier):
+    """tsai InceptionTime classifier wrapped for sktime."""
+
+    def __init__(self, **kwargs):
+        InceptionTime = _safe_import_tsai_model(
+            "tsai.models.InceptionTime", "InceptionTime"
+        )
+        super().__init__(InceptionTime, **kwargs)

--- a/sktime/tsai_integration/delegated_forecaster.py
+++ b/sktime/tsai_integration/delegated_forecaster.py
@@ -1,0 +1,1 @@
+"""Placeholder for future tsai forecasting wrappers (not yet implemented)."""

--- a/sktime/tsai_integration/tests/__init__.py
+++ b/sktime/tsai_integration/tests/__init__.py
@@ -1,0 +1,1 @@
+# makes this a package so pytest finds tests

--- a/sktime/tsai_integration/tests/test_tsai_wrappers.py
+++ b/sktime/tsai_integration/tests/test_tsai_wrappers.py
@@ -1,0 +1,22 @@
+"""Smoke-test that tsai wrappers import, fit, and predict without error."""
+import pandas as pd
+import numpy as np
+import pytest
+
+from sktime.datasets import load_basic_motions
+from sktime.tsai_integration.delegated_classifier import (
+    TsaiTSTClassifier,
+    TsaiInceptionTimeClassifier,
+)
+
+@pytest.mark.parametrize("Cls", [TsaiTSTClassifier, TsaiInceptionTimeClassifier])
+def test_tsai_classifier_smoke(Cls):
+    # load a tiny dataset (5 train instances, 1 channel, ~100 length)
+    X_train, y_train = load_basic_motions(split="train", return_X_y=True)
+
+    clf = Cls(n_epochs=1, bs=4)   # fast smoke test
+    clf.fit(X_train, y_train)
+
+    preds = clf.predict(X_train)
+    assert isinstance(preds, np.ndarray)
+    assert preds.shape[0] == X_train.shape[0]


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for looking at this PR!
I checked the contribution guide at
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes #7885  <[ENH] interface to tsai package>

---

#### What does this implement / fix?

I’ve added wrappers that let sktime call two of the most popular tsai deep-learning architectures out-of-the-box:

New class  (Underlying tsai model):
`TsaiTSTClassifier` (Temporal Self-Attention (TST))
`TsaiInceptionTimeClassifier` (InceptionTime)

Highlights & motivation
---Familiar sktime API– the wrappers inherit from `BaseClassifier`, so `fit / predict / predict_proba` work exactly like the classical estimators.
---Seamless data bridge – nested sktime panels are converted to the 3-D NumPy format (`N, C, L`) expected by tsai, then piped into `get_ts_dls`.
---Custom loss guard– a tiny wrapper around `torch.nn.CrossEntropyLoss` forces `int64` targets, avoiding the notorious CUDA “Float vs Int” crash.
---Lean inference path– prediction uses a direct forward pass (`torch.no_grad()`) instead of `Learner.test_dl`, eliminating the `NoTfmLists` ambiguity that showed up during testing.
---Smoke tests – a small pytest module runs both networks for one epoch on `basic_motions`; total run-time is comfortably < 10 s on CPU.



#### Does this introduce a new dependency?

No hard dependency.  
Both classes carry the tag `python_dependencies = "tsai"`, so a vanilla sktime install remains lightweight; users who _opt-in_ to these classifiers need:

-- `tsai >= 0.4.1` (which pulls `fastai`, `torch`, etc.)
-- `fasttransform` (0.0.2) – this satisfies the recent fastcore dispatch split

Nothing is added to sktime’s core requirements.


#### What should reviewers look at?

---Data conversion & one-cycle training loop – any edge-cases you spot?
---The custom loss wrapper and the new inference shortcut – both keep the runtime errors away, but a double-check is welcome.
---Test placement / execution time.
---Docs: I added the two classes to `docs/source/api_reference/classification.rst` – please skim for style.



#### Tests added?

Yes – `sktime/tsai_integration/tests/test_tsai_wrappers.py`  
---parametrised over both classifiers  
---asserts output shapes + types  
---runs in < 10 s by training for a single epoch with a mini batch-size.



#### Any other comments?
Changes have been additionally made to tsai repository's core.py  in order infer the dtype from a numpy.int64 array with a valid PyTorch tensor type.


#### PR checklist

##### For all contributions
- [ ] Added myself to `.all-contributorsrc` with badge `code`
- [x] PR title starts with **[ENH]**
- [ ] Added myself to the `maintainers` tag  <!-- tick if you actually added it -->

##### For new estimators
- [x] API reference entry
- [x] pydocstyle-compliant `Examples` in each docstring
- [x] Soft dependency isolated via `_tags["python_dependencies"]`

Thanks for reviewing!
