### PR TITLE
[ENH] `tests:libs` tag to specify library dependencies of estimators for differenital testing

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -89,6 +89,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         # default tags for testing
         "tests:core": False,  # core objects have wider trigger conditions in testing
         "tests:vm": False,  # whether the object should be tested in its own VM
+        "tests:libs": None,  # required libraries, for change conditional testing
     }
 
     _config = {

--- a/sktime/classification/foundation_models/momentfm.py
+++ b/sktime/classification/foundation_models/momentfm.py
@@ -130,6 +130,10 @@ class MomentFMClassifier(BaseClassifier):
             "transformers",
         ],
         "python_version": ">= 3.10",
+        # testing configuration
+        # ---------------------
+        "tests:vm": True,
+        "tests:libs": ["sktime.libs.momentfm"]
     }
 
     def __init__(

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -314,6 +314,7 @@ class ChronosForecaster(_BaseGlobalForecaster):
         # testing configuration
         # ---------------------
         "tests:vm": True,
+        "tests:libs": ["sktime.libs.chronos"]
     }
 
     _default_chronos_config = {

--- a/sktime/forecasting/hf_momentfm_forecaster.py
+++ b/sktime/forecasting/hf_momentfm_forecaster.py
@@ -173,6 +173,10 @@ class MomentFMForecaster(_BaseGlobalForecaster):
         "capability:insample": False,
         "capability:pred_int:insample": False,
         "capability:pred_int": False,
+        # testing configuration
+        # ---------------------
+        "tests:vm": True,
+        "tests:libs": ["sktime.libs.momentfm"]
     }
 
     def __init__(

--- a/sktime/forecasting/time_llm.py
+++ b/sktime/forecasting/time_llm.py
@@ -85,6 +85,10 @@ class TimeLLMForecaster(BaseForecaster):
         "X_inner_mtype": "pd.DataFrame",
         "ignores-exogeneous-X": True,
         "requires-fh-in-fit": True,
+        # testing configuration
+        # ---------------------
+        "tests:vm": True,
+        "tests:libs": ["sktime.libs.time_llm"]
     }
 
     def __init__(

--- a/sktime/forecasting/timemoe.py
+++ b/sktime/forecasting/timemoe.py
@@ -127,6 +127,10 @@ class TimeMoEForecaster(_BaseGlobalForecaster):
         "capability:insample": False,
         "capability:pred_int:insample": False,
         "capability:global_forecasting": True,
+        # testing configuration
+        # ---------------------
+        "tests:vm": True,
+        "tests:libs": ["sktime.libs.timemoe"]
     }
 
     def __init__(

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -183,6 +183,7 @@ class TimesFMForecaster(_BaseGlobalForecaster):
         # testing configuration
         # ---------------------
         "tests:vm": True,
+        "tests:libs": ["sktime.libs.timesfm"]
     }
 
     def __init__(

--- a/sktime/forecasting/ttm.py
+++ b/sktime/forecasting/ttm.py
@@ -241,6 +241,7 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
         # testing configuration
         # ---------------------
         "tests:vm": True,
+        "tests:libs": ["sktime.libs.granite_ttm"]
     }
 
     def __init__(

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -432,7 +432,7 @@ class tests__vm(_BaseTag):
     ``sktime``'s CI framework regularly tests estimators in pull request,
     usually only estimators that have changed.
 
-    The ``test_vm`` tag of an object is a boolean,
+    The ``tests:vm`` tag of an object is a boolean,
     it specifies whether the estimator should be tested in a separate VM,
     with a fresh environment set up using the ``python_dependencies`` tag,
     with version/OS matrix defined by ``python_version`` and ``env_marker`` tags.
@@ -453,6 +453,43 @@ class tests__vm(_BaseTag):
         "user_facing": False,
     }
 
+
+class tests__libs(_BaseTag):
+    """Important library dependencies of the object, for test triggers.
+
+    Part of packaging metadata for the object, used only in ``sktime`` CI.
+
+    - String name: ``"tests:libs"``
+    - Private tag, developer and framework facing
+    - Values: list of str, or None
+    - Example: ``["sktime.libs.chronos"]``
+    - Default: ``None``
+
+    ``sktime``'s CI framework regularly tests estimators in pull request,
+    usually only estimators that have changed.
+
+    The ``tests:libs`` tag of an object is a list of strings,
+    it specifies important library dependencies of the object within ``sktime``.
+
+    Setting this tag triggers testing the estimator whenever any of the modules
+    in the ``tests:libs`` tags have changed, in additional to the other
+    test trigger conditions such as a direct change to the object class.
+
+    Developers should not specify framework imports here, e.g., ``sktime.base``,
+    but any modules that contain estimator specific logic, which are not
+    identical with the location of the class.
+
+    This tag is not used in user facing checks, error messages,
+    or recommended build processes otherwise.
+    """
+
+    _tags = {
+        "tag_name": "tests:vm",
+        "parent_type": "object",
+        "tag_type": "list",
+        "short_descr": "Core libraries used by the estimator, to trigger tests.",
+        "user_facing": False,
+    }
 
 # Estimator tags
 # --------------

