### PR TITLE
DO NOT MERGE: Test run of "core classes" test framework change

### DIFF
--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -201,3 +201,21 @@ The tags below have limited use in retrieval or inspection of objects.
     x_inner_mtype
     y_inner_mtype
     visual_block_kind
+
+
+Testing and CI tags
+-------------------
+
+These tags control behaviour of estimators in the ``sktime`` continuous integration
+tests.
+
+They are primarily useful for developers managing CI behaviour of individual objects.
+
+.. currentmodule:: sktime.registry._tags
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: function.rst
+    :nosignatures:
+
+    tests__core

--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -202,6 +202,7 @@ The tags below have limited use in retrieval or inspection of objects.
     y_inner_mtype
     visual_block_kind
 
+.. _dev_testing_tags:
 
 Testing and CI tags
 -------------------

--- a/sktime/alignment/dtw_numba.py
+++ b/sktime/alignment/dtw_numba.py
@@ -128,6 +128,9 @@ class AlignerDtwNumba(BaseAligner):
         "capability:distance-matrix": True,  # does compute/return distance matrix?
         "capability:unequal_length": False,  # can align sequences of unequal length?
         "X_inner_mtype": "numpy3D",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/alignment/dtw_python.py
+++ b/sktime/alignment/dtw_python.py
@@ -93,6 +93,9 @@ class AlignerDTW(BaseAligner):
         "capability:distance-matrix": True,  # does compute/return distance matrix?
         "capability:unequal_length": True,  # can align sequences of unequal length?
         "alignment_type": "partial",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/alignment/lucky.py
+++ b/sktime/alignment/lucky.py
@@ -51,6 +51,9 @@ class AlignerLuckyDtw(BaseAligner):
         "capability:distance-matrix": True,  # does compute/return distance matrix?
         "capability:unequal_length": True,  # can align sequences of unequal length?
         "alignment_type": "full",  # does the aligner produce full or partial alignment
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, window=None):

--- a/sktime/alignment/naive.py
+++ b/sktime/alignment/naive.py
@@ -44,6 +44,9 @@ class AlignerNaive(BaseAligner):
         # --------------
         "capability:multiple-alignment": True,  # can align more than two sequences?
         "capability:unequal_length": True,  # can align sequences of unequal length?
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, strategy="start-end"):

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -84,6 +84,8 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         "python_dependencies": None,  # PEP 440 dependency strs, e.g., "pandas>=1.0"
         "env_marker": None,  # PEP 508 environment marker, e.g., "os_name=='posix'"
         "sktime_version": SKTIME_VERSION,  # current sktime version
+        # default tags for testing
+        "tests:core": False,  # core objects have wider trigger conditions in testing
     }
 
     _config = {

--- a/sktime/classification/compose/_column_ensemble.py
+++ b/sktime/classification/compose/_column_ensemble.py
@@ -24,6 +24,9 @@ class BaseColumnEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
         "capability:multivariate": True,
         "capability:predict_proba": True,
         "X_inner_mtype": ["nested_univ", "pd-multiindex"],
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, estimators, verbose=False):

--- a/sktime/classification/compose/_multiplexer.py
+++ b/sktime/classification/compose/_multiplexer.py
@@ -65,6 +65,9 @@ class MultiplexClassifier(_HeterogenousMetaEstimator, _DelegatedClassifier):
         "X_inner_mtype": MTYPE_LIST_PANEL,
         "y_inner_mtype": MTYPE_LIST_TABLE,
         "fit_is_empty": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # attribute for _DelegatedClassifier, which then delegates

--- a/sktime/classification/compose/_pipeline.py
+++ b/sktime/classification/compose/_pipeline.py
@@ -107,6 +107,9 @@ class ClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
         "capability:multithreading": False,
         "capability:predict_proba": True,
         "capability:categorical_in_X": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # no default tag values - these are set dynamically below
