### PR TITLE
[ENH] change `MeanAbsolutePercentageError` parent to `BaseForecastingErrorMetric`

### DIFF
--- a/sktime/performance_metrics/forecasting/_common.py
+++ b/sktime/performance_metrics/forecasting/_common.py
@@ -1,0 +1,92 @@
+"""Common utilities for forecasting metrics."""
+
+import numpy as np
+
+
+def _relative_error(y_true, y_pred, y_pred_benchmark, eps=None):
+    """Relative error for observations to benchmark method.
+
+    Parameters
+    ----------
+    y_true : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+        Ground truth (correct) target values.
+
+    y_pred : pandas Series, pandas DataFrame or NumPy array of
+            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
+        Forecasted values.
+
+    y_pred_benchmark : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+             (fh, n_outputs) where fh is the forecasting horizon, default=None
+        Forecasted values from benchmark method.
+
+    eps : float, default=None
+        Numerical epsilon used in denominator to avoid division by zero.
+        Absolute values smaller than eps are replaced by eps.
+        If None, defaults to np.finfo(np.float64).eps
+
+    Returns
+    -------
+    relative_error : float
+        relative error
+
+    References
+    ----------
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of \
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
+    """
+    if eps is None:
+        eps = np.finfo(np.float64).eps
+
+    denominator = np.where(
+        y_true - y_pred_benchmark >= 0,
+        np.maximum((y_true - y_pred_benchmark), eps),
+        np.minimum((y_true - y_pred_benchmark), -eps),
+    )
+    return (y_true - y_pred) / denominator
+
+
+def _percentage_error(y_true, y_pred, symmetric=False, relative_to="y_true", eps=None):
+    """Percentage error.
+
+    Parameters
+    ----------
+    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
+        Ground truth (correct) target values.
+
+    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
+             where fh is the forecasting horizon
+        Forecasted values.
+
+    symmetric : bool, default = False
+        Whether to calculate symmetric percentage error.
+
+    relative_to : bool, default = "y_true"
+        Whether to calculate percentage error by forecast.
+
+    eps : float, default=None
+        Numerical epsilon used in denominator to avoid division by zero.
+        Absolute values smaller than eps are replaced by eps.
+        If None, defaults to np.finfo(np.float64).eps
+
+    Returns
+    -------
+    percentage_error : float
+
+    References
+    ----------
+    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of \
+    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
+    """
+    if eps is None:
+        eps = np.finfo(np.float64).eps
+
+    if symmetric:
+        denominator = np.maximum(np.abs(y_true) + np.abs(y_pred), eps) / 2
+    elif relative_to == "y_pred":
+        denominator = np.maximum(np.abs(y_pred), eps)
+    else:
+        denominator = np.maximum(np.abs(y_true), eps)
+    percentage_error = np.abs(y_true - y_pred) / denominator
+    return percentage_error

--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -20,6 +20,10 @@ from sktime.performance_metrics.forecasting._coerce import (
     _coerce_to_1d_numpy,
     _coerce_to_scalar,
 )
+from sktime.performance_metrics.forecasting._common import (
+    _percentage_error,
+    _relative_error,
+)
 from sktime.utils.sklearn import _check_reg_targets
 from sktime.utils.stats import _weighted_geometric_mean
 
@@ -2756,76 +2760,3 @@ def _linex_error(y_true, y_pred, a=1.0, b=1.0):
     a_error = a * error
     linex_error = b * (np.exp(a_error) - a_error - 1)
     return linex_error
