### PR TITLE
[BUG] Forecasting functions incompatible with scikit-learn 1.7 #8457

### DIFF
--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -13,7 +13,7 @@ from scipy.stats import gmean
 from sklearn.metrics import mean_absolute_error as _mean_absolute_error
 from sklearn.metrics import mean_squared_error as _mean_squared_error
 from sklearn.metrics import median_absolute_error as _median_absolute_error
-from sklearn.metrics._regression import _check_reg_targets
+from sktime.utils.sklearn import _check_reg_targets
 from sklearn.utils.stats import _weighted_percentile
 from sklearn.utils.validation import check_consistent_length
 

--- a/sktime/utils/sklearn/__init__.py
+++ b/sktime/utils/sklearn/__init__.py
@@ -1,6 +1,7 @@
 """Sklearn related utility functionality."""
 
 from sktime.utils.sklearn._adapt_df import prep_skl_df
+from sktime.utils.sklearn._metrics import _check_reg_targets
 from sktime.utils.sklearn._scitype import (
     is_sklearn_classifier,
     is_sklearn_clusterer,

--- a/sktime/utils/sklearn/_metrics.py
+++ b/sktime/utils/sklearn/_metrics.py
@@ -1,0 +1,98 @@
+"""Temporary functions to ensure compatibility with sklearn
+See https://github.com/sktime/sktime/issues/8457
+"""
+# Original Authors: The scikit-learn developers
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+from sklearn.utils._array_api import get_namespace
+from sklearn.utils.validation import check_array, check_consistent_length
+
+
+def _check_reg_targets(y_true, y_pred, multioutput, dtype="numeric", xp=None):
+    """Check that y_true and y_pred belong to the same regression task.
+
+    To reduce redundancy when calling `_find_matching_floating_dtype`,
+    please use `_check_reg_targets_with_floating_dtype` instead.
+
+    Extracted from v1.6.X sklearn/metrics/_regression.py#L61
+    Parameter `sample_weight` introduced in 1.7 removed
+
+    Parameters
+    ----------
+    y_true : array-like of shape (n_samples,) or (n_samples, n_outputs)
+        Ground truth (correct) target values.
+
+    y_pred : array-like of shape (n_samples,) or (n_samples, n_outputs)
+        Estimated target values.
+
+    multioutput : array-like or string in ['raw_values', uniform_average',
+        'variance_weighted'] or None
+        None is accepted due to backward compatibility of r2_score().
+
+    dtype : str or list, default="numeric"
+        the dtype argument passed to check_array.
+
+    xp : module, default=None
+        Precomputed array namespace module. When passed, typically from a caller
+        that has already performed inspection of its own inputs, skips array
+        namespace inspection.
+
+    Returns
+    -------
+    type_true : one of {'continuous', continuous-multioutput'}
+        The type of the true target data, as output by
+        'utils.multiclass.type_of_target'.
+
+    y_true : array-like of shape (n_samples, n_outputs)
+        Ground truth (correct) target values.
+
+    y_pred : array-like of shape (n_samples, n_outputs)
+        Estimated target values.
+
+    multioutput : array-like of shape (n_outputs) or string in ['raw_values',
+        uniform_average', 'variance_weighted'] or None
+        Custom output weights if ``multioutput`` is array-like or
+        just the corresponding argument if ``multioutput`` is a
+        correct keyword.
+    """
+    xp, _ = get_namespace(y_true, y_pred, multioutput, xp=xp)
+
+    check_consistent_length(y_true, y_pred)
+    y_true = check_array(y_true, ensure_2d=False, dtype=dtype)
+    y_pred = check_array(y_pred, ensure_2d=False, dtype=dtype)
+
+    if y_true.ndim == 1:
+        y_true = xp.reshape(y_true, (-1, 1))
+
+    if y_pred.ndim == 1:
+        y_pred = xp.reshape(y_pred, (-1, 1))
+
+    if y_true.shape[1] != y_pred.shape[1]:
+        raise ValueError(
+            "y_true and y_pred have different number of output ({0}!={1})".format(
+                y_true.shape[1], y_pred.shape[1]
+            )
+        )
+
+    n_outputs = y_true.shape[1]
+    allowed_multioutput_str = ("raw_values", "uniform_average", "variance_weighted")
+    if isinstance(multioutput, str):
+        if multioutput not in allowed_multioutput_str:
+            raise ValueError(
+                "Allowed 'multioutput' string values are {}. "
+                "You provided multioutput={!r}".format(
+                    allowed_multioutput_str, multioutput
+                )
+            )
+    elif multioutput is not None:
+        multioutput = check_array(multioutput, ensure_2d=False)
+        if n_outputs == 1:
+            raise ValueError("Custom weights are useful only in multi-output cases.")
+        elif n_outputs != multioutput.shape[0]:
+            raise ValueError(
+                "There must be equally many custom weights "
+                f"({multioutput.shape[0]}) as outputs ({n_outputs})."
+            )
+    y_type = "continuous" if n_outputs == 1 else "continuous-multioutput"
+
+    return y_type, y_true, y_pred, multioutput


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #8457. 

#### What does this implement/fix? Explain your changes.
Copies the internal v1.6 [_check_reg_targets from sklearn](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/metrics/_regression.py#L61) into sktime.utils.sklearn._metrics. This is a hotfix for forecasting functions not being compatible with sklearn v1.7 which changed _check_reg_targets' signature in this [MR](https://github.com/scikit-learn/scikit-learn/pull/30886.). See discussion on issue on the longer term fix.

This short term fix is probably worth it since _check_reg_targets is called at the start of most forecasting._functions and there is no workaround or kwarg that you can give to workaround the issue. It is a hard TypeError in the signature. The new 

#### Does your contribution introduce a new dependency? If yes, which one?

No


#### What should a reviewer concentrate their feedback on?

This is a hotfix. I do not love the approach but I do not have time for a more principled approach. 


#### Did you add any tests for the change?

The existing tests should now catch this since the module performance_metrics has changed. I am not happy that this was not detected in the unit tests which is the actual cause of the bug - we skip these performance metrics entirely if the module hasn't changed from our side using our pytest `run_test_module_changed` mark. This should ideally also rerun if dependencies changed but is outside the scope of this MR.

#### Any other comments?
No

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.