### PR TITLE
Add capability:missing_values tag to RecursiveReductionForecaster

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -2363,6 +2363,7 @@ class RecursiveReductionForecaster(BaseForecaster, _ReducerMixin):
         "y_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         # CI and test flags
         # -----------------
+        "capability:missing_values": True,
         "tests:libs": ["sktime.transformations.series.lag"],
     }
 


### PR DESCRIPTION
This PR fixes issue #8446  where RecursiveReductionForecaster was reported as not supporting missing values. 

Added the tag `"capability:missing_values": True` to RecursiveReductionForecaster.