### PR TITLE
[DOC] Correct note about unequal-length TS support in sktime

### DIFF
--- a/examples/transformation/interpolation.ipynb
+++ b/examples/transformation/interpolation.ipynb
@@ -12,7 +12,7 @@
    "metadata": {},
    "source": [
     "Suppose we have a set of time series with different lengths, i.e. different number \n",
-    "of time points. Currently, most of sktime's functionality requires equal-length time series, so to use sktime, we need to first converted our data into equal-length time series. In this tutorial, you will learn how to use the `TSInterpolator` to do so. "
+    "of time points and we want to convert them into equal-length time series, we can do so by interpolation. In this tutorial, you will learn how to use the `TSInterpolator` to do so. "
    ]
   },
   {


### PR DESCRIPTION
Removes the statement about requirement of equal-length TS to use most of the features in sktime.

See discussion thread here, [https://discord.com/channels/1075852648688930887/1392407094057107467](https://discord.com/channels/1075852648688930887/1392407094057107467)