### PR TITLE
[MNT] ensuring OSX packages are installed on macos `test-est` VM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,6 +151,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install OSX packages
+        run: ./.github/scripts/install_osx_dependencies.sh
+
       - name: Install sktime with dev dependencies
         run: |
           python -m pip install --upgrade pip

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -178,8 +178,7 @@ class ChronosBoltStrategy(ChronosModelStrategy):
 
 
 class ChronosForecaster(_BaseGlobalForecaster):
-    """
-    Interface to the Chronos and Chronos-Bolt Zero-Shot Forecaster by Amazon Research.
+    """Chronos and Chronos-Bolt Zero-Shot Forecaster by Amazon Research.
 
     Chronos and Chronos-Bolt are pretrained time-series foundation models
     developed by Amazon for time-series forecasting. This method has been


### PR DESCRIPTION
This PR ensures that OSX packages are installed on macos `test-est` VM.

Potential resolution of https://github.com/sktime/sktime/issues/8540 - tested with `ChronosForecaster`.