### PR TITLE
[MNT] replace unsafe imports from `torch` and `transformers` with `_safe_import` pattern

### DIFF
--- a/sktime/libs/chronos/chronos.py
+++ b/sktime/libs/chronos/chronos.py
@@ -11,7 +11,7 @@ import warnings
 from dataclasses import dataclass
 from typing import Any, Literal, Optional
 
-from sktime.utils.dependencies import _safe_import
+from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
 
 torch = _safe_import("torch")
 nn = _safe_import("torch.nn")
@@ -21,6 +21,15 @@ AutoModelForCausalLM = _safe_import("transformers.AutoModelForCausalLM")
 AutoModelForSeq2SeqLM = _safe_import("transformers.AutoModelForSeq2SeqLM")
 GenerationConfig = _safe_import("transformers.GenerationConfig")
 PreTrainedModel = _safe_import("transformers.PreTrainedModel")
+
+# this is required as a workaround for the dataclass fields
+if not _check_soft_dependencies("torch", severity="none"):
+
+    class nn:
+        """Dummy class if torch is unavailable."""
+
+        class Module:
+            """Dummy class if torch is unavailable."""
 
 
 @dataclass

--- a/sktime/libs/chronos/chronos.py
+++ b/sktime/libs/chronos/chronos.py
@@ -9,7 +9,7 @@ Authors: Lorenzo Stella <stellalo@amazon.com>, Abdul Fatir Ansari <ansarnd@amazo
 
 import warnings
 from dataclasses import dataclass
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal, Optional
 
 from sktime.utils.dependencies import _safe_import
 

--- a/sktime/libs/chronos/chronos.py
+++ b/sktime/libs/chronos/chronos.py
@@ -11,38 +11,16 @@ import warnings
 from dataclasses import dataclass
 from typing import Any, Literal, Optional, Union
 
-from skbase.utils.dependencies import _check_soft_dependencies
+from sktime.utils.dependencies import _safe_import
 
-if _check_soft_dependencies("torch", severity="none"):
-    import torch
-    import torch.nn as nn
-else:
+torch = _safe_import("torch")
+nn = _safe_import("torch.nn")
 
-    class torch:
-        """Dummy class if torch is unavailable."""
-
-        class Tensor:
-            """Dummy class if torch is unavailable."""
-
-    class nn:
-        """Dummy class if torch is unavailable."""
-
-        class Module:
-            """Dummy class if torch is unavailable."""
-
-
-if _check_soft_dependencies("transformers", severity="none"):
-    from transformers import (
-        AutoConfig,
-        AutoModelForCausalLM,
-        AutoModelForSeq2SeqLM,
-        GenerationConfig,
-        PreTrainedModel,
-    )
-else:
-
-    class PreTrainedModel:
-        """Dummy class if transformers is unavailable."""
+AutoConfig = _safe_import("transformers.AutoConfig")
+AutoModelForCausalLM = _safe_import("transformers.AutoModelForCausalLM")
+AutoModelForSeq2SeqLM = _safe_import("transformers.AutoModelForSeq2SeqLM")
+GenerationConfig = _safe_import("transformers.GenerationConfig")
+PreTrainedModel = _safe_import("transformers.PreTrainedModel")
 
 
 @dataclass

--- a/sktime/libs/chronos/chronos.py
+++ b/sktime/libs/chronos/chronos.py
@@ -245,13 +245,13 @@ class ChronosModel(nn.Module):
 
     Parameters
     ----------
-    config
+    config: ChronosConfig
         The configuration to use.
-    model
+    model: PreTrainedModel
         The pretrained model to use.
     """
 
-    def __init__(self, config: ChronosConfig, model: PreTrainedModel) -> None:
+    def __init__(self, config, model) -> None:
         super().__init__()
         self.config = config
         self.model = model
@@ -261,13 +261,8 @@ class ChronosModel(nn.Module):
         """The device where the model is stored."""
         return self.model.device
 
-    def encode(
-        self,
-        input_ids: torch.Tensor,
-        attention_mask: torch.Tensor,
-    ):
-        """
-        Extract the encoder embedding for the given token sequences.
+    def encode(self, input_ids, attention_mask):
+        """Extract the encoder embedding for the given token sequences.
 
         Parameters
         ----------
@@ -293,16 +288,15 @@ class ChronosModel(nn.Module):
 
     def forward(
         self,
-        input_ids: torch.Tensor,
-        attention_mask: torch.Tensor,
+        input_ids,
+        attention_mask,
         prediction_length: Optional[int] = None,
         num_samples: Optional[int] = None,
         temperature: Optional[float] = None,
         top_k: Optional[int] = None,
         top_p: Optional[float] = None,
-    ) -> torch.Tensor:
-        """
-        Predict future sample tokens for the given token sequences.
+    ):
+        """Predict future sample tokens for the given token sequences.
 
         Arguments ``prediction_length``, ``num_samples``, ``temperature``,
         ``top_k``, ``top_p`` can be used to customize the model inference,
@@ -385,9 +379,7 @@ class ChronosPipeline:
     tokenizer: ChronosTokenizer
     model: ChronosModel
 
-    def _prepare_and_validate_context(
-        self, context: Union[torch.Tensor, list[torch.Tensor]]
-    ):
+    def _prepare_and_validate_context(self, context):
         if isinstance(context, list):
             context = left_pad_and_stack_1D(context)
         assert isinstance(context, torch.Tensor)
@@ -397,15 +389,12 @@ class ChronosPipeline:
 
         return context
 
-    def embed(
-        self, context: Union[torch.Tensor, list[torch.Tensor]]
-    ) -> tuple[torch.Tensor, Any]:
-        """
-        Get encoder embeddings for the given time series.
+    def embed(self, context):
+        """Get encoder embeddings for the given time series.
 
         Parameters
         ----------
-        context
+        context : Union[torch.Tensor, list[torch.Tensor]]
             Input series. This is either a 1D tensor, or a list
             of 1D tensors, or a 2D tensor whose first dimension
             is batch. In the latter case, use left-padding with
@@ -413,7 +402,7 @@ class ChronosPipeline:
 
         Returns
         -------
-        embeddings, tokenizer_state
+        embeddings, tokenizer_state : tuple[torch.Tensor, Any]
             A tuple of two tensors: the encoder embeddings and the tokenizer_state,
             e.g., the scale of the time series in the case of mean scaling.
             The encoder embeddings are shaped (batch_size, context_length, d_model)
@@ -435,20 +424,20 @@ class ChronosPipeline:
 
     def predict(
         self,
-        context: Union[torch.Tensor, list[torch.Tensor]],
+        context,
         prediction_length: Optional[int] = None,
         num_samples: Optional[int] = None,
         temperature: Optional[float] = None,
         top_k: Optional[int] = None,
         top_p: Optional[float] = None,
         limit_prediction_length: bool = True,
-    ) -> torch.Tensor:
+    ):
         """
         Get forecasts for the given time series.
 
         Parameters
         ----------
