### PR TITLE
[ENH] Add dedicated `_update` method to `TSB` forecaster

### DIFF
--- a/sktime/forecasting/tests/test_tsb.py
+++ b/sktime/forecasting/tests/test_tsb.py
@@ -206,6 +206,69 @@ def test_tsb_update_no_demand_in_fit():
     not run_test_for_class(TSB),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
+@pytest.mark.parametrize("n_leading_zeros", [1, 5, 17, 40])
+def test_tsb_delayed_initialization_across_several_updates(n_leading_zeros):
+    """Test that zeros accumulated over several updates still match a full fit.
+
+    When no demand has been seen the recursion cannot initialize, and the only
+    thing the history determines is how many zeros preceded the first demand.
+    That count is carried across an arbitrary number of update calls, so
+    chunking the leading zeros must not change the result.
+    """
+    values = [0.0] * n_leading_zeros + [4.0, 0.0, 0.0, 7.0, 0.0, 2.0]
+    idx = pd.date_range("2020-01-01", periods=len(values), freq="D")
+    y = pd.Series(values, index=idx)
+    fh = [1, 2]
+
+    # feed the leading zeros in several separate chunks, then the rest
+    incremental = TSB(0.4, 0.05).fit(y.iloc[:1])
+    pos = 1
+    while pos < n_leading_zeros:
+        step = min(3, n_leading_zeros - pos)
+        incremental.update(y.iloc[pos : pos + step])
+        pos += step
+    incremental.update(y.iloc[pos:])
+
+    full = TSB(0.4, 0.05).fit(y)
+
+    np.testing.assert_allclose(
+        incremental.predict(fh=fh), full.predict(fh=fh), rtol=1e-12
+    )
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSB),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_tsb_update_does_not_retain_history():
+    """Test that the delayed-initialization path stores a count, not the data.
+
+    The point of ``_update`` is constant memory; falling back to a refit on
+    accumulated history would defeat it. Only the number of zeros seen is kept.
+    """
+    idx = pd.date_range("2020-01-01", periods=60, freq="D")
+    y = pd.Series([0.0] * 55 + [3.0, 0.0, 5.0, 0.0, 1.0], index=idx)
+
+    forecaster = TSB(0.4, 0.05).fit(y.iloc[:20])
+    assert forecaster._n_zeros == 20
+    forecaster.update(y.iloc[20:40])
+    assert forecaster._n_zeros == 40
+    assert not forecaster._seen_demand
+
+    forecaster.update(y.iloc[40:])
+    assert forecaster._seen_demand
+    assert forecaster._n_zeros == 0
+
+    full = TSB(0.4, 0.05).fit(y)
+    np.testing.assert_allclose(
+        forecaster.predict(fh=[1]), full.predict(fh=[1]), rtol=1e-12
+    )
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSB),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_tsb_update_params_false_does_not_change_forecast():
     """Test that update(update_params=False) leaves fitted parameters alone."""
     y = load_PBS_dataset()

--- a/sktime/forecasting/tests/test_tsb.py
+++ b/sktime/forecasting/tests/test_tsb.py
@@ -1,6 +1,7 @@
 """Tests for TSB estimator."""
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from sktime.datasets import load_PBS_dataset
@@ -31,3 +32,188 @@ def test_TSB(alpha, beta, fh, expected_forecast):
     np.testing.assert_almost_equal(
         y_pred, np.full(len(fh), expected_forecast), decimal=5
     )
