### PR TITLE
[DOC] add doctest examples for SlidingWindowSegmenter

### DIFF
--- a/sktime/transformations/segment.py
+++ b/sktime/transformations/segment.py
@@ -412,6 +412,27 @@ class SlidingWindowSegmenter(BaseTransformer):
         length of sliding window interval
 
     Used by the ShapeDTW algorithm.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.transformations.segment import SlidingWindowSegmenter
+    >>> X = pd.DataFrame({"a": [1, 2, 3, 4, 5]})
+    >>> t = SlidingWindowSegmenter(window_length=3)
+    >>> t.fit_transform(X)
+       0  1  2  3  4
+    0  1  1  2  3  4
+    1  1  2  3  4  5
+    2  2  3  4  5  5
+
+    The output always has ``window_length`` rows and as many columns as
+    there are original time points, regardless of the window size:
+
+    >>> t2 = SlidingWindowSegmenter(window_length=2)
+    >>> t2.fit_transform(X)
+       0  1  2  3  4
+    0  1  1  2  3  4
+    1  1  2  3  4  5
     """
 
     _tags = {


### PR DESCRIPTION
Adds doctest examples to the `SlidingWindowSegmenter` class docstring, addressing #10782.

Demonstrates output shape with two different window_length values, and calls out explicitly that output is always (window_length rows x n_timepoints columns), since this isn't obvious from the transform logic at a glance.

Verified with:
- `python -m doctest sktime/transformations/segment.py -v` (7 passed)
- `pytest --doctest-modules sktime/transformations/segment.py -v -n 0` (2 passed)
- `pre-commit run --files sktime/transformations/segment.py` (all passed)