### PR TITLE
[ENH] native grid search in TSCGridSearchCV and TSRGridSearchCV via evaluate

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2994,6 +2994,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "atikulmunna",
+      "name": "Atikul Islam Munna",
+      "avatar_url": "https://avatars.githubusercontent.com/u/103902791?v=4",
+      "profile": "https://github.com/atikulmunna",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3005,6 +3005,16 @@
         "doc",
         "test"
       ]
+    },
+    {
+      "login": "atikulmunna",
+      "name": "Atikul Islam Munna",
+      "avatar_url": "https://avatars.githubusercontent.com/u/103902791?v=4",
+      "profile": "https://github.com/atikulmunna",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ]
 }

--- a/sktime/classification/model_selection/_tune.py
+++ b/sktime/classification/model_selection/_tune.py
@@ -1,19 +1,253 @@
 """Tuning for time series classifiers."""
 
-__author__ = ["fkiraly", "achieveordie"]
+__author__ = ["fkiraly", "achieveordie", "atikulmunna"]
+
+import time
 
 import numpy as np
-from sklearn.model_selection import GridSearchCV
+import pandas as pd
 
 from sktime.classification._delegate import _DelegatedClassifier
+from sktime.classification.model_evaluation._functions import _evaluate
+from sktime.exceptions import NotFittedError
+from sktime.utils.parallel import parallelize
+
+# metric name suffixes indicating that lower values are better,
+# used to determine ranking direction for plain sklearn metric callables,
+# which do not carry a "lower_is_better" tag like sktime metric objects
+_LOWER_IS_BETTER_SUFFIXES = ("_error", "_loss", "_deviance", "_risk")
+
+
+def _metric_lower_is_better(metric):
+    """Return True if lower values of the metric indicate better performance."""
+    name = getattr(metric, "__name__", "").lower()
+    return name.endswith(_LOWER_IS_BETTER_SUFFIXES)
+
+
+def _check_scoring_callables(scoring, default):
+    """Coerce scoring to a non-empty list of callables.
+
+    Parameters
+    ----------
+    scoring : callable, list of callables, or None
+        scoring as passed to the tuner
+    default : callable
+        default metric to use if scoring is None
+
+    Returns
+    -------
+    list of callables, the metrics to evaluate
+
+    Raises
+    ------
+    TypeError
+        if scoring or an element of it is not callable
+    """
+    if scoring is None:
+        scoring = [default]
+    if not isinstance(scoring, list):
+        scoring = [scoring]
+    for metric in scoring:
+        if not callable(metric):
+            raise TypeError(
+                "Error in grid search tuner: scoring must be a callable metric "
+                "with signature (y_true, y_pred) -> float, a list of such "
+                f"callables, or None, but found {metric!r}. String scoring "
+                "values are not supported, pass the metric callable instead, "
+                "e.g., accuracy_score from sklearn.metrics."
+            )
+    return scoring
+
+
+def _resolve_cv(cv):
+    """Resolve the cv parameter to a splitter with a split method.
+
+    int and None are resolved to deterministic KFold, so that all
+    parameter candidates are evaluated on identical splits.
+    None resolves to 3 splits, same number as the evaluate default.
+    """
+    from sklearn.model_selection import check_cv
+
+    if cv is None:
+        cv = 3
+    return check_cv(cv)
+
+
+def _check_param_grid(param_grid):
+    """Validate param_grid, from sklearn 1.0.2, before it was removed."""
+    if hasattr(param_grid, "items"):
+        param_grid = [param_grid]
+
+    for p in param_grid:
+        for name, v in p.items():
+            if isinstance(v, np.ndarray) and v.ndim > 1:
+                raise ValueError("Parameter array should be one-dimensional.")
+
+            if isinstance(v, str) or not isinstance(v, (np.ndarray, list, tuple)):
+                raise ValueError(
+                    f"Parameter grid for parameter ({name}) needs to"
+                    f" be a list or numpy array, but got ({type(v)})."
+                    " Single values need to be wrapped in a list"
+                    " with one element."
+                )
+
+            if len(v) == 0:
+                raise ValueError(
+                    f"Parameter values for parameter ({name}) need "
+                    "to be a non-empty sequence."
+                )
+
+
+def _fit_and_score(params, meta):
+    """Fit and score estimator with given parameters.
+
+    Root level function for parallelization, called from
+    _grid_search_fit, within parallelize.
+    """
+    estimator = meta["estimator"].clone()
+    estimator.set_params(**params)
+
+    out = _evaluate(
+        estimator=estimator,
+        cv=meta["cv"],
+        X=meta["X"],
+        y=meta["y"],
+        scoring=meta["scoring"],
+        error_score=meta["error_score"],
+    )
+
+    # keep scores and timings, aggregate means over folds
+    out = out.filter(regex="^(test_|fit_time|pred)", axis=1)
+    out = out.mean()
+    out = out.add_prefix("mean_")
+
+    out["params"] = params
+
+    return out
+
+
+def _grid_search_fit(tuner, X, y, default_scoring):
+    """Run grid search backtesting for tuner, common to TSC and TSR tuners.
+
+    Writes fitted attributes to tuner: cv_results_, best_index_, best_score_,
+    best_params_, best_estimator_, n_splits_, scorer_, multimetric_,
+    and refit_time_ if refit=True.
+
+    Parameters
+    ----------
+    tuner : TSCGridSearchCV or TSRGridSearchCV instance
+    X : panel data container, in an sktime compatible Panel mtype
+    y : 2D np.ndarray, target values
+    default_scoring : callable, metric to use if tuner.scoring is None
+    """
+    from sklearn.model_selection import ParameterGrid
+
+    if y.ndim > 1 and y.shape[1] == 1:
+        y = y.flatten()
+
+    scoring = _check_scoring_callables(tuner.scoring, default_scoring)
+    primary_metric = scoring[0]
+    scoring_name = f"test_{primary_metric.__name__}"
+
+    cv = _resolve_cv(tuner.cv)
+
+    _check_param_grid(tuner.param_grid)
+    candidate_params = list(ParameterGrid(tuner.param_grid))
+
+    if tuner.verbose > 0:
+        n_candidates = len(candidate_params)
+        n_splits = cv.get_n_splits()
+        print(  # noqa: T201
+            f"Fitting {n_splits} folds for each of {n_candidates} candidates,"
+            f" totalling {n_candidates * n_splits} fits"
+        )
+
+    # resolve parallelization backend, legacy n_jobs maps to joblib backends
+    backend = tuner.backend
+    backend_params = tuner.backend_params if tuner.backend_params else {}
+    if backend is None and tuner.n_jobs is not None:
+        backend = "loky"
+        backend_params = {"n_jobs": tuner.n_jobs, **backend_params}
+
+    meta = {
+        "estimator": tuner.estimator,
+        "X": X,
+        "y": y,
+        "cv": cv,
+        "scoring": scoring,
+        "error_score": tuner.error_score,
+    }
+
+    out = parallelize(
+        fun=_fit_and_score,
+        iter=candidate_params,
+        meta=meta,
+        backend=backend,
+        backend_params=backend_params,
+    )
+
+    if len(out) < 1:
+        raise ValueError(
+            "No fits were performed. "
+            "Was the CV iterator empty? "
+            "Were there no candidates?"
+        )
+
+    results = pd.DataFrame(out)
+
+    # rank results, according to whether greater is better for the given scoring,
+    # with min method for ties, same as sklearn rank_test_score semantics
+    lower_is_better = _metric_lower_is_better(primary_metric)
+    results[f"rank_{scoring_name}"] = results.loc[:, f"mean_{scoring_name}"].rank(
+        ascending=lower_is_better, method="min"
+    )
+
+    tuner.cv_results_ = results
+
+    # select best parameters
+    tuner.best_index_ = results.loc[:, f"rank_{scoring_name}"].argmin()
+    # raise error if all fits in evaluate failed because all score values are NaN
+    if tuner.best_index_ == -1:
+        raise NotFittedError(
+            f"""All fits of estimator failed,
+            set error_score='raise' to see the exceptions.
+            Failed estimator: {tuner.estimator}"""
+        )
+    tuner.best_score_ = results.loc[tuner.best_index_, f"mean_{scoring_name}"]
+    tuner.best_params_ = results.loc[tuner.best_index_, "params"]
+    tuner.best_estimator_ = tuner.estimator.clone().set_params(**tuner.best_params_)
+
+    tuner.n_splits_ = cv.get_n_splits()
+    tuner.scorer_ = primary_metric
+    tuner.multimetric_ = len(scoring) > 1
+
+    # refit model with best parameters
+    if tuner.refit:
+        refit_start_time = time.perf_counter()
+        tuner.best_estimator_.fit(X=X, y=y)
+        tuner.refit_time_ = time.perf_counter() - refit_start_time
+
+    return tuner
 
 
 class TSCGridSearchCV(_DelegatedClassifier):
     """Exhaustive search over specified parameter values for an estimator.
 
-    Adapts sklearn GridSearchCV for sktime time series classifiers
+    Optimizes hyper-parameters of ``estimator`` by exhaustive grid search,
+    using backtesting via ``sktime`` native ``evaluate`` for classifiers.
 
-    Optimizes hyper-parameters of ``estimators`` by exhaustive grid search.
+    In ``fit``, for each parameter combination in ``param_grid``,
+    performance is backtested via
+    ``sktime.classification.model_evaluation.evaluate``,
+    on the data provided, using the cross-validation scheme ``cv``
+    and the scoring metric ``scoring``.
+
+    The best parameter combination, as per mean test score across folds,
+    is then selected, and set as ``best_params_``.
+    If ``refit=True``, ``best_estimator_`` is fitted to the entire data.
+
+    In ``predict`` and ``predict``-like methods, calls the respective method
+    of ``best_estimator_``, if ``refit=True``.
 
     Parameters
     ----------
@@ -27,97 +261,57 @@ class TSCGridSearchCV(_DelegatedClassifier):
         in the list are explored. This enables searching over any sequence
         of parameter settings.
 
-    scoring : str, callable, list, tuple or dict, default=None
-        Strategy to evaluate the performance of the cross-validated model on
-        the test set.
+    scoring : callable, list of callables, or None, default=None
+        Metric(s) to evaluate the performance of the cross-validated model on
+        the test set, passed to ``evaluate`` internally.
 
-        If `scoring` represents a single score, one can use:
+        - a callable must have signature
+          ``(y_true: 1D np.ndarray, y_pred: 1D np.ndarray) -> float``,
+          e.g., ``accuracy_score`` from ``sklearn.metrics``
+        - if a list of callables, the first metric in the list
+          is used for ranking and selection of the best parameters,
+          all metrics are computed and available in ``cv_results_``
+        - if None, defaults to ``accuracy_score``
 
-        - a single string (see :ref:`scoring_parameter`);
-        - a callable (see :ref:`scoring`) that returns a single value.
-
-        If `scoring` represents multiple scores, one can use:
-
-        - a list or tuple of unique strings;
-        - a callable returning a dictionary where the keys are the metric
-          names and the values are the metric scores;
-        - a dictionary with metric names as keys and callables a values.
+        Whether lower or higher values are better is determined from the
+        metric name: names ending in ``_error``, ``_loss``, ``_deviance``,
+        or ``_risk`` are assumed lower-is-better, all other higher-is-better.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel.
-        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
-        for more details.
+        Number of jobs to run in parallel for the grid search,
+        via the ``loky`` backend of ``joblib``.
+        ``None`` means 1, ``-1`` means using all processors.
+        Retained for backward compatibility, ignored if ``backend`` is passed.
+        For fine grained control of parallelization,
+        use ``backend`` and ``backend_params`` instead.
 
-    refit : bool, str, or callable, default=True
+    refit : bool, default=True
         Refit an estimator using the best found parameters on the whole
-        dataset. If ``False``, the ``predict`` and ``predict_proba`` will not work.
-
-        For multiple metric evaluation, this needs to be a ``str`` denoting the
-        scorer that would be used to find the best parameters for refitting
-        the estimator at the end.
-
-        Where there are considerations other than maximum score in
-        choosing a best estimator, ``refit`` can be set to a function which
-        returns the selected ``best_index_`` given ``cv_results_``. In that
-        case, the ``best_estimator_`` and ``best_params_`` will be set
-        according to the returned ``best_index_`` while the ``best_score_``
-        attribute will not be available.
-
-        The refitted estimator is made available at the ``best_estimator_``
-        attribute and permits using ``predict`` directly on this
-        ``GridSearchCV`` instance.
-
-        Also for multiple metric evaluation, the attributes ``best_index_``,
-        ``best_score_`` and ``best_params_`` will only be available if
-        ``refit`` is set and all of them will be determined w.r.t this specific
-        scorer.
-
-        See ``scoring`` parameter to know more about multiple metric
-        evaluation.
+        dataset.
+        If ``False``, ``predict`` and ``predict``-like methods will raise,
+        and the tuner can be used only as a parameter estimator,
+        e.g., via ``get_fitted_params``.
 
     cv : int, cross-validation generator or an iterable, default=None
-        Determines the cross-validation splitting strategy.
-        Possible inputs for cv are:
+        Determines the cross-validation splitting strategy, used in
+        ``evaluate`` internally. Possible inputs for cv are:
 
-        - None, to use the default 5-fold cross validation,
-        - integer, to specify the number of folds in a ``(Stratified)KFold``,
-        - :term:`CV splitter`,
+        - None, to use the default 3-fold cross validation via ``KFold``,
+        - integer, to specify the number of folds in a ``KFold`` splitter,
+        - CV splitter with a ``split`` method,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-        For integer/None inputs, if the estimator is a classifier and ``y`` is
-        either binary or multiclass, :class:`StratifiedKFold` is used. In all
-        other cases, :class:`KFold` is used. These splitters are instantiated
-        with ``shuffle=False`` so the splits will be the same across calls.
+        For integer/None inputs, ``KFold`` is instantiated with
+        ``shuffle=False``, so all parameter candidates are evaluated
+        on identical, deterministic splits.
 
-        Refer :ref:`User Guide <cross_validation>` for the various
-        cross-validation strategies that can be used here.
-
-    verbose : int
+    verbose : int, default=0
         Controls the verbosity: the higher, the more messages.
 
-        - >1 : the computation time for each fold and parameter candidate is
-          displayed;
-        - >2 : the score is also displayed;
-        - >3 : the fold and candidate parameter indexes are also displayed
-          together with the starting time of the computation.
-
     pre_dispatch : int, or str, default='2*n_jobs'
-        Controls the number of jobs that get dispatched during parallel
-        execution. Reducing this number can be useful to avoid an
-        explosion of memory consumption when more jobs get dispatched
-        than CPUs can process. This parameter can be:
-
-            - None, in which case all the jobs are immediately
-              created and spawned. Use this for lightweight and
-              fast-running jobs, to avoid delays due to on-demand
-              spawning of the jobs
-
-            - An int, giving the exact number of total jobs that are
-              spawned
-
-            - A str, giving an expression as a function of n_jobs,
-              as in '2*n_jobs'
+        Retained for backward compatibility, this parameter is ignored.
+        Parallelization behaviour can be controlled via
+        ``backend`` and ``backend_params``.
 
     error_score : 'raise' or numeric, default=np.nan
         Value to assign to the score if an error occurs in estimator fitting.
@@ -126,13 +320,8 @@ class TSCGridSearchCV(_DelegatedClassifier):
         step, which will always raise the error.
 
     return_train_score : bool, default=False
-        If ``False``, the ``cv_results_`` attribute will not include training
-        scores.
-        Computing training scores is used to get insights on how different
-        parameter settings impact the overfitting/underfitting trade-off.
-        However computing the scores on the training set can be computationally
-        expensive and is not strictly required to select the parameters that
-        yield the best generalization performance.
+        Retained for backward compatibility, this parameter is ignored.
+        Train scores are not computed by the native grid search.
 
     tune_by_variable : bool, optional (default=False)
         Whether to tune parameter by each time series variable separately,
@@ -143,100 +332,96 @@ class TSCGridSearchCV(_DelegatedClassifier):
         Has the same effect as applying ColumnEnsembleClassifier wrapper to self.
         If False, the same best parameter is selected for all variables.
 
+    backend : {"dask", "loky", "multiprocessing", "threading"}, optional, default=None
+        Runs parallel grid search over the parameter candidates, if specified.
+
+        - "None": executes loop sequentially, simple list comprehension
+        - "loky", "multiprocessing" and "threading": uses ``joblib.Parallel`` loops
+        - "joblib": custom and 3rd party ``joblib`` backends, e.g., ``spark``
+        - "dask": uses ``dask``, requires ``dask`` package in environment
+
+        Recommendation: Use "dask" or "loky" for parallel grid search.
+
+    backend_params : dict, optional
+        additional parameters passed to the backend as config.
+        Directly passed to ``utils.parallel.parallelize``.
+        Valid keys depend on the value of ``backend``:
+
+        - "None": no additional parameters, ``backend_params`` is ignored
+        - "loky", "multiprocessing" and "threading": default ``joblib`` backends
+          any valid keys for ``joblib.Parallel`` can be passed here, e.g., ``n_jobs``,
+          with the exception of ``backend`` which is directly controlled by ``backend``.
+        - "dask": any valid keys for ``dask.compute`` can be passed,
+          e.g., ``scheduler``
+
     Attributes
     ----------
-    cv_results_ : dict of numpy (masked) ndarrays
-        A dict with keys as column headers and values as columns, that can be
-        imported into a pandas ``DataFrame``.
+    cv_results_ : pd.DataFrame
+        DataFrame with one row per parameter candidate, with columns:
 
-        For multi-metric evaluation, the scores for all the scorers are
-        available in the ``cv_results_`` dict at the keys ending with that
-        scorer's name (``'_<scorer_name>'``) instead of ``'_score'`` shown
-        above. ('split0_test_precision', 'mean_train_precision' etc.)
+        - ``mean_test_<metric_name>``: mean test score across folds,
+          one column per metric in ``scoring``
+        - ``mean_fit_time``: mean fit time across folds, in seconds
+        - ``mean_pred_time``: mean prediction time across folds, in seconds
+        - ``params``: the parameter settings of the candidate
+        - ``rank_test_<metric_name>``: rank of the candidate, 1 is best,
+          for the primary (first) metric in ``scoring``
 
     best_estimator_ : estimator
-        Estimator that was chosen by the search, i.e. estimator
-        which gave highest score (or smallest loss if specified)
-        on the left out data. Not available if ``refit=False``.
-
-        See ``refit`` parameter for more information on allowed values.
+        Clone of ``estimator`` with the best found parameters set.
+        Fitted to the entire data if ``refit=True``, otherwise unfitted.
 
     best_score_ : float
-        Mean cross-validated score of the best_estimator
-
-        For multi-metric evaluation, this is present only if ``refit`` is
-        specified.
-
-        This attribute is not available if ``refit`` is a function.
+        Mean cross-validated test score of the best parameter candidate.
 
     best_params_ : dict
-        Parameter setting that gave the best results on the hold out data.
-
-        For multi-metric evaluation, this is present only if ``refit`` is
-        specified.
+        Parameter setting that gave the best mean test score.
 
     best_index_ : int
-        The index (of the ``cv_results_`` arrays) which corresponds to the best
-        candidate parameter setting.
+        The row index in ``cv_results_`` corresponding to the
+        best parameter candidate.
 
-        The dict at ``search.cv_results_['params'][search.best_index_]`` gives
-        the parameter setting for the best model, that gives the highest
-        mean score (``search.best_score_``).
-
-        For multi-metric evaluation, this is present only if ``refit`` is
-        specified.
-
-    scorer_ : function or a dict
-        Scorer function used on the held out data to choose the best
-        parameters for the model.
-
-        For multi-metric evaluation, this attribute holds the validated
-        ``scoring`` dict which maps the scorer key to the scorer callable.
+    scorer_ : callable
+        The primary metric used to rank candidates and select best parameters.
 
     n_splits_ : int
-        The number of cross-validation splits (folds/iterations).
+        The number of cross-validation splits (folds).
 
     refit_time_ : float
         Seconds used for refitting the best model on the whole dataset.
-
-        This is present only if ``refit`` is not False.
+        This is present only if ``refit=True``.
 
     multimetric_ : bool
-        Whether or not the scorers compute several metrics.
+        Whether multiple metrics were passed in ``scoring``.
 
     classes_ : ndarray of shape (n_classes,)
-        The classes labels. This is present only if ``refit`` is specified and
-        the underlying estimator is a classifier.
+        The class labels.
 
-    n_features_in_ : int
-        Number of features seen during :term:`fit`. Only defined if
-        ``best_estimator_`` is defined (see the documentation for the ``refit``
-        parameter for more details) and that ``best_estimator_`` exposes
-        ``n_features_in_`` when fit.
-
-    feature_names_in_ : ndarray of shape (``n_features_in_``,)
-        Names of features seen during :term:`fit`. Only defined if
-        ``best_estimator_`` is defined (see the documentation for the ``refit``
-        parameter for more details) and that ``best_estimator_`` exposes
-        ``feature_names_in_`` when fit.
-
-    See Also
+    Examples
     --------
-    ParameterGrid : Generates all the combinations of a hyperparameter grid.
-    train_test_split : Utility function to split the data into a development
-        set usable for fitting a GridSearchCV instance and an evaluation set
-        for its final evaluation.
-    sklearn.metrics.make_scorer : Make a scorer from a performance metric or
-        loss function.
+    >>> from sklearn.metrics import accuracy_score
+    >>> from sklearn.model_selection import KFold
+    >>> from sktime.classification.dummy import DummyClassifier
+    >>> from sktime.classification.model_selection import TSCGridSearchCV
+    >>> from sktime.datasets import load_unit_test
+    >>> X, y = load_unit_test()
+    >>> tuned_dummy = TSCGridSearchCV(
+    ...     DummyClassifier(),
+    ...     {"strategy": ["most_frequent", "stratified"]},
+    ...     scoring=accuracy_score,
+    ...     cv=KFold(n_splits=2, shuffle=False),
+    ... )
+    >>> tuned_dummy = tuned_dummy.fit(X, y)
+    >>> y_pred = tuned_dummy.predict(X)
     """
 
     _tags = {
         # packaging info
         # --------------
-        "authors": ["fkiraly", "achieveordie"],
+        "authors": ["fkiraly", "achieveordie", "atikulmunna"],
         # estimator type
         # --------------
-        "X_inner_mtype": ["nested_univ", "numpy3D"],
+        "X_inner_mtype": ["pd-multiindex", "nested_univ", "numpy3D"],
         "y_inner_mtype": ["numpy2D"],
         "capability:multivariate": True,
         "capability:multioutput": True,
@@ -248,8 +433,12 @@ class TSCGridSearchCV(_DelegatedClassifier):
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
+
+    # attribute for _DelegatedClassifier, which then delegates
+    #     all non-overridden methods to getattr(self, _delegate_name)
+    #     see further details in _DelegatedClassifier docstring
+    _delegate_name = "best_estimator_"
 
     def __init__(
         self,
@@ -264,6 +453,8 @@ class TSCGridSearchCV(_DelegatedClassifier):
         error_score=np.nan,
         return_train_score=False,
         tune_by_variable=False,
+        backend=None,
+        backend_params=None,
     ):
         self.estimator = estimator
         self.param_grid = param_grid
@@ -276,25 +467,10 @@ class TSCGridSearchCV(_DelegatedClassifier):
         self.error_score = error_score
         self.return_train_score = return_train_score
         self.tune_by_variable = tune_by_variable
+        self.backend = backend
+        self.backend_params = backend_params
 
         super().__init__()
-
-        DELEGATED_PARAMS = [
-            "estimator",
-            "param_grid",
-            "scoring",
-            "n_jobs",
-            "refit",
-            "cv",
-            "verbose",
-            "pre_dispatch",
-            "error_score",
-            "return_train_score",
-        ]
-
-        gcsvargs = {k: getattr(self, k) for k in DELEGATED_PARAMS}
-
-        self.estimator_ = GridSearchCV(**gcsvargs)
 
         if self.tune_by_variable:
             self.set_tags(**{"capability:multioutput": False})
@@ -310,9 +486,7 @@ class TSCGridSearchCV(_DelegatedClassifier):
         Parameters
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
-            if self.get_tag("X_inner_mtype") = "numpy3D":
-            3D np.ndarray of shape = [n_instances, n_dimensions, series_length]
-            if self.get_tag("X_inner_mtype") = "pd-multiindex:":
+            if self.get_tag("X_inner_mtype") = "pd-multiindex":
             pd.DataFrame with columns = variables,
             index = pd.MultiIndex with first level = instance indices,
             second level = time indices
@@ -322,38 +496,26 @@ class TSCGridSearchCV(_DelegatedClassifier):
             1D iterable, of shape [n_instances]
             or 2D iterable, of shape [n_instances, n_dimensions]
             class labels for fitting
-            if self.get_tag("capaility:multioutput") = False, guaranteed to be 1D
-            if self.get_tag("capaility:multioutput") = True, guaranteed to be 2D
+            if self.get_tag("capability:multioutput") = False, guaranteed to be 1D
+            if self.get_tag("capability:multioutput") = True, guaranteed to be 2D
 
         Returns
         -------
         self : Reference to self.
         """
-        if y.shape[1] == 1:
-            y = y.flatten()
+        from sklearn.metrics import accuracy_score
 
-        estimator = self._get_delegate()
-        estimator.fit(X=X, y=y)
+        return _grid_search_fit(self, X=X, y=y, default_scoring=accuracy_score)
 
-        fitted_param_names = [
-            "cv_results_",
-            "best_estimator_",
-            "best_score_",
-            "best_params_",
-            "best_index_",
-            "scorer_",
-            "n_splits_",
-            "refit_time_",
-            "multimetric_",
-            "classes_",
-        ]
-
-        for p in fitted_param_names:
-            if hasattr(estimator, p):
-                val = getattr(estimator, p)
-                setattr(self, p, val)
-
-        return self
+    def _check_refit_for_predict(self, method_name):
+        """Raise error if refit=False and a predict-like method is called."""
+        if not self.refit:
+            raise RuntimeError(
+                f"In {self.__class__.__name__}, refit must be True to make"
+                f" predictions, but found refit=False. If refit=False,"
+                f" {self.__class__.__name__} can be used only to tune"
+                " hyper-parameters, as a parameter estimator."
+            )
 
     def _predict(self, X):
         """Predict labels for sequences in X.
@@ -369,27 +531,44 @@ class TSCGridSearchCV(_DelegatedClassifier):
         Parameters
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
-            if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_dimensions, series_length]
-            if self.get_tag("X_inner_mtype") = "nested_univ":
-                pd.DataFrame with each column a dimension, each cell a pd.Series
-            for list of other mtypes, see datatypes.SCITYPE_REGISTER
-            for specifications, see examples/AA_datatypes_and_datasets.ipynb
 
         Returns
         -------
