### PR TITLE
[BUG] fix (batch, 1) output handling in BaseDeepRegressorTorch

### DIFF
--- a/sktime/regression/deep_learning/base/_base_torch.py
+++ b/sktime/regression/deep_learning/base/_base_torch.py
@@ -109,6 +109,7 @@ class BaseDeepRegressorTorch(BaseRegressor):
         "capability:random_state": True,
         "property:randomness": "stochastic",
         "tests:vm": True,
+        "tests:libs": ["sktime.regression.deep_learning.base._base_torch"],
     }
 
     # _instantiate_activation_vars is an iterable of attribute names of activations

--- a/sktime/regression/deep_learning/base/_base_torch.py
+++ b/sktime/regression/deep_learning/base/_base_torch.py
@@ -205,6 +205,15 @@ class BaseDeepRegressorTorch(BaseRegressor):
 
         for inputs, outputs in dataloader:
             y_pred = self.network(**inputs)
+            # some networks emit (batch_size, 1) while targets are (batch_size,);
+            # without this the loss broadcasts to (batch_size, batch_size)
+            if (
+                y_pred.ndim == 2
+                and y_pred.shape[1] == 1
+                and outputs.ndim == 1
+                and y_pred.shape[0] == outputs.shape[0]
+            ):
+                y_pred = y_pred.squeeze(-1)
             loss = self._criterion(y_pred, outputs)
             self._optimizer.zero_grad()
             loss.backward()
@@ -215,16 +224,6 @@ class BaseDeepRegressorTorch(BaseRegressor):
             if self._metrics_objects:
                 import torch
 
-                # # Some networks output shape (batch_size, 1) while sktime targets are
-                # # (batch_size,). Metrics expect y_pred to be in the same shape
-                # # as outputs.
-                if (
-                    y_pred.ndim == 2
-                    and y_pred.shape[1] == 1
-                    and outputs.ndim == 1
-                    and y_pred.shape[0] == outputs.shape[0]
-                ):
-                    y_pred = y_pred.squeeze(-1)
                 with torch.no_grad():
                     for metric_name, metric_obj in self._metrics_objects.items():
                         metric_value = metric_obj(y_pred, outputs)
@@ -629,12 +628,9 @@ class BaseDeepRegressorTorch(BaseRegressor):
         y_pred = cat(y_pred, dim=0)
         y_pred = y_pred.numpy()
 
-        # For single-output regression, squeeze if needed
-        # if y_pred has shape (n_instances, 1), convert to (n_instances,)
-        # to conform to expected output shape
-        # (n_instances, 1) -> (n_instances,)
+        # (n_instances, 1) -> (n_instances,), also for n_instances == 1
         if y_pred.ndim == 2 and y_pred.shape[1] == 1:
-            y_pred = y_pred.squeeze()
+            y_pred = y_pred.squeeze(-1)
         return y_pred
 
     def _internal_convert(self, X, y=None):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10931 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
The base class yields targets of shape `(batch_size,)` while four networks emit `(batch_size, 1)`, and nothing reconciled them. Two fixes, both in `sktime/regression/deep_learning/base/_base_torch.py`:

**1. Loss shape.** `_run_epoch` now squeezes a trailing singleton off `y_pred` before calling the criterion. Previously `MSELoss` broadcast `(B, 1)` against `(B,)` into a `(B, B)` all-pairs matrix, averaging over B² terms of which only B were real residuals — a wrong training signal. This also makes the identical squeeze already present in the metrics block redundant, so that is removed.

The normalisation is deliberately guarded (`ndim == 2`, `shape[1] == 1`, `outputs.ndim == 1`, matching batch dim) so it leaves multioutput heads and non-regression criteria alone.

**2. `_predict` shape.** A bare `squeeze()` collapsed `(1, 1)` to a 0-d array, so `predict()` on a single instance returned `()` instead of `(1,)`. Changed to `squeeze(-1)`. 

Fixing the loss in the base class rather than in each network keeps one point of control and stops a future network from reintroducing it.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### Did you add any tests for the change?
No. Verified manually locally.
The existing suite is structurally blind to both bugs: `ignore::UserWarning` in `setup.cfg` discards the
only signal the loss bug emits, and nothing asserts single-instance predict shape.