### PR TITLE
[MNT] add `scipy<1.16` bounds to incompatible estimators

### DIFF
--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -1177,9 +1177,9 @@ def load_macroeconomic():
           http://www.bls.gov/data/; accessed December 15, 2009.
     """
     _check_soft_dependencies("statsmodels")
-    from statsmodels.api.datasets import macrodata
+    import statsmodels.api as sm
 
-    y = macrodata.load_pandas().data
+    y = sm.datasets.macrodata.load_pandas().data
     y["year"] = y["year"].astype(int).astype(str)
     y["quarter"] = y["quarter"].astype(int).astype(str).apply(lambda x: "Q" + x)
     y["time"] = y["year"] + "-" + y["quarter"]

--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -1177,9 +1177,9 @@ def load_macroeconomic():
           http://www.bls.gov/data/; accessed December 15, 2009.
     """
     _check_soft_dependencies("statsmodels")
-    import statsmodels.api as sm
+    from statsmodels.api.datasets import macrodata
 
-    y = sm.datasets.macrodata.load_pandas().data
+    y = macrodata.load_pandas().data
     y["year"] = y["year"].astype(int).astype(str)
     y["quarter"] = y["quarter"].astype(int).astype(str).apply(lambda x: "Q" + x)
     y["time"] = y["year"] + "-" + y["quarter"]

--- a/sktime/datasets/forecasting/macroeconomic.py
+++ b/sktime/datasets/forecasting/macroeconomic.py
@@ -12,7 +12,7 @@ class Macroeconomic(_ForecastingDatasetFromLoader):
     Examples
     --------
     >>> from sktime.datasets.forecasting import Macroeconomic
-    >>> y = Macroeconomic().load("y")
+    >>> y = Macroeconomic().load("y")  # doctest: +SKIP
 
     Notes
     -----

--- a/sktime/forecasting/base/adapters/_tbats.py
+++ b/sktime/forecasting/base/adapters/_tbats.py
@@ -24,7 +24,8 @@ class _TbatsAdapter(BaseForecaster):
         "capability:pred_int:insample": True,
         "requires-fh-in-fit": False,
         "capability:missing_values": False,
-        "python_dependencies": ["tbats", "numpy<2"],
+        # todo 0.39.0: check whether numpy and scipy bounds are still needed
+        "python_dependencies": ["tbats", "numpy<2", "scipy<1.16"],
     }
 
     def __init__(

--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -461,12 +461,13 @@ class SeasonalityPeriodogram(BaseParamFitter):
 
     _tags = {
         "authors": ["blazingbhavneek"],
-        "maintainers": ["blaingbhavneek"],
+        "maintainers": ["blazingbhavneek"],
         "X_inner_mtype": "pd.Series",
         "scitype:X": "Series",
         "capability:missing_values": True,
         "capability:multivariate": False,
-        "python_dependencies": "seasonal",
+        # todo 0.39.0: check whether numpy<2.4 is still needed
+        "python_dependencies": ["seasonal", "numpy<2.4"],
     }
 
     def __init__(self, min_period=4, max_period=None, thresh=0.10):

--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -466,8 +466,8 @@ class SeasonalityPeriodogram(BaseParamFitter):
         "scitype:X": "Series",
         "capability:missing_values": True,
         "capability:multivariate": False,
-        # todo 0.39.0: check whether numpy<2.4 is still needed
-        "python_dependencies": ["seasonal", "numpy<2.4"],
+        # todo 0.39.0: check whether scipy<1.16 is still needed
+        "python_dependencies": ["seasonal", "scipy<1.16"],
     }
 
     def __init__(self, min_period=4, max_period=None, thresh=0.10):


### PR DESCRIPTION
The newly erleased `scipy 1.16` has removed some private utilities which were imported by a number of time series packages.

This PR adds a bound `scipy<1.16` to those estimators, and a todo check for release managers to check compatibility at next minor release.