### PR TITLE
[MNT] remove `requires_cython` tag and separate VM handling in favour of `tests:vm`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -345,37 +345,6 @@ jobs:
       - name: Run tests
         run: make test_mlflow
 
-  test-cython-estimators:
-    needs: test-nosoftdeps
-    runs-on: macos-13
-    steps:
-      - uses: actions/checkout@v4
-
-      - run: git remote set-branches origin 'main'
-
-      - run: git fetch --depth 1
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
-
-      - name: Install OSX packages
-        shell: bash
-        run: ./.github/scripts/install_osx_dependencies.sh
-
-      - name: Install sktime and dependencies
-        run: |
-          python -m pip install .[dev,cython_extras] --no-cache-dir
-
-      - name: Show dependencies
-        run: python -m pip list
-
-      - name: Run tests
-        run: make PYTESTOPTIONS="--only_cython_estimators=True --matrixdesign=False --timeout=600" test_check_suite
-
   test-lowerdeps:
     needs: test-nosoftdeps
     runs-on: ubuntu-latest

--- a/sktime/classification/shapelet_based/_mrseql.py
+++ b/sktime/classification/shapelet_based/_mrseql.py
@@ -42,11 +42,13 @@ class MrSEQL(_DelegatedClassifier):
         # --------------
         "authors": ["lnthach", "heerme", "fkiraly"],
         "maintainers": ["lnthach", "heerme", "fkiraly"],
-        "python_dependencies": "mrseql",
-        "requires_cython": True,
+        "python_dependencies": ["mrseql", "numba"],
         # estimator type
         # --------------
         "X_inner_mtype": "nested_univ",
+        # testing configuration
+        # ---------------------
+        "tests:vm": True,
     }
 
     def __init__(

--- a/sktime/classification/shapelet_based/_mrsqm.py
+++ b/sktime/classification/shapelet_based/_mrsqm.py
@@ -52,11 +52,13 @@ class MrSQM(_DelegatedClassifier):
         # --------------
         "authors": ["lnthach", "heerme", "fkiraly"],
         "maintainers": ["lnthach", "heerme", "fkiraly"],
-        "python_dependencies": "mrsqm",
-        "requires_cython": True,
+        "python_dependencies": ["mrsqm", "numba"],
         # estimator type
         # --------------
         "X_inner_mtype": "nested_univ",
+        # testing configuration
+        # ---------------------
+        "tests:vm": True,
     }
 
     def __init__(

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -208,7 +208,6 @@ class python_version(_BaseTag):
     - ``"python_version"``: Python version specifier (PEP 440) for the object,
     - ``"python_dependencies"``: list of required Python packages (PEP 440)
     - ``"env_marker"``: environment marker for the object (PEP 508)
-    - ``"requires_cython"``: whether the object requires a C compiler present
 
     The ``python_version`` tag of an object is a PEP 440 compliant version specifier
     string, specifying python version compatibility of the object.

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -206,10 +206,7 @@ class BaseFixtureGenerator:
         # TODO(fangelim): refactor this _all_estimators
         # to make it possible to set custom tags to filter
         # as class attributes, similar to `estimator_type_filter`
-        if CYTHON_ESTIMATORS:
-            filter_tags = {"requires_cython": True, "tests:skip_all": False}
-        else:
-            filter_tags = {"tests:skip_all": False}
+        filter_tags = {"tests:skip_all": False}
 
         est_list = all_estimators(
             estimator_types=getattr(self, "estimator_type_filter", None),


### PR DESCRIPTION
This PR removes the `requires_cython` tag and related extra CI by replacing it with the more broad `tests:vm` tag for the two estimators affected, `MrSQM` and `MrSEQL`.

As the tag was used only in `sktime` internal testing, no deprecation is required.