### PR TITLE
[BUG] fix HFTransformersForecaster mismatched keys

### DIFF
--- a/sktime/forecasting/hf_transformers.py
+++ b/sktime/forecasting/hf_transformers.py
@@ -280,7 +280,12 @@ class HFTransformersForecaster(BaseForecaster):
             # Freeze loaded parameters and reinitialize mismatched layers
             for param in self.model.parameters():
                 param.requires_grad = False
-            for key, _, _ in self.info["mismatched_keys"]:
+            for entry in self.info["mismatched_keys"]:
+                # transformers may return mismatched keys as strings or tuples.
+                if isinstance(entry, tuple):
+                    key = entry[0]
+                else:
+                    key = entry
                 _model = self.model
                 for attr_name in key.split(".")[:-1]:
                     _model = getattr(_model, attr_name)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10903.

#### What does this implement/fix? Explain your changes.

`HFTransformersForecaster` always assumed that `transformers` returned `mismatched_keys` entries as tuples. Some supported `transformers` versions return these entries as plain strings, resulting in an unpacking error during fitting.

This PR updates the handling of `mismatched_keys` to support both string and tuple formats.

The change:

- handles `mismatched_keys` entries returned as strings or tuples
- extracts the parameter key before traversing the model hierarchy
- preserves the existing behavior for tuple entries

The change is restricted to `sktime/forecasting/hf_transformers.py`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the handling of the different `mismatched_keys` formats is correct.
- Whether the existing model reinitialization behavior is preserved.
- Whether the change is sufficiently minimal for the compatibility issue.

#### Did you add any tests for the change?

No new permanent tests were added.

The changed logic was independently validated for both string and tuple `mismatched_keys` formats.

The existing HFTransformersForecaster test suite could not be fully executed locally due to a Windows PyTorch DLL initialization error when tests are run through the pytest/execnet environment.

#### Any other comments?

The implementation follows the existing compatibility pattern used in `sktime/forecasting/ttm.py`.

No dependency constraints or unrelated code were changed.

#### PR checklist

##### For all contributions

- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the maintainers tag
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators