### PR TITLE
[BUG] fix accidental removal of dataclass type in `ChronosForecaster` and `TinyTimeMixerForecaster`

### DIFF
--- a/sktime/libs/chronos/chronos_bolt.py
+++ b/sktime/libs/chronos/chronos_bolt.py
@@ -12,7 +12,7 @@ import copy
 import logging
 import warnings
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 from sktime.utils.dependencies import _safe_import
 
@@ -53,10 +53,10 @@ class ChronosBoltConfig:
 class ChronosBoltOutput(ModelOutput):
     """Description of the output of the model."""
 
-    loss = None
-    quantile_preds = None
-    attentions = None
-    cross_attentions = None
+    loss: Optional[Any] = None
+    quantile_preds: Optional[Any] = None
+    attentions: Optional[Any] = None
+    cross_attentions: Optional[Any] = None
 
 
 class Patch(nn.Module):

--- a/sktime/libs/granite_ttm/modeling_tinytimemixer.py
+++ b/sktime/libs/granite_ttm/modeling_tinytimemixer.py
@@ -3,7 +3,7 @@
 import copy
 import math
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 from warnings import warn
 
 from sktime.libs.granite_ttm.configuration_tinytimemixer import TinyTimeMixerConfig
@@ -1151,8 +1151,8 @@ class TinyTimeMixerEncoderOutput(ModelOutput):
             Hidden-states of the model at the output of each layer.
     """
 
-    last_hidden_state = None
-    hidden_states = None
+    last_hidden_state: Optional[Any] = None
+    hidden_states: Optional[Any] = None
 
 
 class TinyTimeMixerEncoder(TinyTimeMixerPreTrainedModel):
@@ -1296,11 +1296,11 @@ class TinyTimeMixerModelOutput(ModelOutput):
             enabled.
     """
 
-    last_hidden_state = None
-    hidden_states = None
-    patch_input = None
-    loc = None
-    scale = None
+    last_hidden_state: Optional[Any] = None
+    hidden_states: Optional[Any] = None
+    patch_input: Optional[Any] = None
+    loc: Optional[Any] = None
+    scale: Optional[Any] = None
 
 
 class TinyTimeMixerModel(TinyTimeMixerPreTrainedModel):
@@ -1463,13 +1463,13 @@ class TinyTimeMixerForPredictionOutput(ModelOutput):
 
     """
 
-    loss = None
-    prediction_outputs = None
-    backbone_hidden_state = None
-    decoder_hidden_state = None
-    hidden_states = None
-    loc = None
-    scale = None
+    loss: Optional[Any] = None
+    prediction_outputs: Optional[Any] = None
+    backbone_hidden_state: Optional[Any] = None
+    decoder_hidden_state: Optional[Any] = None
+    hidden_states: Optional[Any] = None
+    loc: Optional[Any] = None
+    scale: Optional[Any] = None
 
 
 class TinyTimeMixerForPrediction(TinyTimeMixerPreTrainedModel):


### PR DESCRIPTION
Fixes #8482, fixes #8486.

Rolling the `transformers 4.53` compatibility patch accidentally removed type annotations from `ModelOutput` children in `ChronosForecaster` and `TinyTimeMixerFoercaster` - rendering them failing.

This was not spotted by tests due to human error. This PR fixes the problem, and releasing a hotfix (after a test run) should limit the impact of the problem.