### PR TITLE
[DOC] add Python 3.14 to supported versions in get started guide

### DIFF
--- a/docs/source/get_started.rst
+++ b/docs/source/get_started.rst
@@ -11,7 +11,7 @@ Installation
 
 ``sktime`` currently supports:
 
-* environments with python version 3.10, 3.11, 3.12, or 3.13.
+* environments with python version 3.10, 3.11, 3.12, 3.13, or 3.14.
 * operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 * installation via ``PyPi`` or ``conda``
 


### PR DESCRIPTION
## Summary
The `Get Started` installation guide listed supported Python versions as `3.10, 3.11, 3.12, or 3.13`, omitting Python 3.14. This is stale: the project's `pyproject.toml` declares `requires-python = ">=3.10,<3.15"` with a `Programming Language :: Python :: 3.14` classifier, and the sibling `docs/source/installation.rst` already documents `Python versions 3.10, 3.11, 3.12, 3.13, and 3.14`.

This PR updates the bullet to include 3.14, aligning `get_started.rst` with `pyproject.toml` and `installation.rst`. It follows the same documentation-accuracy theme as upstream PR #10317 ("add mentions of python 3.14 in missing documentation locations").

## Type
- [x] Documentation fix

## Testing
Docs-only change; no runtime code touched.
- `git diff --check` — clean (no whitespace errors).
- `git diff upstream/main...HEAD --stat` — 1 file changed, 1 insertion(+), 1 deletion(-), `docs/source/get_started.rst` only.
- RST parse check (docutils): changed line parses clean; zero new parse messages versus `upstream/main`.
- Rebase onto latest `upstream/main` — conflict-free.

**AI disclosure:** This contribution was prepared with the assistance of AI tools and was human-reviewed before submission. The author understands and can explain the change.
