### PR TITLE
[MNT] Update test_vms to use `macos-latest` in CI and configure osx setup in github scripts to dynamically install dependencies

### DIFF
--- a/.github/scripts/install_osx_dependencies.sh
+++ b/.github/scripts/install_osx_dependencies.sh
@@ -4,7 +4,9 @@
 # It is called by test workflow in .github/workflows/
 # To build necessary system dependencies for MacOS, run:
 
+# check if os is MacOS using uname
 if [ "$(uname)" = "Darwin" ]; then
+    # install necessary dependencies
     echo "installing necessary dependencies..."
     brew install libomp
 

--- a/.github/scripts/install_osx_dependencies.sh
+++ b/.github/scripts/install_osx_dependencies.sh
@@ -4,17 +4,19 @@
 # It is called by test workflow in .github/workflows/
 # To build necessary system dependencies for MacOS, run:
 
-# check if os is MacOS using uname
 if [ "$(uname)" = "Darwin" ]; then
-    # install necessary dependencies
     echo "installing necessary dependencies..."
     brew install libomp
+
+    LIBOMP_PREFIX="$(brew --prefix libomp)"
+
     echo "Verifying libomp installation..."
-    ls -l /usr/local/opt/libomp/lib/libomp.dylib
+    ls "$LIBOMP_PREFIX/lib/libomp.dylib"
+
     {
-        echo "DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib:\$DYLD_LIBRARY_PATH"
-        echo "LDFLAGS=-L/usr/local/opt/libomp/lib"
-        echo "CPPFLAGS=-I/usr/local/opt/libomp/include"
+        echo "DYLD_LIBRARY_PATH=$LIBOMP_PREFIX/lib:\$DYLD_LIBRARY_PATH"
+        echo "LDFLAGS=-L$LIBOMP_PREFIX/lib"
+        echo "CPPFLAGS=-I$LIBOMP_PREFIX/include"
     } >> "$GITHUB_ENV"
 else
     echo "This script is intended to run on macOS (Darwin)."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
       matrix:
         flag: ${{ fromJson(needs.detect-changed-classes.outputs.obj_list) }}
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This PR aims to update the macos runners in `test_vms` to use `macos-latest` and also updates `install_osx_dependencies.sh` bash script in github to dynamically setup the runner based on Intel or ARM macs

relates to macos fix for global forecasters pr #8331 