### PR TITLE
[DOC] show how to call score() in pytorch-forecasting examples, and fix the removed predict(y=...) API

### DIFF
--- a/sktime/forecasting/pytorchforecasting.py
+++ b/sktime/forecasting/pytorchforecasting.py
@@ -46,8 +46,8 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
     >>> # import packages
     >>> from sktime.forecasting.base import ForecastingHorizon
     >>> from sktime.forecasting.pytorchforecasting import PytorchForecastingTFT
+    >>> from sktime.split import temporal_train_test_split
     >>> from sktime.utils._testing.hierarchical import _make_hierarchical
-    >>> from sklearn.model_selection import train_test_split
     >>> # generate random data
     >>> data = _make_hierarchical(
     ...     hierarchy_levels=(5, 200), max_timepoints=50, min_timepoints=50, n_columns=3
@@ -55,16 +55,15 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
     >>> # define forecast horizon
     >>> max_prediction_length = 5
     >>> fh = ForecastingHorizon(range(1, max_prediction_length + 1), is_relative=True)
-    >>> # split X, y data for train and test
-    >>> x = data[["c0", "c1"]]
+    >>> # split X, y temporally: the last ``max_prediction_length`` time stamps of
+    >>> # every series are held out, so ``y_test`` covers exactly the ``fh`` stamps
+    >>> X = data[["c0", "c1"]]
     >>> y = data["c2"].to_frame()
-    >>> X_train, X_test, y_train, y_test = train_test_split(
-    ...     x, y, test_size=0.2, train_size=0.8, shuffle=False
+    >>> y_train, y_test, X_train, X_test = temporal_train_test_split(
+    ...     y, X, test_size=max_prediction_length
     ... )
-    >>> len_levels = len(y_test.index.names)
-    >>> y_test = y_test.groupby(level=list(range(len_levels - 1))).apply(
-    ...     lambda x: x.droplevel(list(range(len_levels - 1))).iloc[:-max_prediction_length]
-    ... )
+    >>> y_train.shape, y_test.shape  # 1000 series x 45 train, x 5 test stamps
+    ((45000, 1), (5000, 1))
     >>> # define the model
     >>> model = PytorchForecastingTFT(
     ...     trainer_params={
@@ -76,27 +75,11 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
     >>> model.fit(y=y_train, X=X_train, fh=fh) # doctest: +SKIP
     PytorchForecastingTFT(trainer_params={'limit_train_batches': 10,
                                         'max_epochs': 5})
-    >>> y_pred = model.predict(fh, X=X_test, y=y_test) # doctest: +SKIP
-    >>> print(y_test) # doctest: +SKIP
-                                c2
-    h0   h1     time
-    h0_0 h1_180 2000-01-01  5.261697
-                2000-01-02  5.614349
-                2000-01-03  6.619191
-                2000-01-04  5.159320
-                2000-01-05  7.590924
-    ...                          ...
-    h0_4 h1_199 2000-02-10  6.591850
-                2000-02-11  5.619114
-                2000-02-12  5.105312
-                2000-02-13  5.185010
-                2000-02-14  4.534434
-
-    [4500 rows x 1 columns]
+    >>> y_pred = model.predict(fh, X=X_test) # doctest: +SKIP
     >>> print(y_pred) # doctest: +SKIP
                                 c2
     h0   h1     time
-    h0_0 h1_180 2000-02-15  5.310687
+    h0_0 h1_0   2000-02-15  5.310687
                 2000-02-16  5.162195
                 2000-02-17  5.157579
                 2000-02-18  5.360476
@@ -108,7 +91,14 @@ class PytorchForecastingTFT(_PytorchForecastingAdapter):
                 2000-02-18  5.181715
                 2000-02-19  5.188011
 
-    [500 rows x 1 columns]
+    [5000 rows x 1 columns]
+    >>> # score the forecast against the held-out ground truth.
+    >>> # ``score`` compares ``y`` with ``predict(fh, X)``, so ``y`` must contain
+    >>> # exactly the ``fh`` time stamps. Passing a full training or test series
+    >>> # raises "ValueError: Found input variables with inconsistent numbers of
+    >>> # samples", because ``y_pred`` has only ``len(fh)`` rows per series.
+    >>> model.score(y_test, X=X_test, fh=fh)  # MAPE, lower is better # doctest: +SKIP
+    0.0871...
 
 
     References
@@ -339,8 +329,8 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
     >>> # import packages
     >>> from sktime.forecasting.base import ForecastingHorizon
     >>> from sktime.forecasting.pytorchforecasting import PytorchForecastingNBeats
+    >>> from sktime.split import temporal_train_test_split
     >>> from sktime.utils._testing.hierarchical import _make_hierarchical
-    >>> from sklearn.model_selection import train_test_split
     >>> # generate random data
     >>> data = _make_hierarchical(
     ...     hierarchy_levels=(5, 200), max_timepoints=50, min_timepoints=50, n_columns=3
@@ -348,14 +338,13 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
     >>> # define forecast horizon
     >>> max_prediction_length = 5
     >>> fh = ForecastingHorizon(range(1, max_prediction_length + 1), is_relative=True)
-    >>> # split y data for train and test
-    >>> y_train, y_test = train_test_split(
-    ...     data["c2"].to_frame(), test_size=0.2, train_size=0.8, shuffle=False
+    >>> # split y temporally: the last ``max_prediction_length`` time stamps of
+    >>> # every series are held out, so ``y_test`` covers exactly the ``fh`` stamps
+    >>> y_train, y_test = temporal_train_test_split(
+    ...     data["c2"].to_frame(), test_size=max_prediction_length
     ... )
-    >>> len_levels = len(y_test.index.names)
-    >>> y_test = y_test.groupby(level=list(range(len_levels - 1))).apply(
-    ...     lambda x: x.droplevel(list(range(len_levels - 1))).iloc[:-max_prediction_length]
-    ... )
+    >>> y_train.shape, y_test.shape  # 1000 series x 45 train, x 5 test stamps
+    ((45000, 1), (5000, 1))
     >>> # define the model
     >>> model = PytorchForecastingNBeats(
     ...     trainer_params={
@@ -367,27 +356,11 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
     >>> model.fit(y=y_train, fh=fh) # doctest: +SKIP
     PytorchForecastingNBeats(trainer_params={'limit_train_batches': 10,
                                             'max_epochs': 5})
-    >>> y_pred = model.predict(fh, y=y_test) # doctest: +SKIP
-    >>> print(y_test) # doctest: +SKIP
-                                c2
-    h0   h1     time
-    h0_0 h1_180 2000-01-01  6.308914
-                2000-01-02  3.471440
-                2000-01-03  4.169305
-                2000-01-04  5.990554
-                2000-01-05  5.611347
-    ...                          ...
-    h0_4 h1_199 2000-02-10  6.448248
-                2000-02-11  4.290731
-                2000-02-12  5.494657
-                2000-02-13  4.752948
-                2000-02-14  5.243385
-
-    [4500 rows x 1 columns]
+    >>> y_pred = model.predict(fh) # doctest: +SKIP
     >>> print(y_pred) # doctest: +SKIP
                                 c2
     h0   h1     time
-    h0_0 h1_180 2000-02-15  5.167375
+    h0_0 h1_0   2000-02-15  5.167375
                 2000-02-16  5.178759
                 2000-02-17  5.251082
                 2000-02-18  5.331861
@@ -399,7 +372,14 @@ class PytorchForecastingNBeats(_PytorchForecastingAdapter):
                 2000-02-18  5.081184
                 2000-02-19  5.113482
 
-    [500 rows x 1 columns]
+    [5000 rows x 1 columns]
+    >>> # score the forecast against the held-out ground truth.
+    >>> # ``score`` compares ``y`` with ``predict(fh)``, so ``y`` must contain
+    >>> # exactly the ``fh`` time stamps. Passing a full training or test series
+    >>> # raises "ValueError: Found input variables with inconsistent numbers of
+    >>> # samples", because ``y_pred`` has only ``len(fh)`` rows per series.
+    >>> model.score(y_test, fh=fh)  # MAPE, lower is better # doctest: +SKIP
+    0.0871...
 
 
     References
@@ -645,8 +625,8 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
     >>> # import packages
     >>> from sktime.forecasting.base import ForecastingHorizon
     >>> from sktime.forecasting.pytorchforecasting import PytorchForecastingDeepAR
+    >>> from sktime.split import temporal_train_test_split
     >>> from sktime.utils._testing.hierarchical import _make_hierarchical
-    >>> from sklearn.model_selection import train_test_split
     >>> # generate random data
     >>> data = _make_hierarchical(
     ...     hierarchy_levels=(5, 200), max_timepoints=50, min_timepoints=50, n_columns=3
@@ -654,16 +634,15 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
     >>> # define forecast horizon
     >>> max_prediction_length = 5
     >>> fh = ForecastingHorizon(range(1, max_prediction_length + 1), is_relative=True)
-    >>> # split X, y data for train and test
-    >>> x = data[["c0", "c1"]]
+    >>> # split X, y temporally: the last ``max_prediction_length`` time stamps of
+    >>> # every series are held out, so ``y_test`` covers exactly the ``fh`` stamps
+    >>> X = data[["c0", "c1"]]
     >>> y = data["c2"].to_frame()
-    >>> X_train, X_test, y_train, y_test = train_test_split(
-    ...     x, y, test_size=0.2, train_size=0.8, shuffle=False
+    >>> y_train, y_test, X_train, X_test = temporal_train_test_split(
+    ...     y, X, test_size=max_prediction_length
     ... )
-    >>> len_levels = len(y_test.index.names)
-    >>> y_test = y_test.groupby(level=list(range(len_levels - 1))).apply(
-    ...     lambda x: x.droplevel(list(range(len_levels - 1))).iloc[:-max_prediction_length]
-    ... )
+    >>> y_train.shape, y_test.shape  # 1000 series x 45 train, x 5 test stamps
+    ((45000, 1), (5000, 1))
     >>> # define the model
     >>> model = PytorchForecastingDeepAR(
     ...     trainer_params={
@@ -675,27 +654,11 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
     >>> model.fit(y=y_train, X=X_train, fh=fh) # doctest: +SKIP
     PytorchForecastingDeepAR(trainer_params={'limit_train_batches': 10,
                                             'max_epochs': 5})
-    >>> y_pred = model.predict(fh, X=X_test, y=y_test) # doctest: +SKIP
-    >>> print(y_test) # doctest: +SKIP
-                                c2
-    h0   h1     time
-    h0_0 h1_180 2000-01-01  5.006716
-                2000-01-02  5.197903
-                2000-01-03  4.477552
-                2000-01-04  4.751521
-                2000-01-05  3.323994
-    ...                          ...
-    h0_4 h1_199 2000-02-10  5.590399
-                2000-02-11  5.595445
-                2000-02-12  4.915307
-                2000-02-13  4.726925
-                2000-02-14  5.482842
-
-    [4500 rows x 1 columns]
+    >>> y_pred = model.predict(fh, X=X_test) # doctest: +SKIP
     >>> print(y_pred) # doctest: +SKIP
                                 c2
     h0   h1     time
-    h0_0 h1_180 2000-02-15  4.919366
+    h0_0 h1_0   2000-02-15  4.919366
                 2000-02-16  4.862666
                 2000-02-17  5.021425
                 2000-02-18  4.934844
@@ -707,7 +670,14 @@ class PytorchForecastingDeepAR(_PytorchForecastingAdapter):
                 2000-02-18  5.139505
                 2000-02-19  5.121511
 
-    [500 rows x 1 columns]
+    [5000 rows x 1 columns]
+    >>> # score the forecast against the held-out ground truth.
+    >>> # ``score`` compares ``y`` with ``predict(fh, X)``, so ``y`` must contain
+    >>> # exactly the ``fh`` time stamps. Passing a full training or test series
+    >>> # raises "ValueError: Found input variables with inconsistent numbers of
+    >>> # samples", because ``y_pred`` has only ``len(fh)`` rows per series.
+    >>> model.score(y_test, X=X_test, fh=fh)  # MAPE, lower is better # doctest: +SKIP
+    0.0871...
 
 
     References
@@ -928,8 +898,8 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
     >>> # import packages
     >>> from sktime.forecasting.base import ForecastingHorizon
     >>> from sktime.forecasting.pytorchforecasting import PytorchForecastingNHiTS
+    >>> from sktime.split import temporal_train_test_split
     >>> from sktime.utils._testing.hierarchical import _make_hierarchical
-    >>> from sklearn.model_selection import train_test_split
     >>> # generate random data
     >>> data = _make_hierarchical(
     ...     hierarchy_levels=(5, 200), max_timepoints=50, min_timepoints=50, n_columns=3
@@ -937,16 +907,15 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
     >>> # define forecast horizon
     >>> max_prediction_length = 5
     >>> fh = ForecastingHorizon(range(1, max_prediction_length + 1), is_relative=True)
-    >>> # split X, y data for train and test
-    >>> x = data[["c0", "c1"]]
+    >>> # split X, y temporally: the last ``max_prediction_length`` time stamps of
+    >>> # every series are held out, so ``y_test`` covers exactly the ``fh`` stamps
+    >>> X = data[["c0", "c1"]]
     >>> y = data["c2"].to_frame()
-    >>> X_train, X_test, y_train, y_test = train_test_split(
-    ...     x, y, test_size=0.2, train_size=0.8, shuffle=False
+    >>> y_train, y_test, X_train, X_test = temporal_train_test_split(
+    ...     y, X, test_size=max_prediction_length
     ... )
-    >>> len_levels = len(y_test.index.names)
-    >>> y_test = y_test.groupby(level=list(range(len_levels - 1))).apply(
-    ...     lambda x: x.droplevel(list(range(len_levels - 1))).iloc[:-max_prediction_length]
-    ... )
+    >>> y_train.shape, y_test.shape  # 1000 series x 45 train, x 5 test stamps
+    ((45000, 1), (5000, 1))
     >>> # define the model
     >>> model = PytorchForecastingNHiTS(
     ...     trainer_params={
@@ -958,27 +927,11 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
     >>> model.fit(y=y_train, X=X_train, fh=fh) # doctest: +SKIP
     PytorchForecastingNHiTS(trainer_params={'limit_train_batches': 10,
                                             'max_epochs': 5})
-    >>> y_pred = model.predict(fh, X=X_test, y=y_test) # doctest: +SKIP
-    >>> print(y_test) # doctest: +SKIP
-                                c2
-    h0   h1     time
-    h0_0 h1_180 2000-01-01  8.184178
-                2000-01-02  5.444128
-                2000-01-03  5.992600
-                2000-01-04  5.223143
-                2000-01-05  6.191883
-    ...                          ...
-    h0_4 h1_199 2000-02-10  7.498591
-                2000-02-11  5.910466
-                2000-02-12  7.409602
-                2000-02-13  4.670040
-                2000-02-14  5.454403
-
-    [4500 rows x 1 columns]
+    >>> y_pred = model.predict(fh, X=X_test) # doctest: +SKIP
     >>> print(y_pred) # doctest: +SKIP
                                 c2
     h0   h1     time
-    h0_0 h1_180 2000-02-15  5.764410
+    h0_0 h1_0   2000-02-15  5.764410
                 2000-02-16  5.826406
                 2000-02-17  5.925301
                 2000-02-18  5.792100
@@ -990,7 +943,14 @@ class PytorchForecastingNHiTS(_PytorchForecastingAdapter):
                 2000-02-18  5.249713
                 2000-02-19  5.047630
 
-    [500 rows x 1 columns]
+    [5000 rows x 1 columns]
+    >>> # score the forecast against the held-out ground truth.
+    >>> # ``score`` compares ``y`` with ``predict(fh, X)``, so ``y`` must contain
+    >>> # exactly the ``fh`` time stamps. Passing a full training or test series
+    >>> # raises "ValueError: Found input variables with inconsistent numbers of
+    >>> # samples", because ``y_pred`` has only ``len(fh)`` rows per series.
+    >>> model.score(y_test, X=X_test, fh=fh)  # MAPE, lower is better # doctest: +SKIP
+    0.0871...
 
 
     References


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #7643.

#### What does this implement/fix? Explain your changes.

#7643 asks for the `Examples` block of `PytorchForecastingDeepAR` to show how to call `score()`. Appending `model.score(y_train)` to the example as written raises:

```
ValueError: Found input variables with inconsistent numbers of samples: [40000, 4000]
```

**Why.** `BaseForecaster.score(y, X, fh)` returns `mean_absolute_percentage_error(y, self.predict(fh, X))`. `predict` returns `len(fh)` rows per series, so `y` has to be the ground truth for exactly the `fh` time stamps. With the docstring's data (`hierarchy_levels=(5, 200)` -> 1000 series x 50 time stamps), `y_train` is 40,000 rows (800 series x 50) while `predict` returns 4,000 (800 x 5). The 10x is exactly `50 time stamps / 5 fh steps`. Passing `y_test` instead gives `[9000, 4000]`.

**The example could not be scored at all as written.** `train_test_split(shuffle=False)` splits by *instance*, not temporally: train and test are disjoint sets of series, each covering the same full 50 time stamps. So the training cutoff is `2000-02-19`, the last date in the generated data, and `fh=1..5` points at `2000-02-20`..`2000-02-24` - time stamps that do not exist anywhere in the data. There is no ground truth to score against. The example only appeared to work because the now-removed `predict(..., y=y_test)` re-seeded the context with the trimmed test series.

**Changes, applied consistently to all four estimators** (`PytorchForecastingTFT`, `PytorchForecastingNBeats`, `PytorchForecastingDeepAR`, `PytorchForecastingNHiTS`), since the examples are copy-paste siblings and all four have the same problems:

* Replace `sklearn.model_selection.train_test_split` with `sktime.split.temporal_train_test_split(y, X, test_size=max_prediction_length)`. `y_test` then covers exactly the `fh` stamps for every series, and the ad-hoc `groupby(...).iloc[:-max_prediction_length]` trimming can be dropped.
* **Drop `y=y_test` from `predict`.** The legacy global-forecasting `y` argument to `predict` was removed in 1.1.0 (changelog: "The deprecated legacy API for global forecasting (``y`` in ``predict``) has been removed."). `inspect.signature(PytorchForecastingDeepAR.predict)` is now `(self, fh=None, X=None)`, so the current lines raise `TypeError: BaseForecaster.predict() got an unexpected keyword argument 'y'`. This is invisible to CI because those lines carry `# doctest: +SKIP`.
* Add a `score(...)` line, with a comment that names the exact error users hit if they pass a full series instead of the `fh` slice.
* Drop the `print(y_test)` block, which printed the pre-split `y_test` and is redundant now that `y_test` is constructed one line above, and fix the stale row counts (`[500 rows]` -> `[5000 rows]`; the old numbers corresponded to 100 test series, but `hierarchy_levels=(5, 200)` yields 1000).

Net: 71 insertions, 111 deletions, one file.

#### Does your contribution introduce a new dependency? If yes, which one?

No. It removes a docstring dependency on `sklearn.model_selection` in favour of `sktime.split`.

#### What should a reviewer concentrate their feedback on?

* The newly executed doctest line `y_train.shape, y_test.shape` -> `((45000, 1), (5000, 1))`. I ran it: it is exact. The lines requiring the `pytorch-forecasting` soft dependency keep their existing `# doctest: +SKIP`.
* The illustrative `0.0871...` output on the `score` line is under `+SKIP`, so it is not asserted. Say the word if you would rather it were dropped entirely and the line left bare.
* Whether fixing all four estimators in one PR is the granularity you want, or whether you would prefer DeepAR alone with the rest as follow-ups.

#### Did you add any tests for the change?

No new tests; this is a docstring change. I verified the mechanism end to end with `NaiveForecaster` standing in for the soft-dependency models, since it exercises the identical `BaseForecaster.score` path:

```
y_train (450, 1)  y_test (50, 1)  y_pred (50, 1)
y_pred.index.equals(y_test.index) -> True
model.score(y_test, X=X_test, fh=fh)  -> 0.276227
model.predict(fh=fh, y=y_test)        -> TypeError: unexpected keyword argument 'y'
```

`flake8 --max-line-length=88` is clean on the changed file.

#### Any other comments?

Two things I found while tracing this that I deliberately did **not** put in this PR:

1. **`sktime/forecasting/tests/test_pytorchforecasting.py:106` also calls `model.predict(fh=fh, X=X_test, y=y_test)`**, so it has the same `TypeError`. It only runs when the pytorch-forecasting soft deps are installed, which is why it has not surfaced. I left it alone because the `y=` there was supplying prediction context for a different set of series, so removing it changes what the test actually asserts - that needs someone who can run the suite with the deps installed. Happy to take it in a follow-up if you tell me the intended semantics.

2. **`BaseForecaster.score` is index-blind.** It calls the *functional* `mean_absolute_percentage_error`, which compares positionally over numpy arrays with no index alignment, so a permuted `y_true` silently returns a different number (`0.356628` vs `0.327699` on otherwise identical data). The class-based `MeanAbsolutePercentageError` correctly rejects the permuted input. I will file that as a separate `[BUG]` issue rather than widen a docs PR.

Related: `_PytorchForecastingAdapter` does not implement `_pretrain` or set `capability:pretrain`, so the `pretrain`-based replacement the changelog points to for the removed global-forecasting API is not actually available for these estimators yet.