### PR TITLE
[ENH] add missing registry tags to extension templates

### DIFF
--- a/extension_templates/alignment.py
+++ b/extension_templates/alignment.py
@@ -96,6 +96,14 @@ class MyAligner(BaseAligner):
         "capability:distance": False,  # does compute/return overall distance?
         "capability:distance-matrix": False,  # does compute/return distance matrix?
         "capability:unequal_length": True,  # can align sequences of unequal length?
+        "alignment_type": "full",  # "full" (entire series) or "partial" (subsequences)
+        "capability:feature_importance": False,  # can provide feature importance?
+        "capability:sample_weight": False,  # ability to handle sample weights in fit
+        "capability:contractable": False,  # supports a maximum fit time contract?
+        "capability:train_estimate": False,  # can estimate performance on train set?
+        "capability:random_state": False,  # has a random_state parameter?
+        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
+        "fit_is_empty": False,  # is fit empty and can be skipped?
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/alignment.py
+++ b/extension_templates/alignment.py
@@ -96,14 +96,49 @@ class MyAligner(BaseAligner):
         "capability:distance": False,  # does compute/return overall distance?
         "capability:distance-matrix": False,  # does compute/return distance matrix?
         "capability:unequal_length": True,  # can align sequences of unequal length?
-        "alignment_type": "full",  # "full" (entire series) or "partial" (subsequences)
-        "capability:feature_importance": False,  # can provide feature importance?
-        "capability:sample_weight": False,  # ability to handle sample weights in fit
-        "capability:contractable": False,  # supports a maximum fit time contract?
-        "capability:train_estimate": False,  # can estimate performance on train set?
-        "capability:random_state": False,  # has a random_state parameter?
-        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
-        "fit_is_empty": False,  # is fit empty and can be skipped?
+        #
+        # alignment_type = does aligner produce a full or partial alignment?
+        "alignment_type": "full",
+        # valid values: "full", "partial"
+        # "full" = entire input series are aligned, indices cover full series length
+        # "partial" = only subsequences of the input series are aligned
+        #
+        # capability:feature_importance = can the estimator provide feature importance?
+        "capability:feature_importance": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes feature importances via get_fitted_params
+        #
+        # capability:sample_weight = can the estimator handle sample weights in fit?
+        "capability:sample_weight": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:contractable = does estimator support a maximum fit time contract?
+        "capability:contractable": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, some parameter of the estimator can be used to limit max fit time
+        #
+        # capability:train_estimate = can estimator estimate performance on train set?
+        "capability:train_estimate": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes a training performance estimate via get_fitted_params
+        #
+        # capability:random_state = does estimator have a random_state parameter?
+        "capability:random_state": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, estimator can be derandomized by setting random_state,
+        # producing the same result on every run (up to numerical precision)
+        #
+        # property:randomness = deterministic or stochastic behaviour?
+        "property:randomness": "deterministic",
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "stochastic" = may produce different results on different runs
+        # "deterministic" = always produces the same result
+        # "derandomized" = stochastic unless random_state is set, then deterministic
+        #
+        # fit_is_empty = is fit empty and can be skipped?
+        "fit_is_empty": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, _fit is considered empty and calling it has no effect
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/catalogue.py
+++ b/extension_templates/catalogue.py
@@ -68,6 +68,9 @@ class MyCatalogue(BaseCatalogue):
         "info:name": "MyCatalogue",
         "info:description": "Example catalogue template",
         "info:source": "DOI",
+        "capability:sample_weight": False,  # ability to handle sample weights in fit
+        "capability:random_state": False,  # has a random_state parameter?
+        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/catalogue.py
+++ b/extension_templates/catalogue.py
@@ -68,9 +68,23 @@ class MyCatalogue(BaseCatalogue):
         "info:name": "MyCatalogue",
         "info:description": "Example catalogue template",
         "info:source": "DOI",
-        "capability:sample_weight": False,  # ability to handle sample weights in fit
-        "capability:random_state": False,  # has a random_state parameter?
-        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
+        #
+        # capability:sample_weight = can the estimator handle sample weights in fit?
+        "capability:sample_weight": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:random_state = does estimator have a random_state parameter?
+        "capability:random_state": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, estimator can be derandomized by setting random_state,
+        # producing the same result on every run (up to numerical precision)
+        #
+        # property:randomness = deterministic or stochastic behaviour?
+        "property:randomness": "deterministic",
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "stochastic" = may produce different results on different runs
+        # "deterministic" = always produces the same result
+        # "derandomized" = stochastic unless random_state is set, then deterministic
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -107,13 +107,41 @@ class MyTimeSeriesClassifier(BaseClassifier):
         "capability:contractable": False,
         "capability:multithreading": False,
         "capability:class_weight": False,  # ability to handle class weights
