### PR TITLE
[ENH] migrate pwtrafo_type tag to BaseTag

### DIFF
--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -189,6 +189,7 @@ transform pairs of time series (``"transformer-pairwise"`` and ``"transformer-pa
     :nosignatures:
 
     symmetric
+    pwtrafo_type
 
 
 .. _detector_tags:

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -2369,6 +2369,33 @@ class symmetric(_BaseTag):
     }
 
 
+class pwtrafo_type(_BaseTag):
+    """Mathematical type of pairwise transformer.
+
+    - String name: ``"pwtrafo_type"``
+    - Public property tag
+    - Values: string, one of ``"distance"``, ``"kernel"``, ``"other"``
+    - Example: ``"distance"``
+
+    This tag applies to pairwise transformers.
+
+    The tag specifies the mathematical type of the pairwise transformer,
+    which can be one of the following:
+
+    * ``"distance"``: the transformer computes a distance between time series.
+    * ``"kernel"``: the transformer computes a kernel between time series.
+    * ``"other"``: the transformer computes another type of pairwise transformation.
+    """
+
+    _tags = {
+        "tag_name": "pwtrafo_type",
+        "parent_type": ["transformer-pairwise", "transformer-pairwise-panel"],
+        "tag_type": ("str", ["distance", "kernel", "other"]),
+        "short_descr": "mathematical type of pairwise transformer - distance, kernel, or other",
+        "user_facing": True,
+    }
+
+
 # Detector tags
 # --------------
 
@@ -3814,12 +3841,6 @@ ESTIMATOR_TAG_REGISTER = [
         ["forecaster", "regressor"],
         "type",
         "passed to input checks, input conversion index type to enforce",
-    ),
-    (
-        "pwtrafo_type",
-        ["transformer-pairwise", "transformer-pairwise-panel"],
-        ("str", ["distance", "kernel", "other"]),
-        "mathematical type of pairwise transformer - distance, kernel, or other",
     ),
     (
         "scitype:y",


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10804.


#### What does this implement/fix? Explain your changes.

This PR migrates the `pwtrafo_type` tag from the older tuple-based format in `ESTIMATOR_TAG_REGISTER` to the class-based `_BaseTag` representation.

Changes made:
- Added `pwtrafo_type` as a `_BaseTag` class in `sktime/registry/_tags.py`.
- Kept the existing tag metadata unchanged:
  - `tag_name`
  - `parent_type`
  - `tag_type`
  - `short_descr`
  - `user_facing`
- Removed the old `pwtrafo_type` tuple from `ESTIMATOR_TAG_REGISTER`.
- Added `pwtrafo_type` to the pairwise transformer section in `docs/source/api_reference/tags.rst`.

There are no intentional changes to estimator behaviour or the tag's existing metadata.


#### Does your contribution introduce a new dependency? If yes, which one?

No.


#### What should a reviewer concentrate their feedback on?

- Whether the `_BaseTag` implementation correctly preserves the existing `pwtrafo_type` metadata.
- Whether the placement and documentation follow the existing tag migration pattern.


#### Did you add any tests for the change?

No new tests were added.

The existing registry test suite was run successfully:

`214 passed in 30.78s`


#### Any other comments?

The migration follows the existing `_BaseTag` pattern used by tags such as `symmetric`.


#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators

Not applicable.