### PR TITLE
[MNT] remove `python<3.13` bound in some dependency sets for `numba`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ all_extras = [
   'hmmlearn>=0.2.7; python_version < "3.11"',
   'holidays; python_version < "3.13"',
   'matplotlib!=3.9.1,>=3.3.2; python_version < "3.13"',
-  'numba<0.63,>=0.53; python_version < "3.13"',
+  'numba<0.63,>=0.53',
   'optuna<4.5',
   'pmdarima!=1.8.1,<3.0.0,>=1.8; python_version < "3.12"',
   'polars[pandas]>=0.20,<2.0; python_version < "3.13"',
@@ -122,7 +122,7 @@ all_extras_pandas2 = [
   'hmmlearn>=0.2.7; python_version < "3.11"',
   'holidays; python_version < "3.13"',
   'matplotlib!=3.9.1,>=3.3.2; python_version < "3.13"',
-  'numba<0.63,>=0.53; python_version < "3.13"',
+  'numba<0.63,>=0.53',
   'optuna<4.5',
   'pmdarima!=1.8.1,<3.0.0,>=1.8; python_version < "3.12"',
   'polars[pandas]>=0.20,<2.0; python_version < "3.13"',
@@ -155,27 +155,27 @@ all_extras_pandas2 = [
 alignment = [
   'dtaidistance<2.4; python_version < "3.13"',
   'dtw-python>=1.3,<1.6; python_version < "3.13"',
-  'numba<0.63,>=0.53; python_version < "3.13"',
+  'numba<0.63,>=0.53',
 ]
 annotation = [
   'hmmlearn<0.4,>=0.2.7; python_version < "3.13"',
-  'numba<0.63,>=0.53; python_version < "3.13"',
+  'numba<0.63,>=0.53',
   'pyod<1.2,>=0.8; python_version < "3.12"',
 ]
 classification = [
-  'numba<0.63,>=0.53; python_version < "3.13"',
+  'numba<0.63,>=0.53',
   'tensorflow<2.20,>=2; python_version < "3.13"',
   'tsfresh<0.21,>=0.17; python_version < "3.12"',
 ]
 clustering = [
   'networkx<3.5',
-  'numba<0.63,>=0.53; python_version < "3.13"',
+  'numba<0.63,>=0.53',
   'tslearn<0.7.0,!=0.6.0,>=0.5.2; python_version < "3.12"',
   'ts2vg<1.3; python_version < "3.13" and platform_machine != "aarch64"',
 ]
 detection = [
   'hmmlearn<0.4,>=0.2.7; python_version < "3.13"',
-  'numba<0.63,>=0.53; python_version < "3.13"',
+  'numba<0.63,>=0.53',
   'pyod<1.2,>=0.8; python_version < "3.12"',
 ]
 forecasting = [
@@ -196,12 +196,12 @@ param_est = [
   'statsmodels<0.15,>=0.12.1; python_version < "3.13"',
 ]
 regression = [
-  'numba<0.63,>=0.53; python_version < "3.13"',
+  'numba<0.63,>=0.53',
   'tensorflow<2.20,>=2; python_version < "3.13"',
 ]
 transformations = [
   'holidays>=0.29,<0.59; python_version < "3.13"',
-  'numba<0.63,>=0.53; python_version < "3.13"',
+  'numba<0.63,>=0.53',
   'pycatch22>=0.4,<0.4.6; python_version < "3.13"',
   'simdkalman',
   'statsmodels<0.15,>=0.12.1; python_version < "3.13"',


### PR DESCRIPTION
removes `python<3.13` bound in some dependency sets for `numba`.

This only removes a restriction in explicit install commands - previously, `sktime` could already be installed with `numba`, but the tests for `numba` did not run on `python 3.13`.