### PR TITLE
[BUG] fix `HierarchicalToyData` dataset `n_instances` tag value

### DIFF
--- a/sktime/datasets/forecasting/hierarchical_sales_toydata.py
+++ b/sktime/datasets/forecasting/hierarchical_sales_toydata.py
@@ -37,7 +37,7 @@ class HierarchicalSalesToydata(_ForecastingDatasetFromLoader):
         "is_empty": False,
         "has_nans": False,
         "has_exogenous": False,
-        "n_instances": 12 * 5 * 4,
+        "n_instances": 4,
         "n_timepoints": 12 * 5 * 4,
         "frequency": "M",
         "n_dimensions": 1,


### PR DESCRIPTION
fixes the `HierarchicalToyData` dataset `n_instances` tag value, there are 4 time series, so the value should be 4.