### PR TITLE
[ENH] Add temporal CV to forecasting ensembles

### DIFF
--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -23,7 +23,8 @@ from sktime.utils.stats import (
     _weighted_median,
     _weighted_min,
 )
-from sktime.utils.validation.forecasting import check_regressor
+from sktime.utils.validation import array_is_int
+from sktime.utils.validation.forecasting import check_cv, check_regressor
 
 VALID_AGG_FUNCS = {
     "mean": {"unweighted": np.mean, "weighted": np.average},
@@ -68,13 +69,22 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
         Used to do an internal temporal_train_test_split(). The test_size data
         will be the endog data of the regressor and it is the most recent data.
         The exog data of the regressor are the predictions from the temporarily
-        trained ensemble models. If None, it will be set to 0.25.
+        trained ensemble models. If None, it will be set to 0.25. Only used if
+        ``cv`` is None.
     random_state : int, RandomState instance or None, default=None
         Used to set random_state of the default regressor.
     n_jobs : int or None, optional, default=None
         The number of jobs to run in parallel for fit. None means 1 unless
         in a joblib.parallel_backend context.
         -1 means using all processors.
+    cv : temporal cross-validation splitter, optional, default=None
+        The sktime splitter to use for generating validation predictions for
+        automatic weight estimation. The splitter must generate strictly
+        temporal train/test splits, where every test window is after the
+        corresponding train window. If None, weights are estimated from the
+        existing single internal temporal train-test split controlled by
+        ``test_size``. If a forecasting horizon is passed to ``fit`` together
+        with ``cv``, every validation fold must use a compatible horizon.
 
     Attributes
     ----------
@@ -103,6 +113,18 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
     >>> forecaster.fit(y=y, fh=[1,2,3])
     AutoEnsembleForecaster(...)
     >>> y_pred = forecaster.predict()
+
+    Use ``cv`` to estimate weights from multiple temporal validation folds
+    instead of one validation window:
+
+    >>> from sktime.split import ExpandingWindowSplitter
+    >>> cv = ExpandingWindowSplitter(
+    ...     fh=[1, 2, 3], initial_window=36, step_length=24
+    ... )
+    >>> forecaster = AutoEnsembleForecaster(forecasters=forecasters, cv=cv)
+    >>> forecaster.fit(y=y, fh=[1, 2, 3])
+    AutoEnsembleForecaster(...)
+    >>> y_pred = forecaster.predict()
     """
 
     _tags = {
@@ -127,11 +149,13 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
         test_size=None,
         random_state=None,
         n_jobs=None,
+        cv=None,
     ):
         self.method = method
         self.regressor = regressor
         self.test_size = test_size
         self.random_state = random_state
+        self.cv = cv
 
         super().__init__(
             forecasters=forecasters,
@@ -156,29 +180,15 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
         """
         forecasters = [x[1] for x in self.forecasters_]
 
-        # get training data for meta-model
-        if X is not None:
-            y_train, y_test, X_train, X_test = temporal_train_test_split(
-                y, X, test_size=self.test_size
-            )
-        else:
-            y_train, y_test = temporal_train_test_split(y, test_size=self.test_size)
-            X_train, X_test = None, None
-
-        # fit ensemble models
-        fh_test = ForecastingHorizon(y_test.index, is_relative=False)
-        self._fit_forecasters(forecasters, y_train, X_train, fh_test)
-
         if self.method == "feature-importance":
             self.regressor_ = check_regressor(
                 regressor=self.regressor, random_state=self.random_state
             )
-            X_meta = pd.concat(self._predict_forecasters(fh_test, X_test), axis=1)
-            X_meta.columns = pd.RangeIndex(len(X_meta.columns))
+            X_meta, y_meta = self._get_meta_data(forecasters, y, X, fh)
 
             # fit meta-model (regressor) on predictions of ensemble models
-            # with y_test as endog/target
-            self.regressor_.fit(X=X_meta, y=y_test)
+            # with validation y as endog/target
+            self.regressor_.fit(X=X_meta, y=y_meta)
 
             # check if regressor is a sklearn.Pipeline
             if isinstance(self.regressor_, Pipeline):
@@ -188,15 +198,11 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
                 self.weights_ = _get_weights(self.regressor_)
 
         elif self.method == "inverse-variance":
-            # get in-sample forecasts
             if self.regressor is not None:
                 Warning(f"regressor will not be used because ${self.method} is set.")
-            inv_var = np.array(
-                [
-                    1 / np.var(y_test - y_pred_test)
-                    for y_pred_test in self._predict_forecasters(fh_test, X_test)
-                ]
-            )
+            X_meta, y_meta = self._get_meta_data(forecasters, y, X, fh)
+            errors = y_meta.to_numpy().reshape(-1, 1) - X_meta.to_numpy()
+            inv_var = 1 / np.var(errors, axis=0)
             # standardize the inverse variance
             self.weights_ = list(inv_var / np.sum(inv_var))
         else:
@@ -207,6 +213,233 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
 
         self._fit_forecasters(forecasters, y, X, fh)
         return self
+
+    def _get_meta_data(self, forecasters, y, X, fh):
+        """Return validation predictions and targets for weight estimation."""
+        if self.cv is None:
+            return self._get_single_split_meta_data(forecasters, y, X)
+
+        cv = self._check_cv()
+        X_meta = []
+        y_meta = []
+
+        for fold, train_window, test_window in self._iter_cv_splits(cv, y):
+            y_train, y_test, X_train, X_test = self._get_fold_data(
+                y, X, train_window, test_window
+            )
+            fh_test = self._get_fold_fh(
+                y_train, y_test, train_window, test_window, cv, fh, fold
+            )
+            X_fold = self._get_fold_meta_data(
+                forecasters, y_train, X_train, X_test, fh_test, y_test, fold
+            )
+
+            X_meta.append(X_fold)
+            y_meta.append(y_test)
+
+        X_meta = pd.concat(X_meta, axis=0)
+        y_meta = pd.concat(y_meta, axis=0)
+        return X_meta, y_meta
+
+    def _get_fold_fh(self, y_train, y_test, train_window, test_window, cv, fh, fold):
+        """Return fold forecasting horizon and validate it against fit ``fh``."""
+        if self._fh_is_integer(cv.fh):
+            fh_test = ForecastingHorizon(
+                test_window - train_window[-1], is_relative=True
+            )
+        else:
+            fh_test = ForecastingHorizon(y_test.index, is_relative=False)
+
+        if fh is None:
+            return fh_test
+
+        expected_fh = fh.to_relative(self.cutoff)
+        fold_cutoff = pd.Index([y_train.index[-1]])
+        actual_fh = fh_test.to_relative(fold_cutoff)
+
+        if not np.array_equal(actual_fh.to_numpy(), expected_fh.to_numpy()):
+            raise ValueError(
+                "`cv` forecasting horizon is incompatible with the forecasting "
+                f"horizon passed to `fit` in fold {fold}. Expected "
+                f"{expected_fh.to_numpy()}, but found {actual_fh.to_numpy()} for "
+                f"train cutoff {y_train.index[-1]!r} and test index "
+                f"{y_test.index.tolist()}."
+            )
+
+        return fh_test
+
+    @staticmethod
+    def _fh_is_integer(fh):
+        """Return whether a splitter fh is integer-valued."""
+        if isinstance(fh, ForecastingHorizon):
+            fh_values = fh.to_numpy()
+        elif np.isscalar(fh):
+            fh_values = [fh]
+        else:
+            fh_values = np.atleast_1d(fh)
+
+        return array_is_int(fh_values)
+
+    def _get_single_split_meta_data(self, forecasters, y, X):
+        """Return validation predictions and targets from the legacy holdout."""
+        if X is not None:
+            y_train, y_test, X_train, X_test = temporal_train_test_split(
+                y, X, test_size=self.test_size
+            )
+        else:
+            y_train, y_test = temporal_train_test_split(y, test_size=self.test_size)
+            X_train, X_test = None, None
+
+        fh_test = ForecastingHorizon(y_test.index, is_relative=False)
+        X_meta = self._get_fold_meta_data(
+            forecasters, y_train, X_train, X_test, fh_test, y_test, fold=0
+        )
+        return X_meta, y_test
+
+    def _get_fold_meta_data(
+        self, forecasters, y_train, X_train, X_test, fh_test, y_test, fold
+    ):
+        """Return base forecaster predictions for one validation fold."""
+        self._fit_forecasters(forecasters, y_train, X_train, fh_test)
+        y_preds = self._predict_forecasters(fh_test, X_test)
+        self._check_fold_predictions(y_preds, y_test, fold)
+
+        X_meta = pd.concat(y_preds, axis=1)
+        X_meta.columns = pd.RangeIndex(len(X_meta.columns))
+        return X_meta
+
+    def _check_cv(self):
+        """Validate the temporal splitter for weight estimation."""
+        cv = check_cv(self.cv)
+        split_type = cv.get_tag("split_type", "temporal", raise_error=False)
+        if split_type != "temporal":
+            raise ValueError(
+                "`cv` must be an sktime temporal splitter, but found splitter "
+                f"with split_type={split_type!r}."
+            )
+        return cv
+
+    def _iter_cv_splits(self, cv, y):
+        """Yield normalized and validated cv split windows."""
+        splits = list(cv.split(y))
+
+        if len(splits) == 0:
+            raise ValueError("`cv` does not produce any valid train/test splits.")
+
+        for fold, (train_window, test_window) in enumerate(splits):
+            train_window, test_window = self._coerce_cv_split_windows(
+                train_window, test_window, fold
+            )
+            self._check_cv_split(train_window, test_window, len(y), fold)
+
+            yield fold, train_window, test_window
+
+    @staticmethod
+    def _coerce_cv_split_windows(train_window, test_window, fold):
+        """Return train and test windows as one-dimensional integer arrays."""
+        train_window = np.asarray(train_window)
+        test_window = np.asarray(test_window)
+
+        if train_window.ndim != 1 or test_window.ndim != 1:
+            raise ValueError(
+                "`cv` must produce one-dimensional train/test windows, but "
+                f"fold {fold} produced shapes {train_window.shape} and "
+                f"{test_window.shape}."
+            )
+
+        for name, window in [("train", train_window), ("test", test_window)]:
+            if len(window) > 0 and not np.issubdtype(window.dtype, np.integer):
+                raise ValueError(
+                    "`cv` must produce positional integer indices, but "
+                    f"the {name} window in fold {fold} has dtype "
+                    f"{window.dtype}."
+                )
+
+        return train_window.astype(int, copy=False), test_window.astype(int, copy=False)
+
+    @staticmethod
+    def _check_cv_split(train_window, test_window, n_timepoints, fold):
+        """Validate that a split is non-empty and temporally valid."""
+        if len(train_window) == 0 or len(test_window) == 0:
+            raise ValueError(
+                f"`cv` produced an empty train or test window in fold {fold}."
+            )
+
+        AutoEnsembleForecaster._check_window_is_strictly_increasing(
+            train_window, "train", fold
+        )
+        AutoEnsembleForecaster._check_window_is_strictly_increasing(
+            test_window, "test", fold
+        )
+        AutoEnsembleForecaster._check_window_bounds(
+            train_window, n_timepoints, "train", fold
+        )
+        AutoEnsembleForecaster._check_window_bounds(
+            test_window, n_timepoints, "test", fold
+        )
+
+        if np.max(train_window) >= np.min(test_window):
+            raise ValueError(
+                "`cv` must produce temporal validation splits where all test "
+                f"indices are after all train indices, but fold {fold} violates "
+                "this requirement."
+            )
+
+    @staticmethod
+    def _check_window_is_strictly_increasing(window, window_name, fold):
+        """Validate that a split window is sorted and duplicate-free."""
+        if len(window) > 1 and np.any(np.diff(window) <= 0):
+            raise ValueError(
+                "`cv` must produce strictly increasing, duplicate-free "
+                f"{window_name} windows, but fold {fold} produced "
+                f"{window.tolist()}."
+            )
+
+    @staticmethod
+    def _check_window_bounds(window, n_timepoints, window_name, fold):
+        """Validate that a split window contains valid positional indices."""
+        if np.min(window) < 0 or np.max(window) >= n_timepoints:
+            raise ValueError(
+                "`cv` must produce positional indices within the bounds of `y`, "
+                f"but the {window_name} window in fold {fold} contains "
+                f"{window.tolist()} for y of length {n_timepoints}."
+            )
+
+    @staticmethod
+    def _get_fold_data(y, X, train_window, test_window):
+        """Return y and X slices for one fold."""
+        y_train = y.iloc[train_window]
+        y_test = y.iloc[test_window]
+
+        if X is None:
+            return y_train, y_test, None, None
+
+        X_train = X.iloc[train_window]
+        X_test = X.iloc[test_window]
+
+        return y_train, y_test, X_train, X_test
+
+    @staticmethod
+    def _check_fold_predictions(y_preds, y_test, fold):
+        """Validate base forecaster predictions for one validation fold."""
+        for i, y_pred in enumerate(y_preds):
+            y_pred_array = np.asarray(y_pred)
+
+            if y_pred_array.ndim != 1:
+                raise ValueError(
+                    "Base forecaster prediction shape is incompatible with "
+                    f"`cv` fold {fold}. Forecaster at position {i} returned "
+                    f"shape {y_pred_array.shape}; expected a one-dimensional "
+                    "point forecast."
+                )
+
+            if len(y_pred_array) != len(y_test):
+                raise ValueError(
+                    "Base forecaster prediction length is incompatible with "
+                    f"`cv` fold {fold}. Forecaster at position {i} predicted "
+                    f"{len(y_pred_array)} rows, but the validation window has "
+                    f"{len(y_test)} rows."
+                )
 
     def _predict(self, fh, X):
         """Return the predicted reduction.

--- a/sktime/forecasting/compose/_stack.py
+++ b/sktime/forecasting/compose/_stack.py
@@ -8,9 +8,11 @@ __all__ = ["StackingForecaster"]
 import numpy as np
 import pandas as pd
 
+from sktime.forecasting.base import ForecastingHorizon
 from sktime.forecasting.base._meta import _HeterogenousEnsembleForecaster
 from sktime.split import SingleWindowSplitter
-from sktime.utils.validation.forecasting import check_regressor
+from sktime.utils.validation import array_is_int
+from sktime.utils.validation.forecasting import check_cv, check_regressor
 from sktime.utils.warnings import warn
 
 
@@ -36,6 +38,13 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
         The number of jobs to run in parallel for fit. None means 1 unless
         in a joblib.parallel_backend context.
         -1 means using all processors.
+    cv : temporal cross-validation splitter, optional, default=None
+        The sktime splitter to use for generating validation predictions for
+        training the meta-regressor. The splitter must generate strictly
+        temporal train/test splits, where every test window is after the
+        corresponding train window. Test windows must match the forecasting
+        horizon passed to ``fit``. If None, a single temporal validation window
+        matching ``fh`` is used, preserving the previous behavior.
 
     Attributes
     ----------
@@ -57,6 +66,18 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
     >>> forecaster.fit(y=y, fh=[1,2,3])
     StackingForecaster(...)
     >>> y_pred = forecaster.predict()
+
+    Use ``cv`` to train the meta-regressor from multiple temporal validation
+    folds instead of one validation window:
+
+    >>> from sktime.split import ExpandingWindowSplitter
+    >>> cv = ExpandingWindowSplitter(
+    ...     fh=[1, 2, 3], initial_window=36, step_length=24
+    ... )
+    >>> forecaster = StackingForecaster(forecasters=forecasters, cv=cv)
+    >>> forecaster.fit(y=y, fh=[1, 2, 3])
+    StackingForecaster(...)
+    >>> y_pred = forecaster.predict()
     """
 
     _tags = {
@@ -67,13 +88,18 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
         "capability:random_state": True,
         "property:randomness": "derandomized",
         "capability:multivariate": False,
+        "capability:insample": False,
+        "capability:pred_int:insample": False,
         "X-y-must-have-same-index": True,
         "tests:skip_by_name": ["test_predict_time_index_with_X"],
     }
 
-    def __init__(self, forecasters, regressor=None, random_state=None, n_jobs=None):
+    def __init__(
+        self, forecasters, regressor=None, random_state=None, n_jobs=None, cv=None
+    ):
         self.regressor = regressor
         self.random_state = random_state
+        self.cv = cv
 
         super().__init__(forecasters=forecasters, n_jobs=n_jobs)
 
@@ -102,26 +128,9 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
             regressor=self.regressor, random_state=self.random_state
         )
 
