### PR TITLE
[BUG] Correct BaseClusterer predict_proba capability tag

### DIFF
--- a/sktime/clustering/base.py
+++ b/sktime/clustering/base.py
@@ -37,7 +37,7 @@ class BaseClusterer(BaseEstimator):
         "capability:multithreading": False,
         "capability:out_of_sample": True,
         "capability:predict": True,
-        "capability:predict_proba": True,
+        "capability:predict_proba": False,
     }
 
     def __init__(self, n_clusters: int = None):

--- a/sktime/clustering/tests/test_all_clusterers.py
+++ b/sktime/clustering/tests/test_all_clusterers.py
@@ -3,15 +3,9 @@
 import numpy as np
 import pytest
 
-from sktime.clustering.base import BaseClusterer
 from sktime.datatypes import check_is_scitype
 from sktime.tests.test_all_estimators import BaseFixtureGenerator, QuickTester
 from sktime.utils._testing.scenarios_clustering import ClustererFitPredictMultivariate
-
-
-def test_base_clusterer_predict_proba_tag_default():
-    """Test that the base clusterer does not claim probabilistic predictions."""
-    assert not BaseClusterer.get_class_tag("capability:predict_proba")
 
 
 class ClustererFixtureGenerator(BaseFixtureGenerator):

--- a/sktime/clustering/tests/test_all_clusterers.py
+++ b/sktime/clustering/tests/test_all_clusterers.py
@@ -3,9 +3,15 @@
 import numpy as np
 import pytest
 
+from sktime.clustering.base import BaseClusterer
 from sktime.datatypes import check_is_scitype
 from sktime.tests.test_all_estimators import BaseFixtureGenerator, QuickTester
 from sktime.utils._testing.scenarios_clustering import ClustererFitPredictMultivariate
+
+
+def test_base_clusterer_predict_proba_tag_default():
+    """Test that the base clusterer does not claim probabilistic predictions."""
+    assert not BaseClusterer.get_class_tag("capability:predict_proba")
 
 
 class ClustererFixtureGenerator(BaseFixtureGenerator):


### PR DESCRIPTION
Title: [BUG] Correct BaseClusterer predict_proba capability tag

## Summary

Fixes #10887.

- Default `BaseClusterer`'s `capability:predict_proba` tag to `False`, matching its deterministic 0/1 fallback.
- Add a regression test for the base tag.
- Keep pipeline delegation unchanged; composites continue cloning the wrapped clusterer's capability tag.
- No new dependency is introduced.

## Test evidence

- Focused source assertion for the `BaseClusterer` tag: passed.
- `git diff --check`: passed.
- The focused pytest test was added but could not be run locally because the supplied Python environment does not include pytest or NumPy.

## Risks or notes for maintainers

This intentionally narrows results from tag-based clusterer discovery. Please confirm whether the correction needs a release note; no compatibility shim is included because retaining the incorrect tag would preserve the reported bug.

Review focus: whether `False` accurately describes the base 0/1 fallback semantics.
