### PR TITLE
[ENH] make `FourierFeatures` transformation compatible with `pandas 3` frequency aliases

### DIFF
--- a/sktime/transformations/fourier.py
+++ b/sktime/transformations/fourier.py
@@ -10,6 +10,7 @@ import pandas as pd
 from numpy.fft import rfft
 
 from sktime.transformations.base import BaseTransformer
+from sktime.utils.datetime import _to_offset_compat
 
 
 class FourierFeatures(BaseTransformer):
@@ -313,11 +314,11 @@ class FourierFeatures(BaseTransformer):
             since_prev_timedelta = datetime - prev
             return since_prev_timedelta / period_timedelta
 
-        offset = pd.tseries.frequencies.to_offset(period_str)
+        offset = _to_offset_compat(period_str)
         offset_boundaries = pd.date_range(
             start=np.amin(datetime_index) - offset,
             end=np.amax(datetime_index) + offset,
-            freq=period_str,
+            freq=offset,
             tz=datetime_index.tz,
         )
 


### PR DESCRIPTION
#### Reference Issues/PRs

Related to the pandas 3 compatibility work after #10868.

#### What does this implement/fix? Explain your changes.

FourierFeatures accepted period aliases such as `"Y"` and `"Q"` (shown in the docstring and used in `get_test_params`).

On pandas 3 these aliases are no longer accepted by `to_offset` and `date_range`.

This change:
- routes the frequency through `_to_offset_compat` (already added in #10868)
- passes the resolved offset object to `date_range`

Behaviour stays the same on pandas 2.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Did you add any tests for the change?

No new tests. Existing tests already cover this (including `sp_list=["Y"]`).