### PR TITLE
 Add workflow to auto-label PRs by size

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,23 @@
+name: Auto-Label PRs by Size
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size/XS'
+          xs_max_size: '10'
+          s_label: 'size/S'
+          s_max_size: '50'
+          m_label: 'size/M'
+          m_max_size: '100'
+          l_label: 'size/L'
+          l_max_size: '500'
+          xl_label: 'size/XL'


### PR DESCRIPTION
Hey sktime folks,

I’m Nitish, new here and super excited to contribute! With lots of PRs open, I thought labeling them by size could help maintainers like `@fkiraly` review faster. This adds a small GitHub Actions workflow to tag PRs as “size/XS” (<10 lines), “size/S” (<50), “size/M” (<100), “size/L” (<500), or “size/XL” (>500).

It’s just a config file, so it won’t mess with tests. I checked the GitHub Actions docs to make sure it’s solid. Open to any tweaks, like changing the size limits! Maybe worth a mention in the contributing guide? Thanks for the warm community and mentorship!

Cheers,  
Nitish  
CC: @fkiraly