### PR TITLE
[ENH] Moved ProximityStump skipped test from tests._config to estimator tags

### DIFF
--- a/sktime/classification/distance_based/_proximity_forest.py
+++ b/sktime/classification/distance_based/_proximity_forest.py
@@ -689,6 +689,12 @@ class ProximityStump(BaseClassifier):
         "capability:random_state": True,
         "property:randomness": "derandomized",
         "X_inner_mtype": "nested_univ",  # input in nested dataframe
+        # pickling problem with local method see #2490
+        "tests:skip_by_name": [
+            "test_persistence_via_pickle",
+            "test_fit_does_not_overwrite_hyper_params",
+            "test_save_estimators_to_file",
+        ],
     }
 
     def __init__(

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -98,12 +98,6 @@ EXCLUDED_TESTS = {
     ],
     # known issue when X is passed, wrong time indices are returned, #1364
     "StackingForecaster": ["test_predict_time_index_with_X"],
-    # pickling problem with local method see #2490
-    "ProximityStump": [
-        "test_persistence_via_pickle",
-        "test_fit_does_not_overwrite_hyper_params",
-        "test_save_estimators_to_file",
-    ],
     "ProximityTree": [
         "test_persistence_via_pickle",
         "test_fit_does_not_overwrite_hyper_params",


### PR DESCRIPTION
#### Reference Issues/PRs
#8515 


#### What does this implement/fix? Explain your changes.
It follow the procedure explained in the referenced Issue of moving test from EXCLUDED_TESTS to "tests:skip_by_name" inside estimator's tags.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
The added tags 

#### Did you add any tests for the change?
No

#### Any other comments?
No

#### PR checklist


##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.