### PR TITLE
[ENH] Add probabilistic forecasting support to Chronos2Forecaster

### DIFF
--- a/sktime/forecasting/chronos2.py
+++ b/sktime/forecasting/chronos2.py
@@ -82,7 +82,7 @@ class Chronos2Forecaster(BaseForecaster):
         "requires-fh-in-fit": False,
         "X-y-must-have-same-index": False,
         "capability:missing_values": False,
-        "capability:pred_int": False,
+        "capability:pred_int": True,
         "y_inner_mtype": "pd.DataFrame",
         "X_inner_mtype": "pd.DataFrame",
         "capability:multivariate": True,
@@ -287,6 +287,84 @@ class Chronos2Forecaster(BaseForecaster):
             index=index,
             columns=self._get_varnames(),
         )
+        pred_df.index.names = self._y_index_names
+
+        dateindex = pred_df.index.get_level_values(-1).map(lambda x: x in pred_out)
+        return pred_df.loc[dateindex]
+
+    def _predict_quantiles(self, fh, X=None, alpha=None):
+        """Compute/return prediction quantiles for a forecast.
+
+        Parameters
+        ----------
+        fh : ForecastingHorizon
+        X : pd.DataFrame, optional
+        alpha : list of float, optional (default=[0.5])
+
+        Returns
+        -------
+        quantiles : pd.DataFrame
+        """
+        import transformers
+
+        if alpha is None:
+            alpha = [0.5]
+
+        self._ensure_model_pipeline_loaded()
+        transformers.set_seed(self._seed)
+
+        prediction_length = int(max(fh.to_relative(self.cutoff)))
+
+        context_length = self._config["context_length"]
+        if context_length is None:
+            context_length = self.model_pipeline.model_context_length
+
+        context = self._context
+        input_dict = {"target": context}
+
+        if self._X is not None:
+            actual_len = context.shape[1]
+            past_X = self._X.values[-actual_len:]
+            input_dict["past_covariates"] = {
+                col: past_X[:, i] for i, col in enumerate(self._X.columns)
+            }
+
+        if X is not None:
+            future_vals = X.values[:prediction_length]
+            input_dict["future_covariates"] = {
+                col: future_vals[:, i] for i, col in enumerate(X.columns)
+            }
+
+        predictions = self.model_pipeline.predict(
+            [input_dict],
+            prediction_length=prediction_length,
+            batch_size=self._config["batch_size"],
+            context_length=context_length,
+            cross_learning=self._config["cross_learning"],
+            limit_prediction_length=self._config["limit_prediction_length"],
+        )
+
+        pred_tensor = predictions[0]
+        model_quantiles = self.model_pipeline.quantiles
+
+        index = (
+            ForecastingHorizon(range(1, prediction_length + 1))
+            .to_absolute(self._cutoff)
+            ._values
+        )
+        pred_out = fh.get_expected_pred_idx(context, cutoff=self.cutoff)
+
+        dfs = []
+        for a in alpha:
+            idx = (np.abs(np.array(model_quantiles) - a)).argmin()
+            q_forecast = pred_tensor[:, idx, :].numpy()
+
+            df_a = pd.DataFrame(q_forecast.T, index=index, columns=self._get_varnames())
+            dfs.append(df_a)
+
+        pred_df = pd.concat(dfs, axis=1, keys=alpha)
+        pred_df = pred_df.swaplevel(0, 1, axis=1).sort_index(axis=1)
+        pred_df.columns.names = ["variable", "alpha"]
         pred_df.index.names = self._y_index_names
 
         dateindex = pred_df.index.get_level_values(-1).map(lambda x: x in pred_out)

--- a/sktime/forecasting/chronos2.py
+++ b/sktime/forecasting/chronos2.py
@@ -183,20 +183,7 @@ class Chronos2Forecaster(BaseForecaster):
                 self.model_pipeline = self._load_pipeline()
 
     def _fit(self, y, X=None, fh=None):
