### PR TITLE
[MNT] Upgrade CI to set `test-full` to use `macos-latest` runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -457,7 +457,7 @@ jobs:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, macos-13, windows-latest, ubuntu-22.04-arm]
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Small change to update macos-runners in `test-full` to use `macos-latest` @fkiraly 