-        "capability:categorical_in_X": False,  # ability to handle categorical data in X
-        "capability:categorical_in_y": False,  # ability to handle categorical data in y
-        "capability:predict_proba": False,  # implements non-default predict_proba?
-        "capability:sample_weight": False,  # ability to handle sample weights in fit
-        "capability:random_state": False,  # has a random_state parameter?
-        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
-        "fit_is_empty": False,  # is fit empty and can be skipped?
+        #
+        # capability:categorical_in_X = can estimator handle categorical data in X?
+        "capability:categorical_in_X": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:categorical_in_y = can estimator handle categorical data in y?
+        "capability:categorical_in_y": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:predict_proba = does estimator implement non-default predict_proba?
+        "capability:predict_proba": False,
+        # valid values: boolean True (yes), False (no)
+        # if False, predict_proba defaults to 0/1 probabilities from predict
+        #
+        # capability:sample_weight = can the estimator handle sample weights in fit?
+        "capability:sample_weight": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:random_state = does estimator have a random_state parameter?
+        "capability:random_state": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, estimator can be derandomized by setting random_state,
+        # producing the same result on every run (up to numerical precision)
+        #
+        # property:randomness = deterministic or stochastic behaviour?
+        "property:randomness": "deterministic",
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "stochastic" = may produce different results on different runs
+        # "deterministic" = always produces the same result
+        # "derandomized" = stochastic unless random_state is set, then deterministic
+        #
+        # fit_is_empty = is fit empty and can be skipped?
+        "fit_is_empty": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, _fit is considered empty and calling it has no effect
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -107,6 +107,13 @@ class MyTimeSeriesClassifier(BaseClassifier):
         "capability:contractable": False,
         "capability:multithreading": False,
         "capability:class_weight": False,  # ability to handle class weights
+        "capability:categorical_in_X": False,  # ability to handle categorical data in X
+        "capability:categorical_in_y": False,  # ability to handle categorical data in y
+        "capability:predict_proba": False,  # implements non-default predict_proba?
+        "capability:sample_weight": False,  # ability to handle sample weights in fit
+        "capability:random_state": False,  # has a random_state parameter?
+        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
+        "fit_is_empty": False,  # is fit empty and can be skipped?
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -102,13 +102,43 @@ class MyClusterer(BaseClusterer):
         "capability:predict": True,  # implements _predict for cluster assignment?
         "capability:predict_proba": False,  # implements non-default _predict_proba?
         "capability:out_of_sample": True,  # implements _predict for new data?
-        "capability:feature_importance": False,  # can provide feature importance?
-        "capability:sample_weight": False,  # ability to handle sample weights in fit
-        "capability:contractable": False,  # supports a maximum fit time contract?
-        "capability:train_estimate": False,  # can estimate performance on train set?
-        "capability:random_state": False,  # has a random_state parameter?
-        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
-        "fit_is_empty": False,  # is fit empty and can be skipped?
+        #
+        # capability:feature_importance = can the estimator provide feature importance?
+        "capability:feature_importance": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes feature importances via get_fitted_params
+        #
+        # capability:sample_weight = can the estimator handle sample weights in fit?
+        "capability:sample_weight": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:contractable = does estimator support a maximum fit time contract?
+        "capability:contractable": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, some parameter of the estimator can be used to limit max fit time
+        #
+        # capability:train_estimate = can estimator estimate performance on train set?
+        "capability:train_estimate": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes a training performance estimate via get_fitted_params
+        #
+        # capability:random_state = does estimator have a random_state parameter?
+        "capability:random_state": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, estimator can be derandomized by setting random_state,
+        # producing the same result on every run (up to numerical precision)
+        #
+        # property:randomness = deterministic or stochastic behaviour?
+        "property:randomness": "deterministic",
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "stochastic" = may produce different results on different runs
+        # "deterministic" = always produces the same result
+        # "derandomized" = stochastic unless random_state is set, then deterministic
+        #
+        # fit_is_empty = is fit empty and can be skipped?
+        "fit_is_empty": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, _fit is considered empty and calling it has no effect
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/clustering.py
+++ b/extension_templates/clustering.py
@@ -102,6 +102,13 @@ class MyClusterer(BaseClusterer):
         "capability:predict": True,  # implements _predict for cluster assignment?
         "capability:predict_proba": False,  # implements non-default _predict_proba?
         "capability:out_of_sample": True,  # implements _predict for new data?