-        # split training series into training set to fit forecasters and
-        # validation set to fit meta-learner
         inner_fh = fh.to_relative(self.cutoff)
-        cv = SingleWindowSplitter(fh=inner_fh)
-        train_window, test_window = next(cv.split(y))
-        y_train = y.iloc[train_window]
-        y_test = y.iloc[test_window]
-        if X is not None:
-            X_test = X.iloc[test_window]
-            X_train = X.iloc[train_window]
-        else:
-            X_test = None
-            X_train = None
-
-        # fit forecasters on training window
-        self._fit_forecasters(forecasters, y_train, fh=inner_fh, X=X_train)
-        y_preds = self._predict_forecasters(fh=inner_fh, X=X_test)
-
-        y_meta = y_test.values
-        X_meta = np.column_stack(y_preds)
+        cv = self._check_cv(inner_fh)
+        X_meta, y_meta = self._get_meta_data(forecasters, y, X, inner_fh, cv)
 
         # fit final regressor on on validation window
         self.regressor_.fit(X_meta, y_meta)
@@ -130,6 +139,257 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
         self._fit_forecasters(forecasters, y, fh=fh, X=X)
 
         return self
+
+    def _check_cv(self, fh):
+        """Validate or construct the temporal splitter for meta-training."""
+        if self.cv is None:
+            return SingleWindowSplitter(fh=fh)
+
+        cv = check_cv(self.cv)
+        split_type = cv.get_tag("split_type", "temporal", raise_error=False)
+        if split_type != "temporal":
+            raise ValueError(
+                "`cv` must be an sktime temporal splitter, but found splitter "
+                f"with split_type={split_type!r}."
+            )
+        return cv
+
+    def _get_meta_data(self, forecasters, y, X, fh, cv):
+        """Return meta-features and target values from temporal validation splits."""
+        X_meta = []
+        y_meta = []
+
+        for fold, train_window, test_window in self._iter_cv_splits(cv, y, fh):
+            y_train, y_test, X_train, X_test = self._get_fold_data(
+                y, X, train_window, test_window
+            )
+            fold_fh = self._get_fold_fh(
+                y_train, y_test, train_window, test_window, fh, fold
+            )
+            X_fold, y_fold = self._get_fold_meta_data(
+                forecasters, y_train, y_test, X_train, X_test, fold_fh, fold
+            )
+
+            X_meta.append(X_fold)
+            y_meta.append(y_fold)
+
+        return self._concatenate_meta_data(X_meta, y_meta)
+
+    def _iter_cv_splits(self, cv, y, fh):
+        """Yield normalized and validated cv split windows."""
+        splits = list(cv.split(y))
+
+        if len(splits) == 0:
+            raise ValueError("`cv` does not produce any valid train/test splits.")
+
+        for fold, (train_window, test_window) in enumerate(splits):
+            train_window, test_window = self._coerce_cv_split_windows(
+                train_window, test_window, fold
+            )
+            self._check_cv_split(train_window, test_window, len(y), fold)
+            self._check_fold_test_window_length(test_window, fh, fold)
+
+            yield fold, train_window, test_window
+
+    @staticmethod
+    def _coerce_cv_split_windows(train_window, test_window, fold):
+        """Return train and test windows as one-dimensional integer arrays."""
+        train_window = np.asarray(train_window)
+        test_window = np.asarray(test_window)
+
+        if train_window.ndim != 1 or test_window.ndim != 1:
+            raise ValueError(
+                "`cv` must produce one-dimensional train/test windows, but "
+                f"fold {fold} produced shapes {train_window.shape} and "
+                f"{test_window.shape}."
+            )
+
+        for name, window in [("train", train_window), ("test", test_window)]:
+            if len(window) > 0 and not np.issubdtype(window.dtype, np.integer):
+                raise ValueError(
+                    "`cv` must produce positional integer indices, but "
+                    f"the {name} window in fold {fold} has dtype "
+                    f"{window.dtype}."
+                )
+
+        return train_window.astype(int, copy=False), test_window.astype(int, copy=False)
+
+    @staticmethod
+    def _get_fold_data(y, X, train_window, test_window):
+        """Return y and X slices for one fold."""
+        y_train = y.iloc[train_window]
+        y_test = y.iloc[test_window]
+
+        if X is None:
+            return y_train, y_test, None, None
+
+        X_train = X.iloc[train_window]
+        X_test = X.iloc[test_window]
+
+        return y_train, y_test, X_train, X_test
+
+    def _get_fold_meta_data(
+        self, forecasters, y_train, y_test, X_train, X_test, fold_fh, fold
+    ):
+        """Return meta-features and targets for one temporal validation fold."""
+        self._fit_forecasters(forecasters, y_train, fh=fold_fh, X=X_train)
+        y_preds = self._predict_forecasters(fh=fold_fh, X=X_test)
+        y_pred_arrays = self._check_fold_predictions(y_preds, y_test, fold)
+
+        X_fold = np.column_stack(y_pred_arrays)
+        y_fold = y_test.values
+        self._check_fold_meta_data_shape(X_fold, y_fold, y_test, fold)
+
+        return X_fold, y_fold
+
+    @staticmethod
+    def _check_cv_split(train_window, test_window, n_timepoints, fold):
+        """Validate that a split is non-empty and temporally valid."""
+        if len(train_window) == 0 or len(test_window) == 0:
+            raise ValueError(
+                f"`cv` produced an empty train or test window in fold {fold}."
+            )
+
+        StackingForecaster._check_window_is_strictly_increasing(
+            train_window, "train", fold
+        )
+        StackingForecaster._check_window_is_strictly_increasing(
+            test_window, "test", fold
+        )
+        StackingForecaster._check_window_bounds(
+            train_window, n_timepoints, "train", fold
+        )
+        StackingForecaster._check_window_bounds(test_window, n_timepoints, "test", fold)
+
+        if np.max(train_window) >= np.min(test_window):
+            raise ValueError(
+                "`cv` must produce temporal validation splits where all test "
+                f"indices are after all train indices, but fold {fold} violates "
+                "this requirement."
+            )
+
+    @staticmethod
+    def _check_window_is_strictly_increasing(window, window_name, fold):
+        """Validate that a split window is sorted and duplicate-free."""
+        if len(window) > 1 and np.any(np.diff(window) <= 0):
+            raise ValueError(
+                "`cv` must produce strictly increasing, duplicate-free "
+                f"{window_name} windows, but fold {fold} produced "
+                f"{window.tolist()}."
+            )
+
+    @staticmethod
+    def _check_window_bounds(window, n_timepoints, window_name, fold):
+        """Validate that a split window contains valid positional indices."""
+        if np.min(window) < 0 or np.max(window) >= n_timepoints:
+            raise ValueError(
+                "`cv` must produce positional indices within the bounds of `y`, "
+                f"but the {window_name} window in fold {fold} contains "
+                f"{window.tolist()} for y of length {n_timepoints}."
+            )
+
+    @staticmethod
+    def _check_fold_test_window_length(test_window, fh, fold):
+        """Validate that the validation window length matches the fit horizon."""
+        expected = len(fh)
+        actual = len(test_window)
+
+        if actual != expected:
+            raise ValueError(
+                "`cv` forecasting horizon is incompatible with the forecasting "
+                f"horizon passed to `fit` in fold {fold}. Expected {expected} "
+                f"validation observations from fh={fh.to_numpy()}, but found "
+                f"{actual}."
+            )
+
+    @staticmethod
+    def _get_fold_fh(y_train, y_test, train_window, test_window, fh, fold):
+        """Return fold forecasting horizon and check it is compatible with ``fh``."""
+        if array_is_int(fh):
+            fold_fh = ForecastingHorizon(
+                test_window - train_window[-1], is_relative=True
+            )
+        else:
+            fold_cutoff = pd.Index([y_train.index[-1]])
+            fold_fh = ForecastingHorizon(y_test.index, is_relative=False).to_relative(
+                fold_cutoff
+            )
+
+        if not np.array_equal(fold_fh.to_numpy(), fh.to_numpy()):
+            raise ValueError(
+                "`cv` forecasting horizon is incompatible with the forecasting "
+                f"horizon passed to `fit` in fold {fold}. Expected "
+                f"{fh.to_numpy()}, but found {fold_fh.to_numpy()} for "
+                f"train cutoff {y_train.index[-1]!r} and test index "
+                f"{y_test.index.tolist()}."
+            )
+
+        return fold_fh
+
+    @staticmethod
+    def _check_fold_predictions(y_preds, y_test, fold):
+        """Validate base forecaster predictions for one validation fold."""
+        y_pred_arrays = []
+
+        for i, y_pred in enumerate(y_preds):
+            y_pred_array = StackingForecaster._coerce_fold_prediction(y_pred, fold, i)
+
+            if len(y_pred_array) != len(y_test):
+                raise ValueError(
+                    "Base forecaster prediction length is incompatible with "
+                    f"`cv` fold {fold}. Forecaster at position {i} predicted "
+                    f"{len(y_pred_array)} rows, but the validation window has "
+                    f"{len(y_test)} rows."
+                )
+
+            y_pred_arrays.append(y_pred_array)
+
+        return y_pred_arrays
+
+    @staticmethod
+    def _coerce_fold_prediction(y_pred, fold, forecaster_position):
+        """Return one base prediction as a one-dimensional numpy array."""
+        y_pred_array = np.asarray(y_pred)
+
+        if y_pred_array.ndim != 1:
+            raise ValueError(
+                "Base forecaster prediction shape is incompatible with "
+                f"`cv` fold {fold}. Forecaster at position "
+                f"{forecaster_position} returned shape {y_pred_array.shape}; "
+                "expected a one-dimensional point forecast."
+            )
+
+        return y_pred_array
+
+    @staticmethod
+    def _check_fold_meta_data_shape(X_fold, y_fold, y_test, fold):
+        """Validate assembled meta-feature and target arrays for one fold."""
+        if X_fold.ndim != 2:
+            raise ValueError(
+                f"`cv` fold {fold} produced meta-features with shape "
+                f"{X_fold.shape}; expected a two-dimensional array."
+            )
+
+        if X_fold.shape[0] != len(y_test) or len(y_fold) != len(y_test):
+            raise ValueError(
+                f"`cv` fold {fold} produced inconsistent meta data shapes: "
+                f"X has {X_fold.shape[0]} rows, y has {len(y_fold)} rows, "
+                f"and the validation window has {len(y_test)} rows."
+            )
+
+    @staticmethod
+    def _concatenate_meta_data(X_meta, y_meta):
+        """Concatenate per-fold meta-features and targets."""
+        X_meta = np.concatenate(X_meta)
+        y_meta = np.concatenate(y_meta)
+
+        if X_meta.shape[0] != len(y_meta):
+            raise ValueError(
+                "Temporal stacking produced inconsistent meta data: "
+                f"X has {X_meta.shape[0]} rows, but y has {len(y_meta)} rows."
+            )
+
+        return X_meta, y_meta
 
     def _update(self, y, X=None, update_params=True):
         """Update fitted parameters.
@@ -186,10 +446,20 @@ class StackingForecaster(_HeterogenousEnsembleForecaster):
         -------
         params : dict or list of dict
         """
