### PR TITLE
[ENH] remove some unstable and long running estimators from the core testing set

### DIFF
--- a/sktime/forecasting/compose/_bagging.py
+++ b/sktime/forecasting/compose/_bagging.py
@@ -96,9 +96,6 @@ class BaggingForecaster(BaseForecaster):
         "capability:insample": True,  # can the estimator make in-sample predictions?
         "capability:pred_int": True,  # can the estimator produce prediction intervals?
         "capability:pred_int:insample": True,  # ... for in-sample horizons?
-        # CI and test flags
-        # -----------------
-        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(

--- a/sktime/forecasting/naive/_naive.py
+++ b/sktime/forecasting/naive/_naive.py
@@ -684,9 +684,6 @@ class NaiveVariance(BaseForecaster):
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,
         "capability:pred_var": True,
-        # CI and test flags
-        # -----------------
-        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, forecaster, initial_window=1, verbose=False):

--- a/sktime/transformations/panel/tsfresh.py
+++ b/sktime/transformations/panel/tsfresh.py
@@ -29,10 +29,6 @@ class _TSFreshFeatureExtractor(BaseTransformer):
         # therefore, we need to restrict the version of scipy
         # the dependency tag translates to:
         # tsfresh is required, and tsfresh>=0.21 or scipy<1.15
-        #
-        # CI and test flags
-        # -----------------
-        "tests:core": True,  # should tests be triggered by framework changes?
     }
 
     def __init__(


### PR DESCRIPTION
This PR removes some unstable estimators with sporadic failures, and long runtimes, from the core testing set:

* `BaggingForecaster` - sporadic failures
* `NaiveVariance` - runs long
* the `tsfresh` transformations - runs long