### PR TITLE
[BUG] Fix `random_state` handling in `statsmodels` adapter

### DIFF
--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -222,8 +222,27 @@ class _StatsModelsAdapter(BaseForecaster):
 
         get_prediction_arguments = {"start": start, "end": end}
 
-        if hasattr(self, "random_state"):
-            get_prediction_arguments["random_state"] = self.random_state
+        # Only pass random_state when supported by get_prediction.
+        if self.random_state is not None:
+            get_prediction_params = inspect.signature(
+                self._fitted_forecaster.get_prediction
+            ).parameters
+
+            if "simulate_kwargs" in get_prediction_params:
+                simulate_params = inspect.signature(
+                    self._fitted_forecaster.simulate
+                ).parameters
+
+                if "rng" in simulate_params:
+                    get_prediction_arguments["simulate_kwargs"] = {
+                        "rng": self.random_state
+                    }
+                else:
+                    get_prediction_arguments["simulate_kwargs"] = {
+                        "random_state": self.random_state
+                    }
+            elif "random_state" in get_prediction_params:
+                get_prediction_arguments["random_state"] = self.random_state
 
         if inspect.signature(self._fitted_forecaster.get_prediction).parameters.get(
             "exog"

--- a/sktime/forecasting/base/adapters/_statsmodels.py
+++ b/sktime/forecasting/base/adapters/_statsmodels.py
@@ -223,7 +223,7 @@ class _StatsModelsAdapter(BaseForecaster):
         get_prediction_arguments = {"start": start, "end": end}
 
         # Only pass random_state when supported by get_prediction.
-        if self.random_state is not None:
+        if hasattr(self, "random_state"):
             get_prediction_params = inspect.signature(
                 self._fitted_forecaster.get_prediction
             ).parameters

--- a/sktime/forecasting/base/tests/test_base_bugs.py
+++ b/sktime/forecasting/base/tests/test_base_bugs.py
@@ -79,3 +79,68 @@ def test_predict_residuals_conversion():
     result = pipe.predict_residuals()
 
     assert type(result) is type(y_train)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.forecasting.base"),
+    reason="run only if base module has changed",
+)
+def test_statsmodels_adapter_random_state_handling():
+    """Regression test for #10968: avoid passing unsupported random_state."""
+    import pandas as pd
+
+    from sktime.forecasting.base import ForecastingHorizon
+    from sktime.forecasting.base.adapters._statsmodels import _StatsModelsAdapter
+
+    class MockPredictionResults:
+        def conf_int(self, alpha):
+            return pd.DataFrame([[0, 1], [0, 1], [0, 1]], columns=["lower", "upper"])
+
+    class MockNonETSModel:
+        def get_prediction(self, start=None, end=None, **kwargs):
+            assert "random_state" not in kwargs
+            return MockPredictionResults()
+
+    class MockETSModel:
+        def get_prediction(
+            self,
+            start=None,
+            end=None,
+            dynamic=False,
+            index=None,
+            method=None,
+            simulate_repetitions=1000,
+            **simulate_kwargs,
+        ):
+            assert simulate_kwargs["simulate_kwargs"] == {"rng": 42}
+            return MockPredictionResults()
+
+        def simulate(self, nsimulations, rng=None, **kwargs):
+            return None
+
+    class MockAdapter(_StatsModelsAdapter):
+        _tags = {
+            "capability:pred_int": True,
+        }
+
+        def __init__(self, model, random_state=None):
+            self.model = model
+            super().__init__(random_state=random_state)
+
+        def _fit_forecaster(self, y, X=None):
+            self._fitted_forecaster = self.model
+
+        @staticmethod
+        def _extract_conf_int(prediction_results, alpha):
+            return prediction_results.conf_int(alpha)
+
+    y = pd.Series([1, 2, 3, 4, 5])
+    fh = ForecastingHorizon([1, 2, 3])
+
+    non_ets = MockAdapter(MockNonETSModel(), random_state=42)
+    non_ets.fit(y, fh=fh)
+    non_ets.predict_interval(fh=fh, coverage=[0.9])
+
+    ets = MockAdapter(MockETSModel(), random_state=42)
+    ets.fit(y, fh=fh)
+    ets.predict_interval(fh=fh, coverage=[0.9])

--- a/sktime/forecasting/exp_smoothing.py
+++ b/sktime/forecasting/exp_smoothing.py
@@ -230,7 +230,7 @@ class ExponentialSmoothing(_StatsModelsAdapter):
             ``create_test_instance`` uses the first (or only) dictionary in `params
         """
         params = [
-            {},
+            {"random_state": 42},
             {
                 "trend": "mul",
                 "damped_trend": True,


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10968.

#### What does this implement/fix? Explain your changes.

`_StatsModelsAdapter._predict_interval` used to pass `random_state` to
`get_prediction` for all statsmodels-based forecasters.

However, this breaks with statsmodels 0.15, since some state-space models
reject the unsupported argument, while ETS models pass simulation arguments
through `simulate_kwargs`, and the `simulate` method now uses `rng` instead
of `random_state`.

This PR:
- only passes `random_state` when it is supported by the underlying
  `get_prediction`;
- for ETS models, passes the random state through `simulate_kwargs`;
- detects whether the underlying `simulate` method expects `rng` or
  `random_state`, preserving compatibility with statsmodels 0.14 and 0.15.

Other than that, the behavior of the forecasting functions is unchanged.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the signature-based approach correctly distinguishes the ETS
  `simulate_kwargs` path from other statsmodels models.
- Whether the `rng`/`random_state` handling is correct for the supported
  statsmodels versions.
- Whether the regression test adequately covers the #10968 scenario.

#### Did you add any tests for the change?

Yes.

A regression test for the scenario described in #10968 was added. It verifies
that `random_state` is not passed to `get_prediction` for non-ETS models,
while for ETS models it is passed through `simulate_kwargs`.

The test was run locally and passed. The complete `test_base_bugs.py` test
file also passes:

- `test_base_bugs.py`: 3/3 tests passed
- `test_statsmodels_adapter_random_state_handling`: passed
- pre-commit formatting and linting checks: passed

#### Any other comments?

The fix was also tested locally with statsmodels 0.15 using SARIMAX,
UnobservedComponents, and AutoETS prediction intervals.

No new dependencies were introduced.