### PR TITLE
[DOC]Corrected typos in examples/02 classification.ipynb

### DIFF
--- a/examples/02_classification.ipynb
+++ b/examples/02_classification.ipynb
@@ -2574,7 +2574,7 @@
     "for panel tasks such as TSC, TSR, clustering, there are two distinctions to be aware of:\n",
     "\n",
     "* series-to-series transformers transform individual series to series, panels to panels. E.g., instance-wise detrender above\n",
-    "* series-to-primitive transformers transform individual series to a set of tabular features. E>g., summary feature extractor\n",
+    "* series-to-primitive transformers transform individual series to a set of tabular features. E.g., summary feature extractor\n",
     "\n",
     "either type of transform can be instance-wise:\n",
     "\n",


### PR DESCRIPTION
Change the typo E>g in examples/02 classification.ipynb to E.g