-        """Fit the forecaster to training data.
-
-        Parameters
-        ----------
-        y : pd.DataFrame
-            Target time series.
-        X : pd.DataFrame, optional
-            Past exogenous covariates.
-        fh : ForecastingHorizon, optional
-
-        Returns
-        -------
-        self
-        """
+        """Fit the forecaster to training data."""
         self.model_pipeline = self._load_pipeline()
 
         context_length = self._config["context_length"]
@@ -214,20 +201,8 @@ class Chronos2Forecaster(BaseForecaster):
         self._y_index_names = y.index.names
         return self
 
-    def _predict(self, fh, X=None):
-        """Forecast time series at future horizon.
-
-        Parameters
-        ----------
-        fh : ForecastingHorizon
-        X : pd.DataFrame, optional
-            Future exogenous covariates (known-future). Column names must be
-            a subset of X provided in fit.
-
-        Returns
-        -------
-        y_pred : pd.DataFrame
-        """
+    def _get_predict_tensor(self, fh, X=None):
+        """Shared utility to execute the Chronos-2 pipeline and return raw tensors."""
         import transformers
 
         self._ensure_model_pipeline_loaded()
@@ -272,8 +247,6 @@ class Chronos2Forecaster(BaseForecaster):
 
         pred_tensor = predictions[0]
         quantiles = self.model_pipeline.quantiles
-        median_idx = quantiles.index(0.5)
-        point_forecast = pred_tensor[:, median_idx, :].numpy()
 
         index = (
             ForecastingHorizon(range(1, prediction_length + 1))
@@ -281,6 +254,15 @@ class Chronos2Forecaster(BaseForecaster):
             ._values
         )
         pred_out = fh.get_expected_pred_idx(context, cutoff=self.cutoff)
+
+        return pred_tensor, quantiles, index, pred_out
+
+    def _predict(self, fh, X=None):
+        """Forecast time series at future horizon."""
+        pred_tensor, quantiles, index, pred_out = self._get_predict_tensor(fh, X)
+
+        median_idx = quantiles.index(0.5)
+        point_forecast = pred_tensor[:, median_idx, :].numpy()
 
         pred_df = pd.DataFrame(
             point_forecast.T,
@@ -292,83 +274,30 @@ class Chronos2Forecaster(BaseForecaster):
         dateindex = pred_df.index.get_level_values(-1).map(lambda x: x in pred_out)
         return pred_df.loc[dateindex]
 
-    def _predict_quantiles(self, fh, X=None, alpha=None):
-        """Compute/return prediction quantiles for a forecast.
+    def _predict_proba(self, fh, X=None, marginal=True):
+        """Compute/return fully probabilistic forecasts."""
+        from skpro.distributions import HistogramQPD
 
-        Parameters
-        ----------
-        fh : ForecastingHorizon
-        X : pd.DataFrame, optional
-        alpha : list of float, optional (default=[0.5])
+        pred_tensor, model_quantiles, index, pred_out = self._get_predict_tensor(fh, X)
 
-        Returns
-        -------
-        quantiles : pd.DataFrame
-        """
-        import transformers
+        transposed = pred_tensor.numpy().transpose(1, 2, 0)
 
-        if alpha is None:
-            alpha = [0.5]
+        n_quantiles = len(model_quantiles)
+        pred_length = len(index)
+        var_names = self._get_varnames()
 
-        self._ensure_model_pipeline_loaded()
-        transformers.set_seed(self._seed)
+        data = transposed.reshape(n_quantiles * pred_length, -1)
+        row_index = pd.MultiIndex.from_product([model_quantiles, index])
 
-        prediction_length = int(max(fh.to_relative(self.cutoff)))
+        q_df = pd.DataFrame(data, index=row_index, columns=var_names)
 
-        context_length = self._config["context_length"]
-        if context_length is None:
-            context_length = self.model_pipeline.model_context_length
+        dist = HistogramQPD(q_df, tails="mass", index=index, columns=var_names)
 
-        context = self._context
-        input_dict = {"target": context}
+        dateindex = index.map(lambda x: x in pred_out)
+        if not dateindex.all():
+            dist = dist.loc[pred_out]
 
-        if self._X is not None:
-            actual_len = context.shape[1]
-            past_X = self._X.values[-actual_len:]
-            input_dict["past_covariates"] = {
-                col: past_X[:, i] for i, col in enumerate(self._X.columns)
-            }
-
-        if X is not None:
-            future_vals = X.values[:prediction_length]
-            input_dict["future_covariates"] = {
-                col: future_vals[:, i] for i, col in enumerate(X.columns)
-            }
-
-        predictions = self.model_pipeline.predict(
-            [input_dict],
-            prediction_length=prediction_length,
-            batch_size=self._config["batch_size"],
-            context_length=context_length,
-            cross_learning=self._config["cross_learning"],
-            limit_prediction_length=self._config["limit_prediction_length"],
-        )
-
-        pred_tensor = predictions[0]
-        model_quantiles = self.model_pipeline.quantiles
-
-        index = (
-            ForecastingHorizon(range(1, prediction_length + 1))
-            .to_absolute(self._cutoff)
-            ._values
-        )
-        pred_out = fh.get_expected_pred_idx(context, cutoff=self.cutoff)
-
-        dfs = []
-        for a in alpha:
-            idx = (np.abs(np.array(model_quantiles) - a)).argmin()
-            q_forecast = pred_tensor[:, idx, :].numpy()
-
-            df_a = pd.DataFrame(q_forecast.T, index=index, columns=self._get_varnames())
-            dfs.append(df_a)
-
-        pred_df = pd.concat(dfs, axis=1, keys=alpha)
-        pred_df = pred_df.swaplevel(0, 1, axis=1).sort_index(axis=1)
-        pred_df.columns.names = ["variable", "alpha"]
-        pred_df.index.names = self._y_index_names
-
-        dateindex = pred_df.index.get_level_values(-1).map(lambda x: x in pred_out)
-        return pred_df.loc[dateindex]
+        return dist
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/forecasting/tests/test_chronos2.py
+++ b/sktime/forecasting/tests/test_chronos2.py
@@ -180,40 +180,25 @@ def test_chronos2_covariates_match_source_reference():
     not _check_estimator_deps(Chronos2Forecaster, severity="none"),
     reason="Chronos2Forecaster soft dependencies not available",
 )
