### PR TITLE
[BUG] Preserve time index names in forecasting outputs

### DIFF
--- a/sktime/forecasting/base/_base.py
+++ b/sktime/forecasting/base/_base.py
@@ -577,6 +577,7 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
             store=self._converter_store_y,
             store_behaviour="freeze",
         )
+        y_out = self._restore_y_index_names(y_out)
 
         return y_out
 
@@ -1602,6 +1603,7 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
             store=self._converter_store_y,
             store_behaviour="freeze",
         )
+        y_pred = self._restore_y_index_names(y_pred)
 
         return y_pred
 
@@ -1936,6 +1938,8 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
                 )
 
             y_scitype = y_metadata["scitype"]
+            if hasattr(y, "index"):
+                y_metadata["index_names"] = list(y.index.names)
             self._y_metadata = y_metadata
             self._y_mtype_last_seen = y_metadata["mtype"]
 
@@ -2674,6 +2678,13 @@ class BaseForecaster(_StateAtMixin, _PredictProbaMixin, BaseEstimator):
         """
         featnames = self._y_metadata["feature_names"]
         return featnames
+
+    def _restore_y_index_names(self, y_pred):
+        """Restore row index names from the most recently seen y."""
+        index_names = self._y_metadata.get("index_names")
+        if index_names is not None and hasattr(y_pred, "index"):
+            y_pred.index.names = index_names
+        return y_pred
 
     def _get_columns(self, method="predict", **kwargs):
         """Return column names for DataFrame-like returns.

--- a/sktime/forecasting/base/tests/test_base.py
+++ b/sktime/forecasting/base/tests/test_base.py
@@ -33,6 +33,21 @@ HIER_MTYPES = ["pd_multiindex_hier"]
 BACKENDS = _get_parallel_test_fixtures("config")
 
 
+def test_predict_preserves_time_index_name():
+    """Test that point forecasts preserve the time index name from y."""
+    y = _make_series(return_mtype="pd.Series", index_type="period")
+    y.index = y.index.rename("time")
+
+    y_pred = NaiveForecaster().fit(y, fh=[1, 2]).predict()
+
+    assert y_pred.index.name == y.index.name
+
+    forecaster = NaiveForecaster().fit(y.iloc[:-2], fh=[1, 2])
+    y_pred = forecaster.update_predict_single(y.iloc[-2:], update_params=False)
+
+    assert y_pred.index.name == y.index.name
+
+
 @pytest.mark.skipif(
     not run_test_module_changed(["sktime.forecasting.base", "sktime.datatypes"])
     or not _check_soft_dependencies("skpro", severity="none"),


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #7671.

#### What does this implement/fix? Explain your changes.

Forecasting outputs could lose the name of the time index. For example, a training series with a `PeriodIndex` named `"time"` produced predictions with an unnamed index.

This change records the index names from the most recently supplied target series and restores them after converting forecasting outputs back to the user's original data type.

The fix applies to both `predict` and `update_predict_single` through `BaseForecaster`, so individual forecasters do not need separate handling.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether restoring index names in `BaseForecaster` is the appropriate shared location.
- Whether index names should always follow the most recently supplied `y`.
- Whether any additional forecasting output methods should use the same restoration helper.

#### Did you add any tests for the change?

Yes. A regression test verifies that both `predict` and `update_predict_single` preserve the time-index name.

The relevant test suites were run with:

`pytest sktime/forecasting/base/tests/test_base.py sktime/forecasting/tests/test_naive.py`

Result: 162 passed and 49 skipped.

`git diff --check` also passed.

The full pre-commit suite was not run because the local pre-commit cache was read-only and Ruff was unavailable in the current environment.

#### Any other comments?

The change does not alter forecast values or index values. It only restores the index-level names from the target series.

#### PR checklist

##### For all contributions

- [ ] I've added myself to the list of contributors with any new badges I've earned.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].