### PR TITLE
[ENH] improve AutoTS exogenous variable handling and add quantile predictions

### DIFF
--- a/sktime/forecasting/autots.py
+++ b/sktime/forecasting/autots.py
@@ -350,13 +350,11 @@ class AutoTS(BaseForecaster):
         # since AutoTS can only deal with dates
         y_date = self._convert_input_to_date(y)
         self._y_date = y_date
+        X_date = self._convert_input_to_date(X)
 
         self._fh = fh
         self._instantiate_model()
-        try:
-            self.forecaster_.fit(df=y_date, future_regressor=X)
-        except Exception as e:
-            raise e
+        self.forecaster_.fit(df=y_date, future_regressor=X_date)
         return self
 
     def _predict(self, fh, X):
@@ -381,10 +379,11 @@ class AutoTS(BaseForecaster):
             Point predictions
         """
         y_date = self._y_date
+        X_date = self._convert_input_to_date(X)
 
         values = self.forecaster_.predict(
             forecast_length=self._get_forecast_length(),
-            future_regressor=X,
+            future_regressor=X_date,
         ).forecast.values
 
         cutoff = self._fh_cutoff_transformation(y_date)
@@ -692,21 +691,15 @@ class AutoTS(BaseForecaster):
             2. "lower"/"upper"
             Row index is fh.
         """
-        import pandas as pd
-
-        # Prepare coverage list for AutoTS
-        # AutoTS supports a list of floats for prediction_interval
         coverage_list = list(coverage)
 
         y_date = self._y_date
+        X_date = self._convert_input_to_date(X)
 
-        # Call predict on the internal forecaster
-        # This returns a dict of PredictionObjects if prediction_interval is a list,
-        # or a single PredictionObject if it's a float.
         prediction = self.forecaster_.predict(
             forecast_length=self._get_forecast_length(),
             prediction_interval=coverage_list,
-            future_regressor=X,
+            future_regressor=X_date,
         )
 
         cutoff = self._fh_cutoff_transformation(y_date)
@@ -733,21 +726,108 @@ class AutoTS(BaseForecaster):
             for c_str, pred_obj in prediction.items():
                 _process_pred_obj(pred_obj, float(c_str))
         else:
-            # Fallback for single object (though passing list usually returns dict)
-            # If we passed a single value list and got an object,
-            # ensure we match it to the coverage
             if len(coverage) == 1:
                 _process_pred_obj(prediction, coverage[0])
             else:
-                # Should not happen if API is consistent
                 raise ValueError(
                     "AutoTS returned single prediction for multiple coverages."
                 )
 
         pred_int = pd.DataFrame(dfs, index=row_idx)
         pred_int.columns.names = ["variable", "coverage", "lower/upper"]
-        # Ensure columns are sorted/ordered correctly if needed,
-        # sktime usually handles it
         pred_int.sort_index(axis=1, inplace=True)
 
         return pred_int
