### PR TITLE
[BUG] Preserve pretrained PatchTSMixer configuration

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4101,6 +4101,17 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "dhruvb2028",
+      "name": "Dhruv Bansal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/177777094?v=4",
+      "profile": "https://github.com/dhruvb2028",
+      "contributions": [
+        "bug",
+        "code",
+        "test"
+      ]
     }
   ]
 }

--- a/sktime/forecasting/patch_tsmixer.py
+++ b/sktime/forecasting/patch_tsmixer.py
@@ -253,6 +253,7 @@ class PatchTSMixerForecaster(BaseForecaster):
         "capability:global_forecasting": False,
         "requires-fh-in-fit": False,
         "tests:vm": True,
+        "tests:specific": ["sktime.forecasting.tests.test_patch_tsmixer"],
     }
 
     def __init__(
@@ -334,11 +335,12 @@ class PatchTSMixerForecaster(BaseForecaster):
         cfg.setdefault("context_length", context_length)
         cfg.setdefault("prediction_length", prediction_length)
         cfg.setdefault("num_input_channels", n_channels)
-        cfg.setdefault(
-            "patch_stride",
-            cfg.get("patch_length", _DEFAULT_CONFIG["patch_length"]),
-        )
-        cfg.setdefault("scaling", _DEFAULT_CONFIG["scaling"])
+        if self.model_path is None:
+            cfg.setdefault(
+                "patch_stride",
+                cfg.get("patch_length", _DEFAULT_CONFIG["patch_length"]),
+            )
+            cfg.setdefault("scaling", _DEFAULT_CONFIG["scaling"])
         return cfg
 
     def _load_model(self, config):

--- a/sktime/forecasting/tests/test_patch_tsmixer.py
+++ b/sktime/forecasting/tests/test_patch_tsmixer.py
@@ -1,0 +1,76 @@
+"""Tests for PatchTSMixerForecaster."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from skbase.utils.dependencies import _check_estimator_deps
+
+from sktime.forecasting.patch_tsmixer import PatchTSMixerForecaster
+
+_MODEL_PATH = "ibm-granite/granite-timeseries-patchtsmixer"
+_MODEL_REVISION = "90dc5a88d45f032b7dceefb5d814ca2af54f2ff9"
+_TARGET_COLUMNS = ["HUFL", "HULL", "MUFL", "MULL", "LUFL", "LULL", "OT"]
+
+
+@pytest.mark.skipif(
+    not _check_estimator_deps(PatchTSMixerForecaster, severity="none"),
+    reason="PatchTSMixerForecaster soft dependencies not available",
+)
+def test_patch_tsmixer_predictions_match_source_reference():
+    """Predictions match the original IBM/Hugging Face implementation."""
+    time = np.arange(512, dtype=np.float32)
+    values = {
+        name: (offset + np.sin(time / (8.0 + offset)) + 0.002 * time).astype(np.float32)
+        for offset, name in enumerate(_TARGET_COLUMNS, start=1)
+    }
+    y = pd.DataFrame(values, index=pd.date_range("2024-01-01", periods=512, freq="h"))
+    forecaster = PatchTSMixerForecaster(
+        model_path=_MODEL_PATH,
+        revision=_MODEL_REVISION,
+        context_length=512,
+        prediction_length=96,
+        validation_split=0.0,
+        train_model=False,
+        scaling=False,
+    )
+
+    y_pred = forecaster.fit(y, fh=range(1, 97)).predict(fh=range(1, 97))
+
+    expected = np.asarray(
+        [
+            [
+                2.46599293,
+                2.63427544,
+                3.11994505,
+                4.97724009,
+                5.2243247,
+                5.28185463,
+                8.13028336,
+            ],
+            [
+                2.30446863,
+                2.62986088,
+                3.00171471,
+                4.88996744,
+                5.05688524,
+                5.28941774,
+                7.91808081,
+            ],
+            [
+                2.19133615,
+                2.69998837,
+                2.96796489,
+                4.89432335,
+                5.0068574,
+                5.408319,
+                7.85999775,
+            ],
+        ],
+        dtype=np.float32,
+    )
+    np.testing.assert_allclose(
+        y_pred.iloc[:3].to_numpy(),
+        expected,
+        rtol=1e-5,
+        atol=1e-5,
+    )


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #10672.

#### What does this implement/fix? Explain your changes.

`PatchTSMixerForecaster` was overriding configuration values from pretrained checkpoints with wrapper defaults.

For the IBM Granite PatchTSMixer checkpoint, this changed `patch_stride` from 16 to 8. As a result, the model produced 63 patches while the pretrained prediction head expected 32, causing the following error during prediction:

`RuntimeError: mat1 and mat2 shapes cannot be multiplied (336x63 and 32x96)`

This PR applies the default `patch_stride` and model `scaling` settings only when constructing a model from scratch. Pretrained models now retain the configuration stored in their checkpoints unless the user explicitly provides an override.

It also registers a focused estimator-specific regression test.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether pretrained checkpoint settings should take precedence over wrapper defaults.
- Whether the distinction between pretrained and from-scratch model construction is handled at the correct level.
- Whether the pinned golden-output test provides sufficient regression coverage.

#### Did you add any tests for the change?

Yes. The new test loads a pinned revision of IBM's PatchTSMixer checkpoint and compares its forecast with reference outputs generated directly using the upstream implementation.

Before the fix, the test failed with the matrix-shape error shown above. After the fix, the focused regression test passes.

Additional validation:

- `check_estimator(PatchTSMixerForecaster)`: 679 checks passed, 0 failed
- Ruff lint check passed
- Ruff formatting check passed
- `git diff --check` passed

#### Any other comments?

The checkpoint revision is pinned so that future upstream model updates do not silently change the expected predictions.

#### PR checklist

##### For all contributions

- [x] I've added myself to the list of contributors with the `bug`, `code`, and `test` badges.
- [x] The PR title starts with `[BUG]`.