### PR TITLE
[ENH] Migrate `scitype:instancewise` tag to `_BaseTag`

### DIFF
--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -153,6 +153,7 @@ transform a single time series object (``"transformer"`` type).
 
     scitype__transform_input
     scitype__transform_output
+    scitype__instancewise
     scitype__transform_labels
     requires_x
     requires_y

--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -153,8 +153,8 @@ transform a single time series object (``"transformer"`` type).
 
     scitype__transform_input
     scitype__transform_output
-    scitype__instancewise
     scitype__transform_labels
+    scitype__instancewise
     requires_x
     requires_y
     capability__missing_values

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -1869,11 +1869,11 @@ class scitype__instancewise(_BaseTag):
     This tag applies to transformations.
 
     If the tag is ``True``, ``fit`` and ``transform`` of the transformer are
-    statistically independent by instance, i.e., the transform of one
-    instance does not depend on any other instance.
+    statistically independent by time series instance, i.e., the transform of one
+    time series instance does not depend on any other instance.
 
     If the tag is ``False``, ``fit`` and/or ``transform`` of the transformer
-    are not independent by instance.
+    are not independent by time series instance.
     """
 
     _tags = {

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -1857,6 +1857,34 @@ class scitype__transform_output(_BaseTag):
     }
 
 
+class scitype__instancewise(_BaseTag):
+    """Whether the transformer transforms instances independently.
+
+    - String name: ``"scitype:instancewise"``
+    - Public scitype tag
+    - Values: boolean, ``True`` / ``False``
+    - Example: ``True``
+    - Default: ``True``
+
+    This tag applies to transformations.
+
+    If the tag is ``True``, ``fit`` and ``transform`` of the transformer are
+    statistically independent by instance, i.e., the transform of one
+    instance does not depend on any other instance.
+
+    If the tag is ``False``, ``fit`` and/or ``transform`` of the transformer
+    are not independent by instance.
+    """
+
+    _tags = {
+        "tag_name": "scitype:instancewise",
+        "parent_type": "transformer",
+        "tag_type": "bool",
+        "short_descr": "does the transformer transform instances independently?",
+        "user_facing": True,
+    }
+
+
 class requires_x(_BaseTag):
     """Behaviour flag: transformer requires X in fit and transform.
 
@@ -3774,12 +3802,6 @@ ESTIMATOR_TAG_REGISTER = [
         ["param_est", "metric"],
         "str",
         "what scitype of y does the object support? must be scitype string",
-    ),
-    (
-        "scitype:instancewise",
-        "transformer",
-        "bool",
-        "does the transformer transform instances independently?",
     ),
     (
         "capability:missing_values:removes",


### PR DESCRIPTION
## Summary

Migrates `scitype:instancewise` from the legacy
`ESTIMATOR_TAG_REGISTER` tuple to a `_BaseTag` class and adds the
corresponding API reference entry.

The legacy registry entry is removed, while the existing tag metadata,
including its name, parent type, value type, and description, is preserved.

No estimator behavior is changed; this is a registry representation
migration.

References #10804

## Tests

- `python -m pytest sktime/registry/tests/test_tags.py -q`
- `python -m pytest sktime/registry/tests/test_lookup.py -k "all_tags" -q`
- `python -m pytest sktime/registry/tests -q`

All 214 registry tests pass.