### PR TITLE
[ENH] minor fixes: replace deprecated internal import path, remove stray newlines in docstring

### DIFF
--- a/sktime/datasets/forecasting/_base.py
+++ b/sktime/datasets/forecasting/_base.py
@@ -17,7 +17,6 @@ class BaseForecastingDataset(BaseDataset):
 
     Tags
     ----
-
     is_univariate: bool, default=True
         Whether the dataset is univariate. In the case of Forecasting dataset,
         this refers to the dimensionality of the `y` dataframe.
@@ -59,8 +58,6 @@ class BaseForecastingDataset(BaseDataset):
     n_hierarchy_levels: int, default=0
         Number of levels in the hierarchy of the dataset. This is the number of
         index levels in the `y` dataframe, excluding the time index.
-
-
     """
 
     _tags = {

--- a/sktime/forecasting/tests/test_timesfm.py
+++ b/sktime/forecasting/tests/test_timesfm.py
@@ -10,7 +10,7 @@ Therefore, we call a check_estimator separately.
 
 import pytest
 
-from sktime.forecasting.timesfm_forecaster import TimesFMForecaster
+from sktime.forecasting.timesfm import TimesFMForecaster
 from sktime.tests.test_switch import run_test_for_class
 from sktime.utils import check_estimator
 


### PR DESCRIPTION
Carries out two minor fixes:

* replaces a deprecated internal import path from `timesfm2_forecaster`
* removes a few stray newlines in a docstring