### PR TITLE
[ENH] Enable transformers for local pooling in reduction

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -63,6 +63,18 @@ def _check_fh(fh):
     return fh.to_indexer().to_numpy()
 
 
+def _apply_transformers(y, transformers):
+    """Fit and transform a series with one or more transformers."""
+    if len(transformers) == 1:
+        tf_fit = transformers[0].fit(y)
+    else:
+        from sktime.transformations.compose import FeatureUnion
+
+        feat = [("trafo_" + str(index), i) for index, i in enumerate(transformers)]
+        tf_fit = FeatureUnion(feat).fit(y)
+    return tf_fit.transform(y)
+
+
 def _sliding_window_transform(
     y,
     window_length,
@@ -131,7 +143,11 @@ def _sliding_window_transform(
         kwargs = {"transformers": transformers}
         _sliding_window_trans_f = _sliding_window_transform_global
     else:  # if pooling == "local":
-        kwargs = {"fh": fh, "windows_identical": windows_identical}
+        kwargs = {
+            "fh": fh,
+            "windows_identical": windows_identical,
+            "transformers": transformers,
+        }
         _sliding_window_trans_f = _sliding_window_transform_local
 
     yt, Xt = _sliding_window_trans_f(y=y, X=X, window_length=window_length, **kwargs)
@@ -147,7 +163,9 @@ def _sliding_window_transform(
     return yt, Xt
 
 
-def _sliding_window_transform_local(y, window_length, fh, X, windows_identical):
+def _sliding_window_transform_local(
+    y, window_length, fh, X, windows_identical, transformers=None
+):
     """Transform time series data using sliding window for local pooling."""
     z = _concat_y_X(y, X)
     n_timepoints, n_variables = z.shape
@@ -186,7 +204,34 @@ def _sliding_window_transform_local(y, window_length, fh, X, windows_identical):
     # would lead to unequal-length data, with more time points for
     # exogenous series than the target series, which is currently not supported.
     yt = Zt[:, 0, window_length + fh]
-    Xt = Zt[:, :, :window_length]
+
+    if transformers is None:
+        Xt = Zt[:, :, :window_length]
+    else:
+        if yt.ndim == 1:
+            yt = pd.Series(yt)
+        else:
+            yt = pd.DataFrame(yt)
+
+        y_hist = Zt[:, 0, :window_length]
+        y_feature_rows = []
+
+        for y_hist_i in y_hist:
+            y_hist_series = pd.Series(y_hist_i)
+            X_from_y = _apply_transformers(y_hist_series, transformers)
+            if isinstance(X_from_y, pd.Series):
+                X_from_y = X_from_y.to_frame()
+            X_from_y = X_from_y.iloc[[-1]].reset_index(drop=True)
+            y_feature_rows.append(X_from_y)
+
+        X_from_y = pd.concat(y_feature_rows, axis=0, ignore_index=True)
+
+        if X is not None:
+            X_hist = Zt[:, 1:, :window_length].reshape(Zt.shape[0], -1)
+            X_hist = pd.DataFrame(X_hist)
+            Xt = pd.concat([X_from_y, X_hist], axis=1)
+        else:
+            Xt = X_from_y
 
     return yt, Xt
 
@@ -195,14 +240,7 @@ def _sliding_window_transform_global(y, window_length, X, transformers):
     """Transform time series data using sliding window for global pooling."""
     n_cut = -window_length
 
-    if len(transformers) == 1:
-        tf_fit = transformers[0].fit(y)
-    else:
-        from sktime.transformations.compose import FeatureUnion
-
-        feat = [("trafo_" + str(index), i) for index, i in enumerate(transformers)]
-        tf_fit = FeatureUnion(feat).fit(y)
-    X_from_y = tf_fit.transform(y)
+    X_from_y = _apply_transformers(y, transformers)
 
     X_from_y_cut = _cut_df(X_from_y, n_obs=n_cut)
     yt = _cut_df(y, n_obs=n_cut)
@@ -552,11 +590,6 @@ class _DirectReducer(_Reducer):
                 + " to derive reduction features. Window length will be"
                 + " inferred, please set to None"
             )
-        if self.transformers is not None and self.pooling == "local":
-            raise ValueError(
-                "Transformers currently cannot be provided"
-                + "for models that run locally"
-            )
         pd_format = isinstance(y, pd.Series) or isinstance(y, pd.DataFrame)
         if self.pooling == "local":
             if pd_format is True and isinstance(y, pd.MultiIndex):
@@ -669,7 +702,7 @@ class _DirectReducer(_Reducer):
                 "`X` must be passed to `predict` if `X` is given in `fit`."
             )
 
-        if self.pooling == "global":
+        if self.pooling == "global" or self.transformers_ is not None:
             y_last, X_last = self._get_shifted_window(X_update=X)
             ys = np.array(y_last)
             if not np.sum(np.isnan(ys)) == 0 and np.sum(np.isinf(ys)) == 0:
@@ -719,26 +752,32 @@ class _DirectReducer(_Reducer):
             y_pred = pool_preds(y_preds)
 
         else:
-            # Pre-allocate arrays.
-            if self._X is None:
-                n_columns = 1
+            if self.transformers_ is not None:
+                if isinstance(X_last, pd.DataFrame):
+                    X_pred = prep_skl_df(X_last)
+                else:
+                    X_pred = X_last
             else:
-                # X is ignored here, since we currently only look at lagged values for
-                # exogenous variables and not contemporaneous ones.
-                n_columns = self._X.shape[1] + 1
+                # Pre-allocate arrays.
+                if self._X is None:
+                    n_columns = 1
+                else:
+                    # X is ignored here, since we currently only look at lagged values for
+                    # exogenous variables and not contemporaneous ones.
+                    n_columns = self._X.shape[1] + 1
 
-            # Pre-allocate arrays.
-            window_length = self.window_length_
-            X_pred = np.zeros((1, n_columns, window_length))
+                # Pre-allocate arrays.
+                window_length = self.window_length_
+                X_pred = np.zeros((1, n_columns, window_length))
 
-            # Fill pre-allocated arrays with available data.
-            X_pred[:, 0, :] = y_last
-            if self._X is not None:
-                X_pred[:, 1:, :] = X_last.T
+                # Fill pre-allocated arrays with available data.
+                X_pred[:, 0, :] = y_last
+                if self._X is not None:
+                    X_pred[:, 1:, :] = X_last.T
 
-            # We need to make sure that X has the same order as used in fit.
-            if self._estimator_scitype == "tabular-regressor":
-                X_pred = X_pred.reshape(1, -1)
+                # We need to make sure that X has the same order as used in fit.
+                if self._estimator_scitype == "tabular-regressor":
+                    X_pred = X_pred.reshape(1, -1)
 
             # Allocate array for predictions.
             if est_type == "regressor":
@@ -908,12 +947,6 @@ class _RecursiveReducer(_Reducer):
                 + " to derive reduction features. Window length will be"
                 + " inferred, please set to None"
             )
