### PR TITLE
[BUG] Honour tag_value_default when tag is explicitly None (#10305)

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -210,6 +210,29 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         pass
 
     @classmethod
+    def get_class_tag(cls, tag_name, tag_value_default=None):
+        """Get class tag value, honouring ``tag_value_default`` for unset ``None`` tags."""
+        tag_val = super().get_class_tag(
+            tag_name=tag_name, tag_value_default=tag_value_default
+        )
+        # _get_class_flag returns stored None instead of tag_value_default when a tag
+        # is explicitly set to None (e.g. "python_version": None in _tags).
+        if tag_val is None and tag_value_default is not None:
+            return tag_value_default
+        return tag_val
+
+    def get_tag(self, tag_name, tag_value_default=None, raise_error=True):
+        """Get tag value, honouring ``tag_value_default`` for unset ``None`` tags."""
+        tag_val = super().get_tag(
+            tag_name=tag_name,
+            tag_value_default=tag_value_default,
+            raise_error=raise_error,
+        )
+        if tag_val is None and tag_value_default is not None:
+            return tag_value_default
+        return tag_val
+
+    @classmethod
     def _get_set_config_doc(cls):
         """Create docstring for set_config from self._config_doc.
 
@@ -518,6 +541,10 @@ class TagAliaserMixin(_TagAliaserMixin):
         tag_val = super().get_class_tag(
             tag_name=tag_name, tag_value_default=tag_value_default
         )
+        # _get_class_flag returns stored None instead of tag_value_default when a tag
+        # is explicitly set to None (e.g. "python_version": None in _tags).
+        if tag_val is None and tag_value_default is not None:
+            return tag_value_default
         return tag_val
 
     def get_tag(self, tag_name, tag_value_default=None, raise_error=True):
@@ -611,6 +638,8 @@ class TagAliaserMixin(_TagAliaserMixin):
             tag_value_default=tag_value_default,
             raise_error=raise_error,
         )
+        if tag_val is None and tag_value_default is not None:
+            return tag_value_default
         return tag_val
 
     def set_tags(self, **tag_dict):

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -67,6 +67,15 @@ FIXTURE_OBJECT_TAGS = {"A": 42424241, "B": 3, "C": 1234, 3: "E"}
 DEFAULT_TAGS = BaseObject._tags
 
 
+class NoneTagTestClass(BaseObject):
+    """Class for testing tag_value_default when tag is explicitly None."""
+
+    _tags = {
+        "none_tag": None,
+        "real_tag": "real_value",
+    }
+
+
 def test_get_class_tags():
     """Tests get_class_tags class method of BaseObject for correctness.
 
@@ -109,6 +118,32 @@ def test_get_class_tag():
 
     assert child_tag_default == "bar", msg
     assert child_tag_defaultNone is None, msg
+
+
+@pytest.mark.parametrize("cls", [NoneTagTestClass])
+def test_get_class_tag_default_when_none(cls):
+    """Test tag_value_default when tag value is None.
+
+    Regression test for #10305.
+    """
+    assert cls.get_class_tag("none_tag", "fallback") == "fallback"
+    assert cls.get_class_tag("none_tag") is None
+    assert cls.get_class_tag("real_tag", "fallback") == "real_value"
+    assert cls.get_class_tag("nonexistent", "fallback") == "fallback"
+    assert cls.get_class_tag("nonexistent") is None
+
+
+@pytest.mark.parametrize("cls", [NoneTagTestClass])
+def test_get_tag_default_when_none(cls):
+    """Test tag_value_default for get_tag when tag value is None.
+
+    Regression test for #10305.
+    """
+    obj = cls()
+
+    assert obj.get_tag("none_tag", "fallback") == "fallback"
+    assert obj.get_tag("none_tag") is None
+    assert obj.get_tag("real_tag", "fallback") == "real_value"
 
 
 def test_get_tags():

--- a/sktime/base/tests/test_base_sktime.py
+++ b/sktime/base/tests/test_base_sktime.py
@@ -4,6 +4,13 @@
 __author__ = ["fkiraly"]
 
 
+def test_naive_forecaster_python_version_default():
+    """NaiveForecaster.python_version is None; default should still apply."""
+    from sktime.forecasting.naive import NaiveForecaster
+
+    assert NaiveForecaster.get_class_tag("python_version", "3.12") == "3.12"
+
+
 def test_get_fitted_params_sklearn():
     """Tests fitted parameter retrieval with sklearn components.
 


### PR DESCRIPTION
### Summary
Fixes [#10305](https://github.com/sktime/sktime/issues/10305).

get_class_tag and get_tag returned None when a tag was explicitly set to None in _tags (e.g. "python_version": None on BaseObject), even when a non-None tag_value_default was provided.

### Reproducer:

from sktime.forecasting.naive import NaiveForecaster
NaiveForecaster.get_class_tag("python_version", "3.12")  # returned None
Expected: return "3.12" when the default is provided and the tag value is unset (None).

### Root cause
skbase resolves tags via _get_class_flag, which uses dict.get(). If a key exists with value None, the stored None is returned and tag_value_default is ignored:

collected_flags.get(flag_name, flag_value_default)
 key exists with None → returns None, not the default
### Fix
After calling super().get_class_tag() / super().get_tag(), if the result is None and a non-None default was passed, return the default. Applied in:

BaseObject — covers direct BaseObject subclasses
TagAliaserMixin — covers estimators (e.g. NaiveForecaster via BaseEstimator)
Tests
test_get_class_tag_default_when_none / test_get_tag_default_when_none in test_base.py using NoneTagTestClass(BaseObject)
test_naive_forecaster_python_version_default in test_base_sktime.py — exact issue reproducer
### Test plan

 pytest sktime/base/tests/test_base.py::test_get_class_tag_default_when_none -o addopts=

 pytest sktime/base/tests/test_base.py::test_get_tag_default_when_none -o addopts=

 pytest sktime/base/tests/test_base_sktime.py::test_naive_forecaster_python_version_default -o addopts=

 Manual: NaiveForecaster.get_class_tag("python_version", "3.12") returns "3.12"