@@ -442,6 +445,9 @@ class SklearnClassifierPipeline(_HeterogenousMetaEstimator, BaseClassifier):
         "capability:multithreading": False,
         "capability:predict_proba": True,
         "capability:categorical_in_X": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # no default tag values - these are set dynamically below

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -148,6 +148,9 @@ class KNeighborsTimeSeriesClassifier(_BaseKnnTimeSeriesEstimator, BaseClassifier
         "capability:predict_proba": True,
         "X_inner_mtype": ["pd-multiindex", "numpy3D"],
         "classifier_type": "distance",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/classification/distance_based/_time_series_neighbors_pyts.py
+++ b/sktime/classification/distance_based/_time_series_neighbors_pyts.py
@@ -107,6 +107,9 @@ class KNeighborsTimeSeriesClassifierPyts(_PytsAdapter, BaseClassifier):
         "capability:missing_values": True,
         "capability:predict_proba": True,
         "classifier_type": "distance",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # defines the name of the attribute containing the pyts estimator

--- a/sktime/classification/distance_based/_time_series_neighbors_tslearn.py
+++ b/sktime/classification/distance_based/_time_series_neighbors_tslearn.py
@@ -87,6 +87,9 @@ class KNeighborsTimeSeriesClassifierTslearn(_TslearnAdapter, BaseClassifier):
         # --------------
         "capability:multivariate": True,
         "capability:unequal_length": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # defines the name of the attribute containing the tslearn estimator

--- a/sktime/classification/dummy/_dummy.py
+++ b/sktime/classification/dummy/_dummy.py
@@ -83,6 +83,9 @@ class DummyClassifier(BaseClassifier):
         "capability:unequal_length": True,
         "capability:multivariate": True,
         "capability:predict_proba": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     VALID_STRATEGIES = ["most_frequent", "prior", "stratified", "uniform", "constant"]

--- a/sktime/classification/feature_based/_catch22_classifier.py
+++ b/sktime/classification/feature_based/_catch22_classifier.py
@@ -92,6 +92,9 @@ class Catch22Classifier(_DelegatedClassifier):
         "capability:multithreading": True,
         "capability:predict_proba": True,
         "classifier_type": "feature",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/classification/kernel_based/_svc.py
+++ b/sktime/classification/kernel_based/_svc.py
@@ -115,6 +115,9 @@ class TimeSeriesSVC(BaseClassifier):
         "capability:predict_proba": True,
         "X_inner_mtype": ["pd-multiindex", "numpy3D"],
         "classifier_type": "kernel",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     DELEGATED_PARAMS = [

--- a/sktime/classification/model_selection/_tune.py
+++ b/sktime/classification/model_selection/_tune.py
@@ -247,6 +247,9 @@ class TSCGridSearchCV(_DelegatedClassifier):
         "capability:multithreading": True,
         "capability:predict_proba": True,
         "capability:categorical_in_X": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/clustering/compose/_as_transform.py
+++ b/sktime/clustering/compose/_as_transform.py
@@ -69,6 +69,9 @@ class ClustererAsTransformer(BaseTransformer):
         "capability:unequal_length:removes": False,
         "capability:missing_values": True,
         "capability:missing_values:removes": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, clusterer):

--- a/sktime/clustering/compose/_pipeline.py
+++ b/sktime/clustering/compose/_pipeline.py
@@ -105,6 +105,9 @@ class ClustererPipeline(_HeterogenousMetaEstimator, BaseClusterer):
         "capability:train_estimate": False,
         "capability:contractable": False,
         "capability:multithreading": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # no default tag values - these are set dynamically below

--- a/sktime/clustering/dbscan.py
+++ b/sktime/clustering/dbscan.py
@@ -75,6 +75,9 @@ class TimeSeriesDBSCAN(BaseClusterer):
         "capability:out_of_sample": False,
         "capability:predict": True,
         "capability:predict_proba": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     DELEGATED_PARAMS = ["eps", "min_samples", "algorithm", "leaf_size", "n_jobs"]

--- a/sktime/clustering/k_medoids.py
+++ b/sktime/clustering/k_medoids.py
@@ -87,6 +87,9 @@ class TimeSeriesKMedoids(BaseTimeSeriesLloyds):
         "capability:out_of_sample": True,
         "capability:predict": True,
         "capability:predict_proba": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/clustering/kernel_k_means.py
+++ b/sktime/clustering/kernel_k_means.py
@@ -89,6 +89,9 @@ class TimeSeriesKernelKMeans(_TslearnAdapter, BaseClusterer):
         "capability:out_of_sample": True,
         "capability:predict": True,
         "capability:predict_proba": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # defines the name of the attribute containing the tslearn estimator

--- a/sktime/datasets/base/_base.py
+++ b/sktime/datasets/base/_base.py
@@ -34,6 +34,9 @@ class BaseDataset(BaseObject):
         "python_dependencies": None,  # python dependencies required to load the dataset
         "python_version": None,  # python version required to load the dataset
         "n_splits": 0,  # Number of cross-validation splits, if any.
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self):

--- a/sktime/detection/adapters/_pyod.py
+++ b/sktime/detection/adapters/_pyod.py
@@ -55,6 +55,9 @@ class PyODDetector(BaseDetector):
         "python_dependencies": "pyod",
         "task": "anomaly_detection",
         "learning_type": "unsupervised",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, estimator, labels="indicator"):

--- a/sktime/detection/compose/_as_transform.py
+++ b/sktime/detection/compose/_as_transform.py
@@ -70,6 +70,9 @@ class DetectorAsTransformer(BaseTransformer):
         "capability:unequal_length:removes": False,
         "capability:missing_values": True,
         "capability:missing_values:removes": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, estimator):

--- a/sktime/detection/compose/_pipeline.py
+++ b/sktime/detection/compose/_pipeline.py
@@ -49,6 +49,9 @@ class DetectorPipeline(_HeterogenousMetaEstimator, BaseDetector):
         # estimator type
         # --------------
         "learning_type": "unsupervised",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # for default get_params/set_params from _HeterogenousMetaEstimator

--- a/sktime/detection/dummy/_dummy_regular_an.py
+++ b/sktime/detection/dummy/_dummy_regular_an.py
@@ -35,6 +35,9 @@ class DummyRegularAnomalies(BaseDetector):
         "fit_is_empty": False,
         "task": "anomaly_detection",
         "learning_type": "unsupervised",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, step_size=2):

--- a/sktime/detection/dummy/_zero_cp.py
+++ b/sktime/detection/dummy/_zero_cp.py
@@ -20,4 +20,9 @@ class ZeroChangePoints(ZeroAnomalies):
     """
 
     # same code except the tag
-    _tags = {"task": "change_point_detection"}
+    _tags = {
+        "task": "change_point_detection",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
+    }

--- a/sktime/detection/dummy/_zero_seg.py
+++ b/sktime/detection/dummy/_zero_seg.py
@@ -26,6 +26,9 @@ class ZeroSegments(BaseDetector):
         "fit_is_empty": True,
         "task": "segmentation",
         "learning_type": "unsupervised",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self):

--- a/sktime/detection/hmm.py
+++ b/sktime/detection/hmm.py
@@ -140,6 +140,9 @@ class HMM(BaseDetector):
         "fit_is_empty": True,
         "task": "segmentation",
         "learning_type": "unsupervised",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/detection/lof.py
+++ b/sktime/detection/lof.py
@@ -135,6 +135,9 @@ class SubLOF(BaseDetector):
         "learning_type": "unsupervised",
         "univariate-only": False,
         "fit_is_empty": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/dists_kernels/algebra.py
+++ b/sktime/dists_kernels/algebra.py
@@ -63,6 +63,9 @@ class CombinedDistance(_HeterogenousMetaEstimator, BasePairwiseTransformerPanel)
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "capability:unequal_length": True,  # can dist handle unequal length panels?
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # for default get_params/set_params from _HeterogenousMetaEstimator

--- a/sktime/dists_kernels/compose.py
+++ b/sktime/dists_kernels/compose.py
@@ -65,6 +65,9 @@ class PwTrafoPanelPipeline(_HeterogenousMetaEstimator, BasePairwiseTransformerPa
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "capability:unequal_length": True,  # can dist handle unequal length panels?
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, pw_trafo, transformers):

--- a/sktime/dists_kernels/compose_from_align.py
+++ b/sktime/dists_kernels/compose_from_align.py
@@ -22,6 +22,9 @@ class DistFromAligner(BasePairwiseTransformerPanel):
         "authors": ["fkiraly"],
         "symmetric": True,  # all the distances are symmetric
         "capability:unequal_length": True,  # aligners can usually handle unequal length
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, aligner=None):

--- a/sktime/dists_kernels/compose_tab_to_panel.py
+++ b/sktime/dists_kernels/compose_tab_to_panel.py
@@ -65,7 +65,12 @@ class AggrDist(BasePairwiseTransformerPanel):
     >>> mean_gaussian_tskernel = AggrDist(RBF())
     """
 