-        y : 1D np.array of int, of shape [n_instances] - predicted class labels
-            indices correspond to instance indices in X
+        y : predictions of labels for X, np.ndarray
         """
+        self._check_refit_for_predict("predict")
         estimator = self._get_delegate()
         y_pred = estimator.predict(X=X)
+        # coerce to 2D np.ndarray, the return contract for y_inner_mtype numpy2D
+        if hasattr(y_pred, "to_numpy"):
+            y_pred = y_pred.to_numpy()
+        y_pred = np.asarray(y_pred)
         if y_pred.ndim == 1:
             y_pred = y_pred.reshape(-1, 1)
         return y_pred
 
-    # the delegate is an sklearn estimator and it does not have get_fitted_params
-    # therefore we have to override _get_fitted_params from the delegator,
-    # which would otherwise call it
+    def _predict_proba(self, X):
+        """Predict labels probabilities for sequences in X.
+
+        private _predict_proba containing the core logic, called from predict_proba
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+
+        Parameters
+        ----------
+        X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
+
+        Returns
+        -------
+        y : 2D array of shape [n_instances, n_classes] - predicted class probabilities
+        """
+        self._check_refit_for_predict("predict_proba")
+        return super()._predict_proba(X)
+
     def _get_fitted_params(self):
         """Get fitted parameters.
 
