### PR TITLE
[MNT] reorder CI steps to minimize expected runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         shell: bash
 
   run-notebook-examples:
-    needs: code-quality
+    needs: test-nosoftdeps
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
         shell: bash
 
   run-blogpost-examples:
-    needs: code-quality
+    needs: test-nosoftdeps
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +91,8 @@ jobs:
         shell: bash
 
   detect-changed-classes:
-    needs: code-quality
+    needs: detect-package-change
+    if: ${{ needs.detect-package-change.outputs.sktime == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       obj_list: ${{ steps.get-change-list.outputs.obj_list }}
@@ -172,7 +173,7 @@ jobs:
         run: python -c "from sktime.tests._test_vm import run_test_vm; run_test_vm('${{ matrix.flag }}')"
 
   detect-package-change:
-    needs: [code-quality, detect-changed-classes]
+    needs: test-nodevdeps
     name: detect package changes
     runs-on: ubuntu-latest
     permissions:
@@ -190,8 +191,7 @@ jobs:
               - pyproject.toml
 
   test-nodevdeps:
-    needs: detect-package-change
-    if: ${{ needs.detect-package-change.outputs.sktime == 'true' }}
+    needs: code-quality
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -290,8 +290,7 @@ jobs:
         run: make test_without_datasets
 
   test-mlflow:
-    needs: detect-package-change
-    if: ${{ needs.detect-package-change.outputs.sktime == 'true' }}
+    needs: test-nosoftdeps
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,36 @@ jobs:
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash
 
+  detect-notebooks-change:
+    needs: code-quality
+    name: detect package changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      notebooks: ${{ steps.check.outputs.notebooks }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed to access the full git history
+
+      - name: Fetch main branch
+        run: git fetch origin main
+
+      - name: Check if examples, sktime or pyproject.toml changed
+        id: check
+        run: |
+          if git diff --quiet origin/main -- examples/ sktime/ pyproject.toml; then
+            echo "No notebook related changes"
+            echo "notebooks=false" >> $GITHUB_OUTPUT
+          else
+            echo "Detected changes in notebooks or sktime"
+            echo "notebooks=true" >> $GITHUB_OUTPUT
+          fi
+
   run-notebook-examples:
-    needs: test-nosoftdeps
+    needs: detect-notebooks-change
+    if: ${{ needs.detect-notebooks-change.outputs.notebooks == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +102,8 @@ jobs:
         shell: bash
 
   run-blogpost-examples:
-    needs: test-nosoftdeps
+    needs: detect-notebooks-change
+    if: ${{ needs.detect-notebooks-change.outputs.notebooks == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -173,24 +202,6 @@ jobs:
         run: python -c "from sktime.tests._test_vm import run_test_vm; run_test_vm('${{ matrix.flag }}')"
 
   detect-package-change:
-    needs: code-quality
-    name: detect package changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      sktime: ${{ steps.filter.outputs.sktime }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            sktime:
-              - sktime/**
-              - pyproject.toml
-
-  detect-notebooks-change:
     needs: code-quality
     name: detect package changes
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,7 +173,25 @@ jobs:
         run: python -c "from sktime.tests._test_vm import run_test_vm; run_test_vm('${{ matrix.flag }}')"
 
   detect-package-change:
-    needs: test-nodevdeps
+    needs: code-quality
+    name: detect package changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      sktime: ${{ steps.filter.outputs.sktime }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            sktime:
+              - sktime/**
+              - pyproject.toml
+
+  detect-notebooks-change:
+    needs: code-quality
     name: detect package changes
     runs-on: ubuntu-latest
     permissions:
@@ -191,7 +209,7 @@ jobs:
               - pyproject.toml
 
   test-nodevdeps:
-    needs: code-quality
+    needs: detect-package-change
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
 
   detect-notebooks-change:
     needs: code-quality
-    name: detect package changes
+    name: detect change affecting notebooks
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
This PR reorders CI steps to minimize expected runtime, by moving quick steps ahead to gate slow or long running steps.

Important changes:

* notebook runs are now gated behind a new step `detect-notebooks-change`
* `test-nosoftdeps` is gated behind `test-devdeps`
* `detect-changed-classes` is gated behind `detect-package-change`