### PR TITLE
[BUG] fix `SeasonalDummiesOneHot` rejecting hourly, weekly and quarterly frequencies

### DIFF
--- a/sktime/transformations/dummies.py
+++ b/sktime/transformations/dummies.py
@@ -191,31 +191,36 @@ class SeasonalDummiesOneHot(BaseTransformer):
 
             period_index = index.to_period(freq)
 
+        # `freqstr` is not the bare frequency code - anchored frequencies carry a
+        # suffix ("W-SUN", "Q-DEC"), and since pandas 2.2 sub-daily frequencies are
+        # lower case ("h"). Normalize to the bare, upper case code before matching.
+        freq_code = period_index.freqstr.split("-")[0].upper()
+
         # Extract the appropriate attribute based on the frequency of the period index
-        if period_index.freqstr == "M":
+        if freq_code == "M":
             time_index = period_index.month
-        elif period_index.freqstr == "Q":
+        elif freq_code == "Q":
             time_index = period_index.quarter
-        elif period_index.freqstr == "W":
+        elif freq_code == "W":
             time_index = period_index.week
-        elif period_index.freqstr == "D":
+        elif freq_code == "D":
             time_index = period_index.day
-        elif period_index.freqstr == "H":
+        elif freq_code == "H":
             time_index = period_index.hour
         else:
             raise ValueError(f"Unsupported frequency: {period_index.freqstr}")
 
         # Create dummy variables for the time periods
         dummies = pd.get_dummies(time_index, prefix="", prefix_sep="")
-        if period_index.freqstr == "M":
+        if freq_code == "M":
             dummies.columns = dummies.columns.map(lambda x: calendar.month_abbr[int(x)])
-        elif period_index.freqstr == "Q":
+        elif freq_code == "Q":
             dummies.columns = dummies.columns.map(lambda x: f"Q{int(x)}")
-        elif period_index.freqstr == "W":
+        elif freq_code == "W":
             dummies.columns = dummies.columns.map(lambda x: f"W{int(x)}")
-        elif period_index.freqstr == "D":
+        elif freq_code == "D":
             dummies.columns = dummies.columns.map(lambda x: f"D{int(x)}")
-        elif period_index.freqstr == "H":
+        elif freq_code == "H":
             dummies.columns = dummies.columns.map(lambda x: f"H{int(x)}")
         dummies = dummies.astype(int)  # Convert boolean values to integers
 

--- a/sktime/transformations/tests/test_dummies.py
+++ b/sktime/transformations/tests/test_dummies.py
@@ -33,3 +33,63 @@ def test_seasonal_dummies():
     X_expected = X_expected.astype(int)
     X_expected = X_expected.iloc[:, 1:]  # drop the first dummy
     assert X.equals(X_expected), "Test failed: X does not match X_expected."
