### PR TITLE
[BUG] isolate imports in momentFM and moirai foundation model vendor libraries

### DIFF
--- a/sktime/libs/momentfm/models/layers/embed.py
+++ b/sktime/libs/momentfm/models/layers/embed.py
@@ -3,13 +3,12 @@
 import math
 import warnings
 
-from skbase.utils.dependencies import _check_soft_dependencies
-
 from sktime.libs.momentfm.utils.masking import Masking
+from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
 
 if _check_soft_dependencies(["torch"], severity="none"):
-    import torch
-    import torch.nn as nn
+    torch = _safe_import("torch")
+    nn = _safe_import("torch.nn")
 
     class PositionalEmbedding(nn.Module):
         """Positional Embedding."""

--- a/sktime/libs/momentfm/models/layers/revin.py
+++ b/sktime/libs/momentfm/models/layers/revin.py
@@ -1,10 +1,10 @@
 """Layer revin file."""
 
-from skbase.utils.dependencies import _check_soft_dependencies
+from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
 
 if _check_soft_dependencies(["torch"], severity="none"):
-    import torch
-    from torch import nn
+    torch = _safe_import("torch")
+    nn = _safe_import("torch.nn")
 
     def nanvar(tensor, dim=None, keepdim=False):
         """Calculate the variance of all non-NaN elements."""

--- a/sktime/libs/momentfm/models/moment.py
+++ b/sktime/libs/momentfm/models/moment.py
@@ -6,8 +6,6 @@ from argparse import Namespace
 from copy import deepcopy
 from math import ceil
 
-from skbase.utils.dependencies import _check_soft_dependencies
-
 from sktime.libs.momentfm.common import TASKS
 from sktime.libs.momentfm.data.base import TimeseriesOutputs
 from sktime.libs.momentfm.models.layers.embed import PatchEmbedding, Patching
@@ -18,6 +16,7 @@ from sktime.libs.momentfm.utils.utils import (
     get_anomaly_criterion,
     get_huggingface_model_dimensions,
 )
