### PR TITLE
[MNT] turn off `pytest-xdist` parallelization in single-estimator VM tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,7 @@ jobs:
         env:
           FLAG: ${{ matrix.flag }}
         shell: bash
-        run: pytest -v build_tools/check_estimator.py --estimator ${{ matrix.flag }}
+        run: pytest -v -n0 build_tools/check_estimator.py --estimator ${{ matrix.flag }}
 
   detect-package-change:
     needs: code-quality


### PR DESCRIPTION
This PR turns off `pytest-xdist` parallelization in single-estimator VM tests