### PR TITLE
[ENH] Migrate capability:missing_values:removes tag to class

### DIFF
--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -159,6 +159,7 @@ transform a single time series object (``"transformer"`` type).
     requires_x
     requires_y
     capability__missing_values
+    capability__missing_values__removes
     capability__unequal_length
     capability__unequal_length__adds
     capability__unequal_length__removes

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -2267,6 +2267,30 @@ class capability__bootstrap_index(_BaseTag):
     }
 
 
+class capability__missing_values__removes(_BaseTag):
+    """Capability: transformer output is guaranteed to have no missing values.
+
+    - String name: ``"capability:missing_values:removes"``
+    - Public capability tag
+    - Values: boolean, ``True`` / ``False``
+    - Example: ``True``
+    - Default: ``False``
+
+    This tag specifies whether the transformer result is guaranteed to have
+    no missing values.
+    """
+
+    _tags = {
+        "tag_name": "capability:missing_values:removes",
+        "parent_type": "transformer",
+        "tag_type": "bool",
+        "short_descr": (
+            "is the transformer result guaranteed to have no missing values?"
+        ),
+        "user_facing": True,
+    }
+
+
 class capability__unequal_length__removes(_BaseTag):
     """Capability: the transformer produces equal length series on unequal length input.
 
@@ -3829,12 +3853,6 @@ ESTIMATOR_TAG_REGISTER = [
         ["param_est", "metric"],
         "str",
         "what scitype of y does the object support? must be scitype string",
-    ),
-    (
-        "capability:missing_values:removes",
-        "transformer",
-        "bool",
-        "is the transformer result guaranteed to have no missing values?",
     ),
     (
         "classifier_type",


### PR DESCRIPTION
# LLM generated content, by GPT-5 Codex

#### Reference Issues/PRs

Fixes #10804

#### What does this implement/fix? Explain your changes.

Migrates the legacy `capability:missing_values:removes` tuple entry to a transformer-specific `_BaseTag` class. The class preserves the existing tag name, parent type, value type, and short description, so the generated tag registry continues to expose the same public metadata. It also adds the tag to the ordinary-transformer API reference.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Preservation of the legacy tuple's registry metadata.
- Placement and API-reference naming consistency with adjacent transformer tags.

#### Did you add any tests for the change?

No new test file was needed for this mechanical migration. I ran the focused registry tests (`52 passed`), an exact `all_tags`/class-metadata assertion, Ruff lint/format checks, and `git diff --check`.

#### Any other comments?

No contributor-list attribution or personal metadata was changed.

#### PR checklist

- [x] The PR title starts with `[ENH]`.