-    _tags = {"authors": "fkiraly"}
+    _tags = {
+        "authors": "fkiraly",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
+    }
 
     def __init__(
         self,
@@ -202,6 +207,9 @@ class FlatDist(BasePairwiseTransformerPanel):
         "authors": "fkiraly",
         "X_inner_mtype": "numpy3D",  # which mtype is used internally in _transform?
         "capability:unequal_length": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, transformer):

--- a/sktime/dists_kernels/dist_to_kern.py
+++ b/sktime/dists_kernels/dist_to_kern.py
@@ -51,6 +51,9 @@ class KernelFromDist(BasePairwiseTransformerPanel):
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "capability:unequal_length": True,  # can dist handle unequal length panels?
         "pwtrafo_type": "kernel",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, dist, dist_diag=None):
@@ -184,6 +187,9 @@ class DistFromKernel(BasePairwiseTransformerPanel):
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "capability:unequal_length": True,  # can dist handle unequal length panels?
         "pwtrafo_type": "distance",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, kernel):

--- a/sktime/dists_kernels/dtw/_dtw_python.py
+++ b/sktime/dists_kernels/dtw/_dtw_python.py
@@ -49,6 +49,9 @@ class DtwPythonDist(_DelegatedPairwiseTransformerPanel):
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "capability:unequal_length": True,  # can dist handle unequal length panels?
         "X_inner_mtype": "df-list",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/dists_kernels/dtw/_dtw_sktime.py
+++ b/sktime/dists_kernels/dtw/_dtw_sktime.py
@@ -132,6 +132,9 @@ class DtwDist(BasePairwiseTransformerPanel):
         "symmetric": True,  # all the distances are symmetric
         "X_inner_mtype": "numpy3D",
         "capability:unequal_length": False,  # can dist handle unequal length panels?
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/dists_kernels/dtw/_dtw_tslearn.py
+++ b/sktime/dists_kernels/dtw/_dtw_tslearn.py
@@ -60,6 +60,9 @@ class DtwDistTslearn(_TslearnPwTrafoAdapter, BasePairwiseTransformerPanel):
         # --------------
         "symmetric": True,
         "pwtrafo_type": "distance",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/dists_kernels/dummy.py
+++ b/sktime/dists_kernels/dummy.py
@@ -24,6 +24,9 @@ class ConstantPwTrafoPanel(BasePairwiseTransformerPanel):
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "capability:unequal_length": True,  # can dist handle unequal length panels?
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, constant=0):

--- a/sktime/dists_kernels/indep.py
+++ b/sktime/dists_kernels/indep.py
@@ -69,6 +69,9 @@ class IndepDist(BasePairwiseTransformerPanel):
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:multivariate": True,  # can estimator handle multivariate data?
         "capability:unequal_length": True,  # can dist handle unequal length panels?
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, dist, aggfun=None):

--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -96,6 +96,9 @@ class BaggingForecaster(BaseForecaster):
         "capability:insample": True,  # can the estimator make in-sample predictions?
         "capability:pred_int": True,  # can the estimator produce prediction intervals?
         "capability:pred_int:insample": True,  # ... for in-sample horizons?
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/forecasting/compose/_column_ensemble.py
+++ b/sktime/forecasting/compose/_column_ensemble.py
@@ -98,6 +98,9 @@ class ColumnEnsembleForecaster(_HeterogenousEnsembleForecaster, _ColumnEstimator
         "capability:missing_values": False,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # for default get_params/set_params from _HeterogenousMetaEstimator

--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -326,6 +326,9 @@ class EnsembleForecaster(_HeterogenousEnsembleForecaster):
         "X_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         "y_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         "scitype:y": "both",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, forecasters, n_jobs=None, aggfunc="mean", weights=None):

--- a/sktime/forecasting/compose/_fallback.py
+++ b/sktime/forecasting/compose/_fallback.py
@@ -115,6 +115,9 @@ class FallbackForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
         "y_inner_mtype": ALL_TIME_SERIES_MTYPES,
         "X_inner_mtype": ALL_TIME_SERIES_MTYPES,
         "fit_is_empty": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
     # for default get_params/set_params from _HeterogenousMetaEstimator
     # _steps_attr points to the attribute of self

--- a/sktime/forecasting/compose/_grouped.py
+++ b/sktime/forecasting/compose/_grouped.py
@@ -69,6 +69,9 @@ class ForecastByLevel(_DelegatedForecaster):
         "y_inner_mtype": ALL_TIME_SERIES_MTYPES,
         "X_inner_mtype": ALL_TIME_SERIES_MTYPES,
         "fit_is_empty": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # attribute for _DelegatedForecaster, which then delegates

