### PR TITLE
[ENH] tests for `parallelize` backend abstraction utility

### DIFF
--- a/sktime/utils/tests/test_parallelize.py
+++ b/sktime/utils/tests/test_parallelize.py
@@ -1,0 +1,29 @@
+import copy
+
+import pytest
+
+from sktime.utils.parallel import _get_parallel_test_fixtures, parallelize
+
+
+def square(x, **kwargs):
+    return x**2
+
+
+@pytest.mark.parametrize("fixture", _get_parallel_test_fixtures())
+def test_parallelize_simple_loop(fixture):
+    backend = fixture["backend"]
+    backend_params = copy.deepcopy(fixture["backend_params"])
+    params_before = copy.deepcopy(fixture["backend_params"])
+
+    nums = range(8)
+    expected = [x**2 for x in nums]
+
+    result = parallelize(
+        square,
+        nums,
+        backend=backend,
+        backend_params=backend_params,
+    )
+
+    assert list(result) == expected
+    assert backend_params == params_before

--- a/sktime/utils/tests/test_parallelize.py
+++ b/sktime/utils/tests/test_parallelize.py
@@ -2,13 +2,20 @@ import copy
 
 import pytest
 
+from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils.parallel import _get_parallel_test_fixtures, parallelize
+
+_should_run = run_test_module_changed("sktime.utils.parallel")
 
 
 def square(x, **kwargs):
     return x**2
 
 
+@pytest.mark.skipif(
+    not _should_run,
+    reason="sktime.utils.parallel unchanged, skipping parallelize tests",
+)
 @pytest.mark.parametrize("fixture", _get_parallel_test_fixtures())
 def test_parallelize_simple_loop(fixture):
     backend = fixture["backend"]


### PR DESCRIPTION
Fixes #8619 

#### What does this implement/fix? Explain your changes.

I have implemented a test for `parallelize` where I am running a simple for loop and checking if the results are as expected and ensuring that `backend_params` is not being mutated.

#### Does your contribution introduce a new dependency? If yes, which one?

No, it does not.