### PR TITLE
[ENH] `ForecastingHorizon` based splitter

### DIFF
--- a/docs/source/api_reference/split.rst
+++ b/docs/source/api_reference/split.rst
@@ -57,6 +57,7 @@ They have tag ``"split_type"="temporal"``.
     expandingcutoff.ExpandingCutoffSplitter
     expandinggreedy.ExpandingGreedySplitter
     expandingslidingwindow.ExpandingSlidingWindowSplitter
+    fh.ForecastingHorizonSplitter
     temporal_train_test_split.TemporalTrainTestSplitter
 
 Time index splitter composition

--- a/sktime/forecasting/model_evaluation/_functions.py
+++ b/sktime/forecasting/model_evaluation/_functions.py
@@ -430,7 +430,7 @@ def evaluate(
 
     The experiment run is the following:
 
-    In  case of non-global evaluation (cv_global=None):
+    In case of non-global evaluation (cv_global=None):
 
     Denote by :math:`y_{train, 1}, y_{test, 1}, \dots, y_{train, K}, y_{test, K}`
     the train/test folds produced by the generator ``cv.split_series(y)``.

--- a/sktime/split/__init__.py
+++ b/sktime/split/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "ExpandingGreedySplitter",
     "ExpandingWindowSplitter",
     "ExpandingSlidingWindowSplitter",
+    "ForecastingHorizonSplitter",
     "InstanceSplitter",
     "SameLocSplitter",
     "SingleWindowSplitter",
@@ -22,6 +23,7 @@ from sktime.split.expandingcutoff import ExpandingCutoffSplitter
 from sktime.split.expandinggreedy import ExpandingGreedySplitter
 from sktime.split.expandingslidingwindow import ExpandingSlidingWindowSplitter
 from sktime.split.expandingwindow import ExpandingWindowSplitter
+from sktime.split.fh import ForecastingHorizonSplitter
 from sktime.split.instance import InstanceSplitter
 from sktime.split.sameloc import SameLocSplitter
 from sktime.split.singlewindow import SingleWindowSplitter

--- a/sktime/split/base/_common.py
+++ b/sktime/split/base/_common.py
@@ -3,7 +3,7 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
 from collections.abc import Iterator
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -18,7 +18,6 @@ from sktime.utils.validation import (
     is_int,
 )
 from sktime.utils.validation.forecasting import check_fh
-from sktime.utils.validation.series import check_equal_time_index
 
 DEFAULT_STEP_LENGTH = 1
 DEFAULT_WINDOW_LENGTH = 10

--- a/sktime/split/base/_common.py
+++ b/sktime/split/base/_common.py
@@ -112,45 +112,6 @@ def _get_end(y_index: pd.Index, fh: ForecastingHorizon) -> int:
     return y_index.get_loc(y_index[-1] - fh_offset)
 
 
-def _split_by_fh(
-    y: ACCEPTED_Y_TYPES, fh: FORECASTING_HORIZON_TYPES, X: Optional[pd.DataFrame] = None
-) -> SPLIT_TYPE:
-    """Split time series with forecasting horizon.
-
-    Handles both relative and absolute horizons.
-    """
-    if X is not None:
-        check_equal_time_index(y, X)
-    index = y.index
-    fh = check_fh(fh, freq=index)
-    idx = fh.to_pandas()
-
-    if fh.is_relative:
-        if not fh.is_all_out_of_sample():
-            raise ValueError("`fh` must only contain out-of-sample values")
-        max_step = idx.max()
-        steps = fh.to_indexer()
-        train = index[:-max_step]
-        test = index[-max_step:]
-
-        y_test = y.loc[test[steps]]
-
-    else:
-        min_step, max_step = idx.min(), idx.max()
-        train = index[index < min_step]
-        test = index[(index <= max_step) & (min_step <= index)]
-
-        y_test = y.loc[idx]
-
-    y_train = y.loc[train]
-    if X is None:
-        return y_train, y_test
-
-    X_train = X.loc[train]
-    X_test = X.loc[test]
-    return y_train, y_test, X_train, X_test
-
-
 def _get_train_window_via_endpoint(y, train_endpoint, window_length):
     """
     Split time series at given end points into a fixed-length training set.

--- a/sktime/split/fh.py
+++ b/sktime/split/fh.py
@@ -2,9 +2,10 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Forecasting horizon based train test split utility function."""
 
+from typing import Optional
+
 import numpy as np
 import pandas as pd
-from typing import Optional
 
 from sktime.split.base import BaseSplitter
 from sktime.utils.validation.forecasting import check_fh
@@ -58,7 +59,6 @@ class ForecastingHorizonSplitter(BaseSplitter):
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the splitter."""
-        import numpy as np
         from sktime.forecasting.base import ForecastingHorizon
 
         fh_rel = ForecastingHorizon([1, 2, 3], is_relative=True)

--- a/sktime/split/fh.py
+++ b/sktime/split/fh.py
@@ -31,7 +31,8 @@ class ForecastingHorizonSplitter(BaseSplitter):
 
     def _split(self, y: pd.Index):
         """Return train/test indices based on forecasting horizon."""
-        fh = check_fh(self.fh, freq=y)
+        ix = y.index
+        fh = check_fh(self.fh, freq=ix)
         idx = fh.to_pandas()
 
         if fh.is_relative:
@@ -47,8 +48,8 @@ class ForecastingHorizonSplitter(BaseSplitter):
         else:
             min_step, max_step = idx.min(), idx.max()
 
-            train_ix = np.where(y < min_step)[0]
-            test_ix = np.where((y >= min_step) & (y <= max_step))[0]
+            train_ix = np.where(ix < min_step)[0]
+            test_ix = np.where((ix >= min_step) & (ix <= max_step))[0]
 
         yield train_ix, test_ix
 

--- a/sktime/split/fh.py
+++ b/sktime/split/fh.py
@@ -31,7 +31,7 @@ class ForecastingHorizonSplitter(BaseSplitter):
     and :math:`h_1, h_2, \ldots, h_H` are the relative forecasting horizons, i.e.,
     time offsets, then training and test sets are defined as follows:
 
-    - training set: all time points :math:`t_i` such that :math:`t_i < t_N - h_H + h_1`
+    - training set: all time points :math:`t_i` such that :math:`t_i \lneq t_N - h_H`
     - test set: if :math:`t_j` is the last time point in the training set,
       then the test set consists of the time points
       :math:`(t_j + h_1, t_j + h_2, \ldots, t_j + h_H)`.
@@ -40,7 +40,8 @@ class ForecastingHorizonSplitter(BaseSplitter):
     the union of training and test sets will not cover the entire time series.
 
     For negative relative forecasting horizons, the training set
-    will not contain all time points up to present.
+    will contain time points that are later than some time points in the test set,
+    leading to leakage - users should ensure this is intentional when requested.
 
     Parameters
     ----------
@@ -63,9 +64,10 @@ class ForecastingHorizonSplitter(BaseSplitter):
             min_step, max_step = idx.min(), idx.max()
             steps = fh.to_indexer()
 
-            first_test_ix = len(y) - max_step - 1 + min(0, min_step - 1)
+            last_train_ix_minus_one = len(y) - max_step - 1
+            first_test_ix = last_train_ix_minus_one + min(0, min_step - 1)
 
-            train_ix = np.arange(first_test_ix)
+            train_ix = np.arange(last_train_ix_minus_one)
             test_ix = (np.arange(first_test_ix, len(y)))[steps]
 
         else:

--- a/sktime/split/fh.py
+++ b/sktime/split/fh.py
@@ -39,7 +39,7 @@ class ForecastingHorizonSplitter(BaseSplitter):
     Users should note that, for non-contiguous forecasting horizons,
     the union of training and test sets will not cover the entire time series.
 
-    For negative relative forecasting horizons, the training set
+    For zero or negative relative forecasting horizons, the training set
     will contain time points that are later than some time points in the test set,
     leading to leakage - users should ensure this is intentional when requested.
 

--- a/sktime/split/fh.py
+++ b/sktime/split/fh.py
@@ -31,8 +31,7 @@ class ForecastingHorizonSplitter(BaseSplitter):
 
     def _split(self, y: pd.Index):
         """Return train/test indices based on forecasting horizon."""
-        ix = y.index
-        fh = check_fh(self.fh, freq=ix)
+        fh = check_fh(self.fh, freq=y)
         idx = fh.to_pandas()
 
         if fh.is_relative:
@@ -48,8 +47,8 @@ class ForecastingHorizonSplitter(BaseSplitter):
         else:
             min_step, max_step = idx.min(), idx.max()
 
-            train_ix = np.where(ix < min_step)[0]
-            test_ix = np.where((ix >= min_step) & (ix <= max_step))[0]
+            train_ix = np.where(idx < min_step)[0]
+            test_ix = np.where((idx >= min_step) & (idx <= max_step))[0]
 
         yield train_ix, test_ix
 

--- a/sktime/split/fh.py
+++ b/sktime/split/fh.py
@@ -61,6 +61,12 @@ class ForecastingHorizonSplitter(BaseSplitter):
         from sktime.forecasting.base import ForecastingHorizon
 
         fh_rel = ForecastingHorizon([1, 2, 3], is_relative=True)
-        fh_abs = ForecastingHorizon([7, 8, 9], is_relative=False)
+        fh_abs = ForecastingHorizon([7, 8, 9], is_relative=True)
+        fh_abs_2 = ForecastingHorizon([-2, 5], is_relative=True)
 
-        return [{"fh": fh_rel}, {"fh": fh_abs}]
+        # absolute horizons are tested indirectly through
+        # testing temporal_train_test_split
+        # it is not possible via get_test_params, since
+        # the fh type must depend on the data index type
+
+        return [{"fh": fh_rel}, {"fh": fh_abs}, {"fh": fh_abs_2}]

--- a/sktime/split/fh.py
+++ b/sktime/split/fh.py
@@ -41,8 +41,8 @@ class ForecastingHorizonSplitter(BaseSplitter):
             max_step = idx.max()
             steps = fh.to_indexer()
 
-            train_ix = np.arange(len(y) - max_step)
-            test_ix = (np.arange(len(y) - max_step, len(y)))[steps]
+            train_ix = np.arange(len(y) - max_step - 1)
+            test_ix = (np.arange(len(y) - max_step - 1, len(y)))[steps]
 
         else:
             min_step, max_step = idx.min(), idx.max()

--- a/sktime/split/fh.py
+++ b/sktime/split/fh.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3 -u
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Forecasting horizon based train test split utility function."""
+
+import numpy as np
+import pandas as pd
+from typing import Optional
+
+from sktime.split.base import BaseSplitter
+from sktime.utils.validation.forecasting import check_fh
+
+
+class ForecastingHorizonSplitter(BaseSplitter):
+    """Splitter that creates a single train/test split based on a forecasting horizon.
+
+    Handles both relative and absolute forecasting horizons.
+
+    Parameters
+    ----------
+    fh : ForecastingHorizon or compatible input
+        Forecasting horizon that defines the test set.
+        Must be all out-of-sample if relative.
+    """
+
+    _tags = {"split_hierarchical": False}
+
+    def __init__(self, fh):
+        self.fh = fh
+        super().__init__()
+
+    def _split(self, y: pd.Index):
+        """Return train/test indices based on forecasting horizon."""
+        fh = check_fh(self.fh, freq=y)
+        idx = fh.to_pandas()
+
+        if fh.is_relative:
+            if not fh.is_all_out_of_sample():
+                raise ValueError("`fh` must only contain out-of-sample values")
+
+            max_step = idx.max()
+            steps = fh.to_indexer()
+
+            train_ix = np.arange(len(y) - max_step)
+            test_ix = (np.arange(len(y) - max_step, len(y)))[steps]
+
+        else:
+            min_step, max_step = idx.min(), idx.max()
+
+            train_ix = np.where(y < min_step)[0]
+            test_ix = np.where((y >= min_step) & (y <= max_step))[0]
+
+        yield train_ix, test_ix
+
+    def get_n_splits(self, y: Optional[pd.Index] = None) -> int:
+        """Return number of splits (always 1)."""
+        return 1
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the splitter."""
+        import numpy as np
+        from sktime.forecasting.base import ForecastingHorizon
+
+        fh_rel = ForecastingHorizon([1, 2, 3], is_relative=True)
+        fh_abs = ForecastingHorizon([7, 8, 9], is_relative=False)
+
+        return [{"fh": fh_rel}, {"fh": fh_abs}]

--- a/sktime/split/fh.py
+++ b/sktime/split/fh.py
@@ -26,8 +26,7 @@ class ForecastingHorizonSplitter(BaseSplitter):
     _tags = {"split_hierarchical": False}
 
     def __init__(self, fh):
-        self.fh = fh
-        super().__init__()
+        super().__init__(fh=fh)
 
     def _split(self, y: pd.Index):
         """Return train/test indices based on forecasting horizon."""
@@ -47,8 +46,8 @@ class ForecastingHorizonSplitter(BaseSplitter):
         else:
             min_step, max_step = idx.min(), idx.max()
 
-            train_ix = np.where(idx < min_step)[0]
-            test_ix = np.where((idx >= min_step) & (idx <= max_step))[0]
+            train_ix = np.where(y < min_step)[0]
+            test_ix = y.get_indexer(idx)
 
         yield train_ix, test_ix
 

--- a/sktime/split/temporal_train_test_split.py
+++ b/sktime/split/temporal_train_test_split.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.split.base import BaseSplitter
-from sktime.split.base._common import ACCEPTED_Y_TYPES, SPLIT_TYPE,
+from sktime.split.base._common import ACCEPTED_Y_TYPES, SPLIT_TYPE
 from sktime.split.fh import ForecastingHorizonSplitter
 
 

--- a/sktime/split/temporal_train_test_split.py
+++ b/sktime/split/temporal_train_test_split.py
@@ -14,12 +14,8 @@ import numpy as np
 import pandas as pd
 
 from sktime.split.base import BaseSplitter
-from sktime.split.base._common import (
-    ACCEPTED_Y_TYPES,
-    FORECASTING_HORIZON_TYPES,
-    SPLIT_TYPE,
-    _split_by_fh,
-)
+from sktime.split.base._common import ACCEPTED_Y_TYPES, SPLIT_TYPE,
+from sktime.split.fh import ForecastingHorizonSplitter
 
 
 def temporal_train_test_split(
@@ -27,7 +23,7 @@ def temporal_train_test_split(
     X: Optional[pd.DataFrame] = None,
     test_size: Optional[float] = None,
     train_size: Optional[float] = None,
-    fh: Optional[FORECASTING_HORIZON_TYPES] = None,
+    fh=None,
     anchor: str = "start",
 ) -> SPLIT_TYPE:
     """Split time series data containers into a single train/test split.
@@ -114,7 +110,7 @@ def temporal_train_test_split(
     """
     # the code has two disjoint branches, one for fh and one for test_size/train_size
 
-    # branch 1: fh is not None, use fh to split
+    # case 1: fh is not None, use fh to split
     # this assumes (or enforces) that test_size and train_size are None
     if fh is not None:
         if test_size is not None or train_size is not None:
@@ -122,13 +118,13 @@ def temporal_train_test_split(
                 "If `fh` is given, `test_size` and `train_size` cannot "
                 "also be specified."
             )
-        return _split_by_fh(y, fh, X=X)
-
-    # branch 2: fh is None, use test_size and train_size to split
+        temporal_splitter = ForecastingHorizonSplitter(fh=fh)
+    # case 2: fh is None, use test_size and train_size to split
     # from the above, we know that fh is None
-    temporal_splitter = TemporalTrainTestSplitter(
-        test_size=test_size, train_size=train_size, anchor=anchor
-    )
+    else:
+        temporal_splitter = TemporalTrainTestSplitter(
+            test_size=test_size, train_size=train_size, anchor=anchor
+        )
 
     y_train, y_test = list(temporal_splitter.split_series(y))[0]
 

--- a/sktime/split/tests/test_temporaltraintest.py
+++ b/sktime/split/tests/test_temporaltraintest.py
@@ -8,7 +8,11 @@ import pytest
 from sktime.datasets import load_airline
 from sktime.datatypes._utilities import get_cutoff
 from sktime.forecasting.tests._config import TEST_OOS_FHS, VALID_INDEX_FH_COMBINATIONS
-from sktime.split import TemporalTrainTestSplitter, temporal_train_test_split
+from sktime.split import (
+    ForecastingHorizonSplitter,
+    TemporalTrainTestSplitter,
+    temporal_train_test_split,
+)
 from sktime.tests.test_switch import run_test_for_class
 from sktime.utils._testing.forecasting import _make_fh
 from sktime.utils._testing.series import _make_series
@@ -89,7 +93,13 @@ def test_temporal_train_test_split_float_only_y():
 
 
 @pytest.mark.skipif(
-    not run_test_for_class([TemporalTrainTestSplitter, temporal_train_test_split]),
+    not run_test_for_class(
+        [
+            ForecastingHorizonSplitter,
+            TemporalTrainTestSplitter,
+            temporal_train_test_split,
+        ]
+    ),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_temporal_train_test_split_int_only_y():


### PR DESCRIPTION
Adds a `ForecastingHorizon` based splitter, similar to the behaviour of `temporal_train_test_split` if `fh` is passed.

Also makes `temporal_train_test_split` to point to that splitter instead of the legacy function `_split_by_fh`, which is removed.

This also fixes https://github.com/sktime/sktime/issues/8700 and fixes https://github.com/sktime/sktime/issues/4968