+from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
 
 SUPPORTED_HUGGINGFACE_MODELS = [
     "google/flan-t5-small",
@@ -30,10 +29,13 @@ SUPPORTED_HUGGINGFACE_MODELS = [
 if _check_soft_dependencies(
     ["torch", "huggingface-hub", "transformers"], severity="none"
 ):
-    import torch
-    from huggingface_hub import PyTorchModelHubMixin
-    from torch import nn
-    from transformers import T5Config, T5EncoderModel, T5Model
+    torch = _safe_import("torch")
+    nn = _safe_import("torch.nn")
+    huggingface_hub = _safe_import("huggingface_hub")
+    T5Config = _safe_import("transformers.T5Config")
+    T5EncoderModel = _safe_import("transformers.T5EncoderModel")
+    T5Model = _safe_import("transformers.T5Model")
+    PyTorchModelHubMixin = _safe_import("huggingface_hub.PyTorchModelHubMixin")
 
     class PretrainHead(nn.Module):
         """Pretrained Head."""
@@ -82,7 +84,7 @@ if _check_soft_dependencies(
                     f"Only 'mean' and 'concat' are supported."
                 )
 
-        def forward(self, x, input_mask: torch.Tensor = None):
+        def forward(self, x, input_mask=None):
             """Forward Function."""
             x = torch.mean(x, dim=1)
             x = self.dropout(x)
@@ -103,7 +105,7 @@ if _check_soft_dependencies(
             self.dropout = nn.Dropout(head_dropout)
             self.linear = nn.Linear(head_nf, forecast_horizon)
 
-        def forward(self, x, input_mask: torch.Tensor = None):
+        def forward(self, x, input_mask=None):
             """Forward Function."""
             x = self.flatten(x)
             x = self.linear(x)
@@ -195,7 +197,7 @@ if _check_soft_dependencies(
                 warnings.warn("Patch stride length is not equal to patch length.")
             return config
 
-        def _get_head(self, task_name: str) -> nn.Module:
+        def _get_head(self, task_name: str):
             if task_name == TASKS.RECONSTRUCTION:
                 return PretrainHead(
                     self.config.d_model,
@@ -227,7 +229,7 @@ if _check_soft_dependencies(
             else:
                 raise NotImplementedError(f"Task {task_name} not implemented.")
 
-        def _get_transformer_backbone(self, config) -> nn.Module:
+        def _get_transformer_backbone(self, config):
             if config.getattr("randomly_initialize_backbone", False):
                 model_config = T5Config.from_pretrained(config.transformer_backbone)
                 transformer_backbone = T5Model(model_config)
@@ -258,8 +260,8 @@ if _check_soft_dependencies(
 
         def embed(
             self,
-            x_enc: torch.Tensor,
-            input_mask: torch.Tensor = None,
+            x_enc,
+            input_mask=None,
             reduction: str = "mean",
             **kwargs,
         ) -> TimeseriesOutputs:
@@ -314,9 +316,9 @@ if _check_soft_dependencies(
 
         def reconstruction(
             self,
-            x_enc: torch.Tensor,
-            input_mask: torch.Tensor = None,
-            mask: torch.Tensor = None,
+            x_enc,
+            input_mask=None,
+            mask=None,
             **kwargs,
         ) -> TimeseriesOutputs:
             """Reconstruction Function."""
@@ -373,9 +375,9 @@ if _check_soft_dependencies(
 
         def reconstruct(
             self,
-            x_enc: torch.Tensor,
-            input_mask: torch.Tensor = None,
-            mask: torch.Tensor = None,
+            x_enc,
+            input_mask=None,
+            mask=None,
             **kwargs,
         ) -> TimeseriesOutputs:
             """Reconstruct Function."""
@@ -436,8 +438,8 @@ if _check_soft_dependencies(
 
         def detect_anomalies(
             self,
-            x_enc: torch.Tensor,
-            input_mask: torch.Tensor = None,
+            x_enc,
+            input_mask=None,
             anomaly_criterion: str = "mse",
             **kwargs,
         ) -> TimeseriesOutputs:
@@ -455,7 +457,7 @@ if _check_soft_dependencies(
             )
 
         def forecast(
-            self, x_enc: torch.Tensor, input_mask: torch.Tensor = None, **kwargs
+            self, x_enc, input_mask=None, **kwargs
         ) -> TimeseriesOutputs:
             """Forecast Function."""
             batch_size, n_channels, seq_len = x_enc.shape
@@ -487,8 +489,8 @@ if _check_soft_dependencies(
 
         def short_forecast(
             self,
-            x_enc: torch.Tensor,
-            input_mask: torch.Tensor = None,
+            x_enc,
+            input_mask=None,
             forecast_horizon: int = 1,
             **kwargs,
         ) -> TimeseriesOutputs:
@@ -543,8 +545,8 @@ if _check_soft_dependencies(
 
         def classify(
             self,
-            x_enc: torch.Tensor,
-            input_mask: torch.Tensor = None,
+            x_enc,
+            input_mask=None,
             reduction: str = "concat",
             **kwargs,
         ) -> TimeseriesOutputs:
@@ -603,9 +605,9 @@ if _check_soft_dependencies(
 
         def forward(
             self,
-            x_enc: torch.Tensor,
-            mask: torch.Tensor = None,
-            input_mask: torch.Tensor = None,
+            x_enc,
+            mask=None,
+            input_mask=None,
             **kwargs,
         ) -> TimeseriesOutputs:
             """Forward Function."""

--- a/sktime/libs/momentfm/utils/forecasting_metrics.py
+++ b/sktime/libs/momentfm/utils/forecasting_metrics.py
@@ -6,15 +6,15 @@ from typing import Optional, Union
 
 import numpy as np
 import numpy.typing as npt
-from skbase.utils.dependencies import _check_soft_dependencies
 
-from .utils import _reduce
+from sktime.libs.momentfm.utils import _reduce
+from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
 
 if _check_soft_dependencies(["torch"], severity="none"):
-    import torch
-    import torch.nn.functional as F
-    from torch import Tensor
-    from torch.nn.modules.loss import _Loss
+    torch = _safe_import("torch")
+    F = _safe_import("torch.nn.functional")
+    Tensor = _safe_import("torch.Tensor")
+    _Loss = _safe_import("torch.nn.modules.loss._Loss")
 
     class sMAPELoss(_Loss):
         """sMAPELoss class."""
@@ -36,7 +36,7 @@ if _check_soft_dependencies(["torch"], severity="none"):
             div[div == float("inf")] = 0.0
             return div
 
-        def forward(self, input: Tensor, target: Tensor) -> Tensor:
+        def forward(self, input, target):
             """Forward function."""
             delta_y = self._abs(input - target)
             scale = self._abs(target) + self._abs(input)

--- a/sktime/libs/momentfm/utils/masking.py
+++ b/sktime/libs/momentfm/utils/masking.py
@@ -2,10 +2,10 @@
 
 from typing import Optional
 
-from skbase.utils.dependencies import _check_soft_dependencies
+from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
 
 if _check_soft_dependencies(["torch"], severity="none"):
-    import torch
+    torch = _safe_import("torch")
 
     class Masking:
         """Masking Module."""
@@ -26,7 +26,7 @@ if _check_soft_dependencies(["torch"], severity="none"):
 
         @staticmethod
         def convert_seq_to_patch_view(
-            mask: torch.Tensor, patch_len: int = 8, stride: Optional[int] = None
+            mask, patch_len: int = 8, stride: Optional[int] = None
         ):
             """Convert sequence to patch function.
 
@@ -42,7 +42,7 @@ if _check_soft_dependencies(["torch"], severity="none"):
 
         @staticmethod
         def convert_patch_to_seq_view(
-            mask: torch.Tensor,
+            mask,
             patch_len: int = 8,
         ):
             """Convert patch to sequence function.
@@ -54,9 +54,7 @@ if _check_soft_dependencies(["torch"], severity="none"):
             """
             return mask.repeat_interleave(patch_len, dim=-1)
 
-        def generate_mask(
-            self, x: torch.Tensor, input_mask: Optional[torch.Tensor] = None
-        ):
+        def generate_mask(self, x, input_mask=None):
             """Generate Mask Function.
 
             Input:

--- a/sktime/libs/momentfm/utils/utils.py
+++ b/sktime/libs/momentfm/utils/utils.py
@@ -5,10 +5,11 @@ import random
 from argparse import Namespace
 
 import numpy as np
-from skbase.utils.dependencies import _check_soft_dependencies
+
+from sktime.utils.dependencies import _check_soft_dependencies, _safe_import
 
 if _check_soft_dependencies(["torch", "transformers"], severity="none"):
-    import torch
+    torch = _safe_import("torch")
 
     def control_randomness(seed: int = 13):
         """Control randomness seed function."""

--- a/sktime/libs/uni2ts/distribution/__init__.py
+++ b/sktime/libs/uni2ts/distribution/__init__.py
@@ -1,6 +1,8 @@
 """`distributions` module of `uni2ts` library."""
 
-from skbase.utils.dependencies import _check_soft_dependencies
+from sktime.libs.uni2ts.distribution._base import AffineTransformed, DistributionOutput
 
-if _check_soft_dependencies("torch", severity="none"):
-    from ._base import AffineTransformed, DistributionOutput
+__all__ = [
+    "AffineTransformed",
+    "DistributionOutput",
+]

--- a/sktime/libs/uni2ts/forecast.py
+++ b/sktime/libs/uni2ts/forecast.py
@@ -19,28 +19,19 @@ from copy import deepcopy
 from typing import Any, Optional
 
 import numpy as np
-from skbase.utils.dependencies import _check_soft_dependencies
 
+from sktime.libs.uni2ts.common.torch_util import safe_div
+from sktime.libs.uni2ts.loss.packed import PackedNLLLoss as _PackedNLLLoss
+from sktime.libs.uni2ts.moirai_module import MoiraiModule
 from sktime.utils.dependencies import _safe_import
 
-if _check_soft_dependencies("lightning", severity="none"):
-    import lightning as L
+L = _safe_import("lightning")
 
-else:
-    # Create Dummy class
-    class L:
-        class LightningModule:
-            pass
+torch = _safe_import("torch")
 
-
-if _check_soft_dependencies("torch", severity="none"):
-    import torch
-
-    from .moirai_module import MoiraiModule
-
-if _check_soft_dependencies("einops", severity="none"):
-    from einops import rearrange, reduce, repeat
-
+rearrange = _safe_import("einops.rearrange")
+reduce = _safe_import("einops.reduce")
+repeat = _safe_import("einops.repeat")
 Input = _safe_import("gluonts.model.Input")
 InputSpec = _safe_import("gluonts.model.InputSpec")
 
@@ -54,10 +45,6 @@ ExpandDimArray = _safe_import("gluonts.transform.ExpandDimArray")
 TestSplitSampler = _safe_import("gluonts.transform.TestSplitSampler")
 
 TFTInstanceSplitter = _safe_import("gluonts.transform.split.TFTInstanceSplitter")
-
-
-from sktime.libs.uni2ts.common.torch_util import safe_div
-from sktime.libs.uni2ts.loss.packed import PackedNLLLoss as _PackedNLLLoss
 
 
 class SampleNLLLoss(_PackedNLLLoss):

--- a/sktime/libs/uni2ts/moirai_module.py
+++ b/sktime/libs/uni2ts/moirai_module.py
@@ -1,50 +1,25 @@
 from functools import partial
 
-from skbase.utils.dependencies import _check_soft_dependencies
-
-if _check_soft_dependencies("torch", severity="none"):
-    import torch.nn.functional as F
-    from torch import nn
-    from torch.utils._pytree import tree_map
-
-    from .distribution import DistributionOutput
-    from .module.norm import RMSNorm
-    from .module.position import (
-        BinaryAttentionBias,
-        QueryKeyProjection,
-        RotaryProjection,
-    )
-    from .module.transformer import TransformerEncoder
-    from .module.ts_embed import MultiInSizeLinear
-else:
-
-    class nn:
-        class Module:
-            pass
-
-    class DistributionOutput:
-        pass
+from sktime.utils.dependencies import _safe_import
 
 
-if _check_soft_dependencies("huggingface-hub", severity="none"):
-    from huggingface_hub import PyTorchModelHubMixin
-else:
-    # Create Dummy class
-    class PyTorchModelHubMixin:
-        def __init__(self):
-            pass
+F = _safe_import("torch.nn.functional")
+nn = _safe_import("torch.nn")
+tree_map = _safe_import("torch.utils._pytree.tree_map")
 
-        def __init_subclass__(cls, *args, **kwargs) -> None:
-            """Implement dummy version of __init_subclass__."""
-            pass
+from sktime.libs.uni2ts.common.torch_util import mask_fill, packed_attention_mask
+from sktime.libs.uni2ts.distribution import DistributionOutput
+from sktime.libs.uni2ts.module.norm import RMSNorm
+from sktime.libs.uni2ts.module.packed_scaler import PackedNOPScaler, PackedStdScaler
+from sktime.libs.uni2ts.module.position import (
+    BinaryAttentionBias,
+    QueryKeyProjection,
+    RotaryProjection,
+)
+from sktime.libs.uni2ts.module.transformer import TransformerEncoder
+from sktime.libs.uni2ts.module.ts_embed import MultiInSizeLinear
 
-        pass
-
-
-if _check_soft_dependencies("einops", severity="none"):
-    from .module.packed_scaler import PackedNOPScaler, PackedStdScaler
-
-from .common.torch_util import mask_fill, packed_attention_mask
+PyTorchModelHubMixin = _safe_import("huggingface_hub.PyTorchModelHubMixin")
 
 
 def encode_distr_output(


### PR DESCRIPTION
Isolates imports in the momentFM and moirai foundation model vendor libraries, to prevent broken imports through `huggingface_hub` broken imports.

Uses `_safe_import` utility for isolation, replacing ad-hoc isolation.