### PR TITLE
[ENH] remove internal broadcasting in `ChronosForecaster` in favour of programmatic broadcasting

### DIFF
--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -471,10 +471,7 @@ class ChronosForecaster(_BaseGlobalForecaster):
         _y_df = _y
 
         index_names = _y.index.names
-        if isinstance(_y.index, pd.MultiIndex):
-            _y = _frame2numpy(_y)
-        else:
-            _y = _y.values.reshape(1, -1, 1)
+        _y = _y.values.reshape(1, -1, 1)
 
         results = []
         for i in range(_y.shape[0]):
@@ -540,24 +537,6 @@ class ChronosForecaster(_BaseGlobalForecaster):
             }
         )
         return test_params
-
-
-def _same_index(data):
-    data = data.groupby(level=list(range(len(data.index.levels) - 1))).apply(
-        lambda x: x.index.get_level_values(-1)
-    )
-    assert data.map(lambda x: x.equals(data.iloc[0])).all(), (
-        "All series must has the same index"
-    )
-    return data.iloc[0], len(data.iloc[0])
-
-
-def _frame2numpy(data):
-    idx, length = _same_index(data)
-    arr = np.array(data.values, dtype=np.float32).reshape(
-        (-1, length, len(data.columns))
-    )
-    return arr
 
 
 @_multiton

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -508,7 +508,7 @@ class ChronosForecaster(BaseForecaster):
         if y is not None:
             return self.fit_predict(fh=_fh, X=X, y=y)
 
-        super().predict(fh=fh, X=X, y=y)
+        super().predict(fh=fh, X=X)
 
     def _predict(self, fh, y=None, X=None):
         """Forecast time series at future horizon.

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -301,12 +301,8 @@ class ChronosForecaster(_BaseGlobalForecaster):
         "enforce_index_type": None,
         "capability:missing_values": False,
         "capability:pred_int": False,
-        "X_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
-        "y_inner_mtype": [
-            "pd.DataFrame",
-            "pd-multiindex",
-            "pd_multiindex_hier",
-        ],
+        "X_inner_mtype": "pd.DataFrame",
+        "y_inner_mtype": "pd.DataFrame",
         "scitype:y": "univariate",
         "capability:insample": False,
         "capability:pred_int:insample": False,
@@ -491,28 +487,12 @@ class ChronosForecaster(_BaseGlobalForecaster):
             results.append(values)
 
         pred = np.stack(results, axis=1)
-        if isinstance(_y_df.index, pd.MultiIndex):
-            ins = np.array(
-                list(np.unique(_y_df.index.droplevel(-1)).repeat(pred.shape[0]))
-            )
-            ins = [ins[..., i] for i in range(ins.shape[-1])] if ins.ndim > 1 else [ins]
 
-            idx = (
-                ForecastingHorizon(range(1, pred.shape[0] + 1), freq=self.fh.freq)
-                .to_absolute(self._cutoff)
-                ._values.tolist()
-                * pred.shape[1]
-            )
-            index = pd.MultiIndex.from_arrays(
-                ins + [idx],
-                names=_y_df.index.names,
-            )
-        else:
-            index = (
-                ForecastingHorizon(range(1, pred.shape[0] + 1))
-                .to_absolute(self._cutoff)
-                ._values
-            )
+        index = (
+            ForecastingHorizon(range(1, pred.shape[0] + 1))
+            .to_absolute(self._cutoff)
+            ._values
+        )
         pred_out = fh.get_expected_pred_idx(_y, cutoff=self.cutoff)
 
         pred = pd.DataFrame(

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -508,7 +508,7 @@ class ChronosForecaster(BaseForecaster):
         if y is not None:
             return self.fit_predict(fh=_fh, X=X, y=y)
 
-        super().predict(fh=fh, X=X)
+        return super().predict(fh=fh, X=X)
 
     def _predict(self, fh, y=None, X=None):
         """Forecast time series at future horizon.


### PR DESCRIPTION
This PR removes internal broadcasting in `ChronosForecaster` in favour of programmatic broadcasting.

This also fixes the unreported issue of not being able to pass unequal length hierarchical data to the forecaster.