### PR TITLE
[ENH] Move Test Skip config for `ResNetClassifier`

### DIFF
--- a/sktime/classification/deep_learning/resnet.py
+++ b/sktime/classification/deep_learning/resnet.py
@@ -71,8 +71,6 @@ class ResNetClassifier(BaseDeepClassifier):
         # `test_fit_idempotent` fails with `AssertionError`, see #3616
         "tests:skip_by_name": [
             "test_fit_idempotent",
-            "test_persistence_via_pickle",
-            "test_save_estimators_to_file",
         ],
     }
 

--- a/sktime/classification/deep_learning/resnet.py
+++ b/sktime/classification/deep_learning/resnet.py
@@ -65,6 +65,15 @@ class ResNetClassifier(BaseDeepClassifier):
         "maintainers": ["James-Large", "AurumnPegasus", "nilesh05apr"],
         "python_dependencies": ["tensorflow"],
         # estimator type handled by parent class
+        # known ResNetClassifier sporafic failures, see #3954
+        # fails due to #3954 or #3616
+        "tests:skip_all": True,
+        # `test_fit_idempotent` fails with `AssertionError`, see #3616
+        "tests:skip_by_name": [
+            "test_fit_idempotent",
+            "test_persistence_via_pickle",
+            "test_save_estimators_to_file",
+        ],
     }
 
     def __init__(

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -46,7 +46,6 @@ EXCLUDE_ESTIMATORS = [
     "MatrixProfileTransformer",
     # tapnet based estimators fail stochastically for unknown reasons, see #3525
     "TapNetRegressor",
-    "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
     "LSTMFCNClassifier",  # unknown cause, see bug report #4033
     # DL classifier suspected to cause hangs and memouts, see #4610
     "FCNClassifier",
@@ -143,10 +142,6 @@ EXCLUDED_TESTS = {
         "test_fit_idempotent",
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
-    ],
-    # `test_fit_idempotent` fails with `AssertionError`, see #3616
-    "ResNetClassifier": [
-        "test_fit_idempotent",
     ],
     "ResNetRegressor": [
         "test_fit_idempotent",


### PR DESCRIPTION
#### Reference Issues/PRs

[ENH] move test skip config from tests._config to estimator tags #8515



#### What does this implement/fix? Explain your changes.

This PR implements part of issue https://github.com/sktime/sktime/issues/8515 by migrating ResNetClassifier test skip configurations from the central tests._config.py file to the estimator's own tags.