### PR TITLE
[MNT] remove `stefanzweifel/git-auto-commit-action` from all-contributors workflow

### DIFF
--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -12,22 +12,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: 18
+
       - name: Set up tool
         run: npm install -g all-contributors-cli@6.24.0
+
       - name: Generate file
         id: generate
         run: npx all-contributors generate
-      - name: commit-and-push
-        id: candp
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: '[AUTOMATED] update CONTRIBUTORS.md'
-          file_pattern: 'CONTRIBUTORS.md'
-          commit_user_name: github-actions[bot]
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if ! git diff --quiet CONTRIBUTORS.md; then
+            git add CONTRIBUTORS.md
+            git commit -m "[AUTOMATED] update CONTRIBUTORS.md"
+            git push
+            echo "changes_detected=true" >> $GITHUB_ENV
+          else
+            echo "No changes to commit."
+            echo "changes_detected=false" >> $GITHUB_ENV
+          fi
+
       - name: Echo Results
         if: steps.candp.outputs.changes_detected == 'true'
         run: echo "changes detected and committed."


### PR DESCRIPTION
Removes the workflow dependency on the 3rd party GitHub workflow action `stefanzweifel/git-auto-commit-action`, by replacing it with a variation on a `git diff` call.

This is to enhance our security posture, as third party actions are possible security vulnerabilities - even if pinned, they can be  compromised (unlike python packages), see for instance the `tj-actions` compromise.