### PR TITLE
[BUG] Fix Aggregator inverse_transform being skipped

### DIFF
--- a/sktime/transformations/hierarchical/aggregate.py
+++ b/sktime/transformations/hierarchical/aggregate.py
@@ -25,6 +25,10 @@ class Aggregator(BaseTransformer):
     flatten_single_level : boolean (default=True)
         Remove aggregate nodes, i.e. ("__total"), where there is only a single
         child to the level
+    bypass_inverse_transform : boolean (default=True)
+        If True, the inverse_transform method is skipped. If False, the
+        inverse_transform method is implemented and can be used to remove
+        aggregate levels from the data.
 
     See Also
     --------
@@ -76,10 +80,20 @@ class Aggregator(BaseTransformer):
         "transform-returns-same-time-index": False,
     }
 
-    def __init__(self, flatten_single_levels=True):
+    def __init__(self, flatten_single_levels=True, bypass_inverse_transform=True):
         self.flatten_single_levels = flatten_single_levels
+        self.bypass_inverse_transform = bypass_inverse_transform
 
         super().__init__()
+
+        if not self.bypass_inverse_transform:
+            self.set_tags(
+                **{
+                    "skip-inverse-transform": False,
+                    "capability:inverse_transform": True,
+                    "capability:inverse_transform:exact": False,
+                }
+            )
 
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.
@@ -185,7 +199,7 @@ class Aggregator(BaseTransformer):
             )
         else:
             for i in range(X.index.nlevels - 1):
-                X = X.drop(index="__total", level=i)
+                X = X.drop(index="__total", level=i, errors="ignore")
         return X
 
     @classmethod

--- a/sktime/transformations/hierarchical/tests/test_aggregate.py
+++ b/sktime/transformations/hierarchical/tests/test_aggregate.py
@@ -6,6 +6,7 @@ __author__ = ["ciaran-g"]
 
 import pytest
 
+from sktime.datatypes import get_examples
 from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.hierarchical.aggregate import Aggregator
 from sktime.utils._testing.hierarchical import _bottom_hier_datagen
@@ -79,3 +80,32 @@ def test_aggregator_flatten():
         "with the time index removed, for random_seed=111."
     )
     assert len(X_agg_flat.droplevel(-1).index.unique()) == 17, msg
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(Aggregator),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_aggregator_inverse_transform():
+    """Tests inverse_transform of aggregator function.
+
+    This test asserts that the output of Aggregator using inverse_transform() is equal
+    to the original input data.
+    """
+
+    y = get_examples("pd_multiindex_hier")[1]
+
+    agg_bypass_invt = Aggregator(bypass_inverse_transform=True)
+    agg = Aggregator(bypass_inverse_transform=False)
+
+    yt_bypass_invt = agg_bypass_invt.fit_transform(y)
+    yt = agg.fit_transform(y)
+
+    # inverse transform with bypass
+    yinvt_bypass_invt = agg_bypass_invt.inverse_transform(yt_bypass_invt)
+    yinvt = agg.inverse_transform(yt)
+
+    # When bypassing, totals are kept in the output.
+    ## When not bypassing, we should find the same indexes as before
+    assert yinvt_bypass_invt.index.droplevel(-1).nunique() == 9
+    assert yinvt.index.droplevel(-1).nunique() == y.index.droplevel(-1).nunique()


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #7614 

#### What does this implement/fix? Explain your changes.

* Add `__init__` argument to activate `inverse_transform`, for backward compatibility
* Fix the inverse transform so that it does not fail when a given level does not have aggregated value


#### What should a reviewer concentrate their feedback on?

Is the name of the argument good?

#### Did you add any tests for the change?
Yes

#### Any other comments?

This PR should be merged before #7697 