### PR TITLE
[ENH] fixes to tag deprecation logic

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -398,8 +398,10 @@ class TagAliaserMixin(_TagAliaserMixin):
     * if only the old tag is present, and the new tag is requested,
       returns the value of the new tag, without a warning.
 
-    Note: all warnings above are for the user of the estimator, to use
-    the new tag.
+    Note: all warnings above are for the user of the estimator,
+    when attempting to read the old tag,
+    suggesting to use the new tag instead, which is the deprecation target state.
+
     Warnings and errors for the developer of the estimator,
     to change the old tag to new if
     the old tag is still present, are not raised by this class.

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -450,7 +450,8 @@ class TagAliaserMixin(_TagAliaserMixin):
             old_tag = [k for k, v in alias_dict.items() if v == tag_name][0]
 
         # if we are in a situation of aliaing,
-        # 1. check if the old tag exists. If yes, return its value
+        # i.e., the new tag is queried and the old tag exists
+        # 1. return the value of the old tag
         if tag_name != old_tag:
             old_tag_val = cls._get_class_flag(
                 old_tag, "__tag_not_found__", flag_attr_name="_tags"

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -390,7 +390,8 @@ class TagAliaserMixin(_TagAliaserMixin):
       This is the "target" state of the deprecation process.
     * if both new and old tag are present, and any of the two is requested,
       returns the value of the old tag, and raises a warning.
-      This priority is in order to deprecate in a way that does not break existing code.
+      This priority is in order to deprecate in a way that does not break existing code,
+      in case the values of the two tags differ.
     * if only the new tag is present, and the old tag is requested,
       returns the value of the new tag, raises a warning.
     * if only the old tag is present, and the new tag is requested,

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -404,7 +404,7 @@ class TagAliaserMixin(_TagAliaserMixin):
     to change the old tag to new if
     the old tag is still present, are not raised by this class.
     These warnings should be raised separately, in API conformance tests,
-    preferably at CI time and as exceptions.    
+    preferably at CI time and as exceptions.
     """
 
     alias_dict = {

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -436,6 +436,9 @@ class TagAliaserMixin(_TagAliaserMixin):
         cls._deprecate_tag_warn([tag_name])
         alias_dict = cls.alias_dict
 
+        # check is tag is aliased or aliasing
+        # if yes, ensure that tag_name is the new tag name str
+        # and old_tag is the old tag name str
         old_tag = ""
         if tag_name in alias_dict:
             old_tag = tag_name
@@ -443,6 +446,9 @@ class TagAliaserMixin(_TagAliaserMixin):
         if tag_name in alias_dict.values():
             old_tag = [k for k, v in alias_dict.items() if v == tag_name][0]
 
+        # if we are in a situation of aliaing,
+        # 1. check if the old tag exists. If yes, return its value
+        # 2. else, continue as usual with the new tag name, and return its value
         if tag_name != old_tag:
             old_tag_val = cls._get_class_flag(
                 old_tag, "__tag_not_found__", flag_attr_name="_tags"

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -443,6 +443,9 @@ class TagAliaserMixin(_TagAliaserMixin):
         if tag_name in alias_dict:
             old_tag = tag_name
             tag_name = alias_dict[tag_name]
+            if old_tag in cls.FLIPPED_TAGS:
+                tag_value_default = not tag_value_default
+
         if tag_name in alias_dict.values():
             old_tag = [k for k, v in alias_dict.items() if v == tag_name][0]
 
@@ -457,17 +460,12 @@ class TagAliaserMixin(_TagAliaserMixin):
                 if old_tag in cls.FLIPPED_TAGS:
                     return not old_tag_val
                 return old_tag_val
-            elif old_tag in cls.FLIPPED_TAGS:
-                tag_value_default = not tag_value_default
 
         # 2. else, continue as usual with tag_name, and return its value
         # if aliasing happened, this is the new tag name
         tag_val = super().get_class_tag(
             tag_name=tag_name, tag_value_default=tag_value_default
         )
-        # todo 1.0.0 - remove this special case
-        if old_tag in cls.FLIPPED_TAGS:
-            return not tag_val
         return tag_val
 
     def get_tag(self, tag_name, tag_value_default=None, raise_error=True):
@@ -521,6 +519,8 @@ class TagAliaserMixin(_TagAliaserMixin):
         if tag_name in alias_dict:
             old_tag = tag_name
             tag_name = alias_dict[tag_name]
+            if old_tag in self.FLIPPED_TAGS:
+                tag_value_default = not tag_value_default
         if tag_name in alias_dict.values():
             old_tag = [k for k, v in alias_dict.items() if v == tag_name][0]
 
@@ -533,17 +533,12 @@ class TagAliaserMixin(_TagAliaserMixin):
                 if old_tag in self.FLIPPED_TAGS:
                     return not old_tag_val
                 return old_tag_val
-            elif old_tag in self.FLIPPED_TAGS:
-                tag_value_default = not tag_value_default
 
         tag_val = super().get_tag(
             tag_name=tag_name,
             tag_value_default=tag_value_default,
             raise_error=raise_error,
         )
-        # todo 1.0.0 - remove this special case
-        if old_tag in self.FLIPPED_TAGS:
-            return not tag_val
         return tag_val
 
     @classmethod

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -386,7 +386,8 @@ class TagAliaserMixin(_TagAliaserMixin):
     i.e., an entry ``{"old_tag": "new_tag"}`` in ``alias_dict``:
 
     * if only the new tag is present, and the new tag is requested,
-      returns the value of the new tag, no warning. This is the "target" case.
+      returns the value of the new tag, no warning.
+      This is the "target" state of the deprecation process.
     * if both new and old tag are present, and any of the two is requested,
       returns the value of the old tag, and raises a warning.
       This is in order to deprecate in a way that does not break existing code.

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -390,7 +390,7 @@ class TagAliaserMixin(_TagAliaserMixin):
       This is the "target" state of the deprecation process.
     * if both new and old tag are present, and any of the two is requested,
       returns the value of the old tag, and raises a warning.
-      This is in order to deprecate in a way that does not break existing code.
+      This priority is in order to deprecate in a way that does not break existing code.
     * if only the new tag is present, and the old tag is requested,
       returns the value of the new tag, raises a warning.
     * if only the old tag is present, and the new tag is requested,

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -381,6 +381,27 @@ class TagAliaserMixin(_TagAliaserMixin):
     When removing tags, ensure to remove the removed tags from this class. If no tags
     are deprecated anymore (e.g., all deprecated tags are removed/renamed), ensure
     to remove this class as a parent of ``BaseObject`` or ``BaseEstimator``.
+
+    Exact aliasing logic, in the situation of an "old" and "new" tag,
+    i.e., an entry ``{"old_tag": "new_tag"}`` in ``alias_dict``:
+
+    * if only the new tag is present, and the new tag is requested,
+      returns the value of the new tag, no warning. This is the "target" case.
+    * if both new and old tag are present, and any of the two is requested,
+      returns the value of the old tag, and raises a warning.
+      This is in order to deprecate in a way that does not break existing code.
+    * if only the new tag is present, and the old tag is requested,
+      returns the value of the new tag, raises a warning.
+    * if only the old tag is present, and the new tag is requested,
+      returns the value of the new tag, without a warning.
+
+    Note: all warnings above are for the user of the estimator, to use
+    the new tag.
+    Warnings and errors for the developer of the estimator,
+    to change the old tag to new if
+    the old tag is still present, are not raised by this class.
+    These warnings should be raised separately, in API conformance tests,
+    preferably at CI time and as exceptions.    
     """
 
     alias_dict = {

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -448,7 +448,6 @@ class TagAliaserMixin(_TagAliaserMixin):
 
         # if we are in a situation of aliaing,
         # 1. check if the old tag exists. If yes, return its value
-        # 2. else, continue as usual with the new tag name, and return its value
         if tag_name != old_tag:
             old_tag_val = cls._get_class_flag(
                 old_tag, "__tag_not_found__", flag_attr_name="_tags"
@@ -458,7 +457,11 @@ class TagAliaserMixin(_TagAliaserMixin):
                 if old_tag in cls.FLIPPED_TAGS:
                     return not old_tag_val
                 return old_tag_val
+            elif old_tag in cls.FLIPPED_TAGS:
+                tag_value_default = not tag_value_default
 
+        # 2. else, continue as usual with tag_name, and return its value
+        # if aliasing happened, this is the new tag name
         tag_val = super().get_class_tag(
             tag_name=tag_name, tag_value_default=tag_value_default
         )
@@ -530,6 +533,8 @@ class TagAliaserMixin(_TagAliaserMixin):
                 if old_tag in self.FLIPPED_TAGS:
                     return not old_tag_val
                 return old_tag_val
+            elif old_tag in self.FLIPPED_TAGS:
+                tag_value_default = not tag_value_default
 
         tag_val = super().get_tag(
             tag_name=tag_name,

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -389,9 +389,10 @@ class TagAliaserMixin(_TagAliaserMixin):
       returns the value of the new tag, no warning.
       This is the "target" state of the deprecation process.
     * if both new and old tag are present, and any of the two is requested,
-      returns the value of the old tag, and raises a warning.
+      returns the value of the old tag.
       This priority is in order to deprecate in a way that does not break existing code,
       in case the values of the two tags differ.
+      Raises a warning in addition, if the old tag was requested.
     * if only the new tag is present, and the old tag is requested,
       returns the value of the new tag, raises a warning.
     * if only the old tag is present, and the new tag is requested,

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -440,11 +440,24 @@ class TagAliaserMixin(_TagAliaserMixin):
         if tag_name in alias_dict:
             old_tag = tag_name
             tag_name = alias_dict[tag_name]
+        if tag_name in alias_dict.values():
+            old_tag = [k for k, v in alias_dict.items() if v == tag_name][0]
+
+        if tag_name != old_tag:
+            old_tag_val = cls._get_class_flag(
+                old_tag, "__tag_not_found__", flag_attr_name="_tags"
+            )
+            if old_tag_val != "__tag_not_found__":
+                # todo 1.0.0 - remove this special case
+                if old_tag in cls.FLIPPED_TAGS:
+                    return not old_tag_val
+                return old_tag_val
 
         tag_val = super().get_class_tag(
             tag_name=tag_name, tag_value_default=tag_value_default
         )
-        if old_tag == "ignores-exogeneous-X":
+        # todo 1.0.0 - remove this special case
+        if old_tag in cls.FLIPPED_TAGS:
             return not tag_val
         return tag_val
 
@@ -499,11 +512,24 @@ class TagAliaserMixin(_TagAliaserMixin):
         if tag_name in alias_dict:
             old_tag = tag_name
             tag_name = alias_dict[tag_name]
+        if tag_name in alias_dict.values():
+            old_tag = [k for k, v in alias_dict.items() if v == tag_name][0]
+
+        if tag_name != old_tag:
+            old_tag_val = self._get_flag(
+                old_tag, "__tag_not_found__", raise_error=False, flag_attr_name="_tags"
+            )
+            if old_tag_val != "__tag_not_found__":
+                # todo 1.0.0 - remove this special case
+                if old_tag in self.FLIPPED_TAGS:
+                    return not old_tag_val
+                return old_tag_val
 
         tag_val = super().get_tag(
             tag_name=tag_name, tag_value_default=tag_value_default
         )
-        if old_tag == "ignores-exogeneous-X":
+        # todo 1.0.0 - remove this special case
+        if old_tag in self.FLIPPED_TAGS:
             return not tag_val
         return tag_val
 
@@ -553,22 +579,24 @@ class TagAliaserMixin(_TagAliaserMixin):
         # special treatment for tags that get boolean flipped:
         # "ignores-exogeneous-X", "univariate-only"
         # the new tag is the negation of the old tag
-        if old_tag in ["ignores-exogeneous-X", "univariate-only"]:
-            if old_tag in tag_dict and new_tag != "" and new_tag not in tag_dict:
+        if old_tag in cls.FLIPPED_TAGS:
+            if old_tag in tag_dict and new_tag != "":
                 new_tag_dict[new_tag] = not tag_dict[old_tag]
-            if new_tag in tag_dict:
+            if new_tag in tag_dict and old_tag not in tag_dict:
                 new_tag_dict[old_tag] = not tag_dict[new_tag]
             return new_tag_dict
 
         # standard treatment for all other tags
-        if old_tag in tag_dict and new_tag != "" and new_tag not in tag_dict:
+        if old_tag in tag_dict and new_tag != "":
             new_tag_dict[new_tag] = tag_dict[old_tag]
-        if new_tag in tag_dict:
+        if new_tag in tag_dict and old_tag not in tag_dict:
             new_tag_dict[old_tag] = tag_dict[new_tag]
         return new_tag_dict
 
     # package name used for deprecation warnings
     _package_name = "sktime"
+
+    FLIPPED_TAGS = ["ignores-exogeneous-X", "univariate-only"]
 
 
 # todo 1.0.0: remove TagAliaserMixin from inheritance

--- a/sktime/base/tests/test_tagaliaser.py
+++ b/sktime/base/tests/test_tagaliaser.py
@@ -1,0 +1,84 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests the aliasing logic in the Tag Aliaser."""
+
+from sktime.base import BaseObject as _BaseObject
+from sktime.base._base import TagAliaserMixin as _TagAliaserMixin
+
+
+class AliaserTestClass(_TagAliaserMixin, _BaseObject):
+    """Class for testing tag aliasing logic."""
+
+    _tags = {
+        "new_tag_1": "new_tag_1_value",
+        "old_tag_1": "old_tag_1_value",
+        "new_tag_2": "new_tag_2_value",
+        "old_tag_3": "old_tag_3_value",
+    }
+
+    alias_dict = {
+        "old_tag_1": "new_tag_1",
+        "old_tag_2": "new_tag_2",
+        "old_tag_3": "new_tag_3",
+    }
+    deprecate_dict = {
+        "old_tag_1": "42.0.0",
+        "old_tag_2": "84.0.0",
+        "old_tag_3": "126.0.0",
+    }
+
+    def __init__(self):
+        super().__init__()
+
+
+def test_tag_aliaser():
+    """Tests the tag aliaser logic, as described in its docstring."""
+    # case both new and old tags exist
+    # old tag takes precedence
+    new_tag_1_val = AliaserTestClass().get_tag("new_tag_1")
+    assert new_tag_1_val == "old_tag_1_value"
+    old_tag_1_val = AliaserTestClass().get_tag("old_tag_1")
+    assert old_tag_1_val == "old_tag_1_value"
+
+    new_tag_1_val = AliaserTestClass.get_class_tag("new_tag_1")
+    assert new_tag_1_val == "old_tag_1_value"
+    old_tag_1_val = AliaserTestClass.get_class_tag("old_tag_1")
+    assert old_tag_1_val == "old_tag_1_value"
+
+    # case only new tag exists
+    new_tag_2_val = AliaserTestClass().get_tag("new_tag_2")
+    assert new_tag_2_val == "new_tag_2_value"
+    old_tag_2_val = AliaserTestClass().get_tag("old_tag_2")
+    assert old_tag_2_val == "new_tag_2_value"
+
+    new_tag_2_val = AliaserTestClass.get_class_tag("new_tag_2")
+    assert new_tag_2_val == "new_tag_2_value"
+    old_tag_2_val = AliaserTestClass.get_class_tag("old_tag_2")
+    assert old_tag_2_val == "new_tag_2_value"
+
+    # case only old tag exists
+    new_tag_3_val = AliaserTestClass().get_tag("new_tag_3")
+    assert new_tag_3_val == "old_tag_3_value"
+    old_tag_3_val = AliaserTestClass().get_tag("old_tag_3")
+    assert old_tag_3_val == "old_tag_3_value"
+
+    new_tag_3_val = AliaserTestClass.get_class_tag("new_tag_3")
+    assert new_tag_3_val == "old_tag_3_value"
+    old_tag_3_val = AliaserTestClass.get_class_tag("old_tag_3")
+    assert old_tag_3_val == "old_tag_3_value"
+
+    # test all tags retrieval
+    all_tags = AliaserTestClass().get_tags()
+    assert all_tags["new_tag_1"] == "old_tag_1_value"
+    assert all_tags["old_tag_1"] == "old_tag_1_value"
+    assert all_tags["new_tag_2"] == "new_tag_2_value"
+    assert all_tags["old_tag_2"] == "new_tag_2_value"
+    assert all_tags["new_tag_3"] == "old_tag_3_value"
+    assert all_tags["old_tag_3"] == "old_tag_3_value"
+
+    all_tags_cls = AliaserTestClass.get_class_tags()
+    assert all_tags_cls["new_tag_1"] == "old_tag_1_value"
+    assert all_tags_cls["old_tag_1"] == "old_tag_1_value"
+    assert all_tags_cls["new_tag_2"] == "new_tag_2_value"
+    assert all_tags_cls["old_tag_2"] == "new_tag_2_value"
+    assert all_tags_cls["new_tag_3"] == "old_tag_3_value"
+    assert all_tags_cls["old_tag_3"] == "old_tag_3_value"


### PR DESCRIPTION
For 0.39.0, makes fixes in tag deprecation logic, to behave as follows. Assume a setting where `"old_tag"` is renamed to `"new_tag"`.

If `"new_tag"` is queried and `"old_tag"` is set, retrieves `"old_tag"`. This is to not break third party estimators that set `"old_tag"`.

If `"new_tag"` is queried and `"old_tag"` is not set, retrieves `"new_tag"`.

If `"old_tag"` is queried and `"old_tag"` is not set, and `"new_tag"` is set, retrieves `"new_tag"`. Also raises a warning, since this is a case where the user queries the tag.

If `"old_tag"` is queried and `"old_tag"` is set, retrieves `"old_tag"`, and also raises a warning.

Previously, `"new_tag"` would be retrieved it `"new_tag"` was present - this would break estimators that still had only `"old_tag"` set, but not `"new_tag"`. With the above, third party extenders have a warning until 1.0.0 to move to the new tags.


