### PR TITLE
[ENH] migrate enforce_index_type tag to BaseTag

### DIFF
--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -296,6 +296,7 @@ The tags below have limited use in retrieval or inspection of objects.
 
     x_inner_mtype
     y_inner_mtype
+    enforce_index_type
     visual_block_kind
 
 .. _dev_testing_tags:

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -3011,6 +3011,25 @@ class y_inner_mtype(_BaseTag):
     }
 
 
+class enforce_index_type(_BaseTag):
+    """Index type to enforce during input conversion.
+
+    - String name: ``"enforce_index_type"``
+    - Extension developer tag
+    - Values: type or ``None``
+    - Example: ``pd.DatetimeIndex``
+    - Default: ``None``
+    """
+
+    _tags = {
+        "tag_name": "enforce_index_type",
+        "parent_type": ["forecaster", "regressor"],
+        "tag_type": "type",
+        "short_descr": "passed to input checks, input conversion index type to enforce",
+        "user_facing": False,
+    }
+
+
 class is_univariate(_BaseTag):
     """Property: Whether the dataset is univariate.
 
@@ -3753,12 +3772,6 @@ ESTIMATOR_TAG_REGISTER = [
         ["forecaster", "regressor", "transformer"],
         "bool",
         "do X/y in fit/update and X/fh in predict have to be same indices?",
-    ),
-    (
-        "enforce_index_type",
-        ["forecaster", "regressor"],
-        "type",
-        "passed to input checks, input conversion index type to enforce",
     ),
     (
         "pwtrafo_type",


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10804

#### What function does this tool/patch serve? Please explain the modifications you've made.

This moves `enforce_index_type` from the old tuple-based `ESTIMATOR_TAG_REGISTER` to a dedicated `_BaseTag` class, following the existing tag migration pattern.

The existing tag metadata and behaviour are kept unchanged. The old registry entry is removed so that the tag is picked up through the normal `_BaseTag` registration mechanism. I also added `enforce_index_type` to the developer tags API reference.

#### Does the contribution you provide introduce a new dependency? If so, what is it?

No.

#### On what should a reviewer focus their feedback?

Mainly on whether the new `_BaseTag` definition preserves the existing behaviour and follows the current tag registration pattern, and whether the API reference placement is appropriate.

#### Did you include any tests for the change?

No new tests were added. I ran the existing registry test suite:

`214 passed`

#### Any other comments?

I kept this change limited to the tag migration and its API reference entry, without changing unrelated functionality.

#### PR checklist

- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag
- [x] The PR title begins with one of [ENH], [MNT], [DOC], or [BUG].