### PR TITLE
[ENH] tag deprecation test extension to warn third party developers of deprecated tags

### DIFF
--- a/extension_templates/alignment.py
+++ b/extension_templates/alignment.py
@@ -133,7 +133,7 @@ class MyAligner(BaseAligner):
         # if est.foo == 42:
         #   self.set_tags(handles-missing-data=True)
         # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
+        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _fit(self, X, Z=None):

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -144,7 +144,7 @@ class MyTimeSeriesClassifier(BaseClassifier):
         # if est.foo == 42:
         #   self.set_tags(handles-missing-data=True)
         # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
+        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _fit(self, X, y):

--- a/extension_templates/detection.py
+++ b/extension_templates/detection.py
@@ -171,7 +171,7 @@ class MyDetector(BaseDetector):
         # if est.foo == 42:
         #   self.set_tags(handles-missing-data=True)
         # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
+        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _fit(self, X, y=None):

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -103,7 +103,7 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
         # if est.foo == 42:
         #   self.set_tags(handles-missing-data=True)
         # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
+        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _transform(self, X, X2=None):

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -103,7 +103,7 @@ class MyTrafoPw(BasePairwiseTransformer):
         # if est.foo == 42:
         #   self.set_tags(handles-missing-data=True)
         # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
+        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _transform(self, X, X2=None):

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -113,7 +113,7 @@ class MyEarlyTimeSeriesClassifier(BaseEarlyClassifier):
         # if est.foo == 42:
         #   self.set_tags(handles-missing-data=True)
         # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
+        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _fit(self, X, y):

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -160,7 +160,7 @@ class MySplitter(BaseSplitter):
         # if est.foo == 42:
         #   self.set_tags(handles-missing-data=True)
         # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
+        #   self.clone_tags(est2, ["enforce_index_type", "capability:missing_values"])
 
     # todo: implement this, mandatory
     def _split(self, y):

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -502,7 +502,6 @@ class TagAliaserMixin(_TagAliaserMixin):
                 new_tag_value = cls._get_class_flag(
                     new_tag_name,
                     tag_value_default,
-                    raise_error=False,
                     flag_attr_name="_tags",
                 )
                 if old_tag_queried and old_tag_name in cls.FLIPPED_TAGS:

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -480,7 +480,7 @@ class TagAliaserMixin(_TagAliaserMixin):
 
         if tag_changed:
             # retrieve old tag value, if it exists
