### PR TITLE
[BUG] don't raise in weekly test collection when no python version matches

### DIFF
--- a/.github/workflows/test_classifiers_weekly.yml
+++ b/.github/workflows/test_classifiers_weekly.yml
@@ -42,6 +42,10 @@ jobs:
           for name, est_class in classifiers:
               py_ver = _get_lowest_compatible_python_version(est_class)
 
+              if py_ver is None:
+                  print(f"skipping {name}, no python version compatible with sktime")
+                  continue
+
               matrix_data.append({
                   "name": name,
                   "python_version": py_ver

--- a/.github/workflows/test_forecasters_weekly.yml
+++ b/.github/workflows/test_forecasters_weekly.yml
@@ -44,6 +44,10 @@ jobs:
           for name, est_class in forecasters:
               py_ver = _get_lowest_compatible_python_version(est_class)
 
+              if py_ver is None:
+                  print(f"skipping {name}, no python version compatible with sktime")
+                  continue
+
               matrix_data.append({
                   "name": name,
                   "python_version": py_ver,

--- a/.github/workflows/test_transformers_weekly.yml
+++ b/.github/workflows/test_transformers_weekly.yml
@@ -42,6 +42,10 @@ jobs:
           for name, est_class in transformers:
               py_ver = _get_lowest_compatible_python_version(est_class)
 
+              if py_ver is None:
+                  print(f"skipping {name}, no python version compatible with sktime")
+                  continue
+
               matrix_data.append({
                   "name": name,
                   "python_version": py_ver

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -1128,6 +1128,18 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
                 f"estimator tags."
             )
 
+    def test_python_version_compatible(self, object_class):
+        """Check that the python_version tag is compatible with sktime's own bound."""
+        from sktime.utils.dependencies import _get_lowest_compatible_python_version
+
+        est_spec = object_class.get_class_tag("python_version")
+
+        assert _get_lowest_compatible_python_version(object_class) is not None, (
+            f"python_version tag of {object_class.__name__} is {est_spec!r}, which "
+            "has no python version in common with the bound sktime itself requires. "
+            "The estimator can therefore never be tested or used."
+        )
+
     def test_inheritance(self, object_class):
         """Check that estimator inherits from BaseObject and/or BaseEstimator."""
         assert issubclass(object_class, BaseObject), (

--- a/sktime/utils/dependencies/_dependencies.py
+++ b/sktime/utils/dependencies/_dependencies.py
@@ -105,8 +105,9 @@ def _get_lowest_compatible_python_version(estimator):
 
     Returns
     -------
-    str
+    str, or None
         Lowest compatible Python version, e.g. "3.11".
+        None if the estimator and sktime have no Python version in common.
     """
     estimator_spec = estimator.get_class_tag("python_version")
     sktime_spec = metadata("sktime")["Requires-Python"]
@@ -131,7 +132,6 @@ def _get_lowest_compatible_python_version(estimator):
         if minor > 100:
             break
 
-    raise RuntimeError(
-        f"No compatible Python version found for "
-        f"sktime ({sktime_spec}) and estimator ({estimator_spec})."
-    )
+    # no common version - callers such as the weekly test workflows skip the
+    # estimator, and TestAllObjects.test_python_version_compatible reports it
+    return None

--- a/sktime/utils/dependencies/tests/test_dependencies.py
+++ b/sktime/utils/dependencies/tests/test_dependencies.py
@@ -77,6 +77,9 @@ class _MockEstimator:
         ("==3.11", ">=3.10", "3.11"),
         (">3.10", ">=3.10", "3.11"),
         (None, ">=3.10", "3.10"),
+        # no overlap between estimator and sktime bound -> None, no exception
+        ("<3.10", ">=3.10", None),
+        (">=3.15", ">=3.10,<3.15", None),
     ],
 )
 def test_get_lowest_compatible_python_version(


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10709.

#### What does this implement/fix? Explain your changes.

The weekly classifier, forecaster and transformer workflows build their test matrix
by calling `_get_lowest_compatible_python_version` on every estimator. If an
estimator's `python_version` tag has no overlap with the bound sktime itself
requires, that raised, and the whole collection step died rather than just the one
estimator.

Doing what you suggested in the issue:

* the utility returns `None` instead of raising
* the three weekly workflows skip that estimator, and print which one
* new `TestAllObjects.test_python_version_compatible` flags the bad tag instead

No estimator trips it right now, so nothing actually gets skipped today - what
changes is that one bad tag no longer takes the whole run down with it.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Whether skipping is what you want in the workflows. Returning `None` leaves that
to the caller, and skip-and-print seemed closest to "it should instead fail the
classifier". Happy to make it emit a failing matrix entry instead if you'd rather
it be loud in CI as well as in the test suite.

I also only touched the python bound, not the wider dependency-compatibility check
you mentioned as the more complicated version.

#### Did you add any tests for the change?

Yes - the new `TestAllObjects` test, plus two cases on the existing unit test for
the `None` return.

`test_dependencies.py` 13 passed, the new suite test 56 passed, pre-commit clean.

#### Any other comments?

None.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) - the `.all-contributorsrc` entry is in #10908, left alone here to avoid a conflict between the PRs.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