-        if self.transformers is not None and self.pooling == "local":
-            raise ValueError(
-                "Transformers currently cannot be provided"
-                + "for models that run locally"
-            )
-
         pd_format = isinstance(y, pd.Series) or isinstance(y, pd.DataFrame)
 
         self._timepoints = get_time_index(y)
@@ -1042,51 +1075,70 @@ class _RecursiveReducer(_Reducer):
                         y_update=y_pred, X_update=X, shift=i + 1
                     )
         else:
-            # Pre-allocate arrays.
-            if X is None:
-                n_columns = 1
+            if self.transformers_ is not None:
+                fh_max = fh.to_relative(self.cutoff)[-1]
+                y_pred = np.zeros(fh_max)
+
+                y_window = list(y_last)
+
+                for i in range(fh_max):
+                    y_hist_series = pd.Series(y_window[-self.window_length_:])
+                    X_pred = _apply_transformers(y_hist_series, self.transformers_)
+                    if isinstance(X_pred, pd.Series):
+                        X_pred = X_pred.to_frame()
+                    X_pred = X_pred.iloc[[-1]].reset_index(drop=True)
+
+                    if isinstance(X_pred, pd.DataFrame):
+                        X_pred = prep_skl_df(X_pred)
+
+                    y_pred[i] = self.estimator_.predict(X_pred)[0]
+                    y_window.append(y_pred[i])
             else:
-                n_columns = X.shape[1] + 1
-            window_length = self.window_length_
-            fh_max = fh.to_relative(self.cutoff)[-1]
+                # Pre-allocate arrays.
+                if X is None:
+                    n_columns = 1
+                else:
+                    n_columns = X.shape[1] + 1
+                window_length = self.window_length_
+                fh_max = fh.to_relative(self.cutoff)[-1]
 
-            y_pred = np.zeros(fh_max)
+                y_pred = np.zeros(fh_max)
 
-            # Array with input data for prediction.
-            last = np.zeros((1, n_columns, window_length + fh_max))
+                # Array with input data for prediction.
+                last = np.zeros((1, n_columns, window_length + fh_max))
 
-            # Fill pre-allocated arrays with available data.
-            last[:, 0, :window_length] = y_last
-            if X is not None:
-                X_to_use = np.concatenate(
-                    [X_last.T, X.iloc[-(last.shape[2] - window_length) :, :].T], axis=1
-                )
-                if X_to_use.shape[1] < window_length + fh_max:
-                    X_to_use = np.pad(
-                        X_to_use,
-                        ((0, 0), (0, window_length + fh_max - X_to_use.shape[1])),
-                        "edge",
+                # Fill pre-allocated arrays with available data.
+                last[:, 0, :window_length] = y_last
+                if X is not None:
+                    X_to_use = np.concatenate(
+                        [X_last.T, X.iloc[-(last.shape[2] - window_length) :, :].T], axis=1
                     )
-                elif X_to_use.shape[1] > window_length + fh_max:
-                    X_to_use = X_to_use[:, : window_length + fh_max]
-                # else X_to_use.shape[1] == window_length + fh_max
-                # and there are no additional steps to take
-                last[:, 1:] = X_to_use
+                    if X_to_use.shape[1] < window_length + fh_max:
+                        X_to_use = np.pad(
+                            X_to_use,
+                            ((0, 0), (0, window_length + fh_max - X_to_use.shape[1])),
+                            "edge",
+                        )
+                    elif X_to_use.shape[1] > window_length + fh_max:
+                        X_to_use = X_to_use[:, : window_length + fh_max]
+                    # else X_to_use.shape[1] == window_length + fh_max
+                    # and there are no additional steps to take
+                    last[:, 1:] = X_to_use
 
-            # Recursively generate predictions by iterating over forecasting horizon.
-            for i in range(fh_max):
-                # Slice prediction window.
-                X_pred = last[:, :, i : window_length + i]
+                # Recursively generate predictions by iterating over forecasting horizon.
+                for i in range(fh_max):
+                    # Slice prediction window.
+                    X_pred = last[:, :, i : window_length + i]
 
-                # Reshape data into tabular array.
-                if self._estimator_scitype == "tabular-regressor":
-                    X_pred = X_pred.reshape(1, -1)
+                    # Reshape data into tabular array.
+                    if self._estimator_scitype == "tabular-regressor":
+                        X_pred = X_pred.reshape(1, -1)
 
-                # Generate predictions.
-                y_pred[i] = self.estimator_.predict(X_pred)[0]
+                    # Generate predictions.
+                    y_pred[i] = self.estimator_.predict(X_pred)[0]
 
-                # Update last window with previous prediction.
-                last[:, 0, window_length + i] = y_pred[i]
+                    # Update last window with previous prediction.
+                    last[:, 0, window_length + i] = y_pred[i]
 
         # While the recursive strategy requires to generate predictions for all steps
         # until the furthest step in the forecasting horizon, we only return the

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -29,6 +29,7 @@ from sktime.forecasting.compose import (
     make_reduction,
 )
 from sktime.forecasting.compose._reduce import _sliding_window_transform
+from sktime.transformations.summarize import WindowSummarizer
 from sktime.forecasting.tests._config import TEST_OOS_FHS, TEST_WINDOW_LENGTHS_INT
 from sktime.performance_metrics.forecasting import mean_absolute_percentage_error
 from sktime.regression.base import BaseRegressor
@@ -887,3 +888,37 @@ def test_recursive_reduction_with_period_index():
     manual_pred = manual_lr.predict(manual_input)
 
     assert np.allclose(y_pred, manual_pred)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.compose._reduce"]),
+    reason="run test only if reduce module has changed",
+)
+def test_recursive_reduction_with_transformers_local():
+    """Test RecursiveTabularRegressionForecaster with transformers in local pooling."""
+    from sklearn.ensemble import HistGradientBoostingRegressor
+
+    y = load_airline()[:36]
+    y_train, y_test = temporal_train_test_split(y, test_size=12)
+    fh = ForecastingHorizon(y_test.index, is_relative=False)
+
+    kwargs = {
+        "lag_feature": {
+            "lag": [1, 2, 3],
+        }
+    }
+    transformer = WindowSummarizer(**kwargs, n_jobs=1)
+
+    forecaster = RecursiveTabularRegressionForecaster(
+        estimator=HistGradientBoostingRegressor(),
+        window_length=None,
+        transformers=[transformer],
+        pooling="local",
+    )
+
+    forecaster.fit(y_train, fh=fh)
+    y_pred = forecaster.predict(fh)
+
+    assert len(y_pred) == len(fh)
+    assert not np.any(np.isnan(y_pred))
+    assert not np.any(np.isinf(y_pred))