--- a/sktime/forecasting/compose/_hierarchy_ensemble.py
+++ b/sktime/forecasting/compose/_hierarchy_ensemble.py
@@ -148,6 +148,9 @@ class HierarchyEnsembleForecaster(_HeterogenousEnsembleForecaster):
         "X_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         "requires-fh-in-fit": False,
         "capability:missing_values": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     BY_LIST = ["level", "node"]

--- a/sktime/forecasting/compose/_ignore_x.py
+++ b/sktime/forecasting/compose/_ignore_x.py
@@ -35,6 +35,9 @@ class IgnoreX(_DelegatedForecaster):
 
     _tags = {
         "ignores-exogeneous-X": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, forecaster, ignore_x=True):

--- a/sktime/forecasting/compose/_multiplexer.py
+++ b/sktime/forecasting/compose/_multiplexer.py
@@ -85,6 +85,9 @@ class MultiplexForecaster(_HeterogenousMetaEstimator, _DelegatedForecaster):
         "y_inner_mtype": ALL_TIME_SERIES_MTYPES,
         "X_inner_mtype": ALL_TIME_SERIES_MTYPES,
         "fit_is_empty": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # attribute for _DelegatedForecaster, which then delegates

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -427,6 +427,9 @@ class ForecastingPipeline(_Pipeline):
         "capability:pred_int": True,
         "X-y-must-have-same-index": False,
         "capability:categorical_in_X": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, steps):
@@ -875,6 +878,9 @@ class TransformedTargetForecaster(_Pipeline):
         "capability:missing_values": True,
         "capability:pred_int": True,
         "X-y-must-have-same-index": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, steps):

--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1953,6 +1953,9 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         "ignores-exogeneous-X": False,
         "X_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         "y_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/forecasting/compose/_transform_select_forecaster.py
+++ b/sktime/forecasting/compose/_transform_select_forecaster.py
@@ -107,6 +107,9 @@ class TransformSelectForecaster(BaseForecaster, _HeterogenousMetaEstimator):
         "maintainers": ["shlok191"],
         "python_version": None,
         "visual_block_kind": "parallel",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -133,6 +133,9 @@ class ConformalIntervals(BaseForecaster):
         "capability:pred_int:insample": False,
         "X_inner_mtype": MTYPE_LIST_SERIES,
         "y_inner_mtype": MTYPE_LIST_SERIES,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     ALLOWED_METHODS = [

--- a/sktime/forecasting/croston.py
+++ b/sktime/forecasting/croston.py
@@ -78,6 +78,9 @@ class Croston(BaseForecaster):
         # --------------
         "requires-fh-in-fit": False,  # is forecasting horizon already required in fit?
         "ignores-exogeneous-X": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, smoothing=0.1):

--- a/sktime/forecasting/dummy.py
+++ b/sktime/forecasting/dummy.py
@@ -69,6 +69,9 @@ class ForecastKnownValues(BaseForecaster):
         "scitype:y": "both",
         "ignores-exogeneous-X": True,
         "requires-fh-in-fit": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, y_known, method=None, fill_value=None, limit=None):

