### PR TITLE
[BUG] fix AutoEnsembleForecaster inverse-variance weight calculation with zero-variance forecasters

### DIFF
--- a/sktime/forecasting/compose/_ensemble.py
+++ b/sktime/forecasting/compose/_ensemble.py
@@ -9,6 +9,8 @@ forecasts.
 __author__ = ["mloning", "GuzalBulatova", "aiwalter", "RNKuhns", "AnH0ang"]
 __all__ = ["EnsembleForecaster", "AutoEnsembleForecaster"]
 
+import warnings
+
 import numpy as np
 import pandas as pd
 from scipy.stats import gmean
@@ -190,15 +192,28 @@ class AutoEnsembleForecaster(_HeterogenousEnsembleForecaster):
         elif self.method == "inverse-variance":
             # get in-sample forecasts
             if self.regressor is not None:
-                Warning(f"regressor will not be used because ${self.method} is set.")
-            inv_var = np.array(
+                warnings.warn(
+                    f"regressor will not be used because method="
+                    f"{self.method!r} is set.",
+                    stacklevel=2,
+                )
+            variances = np.array(
                 [
-                    1 / np.var(y_test - y_pred_test)
+                    np.var(y_test - y_pred_test)
                     for y_pred_test in self._predict_forecasters(fh_test, X_test)
                 ]
             )
-            # standardize the inverse variance
-            self.weights_ = list(inv_var / np.sum(inv_var))
+            zero_variance = variances == 0
+            if zero_variance.any():
+                # one or more forecasters fit the test set exactly (variance
+                # zero), so 1 / variance is undefined. Split the weight
+                # equally between the exact forecasters, zero elsewhere.
+                weights = zero_variance / zero_variance.sum()
+            else:
+                inv_var = 1 / variances
+                # standardize the inverse variance
+                weights = inv_var / np.sum(inv_var)
+            self.weights_ = list(weights)
         else:
             raise NotImplementedError(
                 f"Given method {self.method} does not exist, "

--- a/sktime/forecasting/compose/tests/test_autoensemble.py
+++ b/sktime/forecasting/compose/tests/test_autoensemble.py
@@ -15,6 +15,8 @@ from sktime.forecasting.compose import (
     AutoEnsembleForecaster,
     RecursiveTabularRegressionForecaster,
 )
+from sktime.forecasting.exp_smoothing import ExponentialSmoothing
+from sktime.forecasting.naive import NaiveForecaster
 from sktime.split import temporal_train_test_split
 from sktime.tests.test_switch import run_test_for_class
 
@@ -67,3 +69,68 @@ def test_autoensembler(forecasters, method):
 
     assert (predictions.min(axis=1) <= y_pred).all()
     assert (predictions.max(axis=1) >= y_pred).all()
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(AutoEnsembleForecaster),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_autoensembler_inverse_variance_zero_variance():
+    """Weights/predictions must not be NaN if a forecaster fits the test set exactly.
+
+    See bug report in #4212. A zero test-set variance for one or more
+    forecasters previously produced NaN weights via a 1/0 division.
+    """
+    y = pd.Series(
+        [
+            8.0,
+            8.0,
+            9.0,
+            9.0,
+            9.0,
+            9.0,
+            8.0,
+            8.0,
+            9.0,
+            8.0,
+            9.0,
+            10.0,
+            9.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            11.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+        ]
+    )
+    forecasters = [
+        ("naive", NaiveForecaster(strategy="last")),
+        ("exponential", ExponentialSmoothing()),
+    ]
+
+    forecaster = AutoEnsembleForecaster(
+        forecasters=forecasters, method="inverse-variance"
+    )
+    forecaster.fit(y, fh=list(range(1, 13)))
+    y_pred = forecaster.predict()
+
+    assert not any(pd.isna(w) for w in forecaster.weights_)
+    assert abs(sum(forecaster.weights_) - 1.0) < 1e-9
+    assert not y_pred.isna().any()


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #4212

#### What does this implement/fix? Explain your changes.
In `AutoEnsembleForecaster(method="inverse-variance")._fit`, weights are computed as `1 / np.var(y_test - y_pred_test)` per forecaster, then normalized. If any forecaster fits the held-out test split exactly (variance zero — e.g. a `NaiveForecaster` on a flat/repetitive series), `1 / 0` produces `inf`/triggers a `RuntimeWarning`, and normalizing an array containing `inf` yields `nan` for every weight, not just the degenerate one. `weights_` and all downstream `predict()` output become entirely `NaN`.

This was diagnosed in the issue thread, where a maintainer worked out the correct limiting behavior: as one forecaster's variance approaches zero relative to the others, its weight approaches 1 and all others approach 0. So the fix, matching that derivation:

- Compute variances first (no division yet).
- If any are exactly zero, split the weight equally among the zero-variance forecasters and give zero weight to the rest.
- Otherwise, use the existing inverse-variance formula unchanged.

Separately, in the same branch, `Warning(f"regressor will not be used because ...")` only constructed a `Warning` object and never called `warnings.warn(...)`, so the message was silently discarded — users passing both `regressor` and `method="inverse-variance"` were never actually told the regressor would be ignored. Fixed by importing `warnings` and calling `warnings.warn(..., stacklevel=2)`.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
The zero-variance branch in `AutoEnsembleForecaster._fit` (`sktime/forecasting/compose/_ensemble.py`), specifically whether equal-weighting all zero-variance forecasters (and zero-weighting the rest) matches the intended semantics discussed in #4212.

#### Did you add any tests for the change?
Yes — `test_autoensembler_inverse_variance_zero_variance` in `sktime/forecasting/compose/tests/test_autoensemble.py`, using the exact reproduction from #4212, asserting `weights_` sums to 1 with no `NaN`, and `predict()` returns no `NaN`. Ran the full `sktime/forecasting/compose/` test suite locally (239 passed) plus `ruff check`/`ruff format --check` on the changed files.

#### Any other comments?
None.

#### PR checklist
- [x] The PR title starts with `[BUG]`
- [x] Added/modified tests
- [x] Used pre-commit hooks (`ruff check` / `ruff format --check` pass on changed files)