-        context
+        context : Union[torch.Tensor, list[torch.Tensor]]
             Input series. This is either a 1D tensor, or a list
             of 1D tensors, or a 2D tensor whose first dimension
             is batch. In the latter case, use left-padding with
@@ -476,7 +465,7 @@ class ChronosPipeline:
 
         Returns
         -------
-        samples
+        samples : torch.Tensor
             Tensor of sample forecasts, of shape
             (batch_size, num_samples, prediction_length).
         """

--- a/sktime/libs/chronos/chronos_bolt.py
+++ b/sktime/libs/chronos/chronos_bolt.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__file__)
 
 # workaround condition for the case where ModelOutput cannot be imported
 # using the mock class does not work here
-if ModelOutput.__class__.__name__ == "CommonMagicMeta"
+if ModelOutput.__class__.__name__ == "CommonMagicMeta":
 
     class ModelOutput:
         """Dummy model output if transformers is unavailable."""

--- a/sktime/libs/chronos/chronos_bolt.py
+++ b/sktime/libs/chronos/chronos_bolt.py
@@ -12,7 +12,7 @@ import copy
 import logging
 import warnings
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional
 
 from sktime.utils.dependencies import _safe_import
 
@@ -45,10 +45,10 @@ class ChronosBoltConfig:
 class ChronosBoltOutput(ModelOutput):
     """Description of the output of the model."""
 
-    loss=None
-    quantile_preds=None
-    attentions=None
-    cross_attentions=None
+    loss = None
+    quantile_preds = None
+    attentions = None
+    cross_attentions = None
 
 
 class Patch(nn.Module):

--- a/sktime/libs/chronos/chronos_bolt.py
+++ b/sktime/libs/chronos/chronos_bolt.py
@@ -29,6 +29,14 @@ ModelOutput = _safe_import("transformers.utils.ModelOutput")
 logger = logging.getLogger(__file__)
 
 
+# workaround condition for the case where ModelOutput cannot be imported
+# using the mock class does not work here
+if ModelOutput.__class__.__name__ == "CommonMagicMeta"
+
+    class ModelOutput:
+        """Dummy model output if transformers is unavailable."""
+
+
 @dataclass
 class ChronosBoltConfig:
     """Configuration for chronos-bolt."""

--- a/sktime/libs/chronos/chronos_bolt.py
+++ b/sktime/libs/chronos/chronos_bolt.py
@@ -14,43 +14,17 @@ import warnings
 from dataclasses import dataclass
 from typing import Optional, Union
 
-from skbase.utils.dependencies import _check_soft_dependencies
+from sktime.utils.dependencies import _safe_import
 
-if _check_soft_dependencies("torch", severity="none"):
-    import torch
-    import torch.nn as nn
-else:
+torch = _safe_import("torch")
+nn = _safe_import("torch.nn")
 
-    class torch:
-        """Dummy class if torch is unavailable."""
-
-        class Tensor:
-            """Dummy class if torch is unavailable."""
-
-    class nn:
-        """Dummy class if torch is unavailable."""
-
-        class Module:
-            """Dummy class if torch is unavailable."""
-
-
-if _check_soft_dependencies("transformers", severity="none"):
-    from transformers import AutoConfig
-    from transformers.models.t5.modeling_t5 import (
-        ACT2FN,
-        T5LayerNorm,
-        T5PreTrainedModel,
-        T5Stack,
-    )
-    from transformers.utils import ModelOutput
-else:
-
-    class T5PreTrainedModel:
-        """Dummy class if transformers is unavailable."""
-
-    class ModelOutput:
-        """Dummy model output if transformers is unavailable."""
-
+AutoConfig = _safe_import("transformers.AutoConfig")
+ACT2FN = _safe_import("transformers.models.t5.modeling_t5.ACT2FN")
+T5LayerNorm = _safe_import("transformers.models.t5.modeling_t5.T5LayerNorm")
+T5PreTrainedModel = _safe_import("transformers.models.t5.modeling_t5.T5PreTrainedModel")
+T5Stack = _safe_import("transformers.models.t5.modeling_t5.T5Stack")
+ModelOutput = _safe_import("transformers.utils.ModelOutput")
 
 logger = logging.getLogger(__file__)
 

--- a/sktime/libs/chronos/chronos_bolt.py
+++ b/sktime/libs/chronos/chronos_bolt.py
@@ -45,10 +45,10 @@ class ChronosBoltConfig:
 class ChronosBoltOutput(ModelOutput):
     """Description of the output of the model."""
 
-    loss: Optional[torch.Tensor] = None
-    quantile_preds: Optional[torch.Tensor] = None
-    attentions: Optional[torch.Tensor] = None
-    cross_attentions: Optional[torch.Tensor] = None
+    loss=None
+    quantile_preds=None
+    attentions=None
+    cross_attentions=None
 
 
 class Patch(nn.Module):
@@ -66,7 +66,7 @@ class Patch(nn.Module):
         self.patch_size = patch_size
         self.patch_stride = patch_stride
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x):
         """
         Convert input time series `x` into patches for further processing.
 
@@ -103,13 +103,8 @@ class InstanceNorm(nn.Module):
         super().__init__()
         self.eps = eps
 
