### PR TITLE
[BUG] ensure `deps` dependency inspection is compatible with disjunctions in estimator dependency tags

### DIFF
--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -92,15 +92,22 @@ def build_obj():
 def deps(spec):
     """Get PEP 440 dependency requirements for a craft spec.
 
+    This will result in a list of PEP 440 compatible requirement string.
+
+    In case the spec includes estimators with disjunctions in their requirement
+    specifications, the first disjunctive requirement is returned, i.e.,
+    any disjunctions are resolved by picking the first dependency in the disjunction.
+
     Parameters
     ----------
     spec : str, sktime/skbase compatible object specification
-        i.e., a string that executes to construct an object if all imports were present
+        i.e., a string that executes to construct an object if all imports were present.
         imports inferred are of any classes in the scope of ``all_estimators``
-        option 1: a string that evaluates to an estimator
-        option 2: a sequence of assignments in valid python code,
-            with the object to be defined preceded by a "return"
-            assignments can use names of classes as if all imports were present
+
+        * option 1: a string that evaluates to an estimator
+        * option 2: a sequence of assignments in valid python code,
+          with the object to be defined preceded by a "return".
+          assignments can use names of classes as if all imports were present
 
     Returns
     -------

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -122,10 +122,22 @@ def deps(spec):
 
         new_deps = cls.get_class_tag("python_dependencies")
 
-        if isinstance(new_deps, list):
-            dep_strs += new_deps
-        elif isinstance(new_deps, str) and len(new_deps) > 0:
-            dep_strs += [new_deps]
+        def _resolve_disjunctions(dep):
+            """Resolve disjunctions in dependencies by picking first."""
+            if isinstance(dep, list):
+                return dep[0]  # pick first dependency in disjunction
+            return dep
+
+        if isinstance(new_deps, str) and len(new_deps) > 0:
+            new_deps_coerced = [new_deps]
+        elif isinstance(new_deps, str) and len(new_deps) == 0:
+            new_deps_coerced = []
+        elif isinstance(new_deps, list):
+            new_deps_coerced = [_resolve_disjunctions(dep) for dep in new_deps]
+        else:
+            new_deps_coerced = new_deps
+
+        dep_strs += new_deps_coerced
 
         reqs = list(set(dep_strs))
 

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -135,7 +135,9 @@ def deps(spec):
                 return dep[0]  # pick first dependency in disjunction
             return dep
 
-        if isinstance(new_deps, str) and len(new_deps) > 0:
+        if new_deps is None:
+            new_deps_coerced = []
+        elif isinstance(new_deps, str) and len(new_deps) > 0:
             new_deps_coerced = [new_deps]
         elif isinstance(new_deps, str) and len(new_deps) == 0:
             new_deps_coerced = []

--- a/sktime/registry/tests/test_craft.py
+++ b/sktime/registry/tests/test_craft.py
@@ -124,6 +124,6 @@ def test_imports():
     assert imports(pipe_spec_with_deps) == pipe_imports
 
 
-def test_deps_with_disjunction(spec):
+def test_deps_with_disjunction():
     """Check that deps retrieves the correct requirement set for disjunctions."""
     assert deps("DartsXGBModel") == ["u8darts>=0.29"]

--- a/sktime/registry/tests/test_craft.py
+++ b/sktime/registry/tests/test_craft.py
@@ -122,3 +122,8 @@ def test_imports():
         "Imputer"
     )
     assert imports(pipe_spec_with_deps) == pipe_imports
+
+
+def test_deps_with_disjunction(spec):
+    """Check that deps retrieves the correct requirement set for disjunctions."""
+    assert deps("DartsXGBModel") == ["u8darts>=0.29"]


### PR DESCRIPTION
This PR fixes an unreported bug, namely that the `deps` dependency inspection utility would fail if an estimator in the spec contained a disjunction dependency, for instance, `DartsXGBRegressor`.

This PR fixes the bug by ensuring that disjunctive statements are resolved by picking the first element, to result in one of multiple possible choices for dependencies.

One could add a feature to return a disjunctive dependency, but doing this by default would violate the implicit contract that the return of `deps` results in a list of PEP 440 dependency specifier str (not a disjunction, possibly).