### PR TITLE
[ENH] `sklearn` compatibility - fork `scikit-learn` `_weighted_percentage`

### DIFF
--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -13,7 +13,6 @@ from scipy.stats import gmean
 from sklearn.metrics import mean_absolute_error as _mean_absolute_error
 from sklearn.metrics import mean_squared_error as _mean_squared_error
 from sklearn.metrics import median_absolute_error as _median_absolute_error
-from sklearn.utils.stats import _weighted_percentile
 from sklearn.utils.validation import check_consistent_length
 
 from sktime.performance_metrics.forecasting._coerce import (
@@ -25,7 +24,7 @@ from sktime.performance_metrics.forecasting._common import (
     _relative_error,
 )
 from sktime.utils.sklearn import _check_reg_targets
-from sktime.utils.stats import _weighted_geometric_mean
+from sktime.utils.stats import _weighted_geometric_mean, _weighted_percentile
 
 if sklearn.__version__ >= "1.4.0":
     from sklearn.metrics import root_mean_squared_error as _root_mean_squared_error

--- a/sktime/utils/stats.py
+++ b/sktime/utils/stats.py
@@ -17,7 +17,7 @@ __all__ = [
 
 # forked from sklearn.utils to ensure compatibility with newer sklearn versions
 def _weighted_percentile(array, sample_weight, percentile=50):
-    """Compute weighted percentile
+    """Compute lower weighted percentile.
 
     Computes lower weighted percentile. If `array` is a 2D array, the
     `percentile` is computed along the axis 0.

--- a/sktime/utils/stats.py
+++ b/sktime/utils/stats.py
@@ -3,7 +3,7 @@
 """Statistical functionality used throughout sktime."""
 
 import numpy as np
-from sklearn.utils.stats import _weighted_percentile
+from sklearn.utils.extmath import stable_cumsum
 from sklearn.utils.validation import check_consistent_length
 
 __author__ = ["RNKuhns", "GuzalBulatova"]
@@ -13,6 +13,70 @@ __all__ = [
     "_weighted_min",
     "_weighted_max",
 ]
+
+
+# forked from sklearn.utils to ensure compatibility with newer sklearn versions
+def _weighted_percentile(array, sample_weight, percentile=50):
+    """Compute weighted percentile
+
+    Computes lower weighted percentile. If `array` is a 2D array, the
+    `percentile` is computed along the axis 0.
+
+    Parameters
+    ----------
+    array : 1D or 2D array
+        Values to take the weighted percentile of.
+
+    sample_weight: 1D or 2D array
+        Weights for each value in `array`. Must be same shape as `array` or
+        of shape `(array.shape[0],)`.
+
+    percentile: int or float, default=50
+        Percentile to compute. Must be value between 0 and 100.
+
+    Returns
+    -------
+    percentile : int if `array` 1D, ndarray if `array` 2D
+        Weighted percentile.
+    """
+    n_dim = array.ndim
+    if n_dim == 0:
+        return array[()]
+    if array.ndim == 1:
+        array = array.reshape((-1, 1))
+    # When sample_weight 1D, repeat for each array.shape[1]
+    if array.shape != sample_weight.shape and array.shape[0] == sample_weight.shape[0]:
+        sample_weight = np.tile(sample_weight, (array.shape[1], 1)).T
+    sorted_idx = np.argsort(array, axis=0)
+    sorted_weights = np.take_along_axis(sample_weight, sorted_idx, axis=0)
+
+    # Find index of median prediction for each sample
+    weight_cdf = stable_cumsum(sorted_weights, axis=0)
+    adjusted_percentile = percentile / 100 * weight_cdf[-1]
+
+    # For percentile=0, ignore leading observations with sample_weight=0. GH20528
+    mask = adjusted_percentile == 0
+    adjusted_percentile[mask] = np.nextafter(
+        adjusted_percentile[mask], adjusted_percentile[mask] + 1
+    )
+
+    percentile_idx = np.array(
+        [
+            np.searchsorted(weight_cdf[:, i], adjusted_percentile[i])
+            for i in range(weight_cdf.shape[1])
+        ]
+    )
+    percentile_idx = np.array(percentile_idx)
+    # In rare cases, percentile_idx equals to sorted_idx.shape[0]
+    max_idx = sorted_idx.shape[0] - 1
+    percentile_idx = np.apply_along_axis(
+        lambda x: np.clip(x, 0, max_idx), axis=0, arr=percentile_idx
+    )
+
+    col_index = np.arange(array.shape[1])
+    percentile_in_sorted = sorted_idx[percentile_idx, col_index]
+    percentile = array[percentile_in_sorted, col_index]
+    return percentile[0] if n_dim == 1 else percentile
 
 
 def _weighted_geometric_mean(y, weights=None, axis=None):


### PR DESCRIPTION
forks `scikit-learn` `_weighted_percentage` to ensure compatibility with newer versions of `scikit-learn`.

The private utility was used in some forecasting metrics, and has a breaking change in a newer `scikit-learn` version..