### PR TITLE
[ENH] Fix Singular matrix in `ImpulseResponseFunction` VECM tests

### DIFF
--- a/sktime/param_est/tests/test_response.py
+++ b/sktime/param_est/tests/test_response.py
@@ -258,10 +258,14 @@ def test_irf_on_vecm():
     """Test ImpulseResponseFunctions on airline data with VECM."""
     from sktime.forecasting.vecm import VECM as skvecm
 
-    # Convergence and estimation warnings happen regularly in statsmodels too.
-    X = load_airline()
-    X2 = X.shift(1).bfill()
-    df = pd.DataFrame({"X": X, "X2": X2})
+    rng = np.random.RandomState(42)
+    X1 = load_airline().values.astype(float)
+    X1_stationary = np.diff(np.log(X1))
+    noise = rng.normal(scale=0.05, size=len(X1_stationary))
+    X2_stationary = 0.6 * X1_stationary + 0.4 * np.roll(X1_stationary, 1) + noise
+
+    df = pd.DataFrame({"X1": X1_stationary[1:], "X2": X2_stationary[1:]})
+    df.index = pd.date_range("1949-02-01", periods=len(df), freq="MS")
 
     sk_model = skvecm().fit(df)
     sk_res = ImpulseResponseFunction(sk_model)
@@ -280,17 +284,21 @@ def test_additional_irfparams_on_vecm():
     """Test more ImpulseResponseFunction parameters with airline data on VECM."""
     from sktime.forecasting.vecm import VECM as skvecm
 
-    # Convergence and estimation warnings happen regularly in statsmodels too.
-    X = load_airline()
-    X2 = X.shift(1).bfill()
-    df = pd.DataFrame({"X": X, "X2": X2})
+    rng = np.random.RandomState(42)
+    X1 = load_airline().values.astype(float)
+    X1_stationary = np.diff(np.log(X1))
+    noise = rng.normal(scale=0.05, size=len(X1_stationary))
+    X2_stationary = 0.6 * X1_stationary + 0.4 * np.roll(X1_stationary, 1) + noise
+
+    df = pd.DataFrame({"X1": X1_stationary[1:], "X2": X2_stationary[1:]})
+    df.index = pd.date_range("1949-02-01", periods=len(df), freq="MS")
 
     sk_model = skvecm().fit(df)
     sk_res = ImpulseResponseFunction(sk_model, cumulative=True, steps=4)
     sk_res.fit(df)
 
     actual = np.round(sk_res.get_fitted_params()["irf"].sum())
-    expected = 30.0
+    expected = 18.0
     np.testing.assert_allclose(actual, expected, rtol=0.10)
 
 
@@ -304,9 +312,14 @@ def test_irf_vecm_against_statsmodels():
 
     from sktime.forecasting.vecm import VECM as skvecm
 
-    X = load_airline()
-    X2 = X.shift(1).bfill()
-    df = pd.DataFrame({"X": X, "X2": X2})
+    rng = np.random.RandomState(42)
+    X1 = load_airline().values.astype(float)
+    X1_stationary = np.diff(np.log(X1))
+    noise = rng.normal(scale=0.05, size=len(X1_stationary))
+    X2_stationary = 0.6 * X1_stationary + 0.4 * np.roll(X1_stationary, 1) + noise
+
+    df = pd.DataFrame({"X1": X1_stationary[1:], "X2": X2_stationary[1:]})
+    df.index = pd.date_range("1949-02-01", periods=len(df), freq="MS")
 
     st_model = statsvecm(df, seasons=2)
     fitted_model = st_model.fit()


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10954. 
*(Note: I noticed #10970 also attempts to fix this using `X.shift(12)`, but because `load_airline` is highly seasonal, a 12-month shift leaves the matrix highly correlated, which could still lead to near-singular matrices and `ConvergenceWarnings` in `statsmodels`. This PR uses seeded, stationary synthetic data to guarantee the matrices are well-conditioned and permanently eliminate `LinAlgError`.)*
#### What does this implement/fix? Explain your changes.
This PR fixes the sporadic `numpy.linalg.LinAlgError: Singular matrix` failures in `ImpulseResponseFunction` tests (specifically `test_response.py`).
The VECM and VARMAX tests were previously using raw dummy data with exact multicollinearity (`X2 = X.shift(1)`). When `statsmodels` tried to invert matrices to calculate impulse responses on this perfectly correlated data, it threw singular matrix errors. 
This PR replaces the collinear dummy data with properly stationary, randomly generated synthetic series (`np.random.RandomState(42)`) that do not suffer from multicollinearity, allowing the `statsmodels` mathematical operations to succeed deterministically and reliably.
#### Does your contribution introduce a new dependency? If yes, which one?
No.
#### What should a reviewer concentrate their feedback on?
- Checking if the new synthetic data generation for the VECM and VARMAX tests is appropriate.
- Note that one test assertion (`test_additional_irfparams_on_vecm`) was updated from expecting `30.0` to `18.0` due to the new properties of the dummy data.
#### Did you add any tests for the change?
No, this PR fixes existing tests.
#### Any other comments?
None!
#### PR checklist
##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. 
##### For new estimators
- [ ] I've added the estimator to the API reference
- [ ] I've added one or more illustrative usage examples to the docstring
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured dependency isolation