### PR TITLE
[MNT] remove unmaintained (?) package `temporian` from recommended `transformations` depset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,6 @@ all_extras_pandas2 = [
   'statsmodels>=0.12.1; python_version < "3.13"',
   'stumpy>=1.5.1; python_version < "3.11"',
   'tbats>=1.1; python_version < "3.12"',
-  'temporian<0.9.0,>=0.7.0,!=0.8.0; python_version < "3.12" and sys_platform != "win32" and platform_machine != "aarch64"' ,
   'tensorflow<2.20,>=2; python_version < "3.13"',
   'tsfresh>=0.17; python_version < "3.12"',
   'tslearn<0.7.0,!=0.6.0,>=0.5.2; python_version < "3.11"',
@@ -229,7 +228,6 @@ transformations = [
   'simdkalman',
   'statsmodels<0.15,>=0.12.1; python_version < "3.13"',
   'stumpy<1.13,>=1.5.1; python_version < "3.12"',
-  'temporian<0.9.0,>=0.7.0,!=0.8.0; python_version < "3.12" and sys_platform != "win32" and platform_machine != "aarch64"' ,
   'tsfresh<0.21,>=0.17; python_version < "3.12"',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,6 @@ all_extras = [
   'statsmodels>=0.12.1; python_version < "3.13"',
   'stumpy>=1.5.1; python_version < "3.11"',
   'tbats>=1.1; python_version < "3.12"',
-  'temporian<0.9.0,>=0.7.0,!=0.8.0; python_version < "3.12" and sys_platform != "win32" and platform_machine != "aarch64"' ,
   'tensorflow<2.20,>=2; python_version < "3.13"',
   'tsfresh>=0.17; python_version < "3.12"',
   'tslearn<0.7.0,!=0.6.0,>=0.5.2; python_version < "3.11"',


### PR DESCRIPTION
The `temporian` packages looks unmaintained - hence I suggest removing it from the recommended `transformations` depset, to avoid indirect bounds on packages arising from it.
Link to repo: https://github.com/google/temporian

The estimator can be tested in a separate environment once the respective PR is merged.