### PR TITLE
[ENH] standardize random_seed capability tags and parameters

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -91,6 +91,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         # default property tags
         "property:randomness": "deterministic",
         "capability:random_state": False,
+        "capability:random_seed": False,
         # default tags for testing
         "tests:core": False,  # core objects have wider trigger conditions in testing
         "tests:vm": False,  # whether the object should be tested in its own VM

--- a/sktime/forecasting/chronos.py
+++ b/sktime/forecasting/chronos.py
@@ -230,7 +230,7 @@ class ChronosForecaster(BaseForecaster):
         If not provided, the default values from the pretrained model or system
         configuration are used.
 
-    seed: int, optional, default=None
+    random_seed: int, optional, default=None
         Random seed for transformers.
 
     use_source_package: bool, optional, default=False
@@ -311,12 +311,14 @@ class ChronosForecaster(BaseForecaster):
         "enforce_index_type": None,
         "capability:missing_values": False,
         "capability:pred_int": False,
+        "capability:random_seed": True,
         "X_inner_mtype": "pd.DataFrame",
         "y_inner_mtype": "pd.DataFrame",
         "capability:multivariate": False,
         "capability:insample": False,
         "capability:pred_int:insample": False,
         "capability:global_forecasting": True,
+        "property:randomness": "derandomized",
         # testing configuration
         # ---------------------
         "tests:vm": True,
@@ -347,17 +349,20 @@ class ChronosForecaster(BaseForecaster):
         self,
         model_path: str,
         config: dict = None,
-        seed: int | None = None,
         use_source_package: bool = False,
         ignore_deps: bool = False,
+        random_seed: int | None = None,
     ):
         self.model_path = model_path
         self.use_source_package = use_source_package
         self.ignore_deps = ignore_deps
 
         # set random seed
-        self.seed = seed
-        self._seed = np.random.randint(0, 2**31) if seed is None else seed
+        self.random_seed = random_seed
+        self.seed = random_seed
+        self._seed = (
+            np.random.randint(0, 2**31) if random_seed is None else random_seed
+        )
 
         # initialize model_strategy as None, will be set correctly after loading config.
         self.model_strategy = None