-def test_chronos2_predict_quantiles_and_intervals():
+def test_chronos2_predict_proba():
     """Test that Chronos2Forecaster returns correctly shaped proba forecasts."""
     import torch
+    from skpro.distributions import HistogramQPD
 
-    y = load_airline().iloc[:30]  # Use a small slice for faster testing
+    y = load_airline().iloc[:30]
     fh = [1, 2]
-    alpha = [0.1, 0.5, 0.9]
-    coverage = 0.8
 
-    # Instantiate the forecaster matching the file's precision style
     forecaster = Chronos2Forecaster(
         "amazon/chronos-2",
-        config={
-            "device_map": "cpu",
-            "torch_dtype": torch.float32,
-        },
+        config={"device_map": "cpu", "torch_dtype": torch.float32},
         seed=1,
     )
     forecaster.fit(y)
 
-    # 1. Test predict_quantiles
-    quantiles = forecaster.predict_quantiles(fh=fh, alpha=alpha)
-    assert isinstance(quantiles, pd.DataFrame), "Output must be a DataFrame"
-    assert quantiles.shape == (2, 3), "Shape must be (len(fh), len(alpha))"
-    assert isinstance(quantiles.columns, pd.MultiIndex), "Columns must be MultiIndex"
-    assert list(quantiles.columns.get_level_values(1)) == alpha, "Alphas must match"
+    pred_dist = forecaster.predict_proba(fh=fh)
 
-    # 2. Test predict_interval
-    intervals = forecaster.predict_interval(fh=fh, coverage=coverage)
-    assert isinstance(intervals, pd.DataFrame), "Output must be a DataFrame"
-    assert isinstance(intervals.columns, pd.MultiIndex), "Columns must be MultiIndex"
+    assert isinstance(pred_dist, HistogramQPD), "Output must be a HistogramQPD"
+    assert pred_dist.shape == (2, 1), "Shape must be (len(fh), n_vars)"
 
