### PR TITLE
[ENH] add missing API reference for `GreykiteForecaster`

### DIFF
--- a/docs/source/api_reference/forecasting.rst
+++ b/docs/source/api_reference/forecasting.rst
@@ -461,6 +461,14 @@ Structural time series models
 
     DynamicFactor
 
+.. currentmodule:: sktime.forecasting.greykite
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    GreykiteForecaster
+
 Deep learning based forecasters
 -------------------------------
 

--- a/sktime/forecasting/greykite.py
+++ b/sktime/forecasting/greykite.py
@@ -26,9 +26,8 @@ class GreykiteForecaster(BaseForecaster):
     Parameters
     ----------
     forecast_config : ForecastConfig, optional
-        Configuration object for Greykite's forecasting pipeline. If None,
-         a default configuration
-        is created.
+        Configuration object for Greykite's forecasting pipeline.
+        If None, a default configuration is created.
     date_format : str, optional
         Format of the timestamp in the data. If None, it is inferred.
     model_template : str, optional


### PR DESCRIPTION
`GreykiteForecaster` was missing from the API reference, this PR adds it