### PR TITLE
[DOC] add doctest examples for detection cost functions

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4122,6 +4122,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "jvsch",
+      "name": "Jasper Victor Schneider",
+      "avatar_url": "https://avatars.githubusercontent.com/u/95355765?v=4",
+      "profile": "https://github.com/jvsch",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/sktime/detection/costs/_empirical_distribution_cost.py
+++ b/sktime/detection/costs/_empirical_distribution_cost.py
@@ -113,6 +113,34 @@ class EmpiricalDistributionCost(BaseCost):
     .. [1] Haynes, K., Fearnhead, P. & Eckley, I.A. A computationally efficient
        nonparametric approach for changepoint detection. Stat Comput 27,
        1293-1305 (2017).
+
+    Examples
+    --------
+    Intervals must contain at least ``min_size`` observations, which is 10 by
+    default, since the empirical distribution is estimated from them.
+
+    >>> import numpy as np
+    >>> from sktime.detection.costs import EmpiricalDistributionCost
+    >>> block = np.tile([0., 1., 2., 3.], 5)
+    >>> X = np.concatenate([block, block + 10.]).reshape(-1, 1)
+    >>> cost = EmpiricalDistributionCost()
+    >>> cost.evaluate(X, [[0, 20], [20, 40], [10, 30]]).round(2)
+    array([[ 82.58],
+           [ 82.58],
+           [124.31]])
+
+    The first two intervals each cover a homogeneous part of the series, while
+    the third straddles the change and is more costly. The cost makes no
+    parametric assumption about the distribution of the data.
+
+    ``num_approximation_quantiles`` controls how finely the empirical
+    distribution is approximated:
+
+    >>> cost = EmpiricalDistributionCost(num_approximation_quantiles=5)
+    >>> cost.evaluate(X, [[0, 20], [20, 40], [10, 30]]).round(2)
+    array([[ 73.01],
+           [ 73.01],
+           [136.09]])
     """
 
     _tags = {

--- a/sktime/detection/costs/_gaussian_cost.py
+++ b/sktime/detection/costs/_gaussian_cost.py
@@ -45,6 +45,29 @@ class GaussianCost(BaseCost):
     param : 2-tuple of float or np.ndarray, or None (default=None)
         Fixed mean(s) and variance(s) for the cost calculation.
         If ``None``, the maximum likelihood estimates are used.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.detection.costs import GaussianCost
+    >>> X = np.array([0., 2., 0., 2., 10., 12., 10., 12.]).reshape(-1, 1)
+    >>> cost = GaussianCost()
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[11.35],
+           [11.35],
+           [48.77]])
+
+    The first two intervals are each well described by a single Gaussian, so
+    their cost is low. The third spans the change in mean and is expensive.
+
+    Passing ``param`` evaluates the cost at a fixed mean and variance instead
+    of the maximum likelihood estimates of the interval:
+
+    >>> cost = GaussianCost(param=(1.0, 1.0))
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[ 11.35],
+           [411.35],
+           [422.7 ]])
     """
 
     _tags = {

--- a/sktime/detection/costs/_l1_cost.py
+++ b/sktime/detection/costs/_l1_cost.py
@@ -47,6 +47,29 @@ class L1Cost(BaseCost):
     param : float or array-like, optional (default=None)
         Fixed mean for the cost calculation. If ``None``, the optimal mean is
         calculated as the median of each variable, for each interval.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.detection.costs import L1Cost
+    >>> X = np.concatenate([np.zeros(5), 10 * np.ones(5)]).reshape(-1, 1)
+    >>> cost = L1Cost()
+    >>> cost.evaluate(X, [[0, 5], [5, 10], [0, 10]])
+    array([[ 0.],
+           [ 0.],
+           [50.]])
+
+    The first two intervals each cover a constant level, so their cost is zero.
+    The third spans the change and is therefore expensive.
+
+    Passing ``param`` evaluates the cost at a fixed location instead of the
+    median of the interval:
+
+    >>> cost = L1Cost(param=0.0)
+    >>> cost.evaluate(X, [[0, 5], [5, 10], [0, 10]])
+    array([[ 0.],
+           [50.],
+           [50.]])
     """
 
     _tags = {

--- a/sktime/detection/costs/_l2_cost.py
+++ b/sktime/detection/costs/_l2_cost.py
@@ -104,6 +104,29 @@ class L2Cost(BaseCost):
     param : float or array-like, optional (default=None)
         Fixed mean for the cost calculation. If ``None``, the optimal mean is
         calculated.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.detection.costs import L2Cost
+    >>> X = np.concatenate([np.zeros(5), 10 * np.ones(5)]).reshape(-1, 1)
+    >>> cost = L2Cost()
+    >>> cost.evaluate(X, [[0, 5], [5, 10], [0, 10]])
+    array([[  0.],
+           [  0.],
+           [250.]])
+
+    The first two intervals each cover a constant level, so their cost is zero.
+    The third spans the change and is therefore expensive.
+
+    Passing ``param`` evaluates the cost at a fixed mean instead of the optimal
+    one, which makes the second interval costly as well:
+
+    >>> cost = L2Cost(param=0.0)
+    >>> cost.evaluate(X, [[0, 5], [5, 10], [0, 10]])
+    array([[  0.],
+           [500.],
+           [500.]])
     """
 
     _tags = {

--- a/sktime/detection/costs/_laplace_cost.py
+++ b/sktime/detection/costs/_laplace_cost.py
@@ -61,6 +61,30 @@ class LaplaceCost(BaseCost):
         Fixed location and scale parameters of the Laplace distribution.
         If None, the cost is evaluated with location and scale set to
         the MLE estimates of the parameters over each interval.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.detection.costs import LaplaceCost
+    >>> X = np.array([0., 2., 0., 2., 10., 12., 10., 12.]).reshape(-1, 1)
+    >>> cost = LaplaceCost()
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[13.55],
+           [13.55],
+           [52.84]])
+
+    The first two intervals are each well described by a single Laplace
+    distribution, so their cost is low. The third spans the change in location
+    and is expensive.
+
+    Passing ``param`` evaluates the cost at a fixed location and scale instead
+    of the MLE estimates of the interval:
+
+    >>> cost = LaplaceCost(param=(1.0, 1.0))
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[13.55],
+           [85.55],
+           [99.09]])
     """
 
     _tags = {

--- a/sktime/detection/costs/_linear_regression_cost.py
+++ b/sktime/detection/costs/_linear_regression_cost.py
@@ -57,6 +57,32 @@ class LinearRegressionCost(BaseCost):
         except the response column are used as predictors.
     param : array-like, optional (default=None)
         Fixed regression coefficients.
+
+    Examples
+    --------
+    The first column of ``X`` is the response, the remaining columns are the
+    predictors. Here the response is proportional to the predictor, with a
+    change in the proportionality constant halfway through.
+
+    >>> import numpy as np
+    >>> from sktime.detection.costs import LinearRegressionCost
+    >>> covariate = np.arange(1., 9.)
+    >>> response = np.concatenate([2 * covariate[:4], 5 * covariate[4:]])
+    >>> X = np.column_stack([response, covariate])
+    >>> cost = LinearRegressionCost()
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[  0.  ],
+           [  0.  ],
+           [230.29]])
+
+    The regression has no implicit intercept term. To fit one, add a column of
+    ones to ``X``, which is then picked up as a predictor:
+
+    >>> X = np.column_stack([response, np.ones(8), covariate])
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[  0.  ],
+           [  0.  ],
+           [109.29]])
     """
 
     _tags = {

--- a/sktime/detection/costs/_linear_trend_cost.py
+++ b/sktime/detection/costs/_linear_trend_cost.py
@@ -101,6 +101,31 @@ class LinearTrendCost(BaseCost):
     share_fixed_trend : bool, optional (default=False)
         If True, a single ``[slope, intercept]`` pair is broadcast
         to all data columns.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.detection.costs import LinearTrendCost
+    >>> X = np.array([0., 1., 2., 3., 10., 9., 8., 7.]).reshape(-1, 1)
+    >>> cost = LinearTrendCost()
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[ 0.  ],
+           [ 0.  ],
+           [33.33]])
+
+    Each of the first two intervals lies exactly on a straight line, so the
+    residuals, and hence the cost, are zero. The third interval contains the
+    change in slope and cannot be fitted by a single line.
+
+    Passing ``param`` evaluates the cost at a fixed ``[slope, intercept]``
+    instead of fitting the trend to the interval:
+
+    >>> cost = LinearTrendCost(param=np.array([[1.0, 0.0]]),
+    ...                        share_fixed_trend=True)
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[ 0.],
+           [56.],
+           [56.]])
     """
 
     _tags = {

--- a/sktime/detection/costs/_multivariate_gaussian_cost.py
+++ b/sktime/detection/costs/_multivariate_gaussian_cost.py
@@ -72,6 +72,31 @@ class MultivariateGaussianCost(BaseCost):
     param : 2-tuple of float or np.ndarray, or None (default=None)
         Fixed mean and covariance matrix for the cost calculation.
         If ``None``, the maximum likelihood estimates are used.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.detection.costs import MultivariateGaussianCost
+    >>> X = np.array([[0., 0.], [2., 1.], [0., 1.], [2., 0.],
+    ...               [10., 5.], [12., 6.], [10., 6.], [12., 5.]])
+    >>> cost = MultivariateGaussianCost()
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[17.16],
+           [17.16],
+           [65.77]])
+
+    The cost is aggregated over all variables, so the result has a single
+    column. The first two intervals are each well described by one multivariate
+    Gaussian; the third spans the change in mean and is expensive.
+
+    Passing ``param`` evaluates the cost at a fixed mean and covariance matrix
+    instead of the maximum likelihood estimates of the interval:
+
+    >>> cost = MultivariateGaussianCost(param=(1.0, np.eye(2)))
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[ 20.7 ],
+           [500.7 ],
+           [521.41]])
     """
 
     _tags = {

--- a/sktime/detection/costs/_multivariate_t_cost.py
+++ b/sktime/detection/costs/_multivariate_t_cost.py
@@ -344,6 +344,33 @@ class MultivariateTCost(BaseCost):
         Relative tolerance for MLE scale matrix convergence.
     mle_scale_max_iter : int, optional (default=100)
         Maximum iterations for MLE scale matrix estimation.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.detection.costs import MultivariateTCost
+    >>> X = np.array([[0., 0.], [2., 1.], [0., 1.], [2., 0.],
+    ...               [10., 5.], [12., 6.], [10., 6.], [12., 5.]])
+    >>> cost = MultivariateTCost()
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[17.16],
+           [17.16],
+           [65.77]])
+
+    The first two intervals are each well described by a single distribution,
+    so their cost is low. The third spans the change in location and is
+    expensive.
+
+    The degrees of freedom are estimated from the data by default. Where the
+    estimate exceeds ``infinite_dof_threshold``, the distribution is
+    approximated by a Gaussian. Fixing a small number of degrees of freedom
+    gives the heavier tails of the t distribution:
+
+    >>> cost = MultivariateTCost(fixed_dof=3)
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[19.37],
+           [19.37],
+           [69.13]])
     """
 
     _tags = {

--- a/sktime/detection/costs/_poisson_cost.py
+++ b/sktime/detection/costs/_poisson_cost.py
@@ -93,6 +93,31 @@ class PoissonCost(BaseCost):
         Fixed rate parameter of the Poisson distribution.
         If None, the cost is evaluated with rate set to
         the MLE estimate (sample mean) over each interval.
+
+    Examples
+    --------
+    The data must consist of non-negative integer counts.
+
+    >>> import numpy as np
+    >>> from sktime.detection.costs import PoissonCost
+    >>> X = np.array([1, 2, 1, 2, 20, 22, 20, 22]).reshape(-1, 1)
+    >>> cost = PoissonCost()
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[  9.91],
+           [ 19.75],
+           [110.33]])
+
+    The first two intervals are each well described by a single rate, so their
+    cost is low. The third spans the change in rate and is expensive.
+
+    Passing ``param`` evaluates the cost at a fixed rate instead of the MLE
+    estimate of the interval:
+
+    >>> cost = PoissonCost(param=2.0)
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [0, 8]]).round(2)
+    array([[ 10.45],
+           [262.78],
+           [273.23]])
     """
 
     _tags = {

--- a/sktime/detection/costs/_rank_cost.py
+++ b/sktime/detection/costs/_rank_cost.py
@@ -65,6 +65,22 @@ class RankCost(BaseCost):
     .. [1] Lung-Yut-Fong, A., Levy-Leduc, C., & Cappe, O. (2015).
        Homogeneity and change-point detection tests for multivariate data
        using rank statistics.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.detection.costs import RankCost
+    >>> X = np.array([[0., 0.], [2., 1.], [0., 1.], [2., 0.],
+    ...               [10., 5.], [12., 6.], [10., 6.], [12., 5.]])
+    >>> cost = RankCost()
+    >>> cost.evaluate(X, [[0, 4], [4, 8], [1, 5]]).round(2)
+    array([[-3.37],
+           [-3.37],
+           [-0.84]])
+
+    The cost is based on rank statistics and is therefore distribution free.
+    The first two intervals each cover a homogeneous part of the series and
+    attain a low cost, while the third straddles the change and is more costly.
     """
 
     _tags = {


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #10782.

#### What does this implement/fix? Explain your changes.

Adds an `Examples` section to the 11 cost functions in `sktime/detection/costs/`:
`L1Cost`, `L2Cost`, `GaussianCost`, `LaplaceCost`, `PoissonCost`, `RankCost`,
`LinearTrendCost`, `LinearRegressionCost`, `MultivariateGaussianCost`,
`MultivariateTCost`, `EmpiricalDistributionCost`. None of them had one, so they
all failed `test_class_has_doctest_example`.

Docstrings only, no change to any code path.

Each example follows the same shape: two intervals that each cover a homogeneous
part of the series, and one that spans the change. This shows the cost being low
on the former and high on the latter, so the example also conveys what the cost
is for. Where the class supports it, a second example evaluates at a fixed
`param` rather than the optimal one.

All examples use the public `sktime.detection.costs` import path and are run
rather than skipped, the cost classes have no soft dependency (`numba` is
optional with a pure-Python fallback), so they execute in CI.

One thing worth flagging: `LinearRegressionCost` has no implicit intercept term
(`covariate_data @ coeffs`). The example now shows that a column of ones has to
be added explicitly if an intercept is wanted, which did not seem to be
documented anywhere.

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies.

#### What should a reviewer concentrate their feedback on?

* Whether the chosen data and cuts illustrate each cost well, particularly
  `RankCost` and `EmpiricalDistributionCost`, where the interpretation of the
  values is less obvious than for the others.
* `MultivariateTCost`: with the default settings the estimated degrees of freedom
  exceed `infinite_dof_threshold`, so the first example returns the same values as
  `MultivariateGaussianCost`. I added a second example with `fixed_dof=3` and a
  sentence explaining this, but let me know if you would prefer a different setup.

#### Did you add any tests for the change?

No new tests.

#### Any other comments?

This is my first PR to sktime. Happy to adjust anything about the style or the
choice of examples.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].