### PR TITLE
[MNT] Skip mlflow test jobs if sktime folder or pyproject.toml is untouched

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,6 +182,7 @@ jobs:
 
   test-mlflow:
     needs: detect-package-change
+    if: ${{ needs.detect-package-change.outputs.sktime == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,7 +181,7 @@ jobs:
         run: make PYTESTOPTIONS="--matrixdesign=False --timeout=600" test_softdeps_full
 
   test-mlflow:
-    needs: test-nosoftdeps
+    needs: detect-package-change
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This changes "needs" of the mlflow jobs in CI and ensures those are skipped if both `sktime/` and `pyproject.toml` are not modified.