### PR TITLE
[MNT] 0.39.0 deprecations and change actions

### DIFF
--- a/sktime/classification/early_classification/_probability_threshold.py
+++ b/sktime/classification/early_classification/_probability_threshold.py
@@ -20,7 +20,7 @@ from sktime.classification.interval_based import CanonicalIntervalForest
 from sktime.utils.validation.panel import check_X
 
 
-# TODO: fix this in 0.39.0
+# TODO: fix this in 0.40.0
 # base class should have been changed to BaseEarlyClassifier
 class ProbabilityThresholdEarlyClassifier(BaseClassifier):
     """Probability Threshold Early Classifier.

--- a/sktime/forecasting/arch/_statsforecast_arch.py
+++ b/sktime/forecasting/arch/_statsforecast_arch.py
@@ -61,8 +61,7 @@ class StatsForecastGARCH(_GeneralisedStatsForecastAdapter):
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
-        # todo 0.39.0: check whether scipy<1.16 is still needed
-        "python_dependencies": ["statsforecast>=1.5.0", "scipy<1.16"],
+        "python_dependencies": ["statsforecast>=1.5.0"],
     }
 
     def __init__(
@@ -143,8 +142,7 @@ class StatsForecastARCH(_GeneralisedStatsForecastAdapter):
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
-        # todo 0.39.0: check whether scipy<1.16 is still needed
-        "python_dependencies": ["statsforecast>=1.5.0", "scipy<1.16"],
+        "python_dependencies": ["statsforecast>=1.5.0"],
     }
 
     def __init__(

--- a/sktime/forecasting/base/_fh.py
+++ b/sktime/forecasting/base/_fh.py
@@ -967,7 +967,7 @@ def _index_range(relative, cutoff):
 
 def _is_pandas_arithmetic_bug_fixed():
     """Check if pandas supports correct arithmetic without a workaround."""
-    # TODO: 0.39.0:
+    # TODO: 0.40.0:
     # Check at every minor release whether lower pandas bound >=1.5.0
     # if yes, can remove the workaround in the "else" condition and the check
     #

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -185,7 +185,7 @@ class _Pipeline(_HeterogenousMetaEstimator, BaseForecaster):
                         if len(levels) == 1:
                             levels = levels[0]
                         yt[ix] = y.xs(ix, level=levels, axis=1)
-                        # todo 0.39.0 - check why this cannot be easily removed
+                        # todo 0.40.0 - check why this cannot be easily removed
                         # in theory, we should get rid of the "Coverage" case treatment
                         # (the legacy naming convention was removed in 0.23.0)
                         # deal with the "Coverage" case, we need to get rid of this

--- a/sktime/forecasting/enbpi.py
+++ b/sktime/forecasting/enbpi.py
@@ -158,21 +158,8 @@ class EnbPIForecaster(BaseForecaster):
             self.bootstrap_transformer_ = bootstrap_transformer
 
         if self.bootstrap_transformer is None:
-            # todo 0.39.0: remove this warning
-            warn(
-                "The default value for the bootstrap_transformer will change to the"
-                "sktime MovingBlockBootstrap in version 0.39.0."
-                "For obtaining the current default behaviour after 0.39.0, pass "
-                "bootstrap_transformer=TSBootstrapAdapter(MovingBlockBootstrap()), "
-                "with moving block bootstrap from tsbootstrap.",
-                obj=self,
-                stacklevel=2,
-            )
-            from tsbootstrap import MovingBlockBootstrap
-
-            # todo 0.39.0: replace with Moving Block Bootstrap from sktime. And set
-            # the return_indices=True
-            self.bootstrap_transformer_ = TSBootstrapAdapter(MovingBlockBootstrap())
+            mbb = MovingBlockBootstrapTransformer(return_indices=True)
+            self.bootstrap_transformer_ = mbb
 
         bs_capable = self.bootstrap_transformer_.get_tag(
             "capability:bootstrap_index", False, raise_error=False

--- a/sktime/forecasting/prophetverse.py
+++ b/sktime/forecasting/prophetverse.py
@@ -11,7 +11,7 @@ from sktime.forecasting.base._delegate import _DelegatedForecaster
 from sktime.utils.dependencies import _placeholder_record
 
 
-# TODO 0.39.0: update upper and lower bounds when Prophetverse 0.9.0 is released
+# TODO 0.40.0: update upper and lower bounds when Prophetverse 0.9.0 is released
 @_placeholder_record("prophetverse.sktime", dependencies="prophetverse>=0.3.0,<0.9.0")
 class Prophetverse(_DelegatedForecaster):
     """Univariate prophetverse forecaster - prophet model implemented in numpyro.
