### PR TITLE
[MNT] Move PlateauFinder test skip from config to estimator tags

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3673,6 +3673,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "Navya-1817",
+      "name": "Navya-1817",
+      "avatar_url": "https://avatars.githubusercontent.com/u/Navya-1817?v=4",
+      "profile": "https://github.com/Navya-1817",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -29,8 +29,6 @@ ONLY_CHANGED_MODULES = False
 # DO NOT ADD ESTIMATORS HERE ANYMORE
 # ADD TEST SKIPS TO TAG tag tests:skip_all INSTEAD
 EXCLUDE_ESTIMATORS = [
-    # PlateauFinder seems to be broken, see #2259
-    "PlateauFinder",
     # below are removed due to mac failures we don't fully understand, see #3103
     "HIVECOTEV1",
     "HIVECOTEV2",

--- a/sktime/transformations/panel/summarize/_extract.py
+++ b/sktime/transformations/panel/summarize/_extract.py
@@ -41,6 +41,7 @@ class PlateauFinder(BaseTransformer):
         "scitype:instancewise": False,  # is this an instance-wise transform?
         "X_inner_mtype": "nested_univ",  # which mtypes do _fit/_predict support for X?
         "y_inner_mtype": "None",  # which mtypes do _fit/_predict support for X?
+        "tests:skip_all": True,  # PlateauFinder seems to be broken, see #2259
     }
 
     def __init__(self, value=np.nan, min_length=2):


### PR DESCRIPTION
FIX
## Summary
Migrates `PlateauFinder` test exclusion from `tests._config.EXCLUDE_ESTIMATORS` to estimator tags as part of the test skip config migration initiative.

## Changes
- ✅ Remove `PlateauFinder` from `EXCLUDE_ESTIMATORS` in `sktime/tests/_config.py`
- ✅ Add `"tests:skip_all": True` tag to `PlateauFinder` class in `sktime/transformations/panel/summarize/_extract.py`
- ✅ Preserve existing skip behavior and reasoning (issue #2259 - PlateauFinder seems to be broken)

## Testing
- Verified `PlateauFinder` has `tests:skip_all` tag set to `True`
- Verified `PlateauFinder` removed from `EXCLUDE_ESTIMATORS`
-  Confirmed test exclusion behavior is preserved

## Related Issues
- Addresses part of the test skip config migration initiative
- References issue #2259 (PlateauFinder seems to be broken)

##### For all contributions
- I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- The PR title starts with either [ENH], [MNT], [DOC], or [BUG]