--- a/sktime/tests/test_switch.py
+++ b/sktime/tests/test_switch.py
@@ -24,7 +24,7 @@ def run_test_for_class(cls, return_reason=False):
        If yes, behaviour depends on ONLY_CHANGED_MODULES setting:
        if off (False), always runs the test (return True);
        if on (True), runs test if and only if
-       at least one of conditions 2, 3, 4, 5 below are met.
+       at least one of conditions 2, 3, 4, 5, 6 below are met.
 
     2. Condition 2:
 
@@ -50,6 +50,11 @@ def run_test_for_class(cls, return_reason=False):
       If the object is an sktime ``BaseObject``,
       and one of the core framework modules ``datatypes``, ``tests``, ``utils``
       have changed, then condition 5 is met.
+
+    6. Condition 6:
+
+      If the object is an sktime ``BaseObject``, and any of the modules
+      in the class tag ``tests:libs`` hvae changed, condition 6 is met.
 
     cls can also be a list of classes or functions,
     in this case the test is run if and only if both of the following are True:
@@ -86,6 +91,7 @@ def run_test_for_class(cls, return_reason=False):
         * "True_changed_tests" - run reason, test(s) covering class have changed
         * "True_changed_class" - run reason, module(s) containing class changed
         * "True_changed_framework" - run reason, core framework modules changed
+        * "True_changed_libs" - run reason, library dependencies have changed
 
         If multiple reasons are present, the first one in the above list is returned.
 
@@ -130,6 +136,7 @@ def run_test_for_class(cls, return_reason=False):
             "True_changed_tests",
             "True_changed_class",
             "True_changed_framework",
+            "True_changed_libs",
         ]
         for pos_reason in POS_REASONS:
             if any(reason == pos_reason for reason in reasons):
@@ -202,6 +209,7 @@ def _run_test_for_class(
         * "True_changed_tests" - run reason, test(s) covering class have changed
         * "True_changed_class" - run reason, module(s) containing class changed
         * "True_changed_framework" - run reason, core framework modules changed
+        * "True_changed_libs" - run reason, library dependencies changed
 
         If multiple reasons are present, the first one in the above list is returned.
     """
@@ -281,6 +289,17 @@ def _run_test_for_class(
 
         return any(x in PACKAGE_REQ_CHANGED for x in package_deps)
 
+    def _is_impacted_by_lib_dep_change(cls):
+        """Check if library dependencies have changed, return bool."""
+        if not isclass(cls) or not hasattr(cls, "get_class_tags"):
+            return False
+
+        libs = cls.get_class_tags("tests:libs")
+        if libs is None or libs == []:
+            return False
+
+        return run_test_module_changed(libs)
+
     # Condition 1:
     # if any of the required soft dependencies are not present, do not run the test
     if not ignore_deps and not _required_deps_present(cls):
@@ -341,6 +360,11 @@ def _run_test_for_class(
         ]
         if any([is_module_changed(x) for x in FRAMEWORK_MODULES]):
             return True, "True_changed_framework"
+
+    # Condition 6:
+    # any of the specified library dependencies within sktime have changed
+    if _is_impacted_by_lib_dep_change(cls):
+        return True, "True_changed_libs"
 
     # if none of the conditions are met, do not run the test
     # reason is that there was no change

--- a/sktime/tests/tests/test_test_utils.py
+++ b/sktime/tests/tests/test_test_utils.py
@@ -102,6 +102,7 @@ def test_run_test_for_class():
         "True_changed_class",
         "True_changed_tests",
         "True_changed_framework",
+        "True_changed_libs",
     ]
 
     if not ONLY_CHANGED_MODULES:

--- a/sktime/transformations/series/vmd.py
+++ b/sktime/transformations/series/vmd.py
@@ -136,6 +136,7 @@ class VmdTransformer(BaseTransformer):
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
+        "tests:libs": ["sktime.libs.vmdpy"]
     }
 
     def __init__(


### PR DESCRIPTION
Currently, if an estimator has a business logic dependency in another module, say, `sktime.my_estimator._other_module`, a change to `_other_module` does not trigger a test to the estimator.

This is in particular problematic for estimators with dependencies in the `sktime.libs` folder which contains, for instance, the foundation model forks and other libraries - since a change in those libraries can break the estimators depending on them, which are not tested.

This PR adds a `tests:libs` tag which allows to specify the locations of such important dependencies, triggering the tests.
The tag is added to all reverse dependencies of the `libs` module, in particular, all foundation models.

The changes in the models should now trigger all tests for aforementioned estimators, although not directly through the tag.