### PR TITLE
[ENH] add quantile prediction capability to Chronos2Forecaster

### DIFF
--- a/sktime/forecasting/chronos2.py
+++ b/sktime/forecasting/chronos2.py
@@ -82,7 +82,8 @@ class Chronos2Forecaster(BaseForecaster):
         "requires-fh-in-fit": False,
         "X-y-must-have-same-index": False,
         "capability:missing_values": False,
-        "capability:pred_int": False,
+        "capability:pred_int": True,
+        "capability:pred_int:insample": False,
         "y_inner_mtype": "pd.DataFrame",
         "X_inner_mtype": "pd.DataFrame",
         "capability:multivariate": True,
@@ -228,6 +229,48 @@ class Chronos2Forecaster(BaseForecaster):
         -------
         y_pred : pd.DataFrame
         """
+        pred_tensor, prediction_length = self._predict_tensor(fh, X)
+
+        quantiles = self.model_pipeline.quantiles
+        median_idx = quantiles.index(0.5)
+        point_forecast = pred_tensor[:, median_idx, :].numpy()
+
+        index = (
+            ForecastingHorizon(range(1, prediction_length + 1))
+            .to_absolute(self._cutoff)
+            ._values
+        )
+        pred_out = fh.get_expected_pred_idx(self._context, cutoff=self.cutoff)
+
+        pred_df = pd.DataFrame(
+            point_forecast.T,
+            index=index,
+            columns=self._get_varnames(),
+        )
+        pred_df.index.names = self._y_index_names
+
+        dateindex = pred_df.index.get_level_values(-1).map(lambda x: x in pred_out)
+        return pred_df.loc[dateindex]
+
+    def _predict_tensor(self, fh, X=None):
+        """Run the underlying Chronos-2 pipeline and return the raw prediction tensor.
+
+        Parameters
+        ----------
+        fh : ForecastingHorizon
+        X : pd.DataFrame, optional
+            Future exogenous covariates (known-future). Column names must be
+            a subset of X provided in fit.
+
+        Returns
+        -------
+        pred_tensor : torch.Tensor
+            Raw prediction tensor of shape
+            ``(n_variates, n_quantiles, prediction_length)``
+            as returned by ``Chronos2Pipeline.predict``.
+        prediction_length : int
+            Number of steps ahead the tensor was generated for.
+        """
         import transformers
 
         self._ensure_model_pipeline_loaded()
@@ -270,27 +313,71 @@ class Chronos2Forecaster(BaseForecaster):
             limit_prediction_length=self._config["limit_prediction_length"],
         )
 
-        pred_tensor = predictions[0]
-        quantiles = self.model_pipeline.quantiles
-        median_idx = quantiles.index(0.5)
-        point_forecast = pred_tensor[:, median_idx, :].numpy()
+        return predictions[0], prediction_length
+
+    def _predict_quantiles(self, fh, X=None, alpha=None):
+        """Compute/return prediction quantiles for a forecast.
+
+        The underlying Chronos-2 pipeline natively outputs a grid of quantile
+        forecasts (``model_pipeline.quantiles``). This method interpolates that
+        grid onto the requested ``alpha`` levels, so arbitrary quantile levels
+        can be returned without a second forward pass.
+
+        Parameters
+        ----------
+        fh : ForecastingHorizon
+        X : pd.DataFrame, optional
+            Future exogenous covariates (known-future). Column names must be
+            a subset of X provided in fit.
+        alpha : list of float
+            A list of probabilities at which quantile forecasts are computed.
+
+        Returns
+        -------
+        quantiles : pd.DataFrame
+            Column has multi-index: first level is variable name from y in fit,
+            second level being the values of alpha passed to the function.
+            Row index is fh. Entries are quantile forecasts, for var in col index,
+            at quantile probability in second col index, for the row index.
+        """
+        pred_tensor, prediction_length = self._predict_tensor(fh, X)
+
+        native_quantiles = np.asarray(self.model_pipeline.quantiles, dtype=float)
+        sort_idx = np.argsort(native_quantiles)
+        native_quantiles = native_quantiles[sort_idx]
+        sorted_tensor = pred_tensor.detach().cpu().numpy()[:, sort_idx, :]
+
+        alpha_arr = np.asarray(alpha, dtype=float)
+        # interpolate the native quantile grid onto the requested alpha levels,
+        # for each variate and each horizon step
+        quantile_vals = np.stack(
+            [
+                np.interp(alpha_arr, native_quantiles, sorted_tensor[v, :, t])
+                for v in range(sorted_tensor.shape[0])
+                for t in range(sorted_tensor.shape[2])
+            ]
+        ).reshape(sorted_tensor.shape[0], sorted_tensor.shape[2], len(alpha))
 
         index = (
             ForecastingHorizon(range(1, prediction_length + 1))
             .to_absolute(self._cutoff)
             ._values
         )
-        pred_out = fh.get_expected_pred_idx(context, cutoff=self.cutoff)
+        pred_out = fh.get_expected_pred_idx(self._context, cutoff=self.cutoff)
 
-        pred_df = pd.DataFrame(
-            point_forecast.T,
-            index=index,
-            columns=self._get_varnames(),
+        var_names = self._get_varnames()
+        cols_idx = pd.MultiIndex.from_product([var_names, alpha])
+        pred_quantiles = pd.DataFrame(index=index, columns=cols_idx)
+        pred_quantiles.index.names = self._y_index_names
+
+        for i, var_name in enumerate(var_names):
+            for j, a in enumerate(alpha):
+                pred_quantiles[(var_name, a)] = quantile_vals[i, :, j]
+
+        dateindex = pred_quantiles.index.get_level_values(-1).map(
+            lambda x: x in pred_out
         )
-        pred_df.index.names = self._y_index_names
-
-        dateindex = pred_df.index.get_level_values(-1).map(lambda x: x in pred_out)
-        return pred_df.loc[dateindex]
+        return pred_quantiles.loc[dateindex]
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/forecasting/tests/test_chronos2.py
+++ b/sktime/forecasting/tests/test_chronos2.py
@@ -141,6 +141,112 @@ def test_chronos2_multivariate_cross_learning_matches_source_reference():
     not _check_estimator_deps(Chronos2Forecaster, severity="none"),
     reason="Chronos2Forecaster soft dependencies not available",
 )
+def test_chronos2_predict_quantiles_median_matches_point_forecast():
+    """The median quantile forecast equals the point forecast.
+
+    Chronos2Forecaster discards all native quantile levels except the median in
+    ``_predict``; ``predict_quantiles`` reuses the same tensor, so the 0.5 quantile
+    must coincide with the point forecast exactly.
+    """
+    import torch
+
+    y = load_airline()
+    y_train = y.iloc[:-12]
+    fh = np.arange(1, 13)
+
+    forecaster = Chronos2Forecaster(
+        model_path="autogluon/chronos-2-small",
+        config={"device_map": "cpu", "torch_dtype": torch.float32},
+        seed=1,
+    )
+    forecaster.fit(y_train, fh=fh)
+
+    assert forecaster.get_tag("capability:pred_int") is True
+
+    y_pred = forecaster.predict(fh=fh)
+    quantiles = forecaster.predict_quantiles(fh=fh, alpha=[0.5])
+
+    median_col = ("Number of airline passengers", 0.5)
+    np.testing.assert_allclose(
+        quantiles[median_col].to_numpy(),
+        y_pred.to_numpy().flatten(),
+        atol=1e-4,
+    )
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(Chronos2Forecaster, severity="none"),
+    reason="Chronos2Forecaster soft dependencies not available",
+)
+def test_chronos2_predict_quantiles_are_monotone_in_alpha():
+    """Quantile forecasts are non-decreasing in the quantile level alpha."""
+    import torch
+
+    y = load_airline()
+    y_train = y.iloc[:-12]
+    fh = np.arange(1, 13)
+
+    forecaster = Chronos2Forecaster(
+        model_path="autogluon/chronos-2-small",
+        config={"device_map": "cpu", "torch_dtype": torch.float32},
+        seed=1,
+    )
+    forecaster.fit(y_train, fh=fh)
+
+    alpha = [0.1, 0.5, 0.9]
+    quantiles = forecaster.predict_quantiles(fh=fh, alpha=alpha)
+
+    # alpha levels not on the native Chronos-2 grid (0.01..0.99 in steps of 0.05
+    # for the boundary levels) must be interpolated; the interpolated quantiles
+    # must still bracket the median.
+    quantiles_interp = forecaster.predict_quantiles(fh=fh, alpha=[0.025, 0.975])
+
+    name = "Number of airline passengers"
+    lo, med, hi = (quantiles[(name, a)].to_numpy() for a in [0.1, 0.5, 0.9])
+    assert np.all(lo <= med) and np.all(med <= hi)
+
+    lo2 = quantiles_interp[(name, 0.025)].to_numpy()
+    hi2 = quantiles_interp[(name, 0.975)].to_numpy()
+    assert np.all(lo2 <= med) and np.all(med <= hi2)
+
+    # all requested columns must be present, in the order requested
+    assert quantiles.columns.tolist() == [(name, a) for a in alpha]
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(Chronos2Forecaster, severity="none"),
+    reason="Chronos2Forecaster soft dependencies not available",
+)
+def test_chronos2_predict_interval_bounds_enclose_median():
+    """Prediction intervals returned via predict_interval enclose the median."""
+    import torch
+
+    y = load_airline()
+    y_train = y.iloc[:-12]
+    fh = np.arange(1, 13)
+
+    forecaster = Chronos2Forecaster(
+        model_path="autogluon/chronos-2-small",
+        config={"device_map": "cpu", "torch_dtype": torch.float32},
+        seed=1,
+    )
+    forecaster.fit(y_train, fh=fh)
+
+    y_pred = forecaster.predict(fh=fh)
+    intervals = forecaster.predict_interval(fh=fh, coverage=0.9)
+
+    name = "Number of airline passengers"
+    lo = intervals[(name, 0.9, "lower")].to_numpy()
+    up = intervals[(name, 0.9, "upper")].to_numpy()
+    med = y_pred.to_numpy().flatten()
+
+    assert np.all(lo <= med) and np.all(med <= up)
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(Chronos2Forecaster, severity="none"),
+    reason="Chronos2Forecaster soft dependencies not available",
+)
 def test_chronos2_covariates_match_source_reference():
     """Predictions with past/future covariates match the source implementation."""
     import torch


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10850

#### What does this implement/fix? Explain your changes.

`Chronos2Forecaster` advertised `capability:pred_int: False` and did not implement `_predict_quantiles`, so `predict_quantiles()` (directly, or indirectly via a `ForecastingPipeline`) raised `NotImplementedError`. This was a genuine capability gap: `Chronos2Pipeline.predict` already returns a full multi-quantile tensor, and `_predict` discarded everything except the median.

Changes in `sktime/forecasting/chronos2.py`:

- implement `_predict_quantiles`, which reuses the single pipeline forward pass (extracted into a shared `_predict_tensor` helper) and linearly interpolates the native quantile grid (`model_pipeline.quantiles`, e.g. 0.01–0.99) onto the requested `alpha` levels. Arbitrary alpha levels can therefore be returned without a second forward pass.
- set `capability:pred_int: True` and `capability:pred_int:insample: False` (insample forecasting is unsupported, matching `capability:insample: False`).

This follows the established pattern in the sibling zero-shot foundation-model adapter `sktime/forecasting/toto.py`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Correctness of the quantile interpolation (native grid → requested alpha levels).
- Whether the docstrings and the shared `_predict_tensor` refactor match the project's conventions.

#### Did you add any tests for the change?

Yes – new tests in `sktime/forecasting/tests/test_chronos2.py`:

- median quantile forecast equals the point forecast exactly (both come from the same tensor);
- quantile forecasts are monotone non-decreasing in alpha, including interpolated levels not on the native grid;
- `predict_interval` bounds enclose the median.

Test evidence (local run, Windows CPU, `autogluon/chronos-2-small`):

```
$ python -m pytest sktime/forecasting/tests/test_chronos2.py -o addopts="" -q
9 passed in 18.61s
```

Additional end-to-end checks on the airline dataset: `capability:pred_int` reads True after the change; interpolated alpha levels (0.025/0.975) stay bounded by the median; `predict_interval(coverage=0.9)` encloses the median.

Lint/format: `ruff check` and `ruff format --check` clean on both changed files.

### Any other comments?

#### PR checklist

##### For all contributions

- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/sktime/blob/main/.all-contributorsrc) in the `sktime` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag - do this if you want to become the owner or maintainer of an estimator you added.
  See here for further details on the [algorithm maintainer role](https://www.sktime.net/en/latest/get_involved/governance.html#algorithm-maintainers).
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. ([ENH] - adding or improving code)

##### For new estimators

- [ ] N/A – no new estimator is added; this extends an existing one.
