### PR TITLE
[BUG] fix `CNTCClassifier` custom objects method name for save/load

### DIFF
--- a/sktime/classification/deep_learning/cntc/_cntc_tf.py
+++ b/sktime/classification/deep_learning/cntc/_cntc_tf.py
@@ -385,3 +385,15 @@ class CNTCClassifier(BaseDeepClassifier):
             params.append(param_callbacks)
 
         return params
+
+    @staticmethod
+    def _get_keras_custom_objects():
+        """Return custom Keras objects required to deserialize the fitted model.
+
+        Returns
+        -------
+        dict of str to type, mapping names to classes
+        """
+        from sktime.libs._keras_self_attention import SeqSelfAttention
+
+        return SeqSelfAttention.get_custom_objects()


### PR DESCRIPTION
Closes #10745. 

The following test errors remain in the CNTC Keras estimators:

```
=== test_deepcopy_fitted_predict  [AttributeError]  x18
    'CNTCClassifier' object has no attribute 'model_'

=== test_persistence_via_pickle  [AssertionError]  x9
     | Arrays are not almost equal to 6 decimals | Results of predict_proba differ between when pickling and not pickling, estimator CNTCClassifier | Mismatched elements: 8 / 10 (80%) | Max absolute difference among violations: 7.669628e-05 | Max relative difference among violations: 0.00225931 |  ACTUAL: array([[0

=== test_save_estimators_to_file  [AssertionError]  x9
     | Arrays are not almost equal to 6 decimals | Results of predict_proba differ between saved and loaded estimator CNTCClassifier | Mismatched elements: 10 / 10 (100%) | Max absolute difference among violations: 0.0001086 | Max relative difference among violations: 0.040176 |  ACTUAL: array([[0.997386, 0.002614]
```

The `test_deepcopy_fitted_predict` is tracked in #10712 -- it will be fixed once #10453 is merged.
The persistence failures need to be investigated further.