-    def forward(
-        self,
-        x: torch.Tensor,
-        loc_scale: Optional[tuple[torch.Tensor, torch.Tensor]] = None,
-    ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
-        """
-        Apply instance normalization to the input tensor.
+    def forward(self, x, loc_scale=None):
+        """Apply instance normalization to the input tensor.
 
         This method normalizes the input tensor by subtracting the mean and dividing by
         the standard deviation, computed separately for each instance of the batch.
@@ -135,11 +130,8 @@ class InstanceNorm(nn.Module):
 
         return (x - loc) / scale, (loc, scale)
 
-    def inverse(
-        self, x: torch.Tensor, loc_scale: tuple[torch.Tensor, torch.Tensor]
-    ) -> torch.Tensor:
-        """
-        Reverses the normalization process of the InstanceNorm during ``forward()``.
+    def inverse(self, x, loc_scale):
+        """Reverses the normalization process of the InstanceNorm during ``forward()``.
 
         Parameter
         ---------
@@ -202,7 +194,7 @@ class ResidualBlock(nn.Module):
         if use_layer_norm:
             self.layer_norm = T5LayerNorm(out_dim)
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x):
         """
         Forward pass through the Residual Block.
 
@@ -343,13 +335,8 @@ class ChronosBoltModelForForecasting(T5PreTrainedModel):
             ):
                 module.output_layer.bias.data.zero_()
 
-    def encode(
-        self, context: torch.Tensor, mask: Optional[torch.Tensor] = None
-    ) -> tuple[
-        torch.Tensor, tuple[torch.Tensor, torch.Tensor], torch.Tensor, torch.Tensor
-    ]:
-        """
-        Encode the input context tensor using the model's architecture.
+    def encode(self, context, mask=None):
+        """Encode the input context tensor using the model's architecture.
 
         Parameters
         ----------
@@ -428,15 +415,8 @@ class ChronosBoltModelForForecasting(T5PreTrainedModel):
 
         return encoder_outputs[0], loc_scale, input_embeds, attention_mask
 
-    def forward(
-        self,
-        context: torch.Tensor,
-        mask: Optional[torch.Tensor] = None,
-        target: Optional[torch.Tensor] = None,
-        target_mask: Optional[torch.Tensor] = None,
-    ) -> ChronosBoltOutput:
-        """
-        Predict the future sample tokens for the given sequences.
+    def forward(self, context, mask=None, target=None, target_mask=None):
+        """Predict the future sample tokens for the given sequences.
 
         Arguments `context`, `mask`, `target` and `target_mask` can be used to customize
         the model inference at runtime.
@@ -617,9 +597,7 @@ class ChronosBoltPipeline:
     model: ChronosBoltModelForForecasting
     default_context_length: int = 2048
 
-    def _prepare_and_validate_context(
-        self, context: Union[torch.Tensor, list[torch.Tensor]]
-    ):
+    def _prepare_and_validate_context(self, context):
         if isinstance(context, list):
             context = left_pad_and_stack_1D(context)
         assert isinstance(context, torch.Tensor)
@@ -629,11 +607,8 @@ class ChronosBoltPipeline:
 
         return context
 
-    def embed(
-        self, context: Union[torch.Tensor, list[torch.Tensor]]
-    ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
-        """
-        Get encoder embeddings for the given time series.
+    def embed(self, context):
+        """Get encoder embeddings for the given time series.
 
         Parameters
         ----------
@@ -671,12 +646,11 @@ class ChronosBoltPipeline:
 
     def predict(  # type: ignore[override]
         self,
-        context: Union[torch.Tensor, list[torch.Tensor]],
+        context,
         prediction_length: Optional[int] = None,
         limit_prediction_length: bool = False,
-    ) -> torch.Tensor:
-        """
-        Get forecasts for the given time series.
+    ):
+        """Get forecasts for the given time series.
 
         Refer to the base method (``BaseChronosPipeline.predict``)
         for details on shared parameters.

--- a/sktime/libs/granite_ttm/configuration_tinytimemixer.py
+++ b/sktime/libs/granite_ttm/configuration_tinytimemixer.py
@@ -2,14 +2,9 @@
 
 from typing import Optional, Union
 
-from skbase.utils.dependencies import _check_soft_dependencies
+from sktime.utils.dependencies import _safe_import
 
-if _check_soft_dependencies("transformers", severity="none"):
-    from transformers.configuration_utils import PretrainedConfig
-else:
-
-    class PretrainedConfig:
-        """Dummy class if transformers is unavailable."""
+PretrainedConfig = _safe_import("transformers.configuration_utils.PretrainedConfig")
 
 
 class TinyTimeMixerConfig(PretrainedConfig):

--- a/sktime/libs/granite_ttm/modeling_tinytimemixer.py
+++ b/sktime/libs/granite_ttm/modeling_tinytimemixer.py
@@ -52,7 +52,7 @@ class TinyTimeMixerBatchNorm(nn_module):
         super().__init__()
         self.batchnorm = nn.BatchNorm1d(config.d_model, eps=config.norm_eps)
 
-    def forward(self, inputs: torch_tensor):
+    def forward(self, inputs):
         """
         Forward Pass.
 
@@ -107,7 +107,7 @@ class TinyTimeMixerPositionalEncoding(nn_module):
             )
         return position_enc
 
-    def forward(self, patch_input: torch_tensor):
+    def forward(self, patch_input):
         """Forward Pass."""
         hidden_state = patch_input + self.position_enc
         return hidden_state
@@ -131,7 +131,7 @@ class TinyTimeMixerNormLayer(nn_module):
         else:
             self.norm = nn.LayerNorm(config.d_model, eps=config.norm_eps)
 
-    def forward(self, inputs: torch_tensor):
+    def forward(self, inputs):
         """
         Forward Pass.
 
@@ -174,7 +174,7 @@ class TinyTimeMixerMLP(nn_module):
         self.fc2 = nn.Linear(num_hidden, out_features)
         self.dropout2 = nn.Dropout(config.dropout)
 
-    def forward(self, inputs: torch_tensor):
+    def forward(self, inputs):
         """
         Forward Pass.
 
@@ -218,7 +218,7 @@ class TinyTimeMixerChannelFeatureMixerBlock(nn_module):
                 in_size=config.num_input_channels, out_size=config.num_input_channels
             )
 