--- a/sktime/forecasting/model_selection/_tune.py
+++ b/sktime/forecasting/model_selection/_tune.py
@@ -605,6 +605,12 @@ class ForecastingGridSearchCV(BaseGridSearch):
     >>> y_pred = gscv.predict(fh=[1,2,3])  # doctest: +SKIP
     """
 
+    _tags = {
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
+    }
+
     def __init__(
         self,
         forecaster,

--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -129,6 +129,9 @@ class NaiveForecaster(_BaseWindowForecaster):
         "scitype:y": "univariate",
         "capability:pred_var": True,
         "capability:pred_int": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, strategy="last", window_length=None, sp=1):
@@ -681,6 +684,9 @@ class NaiveVariance(BaseForecaster):
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,
         "capability:pred_var": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, forecaster, initial_window=1, verbose=False):

--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -120,6 +120,9 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
         "X-y-must-have-same-index": True,
         "scitype:y": "univariate",
         "capability:pred_int": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/forecasting/reconcile.py
+++ b/sktime/forecasting/reconcile.py
@@ -120,6 +120,9 @@ class ReconcilerForecaster(BaseForecaster):
         "enforce_index_type": None,  # index type that needs to be enforced in X/y
         "capability:pred_int": False,  # does forecaster implement proba forecasts?
         "fit_is_empty": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # We do not create the instances to avoid error due to

--- a/sktime/forecasting/stream/_update.py
+++ b/sktime/forecasting/stream/_update.py
@@ -49,6 +49,9 @@ class UpdateRefitsEvery(_DelegatedForecaster):
         "requires-fh-in-fit": False,
         "y_inner_mtype": ALL_TIME_SERIES_MTYPES,
         "X_inner_mtype": ALL_TIME_SERIES_MTYPES,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/forecasting/structural.py
+++ b/sktime/forecasting/structural.py
@@ -303,6 +303,8 @@ class UnobservedComponents(_StatsModelsAdapter):
             UnobservedComponents as _UnobservedComponents,
         )
 
+        raise ValueError("Oops")
+
         self._forecaster = _UnobservedComponents(
             endog=y,
             exog=X,

--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -101,6 +101,9 @@ class ThetaForecaster(ExponentialSmoothing):
         "capability:pred_int:insample": True,
         "requires-fh-in-fit": False,
         "capability:missing_values": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, initial_level=None, deseasonalize=True, sp=1):

--- a/sktime/forecasting/trend/_trend_forecaster.py
+++ b/sktime/forecasting/trend/_trend_forecaster.py
@@ -64,6 +64,9 @@ class TrendForecaster(BaseForecaster):
         "ignores-exogeneous-X": True,
         "requires-fh-in-fit": False,
         "capability:missing_values": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, regressor=None):

--- a/sktime/forecasting/var_reduce.py
+++ b/sktime/forecasting/var_reduce.py
@@ -131,6 +131,9 @@ class VARReduce(BaseForecaster):
         "X_inner_mtype": "pd.DataFrame",
         "ignores-exogeneous-X": True,
         "requires-fh-in-fit": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, lags=1, regressor=None):

--- a/sktime/param_est/base.py
+++ b/sktime/param_est/base.py
@@ -76,6 +76,9 @@ class BaseParamFitter(BaseEstimator):
         "python_dependencies": None,  # string or str list of pkg soft dependencies
         "authors": "sktime developers",  # author(s) of the object
         "maintainers": "sktime developers",  # current maintainer(s) of the object
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self):

--- a/sktime/performance_metrics/detection/_base.py
+++ b/sktime/performance_metrics/detection/_base.py
@@ -22,6 +22,9 @@ class BaseDetectionMetric(BaseMetric):
         "requires_X": False,
         "requires_y_true": True,  # if False, is unsupervised metric
         "lower_is_better": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __call__(self, y_true=None, y_pred=None, X=None):

--- a/sktime/performance_metrics/forecasting/_base.py
+++ b/sktime/performance_metrics/forecasting/_base.py
@@ -98,6 +98,9 @@ class BaseForecastingErrorMetric(BaseMetric):
         # "y_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"]
         "inner_implements_multilevel": False,
         "reserved_params": ["multioutput", "multilevel", "by_index"],
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -383,6 +383,41 @@ class requires_cython(_BaseTag):
     }
 
 
+class tests__core(_BaseTag):
+    """Whether tests for this estimator are triggered by framework changes.
+
+    Part of packaging metadata for the object, used only in ``sktime`` CI.
+
+    - String name: ``"tests:core"``
+    - Private tag, developer and framework facing
+    - Values: boolean, ``True`` / ``False``
+    - Example: ``True``
+    - Default: ``False``
+
+    ``sktime``'s CI framework regularly tests estimators in pull requests,
+    usually only estimators that have changed, via ``run_test_for_class``.
+
+    The ``tests:core`` tag of an object is a boolean,
+    it specifies whether changes to the framework or base classes
+    trigger tests for the estimator.
+
+    Only a core selection of estimators should have the ``tests:core``
+    tag set to true, to avoid that all estimators in ``sktime`` are triggered
+    by a framework change.
+
+    It is not used in user facing checks, error messages,
+    or recommended build processes otherwise.
+    """
+
+    _tags = {
+        "tag_name": "tests:core",
+        "parent_type": "object",
+        "tag_type": "bool",
+        "short_descr": "whether framework changes trigger estimator tests",
+        "user_facing": False,
+    }
+
+
 # Estimator tags
 # --------------
 

--- a/sktime/regression/compose/_multiplexer.py
+++ b/sktime/regression/compose/_multiplexer.py
@@ -64,6 +64,9 @@ class MultiplexRegressor(_HeterogenousMetaEstimator, _DelegatedRegressor):
         "X_inner_mtype": MTYPE_LIST_PANEL,
         "y_inner_mtype": MTYPE_LIST_TABLE,
         "fit_is_empty": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # attribute for _DelegatedRegressor, which then delegates

--- a/sktime/regression/compose/_pipeline.py
+++ b/sktime/regression/compose/_pipeline.py
@@ -97,6 +97,9 @@ class RegressorPipeline(_HeterogenousMetaEstimator, BaseRegressor):
         "capability:contractable": False,
         "capability:multithreading": False,
         "capability:categorical_in_X": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     _required_parameters = ["regressor"]

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -100,6 +100,9 @@ class BaseSplitter(BaseObject):
         # whether the splitter splits by time, or by instance
         "authors": "sktime developers",  # author(s) of the object
         "maintainers": "sktime developers",  # current maintainer(s) of the object
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -205,8 +205,9 @@ def _run_test_for_class(cls):
 
     def _is_core_object(cls):
         """Check if the class is a core object, for condition 3 and 5."""
-        is_core = cls.get_class_tag("tests:core", False)
-        return is_core
+        if hasattr(cls, "get_class_tag"):
+            return cls.get_class_tag("tests:core", False)
+        return False
 
     def _is_class_changed_or_local_parents(cls):
         """Check if class or any of its local parents have changed, return bool."""

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -29,10 +29,12 @@ def run_test_for_class(cls, return_reason=False):
     2. Condition 2:
 
       If the module containing the class/func has changed according to is_class_changed,
-      or one of the modules containing any parent classes  in the local package,
       then condition 2 is met.
+      If the class is a core object, then in addition, condition 2 is also met,
+      if one of the modules containing any parent classes in the local package
+      have changed.
 
-    3. Condition 3:
+    3. Condition 3 (only checked for core objects):
 
       If the object is an sktime ``BaseObject``, and one of the test classes
       covering the class have changed, then condition 3 is met.
@@ -43,7 +45,7 @@ def run_test_for_class(cls, return_reason=False):
       for any of its dependencies have changed in ``pyproject.toml``,
       condition 4 is met.
 
-    5. Condition 5:
+    5. Condition 5 (only checked for core objects):
 
       If the object is an sktime ``BaseObject``,
       and one of the core framework modules ``datatypes``, ``tests``, ``utils``
@@ -201,10 +203,15 @@ def _run_test_for_class(cls):
         else:
             return True
 
+    def _is_core_object(cls):
+        """Check if the class is a core object, for condition 3 and 5."""
+        is_core = cls.get_class_tag("tests:core", False)
+        return is_core
+
     def _is_class_changed_or_local_parents(cls):
         """Check if class or any of its local parents have changed, return bool."""
         # if cls is a function, not a class, default to is_class_changed
-        if not isclass(cls):
+        if not isclass(cls) or not _is_core_object(cls):
             return is_class_changed(cls)
 
         # now we know cls is a class, so has an mro
@@ -261,25 +268,26 @@ def _run_test_for_class(cls):
     # Condition 3:
     # if the object is an sktime BaseObject, and one of the test classes
     # covering the class have changed, then run the test
-    cond3 = _tests_covering_class_changed(cls)
-    if cond3:
+    if _is_core_object(cls) and _tests_covering_class_changed(cls):
         return True, "True_changed_tests"
 
     # Condition 2:
     # any of the modules containing any of the classes in the list have changed
-    # or any of the modules containing any parent classes in local package have changed
+    # additionally, for core objects:
+    # any of the modules containing any parent classes in local package have changed
     cond2 = _is_class_changed_or_local_parents(cls)
     if cond2:
         return True, "True_changed_class"
 
-    # Condition 5:
+    # Condition 5 (only for core objects):
     # if the object is an sktime BaseObject, and one of the core framework modules
     # datatypes, tests, utils have changed, then run the test
-    datatypes_changed = is_module_changed("sktime.datatypes")
-    tests_changed = is_module_changed("sktime.tests")
-    utils_changed = is_module_changed("sktime.utils")
-    if any([datatypes_changed, tests_changed, utils_changed]):
-        return True, "True_changed_framework"
+    if _is_core_object(cls):
+        datatypes_changed = is_module_changed("sktime.datatypes")
+        tests_changed = is_module_changed("sktime.tests")
+        utils_changed = is_module_changed("sktime.utils")
+        if any([datatypes_changed, tests_changed, utils_changed]):
+            return True, "True_changed_framework"
 
     # if none of the conditions are met, do not run the test
     # reason is that there was no change

--- a/sktime/transformations/bootstrap/_mbb.py
+++ b/sktime/transformations/bootstrap/_mbb.py
@@ -192,6 +192,9 @@ class STLBootstrapTransformer(BaseTransformer):
         "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
         "transform-returns-same-time-index": False,
         "capability:bootstrap_index": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/compose/_column.py
+++ b/sktime/transformations/compose/_column.py
@@ -129,6 +129,9 @@ class ColumnEnsembleTransformer(
         "capability:unequal_length": True,
         "capability:missing_values": True,
         "visual_block_kind": "parallel",
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # for default get_params/set_params from _HeterogenousMetaEstimator

--- a/sktime/transformations/compose/_featureunion.py
+++ b/sktime/transformations/compose/_featureunion.py
@@ -61,6 +61,10 @@ class FeatureUnion(_HeterogenousMetaEstimator, BaseTransformer):
         "visual_block_kind": "parallel",
         # unclear what inverse transform should be, since multiple inverse_transform
         #   would have to inverse transform to one
+        #
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # for default get_params/set_params from _HeterogenousMetaEstimator

--- a/sktime/transformations/compose/_fitintransform.py
+++ b/sktime/transformations/compose/_fitintransform.py
@@ -62,7 +62,12 @@ class FitInTransform(BaseTransformer):
     >>> y_pred = pipe.predict(fh=fh, X=X_test)
     """
 
