### PR TITLE
[BUG] fix `DirectReductionForecaster` failure on newer `pandas`

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1956,6 +1956,7 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
+        "tests:libs": ["sktime.transformations.series.lag"],
     }
 
     def __init__(
@@ -2360,6 +2361,9 @@ class RecursiveReductionForecaster(BaseForecaster, _ReducerMixin):
         "ignores-exogeneous-X": False,
         "X_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         "y_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
+        # CI and test flags
+        # -----------------
+        "tests:libs": ["sktime.transformations.series.lag"],
     }
 
     def __init__(

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -253,7 +253,7 @@ class Lag(BaseTransformer):
                     freq = pd.infer_freq(X.index)
                 if freq is None and isinstance(X.index, pd.DatetimeIndex):
                     # convert to PeriodIndex and then infer freq
-                    freq = pd.infer_freq(X.index[:4].to_period())
+                    freq = X.index[:4].to_period().freq
                 X_orig_idx_shifted = X_orig_idx.shift(periods=lag, freq=freq)
                 if isinstance(lag, int) and freq is None:
                     freq = "infer"

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -252,7 +252,7 @@ class Lag(BaseTransformer):
                 if hasattr(X.index, "freq") and X.index.freq is None and freq is None:
                     freq = pd.infer_freq(X.index)
                 if freq is None and isinstance(X.index, pd.DatetimeIndex):
-                    freq = pd.infer_freq(X.index)
+                    freq = pd.infer_freq(X.index[:4])
                 X_orig_idx_shifted = X_orig_idx.shift(periods=lag, freq=freq)
                 if isinstance(lag, int) and freq is None:
                     freq = "infer"

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -252,7 +252,8 @@ class Lag(BaseTransformer):
                 if hasattr(X.index, "freq") and X.index.freq is None and freq is None:
                     freq = pd.infer_freq(X.index)
                 if freq is None and isinstance(X.index, pd.DatetimeIndex):
-                    freq = pd.infer_freq(X.index[:4])
+                    # convert to PeriodIndex and then infer freq
+                    freq = pd.infer_freq(X.index[:4].to_period())
                 X_orig_idx_shifted = X_orig_idx.shift(periods=lag, freq=freq)
                 if isinstance(lag, int) and freq is None:
                     freq = "infer"

--- a/sktime/transformations/series/lag.py
+++ b/sktime/transformations/series/lag.py
@@ -251,6 +251,8 @@ class Lag(BaseTransformer):
             else:
                 if hasattr(X.index, "freq") and X.index.freq is None and freq is None:
                     freq = pd.infer_freq(X.index)
+                if freq is None and isinstance(X.index, pd.DatetimeIndex):
+                    freq = pd.infer_freq(X.index)
                 X_orig_idx_shifted = X_orig_idx.shift(periods=lag, freq=freq)
                 if isinstance(lag, int) and freq is None:
                     freq = "infer"


### PR DESCRIPTION
fixes the `DirectReductionForecaster` failure on newer `pandas`, arising from attempting to `shift` a regular `pd.DatetimeIndex`.

The fix needs to be applied in the `Lag` transformer, used internally.