### PR TITLE
[ENH] refactor splitters with cleaner extension and composition contract related to `fh` parameter

### DIFF
--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -22,10 +22,8 @@ class BaseSplitter(BaseObject):
     <https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.TimeSeriesSplit.html>`__
     which implements only expanding window split strategy, and only integer based.
 
-    The most important method in this class is `.split(y)` which generates indices
-    of non-overlapping train/test splits of a time series `y`.
-    The length of the train split is determined by `window_length`.
-    The length of the test split is determined by forecasting horizon `fh`.
+    The most important method in this class is ``.split(y)`` which generates indices
+    of non-overlapping train/test splits of a time series ``y``.
 
     In general, splitting a time series :math:`y=(y_1,\ldots,y_T)`
     into train/test splits means separating it into two non-overlapping series:
@@ -34,37 +32,30 @@ class BaseSplitter(BaseObject):
     where :math:`k,l` are all integers greater than zero,
     and :math:`t(k)<t(k+1)` are ordered time indices.
     The exact set of indices depends on a concrete splitter.
-    Method `.split` is used to generate a pair of index sets:
+    Method ``.split(y)`` is used to generate a pair of index sets:
     train :math:`(t(1),\ldots,t(k))` and test :math:`(t(k+1),\ldots,t(k+l))`.
 
-    In case `window_length` and `fh` are integer valued,
-    they translate into :math:`k` and :math:`l`, respectively.
-
-    In case `window_length` and `fh` can be interpreted
-    as time interval length (time deltas), then they correspond to
-    :math:`t(k)-t(1)` and :math:`t(k+l)-t(k+1)`, respectively.
-
-    Method `.get_n_splits` returns the number of splitting iterations.
+    Method ``.get_n_splits`` returns the number of splitting iterations.
     This number depends on a concrete splitting strategy and splitter parameters.
 
-    Method `.get_cutoffs` returns the cutoff points between each train/test split.
+    Method  ``.get_cutoffs`` returns the cutoff points between each train/test split.
     Using the above notation, for a single split it corresponds
     to the last integer index of the training window, :math:`k`
 
     In order to illustrate the difference in integer/interval arithmetic
     in calculating train/test indices, let us consider the following examples.
-    Suppose, the arguments of a splitter are `cutoff = 10` and `window_length = 6`.
-    Then, we have `train_start = cutoff - window_length = 4`.
+    Suppose, the arguments of a splitter are ``cutoff = 10`` and ``window_length = 6``.
+    Then, we have ``train_start = cutoff - window_length = 4``.
     For timedelta-like values the logic is a bit more complicated.
-    The time point corresponding to the `cutoff`
-    (index value of the `y` series) is shifted back
-    by the timedelta `window_length`,
+    The time point corresponding to the ``cutoff``
+    (index value of the ``y`` series) is shifted back
+    by the timedelta ``window_length``,
     and then the integer position of the resulting datetime
     is considered to be the training window start.
-    For example, for `cutoff = 10`, and `window_length = pd.Timedelta(6, freq="D")`,
-    we have `y[cutoff] = pd.Timestamp("2021-01-10")`,
-    and `y[cutoff] - window_length = pd.Timestamp("2021-01-04")`,
-    which leads to `train_start = y.loc(y[cutoff] - window_length) = 4`.
+    For example, for ``cutoff = 10``, and ``window_length = pd.Timedelta(6, freq="D")``,
+    we have ``y[cutoff] = pd.Timestamp("2021-01-10")``,
+    and ``y[cutoff] - window_length = pd.Timestamp("2021-01-04")``,
+    which leads to ``train_start = y.loc(y[cutoff] - window_length) = 4``.
     Similar timedelta arithmetic applies to other splitter arguments.
 
     Parameters
@@ -97,7 +88,6 @@ class BaseSplitter(BaseObject):
     }
 
     def __init__(self) -> None:
-
         super().__init__()
 
         # this block has a double purpose:

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -446,6 +446,13 @@ class BaseSplitter(BaseObject):
     def fh(self):
         """Forecasting horizon, in integer resp array of integer, relative to cutoff.
 
+        Returns the indices of the test splits, relative to the last index of the
+        corresponding training split, in relative integer format,
+        in the unit of periods.
+
+        Returns ``None`` if the forecasting horizon is not defined, or not the same
+        across all train/test folds, or if the training splits have no natural period.
+
         Returns
         -------
         fh : array-like of int, or int, or None
@@ -492,6 +499,14 @@ class BaseSplitter(BaseObject):
 
     def get_fh(self):
         """Forecasting horizon, in ForecastingHorizon format, relative to cutoff.
+
+        Returns the indices of the test splits, relative to the last index of the
+        corresponding training split, in ``ForecastingHorizon`` format.
+
+        This is the same as the property ``fh``, coerced to ``ForecastingHorizon`` type.
+
+        Returns ``None`` if the forecasting horizon is not defined, or not the same
+        across all train/test folds.
 
         Returns
         -------

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -105,7 +105,8 @@ class BaseSplitter(BaseObject):
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
         """
-        pass
+        if not hasattr(self, "fh"):
+            self.fh = self._default_fh()
 
     def split(self, y):
         """Get iloc references to train/test splits of `y`.
@@ -432,9 +433,10 @@ class BaseSplitter(BaseObject):
         """
         raise NotImplementedError("abstract method")
 
-    @property
-    def fh(self):
+    def _default_fh(self):
         """Forecasting horizon, in integer resp array of integer, relative to cutoff.
+
+        Should not be overridden by inheriting classes, use _fh instead.
 
         Returns the indices of the test splits, relative to the last index of the
         corresponding training split, in relative integer format,

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -4,23 +4,13 @@
 
 __author__ = ["fkiraly", "khrapovs", "mateuja", "mloning"]
 
-from collections.abc import Iterator
-
 import numpy as np
 import pandas as pd
 from skbase.utils.dependencies import _check_estimator_deps
 
 from sktime.base import BaseObject
 from sktime.datatypes import check_is_scitype, convert
-from sktime.split.base._common import (
-    ACCEPTED_Y_TYPES,
-    DEFAULT_FH,
-    DEFAULT_WINDOW_LENGTH,
-    PANDAS_MTYPES,
-    SPLIT_GENERATOR_TYPE,
-    SPLIT_TYPE,
-)
-from sktime.utils.validation import NON_FLOAT_WINDOW_LENGTH_TYPES
+from sktime.split.base._common import PANDAS_MTYPES
 from sktime.utils.validation.forecasting import check_fh
 
 
@@ -80,9 +70,14 @@ class BaseSplitter(BaseObject):
     Parameters
     ----------
     window_length : int or timedelta or pd.DateOffset
-        Length of rolling window
-    fh : array-like  or int, optional, (default=None)
-        Single step ahead or array of steps ahead to forecast.
+        Length of rolling window. Only exposed for window-based splitters.
+    fh : array-like or int, optional, (default=None)
+        Forecasting horizon with the steps ahead to predict, if splits are used
+        for forecasting or backtesting.
+
+        * if integer, the indices to forecast are 1, 2, ..., fh, periods ahead.
+        * if array-like, the indices to forecast are given by the values in fh,
+          values must be coercible to integer.
     """
 
     _tags = {
@@ -103,13 +98,7 @@ class BaseSplitter(BaseObject):
         "tests:core": True,  # should tests be triggered by framework changes?
     }
 
-    def __init__(
-        self,
-        fh=DEFAULT_FH,
-        window_length: NON_FLOAT_WINDOW_LENGTH_TYPES = DEFAULT_WINDOW_LENGTH,
-    ) -> None:
-        self.window_length = window_length
-        self.fh = fh
+    def __init__(self) -> None:
 
         super().__init__()
 
@@ -130,7 +119,7 @@ class BaseSplitter(BaseObject):
         """
         pass
 
-    def split(self, y: ACCEPTED_Y_TYPES) -> SPLIT_GENERATOR_TYPE:
+    def split(self, y):
         """Get iloc references to train/test splits of `y`.
 
         Parameters
@@ -160,7 +149,7 @@ class BaseSplitter(BaseObject):
         for train, test in split(y_index):
             yield train[train >= 0], test[test >= 0]
 
-    def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+    def _split(self, y):
         """Get iloc references to train/test splits of `y`.
 
         private _split containing the core logic, called from split
@@ -183,7 +172,7 @@ class BaseSplitter(BaseObject):
             test_iloc = y.get_indexer(test_loc)
             yield train_iloc, test_iloc
 
-    def _split_vectorized(self, y: pd.MultiIndex) -> SPLIT_GENERATOR_TYPE:
+    def _split_vectorized(self, y):
         """Get iloc references to train/test splits of `y`, for pd.MultiIndex.
 
         This applies _split per time series instance in the multiindex.
@@ -218,7 +207,7 @@ class BaseSplitter(BaseObject):
 
         yield from zip(train, test)
 
-    def split_loc(self, y: ACCEPTED_Y_TYPES) -> Iterator[tuple[pd.Index, pd.Index]]:
+    def split_loc(self, y):
         """Get loc references to train/test splits of `y`.
 
         Parameters
@@ -240,7 +229,7 @@ class BaseSplitter(BaseObject):
 
         yield from self._split_loc(y_index)
 
-    def _split_loc(self, y: ACCEPTED_Y_TYPES) -> Iterator[tuple[pd.Index, pd.Index]]:
+    def _split_loc(self, y):
         """Get loc references to train/test splits of `y`.
 
         private _split containing the core logic, called from split_loc
@@ -264,7 +253,7 @@ class BaseSplitter(BaseObject):
             # default gets loc index from iloc index
             yield y[train], y[test]
 
-    def split_series(self, y: ACCEPTED_Y_TYPES) -> Iterator[SPLIT_TYPE]:
+    def split_series(self, y):
         """Split `y` into training and test windows.
 
         Parameters
@@ -308,7 +297,7 @@ class BaseSplitter(BaseObject):
             y_test = convert(y_test, from_type=y_inner_mtype, to_type=y_orig_mtype)
             yield y_train, y_test
 
-    def _coerce_to_index(self, y: ACCEPTED_Y_TYPES) -> pd.Index:
+    def _coerce_to_index(self, y) -> pd.Index:
         """Check and coerce y to pandas index.
 
         Parameters
@@ -422,7 +411,7 @@ class BaseSplitter(BaseObject):
 
         return y_inner, y_mtype, y_inner_mtype
 
-    def get_n_splits(self, y: ACCEPTED_Y_TYPES | None = None) -> int:
+    def get_n_splits(self, y) -> int:
         """Return the number of splits.
 
         Parameters
@@ -440,7 +429,7 @@ class BaseSplitter(BaseObject):
         """
         return len(list(self.split(y)))
 
-    def get_cutoffs(self, y: ACCEPTED_Y_TYPES | None = None) -> np.ndarray:
+    def get_cutoffs(self, y=None) -> np.ndarray:
         """Return the cutoff points in .iloc[] context.
 
         Parameters
@@ -455,20 +444,91 @@ class BaseSplitter(BaseObject):
         """
         raise NotImplementedError("abstract method")
 
-    def get_fh(self):
-        """Return the forecasting horizon.
+    @property
+    def fh(self):
+        """Forecasting horizon, in integer resp array of integer, relative to cutoff.
 
         Returns
         -------
-        fh : ForecastingHorizon
-            The forecasting horizon
+        fh : array-like of int, or int, or None
+            Forecasting horizon with the steps ahead to predict, if splits are used
+            for forecasting or backtesting.
+
+            * if integer, the indices to forecast are ``1, 2, ..., fh``, periods ahead.
+            * if array-like, the indices to forecast are given by the values in ``fh``,
+              values must be coercible to integer.
+            * ``None`` if no forecasting horizon is set. This is returned for splitters
+              that do not have a natural forecasting horizon associated to them.
         """
-        return check_fh(self.fh)
+        fh = self._fh()
+        return fh
+
+    def _fh(self):
+        """Forecasting horizon, in integer resp array of integer, relative to cutoff.
+
+        Private method called by property ``fh``,
+        can be overridden by inheriting classes.
+
+        Default is to return a forecasting horizon of ``1``.
+
+        Returns
+        -------
+        fh : array-like or int, optional, (default=None)
+            Forecasting horizon with the steps ahead to predict, if splits are used
+            for forecasting or backtesting.
+
+            * if integer, the indices to forecast are ``1, 2, ..., fh``, periods ahead.
+            * if array-like, the indices to forecast are given by the values in ``fh``,
+              values must be coercible to integer.
+            * ``None`` if no forecasting horizon is set. This is returned for splitters
+              that do not have a natural forecasting horizon associated to them.
+        """
+        return 1
+
+    def get_fh(self):
+        """Forecasting horizon, in ForecastingHorizon format, relative to cutoff.
+
+        Returns
+        -------
+        fh : ForecastingHorizon, or None
+            Forecasting horizon with the steps ahead to predict, if splits are used
+            for forecasting or backtesting.
+
+            * if ``ForecastingHorizon``, same as ``self.fh`` coerced
+              to ``ForecastingHorizon`` type.
+            * ``None`` if no forecasting horizon is set. This is returned for splitters
+              that do not have a natural forecasting horizon associated to them.
+        """
+        fh = self.fh
+        fh = check_fh(self.fh)  # coerce to ForecastingHorizon
+        return fh
+
+    @property
+    def window_length(self):
+        """Window length, for splitters that are window based..
+
+        Returns
+        -------
+        window_length : int, timedelta, pd.DateOffset, or None
+        """
+        return self._window_length()
+
+    def _window_length(self):
+        """Window length, for splitters that are window based.
+
+        Private method called by property ``window_length``,
+        can be overridden by inheriting classes.
+
+        Default is to return a window length of ``10``.
+
+        Returns
+        -------
+        window_length : int, timedelta, pd.DateOffset, or None
+        """
+        return 10
 
     @staticmethod
-    def _get_train_window(
-        y: pd.Index, train_start: int, split_point: int
-    ) -> np.ndarray:
+    def _get_train_window(y: pd.Index, train_start: int, split_point: int):
         """Get train window.
 
         For formal definition of the train window see docstring of the `BaseSplitter`

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -445,17 +445,22 @@ class BaseSplitter(BaseObject):
 
         Returns
         -------
-        fh : array-like of int, or int, or None
+        fh : 1D np.array of int, or None
             Forecasting horizon with the steps ahead to predict, if splits are used
             for forecasting or backtesting.
 
-            * if integer, the indices to forecast are ``1, 2, ..., fh``, periods ahead.
-            * if array-like, the indices to forecast are given by the values in ``fh``,
+            * if np.array, the indices to forecast are given by the values in ``fh``,
               values must be coercible to integer.
             * ``None`` if no forecasting horizon is set. This is returned for splitters
               that do not have a natural forecasting horizon associated to them.
         """
         fh = self._fh()
+        # if integer type, coerce to range np.array
+        if fh is not None and (isinstance(fh, int) or isinstance(fh, np.integer)):
+            fh = np.arange(fh) + 1
+        if fh is not None and not isinstance(fh, np.ndarray):
+            fh = np.asarray(fh, dtype=int)
+        
         return fh
 
     def _fh(self):

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -467,7 +467,8 @@ class BaseSplitter(BaseObject):
             return fh
         # if integer type, coerce to range np.array
         if fh is not None and (isinstance(fh, int) or isinstance(fh, np.integer)):
-            fh = np.arange(fh) + 1
+            if fh > 0:
+                fh = np.arange(fh) + 1
         # if fh is not None and not isinstance(fh, np.ndarray):
         #     fh = np.asarray(fh, dtype=int)
         return fh

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -454,7 +454,12 @@ class BaseSplitter(BaseObject):
             * ``None`` if no forecasting horizon is set. This is returned for splitters
               that do not have a natural forecasting horizon associated to them.
         """
+        from sktime.forecasting.base import ForecastingHorizon
+
         fh = self._fh()
+        # if ForecastingHorizon type, return (legacy behaviour to be reviewed)
+        if isinstance(fh, ForecastingHorizon):
+            return fh
         # if integer type, coerce to range np.array
         if fh is not None and (isinstance(fh, int) or isinstance(fh, np.integer)):
             fh = np.arange(fh) + 1

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -468,8 +468,8 @@ class BaseSplitter(BaseObject):
         # if integer type, coerce to range np.array
         if fh is not None and (isinstance(fh, int) or isinstance(fh, np.integer)):
             fh = np.arange(fh) + 1
-        if fh is not None and not isinstance(fh, np.ndarray):
-            fh = np.asarray(fh, dtype=int)
+        # if fh is not None and not isinstance(fh, np.ndarray):
+        #     fh = np.asarray(fh, dtype=int)
         return fh
 
     def _fh(self):

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -463,6 +463,8 @@ class BaseSplitter(BaseObject):
         # if ForecastingHorizon type, return (legacy behaviour to be reviewed)
         if isinstance(fh, ForecastingHorizon):
             return fh
+        if isinstance(fh, pd.Timedelta) or isinstance(fh, pd.DateOffset):
+            return fh
         # if integer type, coerce to range np.array
         if fh is not None and (isinstance(fh, int) or isinstance(fh, np.integer)):
             fh = np.arange(fh) + 1

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -69,8 +69,6 @@ class BaseSplitter(BaseObject):
 
     Parameters
     ----------
-    window_length : int or timedelta or pd.DateOffset
-        Length of rolling window. Only exposed for window-based splitters.
     fh : array-like or int, optional, (default=None)
         Forecasting horizon with the steps ahead to predict, if splits are used
         for forecasting or backtesting.
@@ -469,7 +467,10 @@ class BaseSplitter(BaseObject):
         Private method called by property ``fh``,
         can be overridden by inheriting classes.
 
-        Default is to return a forecasting horizon of ``1``.
+        Default is to return a forecasting horizon of ``1`` for temporal splitters,
+        and ``None`` for instance splitters.
+
+        If the attribute ``_fh_`` is set, then it is returned instead.
 
         Returns
         -------
@@ -483,7 +484,11 @@ class BaseSplitter(BaseObject):
             * ``None`` if no forecasting horizon is set. This is returned for splitters
               that do not have a natural forecasting horizon associated to them.
         """
-        return 1
+        if hasattr(self, "_fh_"):
+            return self._fh_
+        if self.get_tag("split_type") == "temporal":
+            return 1
+        return None
 
     def get_fh(self):
         """Forecasting horizon, in ForecastingHorizon format, relative to cutoff.
@@ -502,30 +507,6 @@ class BaseSplitter(BaseObject):
         fh = self.fh
         fh = check_fh(self.fh)  # coerce to ForecastingHorizon
         return fh
-
-    @property
-    def window_length(self):
-        """Window length, for splitters that are window based..
-
-        Returns
-        -------
-        window_length : int, timedelta, pd.DateOffset, or None
-        """
-        return self._window_length()
-
-    def _window_length(self):
-        """Window length, for splitters that are window based.
-
-        Private method called by property ``window_length``,
-        can be overridden by inheriting classes.
-
-        Default is to return a window length of ``10``.
-
-        Returns
-        -------
-        window_length : int, timedelta, pd.DateOffset, or None
-        """
-        return 10
 
     @staticmethod
     def _get_train_window(y: pd.Index, train_start: int, split_point: int):

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -453,6 +453,9 @@ class BaseSplitter(BaseObject):
               values must be coercible to integer.
             * ``None`` if no forecasting horizon is set. This is returned for splitters
               that do not have a natural forecasting horizon associated to them.
+
+            Can return ``ForecastingHorizon`` type, for legacy compatibility reasons,
+            but this is not recommended.
         """
         from sktime.forecasting.base import ForecastingHorizon
 

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -460,7 +460,6 @@ class BaseSplitter(BaseObject):
             fh = np.arange(fh) + 1
         if fh is not None and not isinstance(fh, np.ndarray):
             fh = np.asarray(fh, dtype=int)
-        
         return fh
 
     def _fh(self):

--- a/sktime/split/base/_base_splitter.py
+++ b/sktime/split/base/_base_splitter.py
@@ -520,7 +520,7 @@ class BaseSplitter(BaseObject):
               that do not have a natural forecasting horizon associated to them.
         """
         fh = self.fh
-        fh = check_fh(self.fh)  # coerce to ForecastingHorizon
+        fh = check_fh(fh)  # coerce to ForecastingHorizon
         return fh
 
     @staticmethod

--- a/sktime/split/base/_base_windowsplitter.py
+++ b/sktime/split/base/_base_windowsplitter.py
@@ -95,7 +95,7 @@ class BaseWindowSplitter(BaseSplitter):
         start_with_window: bool,
         max_expanding_window_length=float("inf"),
         window_length=10,
-    ) -> None:
+    ):
         self.window_length = window_length
         self.step_length = step_length
         self.start_with_window = start_with_window

--- a/sktime/split/base/_base_windowsplitter.py
+++ b/sktime/split/base/_base_windowsplitter.py
@@ -100,21 +100,32 @@ class BaseWindowSplitter(BaseSplitter):
 
     def __init__(
         self,
-        fh,
         initial_window: ACCEPTED_WINDOW_LENGTH_TYPES,
-        window_length: ACCEPTED_WINDOW_LENGTH_TYPES,
         step_length: NON_FLOAT_WINDOW_LENGTH_TYPES,
         start_with_window: bool,
         max_expanding_window_length: ACCEPTED_WINDOW_LENGTH_TYPES = float("inf"),
     ) -> None:
-        _check_inputs_for_compatibility(
-            [fh, initial_window, window_length, step_length]
-        )
+
         self.step_length = step_length
         self.start_with_window = start_with_window
         self.initial_window = initial_window
         self.max_expanding_window_length = max_expanding_window_length
-        super().__init__(fh=fh, window_length=window_length)
+
+        super().__init__()
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        _check_inputs_for_compatibility(
+            [self.fh, self._initial_window, self.window_length, self.step_length]
+        )
+        super().__post_init__()
 
     @property
     def _initial_window(self):

--- a/sktime/split/base/_base_windowsplitter.py
+++ b/sktime/split/base/_base_windowsplitter.py
@@ -11,16 +11,11 @@ import pandas as pd
 from sktime.datatypes._utilities import get_index_for_series
 from sktime.split.base import BaseSplitter
 from sktime.split.base._common import (
-    ACCEPTED_Y_TYPES,
-    SPLIT_ARRAY_TYPE,
-    SPLIT_GENERATOR_TYPE,
     _check_fh,
     _check_inputs_for_compatibility,
     _get_end,
 )
 from sktime.utils.validation import (
-    ACCEPTED_WINDOW_LENGTH_TYPES,
-    NON_FLOAT_WINDOW_LENGTH_TYPES,
     array_is_int,
     check_window_length,
     is_int,
@@ -29,12 +24,7 @@ from sktime.utils.validation import (
 from sktime.utils.validation.forecasting import check_step_length
 
 
-def _check_window_lengths(
-    y: pd.Index,
-    fh,
-    window_length: NON_FLOAT_WINDOW_LENGTH_TYPES,
-    initial_window: NON_FLOAT_WINDOW_LENGTH_TYPES,
-) -> None:
+def _check_window_lengths(y, fh, window_length, initial_window):
     """Check that combination of inputs is compatible.
 
     Parameters
@@ -100,13 +90,12 @@ class BaseWindowSplitter(BaseSplitter):
 
     def __init__(
         self,
-        initial_window: ACCEPTED_WINDOW_LENGTH_TYPES,
-        step_length: NON_FLOAT_WINDOW_LENGTH_TYPES,
+        initial_window,
+        step_length,
         start_with_window: bool,
-        max_expanding_window_length: ACCEPTED_WINDOW_LENGTH_TYPES = float("inf"),
+        max_expanding_window_length=float("inf"),
         window_length=10,
     ) -> None:
-
         self.window_length = window_length
         self.step_length = step_length
         self.start_with_window = start_with_window
@@ -135,7 +124,7 @@ class BaseWindowSplitter(BaseSplitter):
             return self.initial_window
         return None
 
-    def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+    def _split(self, y):
         n_timepoints = y.shape[0]
         window_length = check_window_length(
             window_length=self.window_length,
@@ -157,7 +146,7 @@ class BaseWindowSplitter(BaseSplitter):
 
         yield from self._split_windows(window_length=window_length, y=y, fh=fh)
 
-    def _split_for_initial_window(self, y: pd.Index) -> SPLIT_ARRAY_TYPE:
+    def _split_for_initial_window(self, y):
         """Get train/test splits for non-empty initial window.
 
         Parameters
@@ -188,22 +177,11 @@ class BaseWindowSplitter(BaseSplitter):
             test = np.argwhere(y.isin(y[end - 1] + fh)).flatten()
         return train, test
 
-    def _split_windows(
-        self,
-        window_length: ACCEPTED_WINDOW_LENGTH_TYPES,
-        y: pd.Index,
-        fh,
-    ) -> SPLIT_GENERATOR_TYPE:
+    def _split_windows(self, window_length, y, fh):
         """Abstract method for sliding/expanding windows."""
         raise NotImplementedError("abstract method")
 
-    def _split_windows_generic(
-        self,
-        window_length: ACCEPTED_WINDOW_LENGTH_TYPES,
-        y: pd.Index,
-        fh,
-        expanding: bool,
-    ) -> SPLIT_GENERATOR_TYPE:
+    def _split_windows_generic(self, window_length, y, fh, expanding: bool):
         """Split `y` into training and test windows.
 
         This function encapsulates common functionality
@@ -256,9 +234,7 @@ class BaseWindowSplitter(BaseSplitter):
             yield train, test
 
     @staticmethod
-    def _get_train_start(
-        start: int, window_length: ACCEPTED_WINDOW_LENGTH_TYPES, y: pd.Index
-    ) -> int:
+    def _get_train_start(start: int, window_length, y) -> int:
         if is_timedelta_or_date_offset(x=window_length):
             train_start = y.get_loc(
                 max(y[min(start, len(y) - 1)] - window_length, min(y))
@@ -269,7 +245,7 @@ class BaseWindowSplitter(BaseSplitter):
             train_start = start - window_length
         return train_start
 
-    def _get_start(self, y: pd.Index, fh) -> int:
+    def _get_start(self, y, fh) -> int:
         """Get the first split point."""
         # By default, the first split point is the index zero, the first
         # observation in
@@ -303,7 +279,7 @@ class BaseWindowSplitter(BaseSplitter):
                 start = np.argmin(y <= shifted_y0) if shifted_y0 >= y[start] else start
         return start
 
-    def get_n_splits(self, y: ACCEPTED_Y_TYPES | None = None) -> int:
+    def get_n_splits(self, y=None) -> int:
         """Return the number of splits.
 
         Parameters
@@ -349,7 +325,7 @@ class BaseWindowSplitter(BaseSplitter):
             n_splits = len(self.get_cutoffs(y))
         return n_splits
 
-    def get_cutoffs(self, y: ACCEPTED_Y_TYPES | None = None) -> np.ndarray:
+    def get_cutoffs(self, y=None) -> np.ndarray:
         """Return the cutoff points in .iloc[] context.
 
         Parameters

--- a/sktime/split/base/_base_windowsplitter.py
+++ b/sktime/split/base/_base_windowsplitter.py
@@ -104,8 +104,10 @@ class BaseWindowSplitter(BaseSplitter):
         step_length: NON_FLOAT_WINDOW_LENGTH_TYPES,
         start_with_window: bool,
         max_expanding_window_length: ACCEPTED_WINDOW_LENGTH_TYPES = float("inf"),
+        window_length=10,
     ) -> None:
 
+        self.window_length = window_length
         self.step_length = step_length
         self.start_with_window = start_with_window
         self.initial_window = initial_window

--- a/sktime/split/base/_base_windowsplitter.py
+++ b/sktime/split/base/_base_windowsplitter.py
@@ -114,7 +114,7 @@ class BaseWindowSplitter(BaseSplitter):
         * any soft dependency imports in the constructor
         """
         _check_inputs_for_compatibility(
-            [self._fh_, self._initial_window, self.window_length, self.step_length]
+            [self.fh, self._initial_window, self.window_length, self.step_length]
         )
         super().__post_init__()
 

--- a/sktime/split/base/_base_windowsplitter.py
+++ b/sktime/split/base/_base_windowsplitter.py
@@ -114,7 +114,7 @@ class BaseWindowSplitter(BaseSplitter):
         * any soft dependency imports in the constructor
         """
         _check_inputs_for_compatibility(
-            [self.fh, self._initial_window, self.window_length, self.step_length]
+            [self._fh_, self._initial_window, self.window_length, self.step_length]
         )
         super().__post_init__()
 

--- a/sktime/split/base/_common.py
+++ b/sktime/split/base/_common.py
@@ -16,17 +16,6 @@ from sktime.utils.validation import (
 )
 from sktime.utils.validation.forecasting import check_fh
 
-DEFAULT_STEP_LENGTH = 1
-DEFAULT_WINDOW_LENGTH = 10
-DEFAULT_FH = 1
-
-ACCEPTED_Y_TYPES = pd.Series | pd.DataFrame | np.ndarray | pd.Index
-SPLIT_TYPE = (
-    tuple[pd.Series, pd.Series]
-    | tuple[pd.Series, pd.Series, pd.DataFrame, pd.DataFrame]
-)
-SPLIT_ARRAY_TYPE = tuple[np.ndarray, np.ndarray]
-SPLIT_GENERATOR_TYPE = Iterator[SPLIT_ARRAY_TYPE]
 PANDAS_MTYPES = ["pd.DataFrame", "pd.Series", "pd-multiindex", "pd_multiindex_hier"]
 
 

--- a/sktime/split/base/_common.py
+++ b/sktime/split/base/_common.py
@@ -2,9 +2,6 @@
 """Common utilities and constants for time series splitter module."""
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 
-from collections.abc import Iterator
-
-import numpy as np
 import pandas as pd
 
 from sktime.datatypes._utilities import get_window

--- a/sktime/split/cutoff.py
+++ b/sktime/split/cutoff.py
@@ -16,16 +16,11 @@ from pandas.api.types import is_datetime64_any_dtype
 
 from sktime.split.base import BaseSplitter
 from sktime.split.base._common import (
-    ACCEPTED_Y_TYPES,
-    DEFAULT_FH,
-    DEFAULT_WINDOW_LENGTH,
-    SPLIT_GENERATOR_TYPE,
     _check_fh,
     _check_inputs_for_compatibility,
     _get_train_window_via_endpoint,
 )
 from sktime.utils.validation import (
-    ACCEPTED_WINDOW_LENGTH_TYPES,
     array_is_datetime64,
     array_is_int,
     check_window_length,
@@ -36,7 +31,7 @@ from sktime.utils.validation import (
 from sktime.utils.validation.forecasting import VALID_CUTOFF_TYPES, check_cutoffs
 
 
-def _check_cutoffs_and_y(cutoffs: VALID_CUTOFF_TYPES, y: ACCEPTED_Y_TYPES) -> None:
+def _check_cutoffs_and_y(cutoffs: VALID_CUTOFF_TYPES, y) -> None:
     """Check that combination of inputs is compatible.
 
     Parameters
@@ -137,9 +132,11 @@ class CutoffSplitter(BaseSplitter):
     cutoffs : list or np.ndarray or pd.Index
         Cutoff points, positive and integer- or datetime-index like.
         Type should match the type of ``fh`` input.
-    fh : int, timedelta, list or np.ndarray of ints or timedeltas
+    fh : int, timedelta, list or np.ndarray of ints or timedeltas, optional (default=1)
+        Forecasting horizon, relative, to determine test folds.
         Type should match the type of ``cutoffs`` input.
-    window_length : int or timedelta or pd.DateOffset
+    window_length : int or timedelta or pd.DateOffset, optional (default=10)
+        Window length of the training window.
 
     Examples
     --------
@@ -151,12 +148,7 @@ class CutoffSplitter(BaseSplitter):
     [(array([1, 2, 3]), array([5, 7])), (array([3, 4, 5]), array([7, 9]))]
     """
 
-    def __init__(
-        self,
-        cutoffs: VALID_CUTOFF_TYPES,
-        fh=DEFAULT_FH,
-        window_length: ACCEPTED_WINDOW_LENGTH_TYPES = DEFAULT_WINDOW_LENGTH,
-    ) -> None:
+    def __init__(self, cutoffs: VALID_CUTOFF_TYPES, fh=1, window_length=10):
         self.cutoffs = cutoffs
         self.window_length = window_length
 
@@ -178,7 +170,7 @@ class CutoffSplitter(BaseSplitter):
         _check_inputs_for_compatibility([self.cutoffs, self.fh, self.window_length])
         super().__post_init__()
 
-    def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+    def _split(self, y: pd.Index):
         n_timepoints = y.shape[0]
         cutoffs = check_cutoffs(cutoffs=self.cutoffs)
         fh = _check_fh(fh=self.fh)
@@ -217,7 +209,7 @@ class CutoffSplitter(BaseSplitter):
         """
         return self._fh_
 
-    def get_n_splits(self, y: ACCEPTED_Y_TYPES | None = None) -> int:
+    def get_n_splits(self, y=None) -> int:
         """Return the number of splits.
 
         For this splitter the number is trivially equal to
@@ -235,7 +227,7 @@ class CutoffSplitter(BaseSplitter):
         """
         return len(self.cutoffs)
 
-    def get_cutoffs(self, y: ACCEPTED_Y_TYPES | None = None) -> np.ndarray:
+    def get_cutoffs(self, y=None) -> np.ndarray:
         """Return the cutoff points in .iloc[] context.
 
         This method trivially returns the cutoffs given during instance initialization,

--- a/sktime/split/cutoff.py
+++ b/sktime/split/cutoff.py
@@ -157,9 +157,24 @@ class CutoffSplitter(BaseSplitter):
         fh=DEFAULT_FH,
         window_length: ACCEPTED_WINDOW_LENGTH_TYPES = DEFAULT_WINDOW_LENGTH,
     ) -> None:
-        _check_inputs_for_compatibility([fh, cutoffs, window_length])
         self.cutoffs = cutoffs
-        super().__init__(fh, window_length)
+        # self.fh = fh  - we do not do that since the fh is a reserved property,
+        # instead we loop via the _fh method, which is called by the property
+        # self.window_length = window_length  - sameas above, via _window_length
+        super().__init__()
+
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        _check_inputs_for_compatibility([self.cutoffs, self.fh, self.window_length])
+        super().__post_init__()
 
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
         n_timepoints = y.shape[0]
@@ -177,6 +192,43 @@ class CutoffSplitter(BaseSplitter):
             if is_datetime(x=cutoff):
                 test_window = y.get_indexer(test_window[test_window >= y.min()])
             yield training_window, test_window
+
+
+    def _fh(self):
+        """Forecasting horizon, in integer resp array of integer, relative to cutoff.
+
+        Private method called by property ``fh``,
+        can be overridden by inheriting classes.
+
+        Default is to return a forecasting horizon of ``1``.
+
+        Returns
+        -------
+        fh : array-like or int, optional, (default=None)
+            Forecasting horizon with the steps ahead to predict, if splits are used
+            for forecasting or backtesting.
+
+            * if integer, the indices to forecast are ``1, 2, ..., fh``, periods ahead.
+            * if array-like, the indices to forecast are given by the values in ``fh``,
+              values must be coercible to integer.
+            * ``None`` if no forecasting horizon is set. This is returned for splitters
+              that do not have a natural forecasting horizon associated to them.
+        """
+        return 1
+
+    def _window_length(self):
+        """Window length, for splitters that are window based.
+
+        Private method called by property ``window_length``,
+        can be overridden by inheriting classes.
+
+        Default is to return a window length of ``10``.
+
+        Returns
+        -------
+        window_length : int, timedelta, pd.DateOffset, or None
+        """
+        return 10
 
     def get_n_splits(self, y: ACCEPTED_Y_TYPES | None = None) -> int:
         """Return the number of splits.

--- a/sktime/split/cutoff.py
+++ b/sktime/split/cutoff.py
@@ -158,6 +158,14 @@ class CutoffSplitter(BaseSplitter):
 
         super().__init__()
 
+    @fh.setter
+    def fh(self, value):
+        """Set forecasting horizon.
+
+        Writes to _fh_ attribute due to property logic and inheritance.
+        """
+        self._fh_ = value
+
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/sktime/split/cutoff.py
+++ b/sktime/split/cutoff.py
@@ -317,7 +317,7 @@ class CutoffFhSplitter(BaseSplitter):
     def __init__(self, cutoff, fh=None):
         self.cutoff = cutoff
         self.fh = fh
-        super().__init__(fh=fh)
+        super().__init__()
 
     def _split_loc(self, y):
         """Get loc references to train/test splits of ``y``.

--- a/sktime/split/cutoff.py
+++ b/sktime/split/cutoff.py
@@ -151,20 +151,9 @@ class CutoffSplitter(BaseSplitter):
     def __init__(self, cutoffs: VALID_CUTOFF_TYPES, fh=1, window_length=10):
         self.cutoffs = cutoffs
         self.window_length = window_length
-
-        # self.fh = fh  - we do not do that since the fh is a reserved property,
-        # instead we loop via the _fh method, which is called by the property
-        self._fh_ = fh
+        self.fh = fh
 
         super().__init__()
-
-    @fh.setter
-    def fh(self, value):
-        """Set forecasting horizon.
-
-        Writes to _fh_ attribute due to property logic and inheritance.
-        """
-        self._fh_ = value
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.

--- a/sktime/split/cutoff.py
+++ b/sktime/split/cutoff.py
@@ -158,11 +158,13 @@ class CutoffSplitter(BaseSplitter):
         window_length: ACCEPTED_WINDOW_LENGTH_TYPES = DEFAULT_WINDOW_LENGTH,
     ) -> None:
         self.cutoffs = cutoffs
+        self.window_length = window_length
+
         # self.fh = fh  - we do not do that since the fh is a reserved property,
         # instead we loop via the _fh method, which is called by the property
-        # self.window_length = window_length  - sameas above, via _window_length
-        super().__init__()
+        self._fh_ = fh
 
+        super().__init__()
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
@@ -193,7 +195,6 @@ class CutoffSplitter(BaseSplitter):
                 test_window = y.get_indexer(test_window[test_window >= y.min()])
             yield training_window, test_window
 
-
     def _fh(self):
         """Forecasting horizon, in integer resp array of integer, relative to cutoff.
 
@@ -214,21 +215,7 @@ class CutoffSplitter(BaseSplitter):
             * ``None`` if no forecasting horizon is set. This is returned for splitters
               that do not have a natural forecasting horizon associated to them.
         """
-        return 1
-
-    def _window_length(self):
-        """Window length, for splitters that are window based.
-
-        Private method called by property ``window_length``,
-        can be overridden by inheriting classes.
-
-        Default is to return a window length of ``10``.
-
-        Returns
-        -------
-        window_length : int, timedelta, pd.DateOffset, or None
-        """
-        return 10
+        return self._fh_
 
     def get_n_splits(self, y: ACCEPTED_Y_TYPES | None = None) -> int:
         """Return the number of splits.

--- a/sktime/split/expandingcutoff.py
+++ b/sktime/split/expandingcutoff.py
@@ -129,7 +129,7 @@ class ExpandingCutoffSplitter(BaseSplitter):
         test : ndarray
             The testing set indices for that split.
         """
-        fh = self._fh
+        fh = self.get_fh().to_relative(self.cutoff)
         for cutoff in self.get_cutoffs(y):
             train_window = np.arange(0, cutoff + 1, step=1)
             test_window = cutoff + fh

--- a/sktime/split/expandingcutoff.py
+++ b/sktime/split/expandingcutoff.py
@@ -183,6 +183,8 @@ class ExpandingCutoffSplitter(BaseSplitter):
         cutoffs : 1D np.ndarray of int
             iloc location indices, in reference to y, of cutoff indices
         """
+        from sktime.forecasting.base import ForecastingHorizon
+
         if y is None:
             raise ValueError(
                 f"{self.__class__.__name__} requires `y` to compute the cutoffs."
@@ -191,10 +193,12 @@ class ExpandingCutoffSplitter(BaseSplitter):
         fh = self.fh
         if isinstance(fh, list):
             fh = np.asarray(fh, dtype=int)
+        if isinstance(fh, ForecastingHorizon):
+            fh = fh.to_relative(self.cutoff).to_numpy()
         step_length = check_step_length(self.step_length)
         cutoff_index = self._get_first_cutoff_index(y)
         cutoffs = np.array([cutoff_index])
-        offset = fh.to_numpy().max()
+        offset = fh.max()
         while cutoff_index + offset + step_length < len(y):
             cutoff_index += step_length
             cutoffs = np.append(cutoffs, cutoff_index)

--- a/sktime/split/expandingcutoff.py
+++ b/sktime/split/expandingcutoff.py
@@ -195,7 +195,7 @@ class ExpandingCutoffSplitter(BaseSplitter):
                 f"{self.__class__.__name__} requires `y` to compute the cutoffs."
             )
         y = self._validate_y(y)
-        fh = self._fh
+        fh = self.fh
         step_length = check_step_length(self.step_length)
         cutoff_index = self._get_first_cutoff_index(y)
         cutoffs = np.array([cutoff_index])

--- a/sktime/split/expandingcutoff.py
+++ b/sktime/split/expandingcutoff.py
@@ -117,7 +117,7 @@ class ExpandingCutoffSplitter(BaseSplitter):
         _validate_cutoff(self.cutoff)
         super().__post_init__()
 
-    def _split(self, y, fh=None):
+    def _split(self, y):
         """
         Generate indices to split data into training and testing sets.
 
@@ -125,8 +125,6 @@ class ExpandingCutoffSplitter(BaseSplitter):
         ----------
         y : array-like, shape = [n_samples]
             Time series data.
-        fh : int, default=None
-            Forecast horizon, if None, uses self.fh
 
         Yields
         ------
@@ -135,8 +133,7 @@ class ExpandingCutoffSplitter(BaseSplitter):
         test : ndarray
             The testing set indices for that split.
         """
-        if fh is None:
-            fh = self._fh
+        fh = self._fh
         for cutoff in self.get_cutoffs(y):
             train_window = np.arange(0, cutoff + 1, step=1)
             test_window = cutoff + fh
@@ -196,6 +193,8 @@ class ExpandingCutoffSplitter(BaseSplitter):
             )
         y = self._validate_y(y)
         fh = self.fh
+        if isinstance(fh, list):
+            fh = np.asarray(fh, dtype=int)
         step_length = check_step_length(self.step_length)
         cutoff_index = self._get_first_cutoff_index(y)
         cutoffs = np.array([cutoff_index])

--- a/sktime/split/expandingcutoff.py
+++ b/sktime/split/expandingcutoff.py
@@ -98,12 +98,8 @@ class ExpandingCutoffSplitter(BaseSplitter):
     def __init__(self, cutoff, fh, step_length):
         self.cutoff = cutoff
         self.step_length = step_length
+        self.fh = fh
         super().__init__()
-
-        # self.fh = fh  - we do not do that since the fh is a reserved property,
-        # instead we loop via the _fh method, which is called by the property
-        self._fh_ = fh
-        return
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.

--- a/sktime/split/expandingcutoff.py
+++ b/sktime/split/expandingcutoff.py
@@ -97,12 +97,26 @@ class ExpandingCutoffSplitter(BaseSplitter):
     """
 
     def __init__(self, cutoff, fh, step_length):
-        super().__init__()
-        self.cutoff = _validate_cutoff(cutoff)
-        self.fh = fh
-        self._fh = _check_fh(fh)
+        self.cutoff = cutoff
         self.step_length = step_length
+        super().__init__()
+
+        # self.fh = fh  - we do not do that since the fh is a reserved property,
+        # instead we loop via the _fh method, which is called by the property
+        self._fh_ = fh
         return
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        _validate_cutoff(self.cutoff)
+        super().__post_init__()
 
     def _split(self, y, fh=None):
         """

--- a/sktime/split/expandingcutoff.py
+++ b/sktime/split/expandingcutoff.py
@@ -13,7 +13,6 @@ import numpy as np
 import pandas as pd
 
 from sktime.split.base import BaseSplitter
-from sktime.split.base._common import ACCEPTED_Y_TYPES, _check_fh
 from sktime.utils.validation.forecasting import check_step_length
 
 
@@ -178,7 +177,7 @@ class ExpandingCutoffSplitter(BaseSplitter):
                 )
         return index
 
-    def get_cutoffs(self, y: ACCEPTED_Y_TYPES | None = None) -> np.ndarray:
+    def get_cutoffs(self, y=None) -> np.ndarray:
         """Return the cutoff points in .iloc[] context.
 
         Parameters

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -88,7 +88,7 @@ class ExpandingGreedySplitter(BaseSplitter):
 
         if isinstance(test_size, float):
             _test_size = int(np.ceil(len(y) * test_size))
-            self._fh_ = np.arange(_test_size) + 1
+            self.fh = np.arange(_test_size) + 1
         else:
             _test_size = test_size
 

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -14,7 +14,6 @@ import numpy as np
 import pandas as pd
 
 from sktime.split.base import BaseSplitter
-from sktime.split.base._common import SPLIT_GENERATOR_TYPE
 
 
 class ExpandingGreedySplitter(BaseSplitter):
@@ -84,7 +83,7 @@ class ExpandingGreedySplitter(BaseSplitter):
         if isinstance(self.test_size, float):
             self.set_tags(**{"split_hierarchical": False})
 
-    def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+    def _split(self, y: pd.Index):
         test_size = self.test_size
 
         if isinstance(test_size, float):

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -88,7 +88,7 @@ class ExpandingGreedySplitter(BaseSplitter):
 
         if isinstance(test_size, float):
             _test_size = int(np.ceil(len(y) * test_size))
-            self.fh = np.arange(_test_size) + 1
+            self._fh_ = np.arange(_test_size) + 1
         else:
             _test_size = test_size
 
@@ -133,6 +133,9 @@ class ExpandingGreedySplitter(BaseSplitter):
         """
         test_size = self.test_size
         fh = np.arange(test_size) + 1 if isinstance(test_size, int) else None
+        # if test_size is float, fh is set later in _split, so we check for that here
+        if fh is None and hasattr(self, "_fh_"):
+            fh = self._fh_
         return fh
 
     @classmethod

--- a/sktime/split/expandinggreedy.py
+++ b/sktime/split/expandinggreedy.py
@@ -69,14 +69,19 @@ class ExpandingGreedySplitter(BaseSplitter):
         folds: int = 5,
         step_length: int | None = None,
     ):
-        super().__init__()
         self.test_size = test_size
         self.folds = folds
         self.step_length = step_length
-        self.fh = np.arange(test_size) + 1 if isinstance(test_size, int) else None
 
+        super().__init__()
+
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         # no algorithm implemented that is faster for float than naive iteration
-        if isinstance(test_size, float):
+        if isinstance(self.test_size, float):
             self.set_tags(**{"split_hierarchical": False})
 
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
@@ -104,6 +109,32 @@ class ExpandingGreedySplitter(BaseSplitter):
                 (reverse_idx < trn_end) & (reverse_idx >= tst_end)
             )
             yield trn_indices, tst_indices
+
+    def _fh(self):
+        """Forecasting horizon, in integer resp array of integer, relative to cutoff.
+
+        Private method called by property ``fh``,
+        can be overridden by inheriting classes.
+
+        Default is to return a forecasting horizon of ``1``.
+
+        If the attribute ``_fh_`` is set, then it is returned instead.
+
+        Returns
+        -------
+        fh : array-like or int, optional, (default=None)
+            Forecasting horizon with the steps ahead to predict, if splits are used
+            for forecasting or backtesting.
+
+            * if integer, the indices to forecast are ``1, 2, ..., fh``, periods ahead.
+            * if array-like, the indices to forecast are given by the values in ``fh``,
+              values must be coercible to integer.
+            * ``None`` if no forecasting horizon is set. This is returned for splitters
+              that do not have a natural forecasting horizon associated to them.
+        """
+        test_size = self.test_size
+        fh = np.arange(test_size) + 1 if isinstance(test_size, int) else None
+        return fh
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/split/expandingslidingwindow.py
+++ b/sktime/split/expandingslidingwindow.py
@@ -9,16 +9,6 @@ __all__ = [
 ]
 
 from sktime.split.base import BaseWindowSplitter
-from sktime.split.base._common import (
-    DEFAULT_FH,
-    DEFAULT_STEP_LENGTH,
-    DEFAULT_WINDOW_LENGTH,
-    SPLIT_GENERATOR_TYPE,
-)
-from sktime.utils.validation import (
-    ACCEPTED_WINDOW_LENGTH_TYPES,
-    NON_FLOAT_WINDOW_LENGTH_TYPES,
-)
 
 
 class ExpandingSlidingWindowSplitter(BaseWindowSplitter):
@@ -52,10 +42,10 @@ class ExpandingSlidingWindowSplitter(BaseWindowSplitter):
     ----------
     fh : int, list or np.array, optional (default=1)
         Forecasting horizon
-    initial_window : int or timedelta or pd.DateOffset, optional (default=10)
-        Initial window length for the expanding window phase
     step_length : int or timedelta or pd.DateOffset, optional (default=1)
         Step length between windows
+    initial_window : int or timedelta or pd.DateOffset, optional (default=10)
+        Initial window length for the expanding window phase
     max_expanding_window_length : int, optional (default=float('inf'))
         Maximum window length. If none is passed in, it will expanding indefinitely.
 
@@ -92,15 +82,18 @@ class ExpandingSlidingWindowSplitter(BaseWindowSplitter):
 
     def __init__(
         self,
-        fh=DEFAULT_FH,
-        step_length: NON_FLOAT_WINDOW_LENGTH_TYPES = DEFAULT_STEP_LENGTH,
-        initial_window: ACCEPTED_WINDOW_LENGTH_TYPES = DEFAULT_WINDOW_LENGTH,
-        max_expanding_window_length: ACCEPTED_WINDOW_LENGTH_TYPES = float("inf"),
-    ) -> None:
+        fh=1,
+        step_length=1,
+        initial_window=10,
+        max_expanding_window_length=float("inf"),
+    ):
         start_with_window = initial_window != 0
 
+        # self.fh = fh  - we do not do that since the fh is a reserved property,
+        # instead we loop via the _fh method, which is called by the property
+        self._fh_ = fh
+
         super().__init__(
-            fh=fh,
             window_length=initial_window,
             initial_window=None,
             step_length=step_length,
@@ -120,7 +113,7 @@ class ExpandingSlidingWindowSplitter(BaseWindowSplitter):
     def _initial_window(self):
         return None
 
-    def _split_windows(self, **kwargs) -> SPLIT_GENERATOR_TYPE:
+    def _split_windows(self, **kwargs):
         return self._split_windows_generic(expanding=True, **kwargs)
 
     @classmethod

--- a/sktime/split/expandingslidingwindow.py
+++ b/sktime/split/expandingslidingwindow.py
@@ -88,10 +88,7 @@ class ExpandingSlidingWindowSplitter(BaseWindowSplitter):
         max_expanding_window_length=float("inf"),
     ):
         start_with_window = initial_window != 0
-
-        # self.fh = fh  - we do not do that since the fh is a reserved property,
-        # instead we loop via the _fh method, which is called by the property
-        self._fh_ = fh
+        self.fh = fh
 
         super().__init__(
             window_length=initial_window,

--- a/sktime/split/expandingwindow.py
+++ b/sktime/split/expandingwindow.py
@@ -57,12 +57,9 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
     """
 
     def __init__(self, fh=1, initial_window=10, step_length=1):
+        self.fh = fh
+
         start_with_window = initial_window != 0
-
-        # self.fh = fh  - we do not do that since the fh is a reserved property,
-        # instead we loop via the _fh method, which is called by the property
-        self._fh_ = fh
-
         # Note that we pass the initial window as the window_length below. This
         # allows us to use the common logic from the parent class, while at the same
         # time expose the more intuitive name for the ExpandingWindowSplitter.
@@ -77,14 +74,6 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
         self.initial_window = initial_window
         # this class still acts as if it were overwritten with None,
         # via the _initial_window property that is read everywhere
-
-    @fh.setter
-    def fh(self, value):
-        """Set forecasting horizon.
-
-        Writes to _fh_ attribute due to property logic and inheritance.
-        """
-        self._fh_ = value
 
     @property
     def _initial_window(self):

--- a/sktime/split/expandingwindow.py
+++ b/sktime/split/expandingwindow.py
@@ -78,6 +78,14 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
         # this class still acts as if it were overwritten with None,
         # via the _initial_window property that is read everywhere
 
+    @fh.setter
+    def fh(self, value):
+        """Set forecasting horizon.
+
+        Writes to _fh_ attribute due to property logic and inheritance.
+        """
+        self._fh_ = value
+
     @property
     def _initial_window(self):
         return None

--- a/sktime/split/expandingwindow.py
+++ b/sktime/split/expandingwindow.py
@@ -9,16 +9,6 @@ __all__ = [
 ]
 
 from sktime.split.base import BaseWindowSplitter
-from sktime.split.base._common import (
-    DEFAULT_FH,
-    DEFAULT_STEP_LENGTH,
-    DEFAULT_WINDOW_LENGTH,
-    SPLIT_GENERATOR_TYPE,
-)
-from sktime.utils.validation import (
-    ACCEPTED_WINDOW_LENGTH_TYPES,
-    NON_FLOAT_WINDOW_LENGTH_TYPES,
-)
 
 
 class ExpandingWindowSplitter(BaseWindowSplitter):
@@ -66,19 +56,17 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
     '[(array([0, 1, 2, 3, 4]), array([6, 8]))]'
     """
 
-    def __init__(
-        self,
-        fh=DEFAULT_FH,
-        initial_window: ACCEPTED_WINDOW_LENGTH_TYPES = DEFAULT_WINDOW_LENGTH,
-        step_length: NON_FLOAT_WINDOW_LENGTH_TYPES = DEFAULT_STEP_LENGTH,
-    ) -> None:
+    def __init__(self, fh=1, initial_window=10, step_length=1):
         start_with_window = initial_window != 0
+
+        # self.fh = fh  - we do not do that since the fh is a reserved property,
+        # instead we loop via the _fh method, which is called by the property
+        self._fh_ = fh
 
         # Note that we pass the initial window as the window_length below. This
         # allows us to use the common logic from the parent class, while at the same
         # time expose the more intuitive name for the ExpandingWindowSplitter.
         super().__init__(
-            fh=fh,
             window_length=initial_window,
             initial_window=None,
             step_length=step_length,
@@ -94,7 +82,7 @@ class ExpandingWindowSplitter(BaseWindowSplitter):
     def _initial_window(self):
         return None
 
-    def _split_windows(self, **kwargs) -> SPLIT_GENERATOR_TYPE:
+    def _split_windows(self, **kwargs):
         return self._split_windows_generic(expanding=True, **kwargs)
 
     @classmethod

--- a/sktime/split/fh.py
+++ b/sktime/split/fh.py
@@ -65,7 +65,10 @@ class ForecastingHorizonSplitter(BaseSplitter):
     }
 
     def __init__(self, fh):
-        super().__init__(fh=fh)
+        # self.fh = fh  - we do not do that since the fh is a reserved property,
+        # instead we use the _fh_ attribute to store the forecasting horizon
+        self._fh_ = fh
+        super().__init__()
 
     def _split(self, y: pd.Index):
         """Return train/test indices based on forecasting horizon."""

--- a/sktime/split/fh.py
+++ b/sktime/split/fh.py
@@ -65,9 +65,7 @@ class ForecastingHorizonSplitter(BaseSplitter):
     }
 
     def __init__(self, fh):
-        # self.fh = fh  - we do not do that since the fh is a reserved property,
-        # instead we use the _fh_ attribute to store the forecasting horizon
-        self._fh_ = fh
+        self.fh = fh
         super().__init__()
 
     def _split(self, y: pd.Index):

--- a/sktime/split/instance.py
+++ b/sktime/split/instance.py
@@ -12,7 +12,6 @@ __all__ = [
 import pandas as pd
 
 from sktime.split.base import BaseSplitter
-from sktime.split.base._common import ACCEPTED_Y_TYPES, SPLIT_GENERATOR_TYPE
 from sktime.utils.multiindex import apply_split
 
 
@@ -54,7 +53,7 @@ class InstanceSplitter(BaseSplitter):
         self.cv = cv
         super().__init__()
 
-    def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+    def _split(self, y: pd.Index):
         """Generate indices to split data."""
         if not isinstance(y, pd.MultiIndex):
             zeros = [0] * len(y)
@@ -67,7 +66,7 @@ class InstanceSplitter(BaseSplitter):
             y_test_iloc = apply_split(y, y_test_inst_iloc)
             yield y_train_iloc, y_test_iloc
 
-    def get_n_splits(self, y: ACCEPTED_Y_TYPES | None = None) -> int:
+    def get_n_splits(self, y=None) -> int:
         """Return the number of splits.
 
         This will always be equal to the number of splits

--- a/sktime/split/sameloc.py
+++ b/sktime/split/sameloc.py
@@ -12,7 +12,6 @@ __all__ = [
 import pandas as pd
 
 from sktime.split.base import BaseSplitter
-from sktime.split.base._common import ACCEPTED_Y_TYPES, SPLIT_GENERATOR_TYPE
 
 
 class SameLocSplitter(BaseSplitter):
@@ -74,7 +73,7 @@ class SameLocSplitter(BaseSplitter):
         self.y_template = y_template
         super().__init__()
 
-    def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+    def _split(self, y: pd.Index):
         cv = self.cv
         if self.y_template is None:
             y_template = y
@@ -86,7 +85,7 @@ class SameLocSplitter(BaseSplitter):
             y_test_iloc = y.get_indexer(y_test_loc)
             yield y_train_iloc, y_test_iloc
 
-    def _split_loc(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+    def _split_loc(self, y: pd.Index):
         """Get loc references to train/test splits of ``y``.
 
         private _split containing the core logic, called from split_loc
@@ -111,7 +110,7 @@ class SameLocSplitter(BaseSplitter):
 
         yield from cv.split_loc(y_template)
 
-    def get_n_splits(self, y: ACCEPTED_Y_TYPES | None = None) -> int:
+    def get_n_splits(self, y=None) -> int:
         """Return the number of splits.
 
         This will always be equal to the number of splits

--- a/sktime/split/sameloc.py
+++ b/sktime/split/sameloc.py
@@ -133,6 +133,32 @@ class SameLocSplitter(BaseSplitter):
             y_template = self.y_template
         return self.cv.get_n_splits(y_template)
 
+    def _fh(self):
+        """Forecasting horizon, in integer resp array of integer, relative to cutoff.
+
+        Private method called by property ``fh``,
+        can be overridden by inheriting classes.
+
+        Default is to return a forecasting horizon of ``1`` for temporal splitters,
+        and ``None`` for instance splitters.
+
+        If the attribute ``_fh_`` is set, then it is returned instead.
+
+        Returns
+        -------
+        fh : array-like or int, optional, (default=None)
+            Forecasting horizon with the steps ahead to predict, if splits are used
+            for forecasting or backtesting.
+
+            * if integer, the indices to forecast are ``1, 2, ..., fh``, periods ahead.
+            * if array-like, the indices to forecast are given by the values in ``fh``,
+              values must be coercible to integer.
+            * ``None`` if no forecasting horizon is set. This is returned for splitters
+              that do not have a natural forecasting horizon associated to them.
+        """
+        # inherits the fh from the cv splitter directly, since the splits are the same
+        return self.cv.fh
+
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the splitter.

--- a/sktime/split/singlewindow.py
+++ b/sktime/split/singlewindow.py
@@ -15,8 +15,6 @@ import pandas as pd
 from sktime.datatypes._utilities import get_index_for_series
 from sktime.split.base import BaseSplitter
 from sktime.split.base._common import (
-    ACCEPTED_Y_TYPES,
-    SPLIT_GENERATOR_TYPE,
     _check_fh,
     _check_inputs_for_compatibility,
     _get_end,
@@ -116,7 +114,7 @@ class SingleWindowSplitter(BaseSplitter):
         _check_inputs_for_compatibility(args=[self.fh, self.window_length])
         super().__post_init__()
 
-    def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+    def _split(self, y: pd.Index):
         n_timepoints = y.shape[0]
         window_length = check_window_length(self.window_length, n_timepoints)
         fh = _check_fh(self.fh)
@@ -129,7 +127,7 @@ class SingleWindowSplitter(BaseSplitter):
 
         yield training_window, test_window
 
-    def get_n_splits(self, y: ACCEPTED_Y_TYPES | None = None) -> int:
+    def get_n_splits(self, y=None) -> int:
         """Return the number of splits.
 
         Since this splitter returns a single train/test split,
@@ -147,7 +145,7 @@ class SingleWindowSplitter(BaseSplitter):
         """
         return 1
 
-    def get_cutoffs(self, y: ACCEPTED_Y_TYPES | None = None) -> np.ndarray:
+    def get_cutoffs(self, y=None) -> np.ndarray:
         """Return the cutoff points in .iloc[] context.
 
         Since this splitter returns a single train/test split,

--- a/sktime/split/singlewindow.py
+++ b/sktime/split/singlewindow.py
@@ -98,8 +98,23 @@ class SingleWindowSplitter(BaseSplitter):
     """
 
     def __init__(self, fh, window_length=None):
-        _check_inputs_for_compatibility(args=[fh, window_length])
-        super().__init__(fh=fh, window_length=window_length)
+        self.window_length = window_length
+        # self.fh = fh  - we do not do that since the fh is a reserved property,
+        # instead we use the _fh_ attribute to store the forecasting horizon
+        self._fh_ = fh
+        super().__init__()
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        _check_inputs_for_compatibility(args=[self.fh, self.window_length])
+        super().__post_init__()
 
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
         n_timepoints = y.shape[0]

--- a/sktime/split/singlewindow.py
+++ b/sktime/split/singlewindow.py
@@ -111,7 +111,7 @@ class SingleWindowSplitter(BaseSplitter):
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
         """
-        _check_inputs_for_compatibility(args=[self.fh, self.window_length])
+        _check_inputs_for_compatibility(args=[self._fh_, self.window_length])
         super().__post_init__()
 
     def _split(self, y: pd.Index):

--- a/sktime/split/singlewindow.py
+++ b/sktime/split/singlewindow.py
@@ -102,6 +102,14 @@ class SingleWindowSplitter(BaseSplitter):
         self._fh_ = fh
         super().__init__()
 
+    @fh.setter
+    def fh(self, value):
+        """Set forecasting horizon.
+
+        Writes to _fh_ attribute due to property logic and inheritance.
+        """
+        self._fh_ = value
+
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
 

--- a/sktime/split/singlewindow.py
+++ b/sktime/split/singlewindow.py
@@ -97,18 +97,8 @@ class SingleWindowSplitter(BaseSplitter):
 
     def __init__(self, fh, window_length=None):
         self.window_length = window_length
-        # self.fh = fh  - we do not do that since the fh is a reserved property,
-        # instead we use the _fh_ attribute to store the forecasting horizon
-        self._fh_ = fh
+        self.fh = fh
         super().__init__()
-
-    @fh.setter
-    def fh(self, value):
-        """Set forecasting horizon.
-
-        Writes to _fh_ attribute due to property logic and inheritance.
-        """
-        self._fh_ = value
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.

--- a/sktime/split/singlewindow.py
+++ b/sktime/split/singlewindow.py
@@ -109,7 +109,7 @@ class SingleWindowSplitter(BaseSplitter):
         * initialization logic beyond self.param = param
         * any soft dependency imports in the constructor
         """
-        _check_inputs_for_compatibility(args=[self._fh_, self.window_length])
+        _check_inputs_for_compatibility(args=[self.fh, self.window_length])
         super().__post_init__()
 
     def _split(self, y: pd.Index):

--- a/sktime/split/slidinggreedy.py
+++ b/sktime/split/slidinggreedy.py
@@ -72,14 +72,18 @@ class SlidingGreedySplitter(BaseSplitter):
         folds: int = 5,
         step_length: int | None = None,
     ):
-        super().__init__()
         self.train_size = train_size
         self.test_size = test_size
         self.folds = folds
         self.step_length = step_length
-        self.fh = np.arange(test_size) + 1 if isinstance(test_size, int) else None
+        super().__init__()
 
-        if isinstance(train_size, float) or isinstance(test_size, float):
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        if isinstance(self.train_size, float) or isinstance(self.test_size, float):
             self.set_tags(**{"split_hierarchical": False})
 
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
@@ -120,6 +124,32 @@ class SlidingGreedySplitter(BaseSplitter):
 
             if len(trn_indices) > 0 and len(tst_indices) > 0:
                 yield trn_indices, tst_indices
+
+    def _fh(self):
+        """Forecasting horizon, in integer resp array of integer, relative to cutoff.
+
+        Private method called by property ``fh``,
+        can be overridden by inheriting classes.
+
+        Default is to return a forecasting horizon of ``1``.
+
+        If the attribute ``_fh_`` is set, then it is returned instead.
+
+        Returns
+        -------
+        fh : array-like or int, optional, (default=None)
+            Forecasting horizon with the steps ahead to predict, if splits are used
+            for forecasting or backtesting.
+
+            * if integer, the indices to forecast are ``1, 2, ..., fh``, periods ahead.
+            * if array-like, the indices to forecast are given by the values in ``fh``,
+              values must be coercible to integer.
+            * ``None`` if no forecasting horizon is set. This is returned for splitters
+              that do not have a natural forecasting horizon associated to them.
+        """
+        test_size = self.test_size
+        fh = np.arange(test_size) + 1 if isinstance(test_size, int) else None
+        return fh
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/split/slidinggreedy.py
+++ b/sktime/split/slidinggreedy.py
@@ -96,7 +96,7 @@ class SlidingGreedySplitter(BaseSplitter):
 
         if isinstance(test_size, float):
             _test_size = int(np.ceil(len(y) * test_size))
-            self.fh = np.arange(_test_size) + 1
+            self._fh_ = np.arange(_test_size) + 1
         else:
             _test_size = test_size
 
@@ -148,6 +148,9 @@ class SlidingGreedySplitter(BaseSplitter):
         """
         test_size = self.test_size
         fh = np.arange(test_size) + 1 if isinstance(test_size, int) else None
+        # if test_size is float, fh is set later in _split, so we check for that here
+        if fh is None and hasattr(self, "_fh_"):
+            fh = self._fh_
         return fh
 
     @classmethod

--- a/sktime/split/slidinggreedy.py
+++ b/sktime/split/slidinggreedy.py
@@ -13,7 +13,6 @@ import numpy as np
 import pandas as pd
 
 from sktime.split.base import BaseSplitter
-from sktime.split.base._common import SPLIT_GENERATOR_TYPE
 
 
 class SlidingGreedySplitter(BaseSplitter):
@@ -86,7 +85,7 @@ class SlidingGreedySplitter(BaseSplitter):
         if isinstance(self.train_size, float) or isinstance(self.test_size, float):
             self.set_tags(**{"split_hierarchical": False})
 
-    def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+    def _split(self, y: pd.Index):
         train_size = self.train_size
         test_size = self.test_size
 

--- a/sktime/split/slidinggreedy.py
+++ b/sktime/split/slidinggreedy.py
@@ -96,7 +96,7 @@ class SlidingGreedySplitter(BaseSplitter):
 
         if isinstance(test_size, float):
             _test_size = int(np.ceil(len(y) * test_size))
-            self._fh_ = np.arange(_test_size) + 1
+            self.fh = np.arange(_test_size) + 1
         else:
             _test_size = test_size
 

--- a/sktime/split/slidingwindow.py
+++ b/sktime/split/slidingwindow.py
@@ -100,9 +100,7 @@ class SlidingWindowSplitter(BaseWindowSplitter):
         initial_window=None,
         start_with_window: bool = True,
     ) -> None:
-        # self.fh = fh  - we do not do that since the fh is a reserved property,
-        # instead we loop via the _fh method, which is called by the property
-        self._fh_ = fh
+        self.fh = fh
         super().__init__(
             window_length=window_length,
             initial_window=initial_window,

--- a/sktime/split/slidingwindow.py
+++ b/sktime/split/slidingwindow.py
@@ -10,16 +10,6 @@ __all__ = [
 
 
 from sktime.split.base import BaseWindowSplitter
-from sktime.split.base._common import (
-    DEFAULT_FH,
-    DEFAULT_STEP_LENGTH,
-    DEFAULT_WINDOW_LENGTH,
-    SPLIT_GENERATOR_TYPE,
-)
-from sktime.utils.validation import (
-    ACCEPTED_WINDOW_LENGTH_TYPES,
-    NON_FLOAT_WINDOW_LENGTH_TYPES,
-)
 
 
 class SlidingWindowSplitter(BaseWindowSplitter):
@@ -104,21 +94,23 @@ class SlidingWindowSplitter(BaseWindowSplitter):
 
     def __init__(
         self,
-        fh=DEFAULT_FH,
-        window_length: ACCEPTED_WINDOW_LENGTH_TYPES = DEFAULT_WINDOW_LENGTH,
-        step_length: NON_FLOAT_WINDOW_LENGTH_TYPES = DEFAULT_STEP_LENGTH,
-        initial_window: ACCEPTED_WINDOW_LENGTH_TYPES | None = None,
+        fh=1,
+        window_length=10,
+        step_length=1,
+        initial_window=None,
         start_with_window: bool = True,
     ) -> None:
+        # self.fh = fh  - we do not do that since the fh is a reserved property,
+        # instead we loop via the _fh method, which is called by the property
+        self._fh_ = fh
         super().__init__(
-            fh=fh,
             window_length=window_length,
             initial_window=initial_window,
             step_length=step_length,
             start_with_window=start_with_window,
         )
 
-    def _split_windows(self, **kwargs) -> SPLIT_GENERATOR_TYPE:
+    def _split_windows(self, **kwargs):
         return self._split_windows_generic(expanding=False, **kwargs)
 
     @classmethod

--- a/sktime/split/temporal_train_test_split.py
+++ b/sktime/split/temporal_train_test_split.py
@@ -13,18 +13,17 @@ import numpy as np
 import pandas as pd
 
 from sktime.split.base import BaseSplitter
-from sktime.split.base._common import ACCEPTED_Y_TYPES, SPLIT_TYPE
 from sktime.split.fh import ForecastingHorizonSplitter
 
 
 def temporal_train_test_split(
-    y: ACCEPTED_Y_TYPES,
-    X: pd.DataFrame | None = None,
-    test_size: float | None = None,
-    train_size: float | None = None,
+    y,
+    X=None,
+    test_size=None,
+    train_size=None,
     fh=None,
     anchor: str = "start",
-) -> SPLIT_TYPE:
+):
     """Split time series data containers into a single train/test split.
 
     Creates a single train/test split of endogenous time series ``y``,
@@ -263,7 +262,7 @@ class TemporalTrainTestSplitter(BaseSplitter):
 
         yield y_train_ix, y_test_ix
 
-    def get_n_splits(self, y: ACCEPTED_Y_TYPES | None = None) -> int:
+    def get_n_splits(self, y=None) -> int:
         """Return the number of splits.
 
         Since this splitter returns a single train/test split,

--- a/sktime/split/testplustrain.py
+++ b/sktime/split/testplustrain.py
@@ -42,9 +42,14 @@ class TestPlusTrainSplitter(BaseSplitter):
         self.cv = cv
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         # dispatch split_series to the same split/split_loc as the wrapped cv
         # for performance reasons
-        self.clone_tags(cv, "split_series_uses")
+        self.clone_tags(self.cv, "split_series_uses")
 
     def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
         """Get iloc references to train/test splits of ``y``.
@@ -111,6 +116,32 @@ class TestPlusTrainSplitter(BaseSplitter):
             The number of splits.
         """
         return self.cv.get_n_splits(y)
+
+    def _fh(self):
+        """Forecasting horizon, in integer resp array of integer, relative to cutoff.
+
+        Private method called by property ``fh``,
+        can be overridden by inheriting classes.
+
+        Default is to return a forecasting horizon of ``1`` for temporal splitters,
+        and ``None`` for instance splitters.
+
+        If the attribute ``_fh_`` is set, then it is returned instead.
+
+        Returns
+        -------
+        fh : array-like or int, optional, (default=None)
+            Forecasting horizon with the steps ahead to predict, if splits are used
+            for forecasting or backtesting.
+
+            * if integer, the indices to forecast are ``1, 2, ..., fh``, periods ahead.
+            * if array-like, the indices to forecast are given by the values in ``fh``,
+              values must be coercible to integer.
+            * ``None`` if no forecasting horizon is set. This is returned for splitters
+              that do not have a natural forecasting horizon associated to them.
+        """
+        # inherits the fh from the cv splitter directly, since the splits are the same
+        return self.cv.fh
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/split/testplustrain.py
+++ b/sktime/split/testplustrain.py
@@ -39,7 +39,7 @@ class TestPlusTrainSplitter(BaseSplitter):
 
     def __init__(self, cv):
         self.cv = cv
-        super().__init__(fh=cv.fh, window_length=cv.window_length)
+        super().__init__()
 
     def __dynamic_tags__(self):
         """Dynamic tag setter logic for setting tag values conditional on parameters.

--- a/sktime/split/testplustrain.py
+++ b/sktime/split/testplustrain.py
@@ -11,7 +11,6 @@ import numpy as np
 import pandas as pd
 
 from sktime.split.base import BaseSplitter
-from sktime.split.base._common import ACCEPTED_Y_TYPES, SPLIT_GENERATOR_TYPE
 
 
 class TestPlusTrainSplitter(BaseSplitter):
@@ -51,7 +50,7 @@ class TestPlusTrainSplitter(BaseSplitter):
         # for performance reasons
         self.clone_tags(self.cv, "split_series_uses")
 
-    def _split(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+    def _split(self, y: pd.Index):
         """Get iloc references to train/test splits of ``y``.
 
         private _split containing the core logic, called from split
@@ -75,7 +74,7 @@ class TestPlusTrainSplitter(BaseSplitter):
             y_test_self = np.union1d(y_train_inner, y_test_inner)
             yield y_train_self, y_test_self
 
-    def _split_loc(self, y: pd.Index) -> SPLIT_GENERATOR_TYPE:
+    def _split_loc(self, y: pd.Index):
         """Get loc references to train/test splits of ``y``.
 
         private _split containing the core logic, called from split_loc
@@ -99,7 +98,7 @@ class TestPlusTrainSplitter(BaseSplitter):
             y_test_self = y_train_inner.union(y_test_inner)
             yield y_train_self, y_test_self
 
-    def get_n_splits(self, y: ACCEPTED_Y_TYPES | None = None) -> int:
+    def get_n_splits(self, y=None) -> int:
         """Return the number of splits.
 
         This will always be equal to the number of splits

--- a/sktime/split/tests/test_testplustrain.py
+++ b/sktime/split/tests/test_testplustrain.py
@@ -13,10 +13,10 @@ from sktime.utils._testing.series import _make_series
     not run_test_for_class([SlidingWindowSplitter, TestPlusTrainSplitter]),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-def test_test_plus_train_splitter_fh_and_window_length():
-    """Test that TestPlusTrainSplitter takes fh and window_length from cv.
+def test_test_plus_train_splitter_fh():
+    """Test that TestPlusTrainSplitter takes fh from cv.
 
-    Failure case of bug #10945: fh and window_length silently fell back to the
+    Failure case of bug #10945: fh silently fell back to the
     ``BaseSplitter`` defaults, 1 and 10, instead of those of the wrapped splitter.
     """
     # both values must differ from the BaseSplitter defaults, 10 and 1,
@@ -25,7 +25,6 @@ def test_test_plus_train_splitter_fh_and_window_length():
     splitter = TestPlusTrainSplitter(cv)
 
     assert splitter.fh == [1, 2, 3]
-    assert splitter.window_length == 5
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Addresses one of the deeper issues behind https://github.com/sktime/sktime/issues/10945, FYI @RobKuebler.

The deeper reason in my opinion is that `BaseSplitter` did not define a clear extension or composition contract for the parameter `fh`, which all splitters were assumed to have by interfacing code such as in `evaluate`. The parameter `fh` was also passed on to superclasses in an unstructured way by some child classes, and no compositions were setting it properly.

This PR refactors the `BaseSplitter.fh` interface to be:

* property based
* clearly documented
* extensible and composable, such as for the composite splitter `TestPlusTrainSplitter`

This is meant to be an 1:1 refactor with no change in public behaviour of splitters, except where bugs were fixed (such as the bug in #10945).

The documentation is based on the status quo, e.g., that `self.fh` is always integer and period based is already an undocumented property of the current API. This can be seen as a questionable choice, especially given the simultaneous existence of the `get_fh` API point which always returns `ForecastingHorizon`, but it is not changed because this is an 1:1 refactor to clean up the internal API.

The documented extender interface also does not change - this has not documented `self.fh` or how to pass it to parent classes, same for `self.window_length`, therefore the `fh` and `window_length` can safely be removed from `BaseSplitter`.

However, as a consequence of avoiding to pass unnecessary arguments to `super().__init__`, the `BaseSplitter` no longer interacts with `window_length` as a parameter - this seems to have been spurious coupling with its subclass `BaseWindowSplitter`.