### PR TITLE
[ENH] Harden series-panel converter dispatch

### DIFF
--- a/sktime/datatypes/_series_as_panel/_convert.py
+++ b/sktime/datatypes/_series_as_panel/_convert.py
@@ -300,7 +300,20 @@ def convert_to_scitype(
     if to_scitype == from_scitype:
         return obj
 
-    func_name = f"convert_{from_scitype}_to_{to_scitype}"
-    func = eval(func_name)
+    dispatch = {
+        ("Series", "Panel"): convert_Series_to_Panel,
+        ("Panel", "Series"): convert_Panel_to_Series,
+        ("Series", "Hierarchical"): convert_Series_to_Hierarchical,
+        ("Hierarchical", "Series"): convert_Hierarchical_to_Series,
+        ("Panel", "Hierarchical"): convert_Panel_to_Hierarchical,
+        ("Hierarchical", "Panel"): convert_Hierarchical_to_Panel,
+    }
+
+    try:
+        func = dispatch[(from_scitype, to_scitype)]
+    except KeyError as exc:
+        raise ValueError(
+            f"conversion from {from_scitype} to {to_scitype} is not supported"
+        ) from exc
 
     return func(obj, store=store, return_to_mtype=return_to_mtype)

--- a/sktime/datatypes/_series_as_panel/_convert.py
+++ b/sktime/datatypes/_series_as_panel/_convert.py
@@ -21,6 +21,26 @@ import pandas as pd
 from sktime.datatypes import convert_to, scitype
 
 
+def generate_convert_dict():
+    """Generate converter dispatch dict for series/panel/hierarchical scitypes."""
+    supported_scitypes = {"Series", "Panel", "Hierarchical"}
+    convert_dict = {}
+
+    for name, func in globals().items():
+        if not callable(func) or not name.startswith("convert_"):
+            continue
+
+        route = name[len("convert_") :]
+        if "_to_" not in route:
+            continue
+
+        from_scitype, to_scitype = route.split("_to_", 1)
+        if from_scitype in supported_scitypes and to_scitype in supported_scitypes:
+            convert_dict[(from_scitype, to_scitype)] = func
+
+    return convert_dict
+
+
 def convert_Series_to_Panel(obj, store=None, return_to_mtype=False):
     """Convert series to a single-series panel.
 
@@ -300,14 +320,7 @@ def convert_to_scitype(
     if to_scitype == from_scitype:
         return obj
 
-    dispatch = {
-        ("Series", "Panel"): convert_Series_to_Panel,
-        ("Panel", "Series"): convert_Panel_to_Series,
-        ("Series", "Hierarchical"): convert_Series_to_Hierarchical,
-        ("Hierarchical", "Series"): convert_Hierarchical_to_Series,
-        ("Panel", "Hierarchical"): convert_Panel_to_Hierarchical,
-        ("Hierarchical", "Panel"): convert_Hierarchical_to_Panel,
-    }
+    dispatch = generate_convert_dict()
 
     try:
         func = dispatch[(from_scitype, to_scitype)]

--- a/sktime/datatypes/tests/test_series_to_panel_converters.py
+++ b/sktime/datatypes/tests/test_series_to_panel_converters.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from sktime.datatypes._series_as_panel import (
+    convert_to_scitype,
     convert_Panel_to_Series,
     convert_Series_to_Panel,
 )
@@ -73,3 +74,31 @@ def test_convert_df_panel_to_series():
     assert isinstance(X_series, pd.DataFrame)
     assert len(X_series) == len(X_panel)
     assert (X_series.values == X_panel.values).all()
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.datatypes"),
+    reason="Test only if sktime.datatypes or utils.parallel has been changed",
+)
+def test_convert_to_scitype_dispatch():
+    """Test dispatch in convert_to_scitype across supported routes."""
+    X_series = _make_series(n_columns=2, return_mtype="pd.DataFrame")
+
+    X_panel = convert_to_scitype(X_series, to_scitype="Panel")
+    assert isinstance(X_panel, list)
+
+    X_hierarchical = convert_to_scitype(X_series, to_scitype="Hierarchical")
+    assert isinstance(X_hierarchical, pd.DataFrame)
+    assert X_hierarchical.index.nlevels == 3
+
+    X_series_back, series_mtype = convert_to_scitype(
+        X_panel, to_scitype="Series", return_to_mtype=True
+    )
+    assert isinstance(X_series_back, pd.DataFrame)
+    assert series_mtype == "pd.DataFrame"
+
+    X_panel_back, panel_mtype = convert_to_scitype(
+        X_hierarchical, to_scitype="Panel", return_to_mtype=True
+    )
+    assert isinstance(X_panel_back, pd.DataFrame)
+    assert panel_mtype == "pd-multiindex"

--- a/sktime/datatypes/tests/test_series_to_panel_converters.py
+++ b/sktime/datatypes/tests/test_series_to_panel_converters.py
@@ -82,23 +82,58 @@ def test_convert_df_panel_to_series():
 )
 def test_convert_to_scitype_dispatch():
     """Test dispatch in convert_to_scitype across supported routes."""
-    X_series = _make_series(n_columns=2, return_mtype="pd.DataFrame")
+    calls = []
 
-    X_panel = convert_to_scitype(X_series, to_scitype="Panel")
-    assert isinstance(X_panel, list)
+    def _sentinel(name):
+        def _func(obj, store=None, return_to_mtype=False):
+            calls.append(name)
+            if return_to_mtype:
+                return name, name
+            return name
 
-    X_hierarchical = convert_to_scitype(X_series, to_scitype="Hierarchical")
-    assert isinstance(X_hierarchical, pd.DataFrame)
-    assert X_hierarchical.index.nlevels == 3
+        return _func
 
-    X_series_back, series_mtype = convert_to_scitype(
-        X_panel, to_scitype="Series", return_to_mtype=True
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        "sktime.datatypes._series_as_panel._convert.convert_Series_to_Panel",
+        _sentinel("Series->Panel"),
     )
-    assert isinstance(X_series_back, pd.DataFrame)
-    assert series_mtype == "pd.DataFrame"
-
-    X_panel_back, panel_mtype = convert_to_scitype(
-        X_hierarchical, to_scitype="Panel", return_to_mtype=True
+    monkeypatch.setattr(
+        "sktime.datatypes._series_as_panel._convert.convert_Panel_to_Series",
+        _sentinel("Panel->Series"),
     )
-    assert isinstance(X_panel_back, pd.DataFrame)
-    assert panel_mtype == "pd-multiindex"
+    monkeypatch.setattr(
+        "sktime.datatypes._series_as_panel._convert.convert_Series_to_Hierarchical",
+        _sentinel("Series->Hierarchical"),
+    )
+    monkeypatch.setattr(
+        "sktime.datatypes._series_as_panel._convert.convert_Hierarchical_to_Series",
+        _sentinel("Hierarchical->Series"),
+    )
+    monkeypatch.setattr(
+        "sktime.datatypes._series_as_panel._convert.convert_Panel_to_Hierarchical",
+        _sentinel("Panel->Hierarchical"),
+    )
+    monkeypatch.setattr(
+        "sktime.datatypes._series_as_panel._convert.convert_Hierarchical_to_Panel",
+        _sentinel("Hierarchical->Panel"),
+    )
+
+    try:
+        assert convert_to_scitype("x", to_scitype="Panel", from_scitype="Series") == "Series->Panel"
+        assert convert_to_scitype("x", to_scitype="Series", from_scitype="Panel") == "Panel->Series"
+        assert convert_to_scitype("x", to_scitype="Hierarchical", from_scitype="Series") == "Series->Hierarchical"
+        assert convert_to_scitype("x", to_scitype="Series", from_scitype="Hierarchical") == "Hierarchical->Series"
+        assert convert_to_scitype("x", to_scitype="Hierarchical", from_scitype="Panel") == "Panel->Hierarchical"
+        assert convert_to_scitype("x", to_scitype="Panel", from_scitype="Hierarchical") == "Hierarchical->Panel"
+
+        assert calls == [
+            "Series->Panel",
+            "Panel->Series",
+            "Series->Hierarchical",
+            "Hierarchical->Series",
+            "Panel->Hierarchical",
+            "Hierarchical->Panel",
+        ]
+    finally:
+        monkeypatch.undo()

--- a/sktime/datatypes/tests/test_series_to_panel_converters.py
+++ b/sktime/datatypes/tests/test_series_to_panel_converters.py
@@ -5,9 +5,9 @@ import pandas as pd
 import pytest
 
 from sktime.datatypes._series_as_panel import (
-    convert_to_scitype,
     convert_Panel_to_Series,
     convert_Series_to_Panel,
+    convert_to_scitype,
 )
 from sktime.tests.test_switch import run_test_module_changed
 from sktime.utils._testing.panel import _make_panel
@@ -120,12 +120,30 @@ def test_convert_to_scitype_dispatch():
     )
 
     try:
-        assert convert_to_scitype("x", to_scitype="Panel", from_scitype="Series") == "Series->Panel"
-        assert convert_to_scitype("x", to_scitype="Series", from_scitype="Panel") == "Panel->Series"
-        assert convert_to_scitype("x", to_scitype="Hierarchical", from_scitype="Series") == "Series->Hierarchical"
-        assert convert_to_scitype("x", to_scitype="Series", from_scitype="Hierarchical") == "Hierarchical->Series"
-        assert convert_to_scitype("x", to_scitype="Hierarchical", from_scitype="Panel") == "Panel->Hierarchical"
-        assert convert_to_scitype("x", to_scitype="Panel", from_scitype="Hierarchical") == "Hierarchical->Panel"
+        assert (
+            convert_to_scitype("x", to_scitype="Panel", from_scitype="Series")
+            == "Series->Panel"
+        )
+        assert (
+            convert_to_scitype("x", to_scitype="Series", from_scitype="Panel")
+            == "Panel->Series"
+        )
+        assert (
+            convert_to_scitype("x", to_scitype="Hierarchical", from_scitype="Series")
+            == "Series->Hierarchical"
+        )
+        assert (
+            convert_to_scitype("x", to_scitype="Series", from_scitype="Hierarchical")
+            == "Hierarchical->Series"
+        )
+        assert (
+            convert_to_scitype("x", to_scitype="Hierarchical", from_scitype="Panel")
+            == "Panel->Hierarchical"
+        )
+        assert (
+            convert_to_scitype("x", to_scitype="Panel", from_scitype="Hierarchical")
+            == "Hierarchical->Panel"
+        )
 
         assert calls == [
             "Series->Panel",


### PR DESCRIPTION
#### Reference Issues/PRs
No direct issue exists for this maintenance hardening change.

#### What does this implement/fix? Explain your changes.
This PR removes eval-based dispatch from series/panel converter selection in `_convert.py` and replaces it with an explicit function lookup.
I also added a regression test in `test_series_to_panel_converters.py` to verify that `convert_to_scitype` routes each supported scitype pair to the expected converter.

#### Does your contribution introduce a new dependency? If yes, which one?
No new runtime dependency was introduced.

#### What should a reviewer concentrate their feedback on?
Whether the explicit dispatch table covers all supported scitype pairs.
Whether the unsupported-path ValueError is the right behavior.
Whether the regression test is a good level of isolation for validating dispatch behavior.

#### Did you add any tests for the change?
Yes.
 The regression test checks that `convert_to_scitype` dispatches each supported source/target pair to the expected converter.

#### Any other comments?
This is a maintenance/security-hardening change with no API surface change.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- N/A