### PR TITLE
[DOC] complete `VAR` docstring for `method`, `missing`, `freq`, `dates`

### DIFF
--- a/sktime/forecasting/var.py
+++ b/sktime/forecasting/var.py
@@ -25,8 +25,9 @@ class VAR(_StatsModelsAdapter):
     maxlags: int or None (default=None)
         Maximum number of lags to check for order selection,
         defaults to 12 * (nobs/100.)**(1./4)
-    method : str (default="ols")
-        Estimation method to use
+    method : str {"ols"} (default="ols")
+        Estimation method to use.
+        ``"ols"`` is the only estimation method offered by ``statsmodels``.
     verbose : bool (default=False)
         Print order selection output to the screen
     trend : str {"c", "ct", "ctt", "n"} (default="c")
@@ -37,13 +38,31 @@ class VAR(_StatsModelsAdapter):
         * "n" - co constant, no trend
 
         Note that these are prepended to the columns of the dataset.
-    missing: str, optional (default='none')
-        A string specifying if data is missing
-    freq: str, tuple, datetime.timedelta, DateOffset or None, optional (default=None)
+    missing : str {"none", "drop", "raise"} (default="none")
+        A string specifying how missing values are handled.
+
+        * ``"none"`` - no nan checking is done
+        * ``"drop"`` - any observations with nans are dropped
+        * ``"raise"`` - an error is raised if nans are present
+
+    freq : str, tuple, datetime.timedelta, DateOffset or None, optional (default=None)
         A frequency specification for either ``dates`` or the row labels from
         the endog / exog data.
-    dates: array_like, optional (default=None)
-        An array like object containing dates.
+        A pandas offset, or one of the strings
+
+        * ``"B"`` - business day
+        * ``"D"`` - calendar day
+        * ``"W"`` - weekly
+        * ``"M"`` - monthly
+        * ``"A"`` - annual
+        * ``"Q"`` - quarterly
+
+        This is optional if ``dates`` are provided.
+    dates : array_like of datetime, optional (default=None)
+        An array like object containing ``datetime`` objects,
+        which must match the number of rows of the endogenous data.
+        If a pandas object with a ``DatetimeIndex`` is passed as data,
+        that index is used, and this argument can be left as ``None``.
     ic: One of {'aic', 'fpe', 'hqic', 'bic', None} (default=None)
         Information criterion to use for VAR order selection.
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #4045.

#### What does this implement/fix? Explain your changes.

The `VAR` docstring listed four parameters without their valid values. This fills them in, in the bullet style already used for `trend` and `ic` in the same docstring.

Every value is transcribed from `statsmodels` 0.14.6, which `VAR` is a direct interface to. Sources, so the values are checkable rather than taken on trust:

| Parameter | statsmodels source | Documented value |
|---|---|---|
| `method` | `tsa.vector_ar.var_model.VAR.fit` docstring: ``method : {'ols'}`` | `"ols"` is the only estimation method offered |
| `missing` | `statsmodels.base.model.Model` docstring: *"Available options are 'none', 'drop', and 'raise'"* | `"none"` / `"drop"` / `"raise"`, with the behaviour of each |
| `freq` | `tsa.base.tsa_model._tsa_doc`: *"A Pandas offset or 'B', 'D', 'W', 'M', 'A', or 'Q'. This is optional if dates are given."* | pandas offset, or those six aliases |
| `dates` | `tsa.base.tsa_model._tsa_doc` plus `VAR`'s own *"must match number of rows of endog"* | array-like of `datetime`, must match the number of endog rows; unnecessary when a `DatetimeIndex` is supplied |

One point worth flagging for the reviewer: **`method` accepts only `"ols"`**. `statsmodels` offers no other estimation method for `VAR.fit`, so the docstring now says exactly that rather than implying a choice.

#### Does your contribution introduce a new dependency? If yes, which one?

No. Docstring text only, no code, no imports.

#### What should a reviewer concentrate their feedback on?

Whether the four value sets match your reading of `statsmodels`, and whether the `freq` bullet list should instead just point at the pandas offset-alias table rather than repeating the six aliases `statsmodels` names.

#### Did you add any tests for the change?

No, the change is docstring text only and adds no behaviour to test. Checks run locally:

* `check_estimator(VAR)` — 742 checks, 0 failed
* `sktime/forecasting/tests/test_var.py::test_VAR_against_statsmodels` — passes when executed directly. Under `pytest` it reports `SKIPPED`, because `run_test_for_class(VAR)` returns `False_requires_vm`; that gate is a property of the estimator and is unrelated to this diff
* `ruff check` / `ruff format` / `pre-commit` on the changed file — all pass
* `build_tools/check_backticks.py` — no invalid backticks

#### Any other comments?

Deliberately narrow: only the four parameters named in the issue are touched. The pre-existing single-backticks in the `ic` bullets are left alone to keep the diff to the reported problem.

#### PR checklist

<details><summary>For all contributions</summary>

- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc). Not yet in the list, happy to be added via the all-contributors bot.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

</details>