### PR TITLE
[ENH] ensure that any change in `classification.sklearn` triggers the classification tests

### DIFF
--- a/sktime/classification/sklearn/tests/test_all_classifiers.py
+++ b/sktime/classification/sklearn/tests/test_all_classifiers.py
@@ -7,7 +7,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from sktime.classification.sklearn import ContinuousIntervalTree, RotationForest
-from sktime.tests.test_switch import run_test_for_class
+from sktime.tests.test_switch import run_test_module_changed
 
 ALL_SKLEARN_CLASSIFIERS = [RotationForest, ContinuousIntervalTree]
 
@@ -19,7 +19,7 @@ INSTANCES_TO_TEST = [
 
 
 @pytest.mark.skipif(
-    not run_test_for_class(ALL_SKLEARN_CLASSIFIERS),
+    not run_test_module_changed("sktime.classification.sklearn"),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 @parametrize_with_checks(INSTANCES_TO_TEST)


### PR DESCRIPTION
This PR broadens the run condition for `sklearn` compatible classifiers in `classification.sklearn` - all are run if anything in the module changes.

This is safer as the module has interdependencies.