### PR TITLE
[BUG] suppressing `dict` while running TTM doctest

### DIFF
--- a/sktime/forecasting/ttm.py
+++ b/sktime/forecasting/ttm.py
@@ -7,7 +7,6 @@ __author__ = ["ajati", "wgifford", "vijaye12", "geetu040"]
 import numpy as np
 import pandas as pd
 from skbase.utils.dependencies import _check_soft_dependencies
-from skbase.utils.stderr_mute import StderrMute
 from skbase.utils.stdout_mute import StdoutMute
 
 from sktime.forecasting.base import ForecastingHorizon, _BaseGlobalForecaster
@@ -524,7 +523,7 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
             callbacks=self.callbacks,
         )
 
-        with StderrMute() as _, StdoutMute() as _:
+        with StdoutMute() as _:
             trainer.train()
 
         # Get the model

--- a/sktime/forecasting/ttm.py
+++ b/sktime/forecasting/ttm.py
@@ -188,7 +188,8 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     >>> y = load_airline()
     >>> forecaster = TinyTimeMixerForecaster()
     >>> # performs zero-shot forecasting, as default config (unchanged) is used
-    >>> _ = forecaster.fit(y, fh=[1, 2, 3])
+    >>> forecaster.fit(y, fh=[1, 2, 3]) # doctest: +ELLIPSIS
+    TinyTimeMixerForecaster(...)
     >>> y_pred = forecaster.predict()
 
     >>> from sktime.forecasting.ttm import TinyTimeMixerForecaster
@@ -218,7 +219,8 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     >>>
     >>> # model initialized with random weights due to None model_path
     >>> # and trained with the full strategy.
-    >>> _ = forecaster.fit(y, fh=[1, 2, 3])
+    >>> forecaster.fit(y, fh=[1, 2, 3]) # doctest: +ELLIPSIS
+    TinyTimeMixerForecaster(...)
     >>> y_pred = forecaster.predict()
 
     Example with exogenous variables:
@@ -246,13 +248,8 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     ... )
     >>>
     >>> # Fit with exogenous variables
-    >>> forecaster.fit(y_train, X=X_train, fh=[1, 2])
-    TinyTimeMixerForecaster(config={'context_length': 8, 'prediction_length': 2},
-                            fit_strategy='full', model_path=None,
-                            training_args={'max_steps': 10,
-                                           'output_dir': 'test_output',
-                                           'per_device_train_batch_size': 4,
-                                           'report_to': 'none'})
+    >>> forecaster.fit(y_train, X=X_train, fh=[1, 2]) # doctest: +ELLIPSIS
+    TinyTimeMixerForecaster(...)
     >>>
     >>> # Predict with exogenous variables
     >>> y_pred = forecaster.predict(X=X_future)

--- a/sktime/forecasting/ttm.py
+++ b/sktime/forecasting/ttm.py
@@ -188,7 +188,7 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     >>> y = load_airline()
     >>> forecaster = TinyTimeMixerForecaster()
     >>> # performs zero-shot forecasting, as default config (unchanged) is used
-    >>> forecaster.fit(y, fh=[1, 2, 3]) # doctest: +ELLIPSIS
+    >>> forecaster.fit(y, fh=[1, 2, 3])
     TinyTimeMixerForecaster(...)
     >>> y_pred = forecaster.predict()
 
@@ -219,7 +219,7 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     >>>
     >>> # model initialized with random weights due to None model_path
     >>> # and trained with the full strategy.
-    >>> forecaster.fit(y, fh=[1, 2, 3]) # doctest: +ELLIPSIS
+    >>> forecaster.fit(y, fh=[1, 2, 3])
     TinyTimeMixerForecaster(...)
     >>> y_pred = forecaster.predict()
 
@@ -248,7 +248,7 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     ... )
     >>>
     >>> # Fit with exogenous variables
-    >>> forecaster.fit(y_train, X=X_train, fh=[1, 2]) # doctest: +ELLIPSIS
+    >>> forecaster.fit(y_train, X=X_train, fh=[1, 2])
     TinyTimeMixerForecaster(...)
     >>>
     >>> # Predict with exogenous variables

--- a/sktime/forecasting/ttm.py
+++ b/sktime/forecasting/ttm.py
@@ -7,6 +7,8 @@ __author__ = ["ajati", "wgifford", "vijaye12", "geetu040"]
 import numpy as np
 import pandas as pd
 from skbase.utils.dependencies import _check_soft_dependencies
