### PR TITLE
[ENH] Use `sktime` Provided Dataset in `TSC` Dataset Loaders

### DIFF
--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -205,7 +205,7 @@ def load_tecator(split=None, return_X_y=True, return_type=None, y_dtype="float")
     Manuscript 1132, Danish Meat Research Institute (1993), p 1-12.
     """
     name = "Tecator"
-    return _load_dataset(
+    return _load_provided_dataset(
         name, split, return_X_y, return_type=return_type, y_dtype=y_dtype
     )
 
@@ -249,7 +249,7 @@ def load_plaid(split=None, return_X_y=True, return_type=None):
     >>> X, y = load_plaid()
     """
     name = "PLAID"
-    return _load_dataset(name, split, return_X_y, return_type=return_type)
+    return _load_provided_dataset(name, split, return_X_y, return_type=return_type)
 
 
 def load_gunpoint(split=None, return_X_y=True, return_type=None):
@@ -317,7 +317,7 @@ def load_gunpoint(split=None, return_X_y=True, return_type=None):
     ?Dataset=GunPoint
     """
     name = "GunPoint"
-    return _load_dataset(name, split, return_X_y, return_type=return_type)
+    return _load_provided_dataset(name, split, return_X_y, return_type=return_type)
 
 
 def load_osuleaf(split=None, return_X_y=True, return_type=None):
@@ -375,7 +375,7 @@ def load_osuleaf(split=None, return_X_y=True, return_type=None):
     ?Dataset=OSULeaf
     """
     name = "OSULeaf"
-    return _load_dataset(name, split, return_X_y, return_type=return_type)
+    return _load_provided_dataset(name, split, return_X_y, return_type=return_type)
 
 
 def load_italy_power_demand(split=None, return_X_y=True, return_type=None):
@@ -430,7 +430,7 @@ def load_italy_power_demand(split=None, return_X_y=True, return_type=None):
     http://timeseriesclassification.com/description.php?Dataset=ItalyPowerDemand
     """
     name = "ItalyPowerDemand"
-    return _load_dataset(name, split, return_X_y, return_type=return_type)
+    return _load_provided_dataset(name, split, return_X_y, return_type=return_type)
 
 
 def load_unit_test(split=None, return_X_y=True, return_type=None):
@@ -558,7 +558,7 @@ def load_japanese_vowels(split=None, return_X_y=True, return_type=None):
     ?Dataset=JapaneseVowels
     """
     name = "JapaneseVowels"
-    return _load_dataset(name, split, return_X_y, return_type=return_type)
+    return _load_provided_dataset(name, split, return_X_y, return_type=return_type)
 
 
 def load_arrow_head(split=None, return_X_y=True, return_type=None):
@@ -683,7 +683,7 @@ def load_acsf1(split=None, return_X_y=True, return_type=None):
     =ACSF1
     """
     name = "ACSF1"
-    return _load_dataset(name, split, return_X_y, return_type=return_type)
+    return _load_provided_dataset(name, split, return_X_y, return_type=return_type)
 
 
 def load_basic_motions(split=None, return_X_y=True, return_type=None):


### PR DESCRIPTION
There are two utility functions for loading TSC datasets in `sktime`, `_load_dataset` and `_load_provided_dataset`. The former is for the datasets that need to be downloaded and latter is for the datasets that are shipped with sktime. 

For example, `load_arrow_head` uses `_load_provided_dataset` but loaders like `load_gun_point`, `load_osuleaf` and others use `_load_dataset` even though they are shipped with sktime by default. Thus, it leads to redundant dataset downloads. This PR fixes it.