@@ -566,7 +571,8 @@ class ChronosForecaster(BaseForecaster):
         """
         self._ensure_model_pipeline_loaded()
 
-        transformers.set_seed(self._seed)
+        seed = self.random_seed if self.random_seed is not None else self._seed
+        transformers.set_seed(seed)
         if fh is not None:
             # needs to be integer not np.int64
             prediction_length = int(max(fh.to_relative(self.cutoff)))
@@ -637,7 +643,7 @@ class ChronosForecaster(BaseForecaster):
                 "config": {
                     "num_samples": 20,
                 },
-                "seed": 42,
+                "random_seed": 42,
             }
         )
         test_params.append(

--- a/sktime/forecasting/chronos2.py
+++ b/sktime/forecasting/chronos2.py
@@ -45,7 +45,7 @@ class Chronos2Forecaster(BaseForecaster):
             If True, enables cross-learning across all input series in a batch,
             sharing information via the group attention mechanism.
 
-    seed : int or None, optional, default=None
+    random_seed : int or None, optional, default=None
         Random seed for reproducibility.
 
     ignore_deps : bool, optional, default=False
@@ -83,12 +83,14 @@ class Chronos2Forecaster(BaseForecaster):
         "X-y-must-have-same-index": False,
         "capability:missing_values": False,
         "capability:pred_int": False,
+        "capability:random_seed": True,
         "y_inner_mtype": "pd.DataFrame",
         "X_inner_mtype": "pd.DataFrame",
         "capability:multivariate": True,
         "capability:insample": False,
         "capability:global_forecasting": True,
         "capability:non_contiguous_X": False,
+        "property:randomness": "derandomized",
         "tests:vm": True,
         "tests:skip_by_name": [
             "test_persistence_via_pickle",
@@ -108,12 +110,15 @@ class Chronos2Forecaster(BaseForecaster):
         self,
         model_path: str = "amazon/chronos-2",
         config: dict = None,
-        seed: int | None = None,
         ignore_deps: bool = False,
+        random_seed: int | None = None,
     ):
         self.model_path = model_path
-        self.seed = seed
-        self._seed = np.random.randint(0, 2**31) if seed is None else seed
+        self.random_seed = random_seed
+        self.seed = random_seed
+        self._seed = (
+            np.random.randint(0, 2**31) if random_seed is None else random_seed
+        )
         self.config = config
         self.ignore_deps = ignore_deps
 
@@ -214,7 +219,8 @@ class Chronos2Forecaster(BaseForecaster):
         import transformers
 
         self._ensure_model_pipeline_loaded()
-        transformers.set_seed(self._seed)
+        seed = self.random_seed if self.random_seed is not None else self._seed
+        transformers.set_seed(seed)
 
         prediction_length = int(max(fh.to_relative(self.cutoff)))
 
@@ -280,7 +286,7 @@ class Chronos2Forecaster(BaseForecaster):
         """Return testing parameter settings for the estimator."""
         return [
             {"model_path": "amazon/chronos-2"},
-            {"model_path": "amazon/chronos-2", "seed": 42},
+            {"model_path": "amazon/chronos-2", "random_seed": 42},
         ]
 
 

--- a/sktime/forecasting/timemoe.py
+++ b/sktime/forecasting/timemoe.py
@@ -69,7 +69,7 @@ class TimeMoEForecaster(_BaseGlobalForecaster):
         - tie_word_embeddings: bool, default=False
             Whether to tie word embeddings in the TimeMOE model.
 
-    seed: int, optional (default=None)
+    random_seed: int, optional (default=None)
         Seed for reproducibility.
 
     use_source_package: bool, optional (default=False)
@@ -119,6 +119,7 @@ class TimeMoEForecaster(_BaseGlobalForecaster):
         "enforce_index_type": None,
         "capability:missing_values": False,
         "capability:pred_int": False,
+        "capability:random_seed": True,
         "X_inner_mtype": ["pd.DataFrame", "pd-multiindex", "pd_multiindex_hier"],
         "y_inner_mtype": [
             "pd.DataFrame",
@@ -129,6 +130,7 @@ class TimeMoEForecaster(_BaseGlobalForecaster):
         "capability:insample": False,
         "capability:pred_int:insample": False,
         "capability:global_forecasting": True,
+        "property:randomness": "derandomized",
         # testing configuration
         # ---------------------
         "tests:vm": True,
@@ -139,15 +141,18 @@ class TimeMoEForecaster(_BaseGlobalForecaster):
         self,
         model_path: str,
         config: dict = None,
-        seed: int = None,
         use_source_package: bool = False,
         ignore_deps: bool = False,
+        random_seed: int = None,
     ):
         if not ignore_deps:
             _check_soft_dependencies("torch", severity="error")
             _check_soft_dependencies("transformers", severity="error")
-        self.seed = seed
-        self._seed = np.random.randint(0, 2**31) if seed is None else seed
+        self.random_seed = random_seed
+        self.seed = random_seed
+        self._seed = (
+            np.random.randint(0, 2**31) if random_seed is None else random_seed
+        )
 
         self.config = config
         _config = self._get_default_config()
@@ -290,7 +295,8 @@ class TimeMoEForecaster(_BaseGlobalForecaster):
         import torch
         import transformers
 
-        transformers.set_seed(self._seed)
+        seed = self.random_seed if self.random_seed is not None else self._seed
+        transformers.set_seed(seed)
         if fh is not None:
             prediction_length = int(max(fh.to_relative(self.cutoff)))
         else:

--- a/sktime/forecasting/toto.py
+++ b/sktime/forecasting/toto.py
@@ -59,6 +59,8 @@ class TotoForecaster(BaseForecaster):
         Path to the Toto huggingface model.
     device : string, optional (default=None)
         Specifies the device on which to run the model on ('cpu' or 'cuda').
+    random_seed : int, optional (default=None)
+        Random seed for reproducibility.
 
     References
     ----------
@@ -87,6 +89,8 @@ class TotoForecaster(BaseForecaster):
         "capability:insample": False,
         "capability:pred_int": True,
         "capability:pred_int:insample": False,
+        "capability:random_seed": True,
+        "property:randomness": "derandomized",
         # contribution and dependency tags
         "authors": [
             "JATAYU000",
@@ -114,7 +118,6 @@ class TotoForecaster(BaseForecaster):
 
     def __init__(
         self,
-        seed=None,
         num_samples: int = 1,
         samples_per_batch: int = 1,
         prediction_type: str = "median",
@@ -123,6 +126,7 @@ class TotoForecaster(BaseForecaster):
         use_memory_efficient_attention: bool = False,
         model_path: str = "Datadog/Toto-Open-Base-1.0",
         device=None,
+        random_seed=None,
     ):
         self.model_path = model_path
         self.device = device
@@ -145,8 +149,11 @@ class TotoForecaster(BaseForecaster):
         if prediction_type not in ["mean", "median"]:
             raise ValueError("prediction_type must be either 'mean' or 'median'")
 
-        self.seed = seed
-        self._seed = np.random.randint(0, 2**31) if seed is None else seed
+        self.random_seed = random_seed
+        self.seed = random_seed
+        self._seed = (
+            np.random.randint(0, 2**31) if random_seed is None else random_seed
+        )
         super().__init__()
 
     def _get_toto_key(self):
@@ -274,9 +281,10 @@ class TotoForecaster(BaseForecaster):
         """
         import torch
 
