### PR TITLE
[MNT] in tests, set `matplotlib` silent backend and print python deps

### DIFF
--- a/.github/actions/test-component/action.yml
+++ b/.github/actions/test-component/action.yml
@@ -35,6 +35,7 @@ runs:
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
       shell: bash
+
     - name: Install OSX packages
       run: ./.github/scripts/install_osx_dependencies.sh
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,6 +196,11 @@ jobs:
       - name: Install OSX packages
         run: ./.github/scripts/install_osx_dependencies.sh
 
+      - name: Force non-GUI Matplotlib backend (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
+
       - name: Install sktime with dev dependencies
         run: |
           python -m pip install --upgrade pip
@@ -446,6 +451,11 @@ jobs:
 
       - name: Install OSX packages
         run: ./.github/scripts/install_osx_dependencies.sh
+
+      - name: Force non-GUI Matplotlib backend (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
 
       - name: Install sktime and dependencies
         shell: bash

--- a/.github/workflows/test_datasets.yml
+++ b/.github/workflows/test_datasets.yml
@@ -24,19 +24,27 @@ jobs:
     steps:
       - name: repository checkout step
         uses: actions/checkout@v5
+
       - name: update tracking reference step
         run: git remote set-branches origin main
         shell: bash
+
       - name: shallow clone update step
         run: git fetch --depth 1
         shell: bash
+
       - name: python environment step
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: dependencies installation step
         run: python3 -m pip install .[tests]
         shell: bash
+
+      - name: Show dependencies
+        run: python3 -m pip list
+
       - name: unit test step
         run: python3 -m pytest -m "not datadownload" sktime/datasets
         shell: bash
@@ -60,19 +68,27 @@ jobs:
     steps:
       - name: repository checkout step
         uses: actions/checkout@v5
+
       - name: update tracking reference step
         run: git remote set-branches origin main
         shell: bash
+
       - name: shallow clone update step
         run: git fetch --depth 1
         shell: bash
+
       - name: python environment step
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: dependencies installation step
         run: python3 -m pip install .[tests,datasets]
         shell: bash
+
+      - name: Show dependencies
+        run: python3 -m pip list
+
       - name: unit test step
         run: python3 -m pytest -m "datadownload" sktime/datasets
         shell: bash


### PR DESCRIPTION
Makes two changes to the CI tests:

* redirects the `matplotplib` backend on windows to silent
* adding prints for the python dependencies in jobs where this was still missing