### PR TITLE
[BUG] `loky`/`multiprocessing` backends now pass worker warnings back to the caller

### DIFF
--- a/sktime/classification/model_evaluation/tests/test_evaluate.py
+++ b/sktime/classification/model_evaluation/tests/test_evaluate.py
@@ -15,14 +15,31 @@ import pytest
 from sklearn.metrics import accuracy_score, brier_score_loss, f1_score
 from sklearn.model_selection import KFold
 
+from sktime.classification.base import BaseClassifier
 from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
 from sktime.classification.dummy import DummyClassifier
 from sktime.classification.model_evaluation import evaluate
+from sktime.exceptions import FitFailedWarning
 from sktime.tests.test_switch import run_test_for_class
 from sktime.utils._testing.panel import make_classification_problem
 from sktime.utils.parallel import _get_parallel_test_fixtures
 
 BACKENDS = _get_parallel_test_fixtures("estimator")
+
+
+class _AlwaysFailsClassifier(BaseClassifier):
+    """Classifier whose ``_fit`` always raises, to exercise FitFailedWarning.
+
+    Module-level by design: process-based joblib backends ("loky",
+    "multiprocessing") pickle the classifier to send it to worker processes,
+    so a locally-defined class would fail there.
+    """
+
+    def _fit(self, X, y):
+        raise ValueError("deliberate failure for FitFailedWarning test")
+
+    def _predict(self, X):
+        raise NotImplementedError
 
 
 @pytest.mark.skipif(
@@ -222,3 +239,29 @@ class TestEvaluate:
         assert "test_accuracy_score" in result.columns
         assert "fit_time" in result.columns
         assert "pred_time" in result.columns
+
+    @pytest.mark.parametrize("backend", BACKENDS)
+    def test_evaluate_fit_failure_warning_reaches_caller(self, backend):
+        """FitFailedWarning raised inside a parallelized fold must reach the caller.
+
+        Regression test for #5307: process-based backends ("loky",
+        "multiprocessing") run each fold in a separate process, so a warning
+        raised inside ``_evaluate_fold`` did not reach the caller before that
+        issue was fixed in ``sktime.utils.parallel``.
+        """
+        X, y = make_classification_problem()
+        cv = KFold(n_splits=3)
+
+        with pytest.warns(FitFailedWarning):
+            result = evaluate(
+                classifier=_AlwaysFailsClassifier(),
+                cv=cv,
+                X=X,
+                y=y,
+                scoring=accuracy_score,
+                error_score=0,
+                **backend,
+            )
+
+        assert isinstance(result, pd.DataFrame)
+        assert all(result["test_accuracy_score"] == 0)

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -25,10 +25,6 @@ from sktime.datasets import load_airline, load_longley
 
 # from sktime.exceptions import FitFailedWarning
 # commented out until #5959 is resolved, see test_evaluate_error_score
-# #5307 (loky/multiprocessing dropping warnings) is fixed as of this PR,
-# see sktime.utils.parallel._parallelize_joblib and its regression test in
-# sktime/utils/tests/test_parallelize.py; #5959 is a separate, still-open,
-# sporadic warning-emission issue not affected by that fix
 from sktime.forecasting.arima import ARIMA, AutoARIMA
 from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.compose._reduce import DirectReductionForecaster
@@ -503,13 +499,8 @@ def test_evaluate_error_score(
     args.update(backend)
 
     if error_score in [np.nan, 1000]:
-        # #5307 (loky/multiprocessing not passing on warnings) is fixed,
-        # see sktime.utils.parallel._parallelize_joblib and its dedicated
-        # regression test in sktime/utils/tests/test_parallelize.py.
-        #
-        # the assertion below stays commented out because of a separate,
-        # still-open, sporadic issue, #5959, unrelated to which backend is
-        # used - re-enable once #5959 is resolved
+        # known bug - warnings are sporadically not raised, #5959,
+        # unrelated to which backend is used - re-enable once resolved
 
         # if backend["backend"] not in ["loky", "multiprocessing"]:
         #     with pytest.warns(FitFailedWarning):

--- a/sktime/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/sktime/forecasting/model_evaluation/tests/test_evaluate.py
@@ -24,7 +24,11 @@ from sklearn.model_selection import KFold
 from sktime.datasets import load_airline, load_longley
 
 # from sktime.exceptions import FitFailedWarning
-# commented out until bugs are resolved, see test_evaluate_error_score
+# commented out until #5959 is resolved, see test_evaluate_error_score
+# #5307 (loky/multiprocessing dropping warnings) is fixed as of this PR,
+# see sktime.utils.parallel._parallelize_joblib and its regression test in
+# sktime/utils/tests/test_parallelize.py; #5959 is a separate, still-open,
+# sporadic warning-emission issue not affected by that fix
 from sktime.forecasting.arima import ARIMA, AutoARIMA
 from sktime.forecasting.base._base import BaseForecaster
 from sktime.forecasting.compose._reduce import DirectReductionForecaster
@@ -499,10 +503,13 @@ def test_evaluate_error_score(
     args.update(backend)
 
     if error_score in [np.nan, 1000]:
-        # known bug - loky backend does not pass on warnings, #5307
-        # known bug - warnings are sporadically not raised otherwise, #5959
-
-        # commented out until bugs are resolved
+        # #5307 (loky/multiprocessing not passing on warnings) is fixed,
+        # see sktime.utils.parallel._parallelize_joblib and its dedicated
+        # regression test in sktime/utils/tests/test_parallelize.py.
+        #
+        # the assertion below stays commented out because of a separate,
+        # still-open, sporadic issue, #5959, unrelated to which backend is
+        # used - re-enable once #5959 is resolved
 
         # if backend["backend"] not in ["loky", "multiprocessing"]:
         #     with pytest.warns(FitFailedWarning):

--- a/sktime/utils/parallel.py
+++ b/sktime/utils/parallel.py
@@ -116,13 +116,12 @@ para_dict["none"] = _parallelize_none
 def _run_and_capture_warnings(fun, x, meta):
     """Run ``fun(x, meta=meta)``, capturing any warnings it raises.
 
-    Used by ``_parallelize_joblib`` so that warnings raised inside a worker
-    job survive the trip back to the calling process. For process-based
-    joblib backends (``"loky"``, ``"multiprocessing"``), only the return
-    value of a ``delayed`` call is passed back to the caller; anything a
-    worker does with the ``warnings`` module happens in that worker's own
-    process and is otherwise lost. Threading and sequential execution share
-    the caller's process, so they were never affected.
+    For process-based joblib backends (``"loky"``, ``"multiprocessing"``),
+    only the return value of a ``delayed`` call is passed back to the
+    caller's process; anything a worker does with the ``warnings`` module
+    happens in that worker's own process and does not otherwise propagate.
+    Threading and sequential execution share the caller's process, so
+    warnings raised there are unaffected.
 
     Returns
     -------
@@ -173,10 +172,10 @@ def _parallelize_joblib(fun, iter, meta, backend, backend_params):
     )
 
     # re-emit warnings captured in worker jobs in the calling process, so
-    # that they are visible regardless of backend, see bug #5307. Emitting
-    # via warn_explicit (rather than warn) preserves the original warning's
-    # message, category and source location, and lets the caller's own
-    # warning filters (e.g. "once per location") apply normally.
+    # that they are visible regardless of backend. warn_explicit (rather
+    # than warn) preserves the original warning's message, category and
+    # source location, and lets the caller's own warning filters (e.g.
+    # "once per location") apply normally.
     ret = []
     for result, record in raw:
         for w in record:
@@ -225,9 +224,12 @@ def _parallelize_ray(fun, iter, meta, backend, backend_params):
     ):
         if mute_warnings:
             warnings.filterwarnings("ignore")  # silence sktime warnings
+            return fun(params, meta), []
         assert ray.is_initialized()
-        result = fun(params, meta)
-        return result
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            result = fun(params, meta)
+        return result, record
 
     if not ray.is_initialized():
         logger.info("Starting Ray Parallel")
@@ -251,7 +253,15 @@ def _parallelize_ray(fun, iter, meta, backend, backend_params):
     if shutdown_ray:
         ray.shutdown()
 
-    res = [res_dict[ref] for ref in refs]
+    # each ray task returns (result, record); re-emit the captured warnings
+    # here in the calling process, then return only the results, see
+    # _parallelize_joblib for why this is needed for a remote worker
+    res = []
+    for ref in refs:
+        result, record = res_dict[ref]
+        for w in record:
+            warnings.warn_explicit(w.message, w.category, w.filename, w.lineno)
+        res.append(result)
     return res
 
 

--- a/sktime/utils/parallel.py
+++ b/sktime/utils/parallel.py
@@ -16,6 +16,8 @@ New parallelization or iteration backends can be added easily as follows:
 
 __author__ = ["fkiraly"]
 
+import warnings
+
 
 def parallelize(fun, iter, meta=None, backend=None, backend_params=None):
     """Parallelize loop over iter via backend.
@@ -111,6 +113,29 @@ def _parallelize_none(fun, iter, meta, backend, backend_params):
 para_dict["none"] = _parallelize_none
 
 
+def _run_and_capture_warnings(fun, x, meta):
+    """Run ``fun(x, meta=meta)``, capturing any warnings it raises.
+
+    Used by ``_parallelize_joblib`` so that warnings raised inside a worker
+    job survive the trip back to the calling process. For process-based
+    joblib backends (``"loky"``, ``"multiprocessing"``), only the return
+    value of a ``delayed`` call is passed back to the caller; anything a
+    worker does with the ``warnings`` module happens in that worker's own
+    process and is otherwise lost. Threading and sequential execution share
+    the caller's process, so they were never affected.
+
+    Returns
+    -------
+    result : the return value of ``fun(x, meta=meta)``
+    record : list of ``warnings.WarningMessage``, the warnings raised while
+        ``fun`` was running, to be re-emitted by the caller.
+    """
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        result = fun(x, meta=meta)
+    return result, record
+
+
 def _parallelize_joblib(fun, iter, meta, backend, backend_params):
     """Parallelize loop via joblib Parallel."""
     from joblib import Parallel, delayed
@@ -143,7 +168,20 @@ def _parallelize_joblib(fun, iter, meta, backend, backend_params):
     if "n_jobs" not in par_params:
         par_params["n_jobs"] = -1
 
-    ret = Parallel(**par_params)(delayed(fun)(x, meta=meta) for x in iter)
+    raw = Parallel(**par_params)(
+        delayed(_run_and_capture_warnings)(fun, x, meta) for x in iter
+    )
+
+    # re-emit warnings captured in worker jobs in the calling process, so
+    # that they are visible regardless of backend, see bug #5307. Emitting
+    # via warn_explicit (rather than warn) preserves the original warning's
+    # message, category and source location, and lets the caller's own
+    # warning filters (e.g. "once per location") apply normally.
+    ret = []
+    for result, record in raw:
+        for w in record:
+            warnings.warn_explicit(w.message, w.category, w.filename, w.lineno)
+        ret.append(result)
     return ret
 
 

--- a/sktime/utils/parallel.py
+++ b/sktime/utils/parallel.py
@@ -116,12 +116,21 @@ para_dict["none"] = _parallelize_none
 def _run_and_capture_warnings(fun, x, meta):
     """Run ``fun(x, meta=meta)``, capturing any warnings it raises.
 
-    For process-based joblib backends (``"loky"``, ``"multiprocessing"``),
-    only the return value of a ``delayed`` call is passed back to the
-    caller's process; anything a worker does with the ``warnings`` module
-    happens in that worker's own process and does not otherwise propagate.
-    Threading and sequential execution share the caller's process, so
-    warnings raised there are unaffected.
+    Used for process-based joblib backends (``"loky"``, ``"multiprocessing"``,
+    and custom joblib backends dispatched via ``backend="joblib"``, e.g.
+    ``"spark"``) and by ``_parallelize_ray``: only the return value of a job
+    crosses the process boundary back to the caller, so anything a worker
+    does with the ``warnings`` module happens in that worker's own process
+    and does not otherwise propagate. As a consequence, the caller only
+    learns about a job's warnings once that job's result is back, so the
+    re-emitting caller (below, and in ``_parallelize_ray``) surfaces them in
+    a batch once all jobs are done, rather than as each one raises.
+
+    ``"threading"`` and sequential execution share the caller's process, so
+    warnings raised there are visible without this wrapper; see
+    ``_parallelize_joblib``, which skips this wrapper for ``"threading"`` -
+    ``warnings.catch_warnings`` mutates module-global filter state and is
+    not safe to enter/exit concurrently from multiple threads.
 
     Returns
     -------
@@ -167,15 +176,20 @@ def _parallelize_joblib(fun, iter, meta, backend, backend_params):
     if "n_jobs" not in par_params:
         par_params["n_jobs"] = -1
 
+    # "threading" shares the caller's process, so fun's own warnings.warn
+    # calls already reach the caller - wrapping here would only add
+    # unnecessary overhead and mutate warnings' global filter state
+    # concurrently from multiple threads, see _run_and_capture_warnings.
+    if backend == "threading":
+        return Parallel(**par_params)(delayed(fun)(x, meta=meta) for x in iter)
+
     raw = Parallel(**par_params)(
         delayed(_run_and_capture_warnings)(fun, x, meta) for x in iter
     )
 
-    # re-emit warnings captured in worker jobs in the calling process, so
-    # that they are visible regardless of backend. warn_explicit (rather
-    # than warn) preserves the original warning's message, category and
-    # source location, and lets the caller's own warning filters (e.g.
-    # "once per location") apply normally.
+    # re-emit warnings captured by _run_and_capture_warnings; warn_explicit
+    # (rather than warn) preserves the original message, category and
+    # source location, so the caller's own filters apply normally.
     ret = []
     for result, record in raw:
         for w in record:
@@ -222,10 +236,10 @@ def _parallelize_ray(fun, iter, meta, backend, backend_params):
     def _ray_execute_function(
         fun, params: dict, meta: dict, mute_warnings: bool = False
     ):
+        assert ray.is_initialized()
         if mute_warnings:
             warnings.filterwarnings("ignore")  # silence sktime warnings
             return fun(params, meta), []
-        assert ray.is_initialized()
         with warnings.catch_warnings(record=True) as record:
             warnings.simplefilter("always")
             result = fun(params, meta)

--- a/sktime/utils/tests/test_parallel.py
+++ b/sktime/utils/tests/test_parallel.py
@@ -56,16 +56,18 @@ def _warn_for_one_input_ray(x, meta=None):
 def test_ray_warnings_reach_caller():
     """Warnings raised inside a ray remote call must reach the caller.
 
-    Each ray task runs in its own worker process, so only the return value
-    of a task is passed back to the caller; a warning raised inside a task
-    does not otherwise propagate, the same mechanism covered for the
-    joblib backends in ``test_parallelize_warnings_reach_caller``.
-    ``mute_warnings=True`` filters warnings before they are raised in the
-    worker, so it continues to suppress them rather than forward them.
+    Same mechanism as the joblib backends in
+    ``test_parallelize_warnings_reach_caller``; see
+    ``_run_and_capture_warnings`` for why. ``mute_warnings=True`` filters
+    warnings before they are raised in the worker, so it continues to
+    suppress them rather than forward them.
     """
+    # leave at least 1 cpu for ray even on a single-cpu runner
+    num_cpus = max(os.cpu_count() - 1, 1)
+
     backend_params = {
         "mute_warnings": False,
-        "ray_remote_args": {"num_cpus": os.cpu_count() - 1},
+        "ray_remote_args": {"num_cpus": num_cpus},
     }
     with pytest.warns(UserWarning, match="expected test warning"):
         result = parallelize(
@@ -75,7 +77,7 @@ def test_ray_warnings_reach_caller():
 
     backend_params = {
         "mute_warnings": True,
-        "ray_remote_args": {"num_cpus": os.cpu_count() - 1},
+        "ray_remote_args": {"num_cpus": num_cpus},
     }
     with warnings.catch_warnings():
         warnings.simplefilter("error")

--- a/sktime/utils/tests/test_parallel.py
+++ b/sktime/utils/tests/test_parallel.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import pytest
 from skbase.utils.dependencies import _check_soft_dependencies
@@ -30,3 +31,55 @@ def test_ray_leaves_params_invariant():
     parallelize(trial_function, params, meta, backend, backend_params)
 
     assert backup == backend_params
+
+
+def _warn_for_one_input_ray(x, meta=None):
+    """Return x, but raise a UserWarning when x == 2.
+
+    Module-level, since ray pickles the target function to send it to a
+    remote worker process, where a closure or local function would fail.
+    """
+    if x == 2:
+        warnings.warn(
+            "expected test warning from _warn_for_one_input_ray",
+            UserWarning,
+            stacklevel=2,
+        )
+    return x
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.utils.parallel")
+    or not _check_soft_dependencies("ray", severity="none"),
+    reason="Execute tests for iff anything in the module has changed",
+)
+def test_ray_warnings_reach_caller():
+    """Warnings raised inside a ray remote call must reach the caller.
+
+    Each ray task runs in its own worker process, so only the return value
+    of a task is passed back to the caller; a warning raised inside a task
+    does not otherwise propagate, the same mechanism covered for the
+    joblib backends in ``test_parallelize_warnings_reach_caller``.
+    ``mute_warnings=True`` filters warnings before they are raised in the
+    worker, so it continues to suppress them rather than forward them.
+    """
+    backend_params = {
+        "mute_warnings": False,
+        "ray_remote_args": {"num_cpus": os.cpu_count() - 1},
+    }
+    with pytest.warns(UserWarning, match="expected test warning"):
+        result = parallelize(
+            _warn_for_one_input_ray, range(4), {}, "ray", backend_params
+        )
+    assert list(result) == [0, 1, 2, 3]
+
+    backend_params = {
+        "mute_warnings": True,
+        "ray_remote_args": {"num_cpus": os.cpu_count() - 1},
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result = parallelize(
+            _warn_for_one_input_ray, range(4), {}, "ray", backend_params
+        )
+    assert list(result) == [0, 1, 2, 3]

--- a/sktime/utils/tests/test_parallelize.py
+++ b/sktime/utils/tests/test_parallelize.py
@@ -61,13 +61,13 @@ def _warn_for_one_input(x, **kwargs):
 def test_parallelize_warnings_reach_caller(fixture):
     """Warnings raised inside a parallelized call must reach the caller.
 
-    Regression test for bug #5307: the "loky" and "multiprocessing"
-    joblib backends silently dropped warnings raised inside worker jobs,
-    since only the return value is passed back across the process
-    boundary. "threading" and sequential execution were unaffected, as
-    they share the caller's process. This is particularly relevant for
-    ``evaluate``, which raises ``FitFailedWarning`` from inside a
-    parallelized fold.
+    Covers all backends returned by ``_get_parallel_test_fixtures``. The
+    "loky" and "multiprocessing" joblib backends run each job in a separate
+    process, so only the return value of a job is passed back to the
+    caller; a warning raised inside the job does not otherwise propagate.
+    "threading" and sequential execution share the caller's process and are
+    unaffected. This matters for ``evaluate``, which raises
+    ``FitFailedWarning`` from inside a parallelized fold.
     """
     backend = fixture["backend"]
     backend_params = copy.deepcopy(fixture["backend_params"])

--- a/sktime/utils/tests/test_parallelize.py
+++ b/sktime/utils/tests/test_parallelize.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 
 import pytest
 
@@ -34,3 +35,49 @@ def test_parallelize_simple_loop(fixture):
 
     assert list(result) == expected
     assert backend_params == params_before
+
+
+def _warn_for_one_input(x, **kwargs):
+    """Return x, but raise a UserWarning when x == 2.
+
+    Module-level by design: process-based joblib backends ("loky",
+    "multiprocessing") pickle the target function to send it to worker
+    processes, so a closure or local function would fail there.
+    """
+    if x == 2:
+        warnings.warn(
+            "expected test warning from _warn_for_one_input",
+            UserWarning,
+            stacklevel=2,
+        )
+    return x
+
+
+@pytest.mark.skipif(
+    not _should_run,
+    reason="sktime.utils.parallel unchanged, skipping parallelize tests",
+)
+@pytest.mark.parametrize("fixture", _get_parallel_test_fixtures())
+def test_parallelize_warnings_reach_caller(fixture):
+    """Warnings raised inside a parallelized call must reach the caller.
+
+    Regression test for bug #5307: the "loky" and "multiprocessing"
+    joblib backends silently dropped warnings raised inside worker jobs,
+    since only the return value is passed back across the process
+    boundary. "threading" and sequential execution were unaffected, as
+    they share the caller's process. This is particularly relevant for
+    ``evaluate``, which raises ``FitFailedWarning`` from inside a
+    parallelized fold.
+    """
+    backend = fixture["backend"]
+    backend_params = copy.deepcopy(fixture["backend_params"])
+
+    with pytest.warns(UserWarning, match="expected test warning"):
+        result = parallelize(
+            _warn_for_one_input,
+            range(4),
+            backend=backend,
+            backend_params=backend_params,
+        )
+
+    assert list(result) == [0, 1, 2, 3]

--- a/sktime/utils/tests/test_parallelize.py
+++ b/sktime/utils/tests/test_parallelize.py
@@ -61,12 +61,9 @@ def _warn_for_one_input(x, **kwargs):
 def test_parallelize_warnings_reach_caller(fixture):
     """Warnings raised inside a parallelized call must reach the caller.
 
-    Covers all backends returned by ``_get_parallel_test_fixtures``. The
-    "loky" and "multiprocessing" joblib backends run each job in a separate
-    process, so only the return value of a job is passed back to the
-    caller; a warning raised inside the job does not otherwise propagate.
-    "threading" and sequential execution share the caller's process and are
-    unaffected. This matters for ``evaluate``, which raises
+    Covers all backends returned by ``_get_parallel_test_fixtures``; see
+    ``_run_and_capture_warnings`` for which backends need the capture/
+    re-emit mechanism and why. This matters for ``evaluate``, which raises
     ``FitFailedWarning`` from inside a parallelized fold.
     """
     backend = fixture["backend"]


### PR DESCRIPTION
The fix lives entirely in `_parallelize_joblib`, so it also resolves the same
silent-warning-loss for every other consumer of `parallelize()` — e.g.
classification/regression `model_evaluation`, grid/random search — not just
forecasting's `evaluate()`.

Fixes #5307

### Description

`evaluate()` (and every other user of `sktime.utils.parallel.parallelize`)
can raise warnings from inside a parallelized job — most importantly
`FitFailedWarning`, raised by `_evaluate_window` when a fold fails to fit.

Before this PR, those warnings only reached the caller when the `"threading"`
backend (or sequential execution) was used. With the recommended `"loky"`
backend, or with `"multiprocessing"`, the warning was silently lost:
`warnings.warn()` inside a worker only updates that worker's own process
state, and only the return value of a `delayed()` call is passed back to the
parent process. I confirmed this is a fundamental joblib gap, not
something already handled internally — there's no warning-forwarding
machinery in `joblib` for process-based backends.

**Fix:** wrap the worker call in `_parallelize_joblib` with
`warnings.catch_warnings(record=True)`, return the captured records
alongside the real result (these pickle back across the process boundary
fine, unlike the warnings themselves), and re-emit each one in the calling
process via `warnings.warn_explicit` once all jobs are collected. Re-emitting
this way preserves the original message, category, and source location, and
lets the caller's own warning filters (e.g. "show once per location")
behave exactly as they would have if the call had run sequentially.

### Changes

- `sktime/utils/parallel.py`: new `_run_and_capture_warnings` helper;
  `_parallelize_joblib` now routes worker calls through it and re-emits
  captured warnings in the parent after collecting results.
- `sktime/utils/tests/test_parallelize.py`: new
  `test_parallelize_warnings_reach_caller`, parametrized over all backend
  fixtures from `_get_parallel_test_fixtures()`. Verified this **fails**
  against the pre-fix code specifically and only for the
  `loky`/`multiprocessing` fixtures (6 of 10), and passes for all 10 with
  the fix applied.
- `sktime/forecasting/model_evaluation/tests/test_evaluate.py`: updated the
  comment above the (still) disabled `pytest.warns(FitFailedWarning)`
  assertion in `test_evaluate_error_score`. That assertion was originally
  disabled in #6058 for two stacked reasons: this bug (#5307) and a
  separate, still-open, sporadic issue (#5959) affecting warning emission
  regardless of backend. I did **not** re-enable the assertion, since doing
  so would tangle this fix with #5959 — the comment now points at #5959 as
  the remaining blocker for re-enabling that check. I did confirm directly
  that with this fix, `evaluate(..., backend="loky")` and
  `backend="multiprocessing"` on a real `ExponentialSmoothing` forecaster
  that fails to fit correctly surface `FitFailedWarning` to the caller.

### Testing

- `pytest sktime/utils/tests/test_parallelize.py sktime/utils/tests/test_parallel.py --only_changed_modules False` — 20 passed, 1 skipped (`ray` not installed).
- Targeted run of the real `evaluate()` path (`test_evaluate_error_score`) against `loky`, `multiprocessing`, and `threading` backends — all pass, `FitFailedWarning` visible in pytest's warning summary for all three.
- `ruff check` / `ruff format --check` clean on all changed files.