### PR TITLE
[ENH] Move TapNetClassifier test skip config from tests._config to estimator tags.

### DIFF
--- a/sktime/classification/deep_learning/tapnet.py
+++ b/sktime/classification/deep_learning/tapnet.py
@@ -92,6 +92,14 @@ class TapNetClassifier(BaseDeepClassifier):
         "maintainers": ["jnrusson1", "achieveordie"],
         "python_dependencies": "tensorflow",
         # estimator type handled by parent class
+        # TapNet fails due to Lambda layer and stochastic failures,
+        # see #3539, #3616, #3525
+        "tests:skip_all": True,
+        "tests:skip_by_name": [
+            "test_fit_idempotent",
+            "test_persistence_via_pickle",
+            "test_save_estimators_to_file",
+        ],
     }
 
     def __init__(

--- a/sktime/classification/deep_learning/tapnet.py
+++ b/sktime/classification/deep_learning/tapnet.py
@@ -100,6 +100,9 @@ class TapNetClassifier(BaseDeepClassifier):
             "test_persistence_via_pickle",
             "test_save_estimators_to_file",
         ],
+        # Run tests in a dedicated VM due to sporadic crashes and possible
+        # memory leaks (see #8518)
+        "tests:vm": True,
     }
 
     def __init__(

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -46,7 +46,6 @@ EXCLUDE_ESTIMATORS = [
     "MatrixProfileTransformer",
     # tapnet based estimators fail stochastically for unknown reasons, see #3525
     "TapNetRegressor",
-    "TapNetClassifier",
     "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
     "LSTMFCNClassifier",  # unknown cause, see bug report #4033
     # DL classifier suspected to cause hangs and memouts, see #4610
@@ -142,12 +141,6 @@ EXCLUDED_TESTS = {
         "test_save_estimators_to_file",
         "test_fit_idempotent",  # see 6201
         "test_multiprocessing_idempotent",  # see 6637
-    ],
-    # TapNet fails due to Lambda layer, see #3539 and #3616
-    "TapNetClassifier": [
-        "test_fit_idempotent",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
     ],
     "TapNetRegressor": [
         "test_fit_idempotent",


### PR DESCRIPTION

#### Reference Issues/PRs
* #8515 


#### What does this implement/fix? Explain your changes.
This PR implements part of issue #8515 by migrating `TapNetClassifier` test skip configurations from the central tests._config.py file to the estimator's own tags. 