-        torch.manual_seed(self._seed)
+        seed = self.random_seed if self.random_seed is not None else self._seed
+        torch.manual_seed(seed)
         if torch.cuda.is_available():
-            torch.cuda.manual_seed_all(self._seed)
+            torch.cuda.manual_seed_all(seed)
 
         prediction_length = max(fh.to_relative(self._cutoff))
 

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -803,6 +803,34 @@ class capability__random_state(_BaseTag):
     }
 
 
+class capability__random_seed(_BaseTag):
+    """Capability: the estimator can be derandomized using a random_seed.
+
+    - String name: ``"capability:random_seed"``
+    - Public capability tag
+    - Values: bool, ``True`` / ``False``
+    - Example: ``True``
+    - Default: ``False``
+
+    If the tag is ``True``, the estimator can be derandomized using a
+    ``random_seed`` parameter. If the ``random_seed`` parameter is set, then the
+    estimator will produce the same results on every run, up to minimal numerical
+    precision discrepancies (1e-5 relative error).
+    If the tag is ``False``, the estimator does not have a ``random_seed``
+    parameter and cannot be derandomized through that parameter.
+    """
+
+    _tags = {
+        "tag_name": "capability:random_seed",
+        "parent_type": "object",
+        "tag_type": "bool",
+        "short_descr": (
+            "does the object have a random_seed parameter for derandomization?"
+        ),
+        "user_facing": True,
+    }
+
+
 class fit_is_empty(_BaseTag):
     """Property: Whether the estimator has an empty fit method.
 

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -1309,20 +1309,28 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         """Check that estimator randomization tags are compatibly set."""
         randomness = estimator_class.get_class_tag("property:randomness")
         random_state = estimator_class.get_class_tag("capability:random_state")
+        random_seed = estimator_class.get_class_tag("capability:random_seed")
+        has_random_state = "random_state" in estimator_class.get_param_names()
+        has_random_seed = "random_seed" in estimator_class.get_param_names()
 
-        # randomness = "derandomized" should be set only if random_state is available
+        # randomness = "derandomized" should be set only if a seed parameter exists
         if randomness == "derandomized":
-            assert random_state, (
+            assert random_state or random_seed, (
                 f"{estimator_class.__name__} must set "
-                "'capability:random_state' tag to True if "
+                "'capability:random_state' or 'capability:random_seed' tag to True if "
                 "'property:randomness' tag is set to 'derandomized'"
             )
 
-        # random_state tag should be set iff the parameter exists in the signature
-        assert random_state == ("random_state" in estimator_class.get_param_names()), (
+        # randomness capability tags should be set iff the parameter exists
+        assert random_state == has_random_state, (
             f"{estimator_class.__name__} must set "
             "'capability:random_state' tag to True, if and only if the "
             "random_state parameter exists in the estimator signature"
+        )
+        assert random_seed == has_random_seed, (
+            f"{estimator_class.__name__} must set "
+            "'capability:random_seed' tag to True, if and only if the "
+            "random_seed parameter exists in the estimator signature"
         )
 
     def test_obj_vs_cls_signature(self, estimator_class):

--- a/sktime/transformations/series/hidalgo.py
+++ b/sktime/transformations/series/hidalgo.py
@@ -58,7 +58,7 @@ class Hidalgo(BaseTransformer):
         prior parameters of p, the probability that point belongs to manifold k
     f : np.ArrayLike, optional, default=None
         parameters of zeta
-    seed : int, optional, default = 1
+    random_seed : int, optional, default = 1
         generate random numbers with seed
 
     References
@@ -76,7 +76,7 @@ class Hidalgo(BaseTransformer):
     >>> X = np.random.rand(10,3)
     >>> X[:6, 1:] += 10
     >>> X[6:, 1:] = 0
-    >>> model = Hidalgo(K=2, burn_in=0.8, n_iter=100, seed=10)
+    >>> model = Hidalgo(K=2, burn_in=0.8, n_iter=100, random_seed=10)
     >>> fitted_model = model.fit(X)
     >>> Z = fitted_model.transform(X)
     >>> Z.tolist()
@@ -92,7 +92,9 @@ class Hidalgo(BaseTransformer):
         "transform-returns-same-time-index": True,
         "capability:multivariate": True,
         "capability:categorical_in_X": False,
+        "capability:random_seed": True,
         "fit_is_empty": False,
+        "property:randomness": "derandomized",
     }
 
     def __init__(
@@ -112,7 +114,7 @@ class Hidalgo(BaseTransformer):
         b=None,
         c=None,
         f=None,
-        seed=1,
+        random_seed=1,
     ):
         self.metric = metric
         self.K = K
@@ -129,7 +131,8 @@ class Hidalgo(BaseTransformer):
         self.b = b
         self.c = c
         self.f = f
-        self.seed = seed
+        self.random_seed = random_seed
+        self.seed = random_seed
 
         super().__init__()
 
@@ -583,9 +586,7 @@ class Hidalgo(BaseTransformer):
         n_iter = self.n_iter
         sampling_rate = self.sampling_rate
         burn_in = self.burn_in
-        seed = self.seed
-
-        _rng = check_random_state(seed)
+        _rng = check_random_state(self.random_seed)
 
         N, mu, Iin, Iout, Iout_count, Iout_track = self._get_neighbourhood_params(X)
         V, NN, a1, b1, c1, Z, f1, N_in = self._initialise_params(N, mu, Iin, _rng)
@@ -705,7 +706,7 @@ class Hidalgo(BaseTransformer):
             "b": None,
             "c": None,
             "f": None,
-            "seed": 1,
+            "random_seed": 1,
         }
 
 

--- a/sktime/transformations/series/tests/test_hidalgo.py
+++ b/sktime/transformations/series/tests/test_hidalgo.py
@@ -36,7 +36,7 @@ def test_X():
 )
 def test_get_neighbourhood_params():
     """Test for neighbourhood parameter generation."""
-    model = Hidalgo(K=2, n_iter=10, burn_in=0.5, sampling_rate=2, seed=1)
+    model = Hidalgo(K=2, n_iter=10, burn_in=0.5, sampling_rate=2, random_seed=1)
     (
         N_actual,
         mu_actual,
@@ -146,7 +146,7 @@ def test_get_neighbourhood_params():
 )
 def test_initialise_params():
     """Test for initialise parameters."""
-    model = Hidalgo(K=2, n_iter=10, burn_in=0.5, sampling_rate=2, seed=1)
+    model = Hidalgo(K=2, n_iter=10, burn_in=0.5, sampling_rate=2, random_seed=1)
     N = 10
     mu = np.array(
         [
@@ -196,7 +196,7 @@ def test_initialise_params():
             4,
         ]
     )
-    _rng = check_random_state(model.seed)
+    _rng = check_random_state(model.random_seed)
 
     (
         V_actual,
@@ -275,8 +275,8 @@ def test_gibbs():
         ],
     ]
 
-    model = Hidalgo(K=2, n_iter=10, burn_in=0.5, sampling_rate=2, seed=1)
-    _rng = check_random_state(model.seed)
+    model = Hidalgo(K=2, n_iter=10, burn_in=0.5, sampling_rate=2, random_seed=1)
+    _rng = check_random_state(model.random_seed)
 
     N, mu, Iin, Iout, Iout_count, Iout_track = model._get_neighbourhood_params(X)
     V, NN, a1, b1, c1, Z, f1, N_in = model._initialise_params(N, mu, Iin, _rng)

--- a/sktime/utils/random_state.py
+++ b/sktime/utils/random_state.py
@@ -1,4 +1,4 @@
-"""Utilities for handling the random_state variable."""
+"""Utilities for handling estimator randomness parameters."""
 
 # copied from scikit-learn to avoid dependency on sklearn private methods
 
@@ -9,13 +9,13 @@ from sklearn.utils import check_random_state
 def set_random_state(estimator, random_state=0):
     """Set fixed random_state parameters for an estimator.
 