+
+    def _predict_quantiles(self, fh, X, alpha):
+        """Compute/return prediction quantiles for a forecast.
+
+        private _predict_quantiles containing the core logic,
+            called from predict_quantiles
+
+        Parameters
+        ----------
+        fh : guaranteed to be ForecastingHorizon
+            The forecasting horizon with the steps ahead to predict.
+        X : pd.DataFrame, optional (default=None)
+            Exogenous time series
+        alpha : list of float (guaranteed not None and floats in [0,1] interval)
+            A list of probabilities at which quantile forecasts are computed.
+
+        Returns
+        -------
+        quantiles : pd.DataFrame
+            Column has multi-index: first level is variable name from y in fit,
+                second level being the values of alpha passed to the function.
+            Row index is fh, with additional (upper) levels equal to instance
+                levels, from y seen in fit.
+            Entries are quantile forecasts, for var in col index,
+                at quantile probability in second col index,
+                for the row index.
+        """
+        y_date = self._y_date
+        X_date = self._convert_input_to_date(X)
+
+        cutoff = self._fh_cutoff_transformation(y_date)
+        relative_fh_idx = self._fh.to_relative(cutoff)._values - 1
+        var_names = y_date.columns
+        row_idx = self._fh.to_absolute_index(self.cutoff)
+
+        # map alpha values to AutoTS coverage levels
+        # alpha < 0.5 -> lower bound at coverage |1 - 2*alpha|
+        # alpha > 0.5 -> upper bound at coverage |1 - 2*alpha|
+        # alpha = 0.5 -> point forecast
+        coverages_needed = set()
+        for a in alpha:
+            if a != 0.5:
+                coverages_needed.add(abs(1 - 2 * a))
+
+        point_forecast = None
+        pred_objects = {}
+
+        if coverages_needed:
+            coverage_list = sorted(coverages_needed)
+            prediction = self.forecaster_.predict(
+                forecast_length=self._get_forecast_length(),
+                prediction_interval=coverage_list,
+                future_regressor=X_date,
+            )
+            if isinstance(prediction, dict):
+                for c_str, pred_obj in prediction.items():
+                    pred_objects[float(c_str)] = pred_obj
+            else:
+                pred_objects[coverage_list[0]] = prediction
+
+        if 0.5 in alpha:
+            if pred_objects:
+                any_pred = next(iter(pred_objects.values()))
+                point_forecast = any_pred.forecast.values[relative_fh_idx]
+            else:
+                point_pred = self.forecaster_.predict(
+                    forecast_length=self._get_forecast_length(),
+                    future_regressor=X_date,
+                )
+                point_forecast = point_pred.forecast.values[relative_fh_idx]
+
+        dfs = {}
+        for a in alpha:
+            if a == 0.5:
+                for var_idx, var_name in enumerate(var_names):
+                    dfs[(var_name, a)] = point_forecast[:, var_idx]
+            else:
+                cov = abs(1 - 2 * a)
+                pred_obj = pred_objects[cov]
+                if a < 0.5:
+                    vals = pred_obj.lower_forecast.values[relative_fh_idx]
+                else:
+                    vals = pred_obj.upper_forecast.values[relative_fh_idx]
+                for var_idx, var_name in enumerate(var_names):
+                    dfs[(var_name, a)] = vals[:, var_idx]
+
+        quantiles = pd.DataFrame(dfs, index=row_idx)
+        quantiles.columns = pd.MultiIndex.from_tuples(
+            quantiles.columns, names=["variable", "alpha"]
+        )
+        quantiles.sort_index(axis=1, inplace=True)
+
+        return quantiles

--- a/sktime/forecasting/tests/test_autots_custom.py
+++ b/sktime/forecasting/tests/test_autots_custom.py
@@ -1,5 +1,6 @@
 """Tests for AutoTS custom functionality."""
 
+import numpy as np
 import pandas as pd
 import pytest
 from skbase.utils.dependencies import _check_estimator_deps
@@ -17,42 +18,35 @@ def test_autots_prediction_intervals():
 
     y = load_airline()
 
-    # Configure with specific interval and FAST settings for TESTING ONLY
-    # This ensures our local test doesn't take forever, without modifying class defaults
     coverage = 0.9
     forecaster = AutoTS(
         model_list="superfast",
         max_generations=1,
         num_validations=0,
         prediction_interval=coverage,
-        random_seed=42,  # Ensure reproducibility
+        random_seed=42,
     )
 
     forecaster.fit(y, fh=[1, 2, 3])
 
-    # Test successful prediction with single coverage
     intervals = forecaster.predict_interval(coverage=coverage)
 
     assert isinstance(intervals, pd.DataFrame)
     assert intervals.shape == (3, 2)
     assert intervals.columns.nlevels == 3
 
-    # Check values
     lower = intervals.iloc[:, 0]
     upper = intervals.iloc[:, 1]
     assert (upper >= lower).all()
 
-    # Test with multiple coverages (our new feature)
     coverages = [0.9, 0.5]
     intervals_multi = forecaster.predict_interval(coverage=coverages)
-    assert intervals_multi.shape == (3, 4)  # 2 coverages * 2 bounds
+    assert intervals_multi.shape == (3, 4)
 