-    def forward(self, inputs: torch_tensor):
+    def forward(self, inputs):
         """
         Forward Pass.
 
@@ -289,11 +289,11 @@ class TinyTimeMixerAttention(nn_module):
 
     def forward(
         self,
-        hidden_states: torch_tensor,
-        key_value_states: Optional[torch_tensor] = None,
-        past_key_value: Optional[tuple[torch_tensor]] = None,
-        attention_mask: Optional[torch_tensor] = None,
-        layer_head_mask: Optional[torch_tensor] = None,
+        hidden_states,
+        key_value_states=None,
+        past_key_value=None,
+        attention_mask=None,
+        layer_head_mask=None,
         output_attentions: bool = False,
     ):
         """Input shape: Batch x Time x Channel."""

--- a/sktime/libs/granite_ttm/modeling_tinytimemixer.py
+++ b/sktime/libs/granite_ttm/modeling_tinytimemixer.py
@@ -19,6 +19,13 @@ nn_module = nn.Module
 torch_tensor = torch.Tensor
 torch_float = torch.FloatTensor
 
+# workaround condition for the case where ModelOutput cannot be imported
+# using the mock class does not work here
+if ModelOutput.__class__.__name__ == "CommonMagicMeta":
+
+    class ModelOutput:
+        """Dummy model output if transformers is unavailable."""
+
 
 class TinyTimeMixerGatedAttention(nn_module):
     """

--- a/sktime/libs/granite_ttm/modeling_tinytimemixer.py
+++ b/sktime/libs/granite_ttm/modeling_tinytimemixer.py
@@ -12,8 +12,8 @@ from sktime.utils.dependencies import _safe_import
 ModelOutput = _safe_import("transformers.modeling_utils.ModelOutput")
 PreTrainedModel = _safe_import("transformers.modeling_utils.PreTrainedModel")
 
-torch = _safe_import("torch", severity="none")
-nn = _safe_import("torch.nn", severity="none")
+torch = _safe_import("torch")
+nn = _safe_import("torch.nn")
 
 nn_module = nn.Module
 torch_tensor = torch.Tensor

--- a/sktime/libs/granite_ttm/modeling_tinytimemixer.py
+++ b/sktime/libs/granite_ttm/modeling_tinytimemixer.py
@@ -280,7 +280,7 @@ class TinyTimeMixerAttention(nn_module):
         self.q_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
         self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
 
-    def _shape(self, tensor: torch_tensor, seq_len: int, bsz: int):
+    def _shape(self, tensor, seq_len: int, bsz: int):
         return (
             tensor.view(bsz, seq_len, self.num_heads, self.head_dim)
             .transpose(1, 2)
@@ -507,7 +507,7 @@ class FeatureMixerBlock(nn_module):
                 in_size=config.d_model, out_size=config.d_model
             )
 
-    def forward(self, hidden: torch_tensor):
+    def forward(self, hidden):
         """
         Forward Pass.
 
@@ -555,7 +555,7 @@ class TinyTimeMixerLayer(nn_module):
                 config=config
             )
 
-    def forward(self, hidden: torch_tensor):
+    def forward(self, hidden):
         """
         Forward Pass.
 
@@ -612,7 +612,7 @@ class TinyTimeMixerAdaptivePatchingBlock(nn_module):
             [TinyTimeMixerLayer(temp_config) for i in range(temp_config.num_layers)]
         )
 
-    def forward(self, hidden: torch_tensor):
+    def forward(self, hidden):
         """
         Forward Pass.
 
@@ -958,7 +958,7 @@ class TinyTimeMixerPatchify(nn_module):
         )
         self.sequence_start = self.sequence_length - new_sequence_length
 
-    def forward(self, past_values: torch_tensor):
+    def forward(self, past_values):
         """
         Forward Pass.
 
@@ -1005,7 +1005,7 @@ class TinyTimeMixerStdScaler(nn_module):
             config.minimum_scale if hasattr(config, "minimum_scale") else 1e-5
         )
 
-    def forward(self, data: torch_tensor, observed_indicator: torch_tensor):
+    def forward(self, data, observed_indicator):
         """
         Forward Pass.
 
@@ -1055,7 +1055,7 @@ class TinyTimeMixerMeanScaler(nn_module):
             config.default_scale if hasattr(config, "default_scale") else None
         )
 
-    def forward(self, data: torch_tensor, observed_indicator: torch_tensor):
+    def forward(self, data, observed_indicator):
         """
         Forward Pass.
 
@@ -1108,7 +1108,7 @@ class TinyTimeMixerNOPScaler(nn_module):
         self.dim = config.scaling_dim if hasattr(config, "scaling_dim") else 1
         self.keepdim = config.keepdim if hasattr(config, "keepdim") else True
 
-    def forward(self, data: torch_tensor, observed_indicator: torch_tensor = None):
+    def forward(self, data, observed_indicator=None):
         """
         Forward Pass.
 
@@ -1144,8 +1144,8 @@ class TinyTimeMixerEncoderOutput(ModelOutput):
             Hidden-states of the model at the output of each layer.
     """
 
-    last_hidden_state: torch_float = None
-    hidden_states: Optional[tuple[torch_float]] = None
+    last_hidden_state = None
+    hidden_states = None
 
 
 class TinyTimeMixerEncoder(TinyTimeMixerPreTrainedModel):
@@ -1192,10 +1192,10 @@ class TinyTimeMixerEncoder(TinyTimeMixerPreTrainedModel):
 
     def forward(
         self,
-        past_values: torch_tensor,
+        past_values,
         output_hidden_states: Optional[bool] = False,
         return_dict: Optional[bool] = None,
-        freq_token: Optional[torch_tensor] = None,
+        freq_token=None,
     ):
         r"""
         Forward Pass.
@@ -1289,11 +1289,11 @@ class TinyTimeMixerModelOutput(ModelOutput):
             enabled.
     """
 
-    last_hidden_state: torch_float = None
-    hidden_states: Optional[tuple[torch_float]] = None
-    patch_input: torch_float = None
-    loc: Optional[torch_float] = None
-    scale: Optional[torch_float] = None
+    last_hidden_state = None
+    hidden_states = None
+    patch_input = None
+    loc = None
+    scale = None
 
 
 class TinyTimeMixerModel(TinyTimeMixerPreTrainedModel):
