### PR TITLE
[BUG] make `BaseObject.__eq__` check the class, not just the params

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -183,14 +183,14 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
     def __eq__(self, other):
         """Equality dunder. Checks equal class and parameters.
 
-        Returns True iff result of get_params(deep=False) results in equal parameter
-        sets.
+        Returns True iff ``self`` and ``other`` are of the same class, and the
+        results of get_params(deep=False) are equal parameter sets.
 
         Nested BaseObject descendants from get_params are compared via __eq__ as well.
         """
         from sktime.utils.deep_equals import deep_equals
 
-        if not isinstance(other, BaseObject):
+        if type(self) is not type(other):
             return False
 
         self_params = self.get_params(deep=False)

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -490,7 +490,7 @@ def test_set_get_config():
 def test_eq_dunder():
     """Tests equality dunder for BaseObject descendants.
 
-    Equality should be determined only by get_params results.
+    Equality should be determined by class and get_params results.
 
     Raises
     ------
@@ -528,3 +528,41 @@ def test_eq_dunder():
     assert composite == composite_2
     assert composite != composite_3
     assert composite_2 != composite_3
+
+
+def test_eq_dunder_checks_class():
+    """Tests that __eq__ compares the class, not only the parameters.
+
+    Regression test for bug #10780: objects of different classes with equal
+    parameter sets compared equal, which caused silent deduplication of
+    distinct objects, e.g., of distinct metrics in benchmarking.
+
+    Raises
+    ------
+    AssertionError if logic behind __eq__ is incorrect, logic tested:
+        objects of unrelated classes with equal params are not equal
+        objects of a class and its subclass with equal params are not equal
+        objects of the same class with equal params remain equal
+        objects are not equal to non-BaseObject instances
+    """
+    # unrelated classes, identical params
+    unrelated_1 = CompositionDummy(foo=42)
+    unrelated_2 = FittableCompositionDummy(foo=42)
+
+    assert unrelated_1.get_params() == unrelated_2.get_params()
+    assert unrelated_1 != unrelated_2
+    assert unrelated_2 != unrelated_1
+
+    # parent and subclass, identical params
+    parent = FixtureClassParent()
+    child = FixtureClassChild()
+
+    assert parent.get_params() == child.get_params()
+    assert parent != child
+    assert child != parent
+
+    # same class with equal params must still be equal
+    assert CompositionDummy(foo=42) == CompositionDummy(foo=42)
+
+    # comparison against a non-BaseObject must not raise, and must be unequal
+    assert unrelated_1 != 42

--- a/sktime/benchmarking/tests/test_add_methods.py
+++ b/sktime/benchmarking/tests/test_add_methods.py
@@ -251,3 +251,22 @@ class TestBenchmarkAddMethods:
 
         benchmark.add(KFold(n_splits=3))
         assert len(benchmark.tasks.entities) == 1
+
+    def test_add_keeps_distinct_metrics_of_equal_params(self):
+        """Test distinct metrics are not deduplicated when their params are equal.
+
+        Regression test for bug #10780: ``_add_unique`` deduplicates via ``__eq__``,
+        which compared parameters only. ``OverallWeightedAverage(sp=1)`` and
+        ``MeanAbsoluteScaledError()`` have identical params, so the latter was
+        silently dropped from ``M4CompetitionCatalogueYearly``.
+        """
+        from sktime.benchmarking.forecasting import ForecastingBenchmark
+        from sktime.catalogues.forecasting import M4CompetitionCatalogueYearly
+
+        metrics = M4CompetitionCatalogueYearly().get("metric", as_object=True)
+
+        benchmark = ForecastingBenchmark()
+        for metric in metrics:
+            benchmark.add(metric)
+
+        assert len(benchmark._metrics) == len(metrics)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10780.

#### What does this implement/fix? Explain your changes.

`BaseObject.__eq__` only compared `get_params(deep=False)` and never looked at the class, so any two sktime objects with the same parameters came out equal even if they were unrelated classes.

I found it because it silently drops a metric from a catalogue we ship. `M4CompetitionCatalogueYearly` defines 3 metrics but only 2 reach the benchmark, since `BaseBenchmark._add_unique` deduplicates with `if item not in collection`, which goes through `__eq__`. `OverallWeightedAverage(sp=1)` and `MeanAbsoluteScaledError()` have identical params, so the second one gets treated as a duplicate.

The fix is the same check skbase uses:

```python
-        if not isinstance(other, BaseObject):
+        if type(self) is not type(other):
             return False
```

A couple of notes on it:

- The new check is strictly stronger, so the old `isinstance` guard isn't needed alongside it. `metric == 5` still returns `False`.
- I kept our `__eq__` rather than deleting it and inheriting skbase's. Ours calls `sktime.utils.deep_equals`, which registers `csr_matrix`, `dask_dataframe`, `polars`, `gluonts_PandasDataset` and `torchmetrics_metric` plugins that skbase doesn't have. Dropping the override would change results, not just lose type support: any two same-shape `csr_matrix` objects with different values compare equal under skbase's `deep_equals` and unequal under ours.
- This also means a subclass is no longer equal to its parent when their params match. That's a real behaviour change beyond the metric case, but it matches what skbase does, so I think consistency is the right call here.
- The `__eq__` docstring already said "Checks equal class and parameters", so the fix makes the docstring true. I tightened the second line, which still described the params-only behaviour.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

* Whether making a subclass unequal to its parent is acceptable. It matches skbase, and nothing in sktime appeared to depend on the old behaviour, but it is the widest-reaching part of this change.
* Whether the M4 end-to-end test belongs in `benchmarking/tests/` or closer to the catalogues. I put it in benchmarking since `_add_unique` is the code path that actually loses the metric.

#### Did you add any tests for the change?

Yes.

* `sktime/base/tests/test_base.py::test_eq_dunder_checks_class` covers four cases: unrelated classes with equal params, a parent and its subclass with equal params, same-class equality still working, and comparison against a non-`BaseObject`. It reuses fixtures already in that module.
* `sktime/benchmarking/tests/test_add_methods.py::test_add_keeps_distinct_metrics_of_equal_params` guards the M4 Yearly case end to end.
* I also corrected the docstring of the existing `test_eq_dunder`. It said equality "should be determined only by get_params results", which documented the bug as intended behaviour and is probably why this went unnoticed. All of its assertions use a single class, so it keeps passing.

I checked the new tests actually catch the bug: with the fix reverted, both fail, and `test_eq_dunder` still passes.
