### PR TITLE
[DOC] A typo in `test_all_estimators`

### DIFF
--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -313,7 +313,7 @@ class BaseFixtureGenerator:
     @pytest.fixture(scope="function")
     def estimator_instance(self, request):
         """estimator_instance fixture definition for indirect use."""
-        # esetimator_instance is cloned at the start of every test
+        # estimator_instance is cloned at the start of every test
         return request.param.clone()
 
     def _generate_scenario(self, test_name, **kwargs):


### PR DESCRIPTION
There is a typo in `test_all_estimators`, this PR corrects it.