### PR TITLE
[ENH] remove `esig` soft dependency and move `esig` based estimators to own test VM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ all_extras = [
   'dask<2025.2.1,>2024.8.2; extra == "dataframe" and python_version < "3.13"',
   'dtaidistance<2.4; python_version < "3.13"',
   'dtw-python; python_version < "3.13"',
-  'esig==0.9.7; python_version < "3.10" and platform_machine != "aarch64"',
   'filterpy>=1.4.5; python_version < "3.11"',
   'gluonts>=0.9; python_version < "3.13"',
   'h5py; python_version < "3.12"',
@@ -126,7 +125,6 @@ all_extras_pandas2 = [
   'dask<2025.2.1,>2024.8.2; extra == "dataframe" and python_version < "3.13"',
   'dtaidistance<2.4; python_version < "3.13"',
   'dtw-python; python_version < "3.13"',
-  'esig==0.9.7; python_version < "3.10" and platform_machine != "aarch64"',
   'filterpy>=1.4.5; python_version < "3.11"',
   'gluonts>=0.9; python_version < "3.13"',
   'h5py; python_version < "3.12"',
@@ -178,7 +176,6 @@ annotation = [
   'pyod<1.2,>=0.8; python_version < "3.12"',
 ]
 classification = [
-  'esig<0.10,>=0.9.7; python_version < "3.11" and platform_machine != "aarch64"',
   'numba<0.62,>=0.53; python_version < "3.13"',
   'tensorflow<2.20,>=2; python_version < "3.13"',
   'tsfresh<0.21,>=0.17; python_version < "3.12"',
@@ -217,7 +214,6 @@ regression = [
   'tensorflow<2.20,>=2; python_version < "3.13"',
 ]
 transformations = [
-  'esig<0.10,>=0.9.7; python_version < "3.11" and platform_machine != "aarch64"',
   'filterpy<1.5,>=1.4.5; python_version < "3.13"',
   'holidays>=0.29,<0.59; python_version < "3.13"',
   'mne>=1.5,<1.9; python_version < "3.13"',

--- a/sktime/classification/feature_based/_signature_classifier.py
+++ b/sktime/classification/feature_based/_signature_classifier.py
@@ -102,6 +102,14 @@ class SignatureClassifier(BaseClassifier):
         "capability:multivariate": True,
         "capability:predict_proba": True,
         "classifier_type": "feature",
+        # testing configuration
+        # ---------------------
+        "tests:libs": ["sktime.transformations.panel.signature_based"],
+        "tests:skip_by_name": [  # tagged in issue #2490
+            "test_classifier_on_unit_test_data",
+            "test_classifier_on_basic_motions",
+        ],
+        "tests:vm": True,
     }
 
     def __init__(
@@ -235,10 +243,12 @@ class SignatureClassifier(BaseClassifier):
         """
         if parameter_set == "results_comparison":
             return {"estimator": RandomForestClassifier(n_estimators=10)}
-        else:
-            return {
-                "estimator": RandomForestClassifier(n_estimators=2),
-                "augmentation_list": ("basepoint", "addtime"),
-                "depth": 1,
-                "window_name": "global",
-            }
+
+        params0 = {}
+        params1 = {
+            "estimator": RandomForestClassifier(n_estimators=2),
+            "augmentation_list": ("basepoint", "addtime"),
+            "depth": 1,
+            "window_name": "global",
+        }
+        return [params0, params1]

--- a/sktime/classification/feature_based/_signature_classifier.py
+++ b/sktime/classification/feature_based/_signature_classifier.py
@@ -95,8 +95,7 @@ class SignatureClassifier(BaseClassifier):
         # --------------
         "authors": "jambo6",
         "maintainers": "jambo6",
-        "python_dependencies": ["esig", "numpy<2.0"],
-        "python_version": "<3.10",
+        "python_dependencies": ["esig"],
         # estimator type
         # --------------
         "capability:multivariate": True,

--- a/sktime/classification/tests/_classification_test_reproduction.py
+++ b/sktime/classification/tests/_classification_test_reproduction.py
@@ -19,7 +19,6 @@ from sktime.classification.feature_based import (
     Catch22Classifier,
     MatrixProfileClassifier,
     RandomIntervalClassifier,
-    SignatureClassifier,
     SummaryClassifier,
 )
 from sktime.classification.hybrid import HIVECOTEV1, HIVECOTEV2
@@ -275,22 +274,6 @@ if __name__ == "__main__":
                 ),
                 estimator=RandomForestClassifier(n_estimators=10),
                 random_state=0,
-            )
-        ),
-    )
-    _print_array(
-        "SignatureClassifier - UnitTest",
-        _reproduce_classification_unit_test(
-            SignatureClassifier(
-                estimator=RandomForestClassifier(n_estimators=10), random_state=0
-            )
-        ),
-    )
-    _print_array(
-        "SignatureClassifier - BasicMotions",
-        _reproduce_classification_basic_motions(
-            SignatureClassifier(
-                estimator=RandomForestClassifier(n_estimators=10), random_state=0
             )
         ),
     )

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -108,11 +108,6 @@ EXCLUDED_TESTS = {
     "StackingForecaster": ["test_predict_time_index_with_X"],
     # known side effects on multivariate arguments, #2072
     "WindowSummarizer": ["test_methods_have_no_side_effects"],
-    # tagged in issue #2490
-    "SignatureClassifier": [
-        "test_classifier_on_unit_test_data",
-        "test_classifier_on_basic_motions",
-    ],
     # pickling problem with local method see #2490
     "ProximityStump": [
         "test_persistence_via_pickle",
@@ -359,8 +354,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "SeededBinarySegmentation",
         "ShapeletTransform",
         "ShapeletTransformClassifier",
-        "SignatureClassifier",
-        "SignatureTransformer",
         "SlidingWindowSegmenter",
         "SlopeTransformer",
         "StackingForecaster",

--- a/sktime/tests/test_softdeps.py
+++ b/sktime/tests/test_softdeps.py
@@ -26,7 +26,7 @@ from sktime.utils.dependencies import _check_python_version, _check_soft_depende
 # excludes estimators, only for soft dependencies used in non-estimator modules
 SOFT_DEPENDENCIES = {
     "sktime.benchmarking.evaluation": ["matplotlib"],
-    "sktime.benchmarking.experiments": ["tsfresh", "esig"],
+    "sktime.benchmarking.experiments": ["tsfresh"],
     "sktime.classification.deep_learning": ["tensorflow"],
     "sktime.regression.deep_learning": ["tensorflow"],
     "sktime.networks": ["tensorflow"],

--- a/sktime/transformations/panel/signature_based/_compute.py
+++ b/sktime/transformations/panel/signature_based/_compute.py
@@ -34,7 +34,6 @@ class _WindowSignatureTransform(BaseTransformer):
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for X?
         "fit_is_empty": True,
         "python_dependencies": "esig",
-        "python_version": "<3.10",
     }
 
     def __init__(

--- a/sktime/transformations/panel/signature_based/_signature_method.py
+++ b/sktime/transformations/panel/signature_based/_signature_method.py
@@ -21,8 +21,8 @@ class SignatureTransformer(BaseTransformer):
 
     Parameters
     ----------
-    augmentation_list: list or tuple of strings, possible strings are
-        ['leadlag', 'ir', 'addtime', 'cumsum', 'basepoint']
+    augmentation_list: list or tuple of strings, 
+        possible strings are ``['leadlag', 'ir', 'addtime', 'cumsum', 'basepoint']``
         Augmentations to apply to the data before computing the signature.
         The order of the augmentations is the order in which they are applied.
         default: ('basepoint', 'addtime')
@@ -38,15 +38,20 @@ class SignatureTransformer(BaseTransformer):
     window_step: None (default) or int
         The step of the sliding/expanding window.
         Ignored unless ``window_name`` is one of ``['sliding, 'expanding']``.
+
     rescaling: None (default) or str, "pre" or "post",
-        None: No rescaling is applied.
-        "pre": rescale the path last signature term should be roughly O(1)
-        "post": Rescales the output signature by multiplying the depth-d term by d!.
-            Aim is that every term becomes ~O(1).
+
+        * None: No rescaling is applied.
+        * "pre": rescale the path last signature term should be roughly O(1)
+        * "post": Rescales the output signature by multiplying the depth-d term by d!.
+          Aim is that every term becomes ~O(1).
+
     sig_tfm: str, one of ``['signature', 'logsignature']``. default: ``'signature'``
         The type of signature transform to use, plain or logarithmic.
+
     depth: int, default=4
         Signature truncation depth.
+
     backend: str, one of: ``'esig'`` (default), or ``'iisignature'``.
         The backend to use for signature computation.
 
@@ -73,6 +78,10 @@ class SignatureTransformer(BaseTransformer):
         "X_inner_mtype": "numpy3D",  # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for X?#
         "fit_is_empty": False,
+        # testing configuration
+        # ---------------------
+        "tests:libs": ["sktime.transformations.panel.signature_based"],
+        "tests:vm": True,
     }
 
     def __init__(
@@ -167,9 +176,10 @@ class SignatureTransformer(BaseTransformer):
             instance.
             ``create_test_instance`` uses the first (or only) dictionary in ``params``
         """
-        params = {
+        params0 = {}
+        params1 = {
             "augmentation_list": ("basepoint", "addtime"),
             "depth": 3,
             "window_name": "global",
         }
-        return params
+        return [params0, params1]

--- a/sktime/transformations/panel/signature_based/_signature_method.py
+++ b/sktime/transformations/panel/signature_based/_signature_method.py
@@ -66,8 +66,7 @@ class SignatureTransformer(BaseTransformer):
         # --------------
         "authors": "jambo6",
         "maintainers": "jambo6",
-        "python_dependencies": ["esig", "numpy<2.0"],
-        "python_version": "<3.10",
+        "python_dependencies": ["esig"],
         # estimator type
         # --------------
         "scitype:transform-input": "Series",

--- a/sktime/transformations/panel/signature_based/_signature_method.py
+++ b/sktime/transformations/panel/signature_based/_signature_method.py
@@ -21,7 +21,7 @@ class SignatureTransformer(BaseTransformer):
 
     Parameters
     ----------
-    augmentation_list: list or tuple of strings, 
+    augmentation_list: list or tuple of strings,
         possible strings are ``['leadlag', 'ir', 'addtime', 'cumsum', 'basepoint']``
         Augmentations to apply to the data before computing the signature.
         The order of the augmentations is the order in which they are applied.


### PR DESCRIPTION
The `esig` package is sporadically maintained and currently pinned in soft dependency sets, which restricts versions and may cause future degradation.

This PR removes these dependencies and adds the `"tests:vm"` tag to `esig` based estimators.

Also contains minor changes:

* second test parameter sets for aforementioned estimators
* fills `"tests:libs"` tag with correct internal dependencies
* widens bounds for `esig` based estimtors due to release of 1.0.0