### PR TITLE
[BUG] set capability:categorical_in_X to False for forecasters whose backend requires numeric X

### DIFF
--- a/sktime/forecasting/arch/_statsforecast_arch.py
+++ b/sktime/forecasting/arch/_statsforecast_arch.py
@@ -58,7 +58,7 @@ class StatsForecastGARCH(_GeneralisedStatsForecastAdapter):
         "maintainers": ["eyjo"],
         # estimator type
         # --------------
-        "capability:exogenous": True,
+        "capability:exogenous": False,  # statsforecast ARCH/GARCH ignore X
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
         "python_dependencies": ["statsforecast>=1.5.0"],
@@ -139,7 +139,7 @@ class StatsForecastARCH(_GeneralisedStatsForecastAdapter):
         "maintainers": ["eyjo"],
         # estimator type
         # --------------
-        "capability:exogenous": True,
+        "capability:exogenous": False,  # statsforecast ARCH/GARCH ignore X
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
         "python_dependencies": ["statsforecast>=1.5.0"],

--- a/sktime/forecasting/arch/_uarch.py
+++ b/sktime/forecasting/arch/_uarch.py
@@ -172,6 +172,7 @@ class ARCH(BaseForecaster):
         "capability:missing_values": False,
         "capability:pred_int": True,
         "capability:exogenous": True,
+        "capability:categorical_in_X": False,
         "capability:non_contiguous_X": False,
         "capability:random_state": True,
         "property:randomness": "derandomized",

--- a/sktime/forecasting/base/adapters/_fbprophet.py
+++ b/sktime/forecasting/base/adapters/_fbprophet.py
@@ -19,6 +19,7 @@ class _ProphetAdapter(BaseForecaster):
         "authors": ["bletham", "tcuongd", "mloning", "aiwalter", "fkiraly"],
         # bletham and tcuongd for prophet/fbprophet
         "capability:exogenous": True,
+        "capability:categorical_in_X": False,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
         "requires-fh-in-fit": False,

--- a/sktime/forecasting/base/adapters/_generalised_statsforecast.py
+++ b/sktime/forecasting/base/adapters/_generalised_statsforecast.py
@@ -28,6 +28,7 @@ class _GeneralisedStatsForecastAdapter(BaseForecaster):
         "y_inner_mtype": "pd.Series",
         "X_inner_mtype": "pd.DataFrame",
         "capability:multivariate": False,
+        "capability:categorical_in_X": False,
         "requires-fh-in-fit": False,
         # "X-y-must-have-same-index": True,  # TODO: need to check (how?)
         # "enforce_index_type": None,  # TODO: need to check (how?)

--- a/sktime/forecasting/base/adapters/_pmdarima.py
+++ b/sktime/forecasting/base/adapters/_pmdarima.py
@@ -24,6 +24,7 @@ class _PmdArimaAdapter(BaseForecaster):
         # estimator type
         # --------------
         "capability:exogenous": True,
+        "capability:categorical_in_X": False,
         "capability:pred_int": True,
         "capability:pred_int:insample": True,
         "requires-fh-in-fit": False,

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -27,6 +27,7 @@ class _StatsModelsAdapter(BaseForecaster):
         # estimator type
         # --------------
         "capability:exogenous": False,
+        "capability:categorical_in_X": False,
         "requires-fh-in-fit": False,
         "capability:missing_values": False,
         # CI and testing tags


### PR DESCRIPTION
#### Reference Issues/PRs
Ref #10851 (second item: fix wrong `capability:categorical_in_X` tags flagged by the test in #10842). See also #10808.

#### What does this implement/fix? Explain your changes.
Forecasters based on statsmodels, pmdarima, prophet, statsforecast, and arch cast exogenous `X` to a numeric array and fail with  an error on categorical columns (`could not convert string to float`, `Pandas data cast to numpy dtype of object`, `xreg should be a float array`, ...), but inherited the default `capability:categorical_in_X=True`. This sets the tag to `False`, so the base class raises the informative `TypeError` instead:

- on the shared adapter base classes `_StatsModelsAdapter`, `_PmdArimaAdapter`, `_ProphetAdapter`, `_GeneralisedStatsForecastAdapter`
- on `ARCH` (arch package)

Also sets `capability:exogenous=False` on `StatsForecastARCH` and `StatsForecastGARCH`: statsforecast's `ARCH`/`GARCH` `fit` never uses `X` (predictions are identical with no `X`, numeric `X`, or categorical `X`), so the tag was inaccurate. No behaviour change for users, `X` was already ignored.

#### What was checked
Ran the `test_categorical_X_passes` logic from #10842 (`fit` with a string column in `X`) over all forecasters and all their `get_test_params` instances, on Python 3.12 with the `[forecasting]` soft dependencies installed (statsmodels, pmdarima, prophet, statsforecast, skforecast, arch).

| | classes |
|---|---|
| forecasters with `capability:exogenous=True` | 91 |
| tested | 58 |
| not tested, soft dependency not installed | 33 |

**Failed, not scikit-learn based, fixed in this PR (13):** `ARCH`, `ARDL`, `ARIMA`, `AutoARIMA`, `AutoREG`, `DynamicFactor`, `Prophet`, `SARIMAX`, `StatsForecastAutoARIMA`, `StatsModelsARIMA`, `UnobservedComponents`, `VARMAX`, `VECM`. After this PR, all 13 pass `test_categorical_X_raises_error` and none remain in the failing set.

**Failed, scikit-learn based, not in this PR (16):** `DirectReductionForecaster`, `RecursiveReductionForecaster`, `YfromX`, the six `make_reduction` classes, `SkforecastRecursive`, and composites wrapping them (`EnsembleForecaster`, `TransformedTargetForecaster`, `ForecastingPipeline`, `BaggingForecaster`, `ResidualBoostingForecaster`) plus `ForecastX`. Per the discussion in #10851 these need `__dynamic_tags__` logic based on the inner estimator, and composites need to delegate the tag; separate PR.

**Passed (13):** `AutoEnsembleForecaster`, `BoxCoxBiasAdjustedForecaster`, `DoubleMLForecaster`, `DummyGlobalForecaster`, `EnsembleForecaster` (non-sklearn instance), `FallbackForecaster`, `FhPlexForecaster`, `IgnoreX`, `MAPAForecaster`, `ReconcilerForecaster`, `TSB`, `ThetaModularForecaster`, `BaggingForecaster` (non-sklearn instance).

<details><summary>Not tested (33), soft dependency not installed; follow-up</summary>

`AutoResearchForecaster`, `AutoTS`, `CINNForecaster`, `Chronos2Forecaster`, `DartsLinearRegressionModel`, `DartsRegressionModel`, `DartsXGBModel`, `EnbPIForecaster`, `ForecastingOptCV`, `ForecastingSkoptSearchCV`, `GreykiteForecaster`, `HFTransformersForecaster`, `HierarchicalProphet`, `HyperTreeNetARForecaster`, `MOIRAIForecaster`, `Moirai2Forecaster`, `NeuralForecastDilatedRNN`, `NeuralForecastGRU`, `NeuralForecastLSTM`, `NeuralForecastRNN`, `NeuralForecastTCN`, `NeuralProphet`, `Prophetverse`, `PyKANForecaster`, `PytorchForecastingDeepAR`, `PytorchForecastingNHiTS`, `PytorchForecastingTFT`, `SkforecastAutoreg`, `T0Forecaster`, `TiRex2Forecaster`, `TinyTimeMixerForecaster`, `TotoForecaster`, `WindFMForecaster`
</details>

Composites whose test instances wrap a non-exogenous forecaster are not exercised by the check (tag delegated to `exogenous=False`).

#### Does your contribution introduce a new dependency? If yes, which one?
No.
