### PR TITLE
[DOC] doctest examples for EmpiricalCoverage, IntervalWidth and ConstraintViolation

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4122,6 +4122,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "RudraDudhat2509",
+      "name": "Rudra Dudhat",
+      "avatar_url": "https://avatars.githubusercontent.com/u/218722486?v=4",
+      "profile": "https://rudradudhat2509.github.io",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/sktime/performance_metrics/forecasting/probabilistic/_classes.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/_classes.py
@@ -639,14 +639,32 @@ class EmpiricalCoverage(_BaseProbaForecastingErrorMetric):
         Can be specified if no explicit coverages are present in the direct use of
         the metric, for instance in benchmarking via ``evaluate``, or tuning
         via ``ForecastingGridSearchCV``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from sktime.performance_metrics.forecasting.probabilistic import (
+    ...     EmpiricalCoverage,
+    ... )
+    >>> y_true = pd.Series([3, -0.5, 2, 7, 2])
+    >>> y_pred = pd.DataFrame({
+    ...     ('Coverage', 0.8, 'lower'): [1.5, 0.0, 1.5, 5.0, 2.5],
+    ...     ('Coverage', 0.8, 'upper'): [3.5, 1.0, 2.5, 6.0, 3.5],
+    ...     ('Coverage', 0.9, 'lower'): [1.0, -1.0, 1.0, 4.0, 1.5],
+    ...     ('Coverage', 0.9, 'upper'): [4.0, 1.5, 3.5, 7.5, 4.0],
+    ... })
+    >>> ec = EmpiricalCoverage()
+    >>> ec(y_true, y_pred)
+    np.float64(0.7)
+    >>> ec = EmpiricalCoverage(score_average=False)
+    >>> ec(y_true, y_pred).to_numpy()
+    array([0.4, 1. ])
     """
 
     _tags = {
         "scitype:y_pred": "pred_interval",
         "lower_is_better": False,
-        # CI and test flags
-        # -----------------
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(
@@ -747,14 +765,30 @@ class IntervalWidth(_BaseProbaForecastingErrorMetric):
         Can be specified if no explicit coverages are present in the direct use of
         the metric, for instance in benchmarking via ``evaluate``, or tuning
         via ``ForecastingGridSearchCV``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from sktime.performance_metrics.forecasting.probabilistic import IntervalWidth
+    >>> y_true = pd.Series([3, -0.5, 2, 7, 2])
+    >>> y_pred = pd.DataFrame({
+    ...     ('Coverage', 0.8, 'lower'): [1.5, 0.0, 1.5, 5.0, 2.5],
+    ...     ('Coverage', 0.8, 'upper'): [3.5, 1.0, 2.5, 6.0, 3.5],
+    ...     ('Coverage', 0.9, 'lower'): [1.0, -1.0, 1.0, 4.0, 1.5],
+    ...     ('Coverage', 0.9, 'upper'): [4.0, 1.5, 3.5, 7.5, 4.0],
+    ... })
+    >>> iw = IntervalWidth()
+    >>> iw(y_true, y_pred)
+    np.float64(2.0)
+    >>> iw = IntervalWidth(score_average=False)
+    >>> iw(y_true, y_pred).to_numpy()
+    array([1.2, 2.8])
     """
 
     _tags = {
         "scitype:y_pred": "pred_interval",
         "lower_is_better": True,
-        # CI and test flags
-        # -----------------
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(
@@ -860,14 +894,32 @@ class ConstraintViolation(_BaseProbaForecastingErrorMetric):
         Can be specified if no explicit coverages are present in the direct use of
         the metric, for instance in benchmarking via ``evaluate``, or tuning
         via ``ForecastingGridSearchCV``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from sktime.performance_metrics.forecasting.probabilistic import (
+    ...     ConstraintViolation,
+    ... )
+    >>> y_true = pd.Series([3, -0.5, 2, 7, 2])
+    >>> y_pred = pd.DataFrame({
+    ...     ('Coverage', 0.8, 'lower'): [1.5, 0.0, 1.5, 5.0, 2.5],
+    ...     ('Coverage', 0.8, 'upper'): [3.5, 1.0, 2.5, 6.0, 3.5],
+    ...     ('Coverage', 0.9, 'lower'): [1.0, -1.0, 1.0, 4.0, 1.5],
+    ...     ('Coverage', 0.9, 'upper'): [4.0, 1.5, 3.5, 7.5, 4.0],
+    ... })
+    >>> cv = ConstraintViolation()
+    >>> cv(y_true, y_pred)
+    np.float64(0.2)
+    >>> cv = ConstraintViolation(score_average=False)
+    >>> cv(y_true, y_pred).to_numpy()
+    array([0.4, 0. ])
     """
 
     _tags = {
         "scitype:y_pred": "pred_interval",
         "lower_is_better": True,
-        # CI and test flags
-        # -----------------
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #10782.

#### What does this implement/fix? Explain your changes.

Adds `Examples` sections to the three interval metrics in `performance_metrics/forecasting/probabilistic`: `EmpiricalCoverage`, `IntervalWidth` and `ConstraintViolation`. Each one also drops its `"tests:skip_by_name": ["test_class_has_doctest_example"]` tag, as the issue asks.

All three examples share the same `y_pred` with two nested coverage levels (0.8 and 0.9), so reading them side by side shows how the metrics move as the interval widens: coverage 0.4 -> 1.0, width 1.2 -> 2.8, violation 0.4 -> 0.0. Each also shows the `score_average=False` form, matching the existing `PinballLoss` example in the same module.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether sharing one `y_pred` across the three classes is what you want, or whether you would rather each example be fully independent.
- Scalar outputs are written as `np.float64(...)` to match numpy 2 scalar repr, same as the `PinballLoss` docstring right above these.

#### Did you add any tests for the change?

No new tests. Removing the skip tag means `test_class_has_doctest_example` and `test_doctest_examples` now actually run for these three classes.

Checked locally on numpy 2.5.2 / pandas 2.3.3:

- `pytest --doctest-modules sktime/performance_metrics/forecasting/probabilistic/_classes.py` -> 4 passed
- `pytest sktime/tests/test_all_estimators.py -k "EmpiricalCoverage or IntervalWidth or ConstraintViolation"` -> 99 passed

#### PR checklist

##### For all contributions
- [x] I've added myself to the list of contributors with any new badges I've earned :-)
- [x] The PR title starts with [DOC].
