### PR TITLE
[BUG] fix bug in `_safe_import` when importing package and `pkg_name` is not `None`

### DIFF
--- a/sktime/utils/dependencies/_safe_import.py
+++ b/sktime/utils/dependencies/_safe_import.py
@@ -77,7 +77,7 @@ def _safe_import(import_path, pkg_name=None):
     if _check_soft_dependencies(pkg_name, severity="none"):
         try:
             if len(path_list) == 1:
-                return importlib.import_module(pkg_name)
+                return importlib.import_module(obj_name)
             module_name, attr_name = import_path.rsplit(".", 1)
             module = importlib.import_module(module_name)
             return getattr(module, attr_name)

--- a/sktime/utils/dependencies/tests/test_safe_import.py
+++ b/sktime/utils/dependencies/tests/test_safe_import.py
@@ -82,3 +82,13 @@ def test_soft_dependency_chains():
     """
     result = _safe_import("gluonts.torch.PyTorchPredictor")
     assert result is not None
+
+
+def test_safe_import_pkg_with_different_name():
+    """Test that importing a package with a different name works."""
+    result = _safe_import("sklearn", pkg_name="scikit-learn")
+    assert result is not None
+
+    import sklearn
+
+    assert result is sklearn


### PR DESCRIPTION
Fixes an unreported bug in `_safe_import` when importing package and `pkg_name` is not `None` - in this case, the import would always result in a mock, because the `importlib` statement was referring to the `pkg_name` and not to `obj_name` which would have been the correct import name.

A test to prevent regression has also been added.