### PR TITLE
[MNT] Run dataset tests only when datasets module changes

### DIFF
--- a/sktime/datasets/tests/test_dataset_downloader.py
+++ b/sktime/datasets/tests/test_dataset_downloader.py
@@ -4,6 +4,7 @@ import time
 import pytest
 
 from sktime.datasets._dataset_downloader import HuggingFaceDownloader, URLDownloader
+from sktime.tests.test_switch import run_test_module_changed
 
 HF_REPO_NAME = "sktime/tsc-datasets"
 FOLDER_NAME = "Beef"
@@ -11,6 +12,10 @@ URL = ["https://timeseriesclassification.com/aeon-toolkit/Beef.zip"]
 EXPECTED_FILES = ["Beef_TRAIN.ts", "Beef_TEST.ts"]
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.datasets"),
+    reason="run test only if datasets module has changed",
+)
 @pytest.mark.datadownload
 @pytest.mark.parametrize(
     "strategy",


### PR DESCRIPTION
This PR lets dataset tests to be run only when the `datasets` module is changes. Please see the following thread for the entire conversation behind this fix: [https://discord.com/channels/1075852648688930887/1424033905429708871](https://discord.com/channels/1075852648688930887/1424033905429708871)