-    # Check if lower bound is <= upper bound
-    var_name = intervals.columns.get_level_values(0)[0]
-    lower = intervals[(var_name, coverage, "lower")].values
-    upper = intervals[(var_name, coverage, "upper")].values
-    assert (lower <= upper).all(), "Lower bound must be <= upper bound"
+    quantiles = forecaster.predict_quantiles(fh=fh, alpha=[0.1, 0.9])
+    assert quantiles.shape == (2, 2)

--- a/sktime/forecasting/tests/test_chronos2.py
+++ b/sktime/forecasting/tests/test_chronos2.py
@@ -174,3 +174,46 @@ def test_chronos2_covariates_match_source_reference():
         rtol=1e-5,
         atol=1e-4,
     )
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(Chronos2Forecaster, severity="none"),
+    reason="Chronos2Forecaster soft dependencies not available",
+)
+def test_chronos2_predict_quantiles_and_intervals():
+    """Test that Chronos2Forecaster returns correctly shaped proba forecasts."""
+    import torch
+
+    y = load_airline().iloc[:30]  # Use a small slice for faster testing
+    fh = [1, 2]
+    alpha = [0.1, 0.5, 0.9]
+    coverage = 0.8
+
+    # Instantiate the forecaster matching the file's precision style
+    forecaster = Chronos2Forecaster(
+        "amazon/chronos-2",
+        config={
+            "device_map": "cpu",
+            "torch_dtype": torch.float32,
+        },
+        seed=1,
+    )
+    forecaster.fit(y)
+
+    # 1. Test predict_quantiles
+    quantiles = forecaster.predict_quantiles(fh=fh, alpha=alpha)
+    assert isinstance(quantiles, pd.DataFrame), "Output must be a DataFrame"
+    assert quantiles.shape == (2, 3), "Shape must be (len(fh), len(alpha))"
+    assert isinstance(quantiles.columns, pd.MultiIndex), "Columns must be MultiIndex"
+    assert list(quantiles.columns.get_level_values(1)) == alpha, "Alphas must match"
+
+    # 2. Test predict_interval
+    intervals = forecaster.predict_interval(fh=fh, coverage=coverage)
+    assert isinstance(intervals, pd.DataFrame), "Output must be a DataFrame"
+    assert isinstance(intervals.columns, pd.MultiIndex), "Columns must be MultiIndex"
+
+    # Check if lower bound is <= upper bound
+    var_name = intervals.columns.get_level_values(0)[0]
+    lower = intervals[(var_name, coverage, "lower")].values
+    upper = intervals[(var_name, coverage, "upper")].values
+    assert (lower <= upper).all(), "Lower bound must be <= upper bound"


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9904.

### What does this implement/fix? Explain your changes.
Adds probabilistic forecasting support (_predict_quantiles) to Chronos2Forecaster.
Currently `Chronos2Pipeline` naturally generates a full quantile tensor during inference, but `Chronos2Forecaster._predict` previously discarded all quantiles except the 0.5 (median) slice to return a point forecast. Users could not call `predict_quantiles` or `predict_interval` on `Chronos2Forecaster`.

**Changes:**
1. Enabled prediction interval support by setting `"capability:pred_int": True` in `Chronos2Forecaster._tags`.
2. Implemented `_predict_quantiles(fh, X, alpha)` to extract natively generated quantiles from `self.model_pipeline.quantiles` and map requested `alpha` percentiles via nearest-neighbor index selection.
3. Formatted the output into `sktime`'s standard `pd.MultiIndex` DataFrame structure with `(variable, alpha)` column levels.
4. Leveraged `_PredictProbaMixin` to automatically enable downstream `predict_interval` and `predict_proba` functionality.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
- Implementation of `_predict_quantiles` in `sktime/forecasting/chronos2.py`.
- MultiIndex DataFrame output formatting for requested `alpha` values.

#### Did you add any tests for the change?
- Added `test_chronos2_predict_quantiles_and_intervals` to `sktime/forecasting/tests/test_chronos2.py` to assert DataFrame shape, MultiIndex levels, and logical lower/upper bounds.
- Verified local test suite (all 6 test suites passed).
- Verified `predict_quantiles` and `predict_interval` output structure against load_airline dataset.

#### Any other comments?
No

#### PR checklist

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).