-    _tags = {"authors": ["aiwalter", "fkiraly"]}
+    _tags = {
+        "authors": ["aiwalter", "fkiraly"],
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
+    }
 
     def __init__(self, transformer, skip_inverse_transform=True):
         self.transformer = transformer

--- a/sktime/transformations/compose/_grouped.py
+++ b/sktime/transformations/compose/_grouped.py
@@ -66,6 +66,9 @@ class TransformByLevel(_DelegatedTransformer):
         "X_inner_mtype": ALL_TIME_SERIES_MTYPES,
         "y_inner_mtype": ALL_TIME_SERIES_MTYPES,
         "fit_is_empty": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # attribute for _DelegatedTransformer, which then delegates

--- a/sktime/transformations/compose/_id.py
+++ b/sktime/transformations/compose/_id.py
@@ -27,6 +27,9 @@ class Id(BaseTransformer):
         "transform-returns-same-time-index": True,
         # does transform return have the same time index as input X
         "capability:missing_values": True,  # can estimator handle missing data?
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def _transform(self, X, y=None):

--- a/sktime/transformations/compose/_invert.py
+++ b/sktime/transformations/compose/_invert.py
@@ -50,6 +50,9 @@ class InvertTransform(_DelegatedTransformer):
         "univariate-only": False,
         "fit_is_empty": False,
         "capability:inverse_transform": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, transformer):

--- a/sktime/transformations/compose/_ixtox.py
+++ b/sktime/transformations/compose/_ixtox.py
@@ -76,6 +76,9 @@ class IxToX(BaseTransformer):
         "scitype:y": "both",
         "fit_is_empty": True,
         "requires_y": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, coerce_to_type="auto", level=None, ix_source="X"):

--- a/sktime/transformations/compose/_logger.py
+++ b/sktime/transformations/compose/_logger.py
@@ -81,6 +81,9 @@ class Logger(BaseTransformer):
         "transform-returns-same-time-index": True,
         # does transform return have the same time index as input X
         "capability:missing_values": True,  # can estimator handle missing data?
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/compose/_multiplex.py
+++ b/sktime/transformations/compose/_multiplex.py
@@ -94,6 +94,9 @@ class MultiplexTransformer(_HeterogenousMetaEstimator, _DelegatedTransformer):
         "fit_is_empty": False,
         "univariate-only": False,
         "X_inner_mtype": ALL_TIME_SERIES_MTYPES,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # attribute for _DelegatedTransformer, which then delegates

--- a/sktime/transformations/compose/_optional.py
+++ b/sktime/transformations/compose/_optional.py
@@ -85,6 +85,9 @@ class OptionalPassthrough(_DelegatedTransformer):
         "univariate-only": False,
         "fit_is_empty": False,
         "capability:inverse_transform": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, transformer, passthrough=False):

--- a/sktime/transformations/compose/_pipeline.py
+++ b/sktime/transformations/compose/_pipeline.py
@@ -126,6 +126,9 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
         "X_inner_mtype": CORE_MTYPES,
         "univariate-only": False,
         "capability:categorical_in_X": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # no further default tag values - these are set dynamically below

