### PR TITLE
[DOC] add Parameters section to `LSTMFCNNetwork` class docstring

### DIFF
--- a/sktime/networks/lstmfcn/_lstmfcn_tf.py
+++ b/sktime/networks/lstmfcn/_lstmfcn_tf.py
@@ -39,6 +39,13 @@ class LSTMFCNNetwork(BaseDeepNetwork):
     ----------
     .. [1] Karim et al. Multivariate LSTM-FCNs for Time Series Classification, 2019
     https://arxiv.org/pdf/1801.04503.pdf
+
+    Examples
+    --------
+    >>> from sktime.networks.lstmfcn import LSTMFCNNetwork
+    >>> network = LSTMFCNNetwork(
+    ...     random_state=42, kernel_sizes=(8, 5, 3), filter_sizes=(128, 256, 128)
+    ... )
     """
 
     _tags = {

--- a/sktime/networks/lstmfcn/_lstmfcn_tf.py
+++ b/sktime/networks/lstmfcn/_lstmfcn_tf.py
@@ -11,6 +11,25 @@ class LSTMFCNNetwork(BaseDeepNetwork):
     Combines an LSTM arm with a CNN arm. Optionally uses an attention mechanism in the
     LSTM which the author indicates provides improved performance.
 
+    Parameters
+    ----------
+    kernel_sizes : List[int], default=[8, 5, 3]
+        specifying the length of the 1D convolution windows
+    filter_sizes : List[int], default=[128, 256, 128]
+        size of filter for each conv layer
+    random_state : int, default=0
+        seed to any needed random actions
+    lstm_size : int, default=8
+        output dimension for LSTM layer
+    dropout : float, default=0.8
+        controls dropout rate of LSTM layer
+    attention : boolean, default=False
+        If True, uses custom attention LSTM layer
+    activation : string, default = "relu"
+        activation function used for hidden layers;
+        List of available keras activation functions:
+        https://keras.io/api/layers/activations/
+
     Notes
     -----
     Ported from sktime-dl source code
@@ -37,28 +56,7 @@ class LSTMFCNNetwork(BaseDeepNetwork):
         attention=False,
         activation="relu",
     ):
-        """Initialize a new LSTMFCNNetwork object.
-
-        Parameters
-        ----------
-        kernel_sizes : List[int], default=[8, 5, 3]
-            specifying the length of the 1D convolution
-         windows
-        filter_sizes : List[int], default=[128, 256, 128]
-            size of filter for each conv layer
-        random_state : int, default=0
-            seed to any needed random actions
-        lstm_size : int, default=8
-            output dimension for LSTM layer
-        dropout : float, default=0.8
-            controls dropout rate of LSTM layer
-        attention : boolean, default=False
-            If True, uses custom attention LSTM layer
-        activation : string, default = "relu"
-            activation function used for hidden layers;
-            List of available keras activation functions:
-            https://keras.io/api/layers/activations/
-        """
+        """Initialize a new LSTMFCNNetwork object."""
         self.activation = activation
         self.random_state = random_state
         self.kernel_sizes = kernel_sizes


### PR DESCRIPTION
Fixes #9309. LSTMFCNNetwork's class docstring was missing a Parameters section, the params were only documented inside __init__'s docstring instead. Moved them to the class docstring, matching the convention used by LSTMFCNNetworkTorch in the same package.