### PR TITLE
Add optional histogram storage to IndividualBOSS

### DIFF
--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -501,6 +501,9 @@ class IndividualBOSS(BaseClassifier):
         the dictionary of words is returned. If True, the array is saved, which
         can shorten the time to calculate dictionaries using a shorter
         ``word_length`` (since the last "n" letters can be removed).
+    store_histogram : bool, default = False
+        Whether to store the histograms of words in ``fit``. If False, avoids
+        storing the histograms in memory, which can be large for some datasets.
     n_jobs : int, default=1
         The number of jobs to run in parallel for both ``fit`` and ``predict``.
         ``-1`` means using all processors.
@@ -513,6 +516,12 @@ class IndividualBOSS(BaseClassifier):
         Number of classes. Extracted from the data.
     classes_ : list
         The classes labels.
+    histograms_ : list of dict
+        A list of dictionaries, where each dictionary is a word histogram for an
+        individual time series instance. The length of the list is equal to
+        the number of instances passed to ``fit``. Each dictionary maps SFA words
+        (str) to their frequency (int). Only created if ``store_histogram``
+        is ``True``.
 
     See Also
     --------
@@ -562,6 +571,7 @@ class IndividualBOSS(BaseClassifier):
         typed_dict="deprecated",
         use_boss_distance=True,
         feature_selection="none",
+        store_histogram=False,
         n_jobs=1,
         random_state=None,
     ):
@@ -574,6 +584,7 @@ class IndividualBOSS(BaseClassifier):
 
         self.save_words = save_words
         self.typed_dict = typed_dict
+        self.store_histogram = store_histogram
         self.n_jobs = n_jobs
         self.random_state = random_state
 
@@ -583,6 +594,7 @@ class IndividualBOSS(BaseClassifier):
         self._accuracy = 0
         self._subsample = []
         self._train_predictions = []
+        self.histograms_ = []
 
         super().__init__()
 
@@ -622,7 +634,38 @@ class IndividualBOSS(BaseClassifier):
         self._transformed_data = self._transformer.fit_transform(X, y)
         self._class_vals = y
 
+        if self.store_histogram:
+            self._create_histograms()
+
         return self
+
+    def _create_histograms(self):
+        if hasattr(self._transformer, "vocabulary_"):
+            vocab = self._transformer.vocabulary_
+        elif hasattr(self._transformer, "words"):
+            vocab = self._transformer.words
+        else:
+            vocab = None
+
+        if hasattr(self._transformed_data, "toarray") and vocab is not None:
+            arr = self._transformed_data.toarray()
+            if isinstance(vocab, dict):
+                if all(isinstance(v, int) for v in vocab.values()):
+                    idx_to_word = {v: k for k, v in vocab.items()}
+                else:
+                    idx_to_word = vocab
+            else:
+                idx_to_word = {i: str(i) for i in range(arr.shape[1])}
+            self.histograms_ = [
+                {
+                    str(idx_to_word[idx]): int(count)
+                    for idx, count in enumerate(row)
+                    if count > 0
+                }
+                for row in arr
+            ]
+        else:
+            self.histograms_ = self._transformed_data
 
     def _predict(self, X):
         """Predict class values of all instances in X.

--- a/sktime/classification/dictionary_based/tests/test_boss.py
+++ b/sktime/classification/dictionary_based/tests/test_boss.py
@@ -82,3 +82,51 @@ def test_boss_ensemble_classes(dataset, new_class, expected_dtype):
     # assert class type and names
     assert y_pred.dtype == expected_dtype
     assert set(y_pred) == set(y_train)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(IndividualBOSS),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_individual_boss_histograms(dataset):
+    """Test Individual BOSS histograms_ attribute type and size."""
+    X_train, y_train, _, _ = dataset
+
+    iboss = IndividualBOSS(
+        window_size=10, word_length=4, alphabet_size=2, store_histogram=True
+    )
+    iboss.fit(X_train, y_train)
+
+    assert isinstance(iboss.histograms_, list), "histograms_ should be a list"
+    assert len(iboss.histograms_) == len(X_train), (
+        f"histograms_ length ({len(iboss.histograms_)}) should be equal to "
+        f"number of training instances ({len(X_train)})"
+    )
+
+    for hist in iboss.histograms_:
+        assert isinstance(hist, dict), "each histogram should be a dict"
+        if hist:  # only check if not empty
+            key = next(iter(hist.keys()))
+            value = next(iter(hist.values()))
+            assert isinstance(key, str), (
+                f"histogram key should be str, found {type(key)}"
+            )
+            assert isinstance(value, int), (
+                f"histogram value should be int, found {type(value)}"
+            )
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(IndividualBOSS),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_individual_boss_no_histograms(dataset):
+    """Test Individual BOSS with store_histogram=False."""
+    X_train, y_train, _, _ = dataset
+
+    iboss = IndividualBOSS(
+        window_size=10, word_length=4, alphabet_size=2, store_histogram=False
+    )
+    iboss.fit(X_train, y_train)
+
+    assert iboss.histograms_ == [], "histograms_ should be an empty list"


### PR DESCRIPTION
Fixes - #8580 

This pull request introduces a new feature to the `IndividualBOSS` classifier in the `sktime` library, allowing it to optionally store histograms of words during the `fit` process. This feature is controlled by a new parameter, `store_histogram`, and is accompanied by updates to the class attributes, methods, and corresponding tests.

### Enhancements to `IndividualBOSS`:

* **New Parameter and Attribute**:
  - Added the `store_histogram` parameter (default: `False`) to the `__init__` method to control whether histograms of words are stored during `fit`. [[1]](diffhunk://#diff-fdfbdb72002f808f3d8f1a5a23fe21753b4a2e229144c5597f6394aae2447b72R574) [[2]](diffhunk://#diff-fdfbdb72002f808f3d8f1a5a23fe21753b4a2e229144c5597f6394aae2447b72R587)
  - Introduced a new attribute, `histograms_`, to store the word histograms for each time series instance when `store_histogram` is enabled. [[1]](diffhunk://#diff-fdfbdb72002f808f3d8f1a5a23fe21753b4a2e229144c5597f6394aae2447b72R519-R524) [[2]](diffhunk://#diff-fdfbdb72002f808f3d8f1a5a23fe21753b4a2e229144c5597f6394aae2447b72R597)

* **New Method for Histogram Creation**:
  - Added the `_create_histograms` method to generate and store histograms based on the transformed data, using the transformer's vocabulary. This method is invoked during `_fit` if `store_histogram` is `True`.

### Unit Tests:

* **Testing `store_histogram=True`**:
  - Added `test_individual_boss_histograms` to verify the type and size of the `histograms_` attribute when `store_histogram` is enabled. It ensures that the histograms are stored as a list of dictionaries with valid keys and values.

* **Testing `store_histogram=False`**:
  - Added `test_individual_boss_no_histograms` to confirm that the `histograms_` attribute remains an empty list when `store_histogram` is disabled.Introduces the 'store_histogram' parameter to IndividualBOSS, allowing users to optionally store word histograms for each training instance. Updates the class to document and implement this feature, and adds tests to verify correct behavior when histograms are stored or omitted.

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