@@ -401,9 +580,19 @@ class TSCGridSearchCV(_DelegatedClassifier):
         Returns
         -------
         fitted_params : dict with str keys
-            fitted parameters, keyed by names of fitted parameter
+            A dict containing the best hyper parameters and the parameters of
+            the best estimator (if available), merged together with the former
+            taking precedence.
         """
-        return {}
+        fitted_params = {}
+        try:
+            fitted_params = self.best_estimator_.get_fitted_params()
+        except (NotFittedError, NotImplementedError):
+            pass
+        fitted_params = {**fitted_params, **self.best_params_}
+        fitted_params.update(self._get_fitted_params_default())
+
+        return fitted_params
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/classification/model_selection/_tune.py
+++ b/sktime/classification/model_selection/_tune.py
@@ -1,19 +1,253 @@
 """Tuning for time series classifiers."""
 
-__author__ = ["fkiraly", "achieveordie"]
+__author__ = ["fkiraly", "achieveordie", "atikulmunna"]
+
+import time
 
 import numpy as np
-from sklearn.model_selection import GridSearchCV
+import pandas as pd
 
 from sktime.classification._delegate import _DelegatedClassifier
+from sktime.classification.model_evaluation._functions import _evaluate
+from sktime.exceptions import NotFittedError
+from sktime.utils.parallel import parallelize
+
+# metric name suffixes indicating that lower values are better,
+# used to determine ranking direction for plain sklearn metric callables,
+# which do not carry a "lower_is_better" tag like sktime metric objects
+_LOWER_IS_BETTER_SUFFIXES = ("_error", "_loss", "_deviance", "_risk")
+
+
+def _metric_lower_is_better(metric):
+    """Return True if lower values of the metric indicate better performance."""
+    name = getattr(metric, "__name__", "").lower()
+    return name.endswith(_LOWER_IS_BETTER_SUFFIXES)
+
+
+def _check_scoring_callables(scoring, default):
+    """Coerce scoring to a non-empty list of callables.
+
+    Parameters
+    ----------
+    scoring : callable, list of callables, or None
+        scoring as passed to the tuner
+    default : callable
+        default metric to use if scoring is None
+
+    Returns
+    -------
+    list of callables, the metrics to evaluate
+
+    Raises
+    ------
+    TypeError
+        if scoring or an element of it is not callable
+    """
+    if scoring is None:
+        scoring = [default]
+    if not isinstance(scoring, list):
+        scoring = [scoring]
+    for metric in scoring:
+        if not callable(metric):
+            raise TypeError(
+                "Error in grid search tuner: scoring must be a callable metric "
+                "with signature (y_true, y_pred) -> float, a list of such "
+                f"callables, or None, but found {metric!r}. String scoring "
+                "values are not supported, pass the metric callable instead, "
+                "e.g., accuracy_score from sklearn.metrics."
+            )
+    return scoring
+
+
+def _resolve_cv(cv):
+    """Resolve the cv parameter to a splitter with a split method.
+
+    int and None are resolved to deterministic KFold, so that all
+    parameter candidates are evaluated on identical splits.
+    None resolves to 3 splits, same number as the evaluate default.
+    """
+    from sklearn.model_selection import check_cv
+
+    if cv is None:
+        cv = 3
+    return check_cv(cv)
+
+
+def _check_param_grid(param_grid):
+    """Validate param_grid, from sklearn 1.0.2, before it was removed."""
+    if hasattr(param_grid, "items"):
+        param_grid = [param_grid]
+
+    for p in param_grid:
+        for name, v in p.items():
+            if isinstance(v, np.ndarray) and v.ndim > 1:
+                raise ValueError("Parameter array should be one-dimensional.")
+
+            if isinstance(v, str) or not isinstance(v, (np.ndarray, list, tuple)):
+                raise ValueError(
+                    f"Parameter grid for parameter ({name}) needs to"
+                    f" be a list or numpy array, but got ({type(v)})."
+                    " Single values need to be wrapped in a list"
+                    " with one element."
+                )
+
+            if len(v) == 0:
+                raise ValueError(
+                    f"Parameter values for parameter ({name}) need "
+                    "to be a non-empty sequence."
+                )
+
+
+def _fit_and_score(params, meta):
+    """Fit and score estimator with given parameters.
+
+    Root level function for parallelization, called from
+    _grid_search_fit, within parallelize.
+    """
+    estimator = meta["estimator"].clone()
+    estimator.set_params(**params)
+
+    out = _evaluate(
+        estimator=estimator,
+        cv=meta["cv"],
+        X=meta["X"],
+        y=meta["y"],
+        scoring=meta["scoring"],
+        error_score=meta["error_score"],
+    )
+
+    # keep scores and timings, aggregate means over folds
+    out = out.filter(regex="^(test_|fit_time|pred)", axis=1)
+    out = out.mean()
+    out = out.add_prefix("mean_")
+
+    out["params"] = params
+
+    return out
+
+
+def _grid_search_fit(tuner, X, y, default_scoring):
+    """Run grid search backtesting for tuner, common to TSC and TSR tuners.
+
+    Writes fitted attributes to tuner: cv_results_, best_index_, best_score_,
+    best_params_, best_estimator_, n_splits_, scorer_, multimetric_,
+    and refit_time_ if refit=True.
+
+    Parameters
+    ----------
+    tuner : TSCGridSearchCV or TSRGridSearchCV instance
+    X : panel data container, in an sktime compatible Panel mtype
+    y : 2D np.ndarray, target values
+    default_scoring : callable, metric to use if tuner.scoring is None
+    """
+    from sklearn.model_selection import ParameterGrid
+
+    if y.ndim > 1 and y.shape[1] == 1:
+        y = y.flatten()
+
+    scoring = _check_scoring_callables(tuner.scoring, default_scoring)
+    primary_metric = scoring[0]
+    scoring_name = f"test_{primary_metric.__name__}"
+
+    cv = _resolve_cv(tuner.cv)
+
+    _check_param_grid(tuner.param_grid)
+    candidate_params = list(ParameterGrid(tuner.param_grid))
+
+    if tuner.verbose > 0:
+        n_candidates = len(candidate_params)
+        n_splits = cv.get_n_splits()
+        print(  # noqa: T201
+            f"Fitting {n_splits} folds for each of {n_candidates} candidates,"
+            f" totalling {n_candidates * n_splits} fits"
+        )
+
+    # resolve parallelization backend, legacy n_jobs maps to joblib backends
+    backend = tuner.backend
+    backend_params = tuner.backend_params if tuner.backend_params else {}
+    if backend is None and tuner.n_jobs is not None:
+        backend = "loky"
+        backend_params = {"n_jobs": tuner.n_jobs, **backend_params}
+
+    meta = {
+        "estimator": tuner.estimator,
+        "X": X,
+        "y": y,
+        "cv": cv,
+        "scoring": scoring,
+        "error_score": tuner.error_score,
+    }
+
+    out = parallelize(
+        fun=_fit_and_score,
+        iter=candidate_params,
+        meta=meta,
+        backend=backend,
+        backend_params=backend_params,
+    )
+
+    if len(out) < 1:
+        raise ValueError(
+            "No fits were performed. "
+            "Was the CV iterator empty? "
+            "Were there no candidates?"
+        )
+
+    results = pd.DataFrame(out)
+
+    # rank results, according to whether greater is better for the given scoring,
+    # with min method for ties, same as sklearn rank_test_score semantics
+    lower_is_better = _metric_lower_is_better(primary_metric)
+    results[f"rank_{scoring_name}"] = results.loc[:, f"mean_{scoring_name}"].rank(
+        ascending=lower_is_better, method="min"
+    )
+
+    tuner.cv_results_ = results
+
+    # select best parameters
+    tuner.best_index_ = results.loc[:, f"rank_{scoring_name}"].argmin()
+    # raise error if all fits in evaluate failed because all score values are NaN
+    if tuner.best_index_ == -1:
+        raise NotFittedError(
+            f"""All fits of estimator failed,
+            set error_score='raise' to see the exceptions.
+            Failed estimator: {tuner.estimator}"""
+        )
+    tuner.best_score_ = results.loc[tuner.best_index_, f"mean_{scoring_name}"]
+    tuner.best_params_ = results.loc[tuner.best_index_, "params"]
+    tuner.best_estimator_ = tuner.estimator.clone().set_params(**tuner.best_params_)
+
+    tuner.n_splits_ = cv.get_n_splits()
+    tuner.scorer_ = primary_metric
+    tuner.multimetric_ = len(scoring) > 1
+
+    # refit model with best parameters
+    if tuner.refit:
+        refit_start_time = time.perf_counter()
+        tuner.best_estimator_.fit(X=X, y=y)
+        tuner.refit_time_ = time.perf_counter() - refit_start_time
+
+    return tuner
 
 
 class TSCGridSearchCV(_DelegatedClassifier):
     """Exhaustive search over specified parameter values for an estimator.
 
