### PR TITLE
[DOC] use clearer language in extension template preamble

### DIFF
--- a/extension_templates/alignment.py
+++ b/extension_templates/alignment.py
@@ -19,11 +19,11 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     fitting                 - _fit(self, X, Z)
     get alignment           - _get_alignment(self)
 
-Optional implements:
+Optional methods to implement:
     data conversion and capabilities tags - _tags
     get overall distance (scalar)         - _get_distance(self)
     get alignment distance matrix         - _get_distance_matrix(self)

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -19,11 +19,11 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     fitting                 - _fit(self, X, y)
     predicting classes      - _predict(self, X)
 
-Optional implements:
+Optional methods to implement:
     data conversion and capabilities tags - _tags
     fitted parameter inspection           - _get_fitted_params()
     predicting class probabilities        - _predict_proba(self, X)

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -19,10 +19,10 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     fitting            - _fit(self, X)
 
-Optional implements:
+Optional methods to implement:
     cluster assignment          -  _predict(self, X)
     fitted parameter inspection -  _get_fitted_params()
 

--- a/extension_templates/detection.py
+++ b/extension_templates/detection.py
@@ -17,11 +17,11 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     fitting         - _fit(self, X, y=None)
     annotating     - _predict(self, X)
 
-Optional implements:
+Optional methods to implement:
     updating        - _update(self, X, y=None)
 
 Testing - required for sktime test framework and check_estimator usage:

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -14,7 +14,7 @@ How to use this:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     transforming    - _transform(self, X, X2=None)
 
 Testing - required for sktime test framework and check_estimator usage:

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -14,7 +14,7 @@ How to use this:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     transforming    - _transform(self, X, X2=None)
 
 Testing - required for sktime test framework and check_estimator usage:

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -17,13 +17,13 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     fitting                 - _fit(self, X, y)
     predicting classes      - _predict(self, X)
     updating predictions    - _update_predict(self, X)
     performance metrics     - _score(X, y)
 
-Optional implements:
+Optional methods to implement:
     data conversion and capabilities tags - _tags
     fitted parameter inspection           - _get_fitted_params()
     predicting class probabilities        - _predict_proba(self, X)

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -20,11 +20,11 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     fitting         - _fit(self, y, X=None, fh=None)
     forecasting     - _predict(self, fh=None, X=None)
 
-Optional implements:
+Optional methods to implement:
     updating                    - _update(self, y, X=None, update_params=True):
     predicting quantiles        - _predict_quantiles(self, fh, X=None, alpha=None)
     OR predicting intervals     - _predict_interval(self, fh, X=None, coverage=None)

--- a/extension_templates/forecasting_global_supersimple.py
+++ b/extension_templates/forecasting_global_supersimple.py
@@ -28,7 +28,7 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     fitting         - _fit(self, y, X=None, fh=None)
     forecasting     - _predict(self, fh=None, X=None)
 

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -25,7 +25,7 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     fitting         - _fit(self, y, X=None, fh=None)
     forecasting     - _predict(self, fh=None, X=None)
 

--- a/extension_templates/forecasting_supersimple.py
+++ b/extension_templates/forecasting_supersimple.py
@@ -26,7 +26,7 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     fitting         - _fit(self, y, X=None, fh=None)
     forecasting     - _predict(self, fh=None, X=None)
 

--- a/extension_templates/metric_detection.py
+++ b/extension_templates/metric_detection.py
@@ -18,7 +18,7 @@ Purpose of this implementation template:
     - more details:
       https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-    Mandatory implements:
+    Mandatory methods to implement:
         evaluating            - _evaluate(self, X)
 
     Testing - required for sktime test framework and check_estimator usage:

--- a/extension_templates/param_est.py
+++ b/extension_templates/param_est.py
@@ -18,10 +18,10 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     fitting                 - _fit(self, X)
 
-Optional implements:
+Optional methods to implement:
     updating                              - _update(self, X)
     data conversion and capabilities tags - _tags
     fitted parameter inspection           - _get_fitted_params()

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -18,10 +18,10 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     splitting (iloc reference)            - _split(self, y)
 
-Optional implements:
+Optional methods to implement:
     splitting (loc reference)             - _split_loc(self, y)
     get number of splits                  - get_n_splits(self, y)
 

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -20,11 +20,11 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     fitting         - _fit(self, X, y=None)
     transformation  - _transform(self, X, y=None)
 
-Optional implements:
+Optional methods to implement:
     inverse transformation      - _inverse_transform(self, X, y=None)
     update                      - _update(self, X, y=None)
     fitted parameter inspection - _get_fitted_params()

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -25,7 +25,7 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     fitting         - _fit(self, X, y=None)
     transformation  - _transform(self, X, y=None)
 

--- a/extension_templates/transformer_supersimple.py
+++ b/extension_templates/transformer_supersimple.py
@@ -27,7 +27,7 @@ How to use this implementation template to implement a new estimator:
 - more details:
   https://www.sktime.net/en/stable/developer_guide/add_estimators.html
 
-Mandatory implements:
+Mandatory methods to implement:
     fitting         - _fit(self, X, y=None)
     transformation  - _transform(self, X, y=None)
 


### PR DESCRIPTION
This PR makes a small consistent change across all extension templates, improving clarity of language in reference to the methods that need to be implemented.