--- a/sktime/transformations/compose/_transformif.py
+++ b/sktime/transformations/compose/_transformif.py
@@ -97,6 +97,9 @@ class TransformIf(_DelegatedTransformer):
         "univariate-only": False,
         "fit_is_empty": False,
         "capability:inverse_transform": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/compose/_ytox.py
+++ b/sktime/transformations/compose/_ytox.py
@@ -128,6 +128,9 @@ class YtoX(BaseTransformer):
         "fit_is_empty": True,
         "requires_X": False,
         "requires_y": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, subset_index=False):

--- a/sktime/transformations/hierarchical/reconcile/_bottom_up.py
+++ b/sktime/transformations/hierarchical/reconcile/_bottom_up.py
@@ -30,6 +30,12 @@ class BottomUpReconciler(_ReconcilerTransformer):
     >>> y_pred = pipe.predict(fh=[1, 2, 3])
     """
 
+    _tags = {
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
+    }
+
     def _fit_reconciler(self, X, y=None):
         """
         Fit the reconciler.

--- a/sktime/transformations/hierarchical/reconcile/_reconcile.py
+++ b/sktime/transformations/hierarchical/reconcile/_reconcile.py
@@ -112,6 +112,9 @@ class Reconciler(BaseTransformer):
         "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
         "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
         "transform-returns-same-time-index": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     METHOD_LIST = ["bu", "ols", "wls_str", "td_fcst"]

--- a/sktime/transformations/panel/catch22wrapper.py
+++ b/sktime/transformations/panel/catch22wrapper.py
@@ -88,6 +88,9 @@ class Catch22Wrapper(BaseTransformer):
         "X_inner_mtype": "pd.Series",
         "y_inner_mtype": "None",
         "fit_is_empty": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/panel/compose_distance.py
+++ b/sktime/transformations/panel/compose_distance.py
@@ -67,6 +67,9 @@ class DistanceFeatures(BaseTransformer):
         # we leave remember_data as False, since updating self._X in update
         # would increase the number of columns in the transform return
         "remember_data": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, distance=None, distance_mtype=None, flatten_hierarchy=False):

--- a/sktime/transformations/panel/dwt.py
+++ b/sktime/transformations/panel/dwt.py
@@ -42,6 +42,9 @@ class DWTTransformer(BaseTransformer):
         "X_inner_mtype": "nested_univ",  # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for X?
         "fit_is_empty": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, num_levels=3):

--- a/sktime/transformations/panel/padder.py
+++ b/sktime/transformations/panel/padder.py
@@ -66,6 +66,9 @@ class PaddingTransformer(BaseTransformer):
         "fit_is_empty": False,
         "capability:unequal_length:removes": True,
         # is transform result always guaranteed to be equal length (and series)?
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, pad_length=None, fill_value=0):

--- a/sktime/transformations/panel/tsfresh.py
+++ b/sktime/transformations/panel/tsfresh.py
@@ -29,6 +29,10 @@ class _TSFreshFeatureExtractor(BaseTransformer):
         # therefore, we need to restrict the version of scipy
         # the dependency tag translates to:
         # tsfresh is required, and tsfresh>=0.21 or scipy<1.15
+        #
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/series/adapt.py
+++ b/sktime/transformations/series/adapt.py
@@ -153,6 +153,9 @@ class TabularToSeriesAdaptor(BaseTransformer):
         "univariate-only": False,
         "transform-returns-same-time-index": True,
         "fit_is_empty": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(
@@ -504,6 +507,9 @@ class PandasTransformAdaptor(BaseTransformer):
         "fit_is_empty": False,
         "capability:inverse_transform": False,
         "remember_data": False,  # remember all data seen as _X
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, method, kwargs=None, apply_to="call"):

--- a/sktime/transformations/series/adi_cv.py
+++ b/sktime/transformations/series/adi_cv.py
@@ -102,6 +102,9 @@ class ADICVTransformer(BaseTransformer):
         "capability:inverse_transform": False,
         "capability:unequal_length": False,
         "capability:missing_values": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/series/binning.py
+++ b/sktime/transformations/series/binning.py
@@ -72,6 +72,9 @@ class TimeBinAggregate(BaseTransformer):
         "capability:unequal_length:removes": True,
         "transform-returns-same-time-index": False,
         "capability:inverse_transform": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, bins, aggfunc=None, return_index="bin_start"):

--- a/sktime/transformations/series/boxcox.py
+++ b/sktime/transformations/series/boxcox.py
@@ -176,6 +176,9 @@ class BoxCoxTransformer(BaseTransformer):
         "fit_is_empty": False,
         "univariate-only": True,
         "capability:inverse_transform": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/series/clasp.py
+++ b/sktime/transformations/series/clasp.py
@@ -108,6 +108,8 @@ class ClaSPTransformer(BaseTransformer):
 
         scoring_metric_call = self._check_scoring_metric(self.scoring_metric)
 
+        raise ValueError("Oops")
+
         X = X.flatten()
         Xt, _ = clasp(
             X,

--- a/sktime/transformations/series/date.py
+++ b/sktime/transformations/series/date.py
@@ -195,6 +195,9 @@ class DateTimeFeatures(BaseTransformer):
         "transform-returns-same-time-index": True,
         "enforce_index_type": [pd.DatetimeIndex, pd.PeriodIndex],
         "skip-inverse-transform": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/series/detrend/_deseasonalize.py
+++ b/sktime/transformations/series/detrend/_deseasonalize.py
@@ -83,6 +83,9 @@ class Deseasonalizer(BaseTransformer):
         "capability:inverse_transform": True,
         "transform-returns-same-time-index": True,
         "univariate-only": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, sp=1, model="additive"):

--- a/sktime/transformations/series/detrend/_detrend.py
+++ b/sktime/transformations/series/detrend/_detrend.py
@@ -87,6 +87,9 @@ class Detrender(BaseTransformer):
         "fit_is_empty": False,
         "capability:inverse_transform": True,
         "transform-returns-same-time-index": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, forecaster=None, model="additive"):