-    Adapts sklearn GridSearchCV for sktime time series classifiers
+    Optimizes hyper-parameters of ``estimator`` by exhaustive grid search,
+    using backtesting via ``sktime`` native ``evaluate`` for classifiers.
 
-    Optimizes hyper-parameters of ``estimators`` by exhaustive grid search.
+    In ``fit``, for each parameter combination in ``param_grid``,
+    performance is backtested via
+    ``sktime.classification.model_evaluation.evaluate``,
+    on the data provided, using the cross-validation scheme ``cv``
+    and the scoring metric ``scoring``.
+
+    The best parameter combination, as per mean test score across folds,
+    is then selected, and set as ``best_params_``.
+    If ``refit=True``, ``best_estimator_`` is fitted to the entire data.
+
+    In ``predict`` and ``predict``-like methods, calls the respective method
+    of ``best_estimator_``, if ``refit=True``.
 
     Parameters
     ----------
@@ -27,97 +261,57 @@ class TSCGridSearchCV(_DelegatedClassifier):
         in the list are explored. This enables searching over any sequence
         of parameter settings.
 
-    scoring : str, callable, list, tuple or dict, default=None
-        Strategy to evaluate the performance of the cross-validated model on
-        the test set.
+    scoring : callable, list of callables, or None, default=None
+        Metric(s) to evaluate the performance of the cross-validated model on
+        the test set, passed to ``evaluate`` internally.
 
-        If `scoring` represents a single score, one can use:
+        - a callable must have signature
+          ``(y_true: 1D np.ndarray, y_pred: 1D np.ndarray) -> float``,
+          e.g., ``accuracy_score`` from ``sklearn.metrics``
+        - if a list of callables, the first metric in the list
+          is used for ranking and selection of the best parameters,
+          all metrics are computed and available in ``cv_results_``
+        - if None, defaults to ``accuracy_score``
 
-        - a single string (see :ref:`scoring_parameter`);
-        - a callable (see :ref:`scoring`) that returns a single value.
-
-        If `scoring` represents multiple scores, one can use:
-
-        - a list or tuple of unique strings;
-        - a callable returning a dictionary where the keys are the metric
-          names and the values are the metric scores;
-        - a dictionary with metric names as keys and callables a values.
+        Whether lower or higher values are better is determined from the
+        metric name: names ending in ``_error``, ``_loss``, ``_deviance``,
+        or ``_risk`` are assumed lower-is-better, all other higher-is-better.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel.
-        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
-        for more details.
+        Number of jobs to run in parallel for the grid search,
+        via the ``loky`` backend of ``joblib``.
+        ``None`` means 1, ``-1`` means using all processors.
+        Retained for backward compatibility, ignored if ``backend`` is passed.
+        For fine grained control of parallelization,
+        use ``backend`` and ``backend_params`` instead.
 
-    refit : bool, str, or callable, default=True
+    refit : bool, default=True
         Refit an estimator using the best found parameters on the whole
-        dataset. If ``False``, the ``predict`` and ``predict_proba`` will not work.
-
-        For multiple metric evaluation, this needs to be a ``str`` denoting the
-        scorer that would be used to find the best parameters for refitting
-        the estimator at the end.
-
-        Where there are considerations other than maximum score in
-        choosing a best estimator, ``refit`` can be set to a function which
-        returns the selected ``best_index_`` given ``cv_results_``. In that
-        case, the ``best_estimator_`` and ``best_params_`` will be set
-        according to the returned ``best_index_`` while the ``best_score_``
-        attribute will not be available.
-
-        The refitted estimator is made available at the ``best_estimator_``
-        attribute and permits using ``predict`` directly on this
-        ``GridSearchCV`` instance.
-
-        Also for multiple metric evaluation, the attributes ``best_index_``,
-        ``best_score_`` and ``best_params_`` will only be available if
-        ``refit`` is set and all of them will be determined w.r.t this specific
-        scorer.
-
-        See ``scoring`` parameter to know more about multiple metric
-        evaluation.
+        dataset.
+        If ``False``, ``predict`` and ``predict``-like methods will raise,
+        and the tuner can be used only as a parameter estimator,
+        e.g., via ``get_fitted_params``.
 
     cv : int, cross-validation generator or an iterable, default=None
-        Determines the cross-validation splitting strategy.
-        Possible inputs for cv are:
+        Determines the cross-validation splitting strategy, used in
+        ``evaluate`` internally. Possible inputs for cv are:
 
-        - None, to use the default 5-fold cross validation,
-        - integer, to specify the number of folds in a ``(Stratified)KFold``,
-        - :term:`CV splitter`,
+        - None, to use the default 3-fold cross validation via ``KFold``,
+        - integer, to specify the number of folds in a ``KFold`` splitter,
+        - CV splitter with a ``split`` method,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-        For integer/None inputs, if the estimator is a classifier and ``y`` is
-        either binary or multiclass, :class:`StratifiedKFold` is used. In all
-        other cases, :class:`KFold` is used. These splitters are instantiated
-        with ``shuffle=False`` so the splits will be the same across calls.
+        For integer/None inputs, ``KFold`` is instantiated with
+        ``shuffle=False``, so all parameter candidates are evaluated
+        on identical, deterministic splits.
 
-        Refer :ref:`User Guide <cross_validation>` for the various
-        cross-validation strategies that can be used here.
-
-    verbose : int
+    verbose : int, default=0
         Controls the verbosity: the higher, the more messages.
 
-        - >1 : the computation time for each fold and parameter candidate is
-          displayed;
-        - >2 : the score is also displayed;
-        - >3 : the fold and candidate parameter indexes are also displayed
-          together with the starting time of the computation.
-
     pre_dispatch : int, or str, default='2*n_jobs'
-        Controls the number of jobs that get dispatched during parallel
-        execution. Reducing this number can be useful to avoid an
-        explosion of memory consumption when more jobs get dispatched
-        than CPUs can process. This parameter can be:
-
-            - None, in which case all the jobs are immediately
-              created and spawned. Use this for lightweight and
-              fast-running jobs, to avoid delays due to on-demand
-              spawning of the jobs
-
-            - An int, giving the exact number of total jobs that are
-              spawned
-
-            - A str, giving an expression as a function of n_jobs,
-              as in '2*n_jobs'
+        Retained for backward compatibility, this parameter is ignored.
+        Parallelization behaviour can be controlled via
+        ``backend`` and ``backend_params``.
 
     error_score : 'raise' or numeric, default=np.nan
         Value to assign to the score if an error occurs in estimator fitting.
@@ -126,13 +320,8 @@ class TSCGridSearchCV(_DelegatedClassifier):
         step, which will always raise the error.
 
     return_train_score : bool, default=False
-        If ``False``, the ``cv_results_`` attribute will not include training
-        scores.
-        Computing training scores is used to get insights on how different
-        parameter settings impact the overfitting/underfitting trade-off.
-        However computing the scores on the training set can be computationally
-        expensive and is not strictly required to select the parameters that
-        yield the best generalization performance.
+        Retained for backward compatibility, this parameter is ignored.
+        Train scores are not computed by the native grid search.
 
     tune_by_variable : bool, optional (default=False)
         Whether to tune parameter by each time series variable separately,
@@ -143,100 +332,96 @@ class TSCGridSearchCV(_DelegatedClassifier):
         Has the same effect as applying ColumnEnsembleClassifier wrapper to self.
         If False, the same best parameter is selected for all variables.
 
+    backend : {"dask", "loky", "multiprocessing", "threading"}, optional, default=None
+        Runs parallel grid search over the parameter candidates, if specified.
+
+        - "None": executes loop sequentially, simple list comprehension
+        - "loky", "multiprocessing" and "threading": uses ``joblib.Parallel`` loops
+        - "joblib": custom and 3rd party ``joblib`` backends, e.g., ``spark``
+        - "dask": uses ``dask``, requires ``dask`` package in environment
+
+        Recommendation: Use "dask" or "loky" for parallel grid search.
+
+    backend_params : dict, optional
+        additional parameters passed to the backend as config.
+        Directly passed to ``utils.parallel.parallelize``.
+        Valid keys depend on the value of ``backend``:
+
+        - "None": no additional parameters, ``backend_params`` is ignored
+        - "loky", "multiprocessing" and "threading": default ``joblib`` backends
+          any valid keys for ``joblib.Parallel`` can be passed here, e.g., ``n_jobs``,
+          with the exception of ``backend`` which is directly controlled by ``backend``.
+        - "dask": any valid keys for ``dask.compute`` can be passed,
+          e.g., ``scheduler``
+
     Attributes
     ----------
