### PR TITLE
[BUG] fix `get_sklearn_tag`, which raises on sktime estimators with `scikit-learn` 1.9

### DIFF
--- a/sktime/utils/sklearn/_tag_adapter.py
+++ b/sktime/utils/sklearn/_tag_adapter.py
@@ -1,5 +1,14 @@
 """Version bridge for tags."""
 
+# scikit-learn tag names used by ``get_sklearn_tag``, mapped to the sktime tag
+# carrying the same information. Used for sktime estimators, which do not
+# implement the sklearn tag interface, see ``get_sklearn_tag``.
+SKLEARN_TO_SKTIME_TAG = {
+    "capability:multioutput": "capability:multioutput",
+    "capability:categorical": "capability:categorical_in_X",
+    "fit_is_empty": "fit_is_empty",
+}
+
 
 def get_sklearn_tag(estimator, tagname):
     """Get the value of a scikit-learn tag.
@@ -27,7 +36,17 @@ def get_sklearn_tag(estimator, tagname):
     value : object
         Value of the specified tag.
     """
+    from skbase.base import BaseObject
     from skbase.utils.dependencies import _check_soft_dependencies
+
+    # sktime objects do not inherit from ``sklearn.base.BaseEstimator``, so they do
+    # not implement ``__sklearn_tags__``. Up to scikit-learn 1.8, ``get_tags`` fell
+    # back to defaults for such objects; from 1.9 on it raises ``AttributeError``.
+    # sktime carries the same information in its own tags, so read those directly.
+    if isinstance(estimator, BaseObject):
+        sktime_tagname = SKLEARN_TO_SKTIME_TAG.get(tagname)
+        if sktime_tagname is not None:
+            return estimator.get_tag(sktime_tagname, False, raise_error=False)
 
     if tagname == "capability:multioutput":
         if _check_soft_dependencies("scikit-learn<1.6", severity="none"):

--- a/sktime/utils/sklearn/tests/test_tag_adapter.py
+++ b/sktime/utils/sklearn/tests/test_tag_adapter.py
@@ -1,0 +1,52 @@
+"""Tests for the sklearn tag adapter in utils.sklearn."""
+
+__author__ = ["chala2001"]
+
+
+import pytest
+from sklearn.neighbors import KNeighborsRegressor
+from sklearn.preprocessing import StandardScaler
+
+from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor
+from sktime.tests.test_switch import run_test_for_class
+from sktime.utils.sklearn._tag_adapter import get_sklearn_tag
+
+# sklearn tag names understood by get_sklearn_tag, and the sktime tag
+# carrying the same information
+TAG_PAIRS = [
+    ("capability:multioutput", "capability:multioutput"),
+    ("capability:categorical", "capability:categorical_in_X"),
+    ("fit_is_empty", "fit_is_empty"),
+]
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(get_sklearn_tag),
+    reason="Run if tag adapter has changed.",
+)
+@pytest.mark.parametrize("tagname, sktime_tagname", TAG_PAIRS)
+def test_get_sklearn_tag_on_sktime_estimator(tagname, sktime_tagname):
+    """Test that get_sklearn_tag reads sktime tags of sktime estimators.
+
+    sktime objects do not implement ``__sklearn_tags__``. From scikit-learn 1.9 on,
+    ``sklearn.utils.get_tags`` raises ``AttributeError`` on such objects instead of
+    falling back to defaults, so the adapter must read the sktime tag instead.
+    Failure case of bug #10725.
+    """
+    estimator = KNeighborsTimeSeriesRegressor()
+
+    tag_value = get_sklearn_tag(estimator, tagname)
+
+    expected = estimator.get_tag(sktime_tagname, False, False)
+    assert tag_value == expected
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(get_sklearn_tag),
+    reason="Run if tag adapter has changed.",
+)
+@pytest.mark.parametrize("tagname, sktime_tagname", TAG_PAIRS)
+def test_get_sklearn_tag_on_sklearn_estimator(tagname, sktime_tagname):
+    """Test that get_sklearn_tag still reads tags of genuine sklearn estimators."""
+    for estimator in [KNeighborsRegressor(), StandardScaler()]:
+        assert isinstance(get_sklearn_tag(estimator, tagname), bool)


