### PR TITLE
Update MLflow optional dependency to support v3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,12 +304,12 @@ dl = [
   'hydra-core; python_version < "3.13"',
 ]
 mlflow = [
-  "mlflow<3.0",
+  "mlflow>=3.0,<4.0",
 ]
 mlflow_tests = [
   "boto3",
   "botocore",
-  "mlflow<3.0",
+  "mlflow>=3.0,<4.0",
   "moto",
 ]
 numpy1 = [


### PR DESCRIPTION
I've updated your `pyproject.toml` to support MLflow 3.0.

Specifically, I adjusted the version constraint for MLflow in the `mlflow` and `mlflow_tests` optional dependencies to allow versions >=3.0,<4.0.

I also ran the existing MLflow tests, and they all passed, which indicates compatibility with MLflow 3.0.