### PR TITLE
BUG: fix AttributeError in MultioutputTimeSeriesRegressionForecaster.predict when regressor returns a DataFrame

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -866,7 +866,11 @@ class _MultioutputReducer(_Reducer):
 
         # Iterate over estimators/forecast horizon
         y_pred = self.estimator_.predict(X_pred)
-        return y_pred.ravel()
+        # ``.ravel()`` is an ndarray method; some time-series regressors
+        # return a pd.DataFrame for multioutput targets instead of an
+        # ndarray, which has no ``.ravel``. Coerce to an ndarray first so
+        # both cases are handled, see #10829.
+        return np.asarray(y_pred).ravel()
 
 
 class _RecursiveReducer(_Reducer):

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -32,6 +32,7 @@ from sktime.forecasting.compose._reduce import _sliding_window_transform
 from sktime.forecasting.tests._config import TEST_OOS_FHS, TEST_WINDOW_LENGTHS_INT
 from sktime.performance_metrics.forecasting import mean_absolute_percentage_error
 from sktime.regression.base import BaseRegressor
+from sktime.regression.dummy import DummyRegressor as TimeSeriesDummyRegressor
 from sktime.regression.interval_based import TimeSeriesForestRegressor
 from sktime.split import SlidingWindowSplitter, temporal_train_test_split
 from sktime.split.tests.test_split import _get_windows
@@ -613,6 +614,30 @@ def test_reductions_airline_data(forecaster, expected):
     actual = forecaster.fit(y_train, fh=fh).predict(fh)
 
     np.testing.assert_almost_equal(actual, expected)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting.compose._reduce"]),
+    reason="run test only if reduce module has changed",
+)
+def test_multioutput_time_series_regressor_returning_dataframe():
+    """Test multioutput reduction with a regressor that predicts a DataFrame.
+
+    Some time series regressors (e.g. sktime's own ``DummyRegressor``) return a
+    ``pd.DataFrame`` from ``predict`` for multioutput targets, unlike sklearn
+    tabular regressors which always return an ``ndarray``. ``_MultioutputReducer``
+    used to call ``.ravel()`` unconditionally on the regressor's prediction,
+    which raised ``AttributeError: 'DataFrame' object has no attribute 'ravel'``
+    for such regressors. See #10829.
+    """
+    y = load_airline()
+    forecaster = MultioutputTimeSeriesRegressionForecaster(TimeSeriesDummyRegressor())
+
+    forecaster.fit(y, fh=[1, 2, 3])
+    y_pred = forecaster.predict()
+
+    assert isinstance(y_pred, pd.Series)
+    assert len(y_pred) == 3
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

`MultioutputTimeSeriesRegressionForecaster` raises `AttributeError: 'DataFrame' object has no attribute 'ravel'` when the wrapped regressor is a native sktime time-series regressor (e.g. `sktime.regression.dummy.DummyRegressor`), instead of a plain sklearn tabular regressor.

Reproduction (from #10829):

```python
from sktime.datasets import load_airline
from sktime.regression.dummy import DummyRegressor
from sktime.forecasting.compose import MultioutputTimeSeriesRegressionForecaster

y = load_airline()
f = MultioutputTimeSeriesRegressionForecaster(DummyRegressor())
f.fit(y, fh=[1, 2, 3])
f.predict()
```

## Root cause

`_MultioutputReducer._predict_last_window` (in `sktime/forecasting/compose/_reduce.py`) calls `self.estimator_.predict(X_pred).ravel()` unconditionally. sklearn tabular regressors always return an `ndarray` for multioutput predictions, so `.ravel()` works. sktime time-series regressors, however, can return a `pd.DataFrame` for multioutput targets, which has no `.ravel()` method, causing the crash. This wasn't caught by the existing test suite because the existing multioutput + time-series-regressor tests only exercise `make_pipeline(Tabularizer(), LinearRegression())`, i.e. an sklearn estimator under the hood, which always returns an ndarray.

## Fix

Coerce the regressor's prediction to an `ndarray` via `np.asarray(...)` before calling `.ravel()`. This is a no-op for the existing ndarray case and correctly handles the `DataFrame` case. The return contract for `_predict_last_window` (a flat array-like, per `_predict_fixed_cutoff` in `sktime/forecasting/base/_sktime.py`) is unaffected.

## Testing

Added `test_multioutput_time_series_regressor_returning_dataframe` to `sktime/forecasting/compose/tests/test_reduce.py`, using `MultioutputTimeSeriesRegressionForecaster(sktime.regression.dummy.DummyRegressor())` against `load_airline()`, asserting `predict()` returns a `pd.Series` of the expected length.

- New test passes with the fix, and reproduces the exact reported `AttributeError: 'DataFrame' object has no attribute 'ravel'` when the fix is reverted (confirmed via manual revert).
- Full `sktime/forecasting/compose/tests/test_reduce.py` suite: 243 passed, 2 skipped (unrelated, environment-gated), 0 failed.
- `ruff check` / `ruff format --check` clean on both changed files.

Fixes #10829