+
+
+# Golden reference series, short enough that the whole recursion can be
+# written out. With alpha = 0.5, beta = 0.2 and the first non-zero at index 1,
+# initialization is d = 3, p = 0.5, and the recursion runs:
+#
+#   t=0 (y=0): d = 3                 p = .8*.5       = 0.4
+#   t=1 (y=3): d = .5*3 + .5*3 = 3   p = .2 + .8*.4  = 0.52
+#   t=2 (y=0): d = 3                 p = .8*.52      = 0.416
+#   t=3 (y=0): d = 3                 p = .8*.416     = 0.3328
+#   t=4 (y=5): d = .5*5 + .5*3 = 4   p = .2 + .8*.3328 = 0.46624
+#
+# so the forecast is f = d * p = 4 * 0.46624 = 1.86496. The estimator
+# accumulates these in a different order, so agreement is to floating point
+# tolerance rather than bit-exact.
+GOLDEN_SERIES = [0, 3, 0, 0, 5]
+GOLDEN_ALPHA = 0.5
+GOLDEN_BETA = 0.2
+GOLDEN_D = 4.0
+GOLDEN_P = 0.46624
+GOLDEN_FORECAST = GOLDEN_D * GOLDEN_P  # 1.86496
+
+
+def _golden_y():
+    idx = pd.date_range("2020-01-01", periods=len(GOLDEN_SERIES), freq="D")
+    return pd.Series(GOLDEN_SERIES, index=idx, dtype=float)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSB),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_tsb_golden_output():
+    """Test a full fit against a hand-computed forecast.
+
+    See GOLDEN_SERIES above for the full arithmetic.
+    """
+    y = _golden_y()
+    forecaster = TSB(GOLDEN_ALPHA, GOLDEN_BETA).fit(y)
+    y_pred = forecaster.predict(fh=[1, 2, 3]).to_numpy().ravel()
+
+    np.testing.assert_allclose(y_pred, np.full(3, GOLDEN_FORECAST), rtol=1e-12)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSB),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize("split", [1, 2, 3, 4])
+def test_tsb_golden_output_after_update(split):
+    """Test that fit-then-update reaches the same hand-computed forecast.
+
+    Every split point is exercised, so the carried state is checked both
+    mid-zero-run and immediately after a demand period.
+    """
+    y = _golden_y()
+    forecaster = TSB(GOLDEN_ALPHA, GOLDEN_BETA).fit(y.iloc[:split])
+    forecaster.update(y.iloc[split:])
+    y_pred = forecaster.predict(fh=[1]).to_numpy().ravel()
+
+    np.testing.assert_allclose(y_pred, np.full(1, GOLDEN_FORECAST), rtol=1e-12)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSB),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_tsb_forecast_decays_when_update_is_all_zeros():
+    """Test that updating with only zeros decays the forecast.
+
+    This is what separates TSB from Croston. Croston smooths only on demand
+    periods, so an all-zero update leaves its forecast unchanged. TSB decays
+    the demand probability every period, so the same update must reduce the
+    forecast geometrically by ``(1 - beta)`` per zero, which is how TSB
+    represents obsolescence risk.
+    """
+    y = _golden_y()
+    n_zeros = 3
+    zeros_idx = pd.date_range("2020-01-06", periods=n_zeros, freq="D")
+    zeros = pd.Series(np.zeros(n_zeros), index=zeros_idx)
+
+    forecaster = TSB(GOLDEN_ALPHA, GOLDEN_BETA).fit(y)
+    before = forecaster.predict(fh=[1]).to_numpy().ravel()
+    forecaster.update(zeros)
+    after = forecaster.predict(fh=[1]).to_numpy().ravel()
+
+    # d is untouched by zero periods; p decays by (1 - beta) each period
+    expected = GOLDEN_D * GOLDEN_P * (1 - GOLDEN_BETA) ** n_zeros
+    np.testing.assert_allclose(after, np.full(1, expected), rtol=1e-12)
+    assert after[0] < before[0]
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSB),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize("alpha, beta", [(0.1, 0.1), (0.4, 0.05), (0.5, 0.2)])
+@pytest.mark.parametrize("n_update", [1, 5, 20])
+def test_tsb_update_equals_full_fit(alpha, beta, n_update):
+    """Test that fit-then-update matches a fit on the concatenated series.
+
+    The TSB recursion is deterministic given ``(d, p)``, so updating with the
+    tail of a series must reproduce a fit on the whole series exactly.
+    """
+    y = load_PBS_dataset()
+    split = len(y) - n_update
+    fh = [1, 2, 3]
+
+    incremental = TSB(alpha, beta).fit(y.iloc[:split])
+    incremental.update(y.iloc[split:])
+
+    full = TSB(alpha, beta).fit(y)
+
+    np.testing.assert_allclose(
+        incremental.predict(fh=fh), full.predict(fh=fh), rtol=1e-12
+    )
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSB),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_tsb_update_long_zero_run():
+    """Test updating across a long run of zeros.
+
+    TSB decays the demand probability on every zero period, which is what
+    distinguishes it from Croston. A long trailing zero run is therefore the
+    case most sensitive to an incorrectly carried probability.
+    """
+    idx = pd.date_range("2020-01-01", periods=40, freq="D")
+    values = [3.0, 0.0, 0.0, 5.0] + [0.0] * 30 + [2.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    y = pd.Series(values, index=idx)
+    fh = [1, 2]
+
+    incremental = TSB(0.4, 0.05).fit(y.iloc[:10])
+    incremental.update(y.iloc[10:])
+
+    full = TSB(0.4, 0.05).fit(y)
+
+    np.testing.assert_allclose(
+        incremental.predict(fh=fh), full.predict(fh=fh), rtol=1e-12
+    )
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSB),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_tsb_update_no_demand_in_fit():
+    """Test the edge case where the fit window contains no non-zero demand.
+
+    ``_fit`` initializes the demand size from the first non-zero observation,
+    so an all-zero fit window initializes it to zero, which then propagates.
+    Updating with data that does contain demand must still agree with a fit on
+    the concatenated series.
+    """
+    idx = pd.date_range("2020-01-01", periods=20, freq="D")
+    y = pd.Series([0.0] * 12 + [4.0, 0.0, 0.0, 7.0, 0.0, 3.0, 0.0, 5.0], index=idx)
+    fh = [1, 2]
+
+    incremental = TSB(0.4, 0.05).fit(y.iloc[:12])
+    incremental.update(y.iloc[12:])
+
+    full = TSB(0.4, 0.05).fit(y)
+
+    np.testing.assert_allclose(
+        incremental.predict(fh=fh), full.predict(fh=fh), rtol=1e-12
+    )
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(TSB),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_tsb_update_params_false_does_not_change_forecast():
+    """Test that update(update_params=False) leaves fitted parameters alone."""
+    y = load_PBS_dataset()
+    fh = [1, 2, 3]
+
+    forecaster = TSB(0.4, 0.05).fit(y.iloc[:-10])
+    before = forecaster.predict(fh=fh).to_numpy()
+    forecaster.update(y.iloc[-10:], update_params=False)
+    after = forecaster.predict(fh=fh).to_numpy()
+
+    np.testing.assert_allclose(before, after, rtol=1e-12)