### PR DESCRIPTION
LLM generated content, by Claude Opus 5

#### Reference Issues/PRs

Towards #10725.

#### What does this implement/fix? Explain your changes.

On `scikit-learn` 1.9, `get_sklearn_tag` raises for every sktime estimator passed to it:

```python
from sktime.utils.sklearn._tag_adapter import get_sklearn_tag
from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor

get_sklearn_tag(KNeighborsTimeSeriesRegressor(), "capability:multioutput")
# AttributeError: 'KNeighborsTimeSeriesRegressor' object has no attribute
# '__sklearn_tags__'
```

sktime objects do not inherit from `sklearn.base.BaseEstimator`, so they have no
`__sklearn_tags__`. Up to 1.8, sklearn's `get_tags` fell back to defaults for such
objects; from 1.9 on it raises instead.

All three tags the adapter supports have sktime equivalents, so for sktime objects it
now reads the sktime tag directly:

| adapter tag | sktime tag |
|---|---|
| `capability:multioutput` | `capability:multioutput` |
| `capability:categorical` | `capability:categorical_in_X` |
| `fit_is_empty` | `fit_is_empty` |

Behaviour for genuine sklearn estimators is unchanged. This affects the four call sites
of `get_sklearn_tag` - `forecasting/compose/_reduce.py`, `forecasting/var_reduce.py`,
and two in `transformations/adapt.py`. The reducers legitimately receive sktime
estimators, so on 1.9 they currently fail at that point.

#### Does your contribution introduce a new dependency? If yes, which one?

No. I left the `scikit-learn<1.8.0` bound in `pyproject.toml` alone - lifting it belongs
with the rest of #10725, not here.

#### What should a reviewer concentrate their feedback on?

- This is slightly more than a crash fix: sktime objects now get their own tag rather
  than sklearn's defaults. Only four estimators currently declare
  `capability:multioutput` (`MultiplexClassifier`, `MultiplexRegressor`,
  `TSCGridSearchCV`, `TSRGridSearchCV`), so the practical difference is that these are
  no longer wrapped in `MultiOutputRegressor` by `DirectReductionForecaster`. Happy to
  narrow it to a pure crash fix if you would rather keep the old values.
- Whether `capability:categorical` should map to `capability:categorical_in_X` only, or
  also consider `capability:categorical_in_y`.

#### Did you add any tests for the change?

Yes, `sktime/utils/sklearn/tests/test_tag_adapter.py`. The sktime-estimator tests fail
on `main` under `scikit-learn` 1.9.0 and pass with this change.

Checked against 1.9.0 on `python` 3.11 - worth noting 1.9 requires `python>=3.11`, so it
cannot be installed in a 3.10 dev environment, which makes this awkward to reproduce.
1.7.2 was used as the baseline: there, the existing suites for all four call sites pass
unchanged (`utils/sklearn`, `transformations/tests/test_adapt.py`,
`test_sklearn_adaptor.py`, `forecasting/compose/tests/test_reduce.py`,
`test_reduce_global.py`) - 289 passed, 2 skipped.

#### Any other comments?

Two notes from reproducing #10725, in case they help scope the rest of it:

- The four `*TimeSeriesRegressionForecaster` reducers listed in the issue do not appear
  to be affected by 1.9 as such. Three run fine on both 1.7.2 and 1.9.0, and
  `MultioutputTimeSeriesRegressionForecaster` fails identically on both versions, which
  looks like #10896 rather than a version incompatibility.
- `ElasticEnsemble` is affected, but by a different route: it puts a
  `KNeighborsTimeSeriesClassifier` inside sklearn's `GridSearchCV`, which calls
  `get_tags` on it. That needs sktime estimators to be readable by sklearn's tag system,
  which is a bigger question than this PR, so I left it out. `sklearn.base.is_classifier`
  and `is_regressor` also raise on sktime objects on 1.9, for the same reason.

I left `.all-contributorsrc` alone here, since #10908 already adds my entry and editing
it in both PRs would conflict.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) - my entry is added in #10908, so I left the file untouched here to avoid a conflict.
- [x] The PR title starts with [BUG].
