### PR TITLE
[DOC] Note about package names in `_check_soft_dependencies`

### DIFF
--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -48,6 +48,14 @@ def _check_soft_dependencies(
 
         is the same as ``_check_soft_dependencies(("package1", "package2"))``
 
+        If the import name differs from the package name used for installation
+        (e.g., on PyPI), you must provide the **package name**, not the import
+        name, for example:
+
+        - import name: ``"sklearn"`` -> ``_check_soft_dependencies("scikit-learn")``
+        - import name: ``"huggingface_hub"`` ->
+        ``_check_soft_dependencies("huggingface-hub")``
+
     severity : str, "error" (default), "warning", "none"
         behaviour for raising errors or warnings
 

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -31,7 +31,8 @@ def _check_soft_dependencies(
 
         Note that the PEP 440 specifier is what one writes while installing a package,
         e.g., ``scikit-learn``, ``huggingface-hub``, ``scikit-base`` etc. and not what
-        one writes when importing a package.
+        one writes when importing a package. e.g., ``sklearn`, `huggingface_hub`,
+        `skbase` etc.
 
         The argument ``packages`` can be str, kwargs tuple, or tuple/list of str,
         following calls are valid:

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -29,10 +29,12 @@ def _check_soft_dependencies(
         For instance, the PEP 440 compatible package name such as ``"pandas"``;
         or a package requirement specifier string such as ``"pandas>1.2.3"``.
 
-        Note that the package name is what one writes while installing a package,
-        e.g., ``scikit-learn``, ``huggingface-hub``, ``scikit-base`` etc.
+        Note that the PEP 440 specifier is what one writes while installing a package,
+        e.g., ``scikit-learn``, ``huggingface-hub``, ``scikit-base`` etc. and not what
+        one writes when importing a package.
 
-        arg can be str, kwargs tuple, or tuple/list of str, following calls are valid:
+        The argument ``packages`` can be str, kwargs tuple, or tuple/list of str,
+        following calls are valid:
 
         * ``_check_soft_dependencies("package1")``
         * ``_check_soft_dependencies("package1", "package2")``

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -28,6 +28,10 @@ def _check_soft_dependencies(
         Each str must be a PEP 440 compatible specifier string, for a single package.
         For instance, the PEP 440 compatible package name such as ``"pandas"``;
         or a package requirement specifier string such as ``"pandas>1.2.3"``.
+
+        Note that the package name is what one writes while installing a package,
+        e.g., ``scikit-learn``, ``huggingface-hub``, ``scikit-base`` etc.
+
         arg can be str, kwargs tuple, or tuple/list of str, following calls are valid:
 
         * ``_check_soft_dependencies("package1")``
@@ -47,14 +51,6 @@ def _check_soft_dependencies(
         ``_check_soft_dependencies("package1", "package2")``
 
         is the same as ``_check_soft_dependencies(("package1", "package2"))``
-
-        If the import name differs from the package name used for installation
-        (e.g., on PyPI), you must provide the **package name**, not the import
-        name, for example:
-
-        - import name: ``"sklearn"`` -> ``_check_soft_dependencies("scikit-learn")``
-        - import name: ``"huggingface_hub"`` ->
-        ``_check_soft_dependencies("huggingface-hub")``
 
     severity : str, "error" (default), "warning", "none"
         behaviour for raising errors or warnings


### PR DESCRIPTION
This PR adds a note on what to use between the import name and package name with `_check_soft_dependencies`. Users who aren't familiar with the PEP convention, might find it confusing.

See discussion thread here: [https://discord.com/channels/1075852648688930887/1392760533870051398](https://discord.com/channels/1075852648688930887/1392760533870051398)