### PR TITLE
[MNT] partial revert of #7715 for `test-cython-estimators` job.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -347,7 +347,7 @@ jobs:
 
   test-cython-estimators:
     needs: test-nosoftdeps
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Partially reverts https://github.com/sktime/sktime/pull/7715 for `test-cython-estimators` job, since this apparently prevents `mysqm` from building.