-    cv_results_ : dict of numpy (masked) ndarrays
-        A dict with keys as column headers and values as columns, that can be
-        imported into a pandas ``DataFrame``.
+    cv_results_ : pd.DataFrame
+        DataFrame with one row per parameter candidate, with columns:
 
-        For multi-metric evaluation, the scores for all the scorers are
-        available in the ``cv_results_`` dict at the keys ending with that
-        scorer's name (``'_<scorer_name>'``) instead of ``'_score'`` shown
-        above. ('split0_test_precision', 'mean_train_precision' etc.)
+        - ``mean_test_<metric_name>``: mean test score across folds,
+          one column per metric in ``scoring``
+        - ``mean_fit_time``: mean fit time across folds, in seconds
+        - ``mean_pred_time``: mean prediction time across folds, in seconds
+        - ``params``: the parameter settings of the candidate
+        - ``rank_test_<metric_name>``: rank of the candidate, 1 is best,
+          for the primary (first) metric in ``scoring``
 
     best_estimator_ : estimator
-        Estimator that was chosen by the search, i.e. estimator
-        which gave highest score (or smallest loss if specified)
-        on the left out data. Not available if ``refit=False``.
-
-        See ``refit`` parameter for more information on allowed values.
+        Clone of ``estimator`` with the best found parameters set.
+        Fitted to the entire data if ``refit=True``, otherwise unfitted.
 
     best_score_ : float
-        Mean cross-validated score of the best_estimator
-
-        For multi-metric evaluation, this is present only if ``refit`` is
-        specified.
-
-        This attribute is not available if ``refit`` is a function.
+        Mean cross-validated test score of the best parameter candidate.
 
     best_params_ : dict
-        Parameter setting that gave the best results on the hold out data.
-
-        For multi-metric evaluation, this is present only if ``refit`` is
-        specified.
+        Parameter setting that gave the best mean test score.
 
     best_index_ : int
-        The index (of the ``cv_results_`` arrays) which corresponds to the best
-        candidate parameter setting.
+        The row index in ``cv_results_`` corresponding to the
+        best parameter candidate.
 
-        The dict at ``search.cv_results_['params'][search.best_index_]`` gives
-        the parameter setting for the best model, that gives the highest
-        mean score (``search.best_score_``).
-
-        For multi-metric evaluation, this is present only if ``refit`` is
-        specified.
-
-    scorer_ : function or a dict
-        Scorer function used on the held out data to choose the best
-        parameters for the model.
-
-        For multi-metric evaluation, this attribute holds the validated
-        ``scoring`` dict which maps the scorer key to the scorer callable.
+    scorer_ : callable
+        The primary metric used to rank candidates and select best parameters.
 
     n_splits_ : int
-        The number of cross-validation splits (folds/iterations).
+        The number of cross-validation splits (folds).
 
     refit_time_ : float
         Seconds used for refitting the best model on the whole dataset.
-
-        This is present only if ``refit`` is not False.
+        This is present only if ``refit=True``.
 
     multimetric_ : bool
-        Whether or not the scorers compute several metrics.
+        Whether multiple metrics were passed in ``scoring``.
 
     classes_ : ndarray of shape (n_classes,)
-        The classes labels. This is present only if ``refit`` is specified and
-        the underlying estimator is a classifier.
+        The class labels.
 
-    n_features_in_ : int
-        Number of features seen during :term:`fit`. Only defined if
-        ``best_estimator_`` is defined (see the documentation for the ``refit``
-        parameter for more details) and that ``best_estimator_`` exposes
-        ``n_features_in_`` when fit.
-
-    feature_names_in_ : ndarray of shape (``n_features_in_``,)
-        Names of features seen during :term:`fit`. Only defined if
-        ``best_estimator_`` is defined (see the documentation for the ``refit``
-        parameter for more details) and that ``best_estimator_`` exposes
-        ``feature_names_in_`` when fit.
-
-    See Also
+    Examples
     --------
-    ParameterGrid : Generates all the combinations of a hyperparameter grid.
-    train_test_split : Utility function to split the data into a development
-        set usable for fitting a GridSearchCV instance and an evaluation set
-        for its final evaluation.
-    sklearn.metrics.make_scorer : Make a scorer from a performance metric or
-        loss function.
+    >>> from sklearn.metrics import accuracy_score
+    >>> from sklearn.model_selection import KFold
+    >>> from sktime.classification.dummy import DummyClassifier
+    >>> from sktime.classification.model_selection import TSCGridSearchCV
+    >>> from sktime.datasets import load_unit_test
+    >>> X, y = load_unit_test()
+    >>> tuned_dummy = TSCGridSearchCV(
+    ...     DummyClassifier(),
+    ...     {"strategy": ["most_frequent", "stratified"]},
+    ...     scoring=accuracy_score,
+    ...     cv=KFold(n_splits=2, shuffle=False),
+    ... )
+    >>> tuned_dummy = tuned_dummy.fit(X, y)
+    >>> y_pred = tuned_dummy.predict(X)
     """
 
     _tags = {
         # packaging info
         # --------------
-        "authors": ["fkiraly", "achieveordie"],
+        "authors": ["fkiraly", "achieveordie", "atikulmunna"],
         # estimator type
         # --------------
-        "X_inner_mtype": ["nested_univ", "numpy3D"],
+        "X_inner_mtype": ["pd-multiindex", "nested_univ", "numpy3D"],
         "y_inner_mtype": ["numpy2D"],
         "capability:multivariate": True,
         "capability:multioutput": True,
@@ -249,6 +434,11 @@ class TSCGridSearchCV(_DelegatedClassifier):
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
     }
+
+    # attribute for _DelegatedClassifier, which then delegates
+    #     all non-overridden methods to getattr(self, _delegate_name)
+    #     see further details in _DelegatedClassifier docstring
+    _delegate_name = "best_estimator_"
 
     def __init__(
         self,
@@ -263,6 +453,8 @@ class TSCGridSearchCV(_DelegatedClassifier):
         error_score=np.nan,
         return_train_score=False,
         tune_by_variable=False,
+        backend=None,
+        backend_params=None,
     ):
         self.estimator = estimator
         self.param_grid = param_grid
@@ -275,25 +467,10 @@ class TSCGridSearchCV(_DelegatedClassifier):
         self.error_score = error_score
         self.return_train_score = return_train_score
         self.tune_by_variable = tune_by_variable
+        self.backend = backend
+        self.backend_params = backend_params
 
         super().__init__()
-
-        DELEGATED_PARAMS = [
-            "estimator",
-            "param_grid",
-            "scoring",
-            "n_jobs",
-            "refit",
-            "cv",
-            "verbose",
-            "pre_dispatch",
-            "error_score",
-            "return_train_score",
-        ]
-
-        gcsvargs = {k: getattr(self, k) for k in DELEGATED_PARAMS}
-
-        self.estimator_ = GridSearchCV(**gcsvargs)
 
         if self.tune_by_variable:
             self.set_tags(**{"capability:multioutput": False})
@@ -309,9 +486,7 @@ class TSCGridSearchCV(_DelegatedClassifier):
         Parameters
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
-            if self.get_tag("X_inner_mtype") = "numpy3D":
-            3D np.ndarray of shape = [n_instances, n_dimensions, series_length]
-            if self.get_tag("X_inner_mtype") = "pd-multiindex:":
+            if self.get_tag("X_inner_mtype") = "pd-multiindex":
             pd.DataFrame with columns = variables,
             index = pd.MultiIndex with first level = instance indices,
             second level = time indices
@@ -321,38 +496,26 @@ class TSCGridSearchCV(_DelegatedClassifier):
             1D iterable, of shape [n_instances]
             or 2D iterable, of shape [n_instances, n_dimensions]
             class labels for fitting
-            if self.get_tag("capaility:multioutput") = False, guaranteed to be 1D
-            if self.get_tag("capaility:multioutput") = True, guaranteed to be 2D
+            if self.get_tag("capability:multioutput") = False, guaranteed to be 1D
+            if self.get_tag("capability:multioutput") = True, guaranteed to be 2D
 
         Returns
         -------
         self : Reference to self.
         """
-        if y.shape[1] == 1:
-            y = y.flatten()
+        from sklearn.metrics import accuracy_score
 
-        estimator = self._get_delegate()
-        estimator.fit(X=X, y=y)
+        return _grid_search_fit(self, X=X, y=y, default_scoring=accuracy_score)
 
-        fitted_param_names = [
-            "cv_results_",
-            "best_estimator_",
-            "best_score_",
-            "best_params_",
-            "best_index_",
-            "scorer_",
-            "n_splits_",
-            "refit_time_",
-            "multimetric_",
-            "classes_",
-        ]
-
-        for p in fitted_param_names:
-            if hasattr(estimator, p):
-                val = getattr(estimator, p)
-                setattr(self, p, val)
-
-        return self
+    def _check_refit_for_predict(self, method_name):
+        """Raise error if refit=False and a predict-like method is called."""
+        if not self.refit:
+            raise RuntimeError(
+                f"In {self.__class__.__name__}, refit must be True to make"
+                f" predictions, but found refit=False. If refit=False,"
+                f" {self.__class__.__name__} can be used only to tune"
+                " hyper-parameters, as a parameter estimator."
+            )
 
     def _predict(self, X):
         """Predict labels for sequences in X.
@@ -368,27 +531,44 @@ class TSCGridSearchCV(_DelegatedClassifier):
         Parameters
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
-            if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_dimensions, series_length]
-            if self.get_tag("X_inner_mtype") = "nested_univ":
-                pd.DataFrame with each column a dimension, each cell a pd.Series
-            for list of other mtypes, see datatypes.SCITYPE_REGISTER
-            for specifications, see examples/AA_datatypes_and_datasets.ipynb
 
         Returns
         -------
-        y : 1D np.array of int, of shape [n_instances] - predicted class labels
-            indices correspond to instance indices in X
+        y : predictions of labels for X, np.ndarray
         """
+        self._check_refit_for_predict("predict")
         estimator = self._get_delegate()
         y_pred = estimator.predict(X=X)
+        # coerce to 2D np.ndarray, the return contract for y_inner_mtype numpy2D
+        if hasattr(y_pred, "to_numpy"):
+            y_pred = y_pred.to_numpy()
+        y_pred = np.asarray(y_pred)
         if y_pred.ndim == 1:
             y_pred = y_pred.reshape(-1, 1)
         return y_pred
 
-    # the delegate is an sklearn estimator and it does not have get_fitted_params
-    # therefore we have to override _get_fitted_params from the delegator,
-    # which would otherwise call it
+    def _predict_proba(self, X):
+        """Predict labels probabilities for sequences in X.
+
+        private _predict_proba containing the core logic, called from predict_proba
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+
+        Parameters
+        ----------
+        X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
+
+        Returns
+        -------
+        y : 2D array of shape [n_instances, n_classes] - predicted class probabilities
+        """
+        self._check_refit_for_predict("predict_proba")
+        return super()._predict_proba(X)
+
     def _get_fitted_params(self):
         """Get fitted parameters.
 
@@ -400,9 +580,19 @@ class TSCGridSearchCV(_DelegatedClassifier):
         Returns
         -------
         fitted_params : dict with str keys
-            fitted parameters, keyed by names of fitted parameter
+            A dict containing the best hyper parameters and the parameters of
+            the best estimator (if available), merged together with the former
+            taking precedence.
         """
