### PR TITLE
[BUG] Pin `scipy` version for `neuralprophet`

### DIFF
--- a/sktime/forecasting/neuralprophet.py
+++ b/sktime/forecasting/neuralprophet.py
@@ -100,7 +100,14 @@ class NeuralProphet(BaseForecaster):
     _tags = {
         "authors": ["vedantag17"],
         "maintainers": ["vedantag17"],
-        "python_dependencies": ["neuralprophet", "setuptools"],
+        "python_dependencies": [
+            "neuralprophet",
+            "setuptools",
+            # neuralprophet requires numpy<2; scipy>=1.16 pulls numpy>=2, so
+            # keep scipy below that bound as well
+            "numpy<2",
+            "scipy<1.16",
+        ],
         # neuralprophet causes a C-level segfault on Windows + Python 3.13+
         "env_marker": 'platform_system != "Windows" or python_version < "3.13"',
         "capability:exogenous": True,


### PR DESCRIPTION
<!--
Welcome to sktime, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs

Fixes #10737 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
- neuralprophet pulls numpy<2; scipy>=1.16 requires numpy>=2
- so, pinning scipy version `scipy<1.16` to make it compatible with neuralprophet.


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [x] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.