### PR TITLE
[ENH] replace mutable default arguments with immutable tuples in `GRUFCNNClassifier` and `RBFForecaster`

### DIFF
--- a/sktime/classification/deep_learning/gru.py
+++ b/sktime/classification/deep_learning/gru.py
@@ -303,8 +303,8 @@ class GRUFCNNClassifier(BaseDeepClassifierPytorch):
         dropout: float = 0.0,
         gru_dropout: float = 0.0,
         bidirectional: bool = False,
-        conv_layers: list = [128, 256, 128],
-        kernel_sizes: list = [7, 5, 3],
+        conv_layers: tuple = (128, 256, 128),
+        kernel_sizes: tuple = (7, 5, 3),
         # base classifier specific
         num_epochs: int = 10,
         batch_size: int = 8,

--- a/sktime/forecasting/rbf.py
+++ b/sktime/forecasting/rbf.py
@@ -58,7 +58,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         - ``"multiquadric"``: :math:`\sqrt{1 + \gamma (t - c)^2}`
         - ``"inverse_multiquadric"``: :math:`\frac{1}{\sqrt{1 + \gamma (t - c)^2}}`
 
-    hidden_layers : list of int, optional (default=[64, 32])
+    hidden_layers : list or tuple of int, optional (default=(64, 32))
         Sizes of linear layers following the RBF layer.
     optimizer : {"adam", "sgd", "rmsprop"}, optional (default="adam")
         Type of optimizer to use.
@@ -117,7 +117,7 @@ class RBFForecaster(BaseDeepNetworkPyTorch):
         centers=None,
         gamma=1.0,
         rbf_type="gaussian",
-        hidden_layers=[64, 32],
+        hidden_layers=(64, 32),
         optimizer="adam",
         lr=0.01,
         epochs=100,


### PR DESCRIPTION
## Summary

Three estimator `__init__` parameters use mutable list defaults (ruff B006) — one shared list object across every instance constructed with defaults:

- `classification/deep_learning/gru.py` — `conv_layers: list = [128, 256, 128]` and `kernel_sizes: list = [7, 5, 3]`
- `forecasting/rbf.py` — `hidden_layers=[64, 32]`

Because sktime follows the sklearn contract (`__init__` stores params verbatim; no normalization allowed for `get_params`/`clone` fidelity), the usual `None`-sentinel fix would be wrong here. Instead the defaults become **immutable tuples** — stored verbatim exactly as before, introspectable, and only ever iterated downstream, so behavior is unchanged while the shared-mutable hazard is gone. This matches sklearn's own convention for sequence-valued defaults.

Vendored code under `sktime/libs/` (granite_ttm, sundial, timer) has the same pattern but was deliberately left untouched — those track upstream sources.

Docstring for `hidden_layers` updated to match. `get_test_params` fixtures that pass explicit lists are unaffected.

## Testing
`python -m py_compile` passes on both files; `ruff check --select B006` on them goes from 3 errors to clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)