+        "capability:feature_importance": False,  # can provide feature importance?
+        "capability:sample_weight": False,  # ability to handle sample weights in fit
+        "capability:contractable": False,  # supports a maximum fit time contract?
+        "capability:train_estimate": False,  # can estimate performance on train set?
+        "capability:random_state": False,  # has a random_state parameter?
+        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
+        "fit_is_empty": False,  # is fit empty and can be skipped?
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/detection.py
+++ b/extension_templates/detection.py
@@ -98,6 +98,44 @@ class MyDetector(BaseDetector):
         #
         "distribution_type": "None",  # Tag to determine test in test_all_detectors
         #
+        # capability:variable_identification = can detector identify which
+        #   variables caused each detection, for multivariate X?
+        "capability:variable_identification": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:update = can the estimator be run in stream or on-line mode?
+        "capability:update": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, implements a non-default update method for incremental learning
+        #
+        # property:randomness = deterministic or stochastic behaviour?
+        "property:randomness": "deterministic",
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "derandomized" = stochastic unless random_state is set, see below
+        #
+        # capability:random_state = does estimator have a random_state parameter?
+        "capability:random_state": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, estimator can be derandomized by setting random_state
+        #
+        # capability:sample_weight = can the estimator handle sample weights in fit?
+        "capability:sample_weight": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:contractable = does estimator support a maximum fit time contract?
+        "capability:contractable": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:train_estimate = can estimator estimate performance on train set?
+        "capability:train_estimate": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes a training performance estimate via get_fitted_params
+        #
+        # capability:feature_importance = can the estimator provide feature importance?
+        "capability:feature_importance": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes feature importances via get_fitted_params
+        #
         # ----------------------------------------------------------------------------
         # packaging info - only required for sktime contribution or 3rd party packages
         # ----------------------------------------------------------------------------

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -64,6 +64,15 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
         # maintainer = algorithm maintainer role, "owner" of the sktime class
         #     for 3rd party interfaces, the scope is the sktime class only
         # remove maintainer tag if maintained by sktime core team
+        "capability:multivariate": False,  # ability to handle multivariate X
+        "capability:unequal_length": False,  # can handle unequal length panels?
+        "capability:feature_importance": False,  # can provide feature importance?
+        "capability:sample_weight": False,  # ability to handle sample weights in fit
+        "capability:contractable": False,  # supports a maximum fit time contract?
+        "capability:train_estimate": False,  # can estimate performance on train set?
+        "capability:random_state": False,  # has a random_state parameter?
+        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
+        "fit_is_empty": False,  # is fit empty and can be skipped?
     }
     # in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__ (avoid this if possible)

--- a/extension_templates/dist_kern_panel.py
+++ b/extension_templates/dist_kern_panel.py
@@ -66,13 +66,43 @@ class MyTrafoPwPanel(BasePairwiseTransformerPanel):
         # remove maintainer tag if maintained by sktime core team
         "capability:multivariate": False,  # ability to handle multivariate X
         "capability:unequal_length": False,  # can handle unequal length panels?
-        "capability:feature_importance": False,  # can provide feature importance?
-        "capability:sample_weight": False,  # ability to handle sample weights in fit
-        "capability:contractable": False,  # supports a maximum fit time contract?
-        "capability:train_estimate": False,  # can estimate performance on train set?
-        "capability:random_state": False,  # has a random_state parameter?
-        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
-        "fit_is_empty": False,  # is fit empty and can be skipped?
+        #
+        # capability:feature_importance = can the estimator provide feature importance?
+        "capability:feature_importance": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes feature importances via get_fitted_params
+        #
+        # capability:sample_weight = can the estimator handle sample weights in fit?
+        "capability:sample_weight": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:contractable = does estimator support a maximum fit time contract?
+        "capability:contractable": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, some parameter of the estimator can be used to limit max fit time
+        #
+        # capability:train_estimate = can estimator estimate performance on train set?
+        "capability:train_estimate": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes a training performance estimate via get_fitted_params
+        #
+        # capability:random_state = does estimator have a random_state parameter?
+        "capability:random_state": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, estimator can be derandomized by setting random_state,
+        # producing the same result on every run (up to numerical precision)
+        #
+        # property:randomness = deterministic or stochastic behaviour?
+        "property:randomness": "deterministic",
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "stochastic" = may produce different results on different runs
+        # "deterministic" = always produces the same result
+        # "derandomized" = stochastic unless random_state is set, then deterministic
+        #
+        # fit_is_empty = is fit empty and can be skipped?
+        "fit_is_empty": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, _fit is considered empty and calling it has no effect
     }
     # in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__ (avoid this if possible)

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -65,13 +65,43 @@ class MyTrafoPw(BasePairwiseTransformer):
         #     for 3rd party interfaces, the scope is the sktime class only
         # remove maintainer tag if maintained by sktime core team
         "capability:multivariate": False,  # ability to handle multivariate X