-    Finds all parameters ending ``random_state`` and sets them to integers
-    derived from ``random_state``.
+    Finds all parameters ending ``random_state`` or ``random_seed`` and sets them
+    to integers derived from ``random_state``.
 
     Parameters
     ----------
     estimator : estimator supporting get_params, set_params
-        Estimator with potential randomness managed by random_state parameters.
+        Estimator with potential randomness managed by randomization parameters.
 
     random_state : int, RandomState instance or None, default=None
         Pseudo-random number generator to control the generation of the random
@@ -23,14 +23,18 @@ def set_random_state(estimator, random_state=0):
 
     Notes
     -----
-    This does not necessarily set *all* ``random_state`` attributes that
-    control an estimator's randomness, only those accessible through
-    ``estimator.get_params()``.
+    This does not necessarily set *all* estimator attributes that control
+    randomness, only those accessible through ``estimator.get_params()``.
     """
     random_state = check_random_state(random_state)
     to_set = {}
     for key in sorted(estimator.get_params(deep=True)):
-        if key == "random_state" or key.endswith("__random_state"):
+        if (
+            key == "random_state"
+            or key.endswith("__random_state")
+            or key == "random_seed"
+            or key.endswith("__random_seed")
+        ):
             to_set[key] = random_state.randint(np.iinfo(np.int32).max)
 
     if to_set:


### PR DESCRIPTION
fixes #9977 

## Summary
- standardize estimator randomness interfaces by replacing `seed` parameters with `random_seed` in Chronos, Chronos2, TimeMoE, Toto, and Hidalgo
- add and wire a new public tag `capability:random_seed`, plus default base tag support and compatibility checks in `TestAllObjects.test_random_tags`
- update randomness utility handling so `set_random_state` also propagates values to `random_seed` parameters

## Validation
- [x] `uv run -m pytest -q sktime/tests/test_all_estimators.py::TestAllObjects::test_random_tags sktime/transformations/series/tests/test_hidalgo.py`
- [x] verify touched estimators expose `random_seed` (not `seed`) and set `capability:random_seed=True` with `property:randomness="derandomized"`

