### PR TITLE
[ENH] Tests for TSC `evaluate` Parallel Backend

### DIFF
--- a/sktime/classification/model_evaluation/tests/test_evaluate.py
+++ b/sktime/classification/model_evaluation/tests/test_evaluate.py
@@ -172,3 +172,50 @@ class TestEvaluate:
 
         assert all(result["fit_time"] > 0)
         assert all(result["pred_time"] >= 0)
+
+    def test_evaluate_parallel_backend(self):
+        """Test the parrelelization backends"""
+        X, y = make_classification_problem()
+        n_splits = 3
+        cv = KFold(n_splits=n_splits)
+
+        result = evaluate(
+            classifier=DummyClassifier(),
+            cv=cv,
+            X=X,
+            y=y,
+            scoring=accuracy_score,
+            error_score="raise",
+            backend="loky",
+            backend_params={"n_jobs": -1},
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == n_splits
+
+        assert "test_accuracy_score" in result.columns
+        assert "fit_time" in result.columns
+        assert "pred_time" in result.columns
+
+    def test_evaluate_parallel_backend_none(self):
+        """Test the parrelelization backends"""
+        X, y = make_classification_problem()
+        n_splits = 3
+        cv = KFold(n_splits=n_splits)
+
+        result = evaluate(
+            classifier=DummyClassifier(),
+            cv=cv,
+            X=X,
+            y=y,
+            scoring=accuracy_score,
+            error_score="raise",
+            backend="None",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == n_splits
+
+        assert "test_accuracy_score" in result.columns
+        assert "fit_time" in result.columns
+        assert "pred_time" in result.columns

--- a/sktime/classification/model_evaluation/tests/test_evaluate.py
+++ b/sktime/classification/model_evaluation/tests/test_evaluate.py
@@ -198,7 +198,7 @@ class TestEvaluate:
         assert "pred_time" in result.columns
 
     def test_evaluate_parallel_backend_none(self):
-        """Test the parrelelization backends"""
+        """Test the sequential loop if `backend="None"`"""
         X, y = make_classification_problem()
         n_splits = 3
         cv = KFold(n_splits=n_splits)


### PR DESCRIPTION
This PR adds the tests for the recently merged #8347 which adds the parallelization support for TSC `evaluate`. The tests primarily test the parellization with the `loky` backend and with the `backend=None` which results in a sequential loop.