-        return {}
+        fitted_params = {}
+        try:
+            fitted_params = self.best_estimator_.get_fitted_params()
+        except (NotFittedError, NotImplementedError):
+            pass
+        fitted_params = {**fitted_params, **self.best_params_}
+        fitted_params.update(self._get_fitted_params_default())
+
+        return fitted_params
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/classification/model_selection/tests/__init__.py
+++ b/sktime/classification/model_selection/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for classification tuners."""

--- a/sktime/classification/model_selection/tests/test_tune.py
+++ b/sktime/classification/model_selection/tests/test_tune.py
@@ -1,0 +1,163 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Test classification tuners."""
+
+__author__ = ["atikulmunna"]
+
+import numpy as np
+import pytest
+from sklearn.metrics import accuracy_score, balanced_accuracy_score
+from sklearn.model_selection import KFold, ParameterGrid
+
+from sktime.classification.dummy import DummyClassifier
+from sktime.classification.model_evaluation import evaluate
+from sktime.classification.model_selection import TSCGridSearchCV
+from sktime.classification.model_selection._tune import _metric_lower_is_better
+from sktime.datasets import load_unit_test
+from sktime.tests.test_switch import run_test_for_class
+
+PARAM_GRID = {"strategy": ["most_frequent", "prior"]}
+CV = KFold(n_splits=2, shuffle=False)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSCGridSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_gridsearch_fit_and_attributes():
+    """Test that fitted attributes are set and consistent."""
+    X, y = load_unit_test(split="train")
+    tuner = TSCGridSearchCV(
+        DummyClassifier(),
+        param_grid=PARAM_GRID,
+        cv=CV,
+    )
+    tuner.fit(X, y)
+
+    n_candidates = len(ParameterGrid(PARAM_GRID))
+    assert len(tuner.cv_results_) == n_candidates
+
+    expected_columns = {
+        "mean_test_accuracy_score",
+        "mean_fit_time",
+        "mean_pred_time",
+        "params",
+        "rank_test_accuracy_score",
+    }
+    assert expected_columns.issubset(tuner.cv_results_.columns)
+
+    assert tuner.best_params_ in list(ParameterGrid(PARAM_GRID))
+    assert tuner.best_index_ in range(n_candidates)
+    assert tuner.n_splits_ == 2
+    assert tuner.scorer_ is accuracy_score
+    assert not tuner.multimetric_
+    assert hasattr(tuner, "refit_time_")
+
+    best_row = tuner.cv_results_.iloc[tuner.best_index_]
+    assert best_row["rank_test_accuracy_score"] == 1
+    assert tuner.best_score_ == best_row["mean_test_accuracy_score"]
+
+    y_pred = tuner.predict(X)
+    assert len(y_pred) == len(y)
+
+    y_proba = tuner.predict_proba(X)
+    assert y_proba.shape[0] == len(y)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSCGridSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_gridsearch_scores_match_evaluate():
+    """Test that cv_results_ scores equal manual evaluate scores per candidate."""
+    X, y = load_unit_test(split="train")
+    tuner = TSCGridSearchCV(
+        DummyClassifier(),
+        param_grid=PARAM_GRID,
+        cv=CV,
+    )
+    tuner.fit(X, y)
+
+    for _, row in tuner.cv_results_.iterrows():
+        estimator = DummyClassifier().set_params(**row["params"])
+        expected = evaluate(estimator, cv=CV, X=X, y=y, scoring=accuracy_score)
+        expected_mean = expected["test_accuracy_score"].mean()
+        assert np.isclose(row["mean_test_accuracy_score"], expected_mean)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSCGridSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_gridsearch_multiple_metrics():
+    """Test that multiple metrics are computed and the first is used for ranking."""
+    X, y = load_unit_test(split="train")
+    tuner = TSCGridSearchCV(
+        DummyClassifier(),
+        param_grid=PARAM_GRID,
+        scoring=[accuracy_score, balanced_accuracy_score],
+        cv=CV,
+    )
+    tuner.fit(X, y)
+
+    assert "mean_test_accuracy_score" in tuner.cv_results_.columns
+    assert "mean_test_balanced_accuracy_score" in tuner.cv_results_.columns
+    assert "rank_test_accuracy_score" in tuner.cv_results_.columns
+    assert tuner.multimetric_
+    assert tuner.scorer_ is accuracy_score
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSCGridSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_gridsearch_refit_false():
+    """Test that refit=False tunes but refuses to predict."""
+    X, y = load_unit_test(split="train")
+    tuner = TSCGridSearchCV(
+        DummyClassifier(),
+        param_grid=PARAM_GRID,
+        cv=CV,
+        refit=False,
+    )
+    tuner.fit(X, y)
+
+    assert tuner.best_params_ in list(ParameterGrid(PARAM_GRID))
+    assert not hasattr(tuner, "refit_time_")
+
+    with pytest.raises(RuntimeError, match="refit must be True"):
+        tuner.predict(X)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSCGridSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_gridsearch_string_scoring_raises():
+    """Test that string scoring raises an informative error."""
+    X, y = load_unit_test(split="train")
+    tuner = TSCGridSearchCV(
+        DummyClassifier(),
+        param_grid=PARAM_GRID,
+        scoring="accuracy",
+        cv=CV,
+    )
+    with pytest.raises(TypeError, match="String scoring"):
+        tuner.fit(X, y)
+
+
+def test_metric_lower_is_better_heuristic():
+    """Test the metric direction heuristic on common sklearn metrics."""
+    from sklearn.metrics import (
+        brier_score_loss,
+        log_loss,
+        mean_absolute_error,
+        mean_squared_error,
+        r2_score,
+    )
+
+    assert _metric_lower_is_better(mean_squared_error)
+    assert _metric_lower_is_better(mean_absolute_error)
+    assert _metric_lower_is_better(log_loss)
+    assert _metric_lower_is_better(brier_score_loss)
+    assert not _metric_lower_is_better(accuracy_score)
+    assert not _metric_lower_is_better(r2_score)

--- a/sktime/regression/model_selection/_tune.py
+++ b/sktime/regression/model_selection/_tune.py
@@ -1,125 +1,97 @@
 """Tuning for time series regressors."""
 
-__author__ = ["ksharma6"]
+__author__ = ["ksharma6", "atikulmunna"]
 
 import numpy as np
-from sklearn.model_selection import GridSearchCV
 
