### PR TITLE
[ENH] remove `SeasonalityPeriodogram` from framework core estimator tests

### DIFF
--- a/sktime/param_est/seasonality.py
+++ b/sktime/param_est/seasonality.py
@@ -471,6 +471,7 @@ class SeasonalityPeriodogram(BaseParamFitter):
         # CI and test flags
         # -----------------
         "tests:vm": True,  # tested on separate VM due to seasonal dependency
+        "tests:core": False,  # should tests be triggered by framework changes?
     }
 
     def __init__(self, min_period=4, max_period=None, thresh=0.10):


### PR DESCRIPTION
This PR removes `SeasonalityPeriodogram` from framework core estimator tests, i.e., execution whenever a core framework module changes.

The reason is that `SeasonalityPeriodogram` is forced to run on a separate VM due to its dependency set.