### PR TITLE
[MNT] update notebook CI python version to 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,10 +61,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -82,14 +84,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[notebooks,binder,mlflow]
+          python -m pip install .[notebooks,binder]
 
       - name: Show dependencies
         run: python -m pip list
@@ -158,6 +162,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Install OSX packages
+        run: ./.github/scripts/install_osx_dependencies.sh
 
       - name: Install sktime with dev dependencies
         run: |
@@ -288,6 +295,7 @@ jobs:
     name: test-mlflow-${{ matrix.mlflow-version }}
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/examples/07_detection_anomaly_changepoints.ipynb
+++ b/examples/07_detection_anomaly_changepoints.ipynb
@@ -613,7 +613,7 @@
     }
    ],
    "source": [
-    "from skchange.anomaly_detectors.capa import CAPA\n",
+    "from sktime.detection.skchange_aseg import CAPA\n",
     "\n",
     "model = CAPA(max_segment_length=350)\n",
     "model.fit(df[\"data\"])\n",
@@ -957,7 +957,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "sktime-skpro-skbase-311",
    "language": "python",
    "name": "python3"
   },
@@ -971,7 +971,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/sktime/detection/skchange_aseg/capa.py
+++ b/sktime/detection/skchange_aseg/capa.py
@@ -8,7 +8,7 @@ from sktime.utils.dependencies import _placeholder_record
 class CAPA(BaseDetector):
     """CAPA = Collective and point anomaly detection, from skchange.
 
-    Redirects to ``skchange.anomaly_detectors.capa``.
+    Redirects to ``skchange.anomaly_detectors.CAPA``.
 
     An efficient implementation of the CAPA algorithm [1]_ for anomaly detection.
     It is implemented using the 'savings' formulation of the problem given in [2]_ and


### PR DESCRIPTION
updates the notebook CI python version to 3.11.

Also fixes a broken import from newer `skchange` version, by redirecting it to the stable `sktime` import location.