### PR TITLE
[BUG] anchor Arps DCA cumulative forecasts at cutoff, not first fh point

### DIFF
--- a/sktime/forecasting/arps_dca.py
+++ b/sktime/forecasting/arps_dca.py
@@ -250,24 +250,26 @@ class _ArpsDcaBase(BaseForecaster):
 
         return self
 
-    def _apply_forecast_transforms(self, y_pred, cum_baseline_raw=None):
+    def _apply_forecast_transforms(self, y_pred, params):
         """Apply anchoring and cumulative offset to raw model predictions.
 
         Parameters
         ----------
         y_pred : np.ndarray
             Raw model output (rate or cumulative) at the forecast horizon,
-            for the same parameter values used to compute ``cum_baseline_raw``.
-        cum_baseline_raw : np.ndarray or float, default=None
-            Raw (pre-anchor) cumulative-function value evaluated at the
-            cutoff (``t_last_``), using the same parameters as ``y_pred``.
-            Must be passed whenever ``self.output == "cumulative"``; it is
-            unused, and the default applies, when ``self.output == "rate"``.
-            Anchors the cumulative curve to ``base_np`` *at the cutoff*
-            rather than at the first requested forecast horizon point.
+            as produced from ``params``.
+        params : sequence of float or of np.ndarray
+            Curve parameters that produced ``y_pred``. For
+            ``output="cumulative"`` these are re-used to evaluate the
+            cumulative function at the cutoff (``t_last_``), so that the curve
+            is anchored to ``base_np`` at the cutoff rather than at the first
+            requested forecast horizon point. In the Monte Carlo path each
+            entry is a column vector of shape ``(n_samples, 1)``, so the
+            baseline broadcasts per sample.
         """
         y_pred = y_pred * self.anchor_scale_ + self.anchor_shift_
         if self.output == "cumulative":
+            cum_baseline_raw = self._cum_func(self.t_last_, *params)
             baseline = cum_baseline_raw * self.anchor_scale_ + self.anchor_shift_
             y_pred = (y_pred - baseline) + self.base_np
         return y_pred
@@ -290,14 +292,7 @@ class _ArpsDcaBase(BaseForecaster):
         fh_abs = fh.to_absolute_index(self.cutoff)
         t = self._index_to_float_array(fh_abs) - self.t0_
         func = self._rate_func if self.output == "rate" else self._cum_func
-        cum_baseline_raw = (
-            self._cum_func(self.t_last_, *self.params_)
-            if self.output == "cumulative"
-            else None
-        )
-        y_pred = self._apply_forecast_transforms(
-            func(t, *self.params_), cum_baseline_raw
-        )
+        y_pred = self._apply_forecast_transforms(func(t, *self.params_), self.params_)
 
         cols = self._get_varnames()
         y_arr = np.asarray(y_pred).reshape(-1, len(cols))
@@ -319,13 +314,8 @@ class _ArpsDcaBase(BaseForecaster):
                 RuntimeWarning,
                 stacklevel=3,
             )
-            cum_baseline_raw = (
-                self._cum_func(self.t_last_, *self.params_)
-                if self.output == "cumulative"
-                else None
-            )
             y_point = self._apply_forecast_transforms(
-                func(t, *self.params_), cum_baseline_raw
+                func(t, *self.params_), self.params_
             )
             return np.asarray(y_point).reshape(1, -1)
 
@@ -344,12 +334,7 @@ class _ArpsDcaBase(BaseForecaster):
         sample_params = [param_samples[:, [i]] for i in range(param_samples.shape[1])]
 
         y_pred = func(t, *sample_params)