-            old_tag_val = cls._get_classflag(
+            old_tag_val = cls._get_class_flag(
                 old_tag_name,
                 "__tag_not_found__",
                 flag_attr_name="_tags",

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -549,7 +549,7 @@ class TagAliaserMixin(_TagAliaserMixin):
         alias_dict = cls.alias_dict
         new_tag = alias_dict[old_tag]
 
-        # todo 1.0.0 - removve this special case
+        # todo 1.0.0 - remove this special case
         # special treatment for tags that get boolean flipped:
         # "ignores-exogeneous-X", "univariate-only"
         # the new tag is the negation of the old tag

--- a/sktime/forecasting/greykite.py
+++ b/sktime/forecasting/greykite.py
@@ -64,7 +64,7 @@ class GreykiteForecaster(BaseForecaster):
     _tags = {
         "scitype:y": "univariate",  # Handles univariate targets here.
         "capability:exogenous": True,  # Can handle exogenous variables.
-        "handles-missing-data": True,  # Handles missing data.
+        "capability:missing_values": True,  # Handles missing data.
         "y_inner_mtype": "pd.Series",  # Expected input type for y.
         "X_inner_mtype": "pd.DataFrame",  # Expected input type for X.
         "requires-fh-in-fit": True,  # Forecasting horizon is required in fit.

--- a/sktime/forecasting/hf_momentfm_forecaster.py
+++ b/sktime/forecasting/hf_momentfm_forecaster.py
@@ -152,7 +152,7 @@ class MomentFMForecaster(_BaseGlobalForecaster):
         "scitype:y": "both",
         "authors": ["julian-fong"],
         "maintainers": ["julian-fong"],
-        "handles-missing-data": False,
+        "capability:missing_values": False,
         "y_inner_mtype": [
             "pd.DataFrame",
             "pd-multiindex",

--- a/sktime/forecasting/patch_tst.py
+++ b/sktime/forecasting/patch_tst.py
@@ -264,7 +264,7 @@ class PatchTSTForecaster(_BaseGlobalForecaster):
         "requires-fh-in-fit": False,
         "X-y-must-have-same-index": True,
         "enforce_index_type": None,
-        "handles-missing-data": False,
+        "capability:missing_values": False,
         "capability:insample": False,
         "capability:pred_int": False,
         "capability:pred_int:insample": False,

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -1252,14 +1252,46 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
     def test_valid_estimator_class_tags(self, estimator_class):
         """Check that Estimator class tags are in VALID_ESTIMATOR_TAGS."""
         for tag in estimator_class.get_class_tags().keys():
-            msg = "Found invalid tag: %s" % tag
+            msg = (
+                f"{estimator_class} has invalid tag: {tag!r} - "
+                "please check for spelling mistakes and if the tag exists "
+                "in the sktime API reference, or in registry.all_tags."
+            )
             assert tag in VALID_ESTIMATOR_TAGS, msg
+
+        from sktime.base._base import TagAliaserMixin
+
+        ALIAS_DICT = TagAliaserMixin.alias_dict
+
+        for tag in estimator_class._get_class_flags(flag_attr_name="_tags"):
+            msg = (
+                f"{estimator_class} has deprecated tag: {tag!r} - "
+                f"please follow deprecation guide from sktime release notes "
+                f"and replace with {ALIAS_DICT[tag]!r}"
+            )
+            assert tag not in ALIAS_DICT, msg
 
     def test_valid_estimator_tags(self, estimator_instance):
         """Check that Estimator tags are in VALID_ESTIMATOR_TAGS."""
         for tag in estimator_instance.get_tags().keys():
-            msg = "Found invalid tag: %s" % tag
+            msg = (
+                f"{estimator_instance} has invalid tag: {tag!r} - "
+                "please check for spelling mistakes and if the tag exists "
+                "in the sktime API reference, or in registry.all_tags."
+            )
             assert tag in VALID_ESTIMATOR_TAGS, msg
+
+        from sktime.base._base import TagAliaserMixin
+
+        ALIAS_DICT = TagAliaserMixin.alias_dict
+
+        for tag in estimator_instance._get_flags(flag_attr_name="_tags"):
+            msg = (
+                f"{estimator_instance} has deprecated tag: {tag!r} - "
+                f"please follow deprecation guide from sktime release notes "
+                f"and replace with {ALIAS_DICT[tag]!r}"
+            )
+            assert tag not in ALIAS_DICT, msg
 
     def test_random_tags(self, estimator_class):
         """Check that estimator randomization tags are compatibly set."""

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -1264,12 +1264,13 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         ALIAS_DICT = TagAliaserMixin.alias_dict
 
         for tag in estimator_class._get_class_flags(flag_attr_name="_tags"):
-            msg = (
-                f"{estimator_class} has deprecated tag: {tag!r} - "
-                f"please follow deprecation guide from sktime release notes "
-                f"and replace with {ALIAS_DICT[tag]!r}"
-            )
-            assert tag not in ALIAS_DICT, msg
+            if tag in ALIAS_DICT:
+                msg = (
+                    f"{estimator_class} has deprecated tag: {tag!r} - "
+                    f"please follow deprecation guide from sktime release notes "
+                    f"and replace with {ALIAS_DICT[tag]!r}"
+                )
+                raise AssertionError(msg)
 
     def test_valid_estimator_tags(self, estimator_instance):
         """Check that Estimator tags are in VALID_ESTIMATOR_TAGS."""
@@ -1286,12 +1287,13 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         ALIAS_DICT = TagAliaserMixin.alias_dict
 
         for tag in estimator_instance._get_flags(flag_attr_name="_tags"):
-            msg = (
-                f"{estimator_instance} has deprecated tag: {tag!r} - "
-                f"please follow deprecation guide from sktime release notes "
-                f"and replace with {ALIAS_DICT[tag]!r}"
-            )
-            assert tag not in ALIAS_DICT, msg
+            if tag in ALIAS_DICT:
+                msg = (
+                    f"{estimator_instance} has deprecated tag: {tag!r} - "
+                    f"please follow deprecation guide from sktime release notes "
+                    f"and replace with {ALIAS_DICT[tag]!r}"
+                )
+                raise AssertionError(msg)
 
     def test_random_tags(self, estimator_class):
         """Check that estimator randomization tags are compatibly set."""

--- a/sktime/transformations/hierarchical/squeeze_hierarchy.py
+++ b/sktime/transformations/hierarchical/squeeze_hierarchy.py
@@ -52,7 +52,7 @@ class SqueezeHierarchy(BaseTransformer):
         "capability:inverse_transform": True,  # does transformer have inverse
         "skip-inverse-transform": False,  # is inverse-transform skipped when called?
         "capability:multivariate": True,  # can the transformer handle multivariate X?
-        "handles-missing-data": False,  # can estimator handle missing data?
+        "capability:missing_values": False,  # can estimator handle missing data?
         "X-y-must-have-same-index": False,  # can estimator handle different X/y index?
         "fit_is_empty": False,  # is fit empty and can be skipped? Yes = True
         "transform-returns-same-time-index": False,


### PR DESCRIPTION
In order to help third party extension developers, this PR adds a clause to the "valid tags" tests that checks if deprecated tags are being used.

While https://github.com/sktime/sktime/pull/8845 ensures that estimators continue working, for users of third party estimation developers, this PR ensures that conformance tests start failing with a useful error message.

Also makes the following changes:

* fixes `TagAliaserMixin.set_tags` logic which was faulty
* changes some deprecated tag to post-deprecation tags that were missed
