### PR TITLE
[ENH] add conditional testing to `transformations.hierarchical.reconcile` module

### DIFF
--- a/sktime/transformations/hierarchical/tests/reconcile/test_full_hierarchy.py
+++ b/sktime/transformations/hierarchical/tests/reconcile/test_full_hierarchy.py
@@ -11,6 +11,7 @@ from sktime.transformations.hierarchical.reconcile._optimal import (
 )
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils.dependencies import _check_soft_dependencies
+from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
 
 
 @pytest.fixture
@@ -36,6 +37,10 @@ def small_hier_index():
     return pd.MultiIndex.from_tuples(tuples, names=names)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.transformations.hierarchical.reconcile"),
+    reason="run test only if module has changed",
+)
 def test_create_summing_matrix_from_index(small_hier_index):
     # Given our small index, let's compute the summation matrix
     S_df = _create_summing_matrix_from_index(small_hier_index)
@@ -115,6 +120,10 @@ def test_nonnegative_reconciliation(hierarchical_levels):
     assert np.all(yreconc >= 0), "Negative values in reconciled series!"
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([OptimalReconciler, NonNegativeOptimalReconciler]),
+    reason="run test only if classes changed and if softdeps are present",
+)
 @pytest.mark.parametrize(
     "W",
     [

--- a/sktime/transformations/hierarchical/tests/reconcile/test_middle_out.py
+++ b/sktime/transformations/hierarchical/tests/reconcile/test_middle_out.py
@@ -3,11 +3,16 @@ import functools
 import pandas as pd
 import pytest
 
+from sktime.tests.test_switch import run_test_module_changed
 from sktime.transformations.hierarchical.reconcile._utils import (
     _get_series_for_each_hierarchical_level,
 )
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.transformations.hierarchical.reconcile"),
+    reason="run test only if module has changed",
+)
 @pytest.mark.parametrize(
     "hierarchical_level_nodes",
     [

--- a/sktime/transformations/hierarchical/tests/reconcile/test_reconcile.py
+++ b/sktime/transformations/hierarchical/tests/reconcile/test_reconcile.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from pandas.testing import assert_frame_equal
 
+from sktime.tests.test_switch import run_test_for_class
 from sktime.transformations.hierarchical.aggregate import Aggregator
 from sktime.transformations.hierarchical.reconcile import (
     BottomUpReconciler,
@@ -40,6 +41,12 @@ def _generate_hier_data(flatten_single_levels, no_levels, no_bottom_nodes=5):
     return prds
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(
+        [BottomUpReconciler, TopdownReconciler, MiddleOutReconciler]
+    ),
+    reason="run test only if class has changed and softdeps are present",
+)
 @pytest.mark.parametrize(
     "reconciler, expected_immutable_level",
     [
@@ -98,6 +105,10 @@ def test_reconcilers_keep_immutable_levels(
         assert not y_reconc.equals(y)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(OptimalReconciler),
+    reason="run test only if class has changed and softdeps are present",
+)
 def test_optimal_reconciliation_ols():
     """Test optimal reconciliation with OLS.
 

--- a/sktime/transformations/hierarchical/tests/reconcile/test_squeeze_hierarchy.py
+++ b/sktime/transformations/hierarchical/tests/reconcile/test_squeeze_hierarchy.py
@@ -3,6 +3,7 @@ import itertools
 import pandas as pd
 import pytest
 
+from sktime.tests.test_switch import run_test_for_class, run_test_module_changed
 from sktime.transformations.hierarchical.reconcile._topdown import (
     SqueezeHierarchy,
 )
@@ -24,6 +25,10 @@ def hierarchical_data():
     return data
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.transformations.hierarchical.reconcile"),
+    reason="run test only if module has changed",
+)
 def create_redundant_hierarchical_indexes(
     n_hier_levels, n_redundant, n_instances_per_level
 ):
@@ -57,6 +62,10 @@ def create_redundant_hierarchical_indexes(
     ).sort_index()
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(SqueezeHierarchy),
+    reason="run test only if class has changed and softdeps are present",
+)
 @pytest.mark.parametrize(
     "n_redundant,n_hier_levels", [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)]
 )
@@ -77,6 +86,10 @@ def test_fit(n_redundant, n_hier_levels, n_instances_per_level=2):
     )
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(SqueezeHierarchy),
+    reason="run test only if class has changed and softdeps are present",
+)
 @pytest.mark.parametrize(
     "n_redundant,n_hier_levels", [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)]
 )
@@ -97,6 +110,10 @@ def test_transform(n_redundant, n_hier_levels, n_instances_per_level=2):
     )
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(SqueezeHierarchy),
+    reason="run test only if class has changed and softdeps are present",
+)
 @pytest.mark.parametrize(
     "n_redundant,n_hier_levels", [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)]
 )
@@ -116,6 +133,10 @@ def test_inverse_transform(n_redundant, n_hier_levels, n_instances_per_level=2):
     )
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(SqueezeHierarchy),
+    reason="run test only if class has changed and softdeps are present",
+)
 def test_no_hierarchy_handling():
     """Test the transformer with a non-hierarchical DataFrame."""
     non_hierarchical_data = pd.DataFrame({"value": [1, 2, 3]}, index=[0, 1, 2])

--- a/sktime/transformations/hierarchical/tests/reconcile/test_utils.py
+++ b/sktime/transformations/hierarchical/tests/reconcile/test_utils.py
@@ -1,12 +1,17 @@
 import pandas as pd
 import pytest
 
+from sktime.tests.test_switch import run_test_module_changed
 from sktime.transformations.hierarchical.reconcile._utils import (
     _promote_hierarchical_indexes,
     _recursively_propagate_topdown,
 )
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.transformations.hierarchical.reconcile"),
+    reason="run test only if module has changed",
+)
 @pytest.mark.parametrize(
     "idx_tuple, expected_result",
     [
@@ -92,6 +97,10 @@ def example_data_for_topdown_varied():
     return X, expected
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.transformations.hierarchical.reconcile"),
+    reason="run test only if module has changed",
+)
 @pytest.mark.parametrize(
     "example_func", [example_data_for_topdown_all_ones, example_data_for_topdown_varied]
 )


### PR DESCRIPTION
Adds conditional testing logic to tests in `transformations.hierarchical.reconcile` module, based on module change or class change of the class being tested.