-        cum_baseline_raw = (
-            self._cum_func(self.t_last_, *sample_params)
-            if self.output == "cumulative"
-            else None
-        )
-        return self._apply_forecast_transforms(y_pred, cum_baseline_raw)
+        return self._apply_forecast_transforms(y_pred, sample_params)
 
     def _predict_quantiles(self, fh, X, alpha):
         """Compute prediction quantiles via Monte Carlo parameter sampling.

--- a/sktime/forecasting/arps_dca.py
+++ b/sktime/forecasting/arps_dca.py
@@ -223,6 +223,7 @@ class _ArpsDcaBase(BaseForecaster):
         self.params_cov_ = pcov
 
         t_last = t[-1]
+        self.t_last_ = t_last
         q_last_obs = q[-1]
         q_last_model = self._rate_func(t_last, *popt)
 
@@ -249,11 +250,25 @@ class _ArpsDcaBase(BaseForecaster):
 
         return self
 
-    def _apply_forecast_transforms(self, y_pred):
-        """Apply anchoring and cumulative offset to raw model predictions."""
+    def _apply_forecast_transforms(self, y_pred, cum_baseline_raw=None):
+        """Apply anchoring and cumulative offset to raw model predictions.
+
+        Parameters
+        ----------
+        y_pred : np.ndarray
+            Raw model output (rate or cumulative) at the forecast horizon,
+            for the same parameter values used to compute ``cum_baseline_raw``.
+        cum_baseline_raw : np.ndarray or float, default=None
+            Raw (pre-anchor) cumulative-function value evaluated at the
+            cutoff (``t_last_``), using the same parameters as ``y_pred``.
+            Must be passed whenever ``self.output == "cumulative"``; it is
+            unused, and the default applies, when ``self.output == "rate"``.
+            Anchors the cumulative curve to ``base_np`` *at the cutoff*
+            rather than at the first requested forecast horizon point.
+        """
         y_pred = y_pred * self.anchor_scale_ + self.anchor_shift_
         if self.output == "cumulative":
-            baseline = y_pred[0] if y_pred.ndim == 1 else y_pred[:, [0]]
+            baseline = cum_baseline_raw * self.anchor_scale_ + self.anchor_shift_
             y_pred = (y_pred - baseline) + self.base_np
         return y_pred
 
@@ -275,7 +290,14 @@ class _ArpsDcaBase(BaseForecaster):
         fh_abs = fh.to_absolute_index(self.cutoff)
         t = self._index_to_float_array(fh_abs) - self.t0_
         func = self._rate_func if self.output == "rate" else self._cum_func
-        y_pred = self._apply_forecast_transforms(func(t, *self.params_))
+        cum_baseline_raw = (
+            self._cum_func(self.t_last_, *self.params_)
+            if self.output == "cumulative"
+            else None
+        )
+        y_pred = self._apply_forecast_transforms(
+            func(t, *self.params_), cum_baseline_raw
+        )
 
         cols = self._get_varnames()
         y_arr = np.asarray(y_pred).reshape(-1, len(cols))
@@ -297,7 +319,14 @@ class _ArpsDcaBase(BaseForecaster):
                 RuntimeWarning,
                 stacklevel=3,
             )
-            y_point = self._apply_forecast_transforms(func(t, *self.params_))
+            cum_baseline_raw = (
+                self._cum_func(self.t_last_, *self.params_)
+                if self.output == "cumulative"
+                else None
+            )
+            y_point = self._apply_forecast_transforms(
+                func(t, *self.params_), cum_baseline_raw
+            )
             return np.asarray(y_point).reshape(1, -1)
 
         rng = np.random.default_rng(self.random_state)
@@ -312,11 +341,15 @@ class _ArpsDcaBase(BaseForecaster):
             ) from e
 
         param_samples = self._clip_param_samples(param_samples)
+        sample_params = [param_samples[:, [i]] for i in range(param_samples.shape[1])]
 
-        y_pred = func(
-            t, *[param_samples[:, [i]] for i in range(param_samples.shape[1])]
+        y_pred = func(t, *sample_params)
+        cum_baseline_raw = (
+            self._cum_func(self.t_last_, *sample_params)
+            if self.output == "cumulative"
+            else None
         )
-        return self._apply_forecast_transforms(y_pred)
+        return self._apply_forecast_transforms(y_pred, cum_baseline_raw)
 
     def _predict_quantiles(self, fh, X, alpha):
         """Compute prediction quantiles via Monte Carlo parameter sampling.

