### PR TITLE
[BUG] fix `ForecastKnownValues` for hierarchical data with exactly one level

### DIFF
--- a/sktime/forecasting/dummy.py
+++ b/sktime/forecasting/dummy.py
@@ -164,6 +164,11 @@ class ForecastKnownValues(BaseForecaster):
             idx = self._y.index
             if isinstance(idx, pd.MultiIndex):
                 unique_levels = idx.droplevel(-1).unique()
+                if unique_levels.nlevels == 1:
+                    # for a two-level MultiIndex, droplevel returns a flat Index
+                    # whose entries are scalars rather than tuples - wrap them so
+                    # that unpacking below yields one entry per index level
+                    unique_levels = [(level,) for level in unique_levels]
                 fh_abs = pd.MultiIndex.from_tuples(
                     ((*level, time) for level in unique_levels for time in fh_abs),
                     names=idx.names,

--- a/sktime/forecasting/tests/test_known_values.py
+++ b/sktime/forecasting/tests/test_known_values.py
@@ -76,3 +76,71 @@ def test_singleindex(fh, y_known) -> None:
         check_dtype=False,
         check_index_type=False,
     )
+
+
+@pytest.fixture
+def y_known_one_level():
+    index = pd.MultiIndex.from_product(
+        [["AAA", "BBB"], [0, 1, 2]],
+        names=["Level1", "Date"],
+    )
+    data = range(len(index))
+
+    return pd.DataFrame(data, index=index, columns=["Value"])
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ForecastKnownValues),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize("fh", TEST_OOS_FHS)
+def test_multiindex_one_level(fh, y_known_one_level) -> None:
+    """Test y_known with a hierarchy of exactly one level, see issue #8945.
+
+    ``droplevel`` on a two level ``MultiIndex`` returns a flat ``Index``, whose
+    entries are scalars rather than tuples. Unpacking those yielded one entry per
+    character of the level label, so any label that is not a single character
+    raised ``ValueError`` from ``MultiIndex.from_tuples``.
+    """
+    f = ForecastKnownValues(y_known=y_known_one_level)
+    f.fit(y_known_one_level)
+    y_pred = f.predict(fh)
+
+    # Create expected data
+    if not isinstance(fh, np.ndarray):
+        fh = np.array([fh])
+
+    index = pd.MultiIndex.from_product(
+        [["AAA", "BBB"], fh + 2],
+        names=["Level1", "Date"],
+    )
+    expected = pd.DataFrame(None, index=index, columns=["Value"])
+
+    pd.testing.assert_frame_equal(
+        y_pred,
+        expected,
+        check_dtype=False,
+        check_index_type=False,
+    )
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(ForecastKnownValues),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_multiindex_one_level_returns_known_values(y_known_one_level) -> None:
+    """Test that known values are returned for a one level hierarchy, see #8945."""
+    y_train = y_known_one_level.drop(index=2, level="Date")
+
+    f = ForecastKnownValues(y_known=y_known_one_level)
+    f.fit(y_train)
+    y_pred = f.predict(fh=[1])
+
+    expected = y_known_one_level.xs(2, level="Date", drop_level=False)
+
+    pd.testing.assert_frame_equal(
+        y_pred,
+        expected,
+        check_dtype=False,
+        check_index_type=False,
+    )


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #8945.

#### What does this implement/fix? Explain your changes.

`ForecastKnownValues._predict` expands the forecasting horizon across the
hierarchy levels of `y`:

```python
unique_levels = idx.droplevel(-1).unique()
fh_abs = pd.MultiIndex.from_tuples(
    ((*level, time) for level in unique_levels for time in fh_abs),
    names=idx.names,
)
```

For a `MultiIndex` with three or more levels, `droplevel(-1)` returns a
`MultiIndex` and each `level` is a tuple, so `(*level, time)` is correct. For a
`MultiIndex` with exactly two levels it returns a *flat* `Index`, so each `level`
is a scalar. Unpacking a string scalar yields one entry per character, so

```python
(*"AAA", 1)  ->  ("A", "A", "A", 1)   # 4 entries, but idx.names has 2
```

and `MultiIndex.from_tuples` raises
`ValueError: Length of names must match number of levels in MultiIndex`.

The fix wraps the scalars in one-tuples when the dropped index is flat, which is
the fix suggested by the reporter in the issue.

Worth noting why this was not caught: a single character level label happens to
unpack to exactly one entry, so `(*"A", 1) == ("A", 1)` is well formed. The
existing tests in `test_known_values.py` use `"A"` / `"B"` / `"X"` as level
labels, so they pass either way. The tests added here use `"AAA"` / `"BBB"`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the one-tuple wrapping is preferred over an alternative such as
  building the index with `MultiIndex.from_product`, which would avoid the
  tuple/scalar distinction entirely.
- Whether the second test (`..._returns_known_values`) is worth keeping - it is
  slightly stronger than the existing tests, since the existing ones only assert
  the shape of the index and compare against all-missing values.

#### Did you add any tests for the change?

Yes, two, in the existing `sktime/forecasting/tests/test_known_values.py`:

- `test_multiindex_one_level`, mirroring the existing `test_multiindex` but with a
  one level hierarchy and multi-character level labels
- `test_multiindex_one_level_returns_known_values`, asserting that the known
  values are actually returned when the horizon is covered by `y_known`

Both fail on `main` and pass with this change. Also ran the full estimator check
suite for `ForecastKnownValues`: 679 checks, 0 failures.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
