### PR TITLE
[ENH] Add second test parameter set for DOBIN

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3034,6 +3034,16 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "AanchalGupta1162",
+      "name": "Aanchal Gupta",
+      "avatar_url": "https://avatars.githubusercontent.com/u/170348462?v=4",
+      "profile": "https://github.com/AanchalGupta1162",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ]
 }

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -145,7 +145,6 @@ EXCLUDED_TESTS_BY_TEST = {
     "test_get_test_params_coverage": [
         "CNTCNetwork",
         "ContractableBOSS",
-        "DOBIN",
         "DirRecTabularRegressionForecaster",
         "DirRecTimeSeriesRegressionForecaster",
         "DirectTimeSeriesRegressionForecaster",

--- a/sktime/transformations/dobin.py
+++ b/sktime/transformations/dobin.py
@@ -222,6 +222,31 @@ class DOBIN(BaseTransformer):
 
         return self._coords
 
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for transformers.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params1 = {}
+
+        params2 = {"frac": 0.8, "k": 3}
+
+        return [params1, params2]
+
 
 def close_distance_matrix(X: npt.ArrayLike, k: int, frac: float):
     """Calculate distance between close pairs.


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #3429


#### What does this implement/fix? Explain your changes.
Adds a second test parameter set for `DOBIN`

Changes:
- Added a second parameter set using `"frac": 0.8` and `"k": 3`.
- Removed `DOBIN` from `test_get_test_params_coverage` exclusion list.


#### Does your contribution introduce a new dependency? If yes, which one?
No.


#### What should a reviewer concentrate their feedback on?
Whether the added test param is a useful second case.


#### Did you add any tests for the change?
No new tests were added. This PR allows the existing coverage test to run for DOBIN with multiple parameter sets.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
