### PR TITLE
[BUG] fix `ConformalIntervals` `method="empirical_residual"` quantile level

### DIFF
--- a/sktime/forecasting/conformal.py
+++ b/sktime/forecasting/conformal.py
@@ -40,7 +40,7 @@ class ConformalIntervals(BaseForecaster):
         as offsets to the point prediction at forecast horizon h
     method="empirical_residual" uses empirical quantiles of absolute residuals
         on the training set, i.e., quantiles of epsilon-h (in notation [1]_),
-        at quantile point (1-coverage)/2 quantiles, as offsets to point prediction
+        at quantile point coverage, as plusminus offsets to point prediction
 
     Parameters
     ----------
@@ -48,7 +48,7 @@ class ConformalIntervals(BaseForecaster):
         Estimator to which probabilistic forecasts are being added
     method : str, optional, default="empirical"
         "empirical": predictive interval bounds are empirical quantiles from training
-        "empirical_residual": upper/lower are plusminus (1-coverage)/2 quantiles
+        "empirical_residual": upper/lower are plusminus the coverage quantile
             of the absolute residuals at horizon, i.e., of epsilon-h
         "conformal_bonferroni": Bonferroni, as in Stankeviciute et al
             Caveat: this does not give frequentist but conformal predictive intervals
@@ -319,7 +319,7 @@ class ConformalIntervals(BaseForecaster):
                 quantiles = 0.5 + np.tile([-0.5, 0.5], len(coverage)) * coverage2
                 pred_int_row = np.quantile(resids, quantiles)
             if self.method == "empirical_residual":
-                quantiles = 0.5 - 0.5 * coverage2
+                quantiles = coverage2
                 pred_int_row = np.quantile(abs_resids, quantiles)
             elif self.method == "conformal_bonferroni":
                 alphas = 1 - coverage2

--- a/sktime/forecasting/tests/test_conformal.py
+++ b/sktime/forecasting/tests/test_conformal.py
@@ -1,5 +1,6 @@
 """Tests for the ConformalIntervals probability wrapper."""
 
+import numpy as np
 import pytest
 
 from sktime.datasets import load_airline
@@ -8,7 +9,7 @@ from sktime.forecasting.conformal import ConformalIntervals
 from sktime.forecasting.naive import NaiveForecaster
 from sktime.tests.test_switch import run_test_for_class
 
-__author__ = ["fkiraly"]
+__author__ = ["fkiraly", "shivamlalakiya"]
 
 
 @pytest.mark.skipif(
@@ -108,3 +109,43 @@ def test_conformal_with_hierarchical():
 
     forecaster.predict(X=X_test)
     forecaster.predict_interval(X=X_test)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ConformalIntervals),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_conformal_empirical_residual_quantile():
+    """Test that method="empirical_residual" uses the coverage quantile.
+
+    Failure case of bug #10757, where the (1-coverage)/2 quantile of the absolute
+    residuals was used as the interval half-width, so that a requested coverage
+    of 0.9 produced an empirical coverage of about 0.08.
+    """
+    coverage = 0.9
+    y = load_airline()
+
+    forecaster = ConformalIntervals(
+        forecaster=NaiveForecaster(strategy="mean"),
+        method="empirical_residual",
+        initial_window=100,
+    )
+    forecaster.fit(y, fh=[1])
+
+    pred_int = forecaster.predict_interval(fh=[1], coverage=[coverage])
+    y_pred = float(forecaster.predict(fh=[1]).iloc[0])
+
+    lower = float(pred_int.iloc[0, 0])
+    upper = float(pred_int.iloc[0, 1])
+
+    resids = np.diagonal(
+        np.asarray(forecaster.residuals_matrix_, dtype=float), offset=1
+    )
+    abs_resids = np.abs(resids[~np.isnan(resids)])
+
+    expected = np.quantile(abs_resids, coverage)
+    too_narrow = np.quantile(abs_resids, 0.5 - 0.5 * coverage)
+
+    assert np.isclose(upper - y_pred, expected)
+    assert np.isclose(y_pred - lower, expected)
+    assert upper - y_pred > too_narrow


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10757. See also #10758, which is the companion report for `method="conformal"` / `"conformal_bonferroni"` and is relevant to the design question below.

