### PR TITLE
[MNT] python 3.9 end-of-life

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,7 +179,7 @@ jobs:
       fail-fast: false
       matrix:
         flag: ${{ fromJson(needs.detect-changed-classes.outputs.obj_list) }}
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
@@ -251,7 +251,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
@@ -272,7 +272,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
@@ -299,7 +299,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
@@ -327,7 +327,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
@@ -425,7 +425,7 @@ jobs:
     strategy:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
 
@@ -465,7 +465,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -26,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -54,7 +53,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -93,7 +91,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/test_base.yml
+++ b/.github/workflows/test_base.yml
@@ -26,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/test_datasets.yml
+++ b/.github/workflows/test_datasets.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -48,7 +47,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/test_module.yml
+++ b/.github/workflows/test_module.yml
@@ -59,7 +59,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/test_other.yml
+++ b/.github/workflows/test_other.yml
@@ -39,7 +39,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v5
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
         os: [windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ sktime also provides **interfaces to related libraries**, for example [scikit-le
 For troubleshooting and detailed installation instructions, see the [documentation](https://www.sktime.net/en/latest/installation.html).
 
 - **Operating system**: macOS X · Linux · Windows 8.1 or higher
-- **Python version**: Python 3.9, 3.10, 3.11, 3.12, and 3.13 (only 64-bit)
+- **Python version**: Python 3.10, 3.11, 3.12, and 3.13 (only 64-bit)
 - **Package managers**: [pip] · [conda] (via `conda-forge`)
 
 [pip]: https://pip.pypa.io/en/stable/

--- a/docs/source/get_started.rst
+++ b/docs/source/get_started.rst
@@ -11,7 +11,7 @@ Installation
 
 ``sktime`` currently supports:
 
-* environments with python version 3.8, 3.9, 3.10, 3.11, or 3.12.
+* environments with python version 3.10, 3.11, 3.12, or 3.13.
 * operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 * installation via ``PyPi`` or ``conda``
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,7 +5,7 @@ Installation
 
 ``sktime`` currently supports:
 
-* Python versions 3.8, 3.9, 3.10, 3.11, and 3.12.
+* Python versions 3.10, 3.11, 3.12, and 3.13.
 * Operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 
 See here for a `full list of precompiled wheels available on PyPI <https://pypi.org/simple/sktime/>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ maintainers = [
 authors = [
     { name = "sktime developers", email = "sktime.toolbox@gmail.com" },
 ]
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.10,<3.14"
 classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
@@ -40,7 +40,6 @@ classifiers = [
   "Operating System :: Unix",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Removes 3.9 from supported versions, and changes any CI jobs depending on 3.9 to 3.11.

Should be released with 0.39.0.