+from skbase.utils.stderr_mute import StderrMute
+from skbase.utils.stdout_mute import StdoutMute
 
 from sktime.forecasting.base import ForecastingHorizon, _BaseGlobalForecaster
 from sktime.split import temporal_train_test_split
@@ -185,10 +187,10 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     >>> from sktime.forecasting.ttm import TinyTimeMixerForecaster
     >>> from sktime.datasets import load_airline
     >>> y = load_airline()
-    >>> forecaster = TinyTimeMixerForecaster() # doctest: +SKIP
+    >>> forecaster = TinyTimeMixerForecaster()
     >>> # performs zero-shot forecasting, as default config (unchanged) is used
-    >>> forecaster.fit(y, fh=[1, 2, 3]) # doctest: +SKIP
-    >>> y_pred = forecaster.predict() # doctest: +SKIP
+    >>> _ = forecaster.fit(y, fh=[1, 2, 3])
+    >>> y_pred = forecaster.predict()
 
     >>> from sktime.forecasting.ttm import TinyTimeMixerForecaster
     >>> from sktime.datasets import load_tecator
@@ -213,12 +215,12 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     ...         "output_dir": "test_output",
     ...         "per_device_train_batch_size": 32,
     ...     },
-    ... ) # doctest: +SKIP
+    ... )
     >>>
     >>> # model initialized with random weights due to None model_path
     >>> # and trained with the full strategy.
-    >>> forecaster.fit(y, fh=[1, 2, 3]) # doctest: +SKIP
-    >>> y_pred = forecaster.predict() # doctest: +SKIP
+    >>> _ = forecaster.fit(y, fh=[1, 2, 3])
+    >>> y_pred = forecaster.predict()
 
     Example with exogenous variables:
 
@@ -242,14 +244,19 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
     ...         "per_device_train_batch_size": 4,
     ...         "report_to": "none",
     ...     },
-    ... )  # doctest: +SKIP
+    ... )
     >>>
     >>> # Fit with exogenous variables
-    >>> forecaster.fit(y_train, X=X_train, fh=[1, 2])  # doctest: +SKIP
-    TinyTimeMixerForecaster(...)
+    >>> forecaster.fit(y_train, X=X_train, fh=[1, 2])
+    TinyTimeMixerForecaster(config={'context_length': 8, 'prediction_length': 2},
+                            fit_strategy='full', model_path=None,
+                            training_args={'max_steps': 10,
+                                           'output_dir': 'test_output',
+                                           'per_device_train_batch_size': 4,
+                                           'report_to': 'none'})
     >>>
     >>> # Predict with exogenous variables
-    >>> y_pred = forecaster.predict(X=X_future)  # doctest: +SKIP
+    >>> y_pred = forecaster.predict(X=X_future)
     """
 
     _tags = {
@@ -517,8 +524,8 @@ class TinyTimeMixerForecaster(_BaseGlobalForecaster):
             callbacks=self.callbacks,
         )
 
-        # Train the model
-        trainer.train()
+        with StderrMute() as _, StdoutMute() as _:
+            trainer.train()
 
         # Get the model
         self.model = trainer.model


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #8732 

The current PR aims to resolve the unexpected `dict` object that's printed out during `TinyTimeMixerForecaster`'s doctest, causing `sktime`'s remote CI to fail. The root problem arises from two major factors: 

An unexpected dictionary object that's printed out like so: 
```
{'train_runtime': 0.2049, 'train_samples_per_second': 195.186, 'train_steps_per_second': 48.797, 'train_loss': 19674936.0, 'epoch': 10.0}
```
which is outputted from `transformers`'s Trainer class. 

and a `TinyTimeMixerForecaster` configuration information that looks like so: 
```
TinyTimeMixerForecaster(config={'context_length': 8, 'prediction_length': 2},
                            fit_strategy='full', model_path=None,
                            training_args={'max_steps': 10,
                                           'output_dir': 'test_output',
                                           'per_device_train_batch_size': 4,
                                           'report_to': 'none'})
```

Some configurations show insight into training loss, training time and other metrics which are runtime-based and cannot be reproduced. 


#### What does this implement/fix? Explain your changes.
My PR utilizes `skbase`'s `StderrMute` and `StdoutMute` in order to mute the outputs from external libraries such as `transformers`. The second set of training configurations have been silenced by simply ignoring the output during `doctest`. 


#### What should a reviewer concentrate their feedback on?

I would like to make sure that the current changes do not break the existing `sktime` API. 