@@ -208,7 +208,7 @@ class Prophetverse(_DelegatedForecaster):
         self._delegate = Prophet(**self.get_params())
 
 
-# TODO 0.39.0: update upper and lower bounds when Prophetverse 0.9.0 is released
+# TODO 0.40.0: update upper and lower bounds when Prophetverse 0.9.0 is released
 @_placeholder_record("prophetverse.sktime", dependencies="prophetverse>=0.3.0,<0.9.0")
 class HierarchicalProphet(_DelegatedForecaster):
     """A Bayesian hierarchical time series forecasting model based on Meta's Prophet.

--- a/sktime/forecasting/statsforecast.py
+++ b/sktime/forecasting/statsforecast.py
@@ -189,8 +189,7 @@ class StatsForecastAutoARIMA(_GeneralisedStatsForecastAdapter):
         "ignores-exogeneous-X": False,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
-        # todo 0.39.0: check whether scipy<1.16 is still needed
-        "python_dependencies": ["statsforecast>=1.0.0", "scipy<1.16"],
+        "python_dependencies": ["statsforecast>=1.0.0"],
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
@@ -391,8 +390,7 @@ class StatsForecastAutoTheta(_GeneralisedStatsForecastAdapter):
         "ignores-exogeneous-X": True,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
-        # todo 0.39.0: check whether scipy<1.16 is still needed
-        "python_dependencies": ["statsforecast>=1.3.0", "scipy<1.16"],
+        "python_dependencies": ["statsforecast>=1.3.0"],
     }
 
     def __init__(
@@ -507,8 +505,7 @@ class StatsForecastAutoETS(_GeneralisedStatsForecastAdapter):
         "ignores-exogeneous-X": True,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
-        # todo 0.39.0: check whether scipy<1.16 is still needed
-        "python_dependencies": ["statsforecast>=1.3.2", "scipy<1.16"],
+        "python_dependencies": ["statsforecast>=1.3.2"],
     }
 
     def __init__(
@@ -616,8 +613,7 @@ class StatsForecastAutoCES(_GeneralisedStatsForecastAdapter):
         "ignores-exogeneous-X": True,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
-        # todo 0.39.0: check whether scipy<1.16 is still needed
-        "python_dependencies": ["statsforecast>=1.1.0", "scipy<1.16"],
+        "python_dependencies": ["statsforecast>=1.1.0"],
     }
 
     def __init__(self, season_length: int = 1, model: str = "Z"):
@@ -727,8 +723,7 @@ class StatsForecastAutoTBATS(_GeneralisedStatsForecastAdapter):
         "ignores-exogeneous-X": True,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
-        # todo 0.39.0: check whether scipy<1.16 is still needed
-        "python_dependencies": ["statsforecast>=1.7.2", "scipy<1.16"],
+        "python_dependencies": ["statsforecast>=1.7.2"],
     }
 
     def __init__(
@@ -872,8 +867,7 @@ class StatsForecastMSTL(_GeneralisedStatsForecastAdapter):
         "ignores-exogeneous-X": True,
         "capability:pred_int": False,
         "capability:pred_int:insample": False,
-        # todo 0.39.0: check whether scipy<1.16 is still needed
-        "python_dependencies": ["statsforecast>=1.2.0", "scipy<1.16"],
+        "python_dependencies": ["statsforecast>=1.2.0"],
     }
 
     def __init__(
@@ -1044,8 +1038,7 @@ class StatsForecastADIDA(_GeneralisedStatsForecastAdapter):
         "ignores-exogeneous-X": True,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
-        # todo 0.39.0: check whether scipy<1.16 is still needed
-        "python_dependencies": ["statsforecast>=1.4.0", "scipy<1.16"],
+        "python_dependencies": ["statsforecast>=1.4.0"],
     }
 
     def __init__(

--- a/sktime/forecasting/timesfm_forecaster.py
+++ b/sktime/forecasting/timesfm_forecaster.py
@@ -223,7 +223,7 @@ class TimesFMForecaster(_BaseGlobalForecaster):
         if not self.ignore_deps:
             if self.use_source_package:
                 # Use timesfm with a version bound if use_source_package is True
-                # todo 0.39.0: Regularly check whether timesfm version can be updated
+                # todo 0.40.0: Regularly check whether timesfm version can be updated
                 # if changed, also needs to be changed in docstring
                 self.set_tags(python_dependencies=["timesfm<1.2.0"])
         else:


### PR DESCRIPTION
Carries out deprecations and change actions scheduled for 0.39.0:

* remove deprecated methods from `BaseBenchmark` and `forecasting_validation`
* bump deprecation/change checks scheduled for 0.39.0 to 0.40.0 or 1.0.0