@@ -1344,11 +1344,11 @@ class TinyTimeMixerModel(TinyTimeMixerPreTrainedModel):
 
     def forward(
         self,
-        past_values: torch_tensor,
-        observed_mask: Optional[torch_tensor] = None,
+        past_values,
+        observed_mask=None,
         output_hidden_states: Optional[bool] = False,
         return_dict: Optional[bool] = None,
-        freq_token: Optional[torch_tensor] = None,
+        freq_token=None,
     ):
         r"""
         Forward Pass.
@@ -1456,13 +1456,13 @@ class TinyTimeMixerForPredictionOutput(ModelOutput):
 
     """
 
-    loss: Optional[torch_float] = None
-    prediction_outputs: torch_float = None
-    backbone_hidden_state: torch_float = None
-    decoder_hidden_state: torch_float = None
-    hidden_states: Optional[tuple[torch_float]] = None
-    loc: torch_float = None
-    scale: torch_float = None
+    loss = None
+    prediction_outputs = None
+    backbone_hidden_state = None
+    decoder_hidden_state = None
+    hidden_states = None
+    loc = None
+    scale = None
 
 
 class TinyTimeMixerForPrediction(TinyTimeMixerPreTrainedModel):
@@ -1508,13 +1508,13 @@ class TinyTimeMixerForPrediction(TinyTimeMixerPreTrainedModel):
 
     def forward(
         self,
-        past_values: torch_tensor,
-        future_values: Optional[torch_tensor] = None,
-        observed_mask: Optional[torch_tensor] = None,
-        output_hidden_states: Optional[bool] = False,
-        return_loss: bool = True,
-        return_dict: Optional[bool] = None,
-        freq_token: Optional[torch_tensor] = None,
+        past_values,
+        future_values=None,
+        observed_mask=None,
+        output_hidden_states=False,
+        return_loss=True,
+        return_dict=None,
+        freq_token=None,
     ):
         r"""
         Forward Pass.

--- a/sktime/libs/granite_ttm/modeling_tinytimemixer.py
+++ b/sktime/libs/granite_ttm/modeling_tinytimemixer.py
@@ -6,38 +6,18 @@ from dataclasses import dataclass
 from typing import Optional
 from warnings import warn
 
-from skbase.utils.dependencies import _check_soft_dependencies
-
 from sktime.libs.granite_ttm.configuration_tinytimemixer import TinyTimeMixerConfig
+from sktime.utils.dependencies import _safe_import
 
-if _check_soft_dependencies("transformers", severity="none"):
-    from transformers.modeling_utils import ModelOutput, PreTrainedModel
-else:
+ModelOutput = _safe_import("transformers.modeling_utils.ModelOutput")
+PreTrainedModel = _safe_import("transformers.modeling_utils.PreTrainedModel")
 
-    class PreTrainedModel:
-        """Dummy class if transformers is unavailable."""
+torch = _safe_import("torch", severity="none")
+nn = _safe_import("torch.nn", severity="none")
 
-    class ModelOutput:
-        """Dummy class if transformers is unavailable."""
-
-
-if _check_soft_dependencies("torch", severity="none"):
-    import torch
-    import torch.nn as nn
-
-    nn_module = nn.Module
-    torch_tensor = torch.Tensor
-    torch_float = torch.FloatTensor
-else:
-
-    class nn_module:
-        """Dummy class if torch is unavailable."""
-
-    class torch_tensor:
-        """Dummy class if torch is unavailable."""
-
-    class torch_float:
-        """Dummy class if torch is unavailable."""
+nn_module = nn.Module
+torch_tensor = torch.Tensor
+torch_float = torch.FloatTensor
 
 
 class TinyTimeMixerGatedAttention(nn_module):

--- a/sktime/libs/timemoe/timemoe.py
+++ b/sktime/libs/timemoe/timemoe.py
@@ -19,7 +19,6 @@ from typing import Optional, Union
 
 from sktime.utils.dependencies import _safe_import
 
-
 torch = _safe_import("torch")
 nn = _safe_import("torch.nn")
 F = _safe_import("torch.nn.functional")

--- a/sktime/libs/timemoe/timemoe.py
+++ b/sktime/libs/timemoe/timemoe.py
@@ -15,7 +15,7 @@
 
 import math
 import warnings
-from typing import Optional, Union
+from typing import Optional
 
 from sktime.utils.dependencies import _safe_import
 

--- a/sktime/libs/timemoe/timemoe.py
+++ b/sktime/libs/timemoe/timemoe.py
@@ -17,60 +17,27 @@ import math
 import warnings
 from typing import Optional, Union
 
-from sktime.utils.dependencies import _check_soft_dependencies
-
-if _check_soft_dependencies("torch", severity="none"):
-    import torch
-    import torch.nn as nn
-    import torch.nn.functional as F
-else:
-
-    class torch:
-        """Dummy class if torch is not installed."""
-
-        class Tensor:
-            """Dummy class if torch is not installed."""
-
-        class LongTensor:
-            """Dummy class if torch is not installed."""
-
-        class FloatTensor:
-            """Dummy class if torch is not installed."""
-
-    class nn:
-        """Dummy class if torch is not installed."""
-
-        class Module:
-            """Dummy class if torch is not installed."""
-
-    class F:
-        """Dummy class if torch is not installed."""
+from sktime.utils.dependencies import _safe_import
 
 
-if _check_soft_dependencies("transformers", severity="none"):
-    from transformers import Cache, DynamicCache, PreTrainedModel, StaticCache
-    from transformers.activations import ACT2FN
-    from transformers.modeling_attn_mask_utils import _prepare_4d_causal_attention_mask
-    from transformers.modeling_outputs import (
-        MoeCausalLMOutputWithPast,
-        MoeModelOutputWithPast,
-    )
-else:
+torch = _safe_import("torch")
+nn = _safe_import("torch.nn")
+F = _safe_import("torch.nn.functional")
 
-    class Cache:
-        """Dummy class if transformers is not installed."""
-
-    class StaticCache:
-        """Dummy class if transformers is not installed."""
-
-    class PreTrainedModel:
-        """Dummy class if transformers is not installed."""
-
-    class MoeModelOutputWithPast:
-        """Dummy class if transformers is not installed."""
-
-    class MoeCausalLMOutputWithPast:
-        """Dummy class if transformers is not installed."""
+Cache = _safe_import("transformers.Cache")
+DynamicCache = _safe_import("transformers.DynamicCache")
+PreTrainedModel = _safe_import("transformers.PreTrainedModel")
+StaticCache = _safe_import("transformers.StaticCache")
+ACT2FN = _safe_import("transformers.activations.ACT2FN")
+_prepare_4d_causal_attention_mask = _safe_import(
+    "transformers.modeling_attn_mask_utils._prepare_4d_causal_attention_mask"
+)
+MoeCausalLMOutputWithPast = _safe_import(
+    "transformers.modeling_outputs.MoeCausalLMOutputWithPast"
+)
+MoeModelOutputWithPast = _safe_import(
+    "transformers.modeling_outputs.MoeModelOutputWithPast"
+)
 
 
 from .timemoe_config import TimeMoeConfig

--- a/sktime/libs/timemoe/timemoe.py
+++ b/sktime/libs/timemoe/timemoe.py
@@ -56,13 +56,12 @@ def _get_unpad_data(attention_mask):
 
 
 def load_balancing_loss_func(
-    gate_logits: Union[torch.Tensor, tuple[torch.Tensor], list[torch.Tensor]],
+    gate_logits,
     top_k: int,
     num_experts: int = None,
-    attention_mask: Optional[torch.Tensor] = None,
-) -> torch.Tensor:
-    r"""
-    Compute auxiliary load balancing loss as in Switch Transformer.
+    attention_mask=None,
+):
+    r"""Compute auxiliary load balancing loss as in Switch Transformer.
 
     See Switch Transformer (https://arxiv.org/abs/2101.03961) for more details.
     This function implements the loss function presented in equations (4) - (6) of the
@@ -84,6 +83,7 @@ def load_balancing_loss_func(
 
     Returns
     -------
+        torch.Tensor
         The auxiliary loss.
     """
     if (
@@ -153,7 +153,7 @@ def load_balancing_loss_func(
 
 
 # Copied from transformers.models.llama.modeling_llama.repeat_kv
-def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+def repeat_kv(hidden_states, n_rep: int):
     """
     Equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep).
 
@@ -478,9 +478,8 @@ class TimeMoeSparseExpertsLayer(nn.Module):
         )
         self.shared_expert_gate = torch.nn.Linear(config.hidden_size, 1, bias=False)
 
-    def forward(self, hidden_states: torch.Tensor):
-        """
-        Forward pass through the sparse experts layer.
+    def forward(self, hidden_states):
+        """Forward pass through the sparse experts layer.
 
         Parameters
         ----------
@@ -609,15 +608,14 @@ class TimeMoeAttention(nn.Module):
 
     def forward(
         self,
-        hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
-        past_key_value: Optional[Cache] = None,
+        hidden_states,
+        attention_mask=None,
+        position_ids=None,
+        past_key_value=None,
         output_attentions: bool = False,
         **kwargs,
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[tuple[torch.Tensor]]]:
-        """
-        Forward pass through the attention layer.
+    ):
+        """Forward pass through the attention layer.
 
         Parameters
         ----------
@@ -636,7 +634,7 @@ class TimeMoeAttention(nn.Module):
 
         Returns
         -------
-        tuple
+        tuple[torch.Tensor, Optional[torch.Tensor], Optional[tuple[torch.Tensor]]]
             Output states, attention weights (optional), and cached states (optional)
         """
         if "padding_mask" in kwargs:

--- a/sktime/libs/timemoe/timemoe.py
+++ b/sktime/libs/timemoe/timemoe.py
@@ -771,19 +771,14 @@ class TimeMoeDecoderLayer(nn.Module):
 
     def forward(
         self,
-        hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
-        past_key_value: Optional[tuple[torch.Tensor]] = None,
+        hidden_states,
+        attention_mask=None,
+        position_ids=None,
+        past_key_value=None,
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
         **kwargs,
-    ) -> tuple[
-        torch.FloatTensor,
-        torch.FloatTensor,
-        Optional[torch.FloatTensor],
-        Optional[torch.FloatTensor],
-    ]:
+    ):
         """
         Perform a forward pass through the model.
 
@@ -924,16 +919,16 @@ class TimeMoeModel(TimeMoePreTrainedModel):
 
     def forward(
         self,
-        input_ids: torch.FloatTensor = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
-        past_key_values: Optional[list[torch.FloatTensor]] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        past_key_values=None,
+        inputs_embeds=None,
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[tuple, MoeModelOutputWithPast]:
+    ):
         """
         Perform a forward pass of the model.
 
