### PR TITLE
[ENH] fix `ResNetRegressor` broken `__init__`

### DIFF
--- a/sktime/regression/deep_learning/resnet.py
+++ b/sktime/regression/deep_learning/resnet.py
@@ -108,7 +108,7 @@ class ResNetRegressor(BaseDeepRegressor):
         """
         self.history = None
         self._network = ResNetNetwork(
-            activation_hidden=self.activation_hidden,
+            activation=self.activation_hidden,
             random_state=self.random_state,
         )
 


### PR DESCRIPTION
The `__init__` of `ResNetRegressor` was broken since it passed an incorrect argument to `ResNetNetwork`.

Test coverage may have not seen this because the network is not tracked by test triggers, this will be covered in a separate PR.