### PR TITLE
[BUG] fix compound shape descriptor ignoring the second descriptor in `ShapeDTW`

### DIFF
--- a/sktime/classification/distance_based/_shape_dtw.py
+++ b/sktime/classification/distance_based/_shape_dtw.py
@@ -510,7 +510,7 @@ class ShapeDTW(BaseClassifier):
             )
         for x in second_desc.columns:
             second_desc_array.append(
-                convert(first_desc[x], from_type="nested_univ", to_type="numpyflat")
+                convert(second_desc[x], from_type="nested_univ", to_type="numpyflat")
             )
 
         # Concatenate the arrays together

--- a/sktime/classification/distance_based/tests/test_shape_dtw.py
+++ b/sktime/classification/distance_based/tests/test_shape_dtw.py
@@ -1,0 +1,54 @@
+"""Tests for ShapeDTW."""
+
+import numpy as np
+import pytest
+
+from sktime.classification.distance_based._shape_dtw import ShapeDTW
+from sktime.datasets import load_unit_test
+from sktime.tests.test_switch import run_test_for_class
+
+
+def _compound_descriptors(shape_descriptor_functions):
+    """Fit ShapeDTW in compound mode, return combined descriptor of instance 0."""
+    X, y = load_unit_test(split="train", return_type="nested_univ")
+    X, y = X.iloc[:6], y[:6]
+
+    clf = ShapeDTW(
+        n_neighbors=1,
+        shape_descriptor_function="compound",
+        shape_descriptor_functions=shape_descriptor_functions,
+        metric_params={"weighting_factor": 1.0},
+    )
+    clf.fit(X, y)
+    # _generate_shape_descriptors reads the fitted weighting_factor
+    clf.weighting_factor = 1.0
+    combined = clf._generate_shape_descriptors(X)
+    return np.asarray(list(combined.iloc[0, 0]), dtype=float)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ShapeDTW),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_compound_uses_both_descriptors():
+    """Test that compound mode combines two distinct descriptors, see issue #9434.
+
+    ``_combine_data_frames`` iterated over ``second_desc.columns`` but converted
+    ``first_desc[x]``, so the second descriptor was discarded and the first was
+    concatenated with a weighted copy of itself.
+    """
+    raw_deriv = _compound_descriptors(["raw", "derivative"])
+    raw_raw = _compound_descriptors(["raw", "raw"])
+
+    half = len(raw_deriv) // 2
+
+    # the two halves must differ, since "raw" and "derivative" differ
+    assert not np.allclose(raw_deriv[:half], raw_deriv[half:])
+
+    # and a genuinely different second descriptor must change the result
+    assert not np.allclose(raw_deriv, raw_raw)
+
+    # sanity checks: the first half is the raw descriptor in both cases, and
+    # ("raw", "raw") legitimately does produce two identical halves
+    assert np.allclose(raw_deriv[:half], raw_raw[:half])
+    assert np.allclose(raw_raw[:half], raw_raw[half:])


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #9434.

#### What does this implement/fix? Explain your changes.

`ShapeDTW._combine_data_frames` builds the combined representation used when
`shape_descriptor_function="compound"`. The loop that converts the second
descriptor iterates over `second_desc.columns`, but converts `first_desc[x]`:

```python
for x in second_desc.columns:
    second_desc_array.append(
        convert(first_desc[x], from_type="nested_univ", to_type="numpyflat")
    )
```

So the second descriptor is never read. The combined output is the first
descriptor concatenated with a weighted copy of itself, which means the second
entry of `shape_descriptor_functions` has no effect on the result at all.

This is easy to see on `unit_test` - before the change, these two configurations
produce identical output:

```python
ShapeDTW(shape_descriptor_function="compound",
         shape_descriptor_functions=["raw", "derivative"], ...)   # combined
ShapeDTW(shape_descriptor_function="compound",
         shape_descriptor_functions=["raw", "raw"], ...)          # combined
```

and both halves of the combined vector are equal to each other. After the change
the two configurations differ, the halves of `["raw", "derivative"]` differ, and
`["raw", "raw"]` still (correctly) produces two equal halves.

The fix is to convert `second_desc[x]` in the second loop.

Note this changes the numerical output of `ShapeDTW` in `compound` mode, since
that mode previously ignored half of its configuration. The `raw` default path
is unaffected, so the stored `unit_test_proba["ShapeDTW"]` expected output (which
uses default parameters) does not change.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the behaviour change in `compound` mode should be called out in the
  changelog, given it alters results for existing users of that mode.
- Whether the new test belongs in a dedicated
  `sktime/classification/distance_based/tests/test_shape_dtw.py` - there was no
  existing test module for `ShapeDTW`, so I added one.
- The test sets `weighting_factor` before calling `_generate_shape_descriptors`
  directly. Happy to reshape it into a purely public-API test if preferred.

#### Did you add any tests for the change?

Yes - `test_compound_uses_both_descriptors`, in a new
`sktime/classification/distance_based/tests/test_shape_dtw.py`. It asserts that
`compound` mode combines two distinct descriptors, and that a different second
descriptor changes the result. The test fails on `main` and passes with this
change.

Also ran the full estimator check suite for `ShapeDTW` (`check_estimator`), which
covers `compound` mode through `get_test_params` `params2`: 149 checks, 0 failures.

#### Any other comments?

@Abdo-ateM expressed interest in this issue in April but no PR followed - happy to
step aside or collaborate if they are still working on it.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
