### PR TITLE
[DOC] Add reference to the updated roadmap page in `contributing.rst`

### DIFF
--- a/docs/source/get_involved/contributing.rst
+++ b/docs/source/get_involved/contributing.rst
@@ -17,7 +17,7 @@ How to contribute
 Welcome to sktime's contributing guide!
 
 We value all kinds of contributions - not just code.
-For a detailed overview of current and future work, check out our :ref:`roadmap`.
+For a detailed overview of current and future work, check out our :ref:`_roadmap`.
 
 We are particularly motivated to support new contributors
 and people who are looking to learn and develop their skills.


### PR DESCRIPTION
The [roadmap](https://www.sktime.net/en/latest/roadmap_2021.html) page linked on the [contributing](https://www.sktime.net/en/latest/get_involved/contributing.html) page, leads to an outdated roadmap page which is not expected to be there.

What I think the issue might be:

The new roadmap page is contained in `roadmap.rst` and the old one is contained in `roadmap_2021.rst`, `contributing.rst` still references to the old roadmap page. This PR attempts to fix it.