### PR TITLE
[DOC] minor fixes to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ sktime also provides **interfaces to related libraries**, for example [scikit-le
 For troubleshooting and detailed installation instructions, see the [documentation](https://www.sktime.net/en/latest/installation.html).
 
 - **Operating system**: macOS X · Linux · Windows 8.1 or higher
-- **Python version**: Python 3.8, 3.9, 3.10, 3.11, and 3.12 (only 64-bit)
+- **Python version**: Python 3.9, 3.10, 3.11, 3.12, and 3.13 (only 64-bit)
 - **Package managers**: [pip] · [conda] (via `conda-forge`)
 
 [pip]: https://pip.pypa.io/en/stable/

--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -9,9 +9,9 @@ or control its behavior.
 
 Tags are key-value pairs, where the key is a string with the name of the tag.
 The value of the tag can have arbitrary type, and describes a property, capability,
-or controls behaviour of the object, depending on the value.
+or controls behaviour of the object, depending on the tag.
 
-For instance, a forecaster may have the tag ``"capability:pred_int": True`` if it can
+For instance, a forecaster has the tag ``"capability:pred_int": True`` if it can
 make probabilistic predictions.
 Users can find all forecasters that can make probabilistic predictions by filtering
 for this tag.
@@ -21,6 +21,9 @@ for their usage.
 
 To search estimators by tags on the ``sktime`` webpage, use the
 :doc:`Estimator Search Page </estimator_overview>`
+
+To search estimators by tags in a python environment, use the
+``sktime.registry.all_estimators`` utility.
 
 
 Inspecting tags, retrieving by tags

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -532,7 +532,7 @@ class tests__skip_all(_BaseTag):
 
 
 class tests__skip_by_name(_BaseTag):
-    """Whether to spin up a separate VM to test the estimator.
+    """A list of test names that should be skipped for this object.
 
     Part of packaging metadata for the object, used only in ``sktime`` CI.
 
@@ -2178,7 +2178,7 @@ class inner_implements_multilevel(_BaseTag):
 
 
 class x_inner_mtype(_BaseTag):
-    """The machine type(s) the transformer can deal with internally for X.
+    """The machine type(s) the estimator can deal with internally for X.
 
     - String name: ``"X_inner_mtype"``
     - Extension developer tag
@@ -2249,7 +2249,7 @@ class x_inner_mtype(_BaseTag):
 
 
 class y_inner_mtype(_BaseTag):
-    """The machine type(s) the transformer can deal with internally for y.
+    """The machine type(s) the estimator can deal with internally for y.
 
     - String name: ``"y_inner_mtype"``
     - Extension developer tag


### PR DESCRIPTION
Minor fixes to documentation:

* correct python versions in README
* correct tag documentation
* add reference higher up to `all_estimators` in tag API reference