-
-
-def _relative_error(y_true, y_pred, y_pred_benchmark):
-    """Relative error for observations to benchmark method.
-
-    Parameters
-    ----------
-    y_true : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
-        Ground truth (correct) target values.
-
-    y_pred : pandas Series, pandas DataFrame or NumPy array of
-            shape (fh,) or (fh, n_outputs) where fh is the forecasting horizon
-        Forecasted values.
-
-    y_pred_benchmark : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
-             (fh, n_outputs) where fh is the forecasting horizon, default=None
-        Forecasted values from benchmark method.
-
-    Returns
-    -------
-    relative_error : float
-        relative error
-
-    References
-    ----------
-    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of \
-    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
-    """
-    denominator = np.where(
-        y_true - y_pred_benchmark >= 0,
-        np.maximum((y_true - y_pred_benchmark), EPS),
-        np.minimum((y_true - y_pred_benchmark), -EPS),
-    )
-    return (y_true - y_pred) / denominator
-
-
-def _percentage_error(y_true, y_pred, symmetric=False, relative_to="y_true"):
-    """Percentage error.
-
-    Parameters
-    ----------
-    y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
-             where fh is the forecasting horizon
-        Ground truth (correct) target values.
-
-    y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or (fh, n_outputs) \
-             where fh is the forecasting horizon
-        Forecasted values.
-
-    symmetric : bool, default = False
-        Whether to calculate symmetric percentage error.
-
-    relative_to : bool, default = "y_true"
-        Whether to calculate percentage error by forecast.
-
-    Returns
-    -------
-    percentage_error : float
-
-    References
-    ----------
-    Hyndman, R. J and Koehler, A. B. (2006). "Another look at measures of \
-    forecast accuracy", International Journal of Forecasting, Volume 22, Issue 4.
-    """
-    if symmetric:
-        denominator = np.maximum(np.abs(y_true) + np.abs(y_pred), EPS) / 2
-    elif relative_to == "y_pred":
-        denominator = np.maximum(np.abs(y_pred), EPS)
-    else:
-        denominator = np.maximum(np.abs(y_true), EPS)
-    percentage_error = np.abs(y_true - y_pred) / denominator
-    return percentage_error

--- a/sktime/performance_metrics/forecasting/_mape.py
+++ b/sktime/performance_metrics/forecasting/_mape.py
@@ -8,9 +8,6 @@ the lower the better.
 """
 
 from sktime.performance_metrics.forecasting._base import BaseForecastingErrorMetric
-from sktime.performance_metrics.forecasting._functions import (
-    mean_absolute_percentage_error,
-)
 
 
 class MeanAbsolutePercentageError(BaseForecastingErrorMetric):
@@ -179,16 +176,9 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetric):
             denom_values = y_true.abs()
 
         raw_values = numer_values / denom_values
+        raw_values = self._get_weighted_df(raw_values, **kwargs)
 
-        if isinstance(multioutput, str):
-            if multioutput == "raw_values":
-                return raw_values
-
-            if multioutput == "uniform_average":
-                return raw_values.mean(axis=1)
-
-        # else, we expect multioutput to be array-like
-        return raw_values.dot(multioutput)
+        return self._handle_multioutput(raw_values, multioutput)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/performance_metrics/forecasting/_mape.py
+++ b/sktime/performance_metrics/forecasting/_mape.py
@@ -7,13 +7,13 @@ Classes named as ``*Error`` or ``*Loss`` return a value to minimize:
 the lower the better.
 """
 
-from sktime.performance_metrics.forecasting._base import BaseForecastingErrorMetricFunc
+from sktime.performance_metrics.forecasting._base import BaseForecastingErrorMetric
 from sktime.performance_metrics.forecasting._functions import (
     mean_absolute_percentage_error,
 )
 
 
-class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
+class MeanAbsolutePercentageError(BaseForecastingErrorMetric):
     r"""Mean absolute percentage error (MAPE) or symmetric MAPE.
 
     For a univariate, non-hierarchical sample
@@ -125,8 +125,6 @@ class MeanAbsolutePercentageError(BaseForecastingErrorMetricFunc):
     >>> smape(y_true, y_pred)
     np.float64(0.5668686868686869)
     """
-
-    func = mean_absolute_percentage_error
 
     def __init__(
         self,

--- a/sktime/performance_metrics/forecasting/_mse.py
+++ b/sktime/performance_metrics/forecasting/_mse.py
@@ -221,15 +221,7 @@ class MeanSquaredError(BaseForecastingErrorMetric):
 
         pseudo_values = self._get_weighted_df(pseudo_values, **kwargs)
 
-        if isinstance(multioutput, str):
-            if multioutput == "raw_values":
-                return pseudo_values
-
-            if multioutput == "uniform_average":
-                return pseudo_values.mean(axis=1)
-
-        # else, we expect multioutput to be array-like
-        return pseudo_values.dot(multioutput)
+        return self._handle_multioutput(raw_values, multioutput)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
Changes the `MeanAbsolutePercentageError` parent to `BaseForecastingErrorMetric`, from `BaseForecastingErrorMetricFunc`.

Since MAPE is a mean loss, the default `_evaluate` will do the same as the function imported.

As part of this:

* refactors by moving common internal functions `_percentage_error` and `_relative_error` to a `_common` module.
* exposes `relative_to` and `eps` as parameters in the metric

This is an architectural improvement since it makes the class self contained, and avoids dependence on the external function.

Also deduplicates multioutput handling in MAPE and MSE.