### PR TITLE
[ENH] loosen condition for `skpro` dependency exception in `BaseForecaster.predict_proba`

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -936,9 +936,6 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         if not non_default_pred_proba and not skpro_present:
             warn(msg, obj=self, stacklevel=2)
 
-        if non_default_pred_proba and not skpro_present:
-            raise ImportError(msg)
-
         # input checks and conversions
 
         # check fh and coerce to ForecastingHorizon, if not already passed in fit
@@ -948,7 +945,13 @@ class BaseForecaster(_PredictProbaMixin, BaseEstimator):
         X_inner = self._check_X(X=X)
 
         # pass to inner _predict_proba
-        pred_dist = self._predict_proba(fh=fh, X=X_inner, marginal=marginal)
+        try:  # try/except for handling notification about missing skpro softdep
+            pred_dist = self._predict_proba(fh=fh, X=X_inner, marginal=marginal)
+        except ImportError as e:
+            if non_default_pred_proba and not skpro_present:
+                raise ImportError(msg)
+            else:
+                raise e
 
         return pred_dist
 


### PR DESCRIPTION
Currently, `BaseForecaster.predict_proba` will raise an exception if `skpro` is not present, and the `_predict_proba` is not the default.

The intention of this is to give users feedback about requiring `skpro` for non-default implementations of `predict_proba`.

However, this condition is too strict, as some `predict_proba` implementations, including the default, do not require `skpro`.

Important cases which raise exceptions but would not need to are composites where `predict_proba` is simply looped through.

This PR ensures that an exception is raised only if the `_predict_proba` call causes an exception, under the current exception condition, and if we additionally (new) encounter an `ImportError`.

Tested via https://github.com/sktime/sktime/pull/8553