--- a/sktime/forecasting/tsb.py
+++ b/sktime/forecasting/tsb.py
@@ -122,7 +122,41 @@ class TSB(BaseForecaster):
         self._p_last = p[-1]
         self._seen_demand = bool(np.any(y > 0))
 
+        # If no demand was seen, the recursion never initialized: ``d`` was set
+        # from ``y[argmax(y > 0)] == y[0] == 0``. Resuming later needs only the
+        # NUMBER of zeros seen, not the data, so store the count.
+        self._n_zeros = 0 if self._seen_demand else n_timepoints
+
         return self
+
+    def _recurse(self, y, d0, p0):
+        """Run the TSB recursion over ``y`` from initial state ``(d0, p0)``.
+
+        Shared by ``_fit``'s continuation in ``_update`` and by the delayed
+        initialization path, so both follow exactly the same arithmetic.
+
+        Returns
+        -------
+        d, p, f : np.ndarray, each of length ``len(y) + 1``, index 0 holding
+            the initial state.
+        """
+        alpha = self.alpha
+        beta = self.beta
+        n = len(y)
+
+        d, p, f = np.full((3, n + 1), np.nan)
+        d[0], p[0], f[0] = d0, p0, d0 * p0
+
+        for t in range(0, n):
+            if y[t] > 0:
+                d[t + 1] = alpha * y[t] + (1 - alpha) * d[t]
+                p[t + 1] = beta * 1 + (1 - beta) * p[t]
+            else:
+                d[t + 1] = d[t]
+                p[t + 1] = (1 - beta) * p[t]
+            f[t + 1] = d[t + 1] * p[t + 1]
+
+        return d, p, f
 
     def _update(self, y, X=None, update_params=True):
         """Update fitted parameters on new data.
@@ -152,32 +186,45 @@ class TSB(BaseForecaster):
         if n_new == 0:
             return self
 
-        # If ``_fit`` saw no non-zero demand, ``argmax(y > 0)`` returned 0 and
-        # the demand size was initialized to ``y[0] == 0``, which then
-        # propagates unchanged through zero periods. That is not the state a
-        # fit on the concatenated series would reach, so refit on accumulated
-        # history instead. Note this affects ``d`` only: ``p`` is initialized
-        # to the constant 0.5, independently of ``first_occurrence``.
-        if not self._seen_demand and np.any(y > 0):
-            return self._fit(y=self._y, X=X, fh=None)
-
-        alpha = self.alpha
         beta = self.beta
 
-        d, p, f = np.full((3, n_new + 1), np.nan)
-        d[0] = self._d_last
-        p[0] = self._p_last
-        f[0] = self._f[-1]
+        # ---- delayed initialization -------------------------------------
+        # If ``_fit`` saw no non-zero demand, ``argmax(y > 0)`` returned 0 and
+        # the demand size was initialized to ``y[0] == 0``, which propagates
+        # unchanged through zero periods -- not the state a fit on the pooled
+        # series would reach. Since every observation so far was zero, the only
+        # thing that history determines is HOW MANY zeros preceded the first
+        # demand, so a single counter replaces retaining the data.
+        # Note this affects ``d`` only: ``p`` initializes to the constant 0.5,
+        # independently of ``first_occurrence``.
+        if not self._seen_demand:
+            if not np.any(y > 0):
+                # still no demand: accumulate the count, forecast stays zero
+                self._n_zeros += n_new
+                self._f = np.concatenate([self._f, np.zeros(n_new)])
+                return self
 
-        for t in range(0, n_new):
-            if y[t] > 0:
-                d[t + 1] = alpha * y[t] + (1 - alpha) * d[t]
-                p[t + 1] = beta * 1 + (1 - beta) * p[t]
-                f[t + 1] = d[t + 1] * p[t + 1]
-            else:
-                d[t + 1] = d[t]
-                p[t + 1] = (1 - beta) * p[t]
-                f[t + 1] = d[t + 1] * p[t + 1]
+            # First demand arrives at index ``nz`` of this batch. A fit on the
+            # pooled series would have initialized d to that value and decayed
+            # p from 0.5 once per preceding zero. Decay iteratively rather than
+            # via ``(1 - beta) ** n`` so the result is bit-identical to a fit.
+            nz = int(np.argmax(y > 0))
+            d_pre = float(y[nz])
+            p_pre = 0.5
+            for _ in range(self._n_zeros + nz):
+                p_pre *= 1 - beta
+
+            d, p, f = self._recurse(y[nz:], d_pre, p_pre)
+
+            self._f = np.concatenate([self._f, np.zeros(nz), f[1:]])
+            self._d_last = d[-1]
+            self._p_last = p[-1]
+            self._seen_demand = True
+            self._n_zeros = 0
+            return self
+
+        # ---- ordinary continuation --------------------------------------
+        d, p, f = self._recurse(y, self._d_last, self._p_last)
 
         self._f = np.concatenate([self._f, f[1:]])
         self._d_last = d[-1]

--- a/sktime/forecasting/tsb.py
+++ b/sktime/forecasting/tsb.py
@@ -113,6 +113,77 @@ class TSB(BaseForecaster):
 
         self._f = f
 
+        # terminal state of the recursion, so that ``_update`` can continue it
+        # incrementally instead of refitting from scratch. Unlike Croston, TSB
+        # needs no periods-since-last-demand counter: ``p`` is smoothed every
+        # period, towards 1 on demand periods and towards 0 otherwise, so the
+        # elapsed-gap information is already carried in ``p`` itself.
+        self._d_last = d[-1]
+        self._p_last = p[-1]
+        self._seen_demand = bool(np.any(y > 0))
+
+        return self
+
+    def _update(self, y, X=None, update_params=True):
+        """Update fitted parameters on new data.
+
+        Continues the TSB recursion from the state persisted by ``_fit``,
+        rather than refitting on the full history.
+
+        Parameters
+        ----------
+        y : pd.Series
+            Time series with which to update the forecaster. Contains only the
+            new observations, not the full history.
+        X : pd.DataFrame, optional (default=None)
+            Exogenous variables are ignored.
+        update_params : bool, optional (default=True)
+            whether model parameters should be updated
+
+        Returns
+        -------
+        self : reference to self
+        """
+        if not update_params:
+            return self
+
+        y = y.to_numpy()
+        n_new = len(y)
+        if n_new == 0:
+            return self
+
+        # If ``_fit`` saw no non-zero demand, ``argmax(y > 0)`` returned 0 and
+        # the demand size was initialized to ``y[0] == 0``, which then
+        # propagates unchanged through zero periods. That is not the state a
+        # fit on the concatenated series would reach, so refit on accumulated
+        # history instead. Note this affects ``d`` only: ``p`` is initialized
+        # to the constant 0.5, independently of ``first_occurrence``.
+        if not self._seen_demand and np.any(y > 0):
+            return self._fit(y=self._y, X=X, fh=None)
+
+        alpha = self.alpha
+        beta = self.beta
+
+        d, p, f = np.full((3, n_new + 1), np.nan)
+        d[0] = self._d_last
+        p[0] = self._p_last
+        f[0] = self._f[-1]
+
+        for t in range(0, n_new):
+            if y[t] > 0:
+                d[t + 1] = alpha * y[t] + (1 - alpha) * d[t]
+                p[t + 1] = beta * 1 + (1 - beta) * p[t]
+                f[t + 1] = d[t + 1] * p[t + 1]
+            else:
+                d[t + 1] = d[t]
+                p[t + 1] = (1 - beta) * p[t]
+                f[t + 1] = d[t + 1] * p[t + 1]
+
+        self._f = np.concatenate([self._f, f[1:]])
+        self._d_last = d[-1]
+        self._p_last = p[-1]
+        self._seen_demand = self._seen_demand or bool(np.any(y > 0))
+
         return self
 
     def _predict(


### PR DESCRIPTION
Fixes #9773. Same pattern as #10819, now merged.

#### What this does

`TSB` had no `_update`, so `update()` fell back to the `BaseForecaster` default, which refits from scratch on the full history.

TSB needs *less* state than Croston. Croston has to carry `p`, the number of periods since the last non-zero demand, because it only smooths on demand periods. TSB smooths its demand probability every period — towards 1 on demand periods, towards 0 otherwise — so the elapsed-gap information is already in the probability. The complete state is just the smoothed demand size `d` and probability `p`.

So `_fit` persists those two, and `_update` continues the recursion over the new observations only. `update_params=False` returns early without writing to `self`, per the base contract.

#### Delayed initialization

If the fit window contains no non-zero demand, `np.argmax(y > 0)` returns 0 and the demand size initialises to `y[0] == 0`, which propagates unchanged through zero periods — not the state a fit on the pooled series would reach.

Per @fkiraly's suggestion, this is handled without retaining the data. Since every observation so far is zero, the only thing that history determines is *how many* zeros preceded the first demand. `_fit` records that count, `_update` accumulates it across any number of calls, and when the first demand finally arrives the state is reconstructed from `(n_zeros, first_demand)` alone:

- `d = first_demand` exactly, since `alpha*y + (1-alpha)*y = y`
- `p = 0.5` decayed once per preceding zero, then smoothed towards 1

Memory stays constant. `p` is decayed iteratively rather than via `(1 - beta) ** n`, because the power form differs by one ULP for some counts and the iterative form is bit-identical to a fit on the pooled series.

Note this affects `d` only — `p` initialises to the constant `0.5`, independently of `first_occurrence`.

The recursion is factored into `_recurse` so this path and the ordinary continuation run exactly the same arithmetic.

#### Tests

Golden output first, against a recursion short enough to write out in full. With `alpha=0.5`, `beta=0.2` and the first non-zero at index 1, initialisation is `d=3`, `p=0.5`:

```
t=0 (y=0): d = 3                 p = .8*.5         = 0.4
t=1 (y=3): d = .5*3 + .5*3 = 3   p = .2 + .8*.4    = 0.52
t=2 (y=0): d = 3                 p = .8*.52        = 0.416
t=3 (y=0): d = 3                 p = .8*.416       = 0.3328
t=4 (y=5): d = .5*5 + .5*3 = 4   p = .2 + .8*.3328 = 0.46624
```

so `f = 4 * 0.46624 = 1.86496`. The estimator accumulates in a different order, so this agrees to floating point tolerance rather than bit-exactly — noted in a comment above the constants.

Also: the fit-then-update invariant across three `(alpha, beta)` pairs and three update sizes, every split point of the golden series, a 30-period zero run, leading zeros chunked across several `update` calls, an assertion that the zero count accumulates and resets rather than history being retained, and `update_params=False`.

One test pins the behavioural contrast with Croston, which seems worth locking in given it caused confusion on #10819: an all-zero update leaves a Croston forecast *unchanged*, but must decay a TSB forecast by `(1 - beta)` per period. That difference is the whole point of TSB.

Separately verified bit-exact against full fits over 84 combinations of leading-zero count, split point and `(alpha, beta)`.

Locally: 26 passed in `test_tsb.py`, `check_estimator(TSB)` 1343 checks 0 failures, ruff clean.

#### Known limitation, deliberately out of scope

`self._f` still grows by `len(y)` on every update, while `_predict` only ever reads `f[-1]`. So the forecast history is retained even though the recursion state is not. The same is true of `Croston` as merged. Fixing it means changing what `_fit` stores, which felt like scope creep here — happy to follow up across both estimators if that's wanted.

#### Does your contribution introduce a new dependency?

No.

#### Disclosure

Implementation drafted with AI assistance (Claude) under my review; commits carry a `Co-Authored-By` trailer. I've verified the recursion, the tests and the estimator contract checks myself.