--- a/sktime/forecasting/compose/tests/test_reduce_global.py
+++ b/sktime/forecasting/compose/tests/test_reduce_global.py
@@ -129,6 +129,29 @@ def check_eval(test_input, expected):
         assert expected is None
 
 
+def test_recursive_reduction_with_transformers_local_pooling():
+    """Test local pooling supports transformer-based features."""
+    y = load_airline()
+
+    regressor = make_pipeline(
+        RandomForestRegressor(random_state=1),
+    )
+
+    forecaster = make_reduction(
+        regressor,
+        scitype="tabular-regressor",
+        transformers=[WindowSummarizer(**kwargs, n_jobs=1)],
+        window_length=None,
+        strategy="recursive",
+        pooling="local",
+    )
+
+    forecaster.fit(y, fh=[1, 2])
+    y_pred = forecaster.predict(fh=[1, 2, 12])
+
+    assert len(y_pred) == 3
+
+
 @pytest.mark.skipif(
     not run_test_for_class(_RecursiveReducer),
     reason="run test only if softdeps are present and incrementally (if requested)",


### PR DESCRIPTION
**#### Reference Issues/PRs

Fixes #4280**

#### What does this implement/fix? Explain your changes.

This PR enables the use of transformers together with local pooling in reduction forecasters.

Previously, providing `transformers` together with `pooling="local"` resulted in a `ValueError`. This change extends the local pooling workflow to support transformer-based feature generation, bringing it in line with the existing global pooling behavior.

The implementation includes:

- support for transformers in the local sliding window transformation
- a shared helper to reuse transformer application logic
- support for transformer-based features during recursive prediction with local pooling
- removal of the restriction preventing transformers from being used with local pooling

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether transformer-based feature generation produces consistent results during both training and prediction.
- Whether the shared helper appropriately replaces the duplicated transformer logic.
- Whether the implementation integrates well with the existing reduction workflow.

#### Did you add any tests for the change?

Yes.

I added regression tests covering transformer support for local pooling and verified the relevant reduction test suites:

- `test_reduce.py`
- `test_reduce_global.py`

#### Any other comments?

No additional comments.

#### PR checklist

##### For all contributions

- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators

- [ ] I've added the estimator to the API reference.
- [ ] I've added one or more illustrative usage examples to the docstring.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured dependency isolation.