### PR TITLE
[BUG] Disable `capability:non_contiguous_X` for `SARIMAX`

### DIFF
--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -27,6 +27,10 @@ class _StatsModelsAdapter(BaseForecaster):
         # estimator type
         # --------------
         "capability:exogenous": False,
+        # statsmodels ``predict(start, end, exog=...)`` needs exog for every
+        # step from ``start`` to ``end``, so gapped forecasting horizons are
+        # not supported when exogenous variables are present
+        "capability:non_contiguous_X": False,
         "requires-fh-in-fit": False,
         "capability:missing_values": False,
         # CI and testing tags

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -27,10 +27,6 @@ class _StatsModelsAdapter(BaseForecaster):
         # estimator type
         # --------------
         "capability:exogenous": False,
-        # statsmodels ``predict(start, end, exog=...)`` needs exog for every
-        # step from ``start`` to ``end``, so gapped forecasting horizons are
-        # not supported when exogenous variables are present
-        "capability:non_contiguous_X": False,
         "requires-fh-in-fit": False,
         "capability:missing_values": False,
         # CI and testing tags

--- a/sktime/forecasting/sarimax.py
+++ b/sktime/forecasting/sarimax.py
@@ -242,6 +242,7 @@ class SARIMAX(_StatsModelsAdapter):
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
         "tests:skip_all": True,  # Unkown reason
+        "capability:non_contiguous_X": False,
     }
 
     def __init__(

--- a/sktime/forecasting/sarimax.py
+++ b/sktime/forecasting/sarimax.py
@@ -238,6 +238,7 @@ class SARIMAX(_StatsModelsAdapter):
         # estimator type
         # --------------
         "capability:exogenous": True,
+        "capability:random_state": True,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
         "tests:skip_all": True,  # Unkown reason


### PR DESCRIPTION
#### References Issue/PR

Fixes #10742

#### What does this implement/fix? Explain your changes.

- Turns off capability:non_contiguous_X tag
- statsmodels predict(start, end, exog=...) needs exog for every step from start to end, so gapped forecasting horizons are not supported when exogenous variables are present.

Also,
- `SARIMAX` takes `random_state` as init param, but does not set that tag.
- added `capability:random_state` tag to SARIMAX
- codeblock raising error:

https://github.com/sktime/sktime/blob/adb542c2ee961343a50aaf8d1dfbfa0d12314708/sktime/tests/test_all_estimators.py#L1342-L1348


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [x] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.