### PR TITLE
[MNT] skip sporadically failing `ThetaForecaster`

### DIFF
--- a/sktime/forecasting/theta.py
+++ b/sktime/forecasting/theta.py
@@ -103,7 +103,8 @@ class ThetaForecaster(ExponentialSmoothing):
         "capability:missing_values": False,
         # CI and test flags
         # -----------------
-        "tests:core": True,  # should tests be triggered by framework changes?
+        "tests:core": False,  # should tests be triggered by framework changes?
+        "tests:skip_all": True,  # skip all tests by default
     }
 
     def __init__(self, initial_level=None, deseasonalize=True, sp=1):


### PR DESCRIPTION
Skips the `ThetaForecaster` which seems to cause sporadic failures until fixed, see bug report https://github.com/sktime/sktime/issues/8617