-        "capability:feature_importance": False,  # can provide feature importance?
-        "capability:sample_weight": False,  # ability to handle sample weights in fit
-        "capability:contractable": False,  # supports a maximum fit time contract?
-        "capability:train_estimate": False,  # can estimate performance on train set?
-        "capability:random_state": False,  # has a random_state parameter?
-        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
-        "fit_is_empty": False,  # is fit empty and can be skipped?
+        #
+        # capability:feature_importance = can the estimator provide feature importance?
+        "capability:feature_importance": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes feature importances via get_fitted_params
+        #
+        # capability:sample_weight = can the estimator handle sample weights in fit?
+        "capability:sample_weight": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:contractable = does estimator support a maximum fit time contract?
+        "capability:contractable": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, some parameter of the estimator can be used to limit max fit time
+        #
+        # capability:train_estimate = can estimator estimate performance on train set?
+        "capability:train_estimate": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes a training performance estimate via get_fitted_params
+        #
+        # capability:random_state = does estimator have a random_state parameter?
+        "capability:random_state": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, estimator can be derandomized by setting random_state,
+        # producing the same result on every run (up to numerical precision)
+        #
+        # property:randomness = deterministic or stochastic behaviour?
+        "property:randomness": "deterministic",
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "stochastic" = may produce different results on different runs
+        # "deterministic" = always produces the same result
+        # "derandomized" = stochastic unless random_state is set, then deterministic
+        #
+        # fit_is_empty = is fit empty and can be skipped?
+        "fit_is_empty": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, _fit is considered empty and calling it has no effect
     }
     # in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__ (avoid this if possible)

--- a/extension_templates/dist_kern_tab.py
+++ b/extension_templates/dist_kern_tab.py
@@ -64,6 +64,14 @@ class MyTrafoPw(BasePairwiseTransformer):
         # maintainer = algorithm maintainer role, "owner" of the sktime class
         #     for 3rd party interfaces, the scope is the sktime class only
         # remove maintainer tag if maintained by sktime core team