+from sktime.classification.model_selection._tune import _grid_search_fit
+from sktime.exceptions import NotFittedError
 from sktime.regression._delegate import _DelegatedRegressor
 
 
 class TSRGridSearchCV(_DelegatedRegressor):
     """Exhaustive search over specified parameter values for an estimator.
 
-    Adapts sklearn GridSearchCV for sktime time series regressors
+    Optimizes hyper-parameters of ``estimator`` by exhaustive grid search,
+    using backtesting via ``sktime`` native ``evaluate`` for regressors.
 
-    Optimizes hyper-parameters of `estimators` by exhaustive grid search.
+    In ``fit``, for each parameter combination in ``param_grid``,
+    performance is backtested via
+    ``sktime.regression.model_evaluation.evaluate``,
+    on the data provided, using the cross-validation scheme ``cv``
+    and the scoring metric ``scoring``.
+
+    The best parameter combination, as per mean test score across folds,
+    is then selected, and set as ``best_params_``.
+    If ``refit=True``, ``best_estimator_`` is fitted to the entire data.
+
+    In ``predict`` and ``predict``-like methods, calls the respective method
+    of ``best_estimator_``, if ``refit=True``.
 
     Parameters
     ----------
-    estimator : estimator object
-        This is assumed to implement the scikit-learn estimator interface.
-        Either estimator needs to provide a ``score`` function,
-        or ``scoring`` must be passed.
+    estimator : sktime regressor, BaseRegressor instance or interface compatible
+        The regressor to tune, must implement the sktime regressor interface.
 
     param_grid : dict or list of dictionaries
-        Dictionary with parameters names (`str`) as keys and lists of
+        Dictionary with parameters names (``str``) as keys and lists of
         parameter settings to try as values, or a list of such
         dictionaries, in which case the grids spanned by each dictionary
         in the list are explored. This enables searching over any sequence
         of parameter settings.
 
-    scoring : str, callable, list, tuple or dict, default=None
-        Strategy to evaluate the performance of the cross-validated model on
-        the test set.
+    scoring : callable, list of callables, or None, default=None
+        Metric(s) to evaluate the performance of the cross-validated model on
+        the test set, passed to ``evaluate`` internally.
 
-        If `scoring` represents a single score, one can use:
+        - a callable must have signature
+          ``(y_true: 1D np.ndarray, y_pred: 1D np.ndarray) -> float``,
+          e.g., ``mean_squared_error`` from ``sklearn.metrics``
+        - if a list of callables, the first metric in the list
+          is used for ranking and selection of the best parameters,
+          all metrics are computed and available in ``cv_results_``
+        - if None, defaults to ``mean_squared_error``,
+          same default as ``evaluate`` for regressors
 
-        - a single string (see :ref:`scoring_parameter`);
-        - a callable (see :ref:`scoring`) that returns a single value.
-
-        If `scoring` represents multiple scores, one can use:
-
-        - a list or tuple of unique strings;
-        - a callable returning a dictionary where the keys are the metric
-          names and the values are the metric scores;
-        - a dictionary with metric names as keys and callables a values.
+        Whether lower or higher values are better is determined from the
+        metric name: names ending in ``_error``, ``_loss``, ``_deviance``,
+        or ``_risk`` are assumed lower-is-better, all other higher-is-better.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel.
-        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
-        for more details.
+        Number of jobs to run in parallel for the grid search,
+        via the ``loky`` backend of ``joblib``.
+        ``None`` means 1, ``-1`` means using all processors.
+        Retained for backward compatibility, ignored if ``backend`` is passed.
+        For fine grained control of parallelization,
+        use ``backend`` and ``backend_params`` instead.
 
-    refit : bool, str, or callable, default=True
+    refit : bool, default=True
         Refit an estimator using the best found parameters on the whole
-        dataset. If ``False``, then ``predict`` will not work.
-
-        For multiple metric evaluation, this needs to be a `str` denoting the
-        scorer that would be used to find the best parameters for refitting
-        the estimator at the end.
-
-        Where there are considerations other than maximum score in
-        choosing a best estimator, ``refit`` can be set to a function which
-        returns the selected ``best_index_`` given ``cv_results_``. In that
-        case, the ``best_estimator_`` and ``best_params_`` will be set
-        according to the returned ``best_index_`` while the ``best_score_``
-        attribute will not be available.
-
-        The refitted estimator is made available at the ``best_estimator_``
-        attribute and permits using ``predict`` directly on this
-        ``GridSearchCV`` instance.
-
-        Also for multiple metric evaluation, the attributes ``best_index_``,
-        ``best_score_`` and ``best_params_`` will only be available if
-        ``refit`` is set and all of them will be determined w.r.t this specific
-        scorer.
-
-        See ``scoring`` parameter to know more about multiple metric
-        evaluation.
+        dataset.
+        If ``False``, ``predict`` will raise,
+        and the tuner can be used only as a parameter estimator,
+        e.g., via ``get_fitted_params``.
 
     cv : int, cross-validation generator or an iterable, default=None
-        Determines the cross-validation splitting strategy.
-        Possible inputs for cv are:
+        Determines the cross-validation splitting strategy, used in
+        ``evaluate`` internally. Possible inputs for cv are:
 
-        - None, to use the default 5-fold cross validation,
-        - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - :term:`CV splitter`,
+        - None, to use the default 3-fold cross validation via ``KFold``,
+        - integer, to specify the number of folds in a ``KFold`` splitter,
+        - CV splitter with a ``split`` method,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-        For integer/None inputs, if the estimator is a regressor and ``y`` is
-        either binary or multiclass, :class:`StratifiedKFold` is used. In all
-        other cases, :class:`KFold` is used. These splitters are instantiated
-        with `shuffle=False` so the splits will be the same across calls.
+        For integer/None inputs, ``KFold`` is instantiated with
+        ``shuffle=False``, so all parameter candidates are evaluated
+        on identical, deterministic splits.
 
-        Refer :ref:`User Guide <cross_validation>` for the various
-        cross-validation strategies that can be used here.
-
-    verbose : int
+    verbose : int, default=0
         Controls the verbosity: the higher, the more messages.
 
-        - >1 : the computation time for each fold and parameter candidate is
-          displayed;
-        - >2 : the score is also displayed;
-        - >3 : the fold and candidate parameter indexes are also displayed
-          together with the starting time of the computation.
-
     pre_dispatch : int, or str, default='2*n_jobs'
-        Controls the number of jobs that get dispatched during parallel
-        execution. Reducing this number can be useful to avoid an
-        explosion of memory consumption when more jobs get dispatched
-        than CPUs can process. This parameter can be:
-
-            - None, in which case all the jobs are immediately
-              created and spawned. Use this for lightweight and
-              fast-running jobs, to avoid delays due to on-demand
-              spawning of the jobs
-
-            - An int, giving the exact number of total jobs that are
-              spawned
-
-            - A str, giving an expression as a function of n_jobs,
-              as in '2*n_jobs'
+        Retained for backward compatibility, this parameter is ignored.
+        Parallelization behaviour can be controlled via
+        ``backend`` and ``backend_params``.
 
     error_score : 'raise' or numeric, default=np.nan
         Value to assign to the score if an error occurs in estimator fitting.
@@ -128,13 +100,8 @@ class TSRGridSearchCV(_DelegatedRegressor):
         step, which will always raise the error.
 
     return_train_score : bool, default=False
-        If ``False``, the ``cv_results_`` attribute will not include training
-        scores.
-        Computing training scores is used to get insights on how different
-        parameter settings impact the overfitting/underfitting trade-off.
-        However computing the scores on the training set can be computationally
-        expensive and is not strictly required to select the parameters that
-        yield the best generalization performance.
+        Retained for backward compatibility, this parameter is ignored.
+        Train scores are not computed by the native grid search.
 
     tune_by_variable : bool, optional (default=False)
         Whether to tune parameter by each time series variable separately,
@@ -145,96 +112,91 @@ class TSRGridSearchCV(_DelegatedRegressor):
         Has the same effect as applying ColumnEnsembleRegressor wrapper to self.
         If False, the same best parameter is selected for all variables.
 
+    backend : {"dask", "loky", "multiprocessing", "threading"}, optional, default=None
+        Runs parallel grid search over the parameter candidates, if specified.
+
+        - "None": executes loop sequentially, simple list comprehension
+        - "loky", "multiprocessing" and "threading": uses ``joblib.Parallel`` loops
+        - "joblib": custom and 3rd party ``joblib`` backends, e.g., ``spark``
+        - "dask": uses ``dask``, requires ``dask`` package in environment
+
+        Recommendation: Use "dask" or "loky" for parallel grid search.
+
+    backend_params : dict, optional
+        additional parameters passed to the backend as config.
+        Directly passed to ``utils.parallel.parallelize``.
+        Valid keys depend on the value of ``backend``:
+
+        - "None": no additional parameters, ``backend_params`` is ignored
+        - "loky", "multiprocessing" and "threading": default ``joblib`` backends
+          any valid keys for ``joblib.Parallel`` can be passed here, e.g., ``n_jobs``,
+          with the exception of ``backend`` which is directly controlled by ``backend``.
+        - "dask": any valid keys for ``dask.compute`` can be passed,
+          e.g., ``scheduler``
+
     Attributes
     ----------
-    cv_results_ : dict of numpy (masked) ndarrays
-        A dict with keys as column headers and values as columns, that can be
-        imported into a pandas ``DataFrame``.
+    cv_results_ : pd.DataFrame
+        DataFrame with one row per parameter candidate, with columns:
 
-        For multi-metric evaluation, the scores for all the scorers are
-        available in the ``cv_results_`` dict at the keys ending with that
-        scorer's name (``'_<scorer_name>'``) instead of ``'_score'`` shown
-        above. ('split0_test_precision', 'mean_train_precision' etc.)
+        - ``mean_test_<metric_name>``: mean test score across folds,
+          one column per metric in ``scoring``
+        - ``mean_fit_time``: mean fit time across folds, in seconds
+        - ``mean_pred_time``: mean prediction time across folds, in seconds
+        - ``params``: the parameter settings of the candidate
+        - ``rank_test_<metric_name>``: rank of the candidate, 1 is best,
+          for the primary (first) metric in ``scoring``
 
     best_estimator_ : estimator
-        Estimator that was chosen by the search, i.e. estimator
-        which gave highest score (or smallest loss if specified)
-        on the left out data. Not available if ``refit=False``.
-
-        See ``refit`` parameter for more information on allowed values.
+        Clone of ``estimator`` with the best found parameters set.
+        Fitted to the entire data if ``refit=True``, otherwise unfitted.
 
     best_score_ : float
-        Mean cross-validated score of the best_estimator
-
-        For multi-metric evaluation, this is present only if ``refit`` is
-        specified.
-
-        This attribute is not available if ``refit`` is a function.
+        Mean cross-validated test score of the best parameter candidate.
 
     best_params_ : dict
-        Parameter setting that gave the best results on the hold out data.
-
-        For multi-metric evaluation, this is present only if ``refit`` is
-        specified.
+        Parameter setting that gave the best mean test score.
 
     best_index_ : int
-        The index (of the ``cv_results_`` arrays) which corresponds to the best
-        candidate parameter setting.
+        The row index in ``cv_results_`` corresponding to the
+        best parameter candidate.
 
-        The dict at ``search.cv_results_['params'][search.best_index_]`` gives
-        the parameter setting for the best model, that gives the highest
-        mean score (``search.best_score_``).
-
-        For multi-metric evaluation, this is present only if ``refit`` is
-        specified.
-
-    scorer_ : function or a dict
-        Scorer function used on the held out data to choose the best
-        parameters for the model.
-
-        For multi-metric evaluation, this attribute holds the validated
-        ``scoring`` dict which maps the scorer key to the scorer callable.
+    scorer_ : callable
+        The primary metric used to rank candidates and select best parameters.
 
     n_splits_ : int
-        The number of cross-validation splits (folds/iterations).
+        The number of cross-validation splits (folds).
 
     refit_time_ : float
         Seconds used for refitting the best model on the whole dataset.
-
-        This is present only if ``refit`` is not False.
+        This is present only if ``refit=True``.
 
     multimetric_ : bool
-        Whether or not the scorers compute several metrics.
+        Whether multiple metrics were passed in ``scoring``.
 
-    n_features_in_ : int
-        Number of features seen during :term:`fit`. Only defined if
-        `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and that `best_estimator_` exposes
-        `n_features_in_` when fit.
-
-    feature_names_in_ : ndarray of shape (`n_features_in_`,)
-        Names of features seen during :term:`fit`. Only defined if
-        `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and that `best_estimator_` exposes
-        `feature_names_in_` when fit.
-
-    See Also
+    Examples
     --------
-    ParameterGrid : Generates all the combinations of a hyperparameter grid.
-    train_test_split : Utility function to split the data into a development
-        set usable for fitting a GridSearchCV instance and an evaluation set
-        for its final evaluation.
-    sklearn.metrics.make_scorer : Make a scorer from a performance metric or
-        loss function.
+    >>> from sklearn.model_selection import KFold
+    >>> from sktime.datasets import load_unit_test
+    >>> from sktime.regression.dummy import DummyRegressor
+    >>> from sktime.regression.model_selection import TSRGridSearchCV
+    >>> X, y = load_unit_test(return_type="numpy3D")
+    >>> tuned_dummy = TSRGridSearchCV(
+    ...     DummyRegressor(),
+    ...     {"strategy": ["mean", "median"]},
+    ...     cv=KFold(n_splits=2, shuffle=False),
+    ... )
+    >>> tuned_dummy = tuned_dummy.fit(X, y.astype("float"))
+    >>> y_pred = tuned_dummy.predict(X)
     """
 
     _tags = {
         # packaging info
         # --------------
-        "authors": ["ksharma6"],
+        "authors": ["ksharma6", "atikulmunna"],
         # estimator type
         # --------------
-        "X_inner_mtype": ["nested_univ", "numpy3D"],
+        "X_inner_mtype": ["pd-multiindex", "nested_univ", "numpy3D"],
         "y_inner_mtype": ["numpy2D"],
         "capability:multivariate": True,
         "capability:multioutput": True,
@@ -243,6 +205,11 @@ class TSRGridSearchCV(_DelegatedRegressor):
         "capability:multithreading": True,
         "capability:categorical_in_X": True,
     }
+
+    # attribute for _DelegatedRegressor, which then delegates
+    #     all non-overridden methods to getattr(self, _delegate_name)
+    #     see further details in _DelegatedRegressor docstring
+    _delegate_name = "best_estimator_"
 
     def __init__(
         self,
@@ -257,6 +224,8 @@ class TSRGridSearchCV(_DelegatedRegressor):
         error_score=np.nan,
         return_train_score=False,
         tune_by_variable=False,
+        backend=None,
+        backend_params=None,
     ):
         self.estimator = estimator
         self.param_grid = param_grid
@@ -269,25 +238,10 @@ class TSRGridSearchCV(_DelegatedRegressor):
         self.error_score = error_score
         self.return_train_score = return_train_score
         self.tune_by_variable = tune_by_variable
+        self.backend = backend
+        self.backend_params = backend_params
 
         super().__init__()
-
-        DELEGATED_PARAMS = [
-            "estimator",
-            "param_grid",
-            "scoring",
-            "n_jobs",
-            "refit",
-            "cv",
-            "verbose",
-            "pre_dispatch",
-            "error_score",
-            "return_train_score",
-        ]
-
-        gscvargs = {k: getattr(self, k) for k in DELEGATED_PARAMS}
-
-        self.estimator_ = GridSearchCV(**gscvargs)
 
         if self.tune_by_variable:
             self.set_tags(**{"capability:multioutput": False})
@@ -303,9 +257,7 @@ class TSRGridSearchCV(_DelegatedRegressor):
         Parameters
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
-            if self.get_tag("X_inner_mtype") = "numpy3D":
-            3D np.ndarray of shape = [n_instances, n_dimensions, series_length]
-            if self.get_tag("X_inner_mtype") = "pd-multiindex:":
+            if self.get_tag("X_inner_mtype") = "pd-multiindex":
             pd.DataFrame with columns = variables,
             index = pd.MultiIndex with first level = instance indices,
             second level = time indices
@@ -314,38 +266,27 @@ class TSRGridSearchCV(_DelegatedRegressor):
         y : guaranteed to be of a type in self.get_tag("y_inner_mtype")
             1D iterable, of shape [n_instances]
             or 2D iterable, of shape [n_instances, n_dimensions]