#### What does this implement/fix? Explain your changes.

`ConformalIntervals(method="empirical_residual")` used the `(1 - coverage)/2` quantile of the **absolute** residuals as its interval half-width (`conformal.py:322`). At `coverage=0.9` that is the `0.05` quantile of `|resid|`, so the returned interval was far narrower than requested — measured empirical coverage **0.078** against a requested `0.9` over 1000 independent fits (full reproduction in #10757). Because the `0.05` quantile of `|resid|` is estimated more precisely as `n` grows, the deficit *worsens* with more data, which rules out a small-sample explanation.

`(1 - coverage)/2` is the correct lower-tail level for a two-sided interval built from **signed** residuals. Applied symmetrically to **absolute** residuals — which is what membership in `ABS_RESIDUAL_BASED` (`:298`) plus the `sign` flip (`:337-342`) does — the level is `coverage` itself.

```diff
 if self.method == "empirical_residual":
-    quantiles = 0.5 - 0.5 * coverage2
+    quantiles = coverage2
     pred_int_row = np.quantile(abs_resids, quantiles)
```

The class docstring documented the same incorrect formula (`:41-43`, `:51-52`), so both are updated alongside the code.

This is a deliberate behaviour change rather than a typo fix — numeric output changes for anyone using this method. Two things bound the blast radius: `"empirical_residual"` is not the constructor default (`:151`, default is `"empirical"`), and `grep` finds the string nowhere else in the repo, including `get_test_params`, so no existing test pinned the old value.

#### The alternative reading, if you prefer it

@fkiraly — there were two defensible readings and I picked the one above because it is the smaller diff and keeps the method in `ABS_RESIDUAL_BASED`. The other is the signed-residual construction that the `(1 - coverage)/2` level actually belongs to:

```diff
-ABS_RESIDUAL_BASED = ["conformal", "conformal_bonferroni", "empirical_residual"]
+ABS_RESIDUAL_BASED = ["conformal", "conformal_bonferroni"]

 if self.method == "empirical_residual":
-    quantiles = 0.5 - 0.5 * coverage2
-    pred_int_row = np.quantile(abs_resids, quantiles)
+    quantiles = 0.5 + np.tile([-0.5, 0.5], len(coverage)) * coverage2
+    pred_int_row = np.quantile(resids, quantiles)
```

Worth knowing before choosing: **both readings make `empirical_residual` numerically identical to a method that already exists.** The one in this PR reproduces `method="conformal"` (`:329-330`); the signed one reproduces `method="empirical"` (`:319-320`). There is no third construction that is distinct against current `main`.

What separates them again is #10758: `conformal` and `conformal_bonferroni` currently omit the finite-sample `(m+1)/m` quantile correction from Stankeviciute et al. Once that is fixed, `empirical_residual` is the plain empirical `coverage` quantile of `|resid|` and `conformal` is the same quantity with the correction applied — genuinely distinct methods, with the docstring distinction intact. That is the main reason I went this direction rather than the signed one, which would instead leave a permanent duplicate of `"empirical"`.

Happy to swap to the other variant in a single push if you read the intent differently.

#### Does your contribution introduce a new dependency? If yes, which one?

No. `pyproject.toml` is untouched.

#### What should a reviewer concentrate their feedback on?

- The choice between the two readings above. That is the only judgement call in the PR; the rest is mechanical.
- Whether a changelog note is wanted, given that this changes numeric output for existing users of `method="empirical_residual"`.

#### Did you add any tests for the change?

Yes — `test_conformal_empirical_residual_quantile` in `sktime/forecasting/tests/test_conformal.py`. It asserts the returned half-width equals `np.quantile(abs_resids, coverage)` on both the upper and lower side, and that it exceeds the old `(1 - coverage)/2` value.

Verification run locally:

- `pytest sktime/forecasting/tests/test_conformal.py` → **4 passed**
- the new test **fails on unpatched `conformal.py`** (assertion on the half-width) and passes with the fix, so it is not vacuous
- `check_estimator(ConformalIntervals)` → **742 checks, 0 failures**
- `ruff check` and `ruff format --check` clean on both changed files

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
