### PR TITLE
[DOC] Add ConstantPwTrafoPanel doctest example

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3005,6 +3005,15 @@
         "doc",
         "test"
       ]
+    },
+    {
+      "login": "gokul-debugger",
+      "name": "Gokul Krishna",
+      "avatar_url": "https://avatars.githubusercontent.com/gokul-debugger?v=4",
+      "profile": "https://github.com/gokul-debugger",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/sktime/dists_kernels/dummy.py
+++ b/sktime/dists_kernels/dummy.py
@@ -16,6 +16,17 @@ class ConstantPwTrafoPanel(BasePairwiseTransformerPanel):
     ----------
     constant : float, optional, default = 0
         the constant value that this transformer returns
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.dists_kernels import ConstantPwTrafoPanel
+    >>> X = np.arange(12).reshape(3, 1, 4)
+    >>> transformer = ConstantPwTrafoPanel(constant=2)
+    >>> transformer.transform(X)
+    array([[2., 2., 2.],
+           [2., 2., 2.],
+           [2., 2., 2.]])
     """
 
     _tags = {
@@ -27,7 +38,6 @@ class ConstantPwTrafoPanel(BasePairwiseTransformerPanel):
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(self, constant=0):


### PR DESCRIPTION

#### Reference Issues/PRs

Refs #10782.

#### What does this implement/fix? Explain your changes.

Adds an executable usage example to the `ConstantPwTrafoPanel` docstring. The example demonstrates that transforming three time-series instances with `constant=2` produces a 3-by-3 matrix filled with `2.0`.

The obsolete `test_class_has_doctest_example` skip entry is removed so the generic estimator test suite now enforces the example. This PR also adds `gokul-debugger` to `.all-contributorsrc` with the `doc` contribution type.

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies are introduced.

#### What should a reviewer concentrate their feedback on?

- Whether the example clearly demonstrates the transformer's constant pairwise output.
- Whether the small NumPy input and expected output are appropriate for a stable doctest.

#### Did you add any tests for the change?

No separate test module was needed because the example is an executable doctest. The following checks passed locally on Python 3.12:

- `test_class_has_doctest_example[ConstantPwTrafoPanel]`
- `test_doctest_examples[ConstantPwTrafoPanel]`
- All 169 generic estimator checks selected for `ConstantPwTrafoPanel`

#### Any other comments?

This is my first contribution to `sktime`.

#### PR checklist

##### For all contributions

- [x] I've added myself to `.all-contributorsrc` with the `doc` badge.
- [x] I've added an illustrative usage example in a NumPy-style `Examples` section.
- [x] The PR title starts with `[DOC]`.
