### PR TITLE
[DOC] better documentation of time series scitypes, full mathematical documentation of `Hierarchical` and `Table` type

### DIFF
--- a/sktime/datatypes/_hierarchical/_base.py
+++ b/sktime/datatypes/_hierarchical/_base.py
@@ -9,6 +9,51 @@ from sktime.datatypes._base import BaseDatatype
 class ScitypeHierarchical(BaseDatatype):
     """Hierarchical data type. Represents a hierarchical collection of time series.
 
+    The ``Hierarchical`` data type is an abstract data type (= :term:`scitype`).
+
+    A ``Hierarchical`` represents a hierarchically indexed collection of
+    many single monotonously indexed sequences,
+    that is, an indexed collection of objects that follow the ``Series`` data type,
+    where the index is hierarchical (multi-level).
+
+    This including the sub-case of what is commonly called a "hierarchical time series",
+    if the index is interpreted as time.
+
+    Formally, an abstract ``Hierarchical`` object that
+    contains :math:`N` time series has:
+
+    * an index :math:`s_1, \dots, s_N`, where each :math:`s_i` is an :math:`H`-tuple
+      of integer or a categorical types, representing the series identifier, also called
+      "hierarchical index"
+    * individual time series :math:`S_i` for :math:`i = 1, \dots, N`,
+      where each :math:`S_i` is an object of abstract ``Series`` type
+    * above, the domain of the hierarchical index is a
+      fixed Cartesian product of domains,
+      :math:`\mathcal{S} = \mathcal{S}_1 \times \dots \times \mathcal{S}_H`
+      where each :math:`\mathcal{S}_h` is an integer or categorical type domain.
+
+    To be considered of ``Hierarchical`` type, there must be at least two hierarchy
+    levels, i.e., :math:`H \geq 2`. If :math:`H = 1`, the data is considered of
+    ``Panel`` type (to avoid duplicate typing).
+
+    The object :math:`S_i` is interpreted as the time series (or sequence) at
+    the instance index :math:`s_i`.
+
+    The indices :math:`s_i` are assumed distinct, but not necessarily ordered.
+
+    The domains :math:`\mathcal{S}_h` are interpreted as hierarchy levels.
+
+    Concrete types implementing the ``Hierarchical`` data type must specify:
+
+    * hierarchy: how the hierarchy levels are represented
+    * hierarchy names: optional, names of the hierarchy levels
+    * variables: how the dimensions of the individual time series are represented
+    * variable names: optional, names of the variable dimensions
+    * time points: how time points are represented in the individual time series
+    * time index: how the time index is represented
+
+    Concrete implementations may implement only sub-cases of the full abstract type.
+
     Parameters
     ----------
     is_univariate: bool
@@ -26,21 +71,23 @@ class ScitypeHierarchical(BaseDatatype):
         i.e., the collection has a flat hierarchy, plus additional hierarchy levels
         that have only a single value.
     has_nans: bool
-        True iff the table contains NaN values
+        True iff the hierarchical series contains NaN values
     n_instances: int
         number of instances in the hierarchical collection
     n_panels: int
         number of flat panels in the hierarchical collection
     n_features: int
-        number of variables in table
+        number of variables in the hierarchical series
     feature_names: list of int or object
-        names of variables in table
+        names of variables in the hierarchical series
     dtypekind_dfip: list of DtypeKind enum
-        list of DtypeKind enum values for each feature in the panel,
-        following the data frame interface protocol
+        list of DtypeKind enum values for each feature in the hierarchical series,
+        following the data frame interface protocol.
+        In same order as ``feature_names``.
     feature_kind: list of str
-        list of feature kind strings for each feature in the panel,
-        coerced to FLOAT or CATEGORICAL type
+        list of feature-kind strings for each feature in the hierarchical series,
+        coerced to ``"FLOAT"`` or ``"CATEGORICAL"`` type string.
+        In same order as ``feature_names``.
     """
 
     _tags = {

--- a/sktime/datatypes/_hierarchical/_base.py
+++ b/sktime/datatypes/_hierarchical/_base.py
@@ -59,9 +59,9 @@ class ScitypeHierarchical(BaseDatatype):
     is_univariate: bool
         True iff table has one variable
     is_equally_spaced : bool
-        True iff series index is equally spaced
+        True iff all series in the hierarchical collection are equally spaced
     is_equal_length: bool
-        True iff all series in panel are of equal length
+        True iff all series in the hierarchical collection are of equal length
     is_empty: bool
         True iff table has no variables or no instances
     is_one_series: bool
@@ -73,9 +73,13 @@ class ScitypeHierarchical(BaseDatatype):
     has_nans: bool
         True iff the hierarchical series contains NaN values
     n_instances: int
-        number of instances in the hierarchical collection
+        number of instances, i.e., individual time series, in the hierarchical
+        collection. Formally, the number of unique hierarchy indices :math:`s_i`,
+        namely :math:`N`, in the definition above.
     n_panels: int
-        number of flat panels in the hierarchical collection
+        number of flat panels in the hierarchical collection. If the indices are
+        :math:`H`-tuples, this is the number of unique values of the
+        :math:`(H-1)`-tuples obtained by removing the last entry of each :math:`s_i`.
     n_features: int
         number of variables in the hierarchical series
     feature_names: list of int or object

--- a/sktime/datatypes/_hierarchical/_base.py
+++ b/sktime/datatypes/_hierarchical/_base.py
@@ -7,7 +7,7 @@ from sktime.datatypes._base import BaseDatatype
 
 
 class ScitypeHierarchical(BaseDatatype):
-    """Hierarchical data type. Represents a hierarchical collection of time series.
+    r"""Hierarchical data type. Represents a hierarchical collection of time series.
 
     The ``Hierarchical`` data type is an abstract data type (= :term:`scitype`).
 

--- a/sktime/datatypes/_panel/_base.py
+++ b/sktime/datatypes/_panel/_base.py
@@ -11,19 +11,20 @@ class ScitypePanel(BaseDatatype):
 
     The ``Panel`` data type is an abstract data type (= :term:`scitype`).
 
-    It represents an indexed collection of many single monotonously indexed sequences,
+    A ``Panel`` represents an indexed collection of
+    many single monotonously indexed sequences,
     that is, an indexed collection of objects that follow the ``Series`` data type.
 
-    This including the sub-case of a panel of "time series" if the index is interpreted
-    as time.
+    This including the sub-case of a collection of "time series",
+    if the index is interpreted as time.
 
     Formally, an abstract ``Panel`` object that contains :math:`N` time series has:
 
     * an index :math:`s_1, \dots, s_N`, with :math:`s_i` being an integer or
       a categorical type, representing the series identifier, also called
       "instance index" or "case index"
-    * individual time series :math:`S_i` for :math:`i = 1, \dots, N`, each being an
-      object of abstract ``Series`` type
+    * individual time series :math:`S_i` for :math:`i = 1, \dots, N`,
+      where each :math:`S_i` is an object of abstract ``Series`` type
 
     The object :math:`S_i` is interpreted as the time series (or sequence) at
     the instance index :math:`s_i`.
@@ -44,13 +45,13 @@ class ScitypePanel(BaseDatatype):
     Parameters
     ----------
     is_univariate: bool
-        True iff table has one variable
+        True iff all series in the panel have one variable
     is_equally_spaced : bool
-        True iff series index is equally spaced
+        True iff all series in the panel are equally spaced
     is_equal_length: bool
-        True iff all series in panel are of equal length
+        True iff all series in the panel are of equal length
     is_empty: bool
-        True iff table has no variables or no instances
+        True iff panel has no variables or no instances
     is_one_series: bool
         True iff there is only one series in the panel of time series
     has_nans: bool
@@ -58,15 +59,17 @@ class ScitypePanel(BaseDatatype):
     n_instances: int
         number of instances in the panel of time series
     n_features: int
-        number of variables in table
+        number of variables in the panel
     feature_names: list of int or object
-        names of variables in table
+        names of variables in the panel
     dtypekind_dfip: list of DtypeKind enum
         list of DtypeKind enum values for each feature in the panel,
-        following the data frame interface protocol
+        following the data frame interface protocol.
+        In same order as ``feature_names``.
     feature_kind: list of str
-        list of feature kind strings for each feature in the panel,
-        coerced to FLOAT or CATEGORICAL type
+        list of feature-kind strings for each feature in the panel,
+        coerced to ``"FLOAT"`` or ``"CATEGORICAL"`` type string.
+        In same order as ``feature_names``.
     """
 
     _tags = {

--- a/sktime/datatypes/_series/_base.py
+++ b/sktime/datatypes/_series/_base.py
@@ -40,23 +40,26 @@ class ScitypeSeries(BaseDatatype):
     Parameters
     ----------
     is_univariate: bool
-        True iff table has one variable
+        True iff the series has one variable, i.e., :math:`y_i` is a scalar
     is_equally_spaced : bool
-        True iff series index is equally spaced
+        True iff the series index is equally spaced, i.e.,
+        :math:`t_{i} - t_{i-1}` does not depend on :math:`i`
     is_empty: bool
-        True iff table has no variables or no instances
+        True iff the series has no variables, or no instances
     has_nans: bool
-        True iff the table contains NaN values
+        True iff the the series contains NaN values
     n_features: int
-        number of variables in table
+        number of variables in the series
     feature_names: list of int or object
-        names of variables in table
+        names of variables in the series
     dtypekind_dfip: list of DtypeKind enum
-        list of DtypeKind enum values for each feature in the panel,
-        following the data frame interface protocol
+        list of DtypeKind enum values for each feature in the series,
+        following the data frame interface protocol.
+        In same order as ``feature_names``.
     feature_kind: list of str
-        list of feature kind strings for each feature in the panel,
-        coerced to FLOAT or CATEGORICAL type
+        list of feature-kind strings for each feature in the series,
+        coerced to ``"FLOAT"`` or ``"CATEGORICAL"`` type string.
+        In same order as ``feature_names``.
     """
 
     _tags = {

--- a/sktime/datatypes/_table/_base.py
+++ b/sktime/datatypes/_table/_base.py
@@ -9,6 +9,33 @@ from sktime.datatypes._base import BaseDatatype
 class ScitypeTable(BaseDatatype):
     """Data Frame or Table data type.
 
+    The ``Table`` data type is an abstract data type (= :term:`scitype`).
+
+    It represents a row- and column-indexed 2D table of data, commonly
+    referred to as "data frame".
+
+    Formally, an abstract ``Table`` object has:
+
+    * an index :math:`i_1, \dots, i_T`, with :math:`i_i` being any hashable type
+    * values :math:`x_1, \dots, x_T`, with :math:`x_i`, taking values in
+      an abstract typed data frame row domain :math:`\mathcal{Y}`,
+      i.e., vectors with entries being numbers
+      (float, integer) or categorical, always the same type at the same entry
+
+    The value :math:`x_i` is interpreted to be an "observation" or "instance"
+    at index :math:`i_i`.
+
+    The indices :math:`i_i` are assumed distinct, but not necessarily ordered.
+
+    Concrete types implementing the ``Table`` data type must specify:
+
+    * features: how the dimensions of :math:`\mathcal{Y}` are represented
+    * feature names: optional, names of the column dimensions
+    * instances: how the value "observed at" an index is represented
+    * instance index: how the instance index is represented
+
+    Concrete implementations may implement only sub-cases of the full abstract type.
+
     Parameters
     ----------
     is_univariate: bool

--- a/sktime/datatypes/_table/_base.py
+++ b/sktime/datatypes/_table/_base.py
@@ -24,11 +24,13 @@ class ScitypeTable(BaseDatatype):
     feature_names: list of int or object
         names of variables in table
     dtypekind_dfip: list of DtypeKind enum
-        list of DtypeKind enum values for each feature in the panel,
-        following the data frame interface protocol
+        list of DtypeKind enum values for each feature in the table,
+        following the data frame interface protocol.
+        In same order as ``feature_names``.
     feature_kind: list of str
-        list of feature kind strings for each feature in the panel,
-        coerced to FLOAT or CATEGORICAL type
+        list of feature-kind strings for each feature in the table,
+        coerced to ``"FLOAT"`` or ``"CATEGORICAL"`` type string.
+        In same order as ``feature_names``.
     """
 
     _tags = {

--- a/sktime/datatypes/_table/_base.py
+++ b/sktime/datatypes/_table/_base.py
@@ -7,7 +7,7 @@ from sktime.datatypes._base import BaseDatatype
 
 
 class ScitypeTable(BaseDatatype):
-    """Data Frame or Table data type.
+    r"""Data Frame or Table data type.
 
     The ``Table`` data type is an abstract data type (= :term:`scitype`).
 


### PR DESCRIPTION
This PR adds a full documentation of the `Hierarchical` and `Table` object types, and improves the description of other scitypes `Panel` and `Series`.