-    # Verify column structure
     expected_cols = pd.MultiIndex.from_product(
         [["Number of airline passengers"], [0.5, 0.9], ["lower", "upper"]],
         names=["variable", "coverage", "lower/upper"],
     )
-    # Sort to ensure order matches
     intervals_multi = intervals_multi.sort_index(axis=1)
     pd.testing.assert_index_equal(intervals_multi.columns, expected_cols)
 
@@ -65,6 +59,8 @@ def test_autots_tags():
     """Test that AutoTS has correct tags."""
     forecaster = AutoTS()
     assert forecaster.get_tag("capability:pred_int") is True
+    assert forecaster.get_tag("capability:multivariate") is True
+    assert forecaster.get_tag("capability:exogenous") is True
 
 
 @pytest.mark.skipif(
@@ -72,21 +68,16 @@ def test_autots_tags():
     reason="autots not available",
 )
 def test_autots_exogenous():
-    """Test that AutoTS can handle exogenous data."""
-    import numpy as np
-    import pandas as pd
-
+    """Test that AutoTS handles exogenous data in fit and predict."""
     from sktime.datasets import load_airline
 
     y = load_airline()
-    # Create random exogenous data
     X = pd.DataFrame(
         np.random.randint(0, 100, size=(len(y), 2)),
         index=y.index,
         columns=["ex1", "ex2"],
     )
 
-    # Configure with FAST settings
     forecaster = AutoTS(
         model_list="superfast",
         max_generations=1,
@@ -94,17 +85,16 @@ def test_autots_exogenous():
         random_seed=42,
     )
 
-    # Create future X for prediction
     fh = [1, 2, 3]
-
-    # Test fit with X
     forecaster.fit(y, X=X, fh=fh)
-    # Get last index and extend
+
     last_idx = y.index[-1]
     if isinstance(last_idx, pd.Period):
         future_idx = pd.period_range(start=last_idx + 1, periods=3, freq=y.index.freq)
     else:
-        future_idx = pd.date_range(start=last_idx, periods=3 + 1, freq=y.index.freq)[1:]
+        future_idx = pd.date_range(
+            start=last_idx, periods=3 + 1, freq=y.index.freq
+        )[1:]
 
     X_pred = pd.DataFrame(
         np.random.randint(0, 100, size=(3, 2)),
@@ -112,10 +102,116 @@ def test_autots_exogenous():
         columns=["ex1", "ex2"],
     )
 
-    # Test predict with X
     y_pred = forecaster.predict(fh=fh, X=X_pred)
     assert len(y_pred) == 3
 