+        from sklearn.linear_model import LinearRegression
+
         from sktime.forecasting.naive import NaiveForecaster
 
         f1 = NaiveForecaster()
         f2 = NaiveForecaster(strategy="mean", window_length=3)
-        params = {"forecasters": [("f1", f1), ("f2", f2)]}
+        f3 = NaiveForecaster(strategy="last")
+        f4 = NaiveForecaster(strategy="mean", window_length=2)
+        params = [
+            {"forecasters": [("f1", f1), ("f2", f2)]},
+            {
+                "forecasters": [("f3", f3), ("f4", f4)],
+                "regressor": LinearRegression(),
+            },
+        ]
 
         return params

--- a/sktime/forecasting/compose/tests/test_autoensemble.py
+++ b/sktime/forecasting/compose/tests/test_autoensemble.py
@@ -4,25 +4,131 @@
 
 __author__ = ["mloning", "GuzalBulatova", "aiwalter", "RNKuhns", "AnH0ang"]
 
+import numpy as np
 import pandas as pd
 import pytest
+from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.linear_model import LinearRegression
 from sklearn.tree import DecisionTreeRegressor
 
 from sktime.datasets import load_longley
-from sktime.forecasting.base import ForecastingHorizon
+from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
 from sktime.forecasting.compose import (
     AutoEnsembleForecaster,
     RecursiveTabularRegressionForecaster,
 )
