### PR TITLE
[BUG] fix `check_tag_is_valid`, which raised for every input

### DIFF
--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -3980,39 +3980,55 @@ def check_tag_is_valid(tag_name, tag_value):
     Raises
     ------
     KeyError - if tag_name is not a valid tag in ESTIMATOR_TAG_LIST
-    ValueError - if the tag_valid is not a valid for the tag with name tag_name
+    ValueError - if tag_value is not a valid value for the tag with name tag_name
     """
     if tag_name not in ESTIMATOR_TAG_LIST:
-        raise KeyError(tag_name + " is not a valid tag")
+        raise KeyError(f"{tag_name} is not a valid tag")
 
-    tag_type = ESTIMATOR_TAG_TABLE[2][ESTIMATOR_TAG_TABLE[0] == "tag_name"]
+    tag_type = ESTIMATOR_TAG_TABLE[2][ESTIMATOR_TAG_TABLE[0] == tag_name].iloc[0]
+
+    if isinstance(tag_type, tuple):
+        subtype, allowed = tag_type
+
+        if subtype == "str":
+            if tag_value not in allowed:
+                raise ValueError(
+                    f"{tag_name} must be one of {allowed}, found {tag_value}"
+                )
+
+        # the ("list", "str") case must be handled before the general
+        # ("list", list_of_str) case below, since allowed is the str "str" here,
+        # and a subset check against it is not meaningful
+        elif subtype == "list" and allowed == "str":
+            msg = f"{tag_name} must be str or list of str, found {tag_value}"
+            if not isinstance(tag_value, (str, list)):
+                raise ValueError(msg)
+            if isinstance(tag_value, list) and not all(
+                isinstance(x, str) for x in tag_value
+            ):
+                raise ValueError(msg)
+
+        elif subtype == "list":
+            msg = f"{tag_name} must be a subset of {allowed}, found {tag_value}"
+            if not isinstance(tag_value, (list, set, tuple)):
+                raise ValueError(msg)
+            try:
+                is_subset = set(tag_value).issubset(allowed)
+            except TypeError:  # unhashable entries, e.g. a list of dict
+                raise ValueError(msg) from None
+            if not is_subset:
+                raise ValueError(msg)
+
+        return
 
     if tag_type == "bool" and not isinstance(tag_value, bool):
-        raise ValueError(tag_name + " must be True/False, found " + tag_value)
+        raise ValueError(f"{tag_name} must be True/False, found {tag_value}")
 
     if tag_type == "int" and not isinstance(tag_value, int):
-        raise ValueError(tag_name + " must be integer, found " + tag_value)
+        raise ValueError(f"{tag_name} must be integer, found {tag_value}")
 
     if tag_type == "str" and not isinstance(tag_value, str):
-        raise ValueError(tag_name + " must be string, found " + tag_value)
+        raise ValueError(f"{tag_name} must be string, found {tag_value}")
 
     if tag_type == "list" and not isinstance(tag_value, list):
-        raise ValueError(tag_name + " must be list, found " + tag_value)
-
-    if tag_type[0] == "str" and tag_value not in tag_type[1]:
-        raise ValueError(
-            tag_name + " must be one of " + tag_type[1] + " found " + tag_value
-        )
-
-    if tag_type[0] == "list" and not set(tag_value).issubset(tag_type[1]):
-        raise ValueError(
-            tag_name + " must be subest of " + tag_type[1] + " found " + tag_value
-        )
-
-    if tag_type[0] == "list" and tag_type[1] == "str":
-        msg = f"{tag_name} must be str or list of str, found {tag_value}"
-        if not isinstance(tag_value, (str, list)):
-            raise ValueError(msg)
-        if isinstance(tag_value, list):
-            if not all(isinstance(x, str) for x in tag_value):
-                raise ValueError(msg)
+        raise ValueError(f"{tag_name} must be list, found {tag_value}")

--- a/sktime/registry/tests/test_tags.py
+++ b/sktime/registry/tests/test_tags.py
@@ -1,6 +1,10 @@
 """Tests for tag register and tag functionality."""
 
-from sktime.registry._tags import ESTIMATOR_TAG_REGISTER
+import re
+
+import pytest
+
+from sktime.registry._tags import ESTIMATOR_TAG_REGISTER, check_tag_is_valid
 
 
 def test_tag_register_type():
@@ -22,3 +26,134 @@ def test_tag_register_type():
             if isinstance(tag[2][1], list):
                 assert all(isinstance(x, str) for x in tag[2][1])
         assert isinstance(tag[3], str)
+
+
+def _example_value(tag_type):
+    """Return a valid example value for a tag type spec, as used in the register.
+
+    Parameters
+    ----------
+    tag_type : str, or tuple of (str, list of str), or tuple of (str, str)
+        tag type specification, 2nd entry of an ``ESTIMATOR_TAG_REGISTER`` tuple
+
+    Returns
+    -------
+    example value that is valid for ``tag_type``
+    """
+    if isinstance(tag_type, tuple):
+        kind, allowed = tag_type
+        if kind == "str":
+            return allowed[0]
+        if kind == "list" and allowed == "str":
+            return ["foo"]
+        if kind == "list":
+            return [allowed[0]]
+    return {
+        "bool": True,
+        "int": 1,
+        "str": "foo",
+        "list": [],
+        "type": int,
+    }[tag_type]
+
+
+def _first_tag_of_type(predicate):
+    """Return name and type of first registered tag whose type satisfies predicate."""
+    for tag in ESTIMATOR_TAG_REGISTER:
+        if predicate(tag[2]):
+            return tag[0], tag[2]
+    pytest.skip("no tag of the required type present in the register")
+
+
+@pytest.mark.parametrize("tag", ESTIMATOR_TAG_REGISTER, ids=lambda tag: tag[0])
+def test_check_tag_is_valid_accepts_valid_value(tag):
+    """Check that a valid value is accepted, for every tag in the register.
+
+    Regression test: ``check_tag_is_valid`` looked the tag type up by the
+    literal string ``"tag_name"`` rather than by the ``tag_name`` argument,
+    so the lookup matched no row and every call raised
+    ``ValueError: The truth value of a Series is ambiguous``.
+    """
+    tag_name, tag_type = tag[0], tag[2]
+    check_tag_is_valid(tag_name, _example_value(tag_type))
+
+
+def test_check_tag_is_valid_unknown_tag():
+    """Check that an unknown tag name raises KeyError."""
+    with pytest.raises(KeyError):
+        check_tag_is_valid("this_is_not_a_valid_tag", True)
+
+
+def test_check_tag_is_valid_bool():
+    """Check that a bool tag rejects non-bool values."""
+    tag_name, _ = _first_tag_of_type(lambda t: t == "bool")
+    check_tag_is_valid(tag_name, True)
+    check_tag_is_valid(tag_name, False)
+    with pytest.raises(ValueError, match=re.escape(tag_name)):
+        check_tag_is_valid(tag_name, "True")
+
+
+def test_check_tag_is_valid_str_from_list():
+    """Check that a ("str", list) tag accepts listed values and rejects others."""
+    tag_name, tag_type = _first_tag_of_type(
+        lambda t: isinstance(t, tuple) and t[0] == "str"
+    )
+    check_tag_is_valid(tag_name, tag_type[1][0])
+    with pytest.raises(ValueError, match=re.escape(tag_name)):
+        check_tag_is_valid(tag_name, "definitely_not_an_allowed_value")
+
+
+def test_check_tag_is_valid_list_of_str():
+    """Check that a ("list", "str") tag accepts str or list of str.
+
+    This case must be handled before the subset check for ("list", list) tags,
+    since ``set(tag_value).issubset("str")`` is not a meaningful test.
+    """
+    tag_name, _ = _first_tag_of_type(lambda t: isinstance(t, tuple) and t[1] == "str")
+    check_tag_is_valid(tag_name, "foo")
+    check_tag_is_valid(tag_name, ["foo", "bar"])
+    with pytest.raises(ValueError, match=re.escape(tag_name)):
+        check_tag_is_valid(tag_name, [1, 2])
+
+
+def test_check_tag_is_valid_error_is_value_error():
+    """Check that an invalid non-str value raises ValueError, not TypeError.
+
+    The error messages concatenated ``tag_value`` onto a str, which raised
+    ``TypeError`` instead of the documented ``ValueError`` whenever the
+    offending value was not itself a str.
+    """
+    tag_name, _ = _first_tag_of_type(lambda t: t == "bool")
+    with pytest.raises(ValueError, match=re.escape(tag_name)):
+        check_tag_is_valid(tag_name, 3)
+
+
+def test_check_tag_is_valid_subset_unhashable():
+    """Check that unhashable entries raise ValueError, not TypeError.
+
+    The subset check converts ``tag_value`` to a ``set``, which raises
+    ``TypeError`` for unhashable entries. The documented contract is
+    ``ValueError``.
+    """
+    tag_name, tag_type = _first_tag_of_type(
+        lambda t: isinstance(t, tuple) and t[0] == "list" and t[1] != "str"
+    )
+    check_tag_is_valid(tag_name, [tag_type[1][0]])
+    with pytest.raises(ValueError, match=re.escape(tag_name)):
+        check_tag_is_valid(tag_name, [{"unhashable": 1}])
+
+
+@pytest.mark.parametrize(
+    "plain_type, invalid_value",
+    [
+        ("bool", "not_a_bool"),
+        ("int", "not_an_int"),
+        ("str", 42),
+        ("list", "not_a_list"),
+    ],
+)
+def test_check_tag_is_valid_plain_types_reject(plain_type, invalid_value):
+    """Check that the non-tuple tag types reject values of the wrong type."""
+    tag_name, _ = _first_tag_of_type(lambda t: t == plain_type)
+    with pytest.raises(ValueError, match=re.escape(tag_name)):
+        check_tag_is_valid(tag_name, invalid_value)


### PR DESCRIPTION
#### Reference Issues/PRs

None - I ran into this while working on #10429 / #10908, and couldn't find an
existing report. Happy to open an issue first if you'd rather have one.

#### What does this implement/fix? Explain your changes.

`check_tag_is_valid` is exported from `sktime.registry`, but it raises for every
input:

```python
>>> from sktime.registry import check_tag_is_valid
>>> check_tag_is_valid("capability:random_state", True)
ValueError: The truth value of a Series is ambiguous.
```

The lookup compares against the literal string `"tag_name"` instead of the
argument:

```python
tag_type = ESTIMATOR_TAG_TABLE[2][ESTIMATOR_TAG_TABLE[0] == "tag_name"]
```

Nothing is named `"tag_name"`, so the mask is empty and `tag_type` is an empty
Series. I ran all 132 registered tags through it with valid values - all 132 raise.

A few smaller things showed up once it actually ran, fixed here too:

* `("list", "str")` was handled after the general subset check, so
  `set(tag_value).issubset("str")` ran for that shape. That's a character-level
  test, and it rejects valid values - `reserved_params="foo"` gives
  `{"f","o"} ⊆ {"s","t","r"}`, so False.
* error messages concatenated `tag_value` onto a str, which raises `TypeError`
  instead of the documented `ValueError` exactly when the value isn't a str
* unhashable entries in a list value raised `TypeError` out of `set()`

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Mainly whether `None` should be allowed.

Now that the function runs, I pointed it at the declared class tags of every
estimator to see what it says about real data: 625 estimators, 18481 checks,
3488 failures - and 3340 of those are a value of `None`, across 15 tags.

Some of those tags document `None` as their default in their class docstring in
this same file (`python_dependencies`, `env_marker`, `tests:libs`,
`tests:specific`, `tests:skip_by_name`), but they're registered as `"str"` or
`("list", "str")`, and the type spec has no nullable option. So the register and
the docstrings disagree and the checker can't satisfy both.

I've left that alone, since making the specs nullable is a decision about the
register rather than a bugfix, and I didn't want to change semantics quietly.
Happy to do the follow-up whichever way you want it.

The other 148 failures are register-vs-estimator mismatches on `object_type`,
`classifier_type`, `task_type` and a few others - out of scope here, but only
visible now that the checker runs, so worth mentioning.

Also `enforce_index_type` (type `"type"`) still isn't validated, same as before.

#### Did you add any tests for the change?

Yes - there weren't any for this function.

The main one is parametrized over the whole tag register and fails for all 132
tags before the fix. The rest cover the `("list", "str")` ordering, unhashable
values, unknown tag names, and the `TypeError`-instead-of-`ValueError` cases. The
negative tests match on the tag name in the message, so they can't pass by
catching the old "ambiguous Series" error by accident.

I deliberately didn't add a test for the current `None` behaviour, since that's
the open question above.

136 failed / 2 passed before the fix, 143 passed after. `sktime/registry/` plus
`sktime/base/tests/` is 376 passed, `test_softdeps.py` 2419 passed, pre-commit clean.

#### Any other comments?

Tag entries are checked structurally by `test_tag_register_type`, so estimators
were never affected by this - only direct callers of the helper, which is
probably why it went unnoticed.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) - the `.all-contributorsrc` entry is in #10908, so I've left that file alone here to avoid a conflict between the two PRs.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
