### PR TITLE
[ENH] New Dataset Downloaders for TSF and TSC Datasets

### DIFF
--- a/sktime/datasets/_data_io.py
+++ b/sktime/datasets/_data_io.py
@@ -9,15 +9,12 @@ __all__ = [
 ]
 
 import os
-import shutil
-import tempfile
-import zipfile
-from urllib.request import urlretrieve
 
 import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
 
+from sktime.datasets._dataset_downloader import DatasetDownloader
 from sktime.datasets._readers_writers.ts import load_from_tsfile
 from sktime.datasets._readers_writers.utils import _alias_mtype_check
 from sktime.datatypes import convert
@@ -29,52 +26,6 @@ CLASSIF_URLS = [
     "https://timeseriesclassification.com/aeon-toolkit",  # main mirror (UEA)
     "https://github.com/sktime/sktime-datasets/raw/main/TSC",  # backup mirror (sktime)
 ]
-
-
-def _download_and_extract(url, extract_path=None):
-    """Download and unzip datasets (helper function).
-
-    This code was modified from
-    https://github.com/tslearn-team/tslearn/blob
-    /775daddb476b4ab02268a6751da417b8f0711140/tslearn/datasets.py#L28
-
-    Parameters
-    ----------
-    url : string
-        Url pointing to file to download
-    extract_path : string, optional (default: None)
-        path to extract downloaded zip to, None defaults
-        to sktime/datasets/data
-
-    Returns
-    -------
-    extract_path : string or None
-        if successful, string containing the path of the extracted file, None
-        if it wasn't successful
-    """
-    file_name = os.path.basename(url)
-    dl_dir = tempfile.mkdtemp()
-    zip_file_name = os.path.join(dl_dir, file_name)
-    urlretrieve(url, zip_file_name)
-
-    if extract_path is None:
-        extract_path = os.path.join(MODULE, "local_data/%s/" % file_name.split(".")[0])
-    else:
-        extract_path = os.path.join(extract_path, "%s/" % file_name.split(".")[0])
-
-    try:
-        if not os.path.exists(extract_path):
-            os.makedirs(extract_path)
-        zipfile.ZipFile(zip_file_name, "r").extractall(extract_path)
-        shutil.rmtree(dl_dir)
-        return extract_path
-    except zipfile.BadZipFile:
-        shutil.rmtree(dl_dir)
-        if os.path.exists(extract_path):
-            shutil.rmtree(extract_path)
-        raise zipfile.BadZipFile(
-            "Could not unzip dataset. Please make sure the URL is valid."
-        )
 
 
 def _list_available_datasets(extract_path, origin_repo=None):
@@ -161,25 +112,11 @@ def _cache_dataset(url, name, extract_path=None, repeats=1, verbose=False):
                     f"(attempt {repeat} of {repeats} total). "
                 )
 
-            try:
-                _download_and_extract(name_url, extract_path=extract_path)
-                return extract_path, u, repeat
+            downloader = DatasetDownloader(
+                hf_repo_name="sktime/tsc-datasets", fallback_urls=[name_url]
+            )
 
-            except zipfile.BadZipFile:
-                if verbose:
-                    if repeat < repeats - 1:
-                        print(  # noqa: T201
-                            "Download failed, continuing with next attempt. "
-                        )
-                    else:
-                        print(  # noqa: T201
-                            "All attempts for mirror failed, "
-                            "continuing with next mirror."
-                        )
-
-    raise RuntimeError(
-        f"Dataset with name ={name} could not be downloaded from any of the mirrors."
-    )
+            downloader.download_dataset(dataset_name=name, download_path=extract_path)
 
 
 def _mkdir_if_not_exist(*path):