+        "capability:multivariate": False,  # ability to handle multivariate X
+        "capability:feature_importance": False,  # can provide feature importance?
+        "capability:sample_weight": False,  # ability to handle sample weights in fit
+        "capability:contractable": False,  # supports a maximum fit time contract?
+        "capability:train_estimate": False,  # can estimate performance on train set?
+        "capability:random_state": False,  # has a random_state parameter?
+        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
+        "fit_is_empty": False,  # is fit empty and can be skipped?
     }
     # in case of inheritance, concrete class should typically set tags
     #  alternatively, descendants can set tags in __init__ (avoid this if possible)

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -66,6 +66,9 @@ class MyEarlyTimeSeriesClassifier(BaseEarlyClassifier):
     # optional todo: override base class estimator default tags here if necessary
     # these are the default values, only add if different to these.
     _tags = {
+        "authors": ["author1", "author2"],  # authors, GitHub handles
+        "maintainers": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
+        # remove maintainers tag if maintained by sktime core team
         "X_inner_mtype": "numpy3D",  # which type do _fit/_predict accept, usually
         # this is either "numpy3D" or "nested_univ" (nested pd.DataFrame). Other
         # types are allowable, see datatypes/panel/_registry.py for options.
@@ -76,6 +79,10 @@ class MyEarlyTimeSeriesClassifier(BaseEarlyClassifier):
         "capability:feature_importance": False,
         "capability:contractable": False,
         "capability:multithreading": False,
+        "capability:sample_weight": False,  # ability to handle sample weights in fit
+        "capability:random_state": False,  # has a random_state parameter?
+        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
+        "fit_is_empty": False,  # is fit empty and can be skipped?
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/early_classification.py
+++ b/extension_templates/early_classification.py
@@ -79,10 +79,28 @@ class MyEarlyTimeSeriesClassifier(BaseEarlyClassifier):
         "capability:feature_importance": False,
         "capability:contractable": False,
         "capability:multithreading": False,
-        "capability:sample_weight": False,  # ability to handle sample weights in fit
-        "capability:random_state": False,  # has a random_state parameter?
-        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
-        "fit_is_empty": False,  # is fit empty and can be skipped?
+        #
+        # capability:sample_weight = can the estimator handle sample weights in fit?
+        "capability:sample_weight": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:random_state = does estimator have a random_state parameter?
+        "capability:random_state": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, estimator can be derandomized by setting random_state,
+        # producing the same result on every run (up to numerical precision)
+        #
+        # property:randomness = deterministic or stochastic behaviour?
+        "property:randomness": "deterministic",
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "stochastic" = may produce different results on different runs
+        # "deterministic" = always produces the same result
+        # "derandomized" = stochastic unless random_state is set, then deterministic
+        #
+        # fit_is_empty = is fit empty and can be skipped?
+        "fit_is_empty": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, _fit is considered empty and calling it has no effect
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -116,6 +116,13 @@ class MyForecaster(BaseForecaster):
         # valid values: boolean False (ignores X), True (uses X in non-trivial manner)
         # CAVEAT: if tag is set to False, inner methods always see X=None
         #
+        # capability:non_contiguous_X = can handle non-contiguous exogenous X?
+        "capability:non_contiguous_X": True,
+        # valid values: boolean True (yes), False (no)
+        # only relevant if capability:exogenous is True
+        # if False, forecaster requires X covering every time point from the first
+        # to the last element of fh, not just the points requested in fh
+        #
         # requires-fh-in-fit = is forecasting horizon always required in fit?
         "requires-fh-in-fit": True,
         # valid values: boolean True (yes), False (no)
@@ -157,6 +164,56 @@ class MyForecaster(BaseForecaster):
         # valid values: boolean True (yes), False (no)
         # if True, implement _pretrain and optionally _pretrain_update below
         # enables the pretrain -> fit -> predict workflow for global learning
+        #
+        # pretrain:fitted_params = names of attributes carrying pretrained state
+        "pretrain:fitted_params": [],
+        # valid values: list of str, names of attributes set by _pretrain
+        # only relevant if capability:pretrain is True
+        #
+        # capability:categorical_in_X = can estimator handle categorical variables in X?
+        "capability:categorical_in_X": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:categorical_in_y = can estimator handle categorical variables in y?
+        "capability:categorical_in_y": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:unequal_length = can estimator handle unequal length panels/series?
+        "capability:unequal_length": False,
+        # valid values: boolean True (yes), False (no)
+        # only relevant for panel or hierarchical inner_mtype
+        #
+        # property:randomness = deterministic or stochastic behaviour?
+        "property:randomness": "deterministic",
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "derandomized" = stochastic unless random_state is set, see below
+        #
+        # capability:random_state = does estimator have a random_state parameter?
+        "capability:random_state": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, estimator can be derandomized by setting random_state
+        #
+        # fit_is_empty = does the estimator have an empty fit method, i.e., no fitting?
+        "fit_is_empty": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:sample_weight = can the estimator handle sample weights in fit?
+        "capability:sample_weight": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:contractable = does estimator support a maximum fit time contract?
+        "capability:contractable": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:train_estimate = can estimator estimate performance on train set?
+        "capability:train_estimate": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes a training performance estimate via get_fitted_params
+        #
+        # capability:feature_importance = can the estimator provide feature importance?
+        "capability:feature_importance": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes feature importances via get_fitted_params
         #
         # ----------------------------------------------------------------------------
         # packaging info - only required for sktime contribution or 3rd party packages

--- a/extension_templates/metric_detection.py
+++ b/extension_templates/metric_detection.py
@@ -85,6 +85,12 @@ class MyMetric(BaseDetectionMetric):
         "requires_X": False,
         "requires_y_true": True,  # if False, is unsupervised metric
         "lower_is_better": True,
+        "requires-y-train": False,  # whether y_train must be passed in evaluate
+        "requires-y-pred-benchmark": False,  # whether y_pred_benchmark must be passed
+        "capability:multivariate": False,  # whether metric supports multivariate inputs
+        "capability:sample_weight": False,  # ability to handle sample weights
+        "capability:random_state": False,  # has a random_state parameter?
+        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/metric_detection.py
+++ b/extension_templates/metric_detection.py
@@ -85,12 +85,38 @@ class MyMetric(BaseDetectionMetric):
         "requires_X": False,
         "requires_y_true": True,  # if False, is unsupervised metric
         "lower_is_better": True,
-        "requires-y-train": False,  # whether y_train must be passed in evaluate
-        "requires-y-pred-benchmark": False,  # whether y_pred_benchmark must be passed
-        "capability:multivariate": False,  # whether metric supports multivariate inputs
-        "capability:sample_weight": False,  # ability to handle sample weights
-        "capability:random_state": False,  # has a random_state parameter?
-        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
+        #
+        # requires-y-train = does the metric require y_train to be passed in evaluate?
+        "requires-y-train": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # requires-y-pred-benchmark = does the metric require a benchmark prediction
+        #   y_pred_benchmark to be passed in evaluate?
+        "requires-y-pred-benchmark": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:multivariate = does the metric support multivariate (multi-column)
+        #   inputs?
+        "capability:multivariate": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:sample_weight = can the metric handle sample weights in evaluate?
+        "capability:sample_weight": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:random_state = does the metric have a random_state parameter?
+        "capability:random_state": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, metric can be derandomized by setting random_state,
+        # producing the same result on every run (up to numerical precision)
+        #
+        # property:randomness = does the metric behave deterministically or
+        #   stochastically?
+        "property:randomness": "deterministic",
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "stochastic" = may produce different results on different runs
+        # "deterministic" = always produces the same result
+        # "derandomized" = stochastic unless random_state is set, then deterministic
     }
 
     # todo: add any hyper-parameters and components to constructor

