### PR TITLE
[MNT] granular test runs in CI in single-estimator VM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,7 @@ jobs:
         env:
           FLAG: ${{ matrix.flag }}
         shell: bash
-        run: python -c "from sktime.tests._test_vm import run_test_vm; run_test_vm('${{ matrix.flag }}')"
+        run: pytest build_tools/check_estimator.py --estimator ${{ matrix.flag }}
 
   detect-package-change:
     needs: code-quality

--- a/build_tools/check_estimator.py
+++ b/build_tools/check_estimator.py
@@ -1,0 +1,54 @@
+"""Console accessible pytest script to check a single estimator.
+
+Used in test-est job for single-estimator-VM, and for manual testing via pytest.
+"""
+
+import pytest
+
+from sktime.utils.estimator_checks import _get_test_names_from_class, check_estimator
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--estimator",
+        action="store",
+        default="__none__",
+        help="Custom string parameter for this file",
+    )
+
+
+def pytest_generate_tests(metafunc):
+    estimator = metafunc.config.getoption("estimator")
+
+    if estimator == "__none__":
+        pytest.skip("No estimator specified, skipping test.")
+    elif "estimator" in metafunc.fixturenames:
+        metafunc.parametrize("estimator", [estimator], ids=[estimator])
+
+    if "test_name" in metafunc.fixturenames:
+        from sktime.utils.estimator_checks import _get_test_names_from_class
+
+        test_names = _get_test_names_from_class(estimator)
+        metafunc.parametrize("test_name", test_names, ids=test_names)
+
+
+def test_sktime_compatible_estimator(estimator, test_name):
+    from sktime.registry import craft
+    from sktime.utils.dependencies import _check_estimator_deps
+    from sktime.utils.estimator_checks import check_estimator
+
+    cls = craft(estimator)
+    if not _check_estimator_deps(cls, severity="none"):
+        print(
+            f"Skipping estimator: {cls} due to incompatibility "
+            "with python or OS version."
+        )
+        return None
+
+    skips = cls.get_class_tag("tests:skip_by_name", None)
+    check_estimator(
+        cls,
+        raise_exceptions=True,
+        tests_to_run=test_name,
+        tests_to_exclude=skips;
+    )

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -178,8 +178,7 @@ class ChronosBoltStrategy(ChronosModelStrategy):
 
 
 class ChronosForecaster(BaseForecaster):
-    """
-    Interface to the Chronos and Chronos-Bolt Zero-Shot Forecaster by Amazon Research.
+    """Chronos and Chronos-Bolt Zero-Shot Forecaster by Amazon Research.
 
     Chronos and Chronos-Bolt are pretrained time-series foundation models
     developed by Amazon for time-series forecasting. This method has been


### PR DESCRIPTION
The single-estimator VM currently run a single test with all tests dispatched to by `check_estimator`, which makes diagnostics of individual failures difficult.

This PR splits the single tests into multiple, by adding a `check_estimator.py` file in the build tools which generates and runs all tests from a pytest console command, separately.

To test this change, a minimal docstring change is made to `ChronosForecaster` in order to trigger the VM runs.