### PR TITLE
[ENH] Replace deprecated _transform_single_feature with transform in _drcif_feature

### DIFF
--- a/sktime/classification/sklearn/_continuous_interval_tree_numba.py
+++ b/sktime/classification/sklearn/_continuous_interval_tree_numba.py
@@ -9,6 +9,7 @@ __author__ = ["MatthewMiddlehurst"]
 import math
 
 import numpy as np
+import pandas as pd
 
 from sktime.utils.numba.njit import njit
 from sktime.utils.numba.stats import iqr, mean, numba_max, numba_min, slope, std
@@ -47,12 +48,28 @@ def _entropy(x, s):
 
 def _drcif_feature(X, interval, dim, att, c22, case_id=None):
     """Compute DrCIF feature."""
-    if att > 21:
-        return _summary_stat(X[:, dim, interval[0] : interval[1]], att)
+    if isinstance(X, pd.DataFrame):
+        series_col = X.iloc[:, dim]
+        X_interval = series_col.apply(
+            lambda x: pd.Series(x[interval[0] : interval[1]])
+            if isinstance(x, (pd.Series, np.ndarray))
+            else pd.Series([])
+        ).to_frame()
     else:
-        return c22._transform_single_feature(
-            X[:, dim, interval[0] : interval[1]], att, case_id=case_id
-        )
+        sliced = X[:, dim, interval[0] : interval[1]]
+        X_interval = pd.DataFrame({str(dim): [pd.Series(x) for x in sliced]})
+
+    if att > 21:
+        arr = np.stack(X_interval.iloc[:, 0].values)
+        return _summary_stat(arr, att)
+
+    c22.fit(X_interval)
+    full_feats = c22.transform(X_interval)
+    return (
+        full_feats.iloc[:, att]
+        if isinstance(full_feats, pd.DataFrame)
+        else full_feats[:, att]
+    )
 
 
 @njit(fastmath=True, cache=True)


### PR DESCRIPTION


#### Reference Issues/PRs

 Fixes #4172 


#### What does this implement/fix? 
Replaced the deprecated _transform_single_feature call in _drcif_feature with the public transform method from Catch22. The private _transform_single_feature was originally used to compute a single feature on a given interval, but it has been deprecated since version 0.16.0 and is no longer used internally by Catch22 itself.