--- a/sktime/datasets/_dataset_downloader.py
+++ b/sktime/datasets/_dataset_downloader.py
@@ -1,0 +1,248 @@
+"""Utilities for downloading datasets."""
+
+__author__ = ["jgyasu"]
+
+__all__ = ["DatasetDownloader"]
+
+import os
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import urlretrieve
+
+from sktime.utils.dependencies import _safe_import
+
+snapshot_download = _safe_import(
+    "huggingface_hub.snapshot_download", pkg_name="huggingface-hub"
+)
+hf_hub_download = _safe_import(
+    "huggingface_hub.hf_hub_download", pkg_name="huggingface-hub"
+)
+HfHubHTTPError = _safe_import(
+    "huggingface_hub.utils.HfHubHTTPError", pkg_name="huggingface-hub"
+)
+RepositoryNotFoundError = _safe_import(
+    "huggingface_hub.utils.RepositoryNotFoundError", pkg_name="huggingface-hub"
+)
+
+
+class DatasetDownloadStrategy:
+    """Base class for dataset download strategies."""
+
+    def download_dataset(self, **kwargs):
+        """Download a dataset using this strategy."""
+        raise NotImplementedError("Subclasses must implement download_dataset method")
+
+
+class HuggingFaceDownloader(DatasetDownloadStrategy):
+    """Download datasets using the Hugging Face Hub snapshot mechanism.
+
+    Implements a strategy to download datasets stored in Hugging Face
+    repositories.
+
+    Parameters
+    ----------
+    repo_name : str
+        Name of the Hugging Face repository containing the datasets.
+        In the format: "organisation/repository_name",
+        e.g., "sktime/tsf-datasets"
+    repo_type : str, default="dataset"
+        Type of repository (e.g., "dataset", "model", etc.).
+
+    References
+    ----------
+    https://huggingface.co/docs/huggingface_hub/en/guides/download#filter-files-to-download
+    """
+
+    def __init__(self, repo_name, repo_type="dataset"):
+        self.repo_name = repo_name
+        self.repo_type = repo_type
+
+    def download_dataset(
+        self,
+        dataset_folder,
+        download_path=None,
+        force_download=False,
+        token=None,
+        **kwargs,
+    ):
+        """Download a specific dataset folder from the Hugging Face repository.
+
+        Parameters
+        ----------
+        dataset_folder : str
+            Name of the folder (dataset) inside the repository to download.
+        download_path : str or Path, optional
+            Local directory where the dataset should be saved. If not specified,
+            defaults to a 'local_data' folder in the current working directory.
+        force_download : bool, default=False
+            Whether to force re-download the dataset even if it's cached locally.
+        token : str, optional
+            Hugging Face authentication token for private repositories.
+        **kwargs
+            Additional keyword arguments passed to `snapshot_download`.
+
+        Returns
+        -------
+        Path
+            Path to the downloaded dataset folder.
+        """
+        if download_path is None:
+            download_path = Path.cwd() / "local_data"
+        else:
+            download_path = Path(download_path)
+
+        download_path.mkdir(parents=True, exist_ok=True)
+
+        local_dataset_path = download_path / dataset_folder
+
+        try:
+            snapshot_download(
+                repo_id=self.repo_name,
+                repo_type=self.repo_type,
+                allow_patterns=f"{dataset_folder}/**",
+                local_dir=download_path,
+                force_download=force_download,
+                token=token,
+            )
+
+            if not local_dataset_path.exists():
+                raise ValueError(
+                    f"Dataset folder '{dataset_folder}' not found"
+                    " in repository '{self.repo_name}'"
+                )
+
+            return local_dataset_path
+
+        except (RepositoryNotFoundError, HfHubHTTPError, ValueError):
+            raise
+
+
+class URLDownloader(DatasetDownloadStrategy):
+    """Strategy for downloading datasets from URLs (with zip extraction).
+
+    Parameters
+    ----------
+    base_urls: List of URLs to attempt downloading from.
+    """
+
+    def __init__(self, base_urls):
+        self.base_urls = base_urls
+
+    def download_dataset(
+        self, dataset_name, download_path=None, force_download=False, **kwargs
+    ):
+        """Download and extract a dataset from URL."""
+        if download_path is None:
+            download_path = Path.cwd() / "local_data"
+        else:
+            download_path = Path(download_path)
+
+        extract_path = download_path / dataset_name
+
+        if extract_path.exists() and not force_download:
+            return extract_path
+
+        last_error = None
+        for url in self.base_urls:
+            try:
+                dataset_url = f"{url}/{dataset_name}.zip"
+
+                result_path = self._download_and_extract(dataset_url, download_path)
+                if result_path:
+                    return result_path
+
+            except Exception as e:
+                last_error = e
+                continue
+
+        if last_error:
+            raise last_error
+        else:
+            raise RuntimeError(
+                f"Failed to download dataset '{dataset_name}' from any URL"
+            )
+
+    def _download_and_extract(self, url: str, extract_path=None):
+        """Download and unzip datasets (helper function)."""
+        file_name = os.path.basename(url)
+        dl_dir = tempfile.mkdtemp()
+        zip_file_name = os.path.join(dl_dir, file_name)
+
+        try:
+            urlretrieve(url, zip_file_name)
+
+            if extract_path is None:
+                extract_path = Path.cwd() / "local_data" / file_name.split(".")[0]
+            else:
+                extract_path = Path(extract_path) / file_name.split(".")[0]
+
+            extract_path.mkdir(parents=True, exist_ok=True)
+
+            with zipfile.ZipFile(zip_file_name, "r") as zip_ref:
+                zip_ref.extractall(extract_path)
+
+            shutil.rmtree(dl_dir)
+
+            return extract_path
+
+        except (URLError, HTTPError, zipfile.BadZipFile) as e:
+            shutil.rmtree(dl_dir)
+            if extract_path and extract_path.exists():
+                shutil.rmtree(extract_path)
+
+            error_msg = f"Could not download/extract dataset from {url}: {e}"
+            raise Exception(error_msg)
+
+
+class DatasetDownloader:
+    """
+    Main dataset downloader class.
+
+    This class implements the strategy pattern to support multiple download methods:
+    1. Hugging Face repositories (primary)
+    2. URL-based downloads with zip extraction (fallback)
+    """
+
+    def __init__(self, hf_repo_name="sktime/tsf-datasets", fallback_urls=None):
+        """
+        Initialize the Dataset Downloader with multiple strategies.
+
+        Args:
+            hf_repo_name (str): Hugging Face repository name,
+                in the format: "organisation/repo_name", e.g.,
+                "sktime/tsf-datasets"
+            fallback_urls (Optional[List[str]]):
+                List of base URLs for fallback downloads
+        """
+        self.hf_strategy = HuggingFaceDownloader(hf_repo_name)
+
+        self.url_strategy = URLDownloader(fallback_urls)
+
+    def download_dataset(
+        self, dataset_name, download_path=None, force_download=False, **kwargs
+    ):
+        """Download a dataset using multiple strategies."""
+        try:
+            return self.hf_strategy.download_dataset(
+                dataset_folder=dataset_name,
+                download_path=download_path,
+                force_download=force_download,
+                **kwargs,
+            )
+        except Exception as hf_error:
+            try:
+                return self.url_strategy.download_dataset(
+                    dataset_name=dataset_name,
+                    download_path=download_path,
+                    force_download=force_download,
+                    **kwargs,
+                )
+            except Exception as url_error:
+                raise RuntimeError(
+                    f"All download strategies failed.\n"
+                    f"HuggingFace error: {hf_error}\n"
+                    f"URL error: {url_error}"
+                )

