### PR TITLE
[BUG] Roll back set_params on error

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -180,6 +180,30 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         super().__init__()
         self.__dynamic_tags__()
 
+    def set_params(self, **params):
+        """Set the parameters of this object.
+
+        Parameters
+        ----------
+        **params : dict
+            BaseObject parameters.
+
+        Returns
+        -------
+        self : reference to self (after parameters have been set)
+        """
+        if not params:
+            return self
+
+        original_params = self.get_params(deep=False)
+        original_config = self.get_config()
+        try:
+            return super().set_params(**params)
+        except Exception:
+            self.__init__(**original_params)
+            self.set_config(**original_config)
+            raise
+
     def __eq__(self, other):
         """Equality dunder. Checks equal class and parameters.
 

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -33,6 +33,7 @@ __all__ = [
     "test_nested_set_params_and_alias",
     "test_get_fitted_params",
     "test_eq_dunder",
+    "test_set_params_rollback_on_error",
 ]
 
 from copy import deepcopy
@@ -566,3 +567,23 @@ def test_eq_dunder_checks_class():
 
     # comparison against a non-BaseObject must not raise, and must be unequal
     assert unrelated_1 != 42
+
+def test_set_params_rollback_on_error():
+    """Tests that failed set_params leaves estimator unchanged.
+
+    Regression test for issue #10695.
+
+    Raises
+    ------
+    AssertionError if set_params mutates estimator on error
+    """
+    from sktime.transformations.dilation_mapping import DilationMappingTransformer
+
+    transformer = DilationMappingTransformer(dilation=2)
+    original_dilation = transformer.dilation
+
+    with pytest.raises(ValueError, match="Dilation must be greater than 0"):
+        transformer.set_params(dilation=0)
+
+    assert transformer.dilation == original_dilation
+


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10695

#### What function does this tool/patch serve? Please explain the modifications you've made.

If the call to `set_params` fails, the estimator might end up being only partly mutated when an exception is raised during parameter validation.

The rollback feature has been added to the method `BaseObject.set_params`. Before calling the parent's implementation, the original parameters and config are stored. If `set_params` causes an exception to be raised, the estimator is reinitialized using its original parameters and config before the exception is re-raised.

#### Does the contribution you provide introduce a new dependency? If so, what is it?

No.

#### What should the reviewer focus their feedback on?

The way in which parameters are set in `BaseObject.set_params` involves a rollback.

- Whether restoring parameters and config on failure is consistent with the existing reset behavior

#### Did you include any tests for the change?

Yes, I've included a regression test to verify that a failed call to `set_params` leaves the estimator's parameters unchanged.

The base tests relevant to this case have passed: 17 have passed.

#### Any other comments?

None.