--- a/extension_templates/metric_forecasting.py
+++ b/extension_templates/metric_forecasting.py
@@ -130,6 +130,8 @@ class MyForecastingMetric(BaseForecastingErrorMetric):
         # "pred_quantiles" = quantile forecasts
         # "pred_var" = variance forecasts
         "scitype:y_pred": "pred",
+        # whether the metric requires y_true to be passed in evaluate
+        "requires_y_true": True,
         # whether the metric requires training data y_train to be passed
         "requires-y-train": False,
         # whether the metric requires a benchmark forecast y_pred_benchmark
@@ -142,6 +144,9 @@ class MyForecastingMetric(BaseForecastingErrorMetric):
         # data with pd.MultiIndex. If False (default), the framework handles this
         # via vectorization over hierarchy levels automatically.
         "inner_implements_multilevel": False,
+        "capability:sample_weight": False,  # ability to handle sample weights
+        "capability:random_state": False,  # has a random_state parameter?
+        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
     }
 
     # todo: add hyper-parameters to constructor, keep multioutput/multilevel/by_index

--- a/extension_templates/metric_forecasting.py
+++ b/extension_templates/metric_forecasting.py
@@ -144,9 +144,17 @@ class MyForecastingMetric(BaseForecastingErrorMetric):
         # data with pd.MultiIndex. If False (default), the framework handles this
         # via vectorization over hierarchy levels automatically.
         "inner_implements_multilevel": False,
-        "capability:sample_weight": False,  # ability to handle sample weights
-        "capability:random_state": False,  # has a random_state parameter?
-        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
+        # whether the metric can handle sample weights in evaluate
+        "capability:sample_weight": False,
+        # whether the metric has a random_state parameter
+        # if True, metric can be derandomized by setting random_state,
+        # producing the same result on every run (up to numerical precision)
+        "capability:random_state": False,
+        # whether the metric behaves deterministically or stochastically
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "stochastic" = may produce different results on different runs
+        # "derandomized" = stochastic unless random_state is set, then deterministic
+        "property:randomness": "deterministic",
     }
 
     # todo: add hyper-parameters to constructor, keep multioutput/multilevel/by_index

--- a/extension_templates/metric_forecasting_hierarchical.py
+++ b/extension_templates/metric_forecasting_hierarchical.py
@@ -163,9 +163,17 @@ class MyForecastingMetricHierarchical(BaseForecastingErrorMetric):
         # with pd.MultiIndex; framework will NOT vectorize over hierarchy levels.
         # Your _evaluate must handle the MultiIndex pd.DataFrame directly.
         "inner_implements_multilevel": True,
-        "capability:sample_weight": False,  # ability to handle sample weights
-        "capability:random_state": False,  # has a random_state parameter?
-        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
+        # whether the metric can handle sample weights in evaluate
+        "capability:sample_weight": False,
+        # whether the metric has a random_state parameter
+        # if True, metric can be derandomized by setting random_state,
+        # producing the same result on every run (up to numerical precision)
+        "capability:random_state": False,
+        # whether the metric behaves deterministically or stochastically
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "stochastic" = may produce different results on different runs
+        # "derandomized" = stochastic unless random_state is set, then deterministic
+        "property:randomness": "deterministic",
     }
 
     # todo: add hyper-parameters to constructor, keep multioutput/multilevel/by_index