+
+
+@pytest.mark.skipif(
+    not run_test_for_class([SeasonalDummiesOneHot])
+    or _check_soft_dependencies("pandas<2.1.0", severity="none"),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_seasonal_dummies_hourly():
+    """Test hourly frequency, see issue #8840.
+
+    ``PeriodIndex.freqstr`` is ``"h"`` rather than ``"H"`` from pandas 2.2 on, so
+    matching it against ``"H"`` raised ``ValueError: Unsupported frequency: h``.
+    """
+    date_range = pd.date_range(start="2023-01-01", periods=24, freq="h")
+    X = pd.DataFrame({"values": range(24)}, index=date_range)
+
+    Xt = SeasonalDummiesOneHot(freq="h").fit_transform(X)
+
+    # one dummy per hour, less the dropped first one, plus the original column
+    assert list(Xt.columns) == ["values"] + [f"H{i}" for i in range(1, 24)]
+
+
+@pytest.mark.skipif(
+    not run_test_for_class([SeasonalDummiesOneHot])
+    or _check_soft_dependencies("pandas<2.1.0", severity="none"),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+@pytest.mark.parametrize(
+    "freq,sp,expected_prefix",
+    [
+        ("h", 8760, "H"),
+        ("D", 365, "D"),
+        ("W", 52, "W"),
+        ("M", 12, None),  # month dummies are named Jan, Feb, ...
+        ("Q", 4, "Q"),
+    ],
+)
+def test_seasonal_dummies_all_documented_freqs(freq, sp, expected_prefix):
+    """Test every frequency the docstring documents, via both freq and sp.
+
+    Anchored frequencies report ``freqstr`` with a suffix (``"W-SUN"``,
+    ``"Q-DEC"``), so weekly and quarterly were rejected the same way hourly was.
+    Both the ``freq`` and the ``sp`` route reach the same dispatch.
+    """
+    periods = 24 if freq == "h" else 800
+    index_freq = "h" if freq == "h" else "D"
+    date_range = pd.date_range(start="2023-01-01", periods=periods, freq=index_freq)
+    X = pd.DataFrame({"values": range(periods)}, index=date_range)
+
+    Xt_freq = SeasonalDummiesOneHot(freq=freq).fit_transform(X)
+    Xt_sp = SeasonalDummiesOneHot(sp=sp).fit_transform(X)
+
+    # the two routes must agree
+    pd.testing.assert_frame_equal(Xt_freq, Xt_sp)
+
+    # and dummies must actually have been added
+    assert Xt_freq.shape[1] > 1
+    if expected_prefix is not None:
+        dummy_cols = [c for c in Xt_freq.columns if c != "values"]
+        assert all(c.startswith(expected_prefix) for c in dummy_cols)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #8840.

#### What does this implement/fix? Explain your changes.

`SeasonalDummiesOneHot._transform` dispatches on the frequency by comparing
`period_index.freqstr` against bare upper case codes:

```python
if period_index.freqstr == "M":
    ...
elif period_index.freqstr == "H":
    ...
else:
    raise ValueError(f"Unsupported frequency: {period_index.freqstr}")
```

`freqstr` is not the bare code, for two separate reasons:

- since pandas 2.2, sub-daily frequencies are reported lower case, so hourly is
  `"h"`, not `"H"` (this is the case in the issue)
- anchored frequencies carry a suffix, so weekly is `"W-SUN"` and quarterly is
  `"Q-DEC"`

The docstring documents `M`, `Q`, `W`, `D` and `H` as supported. On pandas 2.3.3,
**three of those five are broken**, through both the `freq` and the `sp` route:

| requested | `freqstr` | on `main` |
| --- | --- | --- |
| hourly (`freq="H"`/`"h"`, `sp=8760`) | `h` | `ValueError: Unsupported frequency: h` |
| weekly (`freq="W"`, `sp=52`) | `W-SUN` | `ValueError: Unsupported frequency: W-SUN` |
| quarterly (`freq="Q"`, `sp=4`) | `Q-DEC` | `ValueError: Unsupported frequency: Q-DEC` |
| monthly (`freq="M"`, `sp=12`) | `M` | works |
| daily (`freq="D"`, `sp=365`) | `D` | works |

The fix normalizes `freqstr` to the bare upper case code once, and matches on
that in both dispatch blocks. All five documented frequencies then work through
both routes.

Note the issue suggests always upper casing the alias. That alone is not
sufficient - it fixes hourly but not the anchored weekly and quarterly cases, and
the anchor suffix has to be stripped as well.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether stripping at the first `-` is the preferred normalization, or whether
  something like `period_index.freq.name` / `to_offset` would be more robust.
- Annual is deliberately left alone. `number_to_freq` maps `sp=1` to `"A"`, which
  is deprecated in pandas 2.2, but there is no annual branch in the dispatch at
  all and the docstring does not list annual as supported, so `sp=1` fails on
  `main` and still fails here. Happy to address it in this PR or a separate one
  if you would like annual supported.

#### Did you add any tests for the change?

Yes, in the existing `sktime/transformations/tests/test_dummies.py`, which
previously had a single monthly test - which is why this went unnoticed:

- `test_seasonal_dummies_hourly`, the case from the issue
- `test_seasonal_dummies_all_documented_freqs`, parametrized over all five
  documented frequencies, checking the `freq` and `sp` routes agree and that
  dummies are actually produced

4 of the 7 tests in the file fail on `main` and all pass with this change.

Also ran the full estimator check suite for `SeasonalDummiesOneHot`: 114 checks,
3 failures, all `test_categorical_X_passes`. Those 3 are identical on `main`
before this change - the estimator has `capability:categorical_in_X` set to True
but does not handle categorical `X`. Unrelated to this fix, so I left it alone,
but happy to open a separate issue for it.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
