### PR TITLE
[MNT] separate dependency set for notebooks, reduce dependencies in notebook CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[notebooks,binder,dev]
+          python -m pip install .[notebooks,dev]
 
       - name: Show dependencies
         run: python -m pip list
@@ -89,7 +89,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[notebooks,binder,mlflow]
+          python -m pip install .[notebooks,mlflow]
 
       - name: Show dependencies
         run: python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[all_extras,binder,dev,mlflow,dl]
+          python -m pip install .[notebooks,binder,dev,mlflow]
+
+      - name: Show dependencies
+        run: python -m pip list
+
       - name: Run example notebooks
         run: build_tools/run_examples.sh
         shell: bash
@@ -85,7 +89,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[all_extras,binder,dev,mlflow]
+          python -m pip install .[notebooks,binder,dev,mlflow]
+
+      - name: Show dependencies
+        run: python -m pip list
+
       - name: Run example notebooks
         run: build_tools/run_blogposts.sh
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[notebooks,dev]
+          python -m pip install .[notebooks,binder,dev]
 
       - name: Show dependencies
         run: python -m pip list
@@ -89,7 +89,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[notebooks,mlflow]
+          python -m pip install .[notebooks,binder,mlflow]
 
       - name: Show dependencies
         run: python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[notebooks,binder,dev,mlflow]
+          python -m pip install .[notebooks,binder,dev]
 
       - name: Show dependencies
         run: python -m pip list
@@ -89,7 +89,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[notebooks,binder,dev,mlflow]
+          python -m pip install .[notebooks,binder,mlflow]
 
       - name: Show dependencies
         run: python -m pip list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,6 +315,11 @@ mlflow_tests = [
   "mlflow<4.0",
   "moto",
 ]
+notebooks = [
+  huggingface-hub,
+  pmdarima,
+  skpro,
+]
 numpy1 = [
   "numpy<2.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,6 +323,7 @@ notebooks = [
   "tbats",
   # needed for the examples
   "prophet",
+  "pytorch-forecasting",
   "skpro",
   "statsforecast",
   "huggingface-hub",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,7 +316,9 @@ mlflow_tests = [
 ]
 notebooks = [
   "huggingface-hub",
+  "matplotlib",
   "pmdarima",
+  "seaborn",
   "skpro",
 ]
 numpy1 = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,6 +317,7 @@ mlflow_tests = [
 notebooks = [
   "huggingface-hub",
   "matplotlib",
+  "numpy<2.1",
   "pmdarima",
   "seaborn",
   "skpro",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,7 +274,6 @@ tests = [
 # these are for special uses and may be changed or removed at any time
 binder = [
   "jupyter",
-  "pandas<2.0.0",
   "skchange",
 ]
 cython_extras = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,9 +316,9 @@ mlflow_tests = [
   "moto",
 ]
 notebooks = [
-  huggingface-hub,
-  pmdarima,
-  skpro,
+  "huggingface-hub",
+  "pmdarima",
+  "skpro",
 ]
 numpy1 = [
   "numpy<2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,6 +324,7 @@ notebooks = [
   # needed for the examples
   "prophet",
   "skpro",
+  "statsforecast",
   "huggingface-hub",
 ]
 numpy1 = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,6 +322,7 @@ notebooks = [
   "seaborn",
   "tbats",
   # needed for the examples
+  "dtw-python",
   "prophet",
   "pytorch-forecasting",
   "skpro",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,6 +321,7 @@ notebooks = [
   "pmdarima",
   "seaborn",
   "skpro",
+  "tbats",
 ]
 numpy1 = [
   "numpy<2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,7 +327,6 @@ notebooks = [
   "pytorch-forecasting",
   "skpro",
   "statsforecast",
-  "huggingface-hub",
 ]
 numpy1 = [
   "numpy<2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,7 +317,7 @@ mlflow_tests = [
 notebooks = [
   "huggingface-hub",
   "matplotlib",
-  "numpy<2.1",
+  "numpy<2",
   "pmdarima",
   "seaborn",
   "skpro",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,13 +315,16 @@ mlflow_tests = [
   "moto",
 ]
 notebooks = [
-  "huggingface-hub",
+  # needed for the blog post notebooks
   "matplotlib",
   "numpy<2",
   "pmdarima",
   "seaborn",
-  "skpro",
   "tbats",
+  # needed for the examples
+  "prophet"
+  "skpro",
+  "huggingface-hub",
 ]
 numpy1 = [
   "numpy<2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,7 +322,7 @@ notebooks = [
   "seaborn",
   "tbats",
   # needed for the examples
-  "prophet"
+  "prophet",
   "skpro",
   "huggingface-hub",
 ]


### PR DESCRIPTION
Reduces dependencies in notebook CI to avoid failures in https://github.com/sktime/sktime/pull/8584, or being stuck on very old versions of packages.

Creates a new developer dependency set `notebooks` meant to be comprised of aminimal set of dependencies for running all notebooks.