### PR TITLE
fix off-by-one in PatchTST prediction_length derived from fh

### DIFF
--- a/sktime/forecasting/patch_tst.py
+++ b/sktime/forecasting/patch_tst.py
@@ -384,6 +384,7 @@ class PatchTSTForecaster(BaseForecaster):
         # Tests and CI tags
         # -----------------
         "tests:vm": True,
+        "tests:specific": ["sktime.forecasting.tests.test_patch_tst"],
     }
 
     def __init__(
@@ -448,7 +449,7 @@ class PatchTSTForecaster(BaseForecaster):
             _config["num_input_channels"] = len(y.columns)
             if fh is not None:
                 _config["prediction_length"] = max(
-                    *(fh.to_relative(self._cutoff)._values + 1),
+                    *fh.to_relative(self._cutoff)._values,
                     _config["prediction_length"],
                 )
 

--- a/sktime/forecasting/tests/test_patch_tst.py
+++ b/sktime/forecasting/tests/test_patch_tst.py
@@ -1,0 +1,45 @@
+"""Tests for the PatchTST forecaster."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sktime.forecasting.patch_tst import PatchTSTForecaster
+from sktime.tests.test_switch import run_test_for_class
+
+# public checkpoint whose native prediction_length is 96, loading with no
+# missing or mismatched weights
+_PATCHTST_MODEL = "ibm-granite/granite-timeseries-patchtst"
+_CONTEXT_LENGTH = 512
+_PREDICTION_LENGTH = 96
+_N_CHANNELS = 7
+
+
+def _make_y():
+    """Return data matching the checkpoint's expected context and channels."""
+    values = np.random.RandomState(0).randn(_CONTEXT_LENGTH, _N_CHANNELS)
+    columns = [f"c{i}" for i in range(_N_CHANNELS)]
+    return pd.DataFrame(values.astype("float32"), columns=columns)
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(PatchTSTForecaster),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_patch_tst_zero_shot_native_prediction_length():
+    """Zero-shot forecasting works for the checkpoint's full prediction_length.
+
+    ``_fit`` derives ``prediction_length`` from the forecasting horizon. Requesting
+    the checkpoint's own ``prediction_length`` must not enlarge it, as that reshapes
+    the prediction head and makes the pretrained weights fail to load.
+    """
+    y = _make_y()
+    fh = list(range(1, _PREDICTION_LENGTH + 1))
+
+    forecaster = PatchTSTForecaster(
+        model_path=_PATCHTST_MODEL, fit_strategy="zero-shot"
+    )
+    y_pred = forecaster.fit(y, fh=fh).predict()
+
+    assert len(y_pred) == _PREDICTION_LENGTH
+    assert forecaster.model.config.prediction_length == _PREDICTION_LENGTH


### PR DESCRIPTION
#### Reference Issues/PRs

None yet, bug found while adding golden-output tests for `PatchTSTForecaster` (part of #10672). Happy to open a separate issue first if preferred.

#### What does this implement/fix? Explain your changes.

`_fit` derives the model's `prediction_length` from the forecasting horizon:

```python
_config["prediction_length"] = max(
    *(fh.to_relative(self._cutoff)._values + 1),
    _config["prediction_length"],
)
```

The `+ 1` is an off-by-one. To forecast `n` steps ahead, `prediction_length` needs to be `n`, not `n + 1`,  `fh.to_relative()` is already 1-based, so `fh=[1, ..., 96]` yields relative values `[1, ..., 96]` and the `+ 1` turns the required length into 97.

This is not merely a wasted step. When `fh` reaches the checkpoint's own `prediction_length`, the inflated value reshapes the prediction head, the pretrained weights no longer match, and `fit_strategy="zero-shot"` raises:

```
ValueError: Fit strategy is 'zero-shot', but the model weights in the configuration are mismatched or missing compared to the pre-trained model.
```

with transformers reporting the underlying cause:

```
head.projection.bias   | MISMATCH | ckpt: torch.Size([96])      vs model: torch.Size([97])
head.projection.weight | MISMATCH | ckpt: torch.Size([96, 128]) vs model: torch.Size([97, 128])
```

So a user currently cannot request the model's native horizon. Against `ibm-granite/granite-timeseries-patchtst` (native `prediction_length=96`), `fh=1..95` works and `fh=1..96` fails, while the same checkpoint loads in raw `transformers` with zero missing or mismatched keys.

`prediction_length` only needs to be **at least** the largest relative horizon: `_predict` generates the full-length output and then filters it down to the requested horizons via `absolute_horizons`. For `fit_strategy` `"full"` and `"minimal"` the old value was merely one step too long (trained, then discarded by that filter), which is why this went unnoticed, the failure is only fatal for `"zero-shot"`, where head shape must match the checkpoint exactly.

The fix drops the `+ 1`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Whether the `+ 1` was load-bearing for some horizon convention I haven't traced, I could find no path where it is, given `_predict` filters to `fh` afterwards, but it predates the current file layout so a second opinion is worth having.

#### Did you add any tests for the change?

Yes, `test_patch_tst_zero_shot_native_prediction_length`, which forecasts at the checkpoint's full native `prediction_length` (96). Verified it fails on `main` with the mismatch above and passes with this change. Also added the `tests:specific` tag pointing at the new test file.

Note: this test is `tests:vm`-gated via `run_test_for_class`, so locally it needs `ONLY_VM_ESTIMATORS=True` to actually execute rather than skip.

#### Any other comments?

Unrelated but worth flagging: the `model_path` used throughout this estimator's docstring examples, `namctin/patchtst_etth1_forecast`, is now a **gated** repo, it 403s and redirects to `ibm-research/testing-patchtst_etth1_forecast`, which requires authorization. The examples are `# doctest: +SKIP` so nothing fails in CI, but anyone copying them will hit an access error. Happy to open a separate PR switching those to a public checkpoint if useful.