--- a/sktime/forecasting/tests/test_arps_dca.py
+++ b/sktime/forecasting/tests/test_arps_dca.py
@@ -1,0 +1,124 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for Arps Decline Curve Analysis (DCA) forecasters."""
+
+__author__ = ["OfficialAbhinavSingh"]
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sktime.forecasting.arps_dca import ArpsExponential, ArpsHarmonic, ArpsHyperbolic
+from sktime.tests.test_switch import run_test_for_class
+
+ARPS_CLASSES = [ArpsExponential, ArpsHyperbolic, ArpsHarmonic]
+
+
+def _make_decline_series(n=20, noise=3.0, seed=0):
+    rng = np.random.default_rng(seed)
+    t = np.arange(n)
+    q = 1000 * np.exp(-0.1 * t) + rng.normal(0, noise, size=n)
+    return pd.Series(q, index=t)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ARPS_CLASSES),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize("cls", ARPS_CLASSES)
+def test_cumulative_output_anchored_at_cutoff_not_first_fh(cls):
+    """Cumulative forecasts must not depend on which fh values are requested.
+
+    Regression test: ``_apply_forecast_transforms`` used to rebase the
+    cumulative curve to the model's value at the *first requested* horizon
+    point instead of the cutoff, so predicting a later horizon on its own
+    (e.g. ``fh=[3]``) silently changed the whole curve's baseline. Both
+    calls below must agree, since the underlying trained model and cutoff
+    are identical.
+    """
+    y = _make_decline_series()
+    forecaster = cls(output="cumulative", base_np=5000.0, random_state=0)
+    forecaster.fit(y)
+
+    joint = forecaster.predict(fh=[1, 2, 3, 5, 8])
+
+    late_only = cls(output="cumulative", base_np=5000.0, random_state=0)
+    late_only.fit(y)
+    single = late_only.predict(fh=[8])
+
+    np.testing.assert_allclose(
+        np.asarray(joint).ravel()[-1],
+        np.asarray(single).ravel()[-1],
+        rtol=1e-8,
+    )
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ARPS_CLASSES),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize("cls", ARPS_CLASSES)
+def test_cumulative_base_np_offset_applied_at_cutoff(cls):
+    """``base_np`` should offset the whole cumulative curve, not just fh[0].
+
+    Before the fix, the first predicted cumulative value was always exactly
+    ``base_np`` (since the rebase point coincided with the first fh value),
+    regardless of how far that first fh point was from the cutoff.
+    """
+    y = _make_decline_series()
+    near = cls(output="cumulative", base_np=5000.0, random_state=0)
+    near.fit(y)
+    y_near = near.predict(fh=[1]).values.ravel()[0]
+
+    far = cls(output="cumulative", base_np=5000.0, random_state=0)
+    far.fit(y)
+    y_far = far.predict(fh=[8]).values.ravel()[0]
+
+    # further-out forecasts should have accumulated more production than
+    # the immediate next-step forecast -- both must exceed base_np, and the
+    # near-term one must NOT collapse to exactly base_np.
+    assert y_near > 5000.0
+    assert y_far > y_near
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ARPS_CLASSES),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize("cls", ARPS_CLASSES)
+def test_cumulative_predict_interval_nonzero_width(cls):
+    """Prediction intervals for cumulative output must not degenerate to zero width.
+
+    Before the fix, requesting a single, non-first horizon point (e.g.
+    ``fh=[3]``) rebased that point's Monte Carlo samples to their own
+    baseline, collapsing lower == upper.
+    """
+    y = _make_decline_series()
+    forecaster = cls(output="cumulative", base_np=0.0, random_state=0)
+    forecaster.fit(y)
+
+    pred_int = forecaster.predict_interval(fh=[3], coverage=[0.9])
+    lower = pred_int.xs("lower", level=-1, axis=1).values.ravel()
+    upper = pred_int.xs("upper", level=-1, axis=1).values.ravel()
+
+    assert np.all(upper - lower > 0)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ARPS_CLASSES),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize("cls", ARPS_CLASSES)
+def test_rate_output_unaffected_by_cumulative_fix(cls):
+    """``output="rate"`` forecasts must be identical regardless of requested fh."""
+    y = _make_decline_series()
+    forecaster = cls(output="rate", random_state=0)
+    forecaster.fit(y)
+
+    joint = forecaster.predict(fh=[1, 2, 3])
+    single = cls(output="rate", random_state=0).fit(y).predict(fh=[3])
+
+    np.testing.assert_allclose(
+        np.asarray(joint).ravel()[-1],
+        np.asarray(single).ravel()[-1],
+        rtol=1e-8,
+    )


### PR DESCRIPTION
#### Reference Issues/PRs

No existing issue.

#### What does this implement/fix? Explain your changes.

`_ArpsDcaBase._apply_forecast_transforms` rebases `output="cumulative"` forecasts to the model value at the *first requested* `fh` point, rather than at the training cutoff. Three consequences:

* forecasts depend on which `fh` is asked for - `predict(fh=[8])` and `predict(fh=[1, 2, 3, 5, 8])[-1]` disagree for the same fitted model
* the first returned cumulative value is always exactly `base_np`, dropping production accrued between cutoff and `fh[0]`
* in the Monte Carlo path each sample rebases to its own `fh[0]`, so a single-point `predict_interval` collapses to zero width

`ArpsExponential` on a 20 point noisy exponential decline, `base_np=5000`:

| | main | this PR |
|---|---|---|
| `predict(fh=[8])` | 5000.000 | 5817.097 |
| `predict(fh=[1,2,3,5,8])[-1]` | 5675.717 | 5817.097 |
| `predict_interval(fh=[3], coverage=[0.9])` width | 0.0000 | 5.6925 |

The fix stores the cutoff as `self.t_last_` at fit time, next to the existing `self.t0_`, and passes the raw cumulative value at the cutoff into `_apply_forecast_transforms` explicitly. All three call sites are updated. In the sampling path the parameter samples have shape `(n_samples, 1)`, so the baseline broadcasts per sample against `(n_samples, n_fh)` - each sampled curve anchors at the cutoff under its own parameters, which is what keeps the interval non-degenerate.

Introduced in #10258; #10611 routed the Monte Carlo path through the same helper, extending it to intervals.

Note: this adds a fitted attribute, so estimators pickled before the change need a re-fit.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

* whether `t_last_` warrants a back-compat fallback for old pickles, or whether requiring a re-fit is acceptable here

#### Did you add any tests for the change?

Yes - `sktime/forecasting/tests/test_arps_dca.py`, 4 tests parametrized over `ArpsExponential`, `ArpsHyperbolic`, `ArpsHarmonic`.

Without the fix 9 of the 12 cases fail; the 3 that pass are exactly the `output="rate"` control cases, which are meant to pass on both sides. With the fix all 12 pass. `check_estimator` reports 743 checks / 0 failed on each of the three classes.

#### Any other comments?

An LLM was used as a search and navigation tool to read the codebase and to draft this description. The defect was located by reading `_apply_forecast_transforms` and its three call sites, and every number above -- the before/after values, the interval widths, and the test counts -- was produced by running the code locally on both sides of the fix.

#### PR checklist

- [x] The PR title starts with [BUG].