--- a/sktime/datasets/_single_problem_loaders.py
+++ b/sktime/datasets/_single_problem_loaders.py
@@ -43,7 +43,6 @@ __all__ = [
 ]
 
 import os
-import zipfile
 from urllib.error import HTTPError, URLError
 from warnings import warn
 
@@ -51,12 +50,12 @@ import numpy as np
 import pandas as pd
 
 from sktime.datasets._data_io import (
-    _download_and_extract,
     _list_available_datasets,
     _load_dataset,
     _load_provided_dataset,
     _reduce_memory_usage,
 )
+from sktime.datasets._dataset_downloader import DatasetDownloader
 from sktime.datasets._readers_writers.tsf import load_tsf_to_dataframe
 from sktime.datasets.tsf_dataset_names import tsf_all, tsf_all_datasets
 from sktime.utils.dependencies import _check_soft_dependencies
@@ -1460,19 +1459,13 @@ def load_forecastingdata(
 
         url = f"https://zenodo.org/record/{tsf_all[name]}/files/{name}.zip"
 
-        # This also tests the validity of the URL, can't rely on the html
-        # status code as it always returns 200
-        try:
-            _download_and_extract(
-                url,
-                extract_path=path_to_data_dir,
-            )
-        except zipfile.BadZipFile as e:
-            raise ValueError(
-                f"Invalid dataset name ={name} is not available on extract path ="
-                f"{extract_path}. Nor is it available on "
-                f"https://forecastingdata.org/.",
-            ) from e
+        forecastingdata_downloader = DatasetDownloader(
+            hf_repo_name="sktime/tsf-datasets", fallback_urls=[url]
+        )
+
+        forecastingdata_downloader.download_dataset(
+            dataset_name=name, download_path=path_to_data_dir
+        )
 
     path_to_file = os.path.join(path_to_data_dir, f"{name}/{name}.tsf")
     return load_tsf_to_dataframe(
@@ -1588,9 +1581,13 @@ def load_m5(
             ):
                 path_to_data_dir = os.path.join(extract_path, "m5-forecasting-accuracy")
 
-                _download_and_extract(
-                    "https://zenodo.org/records/12636070/files/m5-forecasting-accuracy.zip",
-                    extract_path=extract_path,
+                m5_url = "https://zenodo.org/records/12636070/files/m5-forecasting-accuracy.zip"
+
+                m5_downloader = DatasetDownloader(
+                    hf_repo_name="sktime/tsf-datasets", fallback_urls=[m5_url]
+                )
+                m5_downloader.download_dataset(
+                    dataset_name="m5-forecasting-accuracy", download_path=extract_path
                 )
 
             else:
@@ -1601,10 +1598,17 @@ def load_m5(
         if not os.path.exists(os.path.join(extract_path, "m5-forecasting-accuracy")):
             path_to_data_dir = os.path.join(extract_path, "m5-forecasting-accuracy")
 
-            _download_and_extract(
-                "https://zenodo.org/records/12636070/files/m5-forecasting-accuracy.zip",
-                extract_path=extract_path,
+            m5_url = (
+                "https://zenodo.org/records/12636070/files/m5-forecasting-accuracy.zip"
             )
+
+            m5_downloader = DatasetDownloader(
+                hf_repo_name="sktime/tsf-datasets", fallback_urls=[m5_url]
+            )
+            m5_downloader.download_dataset(
+                dataset_name="m5-forecasting-accuracy", download_path=extract_path
+            )
+
         else:
             path_to_data_dir = os.path.join(MODULE, "m5-forecasting-accuracy")
 


### PR DESCRIPTION
We recently copied TSF and TSC datasets from different sources to sktime's Hugging Face repository to make downloads more reliable and reduce the payloads by not downloading datasets in redundant formats. This PR adds the utility for downloading those datasets from HF repo. All the public interfaces remain the same.

The `DataDownloader` class follows the strategy pattern and it can be instantiated with both the HF repo and the fallback URLs, it first tries to download from the HF repo and upon failure, it tries all the original sources' URLs. 