--- a/sktime/transformations/series/difference.py
+++ b/sktime/transformations/series/difference.py
@@ -250,6 +250,9 @@ class Differencer(BaseTransformer):
         "transform-returns-same-time-index": False,
         "univariate-only": False,
         "capability:inverse_transform": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     VALID_NA_HANDLING_STR = ["drop_na", "keep_na", "fill_zero"]

--- a/sktime/transformations/series/dropna.py
+++ b/sktime/transformations/series/dropna.py
@@ -68,6 +68,9 @@ class DropNA(BaseTransformer):
         "capability:inverse_transform": False,
         "capability:unequal_length": True,
         "capability:missing_values": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     VALID_AXIS_VALUES = [0, "index", 1, "columns"]

--- a/sktime/transformations/series/dummies.py
+++ b/sktime/transformations/series/dummies.py
@@ -98,6 +98,9 @@ class SeasonalDummiesOneHot(BaseTransformer):
         # todo: rename to capability:missing_values
         "capability:missing_values:removes": True,
         # is transform result always guaranteed to contain no missing values?
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/series/exponent.py
+++ b/sktime/transformations/series/exponent.py
@@ -83,6 +83,9 @@ class ExponentTransformer(BaseTransformer):
         "transform-returns-same-time-index": True,
         "univariate-only": False,
         "capability:inverse_transform": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, power=0.5, offset="auto"):

--- a/sktime/transformations/series/func_transform.py
+++ b/sktime/transformations/series/func_transform.py
@@ -86,6 +86,9 @@ class FunctionTransformer(BaseTransformer):
         "fit_is_empty": True,
         "capability:missing_values": True,
         "capability:inverse_transform": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/series/holiday/_holidayfeats.py
+++ b/sktime/transformations/series/holiday/_holidayfeats.py
@@ -111,6 +111,9 @@ class HolidayFeatures(BaseTransformer):
         "enforce_index_type": [pd.DatetimeIndex],
         "transform-returns-same-time-index": True,
         "skip-inverse-transform": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/series/holiday/country_holidays.py
+++ b/sktime/transformations/series/holiday/country_holidays.py
@@ -88,6 +88,9 @@ class CountryHolidaysTransformer(BaseTransformer):
         "capability:inverse_transform": False,
         "capability:unequal_length": True,
         "capability:missing_values": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/series/holiday/financial_holidays.py
+++ b/sktime/transformations/series/holiday/financial_holidays.py
@@ -88,6 +88,9 @@ class FinancialHolidaysTransformer(BaseTransformer):
         "capability:inverse_transform": False,
         "capability:unequal_length": True,
         "capability:missing_values": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, market, years=None, expand=True, observed=True, name=None):

--- a/sktime/transformations/series/impute.py
+++ b/sktime/transformations/series/impute.py
@@ -112,6 +112,9 @@ class Imputer(BaseTransformer):
         "capability:missing_values:removes": True,
         # is transform result always guaranteed to contain no missing values?
         "remember_data": False,  # remember all data seen as _X
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/series/kalman_filter/_simdkalman.py
+++ b/sktime/transformations/series/kalman_filter/_simdkalman.py
@@ -153,6 +153,9 @@ class KalmanFilterTransformerSIMD(BaseKalmanFilter, BaseTransformer):
         "capability:missing_values:removes": False,
         # is transform result always guaranteed to contain no missing values?
         "scitype:instancewise": True,  # is this an instance-wise transform?
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -139,6 +139,9 @@ class Lag(BaseTransformer):
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:missing_values:removes": False,
         "remember_data": True,  # remember all data seen as _X
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/sktime/transformations/series/peak.py
+++ b/sktime/transformations/series/peak.py
@@ -202,6 +202,9 @@ class PeakTimeFeature(BaseTransformer):
         "transform-returns-same-time-index": True,
         "enforce_index_type": [pd.DatetimeIndex, pd.PeriodIndex],
         "skip-inverse-transform": True,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/series/scaledlogit.py
+++ b/sktime/transformations/series/scaledlogit.py
@@ -107,6 +107,9 @@ class ScaledLogitTransformer(BaseTransformer):
         "univariate-only": False,
         "capability:inverse_transform": True,
         "skip-inverse-transform": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, lower_bound=None, upper_bound=None):

--- a/sktime/transformations/series/subset.py
+++ b/sktime/transformations/series/subset.py
@@ -50,6 +50,9 @@ class IndexSubset(BaseTransformer):
         "univariate-only": False,
         "capability:inverse_transform": False,
         "remember_data": True,  # remember all data seen as _X
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, index_treatment="keep"):

--- a/sktime/transformations/series/summarize.py
+++ b/sktime/transformations/series/summarize.py
@@ -216,6 +216,9 @@ class WindowSummarizer(BaseTransformer):
         "transform-returns-same-time-index": False,
         # does transform return have the same time index as input X
         "remember_data": True,  # remember all data seen as _X
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/series/time_since.py
+++ b/sktime/transformations/series/time_since.py
@@ -102,6 +102,9 @@ class TimeSince(BaseTransformer):
         "capability:unequal_length:removes": False,
         "capability:missing_values": True,  # can estimator handle missing data?
         "capability:missing_values:removes": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/transformations/series/vmd.py
+++ b/sktime/transformations/series/vmd.py
@@ -133,6 +133,9 @@ class VmdTransformer(BaseTransformer):
         "capability:unequal_length:removes": False,
         "capability:missing_values": False,
         "capability:missing_values:removes": False,
+        # CI and test flags
+        # -----------------
+        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(


### PR DESCRIPTION
This PR is a test run of PR https://github.com/sktime/sktime/pull/8408, where two intentional failures are added to two classes not considered a "core class" according to #8404.

This is to test that the test framework indeed runs tests for the two classes if they are directly changed, and detects the failures.