@@ -1243,19 +1238,19 @@ class TimeMoeForPrediction(TimeMoePreTrainedModel, TSGenerationMixin):
 
     def forward(
         self,
-        input_ids: torch.FloatTensor = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
-        past_key_values: Optional[list[torch.FloatTensor]] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        labels: Optional[torch.FloatTensor] = None,
-        loss_masks: Optional[torch.FloatTensor] = None,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        labels=None,
+        loss_masks=None,
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         max_horizon_length: Optional[int] = None,
-    ) -> Union[tuple, MoeCausalLMOutputWithPast]:
+    ):
         """
         Perform a forward pass through the model.
 

--- a/sktime/libs/timemoe/timemoe_config.py
+++ b/sktime/libs/timemoe/timemoe_config.py
@@ -13,14 +13,9 @@
 # limitations under the License.
 """Configuration for TimeMOE model."""
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from sktime.utils.dependencies import _safe_import
 
-if _check_soft_dependencies("transformers", severity="none"):
-    from transformers import PretrainedConfig
-else:
-
-    class PretrainedConfig:
-        """Dummy class if transformers is not installed."""
+PretrainedConfig = _safe_import("transformers.PretrainedConfig")
 
 
 class TimeMoeConfig(PretrainedConfig):

--- a/sktime/libs/timemoe/ts_generation_mixin.py
+++ b/sktime/libs/timemoe/ts_generation_mixin.py
@@ -33,7 +33,6 @@ GenerateDecoderOnlyOutput = _safe_import(
 GenerateEncoderDecoderOutput = _safe_import(
     "transformers.generation.utils.GenerateEncoderDecoderOutput"
 )
-ModelOutput = _safe_import("transformers.utils.ModelOutput")
 
 
 class TSGenerationMixin(GenerationMixin):

--- a/sktime/libs/timemoe/ts_generation_mixin.py
+++ b/sktime/libs/timemoe/ts_generation_mixin.py
@@ -18,7 +18,7 @@ from typing import Any, Optional, Union
 
 from sktime.utils.dependencies import _safe_import
 
-torch = _safe_import("torch", severity="none")
+torch = _safe_import("torch")
 
 GenerationMixin = _safe_import("transformers.GenerationMixin")
 LogitsProcessorList = _safe_import("transformers.LogitsProcessorList")

--- a/sktime/libs/timemoe/ts_generation_mixin.py
+++ b/sktime/libs/timemoe/ts_generation_mixin.py
@@ -41,9 +41,9 @@ class TSGenerationMixin(GenerationMixin):
 
     def _greedy_search(
         self,
-        input_ids: torch.Tensor,
-        logits_processor: Optional[LogitsProcessorList] = None,
-        stopping_criteria: Optional[StoppingCriteriaList] = None,
+        input_ids,
+        logits_processor=None,
+        stopping_criteria=None,
         max_length: Optional[int] = None,
         pad_token_id: Optional[int] = None,
         eos_token_id: Optional[Union[int, list[int]]] = None,
@@ -274,7 +274,7 @@ class TSGenerationMixin(GenerationMixin):
 
     def _update_model_kwargs_for_generation(
         self,
-        outputs: ModelOutput,
+        outputs,
         model_kwargs: dict[str, Any],
         horizon_length: int = 1,
         is_encoder_decoder: bool = False,

--- a/sktime/libs/timemoe/ts_generation_mixin.py
+++ b/sktime/libs/timemoe/ts_generation_mixin.py
@@ -16,40 +16,25 @@
 import warnings
 from typing import Any, Optional, Union
 
-from sktime.utils.dependencies import _check_soft_dependencies
-
-if _check_soft_dependencies("torch", severity="none"):
-    import torch
-else:
-
-    class torch:
-        """Dummy torch class if the torch module is not available."""
-
-        class Tensor:
-            """Dummy Tensor class if the torch module is not available."""
+from sktime.utils.dependencies import _safe_import
 
 
-if _check_soft_dependencies("transformers", severity="none"):
-    from transformers import GenerationMixin, LogitsProcessorList, StoppingCriteriaList
-    from transformers.generation import EosTokenCriteria, validate_stopping_criteria
-    from transformers.generation.utils import (
-        GenerateDecoderOnlyOutput,
-        GenerateEncoderDecoderOutput,
-    )
-    from transformers.utils import ModelOutput
-else:
+torch = _safe_import("torch", severity="none")
 
-    class GenerationMixin:
-        """Dummy GenerationMixin class if the transformers module is not available."""
-
-    class LogitsProcessorList:
-        """Dummy class if the transformers module is not available."""
-
-    class StoppingCriteriaList:
-        """Dummy class if the transformers module is not available."""
-
-    class ModelOutput:
-        """Dummy class if the transformers module is not available."""
+GenerationMixin = _safe_import("transformers.GenerationMixin")
+LogitsProcessorList = _safe_import("transformers.LogitsProcessorList")
+StoppingCriteriaList = _safe_import("transformers.StoppingCriteriaList")
+EosTokenCriteria = _safe_import("transformers.generation.EosTokenCriteria")
+validate_stopping_criteria = _safe_import(
+    "transformers.generation.validate_stopping_criteria"
+)
+GenerateDecoderOnlyOutput = _safe_import(
+    "transformers.generation.utils.GenerateDecoderOnlyOutput"
+)
+GenerateEncoderDecoderOutput = _safe_import(
+    "transformers.generation.utils.GenerateEncoderDecoderOutput"
+)
+ModelOutput = _safe_import("transformers.utils.ModelOutput")
 
 
 class TSGenerationMixin(GenerationMixin):

--- a/sktime/libs/timemoe/ts_generation_mixin.py
+++ b/sktime/libs/timemoe/ts_generation_mixin.py
@@ -18,7 +18,6 @@ from typing import Any, Optional, Union
 
 from sktime.utils.dependencies import _safe_import
 
-
 torch = _safe_import("torch", severity="none")
 
 GenerationMixin = _safe_import("transformers.GenerationMixin")

--- a/sktime/libs/timesfm/patched_decoder.py
+++ b/sktime/libs/timesfm/patched_decoder.py
@@ -16,42 +16,30 @@
 
 import dataclasses
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from sktime.utils.dependencies import _safe_import
 
-if _check_soft_dependencies("einshape", severity="none"):
-    import einshape as es
+es = _safe_import("einshape")
+jnp = _safe_import("jax.numpy")
+lax = _safe_import("jax.lax")
 
-if _check_soft_dependencies("jax", severity="none"):
-    import jax.numpy as jnp
-    from jax import lax
+base_layer = _safe_import("praxis.base_layer")
+layers = _safe_import("praxis.layers")
+pax_fiddle = _safe_import("praxis.pax_fiddle")
+py_utils = _safe_import("praxis.py_utils")
+BaseLayer = _safe_import("praxis.base_layer.BaseLayer")
+BaseModel = _safe_import("praxis.base_model.BaseModel")
+activations = _safe_import("praxis.layers.activations")
+embedding_softmax = _safe_import("praxis.layers.embedding_softmax")
+linears = _safe_import("praxis.layers.linears")
+normalizations = _safe_import("praxis.layers.normalizations")
+stochastics = _safe_import("praxis.layers.stochastics")
+transformers = _safe_import("praxis.layers.transformers")
 
-if _check_soft_dependencies("praxis", severity="none"):
-    from praxis import base_layer, layers, pax_fiddle, py_utils
-    from praxis.base_layer import BaseLayer
-    from praxis.base_model import BaseModel
-    from praxis.layers import (
-        activations,
-        embedding_softmax,
-        linears,
-        normalizations,
-        stochastics,
-        transformers,
-    )
+# PAX shortcuts
+NestedMap = py_utils.NestedMap
 
-    # PAX shortcuts
-    NestedMap = py_utils.NestedMap
-
-    LayerTpl = pax_fiddle.Config[BaseLayer]
-    template_field = base_layer.template_field
-
-else:
-
-    class BaseLayer:
-        """Dummy class if praxis is unavailable."""
-
-    class BaseModel:
-        """Dummy class if praxis is unavailable."""
-
+LayerTpl = pax_fiddle.Config[BaseLayer]
+template_field = base_layer.template_field
 
 PAD_VAL = 1123581321.0
 DEFAULT_QUANTILES = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
@@ -95,16 +83,15 @@ def _shift_padded_seq(mask, seq):
 class ResidualBlock(BaseLayer):
     """ResidualBlock."""
 
-    if _check_soft_dependencies("praxis", severity="none"):
-        # These should not be changed or removed
-        input_dims: int = 0
-        hidden_dims: int = 0
-        output_dims: int = 0
-        dropout_prob: float = 0.0
-        layer_norm: bool = False
-        dropout_tpl: LayerTpl = template_field(stochastics.Dropout)
-        ln_tpl: LayerTpl = template_field(normalizations.LayerNorm)
-        act_tpl: LayerTpl = template_field(activations.Swish)
+    # These should not be changed or removed
+    input_dims: int = 0
+    hidden_dims: int = 0
+    output_dims: int = 0
+    dropout_prob: float = 0.0
+    layer_norm: bool = False
+    dropout_tpl: LayerTpl = template_field(stochastics.Dropout)
+    ln_tpl: LayerTpl = template_field(normalizations.LayerNorm)
+    act_tpl: LayerTpl = template_field(activations.Swish)
 
     def setup(self):
         """Set up."""
@@ -200,18 +187,17 @@ def _create_quantiles():
 class PatchedTimeSeriesDecoder(BaseLayer):
     """PatchedTimeSeriesDecoder."""
 
-    if _check_soft_dependencies("praxis", severity="none"):
-        # These should not be changed or removed
-        patch_len: int = 0
-        horizon_len: int = 0
-        model_dims: int = 0
-        hidden_dims: int = 0
-        quantiles: list[float] = dataclasses.field(default_factory=_create_quantiles)
-        residual_block_tpl: LayerTpl = template_field(ResidualBlock)
-        stacked_transformer_params_tpl: LayerTpl = template_field(
-            transformers.StackedTransformer
-        )
-        use_freq: bool = True
+    # These should not be changed or removed
+    patch_len: int = 0
+    horizon_len: int = 0
+    model_dims: int = 0
+    hidden_dims: int = 0
+    quantiles: list[float] = dataclasses.field(default_factory=_create_quantiles)
+    residual_block_tpl: LayerTpl = template_field(ResidualBlock)
+    stacked_transformer_params_tpl: LayerTpl = template_field(
+        transformers.StackedTransformer
+    )
+    use_freq: bool = True
 
     def setup(self):
         """Construct the model."""

--- a/sktime/libs/timesfm/timesfm.py
+++ b/sktime/libs/timesfm/timesfm.py
@@ -20,7 +20,7 @@ import multiprocessing
 import time
 from os import path
 
-from sktime.utils.dependencies import _safe_import    
+from sktime.utils.dependencies import _safe_import
 
 es = _safe_import("sktime.utils.einshape")
 jax = _safe_import("jax")
@@ -28,7 +28,7 @@ jnp = _safe_import("jax.numpy")
 
 snapshot_download = _safe_import(
     "huggingface_hub.snapshot_download",
-    pkg_name = "huggingfaec-hub",
+    pkg_name="huggingfaec-hub",
 )
 
 checkpoints = _safe_import("paxml.checkpoints")

--- a/sktime/libs/timesfm/timesfm.py
+++ b/sktime/libs/timesfm/timesfm.py
@@ -20,37 +20,35 @@ import multiprocessing
 import time
 from os import path
 
-from sktime.utils.dependencies import _check_soft_dependencies
+from sktime.utils.dependencies import _safe_import    
 
-if _check_soft_dependencies("einshape", severity="none"):
-    import einshape as es
+es = _safe_import("sktime.utils.einshape")
+jax = _safe_import("jax")
+jnp = _safe_import("jax.numpy")
 
-if _check_soft_dependencies("jax", severity="none"):
-    import jax
-    import jax.numpy as jnp
+snapshot_download = _safe_import(
+    "huggingface_hub.snapshot_download",
+    pkg_name = "huggingfaec-hub",
+)
 
-if _check_soft_dependencies("huggingface-hub", severity="none"):
-    from huggingface_hub import snapshot_download
+checkpoints = _safe_import("paxml.checkpoints")
+tasks_lib = _safe_import("paxml.tasks_lib")
 
-if _check_soft_dependencies("paxml", severity="none"):
-    from paxml import checkpoints, tasks_lib
+FLAX = checkpoints.CheckpointType.FLAX
 
-    FLAX = checkpoints.CheckpointType.FLAX
-else:
-    FLAX = None
+base_hyperparams = _safe_import("praxis.base_hyperparams")
+base_layer = _safe_import("praxis.base_layer")
+pax_fiddle = _safe_import("praxis.pax_fiddle")
+py_utils = _safe_import("praxis.py_utils")
+pytypes = _safe_import("praxis.pytypes")
+normalizations = _safe_import("praxis.layers.normalizations")
+transformers = _safe_import("praxis.layers.transformers")
 
-if _check_soft_dependencies("praxis", severity="none"):
-    from praxis import base_hyperparams, base_layer, pax_fiddle, py_utils, pytypes
-    from praxis.layers import normalizations, transformers
+instantiate = base_hyperparams.instantiate
+NestedMap = py_utils.NestedMap
+JTensor = pytypes.JTensor
 
-    instantiate = base_hyperparams.instantiate
-    NestedMap = py_utils.NestedMap
-    JTensor = pytypes.JTensor
-
-
-if _check_soft_dependencies("utilsforecast", severity="none"):
-    from utilsforecast.processing import make_future_dataframe
-
+make_future_dataframe = _safe_import("utilsforecast.processing.make_future_dataframe")
 
 import numpy as np
 


### PR DESCRIPTION
This PR replaces unsafe imports from `torch` and `transformers` with the `_safe_import` pattern.

Also changes the imports of `ModelOutput` to point to `transformers.utils.ModelOutput` which is the current and historically stable location.

Fixes https://github.com/sktime/sktime/issues/8469