--- a/extension_templates/metric_forecasting_hierarchical.py
+++ b/extension_templates/metric_forecasting_hierarchical.py
@@ -148,6 +148,8 @@ class MyForecastingMetricHierarchical(BaseForecastingErrorMetric):
         # "pred_quantiles" = quantile forecasts
         # "pred_var" = variance forecasts
         "scitype:y_pred": "pred",
+        # whether the metric requires y_true to be passed in evaluate
+        "requires_y_true": True,
         # whether the metric requires training data y_train to be passed
         "requires-y-train": False,
         # whether the metric requires a benchmark forecast y_pred_benchmark
@@ -161,6 +163,9 @@ class MyForecastingMetricHierarchical(BaseForecastingErrorMetric):
         # with pd.MultiIndex; framework will NOT vectorize over hierarchy levels.
         # Your _evaluate must handle the MultiIndex pd.DataFrame directly.
         "inner_implements_multilevel": True,
+        "capability:sample_weight": False,  # ability to handle sample weights
+        "capability:random_state": False,  # has a random_state parameter?
+        "property:randomness": "deterministic",  # or "stochastic"/"derandomized"
     }
 
     # todo: add hyper-parameters to constructor, keep multioutput/multilevel/by_index

--- a/extension_templates/param_est.py
+++ b/extension_templates/param_est.py
@@ -99,6 +99,42 @@ class MyTimeSeriesParamFitter(BaseParamFitter):
         # valid values: boolean True (yes), False (no)
         # if False, raises exception if X passed has more than one variable
         #
+        # capability:pairwise = does estimator support pairwise parameter estimation?
+        "capability:pairwise": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # property:randomness = deterministic or stochastic behaviour?
+        "property:randomness": "deterministic",
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "derandomized" = stochastic unless random_state is set, see below
+        #
+        # capability:random_state = does estimator have a random_state parameter?
+        "capability:random_state": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, estimator can be derandomized by setting random_state
+        #
+        # fit_is_empty = is fit empty and can be skipped?
+        "fit_is_empty": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:sample_weight = can the estimator handle sample weights in fit?
+        "capability:sample_weight": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:contractable = does estimator support a maximum fit time contract?
+        "capability:contractable": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:train_estimate = can estimator estimate performance on train set?
+        "capability:train_estimate": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes a training performance estimate via get_fitted_params
+        #
+        # capability:feature_importance = can the estimator provide feature importance?
+        "capability:feature_importance": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes feature importances via get_fitted_params
+        #
         # ----------------------------------------------------------------------------
         # packaging info - only required for sktime contribution or 3rd party packages
         # ----------------------------------------------------------------------------

--- a/extension_templates/split.py
+++ b/extension_templates/split.py
@@ -87,6 +87,20 @@ class MySplitter(BaseSplitter):
         # calls split ("iloc") or split_loc ("loc"). Setting this can give
         # performance advantages, e.g., if "loc" is faster to obtain.
         #
+        # property:randomness = deterministic or stochastic behaviour?
+        "property:randomness": "deterministic",
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "derandomized" = stochastic unless random_state is set, see below
+        #
+        # capability:random_state = does splitter have a random_state parameter?
+        "capability:random_state": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, splitter can be derandomized by setting random_state
+        #
+        # capability:sample_weight = can the splitter handle sample weights?
+        "capability:sample_weight": False,
+        # valid values: boolean True (yes), False (no)
+        #
         # ----------------------------------------------------------------------------
         # packaging info - only required for sktime contribution or 3rd party packages
         # ----------------------------------------------------------------------------

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -174,6 +174,39 @@ class MyTransformer(BaseTransformer):
         # valid values: True = _fit is considered empty and skipped, False = No
         # CAUTION: default is "True", i.e., _fit will be skipped even if implemented
         #
+        # property:randomness = deterministic or stochastic behaviour?
+        "property:randomness": "deterministic",
+        # valid values: "deterministic", "stochastic", "derandomized"
+        # "derandomized" = stochastic unless random_state is set, see below
+        #
+        # capability:random_state = does estimator have a random_state parameter?
+        "capability:random_state": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, estimator can be derandomized by setting random_state
+        #
+        # capability:sample_weight = can the estimator handle sample weights in fit?
+        "capability:sample_weight": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:contractable = does estimator support a maximum fit time contract?
+        "capability:contractable": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:train_estimate = can estimator estimate performance on train set?
+        "capability:train_estimate": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes a training performance estimate via get_fitted_params
+        #
+        # capability:feature_importance = can the estimator provide feature importance?
+        "capability:feature_importance": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, exposes feature importances via get_fitted_params
+        #
+        # capability:update = can the estimator be run in stream or on-line mode?
+        "capability:update": False,
+        # valid values: boolean True (yes), False (no)
+        # if True, implements a non-default update method for incremental learning
+        #
         # X-y-must-have-same-index = can estimator handle different X/y index?
         "X-y-must-have-same-index": False,
         # valid values: boolean True (yes), False (no)
