### PR TITLE
[BUG] ignore sklearn/sktime conftest modules in sklearn estimator registry lookup

### DIFF
--- a/sktime/_nopytest_tests.py
+++ b/sktime/_nopytest_tests.py
@@ -11,3 +11,10 @@ from sktime.registry import all_estimators
 # all_estimators crawls all modules excepting pytest test files
 # if it encounters an unisolated import, it will throw an exception
 results = all_estimators()
+
+# test: check that craft can crawl all sktime and scikit-learn modules without
+# throwing an exception
+# this is a test for soft dependency isolation, in particular of pytest itself
+from sktime.registry import craft
+
+craft("NaiveForecaster")

--- a/sktime/registry/_lookup_sklearn.py
+++ b/sktime/registry/_lookup_sklearn.py
@@ -95,8 +95,14 @@ def _all_sklearn_estimators_cached(
     """
     from sklearn.base import BaseEstimator
 
-    MODULES_TO_IGNORE_SKLEARN = ["array_api_compat", "tests", "experimental"]
+    MODULES_TO_IGNORE_SKLEARN = [
+        "array_api_compat",
+        "conftest",
+        "tests",
+        "experimental",
+    ]
     MODULES_TO_IGNORE_SKTIME = (
+        "conftest",
         "tests",
         "setup",
         "contrib",


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #11003 

In an environment with sktime and scikit-learn installed, but without pytest:

```python
from sktime.registry import craft
craft("NaiveForecaster")
```

Traceback (abbreviated):

```
File ".../sktime/registry/_craft.py", line 135, in craft
    register_sklearn = dict(_all_sklearn_estimators())
File ".../sktime/registry/_lookup_sklearn.py", ...
    result_sklearn = all_objects(object_types=BaseEstimator, package_name="sklearn", ...)
File ".../skbase/lookup/_lookup.py", ...
    module = importlib.import_module(module_name)
File ".../sklearn/conftest.py", line 15, in <module>
    import pytest
ModuleNotFoundError: No module named 'pytest'
```

`craft("NaiveForecaster")` should return a `NaiveForecaster` instance. Registry lookup for sklearn estimators should not import pytest or other test-only modules.

#### What does this implement/fix? Explain your changes.

update `_all_sklearn_estimators_cached` to ignore conftest files