### PR TITLE
[ENH] shorthand `upto` for forecasting horizon `[1, 2, ..., n]`

### DIFF
--- a/sktime/forecasting/__init__.py
+++ b/sktime/forecasting/__init__.py
@@ -1,1 +1,5 @@
 """Implements univariate and multivariate forecasting models."""
+
+from sktime.forecasting.base import upto
+
+__all__ = ["upto"]

--- a/sktime/forecasting/base/__init__.py
+++ b/sktime/forecasting/base/__init__.py
@@ -5,7 +5,9 @@ __all__ = [
     "ForecastingHorizon",
     "BaseForecaster",
     "_BaseGlobalForecaster",
+    "upto",
 ]
 
 from sktime.forecasting.base._base import BaseForecaster, _BaseGlobalForecaster
 from sktime.forecasting.base._fh import ForecastingHorizon
+from sktime.forecasting.base._fh_shorthands import upto

--- a/sktime/forecasting/base/_fh_shorthands.py
+++ b/sktime/forecasting/base/_fh_shorthands.py
@@ -1,0 +1,23 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Shorthands for defining forecasting horizon."""
+
+__all__ = ["upto"]
+
+def upto(n):
+    """Return an integer forecasting horizon that goes up to n, starting from 1.
+
+    Same as range(1, n + 1), i.e., predicting the next n time points or periods.
+    
+    Parameters
+    ----------
+    n : int
+        The maximum time point in the forecasting horizon.
+
+    Returns
+    -------
+    fh : ForecastingHorizon
+        A forecasting horizon that goes up to n.
+    """
+    from sktime.forecasting.base._fh import ForecastingHorizon
+
+    return ForecastingHorizon(range(1, n + 1), is_relative=True)


### PR DESCRIPTION
Introduces a shorthand `upto` for the forecasting horizon `[1, 2, ..., n]`.

The idea is to intend any uses of `arange` or `range` for equivalent 1D array-likes, towards https://github.com/sktime/sktime/issues/8525.

How it looks like in usage:

```python
from sktime.datasets import load_airline
from sktime.forecasting import upto
from sktime.forecasting.naive import NaiveForecaster

y = load_airline()

f = NaiveForecaster()

f.fit(y, fh=upto(36))
```