### PR TITLE
[ENH] more robust tag cloning in multiplexers for classification, regression, clustering

### DIFF
--- a/sktime/classification/_delegate.py
+++ b/sktime/classification/_delegate.py
@@ -38,6 +38,54 @@ class _DelegatedClassifier(BaseClassifier):
     def _get_delegate(self):
         return getattr(self, self._delegate_name)
 
+    def _set_delegated_tags(self, delegate=None):
+        """Set delegated tags, only tags for boilerplate control.
+
+        Writes tags to self.
+        Can be used by descendant classes to set dependent tags.
+        Makes safe baseline assumptions about tags, which can be overwritten.
+
+        * data mtype tags are set to the most general value.
+          This is to ensure that conversion is left to the inner estimator.
+        * packaging tags such as "author" or "python_dependencies" are not cloned.
+        * other boilerplate tags are cloned.
+
+        Parameters
+        ----------
+        delegate : object, optional (default=None)
+            object to get tags from, if None, uses self._get_delegate()
+
+        Returns
+        -------
+        self : reference to self
+        """
+        from sktime.datatypes import MTYPE_LIST_PANEL, MTYPE_LIST_TABLE
+
+        if delegate is None:
+            delegate = self._get_delegate()
+
+        TAGS_TO_DELEGATE = [
+            "capability:multioutput",
+            "capability:multivariate",
+            "capability:unequal_length",
+            "capability:missing_values",
+            "capability:train_estimate",
+            "capability:feature_importance",
+            "capability:contractable",
+            "capability:categorical_in_X",
+            "capability:predict_proba",
+        ]
+
+        TAGS_TO_SET = {
+            "X_inner_mtype": MTYPE_LIST_PANEL,
+            "y_inner_mtype": MTYPE_LIST_TABLE,
+        }
+
+        self.clone_tags(delegate, tag_names=TAGS_TO_DELEGATE)
+        self.set_tags(**TAGS_TO_SET)
+
+        return self
+
     def _fit(self, X, y):
         """Fit time series classifier to training data.
 

--- a/sktime/classification/compose/_multiplexer.py
+++ b/sktime/classification/compose/_multiplexer.py
@@ -103,11 +103,9 @@ class MultiplexClassifier(_HeterogenousMetaEstimator, _DelegatedClassifier):
         )
         self._set_classifier()
 
-        self.clone_tags(self.classifier_)
+        self._set_delegated_tags()
+
         self.set_tags(**{"fit_is_empty": False})
-        # this ensures that we convert in the inner estimator, not in the multiplexer
-        self.set_tags(**{"X_inner_mtype": MTYPE_LIST_PANEL})
-        self.set_tags(**{"y_inner_mtype": MTYPE_LIST_TABLE})
 
     @property
     def _classifiers(self):

--- a/sktime/classification/compose/tests/test_multiplex.py
+++ b/sktime/classification/compose/tests/test_multiplex.py
@@ -2,12 +2,14 @@
 """Unit tests for (dunder) composition functionality attached to the base class."""
 
 import numpy as np
+import pytest
 
 from sktime.classification.compose import MultiplexClassifier
 from sktime.classification.dummy import DummyClassifier
 from sktime.classification.feature_based import SummaryClassifier
 from sktime.classification.model_selection import TSCGridSearchCV
 from sktime.datasets import load_unit_test
+from sktime.tests.test_switch import run_test_module_changed
 
 
 @pytest.mark.skipif(

--- a/sktime/classification/compose/tests/test_multiplex.py
+++ b/sktime/classification/compose/tests/test_multiplex.py
@@ -1,0 +1,47 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Unit tests for (dunder) composition functionality attached to the base class."""
+
+import numpy as np
+
+from sktime.classification.compose import MultiplexClassifier
+from sktime.classification.dummy import DummyClassifier
+from sktime.classification.feature_based import SummaryClassifier
+from sktime.classification.model_selection import TSCGridSearchCV
+from sktime.datasets import load_unit_test
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.classification"]),
+    reason="run test only if classification or distances code has changed",
+)
+def test_multiplex_classifier():
+    """Test the MultiplexClassifier with a grid search.
+
+    Failure case of #8547 as it includes a classifier with
+    capability:multithreading tag.
+    """
+    # Load unit test data
+    X_train, y_train = load_unit_test(split="train", return_X_y=True)
+    X_test, y_test =load_unit_test(split="test", return_X_y=True)
+
+    estimators_list = [
+        ("SimpleRNNClassifier", DummyClassifier()),
+        ("Arsenal", SummaryClassifier()),
+        ("ContractableBOSS", DummyClassifier()),
+    ]
+
+    param_grid = {"selected_classifier": ["SimpleRNNClassifier", "Arsenal"]}
+
+    multiplexer = MultiplexClassifier(classifiers=estimators_list)
+
+    parameter_tuning = TSCGridSearchCV(
+        multiplexer,
+        param_grid,
+        error_score=np.nan, # "raise" np.nan
+        cv=3,
+        scoring="accuracy",  # accuracy balanced_accuracy
+        verbose=3,
+        refit=True,
+        n_jobs=1,
+    )
+    parameter_tuning.fit_predict(X_train, y_train)


### PR DESCRIPTION
This PR improves robustness of tag cloning in multiplexers for classification, regression, clustering.

Previously, all tags would be cloned and some reset, leading to the bug #8547 for the case where one of the multiplexed estimator had the tag `capability:multithreading` set.

Now, only selected tags get cloned, and the multiplexers for the three modules are upgraded to the logic in `MultiplexForecaster` which has a `_set_delegated_tags` method now.

Should also fix https://github.com/sktime/sktime/issues/8547, although both this and #8549 are independent architectural improvements, and only https://github.com/sktime/sktime/pull/8549 is a fix for the specific bug.