### PR TITLE
[DOC] add capability:multivariate and capability:pairwise to docs

### DIFF
--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -254,6 +254,8 @@ This section lists tags applying to parameter estimators (``"param_est"`` type).
     :nosignatures:
 
     scitype__X
+    capability__multivariate
+    capability__pairwise_parameter_estimation
 
 
 Common developer tags

--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -255,7 +255,7 @@ This section lists tags applying to parameter estimators (``"param_est"`` type).
 
     scitype__X
     capability__multivariate
-    capability__pairwise_parameter_estimation
+    capability__pairwise
 
 
 Common developer tags

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -2584,7 +2584,7 @@ class property__alignment_type(_BaseTag):
 # ------------------------
 
 
-class capability__pairwise_parameter_estimation(_BaseTag):
+class capability__pairwise(_BaseTag):
     """Capability: parameter estimator supports pairwise parameter estimation.
 
     - String name: ``"capability:pairwise"``


### PR DESCRIPTION
#### Reference Issues/PRs

Follow-up to #10876. Towards #10804.

#### What does this implement/fix? Explain your changes.

I added `capability:multivariate` and `capability:pairwise`, the other two `param_est` tags, to the "Tags for parameter estimators" section in `tags.rst`. Both already have `_BaseTag` classes, just weren't listed in the docs.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

N/A

#### Did you add any tests for the change?

No.

#### PR checklist

- [x] I've added myself to the list of contributors (already done via #10833).
- [x] The PR title starts with `[DOC]`.
