### PR TITLE
[ENH] Move Test  Skip config for CNTCRegressor

### DIFF
--- a/sktime/regression/deep_learning/cntc.py
+++ b/sktime/regression/deep_learning/cntc.py
@@ -250,6 +250,12 @@ class CNTCRegressor(BaseDeepRegressor):
         preds = self.model_.predict([X2, X, X], self.batch_size, **kwargs)
         preds = np.squeeze(preds, axis=-1)
         return preds
+    def _more_tags(self):
+        return {
+            "tests:skip_all": True,
+            "tests:skip_by_name": ["test_fit_idempotent"]
+        }
+    
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -92,7 +92,6 @@ EXCLUDE_ESTIMATORS = [
     # TimeSeriesKvisibility is not API compliant, see #8026 and #8072
     "TimeSeriesKvisibility",
     # fails due to #8151 or #8059
-    "CNTCRegressor",
     "FreshPRINCE",
     # multiple timeouts and sporadic failures reported related to VARMAX
     # 2997, 3176, 7985
@@ -209,9 +208,6 @@ EXCLUDED_TESTS = {
         "test_fit_idempotent",
     ],
     "InceptionTimeRegressor": [
-        "test_fit_idempotent",
-    ],
-    "CNTCRegressor": [
         "test_fit_idempotent",
     ],
     # sth is not quite right with the RowTransformer-s changing state,


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/sktime/issues
-->
 [[ENH] move test skip config from tests._config to estimator tags #8515](https://github.com/sktime/sktime/issues/8515)

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
It migrates test skip logic for the CNTCRegressor estimator from the centralized tests/_config.py file into the estimator itself using the _more_tags.
#### Does your contribution introduce a new dependency? If yes, which one?

No




