### PR TITLE
[MNT] revert `joblib` bound to `joblib<1.6`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ classifiers = [
 # core dependencies of sktime
 # this set should be kept minimal!
 dependencies = [
-  "joblib>=1.2.0,<1.6",  # required for parallel processing
+  "joblib>=1.2.0,<1.5",  # required for parallel processing
   "numpy>=1.21,<2.3",  # required for framework layer and base class logic
   "packaging",  # for estimator specific dependency parsing
   "pandas<2.3.0,>=1.1",  # pandas is the main in-memory data container


### PR DESCRIPTION
Reverts the `joblib` bound to `joblib<1.6`, this should be increased with 0.38.0 and not with 0.37.1.