### PR TITLE
[ENH] `BOSSEnsemble` second set of test parameters

### DIFF
--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -455,15 +455,12 @@ class BOSSEnsemble(BaseClassifier):
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
         if parameter_set == "results_comparison":
-            param1 = {
+            return {
                 "max_ensemble_size": 5,
                 "feature_selection": "none",
                 "use_boss_distance": False,
                 "alphabet_size": 4,
             }
-            param2 = param1.copy()
-            param2["feature_selection"] = "chi2"
-
         else:
             param1 = {
                 "max_ensemble_size": 2,
@@ -471,8 +468,7 @@ class BOSSEnsemble(BaseClassifier):
                 "feature_selection": "none",
                 "use_boss_distance": False,
             }
-            param2 = param1.copy()
-            param2["feature_selection"] = "chi2"
+            param2 = {**param1, "feature_selection": "chi2"}
 
         return [param1, param2]
 

--- a/sktime/classification/dictionary_based/_boss.py
+++ b/sktime/classification/dictionary_based/_boss.py
@@ -455,19 +455,26 @@ class BOSSEnsemble(BaseClassifier):
             ``create_test_instance`` uses the first (or only) dictionary in ``params``.
         """
         if parameter_set == "results_comparison":
-            return {
+            param1 = {
                 "max_ensemble_size": 5,
                 "feature_selection": "none",
                 "use_boss_distance": False,
                 "alphabet_size": 4,
             }
+            param2 = param1.copy()
+            param2["feature_selection"] = "chi2"
+
         else:
-            return {
+            param1 = {
                 "max_ensemble_size": 2,
                 "save_train_predictions": True,
                 "feature_selection": "none",
                 "use_boss_distance": False,
             }
+            param2 = param1.copy()
+            param2["feature_selection"] = "chi2"
+
+        return [param1, param2]
 
 
 class IndividualBOSS(BaseClassifier):

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -225,7 +225,6 @@ EXCLUDED_TESTS = {
 # exclude tests but keyed by test name
 EXCLUDED_TESTS_BY_TEST = {
     "test_get_test_params_coverage": [
-        "BOSSEnsemble",
         "CAPA",
         "CNTCNetwork",
         "CanonicalIntervalForest",


### PR DESCRIPTION
#### Reference Issues/PRs
#3429


#### What does this implement/fix? Explain your changes.
Adds "feature_selection" = "chi2" to first test parameter creating a second one

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
That parameter makes sense 

#### Did you add any tests for the change?
No

#### Any other comments?
No

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.