### PR TITLE
[BUG] fix deepcopy of estimators using SeqSelfAttentionTorch

### DIFF
--- a/sktime/libs/_torch_self_attention/seq_self_attention.py
+++ b/sktime/libs/_torch_self_attention/seq_self_attention.py
@@ -1,5 +1,7 @@
 """Sequential self-attention layer implemented in PyTorch."""
 
+import copy
+
 from sktime.utils.dependencies import _safe_import
 
 NNModule = _safe_import("torch.nn.Module")
@@ -287,17 +289,22 @@ class SeqSelfAttentionTorch(NNModule):
         if mask is not None:
             e = self._apply_mask(e, mask)
 
-        self.intensity = e
+        # kept for inspection only, and detached so that the layer stays
+        # copyable and picklable once it has been run
+        self.intensity = e.detach()
         e = e - e.max(dim=-1, keepdim=True)[0]
         torch_exp = self._torch_op("torch.exp")
         torch_finfo = self._torch_op("torch.finfo")
         a = torch_exp(e)
         a = a / (a.sum(dim=-1, keepdim=True) + torch_finfo(a.dtype).eps)
-        self.attention = a
+        self.attention = a.detach()
 
         torch_bmm = self._torch_op("torch.bmm")
         v = torch_bmm(a, x)
         if self.attention_regularizer_weight > 0.0:
+            # deliberately kept attached to the graph: callers add this term to
+            # their training loss, so detaching it here would silently turn the
+            # regularizer into a no-op. ``__deepcopy__`` below drops it instead.
             self.attention_regularizer_loss = self._attention_regularizer(a)
         else:
             self.attention_regularizer_loss = None
@@ -305,6 +312,36 @@ class SeqSelfAttentionTorch(NNModule):
         if self.return_attention:
             return v, a
         return v
