### PR TITLE
[BUG] support SubLOF fit_predict with novelty=False

### DIFF
--- a/sktime/detection/lof.py
+++ b/sktime/detection/lof.py
@@ -192,9 +192,44 @@ class SubLOF(BaseDetector):
             interval: LocalOutlierFactor(**model_params) for interval in intervals
         }
 
+        training_anomaly_indexes = []
         for interval, model in self.models.items():
             mask = (X.index >= interval.left) & (X.index < interval.right)
-            model.fit(X.loc[mask])
+            X_subset = X.loc[mask]
+
+            if self.novelty:
+                model.fit(X_subset)
+            else:
+                y_subset = model.fit_predict(X_subset)
+                interval_ilocs = np.flatnonzero(mask)
+                training_anomaly_indexes.extend(interval_ilocs[y_subset == -1])
+
+        if not self.novelty:
+            self._fit_predict_output_ = pd.DataFrame(
+                {"ilocs": pd.Series(training_anomaly_indexes, dtype="int64")}
+            )
+
+    def fit_predict(self, X, y=None):
+        """Fit to data and return anomaly locations in the training data.
+
+        Parameters
+        ----------
+        X : pd.DataFrame, pd.Series or np.ndarray
+            Training data to fit model to (time series).
+        y : pd.DataFrame with RangeIndex, optional
+            Known events for training. Unused because ``SubLOF`` is unsupervised.
+
+        Returns
+        -------
+        y : pd.DataFrame with RangeIndex
+            Detected anomaly locations in the ``"ilocs"`` column.
+        """
+        self.fit(X, y=y)
+
+        if self.novelty:
+            return self.predict(X)
+
+        return self._fit_predict_output_.copy()
 
     @staticmethod
     def _split_into_intervals(x, interval_size):

--- a/sktime/detection/tests/test_lof.py
+++ b/sktime/detection/tests/test_lof.py
@@ -84,6 +84,34 @@ def test_predict(X, y_expected):
     not run_test_for_class(SubLOF),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
+def test_fit_predict_with_novelty_false():
+    """Check training anomalies can be predicted when novelty is disabled."""
+    X = pd.DataFrame([0, 0, 100, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 100, 0])
+    expected = pd.DataFrame({"ilocs": [2, 7, 13]})
+
+    model = SubLOF(3, window_size=5, novelty=False)
+
+    pd.testing.assert_frame_equal(model.fit_predict(X), expected)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SubLOF),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_fit_transform_with_novelty_false():
+    """Check training anomaly labels can be transformed when novelty is disabled."""
+    X = pd.DataFrame([0, 0, 100, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 100, 0])
+    expected = pd.DataFrame({"labels": [0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0]})
+
+    model = SubLOF(3, window_size=5, novelty=False)
+
+    pd.testing.assert_frame_equal(model.fit_transform(X), expected)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(SubLOF),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
 def test_sublof_does_not_mutate_input():
     """Check that SubLOF does not modify the input DataFrame."""
     X = pd.DataFrame([0, 0.5, 100, 0.1, 0, 0.2, 0.3, 50])


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #7652.

#### What does this implement/fix? Explain your changes.

`SubLOF.fit_predict()` previously inherited the default detector implementation, which calls `fit(X).predict(X)`. This fails when `novelty=False` because scikit-learn's `LocalOutlierFactor` only supports `fit_predict()` for detecting anomalies in its training data in that mode.

This change:

- uses `LocalOutlierFactor.fit_predict()` while fitting each interval when `novelty=False`;
- converts interval-level anomaly positions into locations in the complete input series;
- stores and returns those locations using sktime's standard `ilocs` output format;
- preserves the existing `fit()` followed by `predict()` behaviour when `novelty=True`.

Calling `predict()` on unseen data with `novelty=False` remains unsupported, consistent with scikit-learn's API.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether overriding `SubLOF.fit_predict()` is the appropriate way to support the training-only `novelty=False` workflow.
- Whether interval-level anomaly positions are correctly converted to global `iloc` positions.
- Whether the existing `novelty=True` behaviour remains unchanged.

#### Did you add any tests for the change?

Yes.

- Added a regression test for `fit_predict()` with `novelty=False`, checking anomaly locations `[2, 7, 13]`.
- Added a regression test for `fit_transform()` with `novelty=False`, checking the corresponding dense anomaly labels.

Validation performed:

- `8 passed` across the focused `SubLOF` and detector-base tests.
- `92` applicable generic estimator checks passed.
- All applicable pre-commit hooks passed.

#### Any other comments?

The regression tests failed at the reported `LocalOutlierFactor.predict()` call before the implementation change and passed afterward.

#### PR checklist

##### For all contributions

- [x] I've added myself to the list of contributors with the relevant badges. My contributor entry is included in #10921.
- [x] The PR title starts with `[BUG]`.

The “new estimator” checklist is not applicable because this PR fixes an existing estimator.