### PR TITLE
[ENH] ensure `sktime_version` tag is set dynamically to ensure inclusion in object serialization

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -182,7 +182,7 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         #
         # set sktime_version tag as dynamic tag
         # to ensure sktime_version is included in serialization dumps (e.g., pickle)
-        self.set_tag(sktime_version=SKTIME_VERSION)
+        self.set_tags(sktime_version=SKTIME_VERSION)
 
     def __eq__(self, other):
         """Equality dunder. Checks equal class and parameters.

--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -179,6 +179,10 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
     def __init__(self):
         super().__init__()
         self.__dynamic_tags__()
+        #
+        # set sktime_version tag as dynamic tag
+        # to ensure sktime_version is included in serialization dumps (e.g., pickle)
+        self.set_tag(sktime_version=SKTIME_VERSION)
 
     def __eq__(self, other):
         """Equality dunder. Checks equal class and parameters.


### PR DESCRIPTION
This PR adds a dynamic set of the `sktime_version` tag to all instances.

This ensures that `sktime_version` tag is set dynamically to ensure inclusion in object serialization, enabling comparison of source version of a (pickle/cloudpickle) serialized `sktime` object and the current environment version.

Without this, the tag does not get serialized, since it lives in a class attribute.