### PR TITLE
[BUG] - bugfix | MSTL does not support a trend_forecaster that needs `fh` during `fit`

### DIFF
--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -158,7 +158,12 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
         -------
         self : reference to self
         """
-        del fh  # avoid being detected as unused by ``vulture`` like tools
+        if fh is not None and hasattr(self, "_trend_forecaster"):
+            self._trend_forecaster._fh = (
+                fh  # pass the fh to _trend_forecaster in case it needs it
+            )
+        else:
+            del fh  # avoid being detected as unused by ``vulture`` like tools
 
         self._forecaster = self._instantiate_model()
 
@@ -493,7 +498,8 @@ class StatsForecastBackAdapter:
         -------
         self : returns an instance of self.
         """
-        self.estimator = self.estimator.fit(y=y, X=X)
+        fh = getattr(self, "_fh", None)
+        self.estimator = self.estimator.fit(y=y, X=X, fh=fh)
 
         return self
 

--- a/sktime/forecasting/tests/test_statsforecast.py
+++ b/sktime/forecasting/tests/test_statsforecast.py
@@ -51,7 +51,7 @@ def test_statsforecast_mstl(mock_autoets):
     not run_test_for_class(StatsForecastMSTL),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-@pytest.mark.parametrize("fh", [[1, 2, 3], None])
+@pytest.mark.parametrize("fh", [[1, 2, 3], None], ids=["valid fh", "None fh"])
 def test_statsforecast_mstl_with_fh(fh):
     """
     Check that StatsForecast MSTL adapter calls trend forecaster with


### PR DESCRIPTION
#### Reference Issues/PRs
#5666 


#### What does this implement/fix? Explain your changes.
It enables to use estimators that needs `fh` as `trend_forecaster` for `MSTL` as shown in the issue.

##### Implementation details
During the fit of the `MSTL`(`_GeneralisedStatsForecastAdapter`) I add to the `trend_forecaster` object a property on the fly called `_fh` (with value coming from `fh` of it, only if it's not null).

The inside the fit of `StatsForecastBackAdapter` I get the property (None if not present) ad pass it to the `estimator.fit`

I am not sure if this is the most elegant solution...

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
Line `161-166` of  [sktime/forecasting/base/adapters/_generalised_statsforecast.py](https://github.com/sktime/sktime/compare/main...Abelarm:sktime:5666_StatsForecastMSTL_with_fh?expand=1#diff-1b0922c70b453eca4eb090279c72c0c5b6eaacbcfd3b36c15c872d8e36a9db2e)

#### Did you add any tests for the change?
Yes two new tests in `sktime/forecasting/tests/test_statsforecast.py` - `test_statsforecast_mstl_with_fh` : 
- One with valid `fh` 
- One with empty `fh` that should fail in specific way...

#### Any other comments?
No

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