+
+    def __deepcopy__(self, memo):
+        """Deep-copy the layer, dropping the graph from transient state.
+
+        ``attention_regularizer_loss`` is intentionally left attached to the
+        autograd graph by ``forward``, so that callers can add it to their
+        training loss. Non-leaf tensors do not support the deepcopy protocol,
+        which would make any fitted estimator containing this layer
+        uncopyable. The copy therefore carries a detached clone of the value,
+        which is all a copy can meaningfully hold.
+
+        Parameters
+        ----------
+        memo : dict
+            Memoisation dictionary used by :func:`copy.deepcopy`.
+
+        Returns
+        -------
+        SeqSelfAttentionTorch
+            A deep copy of this layer.
+        """
+        cls = self.__class__
+        new = cls.__new__(cls)
+        memo[id(self)] = new
+        for key, value in self.__dict__.items():
+            if key == "attention_regularizer_loss" and value is not None:
+                new.__dict__[key] = value.detach().clone()
+            else:
+                new.__dict__[key] = copy.deepcopy(value, memo)
+        return new
 
     def _call_additive_emission(self, x):
         """Compute additive attention logits for every pair of time steps.

--- a/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_deepcopy.py
+++ b/sktime/libs/_torch_self_attention/tests/seq_self_attention/test_deepcopy.py
@@ -1,0 +1,108 @@
+import copy
+
+import pytest
+from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
+
+from sktime.tests.test_switch import run_test_module_changed
+
+pytestmark = pytest.mark.skipif(
+    not run_test_module_changed("sktime.libs._torch_self_attention")
+    or not _check_soft_dependencies("torch", severity="none"),
+    reason="Execute tests for iff anything in the module has changed",
+)
+
+
+class TestDeepcopy:
+    """Tests that the layer stays copyable once it has been run.
+
+    ``forward`` stores intermediate tensors on the layer. Non-leaf tensors do
+    not support the deepcopy protocol, so any such tensor left attached to the
+    autograd graph makes every fitted estimator containing this layer
+    uncopyable, which breaks ``test_deepcopy_fitted`` for TapNet and CNTC.
+    """
+
+    @staticmethod
+    def _make(weight=0.0, attention_type=None):
+        from sktime.libs._torch_self_attention import SeqSelfAttentionTorch
+
+        if attention_type is None:
+            attention_type = SeqSelfAttentionTorch.ATTENTION_TYPE_ADD
+        return SeqSelfAttentionTorch(
+            input_dim=8,
+            return_attention=False,
+            attention_type=attention_type,
+            attention_regularizer_weight=weight,
+        )
+
+    @pytest.mark.parametrize("weight", [0.0, 1e-4])
+    def test_deepcopy_after_forward(self, weight):
+        """Layer is deep-copyable after a forward pass, with and without the
+        attention regularizer enabled."""
+        from sktime.libs._torch_self_attention import SeqSelfAttentionTorch
+
+        for attention_type in (
+            SeqSelfAttentionTorch.ATTENTION_TYPE_ADD,
+            SeqSelfAttentionTorch.ATTENTION_TYPE_MUL,
+        ):
+            attention = self._make(weight, attention_type)
+            torch_randn = _safe_import("torch.randn")
+            attention(torch_randn(2, 5, 8))
+
+            attention_copy = copy.deepcopy(attention)
+
+            for name, value in vars(attention_copy).items():
+                grad_fn = getattr(value, "grad_fn", None)
+                assert grad_fn is None, (
+                    f"{name} is still attached to the autograd graph on the copy"
+                )
+
+    def test_deepcopy_preserves_behaviour(self):
+        """The copy is independent of the original and computes the same output."""
+        attention = self._make(weight=1e-4)
+        torch_randn = _safe_import("torch.randn")
+        x = torch_randn(2, 5, 8)
+        attention(x)
+
+        attention_copy = copy.deepcopy(attention)
+
+        params = list(attention.parameters())
+        params_copy = list(attention_copy.parameters())
+        assert len(params) == len(params_copy)
+        assert all(p is not q for p, q in zip(params, params_copy))
+
+        torch_allclose = _safe_import("torch.allclose")
+        assert torch_allclose(attention(x), attention_copy(x), atol=1e-6)
+
+    def test_regularizer_loss_is_differentiable(self):
+        """``attention_regularizer_loss`` must stay attached to the graph.
+
+        It is meant to be added to the caller's training loss. Detaching it to
+        make the layer copyable would silently turn the regularizer into a
+        no-op, so guard against that regression here.
+        """
+        attention = self._make(weight=1e-2)
+        torch_randn = _safe_import("torch.randn")
+        attention(torch_randn(2, 5, 8))
+
+        loss = attention.attention_regularizer_loss
+        assert loss is not None
+        assert loss.requires_grad
+        assert loss.grad_fn is not None
+
+        attention.zero_grad()
+        loss.backward()
+        grads = [p.grad for p in attention.parameters() if p.grad is not None]
+        assert grads, "regularizer produced no gradients"
+        assert any(g.abs().sum().item() > 0 for g in grads)
+
+    def test_transient_tensors_are_detached(self):
+        """``intensity`` and ``attention`` are inspection only, so they are
+        detached at assignment rather than at copy time."""
+        attention = self._make(weight=1e-4)
+        torch_randn = _safe_import("torch.randn")
+        attention(torch_randn(2, 5, 8))
+
+        assert attention.intensity is not None
+        assert attention.intensity.grad_fn is None
+        assert attention.attention is not None
+        assert attention.attention.grad_fn is None


### PR DESCRIPTION
Fixes #10928 

#### What does this implement/fix? Explain your changes.
`SeqSelfAttentionTorch.forward` stored three intermediate tensors on the layer while they were still attached to the autograd graph. Non-leaf tensors do not support the deepcopy protocol, so once the layer had been run, any estimator containing it was uncopyable — `TapNetRegressorTorch` and `TapNetClassifierTorch` each failed 16 `test_deepcopy_fitted` checks.

The three tensors need different treatment:

- `intensity` and `attention` are inspection/visualization only, so they are now detached at assignment. This fixes copying and releases the graph, with nothing lost.
- `attention_regularizer_loss` is a **loss term** — callers add it to their training loss. Detaching it would fix the copy error but silently turn the regularizer into a no-op, with no error to reveal it. It therefore stays attached, and a new `__deepcopy__` drops the graph in the copy instead.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### Did you add any tests for the change?
Yes — `sktime/libs/_torch_self_attention/tests/seq_self_attention/test_deepcopy.py`, 5 tests. Full module suite: 21 passed.

Estimator checks:
- `TapNetRegressorTorch` and `TapNetClassifierTorch` all pass.
- `CNTCRegressorTorch` and `CNTCClassifierTorch` all pass when this fix is applied to #10920.