### PR TITLE
[ENH] move test skips to estimators for estimators with their own VM

### DIFF
--- a/sktime/classification/foundation_models/momentfm.py
+++ b/sktime/classification/foundation_models/momentfm.py
@@ -130,6 +130,15 @@ class MomentFMClassifier(BaseClassifier):
             "transformers",
         ],
         "python_version": ">= 3.10",
+        # testing configuration
+        # ---------------------
+        "tests:vm": True,
+        "tests:libs": ["sktime.libs.momentfm"],
+        "tests:skip_by_name": [
+            # see 8253
+            "test_fit_idempotent",
+            "test_multiprocessing_idempotent",
+        ],
     }
 
     def __init__(

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -314,6 +314,11 @@ class ChronosForecaster(_BaseGlobalForecaster):
         # testing configuration
         # ---------------------
         "tests:vm": True,
+        "tests:libs": ["sktime.libs.chronos"],
+        "tests:skip_by_name": [  # pickling problems
+            "test_persistence_via_pickle",
+            "test_save_estimators_to_file",
+        ],
     }
 
     _default_chronos_config = {

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -31,6 +31,8 @@ CYTHON_ESTIMATORS = False
 ONLY_CHANGED_MODULES = False
 
 
+# DO NOT ADD ESTIMATORS HERE ANYMORE
+# ADD TEST SKIPS TO TAG tag tests:skip_all INSTEAD
 EXCLUDE_ESTIMATORS = [
     # PlateauFinder seems to be broken, see #2259
     "PlateauFinder",
@@ -101,6 +103,8 @@ EXCLUDE_ESTIMATORS = [
 ]
 
 
+# DO NOT ADD ESTIMATORS HERE ANYMORE
+# ADD TEST SKIPS TO TAG tag tests:skip_by_name INSTEAD
 EXCLUDED_TESTS = {
     # issue when prediction intervals, see #3479 and #4504
     # known issue with prediction intervals that needs fixing, tracked in #4181
@@ -266,11 +270,6 @@ EXCLUDED_TESTS = {
         "test_fit_idempotent",
     ],
     "TSRGridSearchCV": ["test_multioutput"],  # see 6708
-    # pickling problem
-    "ChronosForecaster": [
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-    ],
     "ClusterSegmenter": [
         "test_doctest_examples",
         "test_predict_points",
@@ -307,12 +306,10 @@ EXCLUDED_TESTS = {
         "test_save_estimators_to_file",
     ],
     "TSFreshClassifier": ["test_multiprocessing_idempotent"],  # see 8150
-    "MomentFMClassifier": [
-        "test_fit_idempotent",
-        "test_multiprocessing_idempotent",
-    ],  # see 8253
 }
 
+# DO NOT ADD ESTIMATORS HERE ANYMORE
+# ADD TEST SKIPS TO TAG tag tests:skip_by_name INSTEAD
 # exclude tests but keyed by test name
 EXCLUDED_TESTS_BY_TEST = {
     "test_get_test_params_coverage": [


### PR DESCRIPTION
This PR moves the test skip configuration for all estimators with their own VM to the tags of said estimators.

This is necessary to ensure that the correct tests are skipped in those VM tests.