-from sktime.split import temporal_train_test_split
+from sktime.split import (
+    ExpandingWindowSplitter,
+    SlidingWindowSplitter,
+    temporal_train_test_split,
+)
+from sktime.split.base import BaseSplitter
 from sktime.tests.test_switch import run_test_for_class
 
-
-@pytest.mark.skipif(
+pytestmark = pytest.mark.skipif(
     not run_test_for_class(AutoEnsembleForecaster),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
+
+
+class RecordingWeightRegressor(RegressorMixin, BaseEstimator):
+    """Regressor that records fit data and exposes deterministic coefficients."""
+
+    def __init__(self, coef=None):
+        self.coef = coef
+
+    def fit(self, X, y):
+        """Record meta-features and targets."""
+        self.X_ = np.asarray(X)
+        self.y_ = np.asarray(y)
+        n_features = self.X_.shape[1]
+
+        if self.coef is None:
+            self.coef_ = np.ones(n_features)
+        else:
+            self.coef_ = np.asarray(self.coef)
+
+        return self
+
+    def predict(self, X):
+        """Predict a deterministic weighted sum."""
+        return np.asarray(X) @ self.coef_
+
+
+class TrainLengthForecaster(BaseForecaster):
+    """Forecaster that predicts the number of observations seen in fit."""
+
+    _tags = {
+        "capability:exogenous": True,
+        "capability:missing_values": True,
+        "requires-fh-in-fit": False,
+    }
+
+    def __init__(self, offset=0):
+        self.offset = offset
+        super().__init__()
+
+    def _fit(self, y, X=None, fh=None):
+        """Record training-window length and index."""
+        self.n_obs_ = len(y)
+        self.fit_index_ = y.index.copy()
+        return self
+
+    def _predict(self, fh=None, X=None):
+        """Return the recorded training-window length plus offset."""
+        index = fh.to_absolute_index(self.cutoff)
+        y_pred = np.repeat(self.n_obs_ + self.offset, len(index))
+        return pd.Series(y_pred, index=index)
+
+
+class EmptySplitter(BaseSplitter):
+    """Temporal splitter that yields no train/test splits."""
+
+    def __init__(self, fh=1):
+        super().__init__(fh=fh, window_length=1)
+
+    def _split(self, y):
+        """Yield no splits."""
+        yield from ()
+
+
+class InSampleSplitter(BaseSplitter):
+    """Temporal splitter that produces a leaking in-sample test window."""
+
+    def __init__(self):
+        super().__init__(fh=[0], window_length=3)
+
+    def _split(self, y):
+        """Yield one split whose test window overlaps the train window."""
+        yield np.array([0, 1, 2]), np.array([2])
+
+
+def _make_y(n_timepoints=28):
+    return pd.Series(
+        np.arange(n_timepoints, dtype=float),
+        index=pd.RangeIndex(n_timepoints),
+        name="y",
+    )
+
+
+def _forecasters():
+    return [
+        ("short", TrainLengthForecaster()),
+        ("long", TrainLengthForecaster(offset=100)),
+    ]
+
+
+def _expected_meta_data(y, cv):
+    X_meta = []
+    y_meta = []
+
+    for train_window, test_window in cv.split(y):
+        X_meta.extend([[len(train_window), len(train_window) + 100]] * len(test_window))
+        y_meta.extend(y.iloc[test_window].values)
+
+    return np.asarray(X_meta), np.asarray(y_meta)
+
+
 @pytest.mark.parametrize(
     "forecasters",
     [
@@ -67,3 +173,133 @@ def test_autoensembler(forecasters, method):
 
     assert (predictions.min(axis=1) <= y_pred).all()
     assert (predictions.max(axis=1) >= y_pred).all()
+
+
+def test_autoensemble_forecaster_accepts_cv_parameter():
+    """Test that cv is accepted and exposed as an estimator parameter."""
+    cv = ExpandingWindowSplitter(fh=[1, 2], initial_window=8, step_length=4)
+    forecaster = AutoEnsembleForecaster(
+        forecasters=_forecasters(), regressor=RecordingWeightRegressor(), cv=cv
+    )
+
+    assert forecaster.cv is cv
+    assert forecaster.get_params()["cv"] is cv
+
+
+@pytest.mark.parametrize(
+    "cv",
+    [
+        ExpandingWindowSplitter(fh=[1, 2, 3], initial_window=8, step_length=5),
+        SlidingWindowSplitter(fh=[1, 2, 3], window_length=8, step_length=5),
+    ],
+)
+def test_autoensemble_feature_importance_uses_temporal_cv(cv):
+    """Test that feature-importance weights are learned from temporal folds."""
+    y = _make_y()
+    expected_X, expected_y = _expected_meta_data(y, cv)
+
+    forecaster = AutoEnsembleForecaster(
+        forecasters=_forecasters(),
+        regressor=RecordingWeightRegressor(coef=[0.25, 0.75]),
+        cv=cv,
+    )
+    forecaster.fit(y, fh=[1, 2, 3])
+
+    np.testing.assert_array_equal(forecaster.regressor_.X_, expected_X)
+    np.testing.assert_array_equal(forecaster.regressor_.y_, expected_y)
+    np.testing.assert_array_equal(forecaster.weights_, [0.25, 0.75])
+
+    for _, fitted_forecaster in forecaster.forecasters_:
+        assert fitted_forecaster.n_obs_ == len(y)
+        pd.testing.assert_index_equal(fitted_forecaster.fit_index_, y.index)
+
+    y_pred = forecaster.predict()
+    assert isinstance(y_pred, pd.Series)
+    pd.testing.assert_index_equal(y_pred.index, pd.Index([28, 29, 30]))
+
+
+def test_autoensemble_uses_positional_fh_with_gapped_integer_index():
+    """Test integer fh validation with non-consecutive index labels."""
+    y = _make_y()
+    y.index = pd.Index(np.arange(len(y)) * 2)
+    fh = [1, 2, 3]
+    cv = ExpandingWindowSplitter(fh=fh, initial_window=8, step_length=5)
+
+    forecaster = AutoEnsembleForecaster(
+        forecasters=_forecasters(),
+        regressor=RecordingWeightRegressor(coef=[0.25, 0.75]),
+        cv=cv,
+    )
+    forecaster.fit(y, fh=fh)
+
+    expected_X, expected_y = _expected_meta_data(y, cv)
+    np.testing.assert_array_equal(forecaster.regressor_.X_, expected_X)
+    np.testing.assert_array_equal(forecaster.regressor_.y_, expected_y)
+
+
+@pytest.mark.parametrize(
+    "cv",
+    [
+        ExpandingWindowSplitter(fh=[1, 2, 3], initial_window=8, step_length=5),
+        SlidingWindowSplitter(fh=[1, 2, 3], window_length=8, step_length=5),
+    ],
+)
+def test_autoensemble_inverse_variance_uses_temporal_cv(cv):
+    """Test that inverse-variance weights are estimated across all cv folds."""
+    y = _make_y()
+    expected_X, expected_y = _expected_meta_data(y, cv)
+    errors = expected_y.reshape(-1, 1) - expected_X
+    inv_var = 1 / np.var(errors, axis=0)
+    expected_weights = inv_var / np.sum(inv_var)
+
+    forecaster = AutoEnsembleForecaster(
+        forecasters=_forecasters(), method="inverse-variance", cv=cv
+    )
+    forecaster.fit(y)
+
+    np.testing.assert_allclose(forecaster.weights_, expected_weights)
+
+
+def test_autoensemble_forecaster_raises_for_invalid_cv():
+    """Test that non-sktime splitters are rejected clearly."""
+    forecaster = AutoEnsembleForecaster(
+        forecasters=_forecasters(), regressor=RecordingWeightRegressor(), cv=object()
+    )
+
+    with pytest.raises(TypeError, match="`cv` is not an instance"):
+        forecaster.fit(_make_y())
+
+
+def test_autoensemble_forecaster_raises_for_empty_cv():
+    """Test that splitters producing no folds are rejected clearly."""
+    forecaster = AutoEnsembleForecaster(
+        forecasters=_forecasters(),
+        regressor=RecordingWeightRegressor(),
+        cv=EmptySplitter(),
+    )
+
+    with pytest.raises(ValueError, match="does not produce any valid"):
+        forecaster.fit(_make_y())
+
+
+def test_autoensemble_forecaster_raises_for_incompatible_cv_fh():
+    """Test that cv test windows must match an explicit fit forecasting horizon."""
+    cv = ExpandingWindowSplitter(fh=[1, 2], initial_window=8, step_length=5)
+    forecaster = AutoEnsembleForecaster(
+        forecasters=_forecasters(), regressor=RecordingWeightRegressor(), cv=cv
+    )
+
+    with pytest.raises(ValueError, match="forecasting horizon is incompatible"):
+        forecaster.fit(_make_y(), fh=[1, 2, 3])
+
+
+def test_autoensemble_forecaster_raises_for_non_temporal_cv_split():
+    """Test that cv folds cannot train on observations they validate on."""
+    forecaster = AutoEnsembleForecaster(
+        forecasters=_forecasters(),
+        regressor=RecordingWeightRegressor(),
+        cv=InSampleSplitter(),
+    )
+
+    with pytest.raises(ValueError, match="temporal validation splits"):
+        forecaster.fit(_make_y())

--- a/sktime/forecasting/compose/tests/test_stack.py
+++ b/sktime/forecasting/compose/tests/test_stack.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3 -u
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file).
+"""Unit tests of StackingForecaster functionality."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.base import BaseEstimator, RegressorMixin
+
+from sktime.forecasting.base import BaseForecaster
+from sktime.forecasting.compose import StackingForecaster
+from sktime.split import (
+    ExpandingWindowSplitter,
+    SingleWindowSplitter,
+    SlidingWindowSplitter,
+)
+from sktime.split.base import BaseSplitter
+from sktime.tests.test_switch import run_test_for_class
+
+pytestmark = pytest.mark.skipif(
+    not run_test_for_class(StackingForecaster),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+
+
+class RecordingRegressor(RegressorMixin, BaseEstimator):
+    """Regressor that records fit data and predicts row means."""
+
+    def fit(self, X, y):
+        """Record meta-features and targets."""
+        self.X_ = np.asarray(X)
+        self.y_ = np.asarray(y)
+        return self
+
+    def predict(self, X):
+        """Predict row means for deterministic point forecasts."""
+        return np.asarray(X).mean(axis=1)
+
+
+class TrainLengthForecaster(BaseForecaster):
+    """Forecaster that predicts the number of observations seen in fit."""
+
+    _tags = {
+        "capability:exogenous": True,
+        "capability:missing_values": True,
+        "requires-fh-in-fit": False,
+    }
+
+    def __init__(self, offset=0):
+        self.offset = offset
+        super().__init__()
+
+    def _fit(self, y, X=None, fh=None):
+        """Record training-window length and index."""
+        self.n_obs_ = len(y)
+        self.fit_index_ = y.index.copy()
+        return self
+
+    def _predict(self, fh=None, X=None):
+        """Return the recorded training-window length plus offset."""
+        index = fh.to_absolute_index(self.cutoff)
+        y_pred = np.repeat(self.n_obs_ + self.offset, len(index))
+        return pd.Series(y_pred, index=index)
+
+
+class EmptySplitter(BaseSplitter):
+    """Temporal splitter that yields no train/test splits."""
+
+    def __init__(self, fh=1):
+        super().__init__(fh=fh, window_length=1)
+
+    def _split(self, y):
+        """Yield no splits."""
+        yield from ()
+
+
+class InSampleSplitter(BaseSplitter):
+    """Temporal splitter that produces a leaking in-sample test window."""
+
+    def __init__(self):
+        super().__init__(fh=[0], window_length=3)
+
+    def _split(self, y):
+        """Yield one split whose test window overlaps the train window."""
+        yield np.array([0, 1, 2]), np.array([2])
+
+
+class DuplicateWindowSplitter(BaseSplitter):
+    """Temporal splitter that produces a duplicate positional index."""
+
+    def __init__(self):
+        super().__init__(fh=[1], window_length=3)
+
+    def _split(self, y):
+        """Yield one split whose train window contains a duplicate."""
+        yield np.array([0, 1, 1]), np.array([3])
+
+
+class OutOfBoundsSplitter(BaseSplitter):
+    """Temporal splitter that produces an out-of-bounds positional index."""
+
+    def __init__(self):
+        super().__init__(fh=[1], window_length=3)
+
+    def _split(self, y):
+        """Yield one split whose test window is outside y."""
+        yield np.array([0, 1, 2]), np.array([len(y)])
+
+
+def _make_y(n_timepoints=28):
+    return pd.Series(
+        np.arange(n_timepoints, dtype=float),
+        index=pd.RangeIndex(n_timepoints),
+        name="y",
+    )
+
+
+def _forecasters():
+    return [
+        ("short", TrainLengthForecaster()),
+        ("long", TrainLengthForecaster(offset=100)),
+    ]
+
+
+def _expected_meta_data(y, cv):
+    X_meta = []
+    y_meta = []
+
+    for train_window, test_window in cv.split(y):
+        X_meta.extend([[len(train_window), len(train_window) + 100]] * len(test_window))
+        y_meta.extend(y.iloc[test_window].values)
+
+    return np.asarray(X_meta), np.asarray(y_meta)
+
+
+def test_stacking_forecaster_accepts_cv_parameter():
+    """Test that cv is accepted and exposed as an estimator parameter."""
+    cv = ExpandingWindowSplitter(fh=[1, 2], initial_window=8, step_length=4)
+    forecaster = StackingForecaster(
+        forecasters=_forecasters(), regressor=RecordingRegressor(), cv=cv
+    )
+
+    assert forecaster.cv is cv
+    assert forecaster.get_params()["cv"] is cv
+
+
+def test_stacking_forecaster_cv_none_matches_single_window_splitter():
+    """Test that cv=None preserves the existing single-window behavior."""
+    y = _make_y()
+    fh = [1, 2, 3]
+
+    forecaster_default = StackingForecaster(
+        forecasters=_forecasters(), regressor=RecordingRegressor()
+    )
+    forecaster_default.fit(y, fh=fh)
+
+    forecaster_single = StackingForecaster(
+        forecasters=_forecasters(),
+        regressor=RecordingRegressor(),
+        cv=SingleWindowSplitter(fh=fh),
+    )
+    forecaster_single.fit(y, fh=fh)
+
+    np.testing.assert_array_equal(
+        forecaster_default.regressor_.X_, forecaster_single.regressor_.X_
+    )
+    np.testing.assert_array_equal(
+        forecaster_default.regressor_.y_, forecaster_single.regressor_.y_
+    )
+
+
+@pytest.mark.parametrize(
+    "cv",
+    [
+        ExpandingWindowSplitter(fh=[1, 2, 3], initial_window=8, step_length=5),
+        SlidingWindowSplitter(fh=[1, 2, 3], window_length=8, step_length=5),
+    ],
+)
+def test_stacking_forecaster_trains_meta_regressor_from_temporal_cv(cv):
+    """Test that meta-regressor data are temporally out-of-fold predictions."""
+    y = _make_y()
+    expected_X, expected_y = _expected_meta_data(y, cv)
+
+    forecaster = StackingForecaster(
+        forecasters=_forecasters(), regressor=RecordingRegressor(), cv=cv
+    )
+    forecaster.fit(y, fh=[1, 2, 3])
+
+    np.testing.assert_array_equal(forecaster.regressor_.X_, expected_X)
+    np.testing.assert_array_equal(forecaster.regressor_.y_, expected_y)
+
+    for _, fitted_forecaster in forecaster.forecasters_:
+        assert fitted_forecaster.n_obs_ == len(y)
+        pd.testing.assert_index_equal(fitted_forecaster.fit_index_, y.index)
+
+
+def test_stacking_forecaster_preserves_prediction_index_and_type():
+    """Test point forecast output type and multi-step prediction index."""
+    y = _make_y()
+    fh = [1, 2, 4]
+    cv = ExpandingWindowSplitter(fh=fh, initial_window=8, step_length=5)
+
+    forecaster = StackingForecaster(
+        forecasters=_forecasters(), regressor=RecordingRegressor(), cv=cv
+    )
+    forecaster.fit(y, fh=fh)
+    y_pred = forecaster.predict()
+
+    assert isinstance(y_pred, pd.Series)
+    assert y_pred.name == y.name
+    pd.testing.assert_index_equal(y_pred.index, pd.Index([28, 29, 31]))
+
+
+def test_stacking_forecaster_uses_positional_fh_with_gapped_integer_index():
+    """Test integer fh validation with non-consecutive index labels."""
+    y = _make_y()
+    y.index = pd.Index(np.arange(len(y)) * 2)
+    fh = [1, 2, 3]
+    cv = ExpandingWindowSplitter(fh=fh, initial_window=8, step_length=5)
+
+    forecaster = StackingForecaster(
+        forecasters=_forecasters(), regressor=RecordingRegressor(), cv=cv
+    )
+    forecaster.fit(y, fh=fh)
+
+    expected_X, expected_y = _expected_meta_data(y, cv)
+    np.testing.assert_array_equal(forecaster.regressor_.X_, expected_X)
+    np.testing.assert_array_equal(forecaster.regressor_.y_, expected_y)
+
+
+def test_stacking_forecaster_is_deterministic_with_deterministic_components():
+    """Test deterministic predictions with deterministic base and meta estimators."""
+    y = _make_y()
+    fh = [1, 2, 3]
+    cv = ExpandingWindowSplitter(fh=fh, initial_window=8, step_length=5)
+
+    forecaster_1 = StackingForecaster(
+        forecasters=_forecasters(), regressor=RecordingRegressor(), cv=cv
+    )
+    forecaster_2 = StackingForecaster(
+        forecasters=_forecasters(), regressor=RecordingRegressor(), cv=cv
+    )
+
+    forecaster_1.fit(y, fh=fh)
+    forecaster_2.fit(y, fh=fh)
+
+    pd.testing.assert_series_equal(forecaster_1.predict(), forecaster_2.predict())
+
+
+def test_stacking_forecaster_raises_for_invalid_cv():
+    """Test that non-sktime splitters are rejected clearly."""
+    forecaster = StackingForecaster(
+        forecasters=_forecasters(), regressor=RecordingRegressor(), cv=object()
+    )
+
+    with pytest.raises(TypeError, match="`cv` is not an instance"):
+        forecaster.fit(_make_y(), fh=[1, 2, 3])
+
+
+def test_stacking_forecaster_raises_for_empty_cv():
+    """Test that splitters producing no folds are rejected clearly."""
+    forecaster = StackingForecaster(
+        forecasters=_forecasters(), regressor=RecordingRegressor(), cv=EmptySplitter()
+    )
+
+    with pytest.raises(ValueError, match="does not produce any valid"):
+        forecaster.fit(_make_y(), fh=[1])
+
+
+def test_stacking_forecaster_raises_for_incompatible_cv_fh():
+    """Test that cv test windows must match the fit forecasting horizon."""
+    cv = ExpandingWindowSplitter(fh=[1, 2], initial_window=8, step_length=5)
+    forecaster = StackingForecaster(
+        forecasters=_forecasters(), regressor=RecordingRegressor(), cv=cv
+    )
+
+    with pytest.raises(ValueError, match="forecasting horizon is incompatible"):
+        forecaster.fit(_make_y(), fh=[1, 2, 3])
+
+
+def test_stacking_forecaster_raises_for_non_temporal_cv_split():
+    """Test that cv folds cannot train on observations they validate on."""
+    forecaster = StackingForecaster(
+        forecasters=_forecasters(),
+        regressor=RecordingRegressor(),
+        cv=InSampleSplitter(),
+    )
+
+    with pytest.raises(ValueError, match="temporal validation splits"):
+        forecaster.fit(_make_y(), fh=[1])
+
+
+def test_stacking_forecaster_raises_for_duplicate_cv_window_indices():
+    """Test that cv train/test windows must be duplicate-free."""
+    forecaster = StackingForecaster(
+        forecasters=_forecasters(),
+        regressor=RecordingRegressor(),
+        cv=DuplicateWindowSplitter(),
+    )
+
+    with pytest.raises(ValueError, match="duplicate-free"):
+        forecaster.fit(_make_y(), fh=[1])
+
+
+def test_stacking_forecaster_raises_for_out_of_bounds_cv_window_indices():
+    """Test that cv train/test windows must stay within y bounds."""
+    forecaster = StackingForecaster(
+        forecasters=_forecasters(),
+        regressor=RecordingRegressor(),
+        cv=OutOfBoundsSplitter(),
+    )
+
+    with pytest.raises(ValueError, match="within the bounds"):
+        forecaster.fit(_make_y(), fh=[1])


### PR DESCRIPTION
LLM generated content, by OpenAI GPT-5

#### Reference Issues/PRs

Related to #2668.
Related to #7402.

#### What does this implement/fix? Explain your changes.

This PR adds an optional `cv` parameter to `StackingForecaster` and `AutoEnsembleForecaster`, so users can train the stacking regressor or estimate ensemble weights from multiple temporal validation folds.

Specifically, it:

- uses temporal splitter folds to collect validation predictions from the base forecasters;
- preserves the existing single-window behavior when `cv=None`;
- validates that `cv` produces temporal, ordered, duplicate-free, in-bounds train/test windows;
- checks validation horizons for compatibility with the `fh` passed to `fit`;
- documents the new public `cv` behavior with `ExpandingWindowSplitter` examples.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the temporal `cv` validation contract is appropriate for these estimators.
- Whether `cv=None` correctly preserves the previous behavior.
- Whether the `fh` compatibility and indexing checks cover expected sktime splitter use cases.

#### Did you add any tests for the change?

Yes.

- Added focused tests for `StackingForecaster` temporal CV behavior, legacy `cv=None` behavior, incompatible horizons, invalid splitters, non-temporal folds, duplicate indices, and out-of-bounds indices.
- Extended `AutoEnsembleForecaster` tests for temporal CV weight estimation, inverse-variance behavior, invalid splitters, incompatible horizons, and non-temporal folds.
- Manually exercised the new docstring examples.

Validation run locally:

```bash
.venv-cpu/bin/pre-commit run --files sktime/forecasting/compose/_stack.py sktime/forecasting/compose/_ensemble.py
.venv-cpu/bin/pytest sktime/forecasting/compose/tests/test_stack.py sktime/forecasting/compose/tests/test_autoensemble.py
```

Result: `25 passed`.

#### Any other comments?

This PR treats #2668 and #7402 as related rather than using closing keywords, because it improves the current algorithm and documentation but those issues include broader discussion.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