-            class labels for fitting
-            if self.get_tag("capaility:multioutput") = False, guaranteed to be 1D
-            if self.get_tag("capaility:multioutput") = True, guaranteed to be 2D
+            target values for fitting
+            if self.get_tag("capability:multioutput") = False, guaranteed to be 1D
+            if self.get_tag("capability:multioutput") = True, guaranteed to be 2D
 
         Returns
         -------
         self : Reference to self.
         """
-        if y.shape[1] == 1:
-            y = y.flatten()
+        from sklearn.metrics import mean_squared_error
 
-        estimator = self._get_delegate()
-        estimator.fit(X=X, y=y)
+        return _grid_search_fit(self, X=X, y=y, default_scoring=mean_squared_error)
 
-        fitted_param_names = [
-            "cv_results_",
-            "best_estimator_",
-            "best_score_",
-            "best_params_",
-            "best_index_",
-            "scorer_",
-            "n_splits_",
-            "refit_time_",
-            "multimetric_",
-        ]
-
-        for p in fitted_param_names:
-            if hasattr(estimator, p):
-                val = getattr(estimator, p)
-                setattr(self, p, val)
-
-        return self
+    def _check_refit_for_predict(self, method_name):
+        """Raise error if refit=False and a predict-like method is called."""
+        if not self.refit:
+            raise RuntimeError(
+                f"In {self.__class__.__name__}, refit must be True to make"
+                f" predictions, but found refit=False. If refit=False,"
+                f" {self.__class__.__name__} can be used only to tune"
+                " hyper-parameters, as a parameter estimator."
+            )
 
     def _predict(self, X):
         """Predict labels for sequences in X.
@@ -361,27 +302,22 @@ class TSRGridSearchCV(_DelegatedRegressor):
         Parameters
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
-            if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_dimensions, series_length]
-            if self.get_tag("X_inner_mtype") = "nested_univ":
-                pd.DataFrame with each column a dimension, each cell a pd.Series
-            for list of other mtypes, see datatypes.SCITYPE_REGISTER
-            for specifications, see examples/AA_datatypes_and_datasets.ipynb
 
         Returns
         -------
-        y : 1D np.array of int, of shape [n_instances] - predicted class labels
-            indices correspond to instance indices in X
+        y : predictions of target values for X, np.ndarray
         """
+        self._check_refit_for_predict("predict")
         estimator = self._get_delegate()
         y_pred = estimator.predict(X=X)
+        # coerce to 2D np.ndarray, the return contract for y_inner_mtype numpy2D
+        if hasattr(y_pred, "to_numpy"):
+            y_pred = y_pred.to_numpy()
+        y_pred = np.asarray(y_pred)
         if y_pred.ndim == 1:
             y_pred = y_pred.reshape(-1, 1)
         return y_pred
 
-    # the delegate is an sklearn estimator and it does not have get_fitted_params
-    # therefore we have to override _get_fitted_params from the delegator,
-    # which would otherwise call it
     def _get_fitted_params(self):
         """Get fitted parameters.
 
@@ -393,9 +329,19 @@ class TSRGridSearchCV(_DelegatedRegressor):
         Returns
         -------
         fitted_params : dict with str keys
-            fitted parameters, keyed by names of fitted parameter
+            A dict containing the best hyper parameters and the parameters of
+            the best estimator (if available), merged together with the former
+            taking precedence.
         """
-        return {}
+        fitted_params = {}
+        try:
+            fitted_params = self.best_estimator_.get_fitted_params()
+        except (NotFittedError, NotImplementedError):
+            pass
+        fitted_params = {**fitted_params, **self.best_params_}
+        fitted_params.update(self._get_fitted_params_default())
+
+        return fitted_params
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/regression/model_selection/tests/test_tune.py
+++ b/sktime/regression/model_selection/tests/test_tune.py
@@ -1,0 +1,122 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Test regression tuners."""
+
+__author__ = ["atikulmunna"]
+
+import numpy as np
+import pytest
+from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import KFold, ParameterGrid
+
+from sktime.datasets import load_unit_test
+from sktime.regression.dummy import DummyRegressor
+from sktime.regression.model_evaluation import evaluate
+from sktime.regression.model_selection import TSRGridSearchCV
+from sktime.tests.test_switch import run_test_for_class
+
+PARAM_GRID = {"strategy": ["mean", "median"]}
+CV = KFold(n_splits=2, shuffle=False)
+
+
+def _load_regression_data():
+    """Load small panel data with float targets for regression tests."""
+    X, y = load_unit_test(split="train")
+    return X, y.astype("float")
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSRGridSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_gridsearch_fit_and_attributes():
+    """Test that fitted attributes are set and consistent."""
+    X, y = _load_regression_data()
+    tuner = TSRGridSearchCV(
+        DummyRegressor(),
+        param_grid=PARAM_GRID,
+        cv=CV,
+    )
+    tuner.fit(X, y)
+
+    n_candidates = len(ParameterGrid(PARAM_GRID))
+    assert len(tuner.cv_results_) == n_candidates
+
+    expected_columns = {
+        "mean_test_mean_squared_error",
+        "mean_fit_time",
+        "mean_pred_time",
+        "params",
+        "rank_test_mean_squared_error",
+    }
+    assert expected_columns.issubset(tuner.cv_results_.columns)
+
+    assert tuner.best_params_ in list(ParameterGrid(PARAM_GRID))
+    assert tuner.n_splits_ == 2
+    assert tuner.scorer_ is mean_squared_error
+
+    y_pred = tuner.predict(X)
+    assert len(y_pred) == len(y)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSRGridSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_gridsearch_ranks_lower_mse_best():
+    """Test that ranking treats mean_squared_error as lower-is-better."""
+    X, y = _load_regression_data()
+    tuner = TSRGridSearchCV(
+        DummyRegressor(),
+        param_grid=PARAM_GRID,
+        cv=CV,
+    )
+    tuner.fit(X, y)
+
+    results = tuner.cv_results_
+    best_row = results.loc[results["rank_test_mean_squared_error"] == 1].iloc[0]
+    assert best_row["mean_test_mean_squared_error"] == (
+        results["mean_test_mean_squared_error"].min()
+    )
+    assert tuner.best_score_ == results["mean_test_mean_squared_error"].min()
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSRGridSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_gridsearch_scores_match_evaluate():
+    """Test that cv_results_ scores equal manual evaluate scores per candidate."""
+    X, y = _load_regression_data()
+    tuner = TSRGridSearchCV(
+        DummyRegressor(),
+        param_grid=PARAM_GRID,
+        cv=CV,
+    )
+    tuner.fit(X, y)
+
+    for _, row in tuner.cv_results_.iterrows():
+        estimator = DummyRegressor().set_params(**row["params"])
+        expected = evaluate(estimator, cv=CV, X=X, y=y, scoring=mean_squared_error)
+        expected_mean = expected["test_mean_squared_error"].mean()
+        assert np.isclose(row["mean_test_mean_squared_error"], expected_mean)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSRGridSearchCV),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_gridsearch_refit_false():
+    """Test that refit=False tunes but refuses to predict."""
+    X, y = _load_regression_data()
+    tuner = TSRGridSearchCV(
+        DummyRegressor(),
+        param_grid=PARAM_GRID,
+        cv=CV,
+        refit=False,
+    )
+    tuner.fit(X, y)
+
+    assert tuner.best_params_ in list(ParameterGrid(PARAM_GRID))
+
+    with pytest.raises(RuntimeError, match="refit must be True"):
+        tuner.predict(X)

--- a/sktime/regression/tests/test_all_regressors.py
+++ b/sktime/regression/tests/test_all_regressors.py
@@ -106,7 +106,8 @@ class TestAllRegressors(RegressorFixtureGenerator, QuickTester):
         assert isinstance(y_pred, pd.DataFrame)
         assert y_pred.shape == y_mult.shape
 
-        vectorized = estimator_instance.get_tag("capability:multioutput")
+        # the estimator vectorizes iff it does not have the multioutput capability
+        vectorized = not estimator_instance.get_tag("capability:multioutput")
         if vectorized:
             assert hasattr(estimator_instance, "regressors_")
             assert isinstance(estimator_instance.regressors_, pd.DataFrame)

--- a/sktime/regression/tests/test_all_regressors.py
+++ b/sktime/regression/tests/test_all_regressors.py
@@ -106,7 +106,8 @@ class TestAllRegressors(RegressorFixtureGenerator, QuickTester):
         assert isinstance(y_pred, pd.DataFrame)
         assert y_pred.shape == y_mult.shape
 
-        vectorized = object_instance.get_tag("capability:multioutput")
+        # the estimator vectorizes iff it does not have the multioutput capability
+        vectorized = not object_instance.get_tag("capability:multioutput")
         if vectorized:
             assert hasattr(object_instance, "regressors_")
             assert isinstance(object_instance.regressors_, pd.DataFrame)

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -122,7 +122,6 @@ EXCLUDED_TESTS = {
         "test_save_estimators_to_file",
         "test_fit_idempotent",
     ],
-    "TSRGridSearchCV": ["test_multioutput"],  # see 6708
     "GreedyGaussianSegmentation": [
         "test_predict_points",
         "test_predict_segments",


### PR DESCRIPTION
*LLM generated content, by Claude Fable 5; reviewed, tested, and submitted by the author.*

#### Reference Issues/PRs

Fixes #10724. Progress on #6708.

#### What does this implement/fix? Explain your changes.

`TSCGridSearchCV` and `TSRGridSearchCV` were thin wrappers around sklearn's `GridSearchCV`, which breaks with upcoming scikit-learn versions due to the tag system incompatibility. This rewrites both tuners to run grid search natively, following the design of `ForecastingGridSearchCV`: candidates come from `ParameterGrid`, each candidate is backtested via the shared `_evaluate` from `classification.model_evaluation`, parallelized via `utils.parallel.parallelize` with new `backend` and `backend_params` parameters. The delegate is now `best_estimator_`. No `hyperactive` vendoring.

Behavior changes a reviewer should be aware of:

- `cv_results_` is now a `pd.DataFrame` with `mean_test_<metric_name>`, `mean_fit_time`, `mean_pred_time`, `params`, and `rank_test_<metric_name>` columns, consistent with the forecasting tuners, instead of the sklearn dict format.
- `scoring` accepts callables or lists of callables. sklearn scorer strings now raise an informative `TypeError`.
- Metric direction is inferred from the metric name: `*_error`, `*_loss`, `*_deviance`, `*_risk` are treated as lower-is-better. Default scoring stays `accuracy_score` for classification and is now `mean_squared_error` for regression, the same default as `evaluate`.
- `cv` int/None resolve to deterministic `KFold` (3 splits for None), so all candidates are evaluated on identical splits. No stratification, since `evaluate` splits without passing `y`.
- `pre_dispatch` and `return_train_score` are retained in the signature for backward compatibility but are inert. `n_jobs` maps to the `loky` backend.
- `refit=False` now raises an informative `RuntimeError` on predict, instead of sklearn's `NotFittedError`.

This also fixes an inverted vectorization assertion in `test_multioutput` in `test_all_regressors.py` (the classifier counterpart has the correct `not`), and removes the `TSRGridSearchCV` exclusion from `tests/_config.py`, since the estimator now passes that test.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- whether the behavior changes above are acceptable, in particular the `cv_results_` format and the metric direction heuristic
- whether deprecation warnings are wanted for `pre_dispatch`, `return_train_score`, and `n_jobs` instead of the silent backward compatible treatment

#### Did you add any tests for the change?

Yes. Dedicated test modules for both tuners, which did not exist before: scores are checked against manual `evaluate` runs per candidate, ranking direction for lower-is-better metrics, multi-metric scoring, `refit=False` behavior, and the string scoring error. Both classes pass `check_estimator` locally, 256 checks for TSC and 144 for TSR, including the previously excluded multioutput test.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) via the all-contributors file.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