-    # Test predict_interval with X
     intervals = forecaster.predict_interval(fh=fh, X=X_pred, coverage=0.9)
     assert len(intervals) == 3
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(AutoTS, severity="none"),
+    reason="autots not available",
+)
+def test_autots_predict_quantiles():
+    """Test that AutoTS can produce quantile forecasts."""
+    from sktime.datasets import load_airline
+
+    y = load_airline()
+
+    forecaster = AutoTS(
+        model_list="superfast",
+        max_generations=1,
+        num_validations=0,
+        random_seed=42,
+    )
+
+    forecaster.fit(y, fh=[1, 2, 3])
+
+    alpha = [0.05, 0.5, 0.95]
+    quantiles = forecaster.predict_quantiles(alpha=alpha)
+
+    assert isinstance(quantiles, pd.DataFrame)
+    assert quantiles.shape == (3, 3)
+    assert quantiles.columns.nlevels == 2
+
+    q05 = quantiles.iloc[:, 0]
+    q50 = quantiles.iloc[:, 1]
+    q95 = quantiles.iloc[:, 2]
+    assert (q50 >= q05).all()
+    assert (q95 >= q50).all()
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(AutoTS, severity="none"),
+    reason="autots not available",
+)
+def test_autots_predict_quantiles_median():
+    """Test quantile prediction with alpha=[0.5] only (solo point forecast path)."""
+    from sktime.datasets import load_airline
+
+    y = load_airline()
+
+    forecaster = AutoTS(
+        model_list="superfast",
+        max_generations=1,
+        num_validations=0,
+        random_seed=42,
+    )
+
+    forecaster.fit(y, fh=[1, 2, 3])
+
+    quantiles = forecaster.predict_quantiles(alpha=[0.5])
+
+    assert isinstance(quantiles, pd.DataFrame)
+    assert quantiles.shape == (3, 1)
+    assert quantiles.columns.nlevels == 2
+
+    y_pred = forecaster.predict()
+    np.testing.assert_array_almost_equal(
+        quantiles.values.ravel(), y_pred.values.ravel()
+    )
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(AutoTS, severity="none"),
+    reason="autots not available",
+)
+def test_autots_multivariate_with_exogenous():
+    """Test AutoTS with multivariate y and exogenous X."""
+    n = 100
+    idx = pd.date_range("2020-01-01", periods=n, freq="D")
+    y = pd.DataFrame(
+        np.random.randn(n, 2),
+        index=idx,
+        columns=["series_a", "series_b"],
+    )
+    X = pd.DataFrame(
+        np.random.randn(n, 1),
+        index=idx,
+        columns=["regressor"],
+    )
+
+    forecaster = AutoTS(
+        model_list="superfast",
+        max_generations=1,
+        num_validations=0,
+        random_seed=42,
+    )
+
+    fh = [1, 2, 3]
+    forecaster.fit(y, X=X, fh=fh)
+
+    future_idx = pd.date_range("2020-04-11", periods=3, freq="D")
+    X_pred = pd.DataFrame(
+        np.random.randn(3, 1),
+        index=future_idx,
+        columns=["regressor"],
+    )
+
+    y_pred = forecaster.predict(fh=fh, X=X_pred)
+    assert y_pred.shape == (3, 2)
+    assert list(y_pred.columns) == ["series_a", "series_b"]
+
+    quantiles = forecaster.predict_quantiles(alpha=[0.1, 0.9])
+    assert quantiles.shape == (3, 4)


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #6773 (items 2 and 3: exogenous variables and probabilistic predictions).

#### What does this implement/fix? Explain your changes.

**Exogenous variable index conversion bug:** `_convert_input_to_date` was applied to `y` but not to `X` in `_fit`, `_predict`, and `_predict_interval`. When `y` has a `PeriodIndex` or integer index, it gets converted to `DatetimeIndex` but `X` was passed through raw, causing index mismatches at the AutoTS boundary.

**Add `_predict_quantiles`:** Direct implementation that maps quantile alpha values to AutoTS coverage intervals, avoiding the default interval-to-quantile round-trip in `BaseForecaster`. Alpha-to-coverage mapping: `alpha < 0.5` → lower bound at coverage `|1 - 2α|`, `alpha > 0.5` → upper bound, `alpha = 0.5` → point forecast (reused from `PredictionObject.forecast` when interval predictions already fetched, solo `predict()` call only when `alpha=[0.5]` alone).

**Cleanup:** Remove dead `try/except` in `_fit` that caught `Exception` and re-raised without context. Remove redundant `import pandas as pd` inside `_predict_interval` (already at module level).

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- The alpha-to-coverage mapping logic in `_predict_quantiles`
- Whether reusing `PredictionObject.forecast` from an interval prediction call is equivalent to a standalone `predict()` call (verified against AutoTS docs, but worth a second look)
- Whether `_convert_input_to_date(X)` is sufficient for all exogenous index edge cases

#### Did you add any tests for the change?

Yes, in `sktime/forecasting/tests/test_autots_custom.py`:
- `test_autots_predict_quantiles` — `alpha=[0.05, 0.5, 0.95]`, checks shape, column structure, monotonicity
- `test_autots_predict_quantiles_median` — `alpha=[0.5]` only, verifies fallback code path and that values match point forecast
- `test_autots_multivariate_with_exogenous` — multivariate y with exogenous X through predict and predict_quantiles
- Expanded `test_autots_tags` to also assert `capability:multivariate` and `capability:exogenous` tags

#### Any other comments?

Items 4-6 from #6773 (sktime↔autots component interop, 2nd party integration) are architectural scope and better suited as separate PRs.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
