### PR TITLE
[BUG] mean_squared_log_error: remove leftover debug print and stack trace

### DIFF
--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -2790,20 +2790,8 @@ def mean_squared_log_error(
     loss : float or ndarray of floats
         The computed metric value.
     """
-    import traceback
-
     import numpy as np
     from sklearn.utils import check_consistent_length
-
-    # Only print if inputs are pandas objects (where the bug happens)
-    if hasattr(y_true, "index") and hasattr(y_pred, "index"):
-        # Check if indices are different
-        if not y_true.index.equals(y_pred.index):
-            print("\n🚨 DETECTED INDEX MISMATCH!")
-            print(f"y_true index: {y_true.index}")
-            print(f"y_pred index: {y_pred.index}")
-            print("🔍 CALL STACK (Who called me?):")
-            traceback.print_stack(limit=3)  # Print the last 3 callers
 
     check_consistent_length(y_true, y_pred)
 

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -566,3 +566,29 @@ def test_owa_aggregate_then_ratio():
     assert np.isfinite(owa)
     assert owa < 100
     assert np.allclose(owa, expected_owa)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.performance_metrics"]),
+    reason="Run if performance_metrics module has changed.",
+)
+def test_msle_no_stdout_on_index_mismatch():
+    """mean_squared_log_error must not print debug output.
+
+    A leftover debug block printed an index-mismatch banner and a stack trace to
+    stdout whenever y_true and y_pred were pandas objects with different indices.
+    A metric must be silent.
+    """
+    import contextlib
+    import io
+
+    from sktime.performance_metrics.forecasting._functions import (
+        mean_squared_log_error,
+    )
+
+    y_true = pd.Series([1.0, 2.0, 3.0], index=[0, 1, 2])
+    y_pred = pd.Series([1.1, 2.1, 2.9], index=[10, 11, 12])
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        mean_squared_log_error(y_true, y_pred)
+    assert buf.getvalue() == ""


### PR DESCRIPTION
#### Reference Issues/PRs

None. Found while reviewing the forecasting metrics.

#### What does this implement/fix? Explain your changes.

`mean_squared_log_error` (in `performance_metrics/forecasting/_functions.py`)
contains leftover debugging code that writes to stdout on every call where
`y_true` and `y_pred` are pandas objects with different indices:

```
🚨 DETECTED INDEX MISMATCH!
y_true index: Index([0, 1, 2], ...)
y_pred index: Index([10, 11, 12], ...)
🔍 CALL STACK (Who called me?):
  File ...
```

A metric must be silent. The index-mismatch concern is already handled by the
`np.asanyarray(...)` conversion right below, so the print block adds nothing but
noise (and leaks a call stack). This PR removes that block and the now-unused
`import traceback`.

#### Verification

```python
import io, contextlib, pandas as pd
from sktime.performance_metrics.forecasting._functions import mean_squared_log_error
yt = pd.Series([1., 2., 3.], index=[0, 1, 2])
yp = pd.Series([1.1, 2.1, 2.9], index=[10, 11, 12])
buf = io.StringIO()
with contextlib.redirect_stdout(buf):
    r = mean_squared_log_error(yt, yp)
assert buf.getvalue() == ""   # empty after the fix; printed the banner before
```

The returned value is unchanged (0.00137 for the example above). Added a
regression test in `performance_metrics/forecasting/tests/test_metrics.py` that
fails on the current code and passes with the fix.

#### PR checklist

- [x] The PR title starts with `[BUG]`.
- [x] Added a test that fails without this change.
- [x] No change to public behaviour other than removing stdout noise.
