### PR TITLE
&fkiraly [DOC] Add guide for module-level soft dependency imports (#7690)

### DIFF
--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -28,7 +28,7 @@ For adding a new soft dependency, see the section "adding a new soft dependency"
 
 **Best practice:**
 
-* (a) Soft dependencies should be restricted to estimators whenever possible.
+* (a) Soft dependencies should be restricted to estimators whenever possible, see the section "Isolating soft dependencies to estimators".
 * (b) If restricting to estimators is not possible, follow the section "Isolating soft dependencies at module level".
 
 Isolating soft dependencies to estimators

--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -26,6 +26,12 @@ Handling soft dependencies
 This section explains how to handle existing soft dependencies.
 For adding a new soft dependency, see the section "adding a new soft dependency".
 
+**Best practices:**
+* (a) Soft dependencies should be restricted to estimators whenever possible.
+* (b) If restricting to estimators is not feasible, follow the guidance in the subsections below.
+
+Isolating soft dependencies to estimators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Soft dependencies in ``sktime`` should usually be isolated to estimators.
 
 Informative warnings or error messages for missing soft dependencies should be raised, in a situation where a user would need them.
@@ -66,7 +72,7 @@ rather than within a class or function. However, directly importing optional dep
 at the top of a module can lead to import errors in user environments where the package 
 is not installed.
 
-Try to avoid importing soft dependencies at the top of a file (module-level imports), even if you're using `_check_soft_dependencies` before it.
+Even when using `_check_soft_dependencies`, avoid placing soft dependency imports at the top of a module.
 
 Instead,the recommended approach is to use the `python_dependencies` tag in your estimator. This lets `sktime` handle missing dependencies automatically and keeps the import behavior clean and predictable.
 
@@ -80,9 +86,20 @@ Example (preferred pattern):
         ...
 
 There might be rare exceptions — like in some deep learning estimators — where a module-level import is the only practical option. But even in those cases, it should be done carefully and only if absolutely necessary.
-If you need to use a soft dependency, import it inside a method or function (like `_fit` or `__init__`) instead of at the top of the module.
-Refer to ``sktime.utils.validation._dependencies._check_soft_dependencies`` for 
-detailed usage and parameters.
+If a module-level import is absolutely necessary—such as in rare cases involving deep learning estimators—consider using `_safe_import` from `sktime.utils.importing`.
+
+**Example using `_safe_import` (not recommended unless unavoidable):**
+
+.. code-block:: python
+
+    from sktime.utils.importing import _safe_import
+
+    keras = _safe_import("keras", import_name="keras")
+
+    if keras is None:
+        raise ImportError("Please install keras to use this module.")
+
+If you do use `_safe_import`, ensure you still call `_check_soft_dependencies` before using the functionality, and document why module-level import is necessary.
 
 Adding and maintaining soft dependencies
 ----------------------------------------

--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -57,6 +57,35 @@ Estimators with a soft dependency need to ensure the following:
    See the tests in ``forecasting.tests.test_pmdarima`` for a concrete example of
    ``run_test_for_class`` usage to decorate a test. See ``utils.tests.test_plotting``
    for an example of ``_check_soft_dependencies`` usage.
+Module-level soft dependency imports
+-------------------------------------
+
+In certain scenarios, it may be necessary to import soft dependencies at the module level,
+rather than within a class or function. However, directly importing optional dependencies 
+at the top of a module can lead to import errors in user environments where the package 
+is not installed.
+
+To handle this properly, use the `_check_soft_dependencies` function before performing 
+the import.
+
+Example pattern:
+
+.. code-block:: python
+
+    _check_soft_dependencies("pmdarima", severity="error", obj="MyForecaster")
+    import pmdarima
+
+Alternatively, use the return value of `_check_soft_dependencies`:
+
+.. code-block:: python
+
+    if _check_soft_dependencies("pmdarima", severity="none"):
+        import pmdarima
+    else:
+        raise ImportError("pmdarima is required for this module.")
+
+Refer to ``sktime.utils.validation._dependencies._check_soft_dependencies`` for 
+detailed usage and parameters.
 
 Adding and maintaining soft dependencies
 ----------------------------------------

--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -57,7 +57,8 @@ Estimators with a soft dependency need to ensure the following:
    See the tests in ``forecasting.tests.test_pmdarima`` for a concrete example of
    ``run_test_for_class`` usage to decorate a test. See ``utils.tests.test_plotting``
    for an example of ``_check_soft_dependencies`` usage.
-Module-level soft dependency imports
+
+Avoiding module-level imports of soft dependencies
 -------------------------------------
 
 In certain scenarios, it may be necessary to import soft dependencies at the module level,
@@ -65,25 +66,21 @@ rather than within a class or function. However, directly importing optional dep
 at the top of a module can lead to import errors in user environments where the package 
 is not installed.
 
-To handle this properly, use the `_check_soft_dependencies` function before performing 
-the import.
+Try to avoid importing soft dependencies at the top of a file (module-level imports), even if you're using `_check_soft_dependencies` before it.
 
-Example pattern:
+Instead,the recommended approach is to use the `python_dependencies` tag in your estimator. This lets `sktime` handle missing dependencies automatically and keeps the import behavior clean and predictable.
 
-.. code-block:: python
-
-    _check_soft_dependencies("pmdarima", severity="error", obj="MyForecaster")
-    import pmdarima
-
-Alternatively, use the return value of `_check_soft_dependencies`:
+Example (preferred pattern):
 
 .. code-block:: python
 
-    if _check_soft_dependencies("pmdarima", severity="none"):
+    def _fit(self, X, y):
+        _check_soft_dependencies("pmdarima", severity="error", obj=self)
         import pmdarima
-    else:
-        raise ImportError("pmdarima is required for this module.")
+        ...
 
+There might be rare exceptions — like in some deep learning estimators — where a module-level import is the only practical option. But even in those cases, it should be done carefully and only if absolutely necessary.
+If you need to use a soft dependency, import it inside a method or function (like `_fit` or `__init__`) instead of at the top of the module.
 Refer to ``sktime.utils.validation._dependencies._check_soft_dependencies`` for 
 detailed usage and parameters.
 

--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -65,7 +65,8 @@ Estimators with a soft dependency need to ensure the following:
    for an example of ``_check_soft_dependencies`` usage.
 
 Informative warnings or error messages for missing soft dependencies should be raised, in a situation where a user would need them.
-Usually, such warnings are already raised in ``__init__`` of the respective estimator.
+Usually, such warnings are automatically raised in ``__init__`` of the respective estimator by the base framework, via ``BaseObject``,
+and do not need to be added manually.
 
 In case a step-out is needed, the ``_check_soft_dependencies`` utility
 `here <https://github.com/sktime/sktime/blob/main/sktime/utils/dependencies/_dependencies.py>`__ can be used.

--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -26,7 +26,8 @@ Handling soft dependencies
 This section explains how to handle existing soft dependencies.
 For adding a new soft dependency, see the section "adding a new soft dependency".
 
-**Best practices:**
+**Best practice:**
+
 * (a) Soft dependencies should be restricted to estimators whenever possible.
 * (b) If restricting to estimators is not possible, follow the section "Isolating soft dependencies at module level".
 


### PR DESCRIPTION
This PR adds documentation for handling module-level soft dependency imports in sktime. The existing developer guide explains how to manage soft dependencies within estimators, but does not cover scenarios where optional dependencies need to be imported at the module level.

To address this, I have added a new section titled "Module-level soft dependency imports" under dependencies.rst. It provides clear usage patterns for using _check_soft_dependencies before importing optional modules directly. Example code snippets are included to demonstrate both severity-based checks and conditional imports.