### PR TITLE
[BUG] Warn when loading estimators saved with a different sktime version

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -352,7 +352,9 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         """
         import pickle
 
-        return pickle.loads(serial)
+        obj = pickle.loads(serial)
+        cls._warn_version_mismatch(obj)
+        return obj
 
     @classmethod
     def load_from_path(cls, serial):
@@ -370,7 +372,34 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         from zipfile import ZipFile
 
         with ZipFile(serial, "r") as file:
-            return pickle.loads(file.open("_obj").read())
+            obj = pickle.loads(file.open("_obj").read())
+        cls._warn_version_mismatch(obj)
+        return obj
+
+    @staticmethod
+    def _warn_version_mismatch(obj):
+        """Warn if ``obj`` was saved with a different sktime version.
+
+        Estimator dumps are not guaranteed to be compatible across sktime
+        versions, so loading an object saved with a different version may
+        silently produce an invalid estimator.
+        """
+        import warnings
+
+        from sktime import __version__ as current_version
+
+        saved_version = obj.get_tag(
+            "sktime_version", tag_value_default=None, raise_error=False
+        )
+        if saved_version is not None and saved_version != current_version:
+            warnings.warn(
+                f"Estimator was saved with sktime version {saved_version}, "
+                f"but the current sktime version is {current_version}. "
+                "Estimator dumps are not guaranteed to be compatible across "
+                "sktime versions; the loaded object may be invalid.",
+                UserWarning,
+                stacklevel=3,
+            )
 
 
 # todo 1.2.0: remove this class from inheritance in BaseObject

--- a/sktime/base/tests/test_base_sktime.py
+++ b/sktime/base/tests/test_base_sktime.py
@@ -64,3 +64,46 @@ def test_clone_nested_sklearn():
 
     # failure condition, see issue #4704: the setting of the copy also sets the orig
     assert original_model.get_params()["estimator__random_state"] == 5
+
+
+def test_load_warns_on_version_mismatch():
+    """Tests that loading an object saved with a different sktime version warns.
+
+    Raises
+    ------
+    AssertionError if a UserWarning mentioning the sktime version mismatch is
+    not raised when deserializing an object saved with a different version.
+    """
+    import warnings
+
+    from sktime.forecasting.naive import NaiveForecaster
+
+    forecaster = NaiveForecaster()
+    # simulate an object that was saved by an older sktime version
+    forecaster.set_tags(sktime_version="0.0.0")
+    cls, stored = forecaster.save()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cls.load_from_serial(stored)
+
+    version_warnings = [w for w in caught if "sktime version" in str(w.message)]
+    assert len(version_warnings) == 1
+    assert issubclass(version_warnings[0].category, UserWarning)
+
+
+def test_load_no_warning_on_version_match():
+    """Tests that no version-mismatch warning is raised when versions match."""
+    import warnings
+
+    from sktime.forecasting.naive import NaiveForecaster
+
+    forecaster = NaiveForecaster()
+    cls, stored = forecaster.save()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cls.load_from_serial(stored)
+
+    version_warnings = [w for w in caught if "sktime version" in str(w.message)]
+    assert len(version_warnings) == 0


### PR DESCRIPTION
Fixes #10579.

#### What does this implement/fix?
Loading an estimator that was serialized with a different sktime version can silently produce an invalid object (e.g. a required attribute added in a later version is missing after pickle restores the old state).

This adds a `UserWarning` in `BaseObject.load_from_serial` and `BaseObject.load_from_path` when the deserialized object's `sktime_version` tag differs from the current sktime version.

#### How does it work?
After deserialization, `_warn_version_mismatch` compares the stored `sktime_version` tag against `sktime.__version__` and emits a warning on mismatch.

#### Does your contribution introduce any new dependencies?
No.

#### Regression tests
Added `test_load_warns_on_version_mismatch` and `test_load_no_warning_on_version_match` in `sktime/base/tests/test_base_sktime.py`.