### PR TITLE
[BUG] fix tsbootstrap compatibility in EnbPIForecaster

### DIFF
--- a/sktime/forecasting/enbpi.py
+++ b/sktime/forecasting/enbpi.py
@@ -76,7 +76,7 @@ class EnbPIForecaster(BaseForecaster):
     Examples
     --------
     >>> import numpy as np
-    >>> from tsbootstrap import MovingBlockBootstrap
+    >>> from tsbootstrap.adapters import MovingBlockBootstrap  # doctest: +SKIP
     >>> from sktime.forecasting.enbpi import EnbPIForecaster
     >>> from sktime.forecasting.naive import NaiveForecaster
     >>> from sktime.datasets import load_airline
@@ -278,12 +278,12 @@ class EnbPIForecaster(BaseForecaster):
             }
         ]
         if _check_soft_dependencies("tsbootstrap", severity="none"):
-            from tsbootstrap import BlockBootstrap
+            from tsbootstrap.adapters import MovingBlockBootstrap
 
             params.append(
                 {
                     "forecaster": NaiveForecaster(),
-                    "bootstrap_transformer": BlockBootstrap(),
+                    "bootstrap_transformer": MovingBlockBootstrap(n_bootstraps=10),
                 }
             )
 

--- a/sktime/transformations/bootstrap/_tsbootstrap.py
+++ b/sktime/transformations/bootstrap/_tsbootstrap.py
@@ -96,7 +96,7 @@ class TSBootstrapAdapter(BaseTransformer):
         """
         # Need to be cloned otherwise it helds a inner state and fails during update
         bootstrapped_samples = self.bootstrap.clone().bootstrap(
-            X, test_ratio=0, return_indices=True
+            X, return_indices=True
         )
 
         def wrap_df(spl):
@@ -148,10 +148,10 @@ class TSBootstrapAdapter(BaseTransformer):
         deps = cls.get_class_tag("python_dependencies")
 
         if _check_soft_dependencies(deps, severity="none"):
-            from tsbootstrap import BlockBootstrap, MovingBlockBootstrap
+            from tsbootstrap.adapters import MovingBlockBootstrap
 
             params = [
-                {"bootstrap": BlockBootstrap(n_bootstraps=10)},
+                {"bootstrap": MovingBlockBootstrap(n_bootstraps=10)},
                 {
                     "bootstrap": MovingBlockBootstrap(n_bootstraps=10, block_length=4),
                     "include_actual": True,


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10901.

#### What does this implement/fix? Explain your changes.

`EnbPIForecaster` and `TSBootstrapAdapter` were using the obsolete `BlockBootstrap` import from `tsbootstrap`, and `TSBootstrapAdapter` passed the unsupported `test_ratio` argument to `bootstrap()`.

This PR:

- updates `MovingBlockBootstrap` imports to `tsbootstrap.adapters`
- replaces the obsolete `BlockBootstrap` test parameter with `MovingBlockBootstrap`
- removes the unsupported `test_ratio=0` argument from `TSBootstrapAdapter`
- leaves the existing `TSBootstrapAdapter` integration path intact via the `object_type="bootstrap"` tag

Changes are limited to `sktime/forecasting/enbpi.py` and `sktime/transformations/bootstrap/_tsbootstrap.py`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the updated `tsbootstrap` API usage is correct.
- Whether the existing `TSBootstrapAdapter` integration and test-parameter coverage are preserved.
- Whether removal of `test_ratio=0` is appropriate for the supported `tsbootstrap` API.

#### Did you add any tests for the change?

No new test files were added.

The updated integration path was manually tested against `tsbootstrap` 0.6.1 and 0.7.1:

- importing and constructing `MovingBlockBootstrap`
- checking that `object_type="bootstrap"` is present
- calling `bootstrap(X, return_indices=True)`
- calling `TSBootstrapAdapter.fit_transform()` successfully

`git diff --check` is also clean.

#### Any other comments?

Changes are limited to addressing the issue described in #10901.

The full `EnbPIForecaster` doctest could not be run locally due to an unrelated PyTorch import/DLL error in the environment.

#### PR checklist

##### For all contributions

- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].