### PR TITLE
[ENH] avoid all-tags retrieval, add package name to tag aliaser

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -370,6 +370,9 @@ class TagAliaserMixin(_TagAliaserMixin):
     alias_dict = {"handles-missing-data": "capability:missing_values"}
     deprecate_dict = {"handles-missing-data": "1.0.0"}
 
+    # package name used for deprecation warnings
+    _package_name = "sktime"
+
 
 class BaseEstimator(TagAliaserMixin, _BaseEstimator, BaseObject):
     """Base class for defining estimators in sktime.

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -106,7 +106,7 @@ def test_vectorization_series_to_hier(mtype, backend):
     y = convert(y, from_type="pd_multiindex_hier", to_type=mtype)
 
     f = YfromX.create_test_instance()
-    assert f.get_tags()["scitype:y"] == "univariate"  # check the assumption
+    assert f.get_tag("scitype:y") == "univariate"  # check the assumption
 
     f.set_config(**backend.copy())
     y_pred = f.fit(y).predict([1, 2, 3])

--- a/sktime/forecasting/compose/_transform_select_forecaster.py
+++ b/sktime/forecasting/compose/_transform_select_forecaster.py
@@ -195,7 +195,7 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
 
         # Finally, dynamically adding implementation of probabilistic
         # functions depending on the tags set.
-        if self.get_tags()["capability:pred_int"]:
+        if self.get_tag("capability:pred_int"):
             self._predict_interval = _predict_interval
             self._predict_var = _predict_var
             self._predict_proba = _predict_proba

--- a/sktime/forecasting/enbpi.py
+++ b/sktime/forecasting/enbpi.py
@@ -174,11 +174,10 @@ class EnbPIForecaster(BaseForecaster):
             # the return_indices=True
             self.bootstrap_transformer_ = TSBootstrapAdapter(MovingBlockBootstrap())
 
-        bs_tags = self.bootstrap_transformer_.get_tags()
-        if (
-            not bs_tags.get("capability:bootstrap_index", False)
-            or not self.bootstrap_transformer_.return_indices
-        ):
+        bs_capable = self.bootstrap_transformer_.get_tag(
+            "capability:bootstrap_index", False, raise_error=False
+        )
+        if not bs_capable or not self.bootstrap_transformer_.return_indices:
             raise ValueError(
                 "Error in EnbPIForecaster: "
                 "The bootstrap_transformer needs to be able to "

--- a/sktime/param_est/plugin/_forecaster.py
+++ b/sktime/param_est/plugin/_forecaster.py
@@ -133,8 +133,8 @@ class PluginParamsForecaster(_DelegatedForecaster):
 
         # parameter estimators that are univariate do not broadcast,
         # so broadcasting needs to be done by the composite (i.e., self)
-        if param_est.get_tags()["object_type"] == "param_est":
-            if not param_est.get_tags()["capability:multivariate"]:
+        if param_est.get_tag("object_type") == "param_est":
+            if not param_est.get_tag("capability:multivariate"):
                 self.set_tags(**{"scitype:y": "univariate"})
 
         self.set_tags(**{"fit_is_empty": False})

--- a/sktime/param_est/plugin/_transformer.py
+++ b/sktime/param_est/plugin/_transformer.py
@@ -147,7 +147,7 @@ class PluginParamsTransformer(_DelegatedTransformer):
         SERIES_MTYPES = ["pd.DataFrame", "pd.Series", "np.ndarray"]
         self.set_tags(**{"X_inner_mtype": SERIES_MTYPES})
 
-        if self.get_tags("y_inner_mtype") not in [None, "None"]:
+        if self.get_tag("y_inner_mtype") not in [None, "None"]:
             self.set_tags(**{"y_inner_mtype": SERIES_MTYPES})
 
     def _fit(self, X, y=None):

--- a/sktime/param_est/plugin/_transformer.py
+++ b/sktime/param_est/plugin/_transformer.py
@@ -147,7 +147,7 @@ class PluginParamsTransformer(_DelegatedTransformer):
         SERIES_MTYPES = ["pd.DataFrame", "pd.Series", "np.ndarray"]
         self.set_tags(**{"X_inner_mtype": SERIES_MTYPES})
 
-        if self.get_tags()["y_inner_mtype"] not in [None, "None"]:
+        if self.get_tags("y_inner_mtype") not in [None, "None"]:
             self.set_tags(**{"y_inner_mtype": SERIES_MTYPES})
 
     def _fit(self, X, y=None):

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -185,7 +185,7 @@ def all_estimators(
         if isinstance(obj, (list, tuple)):
             return [_coerce_to_str(o) for o in obj]
         if isclass(obj):
-            obj = obj.get_tag("object_type")
+            obj = obj.get_class_tag("object_type")
         return obj
 
     def _coerce_to_list_of_str(obj):

--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -361,7 +361,7 @@ def test_check_python_version(
     except ModuleNotFoundError as exception:
         expected_msg = (
             f"{type(dummy_object_instance).__name__} requires python version "
-            f"to be {dummy_object_instance.get_tags()['python_version']}, "
+            f"to be {dummy_object_instance.get_tag('python_version')}, "
             f"but system python version is {mock_sys.version}. "
             "This is due to the release candidate status of your system Python."
         )

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1304,7 +1304,7 @@ class BaseTransformer(BaseEstimator):
         #   skipped for output_scitype = "Primitives"
         #       since then the output always is a pd.DataFrame
         if case == "case 2: higher scitype supported" and output_scitype == "Series":
-            if self.get_tags()["scitype:transform-input"] == "Panel":
+            if self.get_tag("scitype:transform-input") == "Panel":
                 # Conversion from Series to Panel done for being compatible with
                 # algorithm. Thus, the returned Series should stay a Series.
                 pass
@@ -1368,7 +1368,7 @@ class BaseTransformer(BaseEstimator):
 
                 if X_input_mtype == "pd.Series" and not metadata["is_univariate"]:
                     X_output_mtype = "pd.DataFrame"
-            elif self.get_tags()["scitype:transform-input"] == "Panel":
+            elif self.get_tags("scitype:transform-input") == "Panel":
                 # Converting Panel to Series
                 if X_input_scitype == "Hierarchical":
                     # Input was Hierarchical, but output has dropped one level.

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1368,7 +1368,7 @@ class BaseTransformer(BaseEstimator):
 
                 if X_input_mtype == "pd.Series" and not metadata["is_univariate"]:
                     X_output_mtype = "pd.DataFrame"
-            elif self.get_tags("scitype:transform-input") == "Panel":
+            elif self.get_tag("scitype:transform-input") == "Panel":
                 # Converting Panel to Series
                 if X_input_scitype == "Hierarchical":
                     # Input was Hierarchical, but output has dropped one level.

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -371,8 +371,8 @@ def test_input_output_series_panel_chain():
     X = load_airline()
     bootstrap_trafo = STLBootstrapTransformer(4, sp=4) * Imputer(method="nearest")
 
-    assert bootstrap_trafo.get_tags()["scitype:transform-input"] == "Series"
-    assert bootstrap_trafo.get_tags()["scitype:transform-output"] == "Panel"
+    assert bootstrap_trafo.get_tag("scitype:transform-input") == "Series"
+    assert bootstrap_trafo.get_tag("scitype:transform-output") == "Panel"
 
     Xt = bootstrap_trafo.fit_transform(X)
     assert isinstance(Xt, pd.DataFrame)
@@ -403,10 +403,10 @@ def test_requires_tags_trafopipe():
         ]
     )
 
-    assert not pipe.get_tags()["requires_X"]
+    assert not pipe.get_tags("requires_X")
     # should not requires X as input, because YtoX does not
 
-    assert pipe.get_tags()["requires_y"]
+    assert pipe.get_tags("requires_y")
     # should require y as input, because YtoX does
 
     pipe.fit_transform(X=None, y=X)

--- a/sktime/transformations/tests/test_compose.py
+++ b/sktime/transformations/tests/test_compose.py
@@ -403,10 +403,10 @@ def test_requires_tags_trafopipe():
         ]
     )
 
-    assert not pipe.get_tags("requires_X")
+    assert not pipe.get_tag("requires_X")
     # should not requires X as input, because YtoX does not
 
-    assert pipe.get_tags("requires_y")
+    assert pipe.get_tag("requires_y")
     # should require y as input, because YtoX does
 
     pipe.fit_transform(X=None, y=X)


### PR DESCRIPTION
This PR replaces all-tags retrieval via `get_tags` by single-tag retrieval where possible. This is better as it does not trigger, for instance, warning messages about deprecated tags.

It also adds the name of the package to the tag aliaser class.