@@ -231,6 +264,30 @@ class MyTransformer(BaseTransformer):
         # valid values: boolean True (yes), False (no)
         # applicable only if scitype:transform-output is not "Primitives"
         # used for search index and validity checking, does not raise direct exception
+        #
+        # capability:unequal_length:adds = may transformer produce unequal length
+        #   series output from equal length series input?
+        "capability:unequal_length:adds": False,
+        # valid values: boolean True (yes), False (no)
+        # only meaningful if scitype:transform-output is "Series" or "Panel"
+        #
+        # capability:categorical_in_X = can transformer handle categorical data in X?
+        "capability:categorical_in_X": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:categorical_in_y = can transformer handle categorical data in y?
+        "capability:categorical_in_y": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:hierarchical_reconciliation = does transformer reconcile
+        #   hierarchical series, e.g., ensure forecasts sum correctly across hierarchy?
+        "capability:hierarchical_reconciliation": False,
+        # valid values: boolean True (yes), False (no)
+        #
+        # capability:bootstrap_index = is the transformer a bootstrap transformer that
+        #   can return the iloc indices of bootstrapped series via return_indices?
+        "capability:bootstrap_index": False,
+        # valid values: boolean True (yes), False (no)
         #
         # handles-missing-data = can the transformer handle missing data (np or pd.NA)?
         "capability:missing_values": False,  # can estimator handle missing data?


### PR DESCRIPTION
## Summary

Fixes #10429.

When adding a new estimator, contributors copy the relevant "full" template from `extension_templates/` and fill in the `_tags` dict. Several tags that exist in `sktime.registry._tags.py` (the source of truth for all tags) were missing from these templates, so contributors had no indication they should be considered — as raised in review on #10421, where `capability:non_contiguous_X` was missed specifically because it wasn't in `extension_templates/forecasting.py`:

> yes it can be easily missed out since it's not in the extension template

and the maintainer noted a few others are missing too:

> yes, there are a few other tags which should also be present in extension template like `"property:randomness"`, `"capability:random_state"`

## Approach

Rather than fixing only the tags named in the discussion, I cross-checked **every** tag in `registry._tags.py` against **every full extension template** (excluding the `simple`/`supersimple` variants, per the issue), using each tag's `parent_type` and the scitype hierarchy (e.g. `forecaster` → `estimator` → `object`) to determine applicability, and each tag's `user_facing` flag to exclude internal/CI-only packaging tags (`tests:*`, `env_marker`, etc.) that aren't meant for a typical contributor template.

For every applicable, user-facing tag not already present, I added it using:
- the tag's registry-documented default value
- a short comment matching that file's existing tag-documentation style (some templates use verbose block comments, others compact inline comments — followed whichever the file already used)

## Files changed

All 15 full templates in `extension_templates/`:
`alignment.py`, `catalogue.py`, `classification.py`, `clustering.py`, `detection.py`, `dist_kern_panel.py`, `dist_kern_tab.py`, `early_classification.py`, `forecasting.py`, `metric_detection.py`, `metric_forecasting.py`, `metric_forecasting_hierarchical.py`, `param_est.py`, `split.py`, `transformer.py`.

`forecasting_simple.py`, `forecasting_supersimple.py`, `transformer_simple.py`, `transformer_supersimple.py`, and `transformer_supersimple_features.py` were intentionally left untouched, per the issue.

## Validation

```bash
ruff format --check extension_templates/*.py   # 15 files already formatted
ruff check extension_templates/*.py            # all checks passed
python -c "import ast; ..."                    # all 15 files: valid syntax, no duplicate tag keys
```

Also wrote a small script that re-derives, from `registry._tags.py` itself, the set of applicable user-facing tags per template scitype and confirms each is now present as a `"tag_name":` key in the corresponding template — 0 missing across all 15 templates after this change.

These files are documentation/scaffolding only (each has a `do NOT import this file directly` docstring warning) and aren't imported anywhere in the package, so there's no runtime behavior to test.