### PR TITLE
[DOC] add doctest examples for LogLoss, CRPS and AUCalibration

### DIFF
--- a/sktime/performance_metrics/forecasting/probabilistic/_classes.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/_classes.py
@@ -1063,13 +1063,23 @@ class LogLoss(_BaseDistrForecastingMetric):
           the log-loss is computed for entire row, results one score per row
         * if False, is univariate log-loss:
           the log-loss is computed per variable marginal, results in many scores per row
-    """
 
-    _tags = {
-        # CI and test flags
-        # -----------------
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
-    }
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.base._proba._normal import Normal
+    >>> from sktime.performance_metrics.forecasting.probabilistic import LogLoss
+    >>> index = pd.RangeIndex(3)
+    >>> y_true = pd.DataFrame({"a": [0.0, 0.5, 1.0]}, index=index)
+    >>> y_pred = Normal(
+    ...     mu=[[0.1], [0.4], [0.9]],
+    ...     sigma=[[1.0], [1.0], [1.0]],
+    ...     index=index,
+    ...     columns=pd.Index(["a"]),
+    ... )
+    >>> LogLoss()(y_true, y_pred)
+    np.float64(0.9239385332046727)
+    """
 
     def __init__(self, multioutput="uniform_average", multivariate=False):
         self.multivariate = multivariate
@@ -1193,13 +1203,23 @@ class CRPS(_BaseDistrForecastingMetric):
           the score is computed for entire row, results one score per row
         * if False, is univariate CRPS:
           the score is computed per variable marginal, results in many scores per row
-    """  # noqa: E501
 
-    _tags = {
-        # CI and test flags
-        # -----------------
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
-    }
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.base._proba._normal import Normal
+    >>> from sktime.performance_metrics.forecasting.probabilistic import CRPS
+    >>> index = pd.RangeIndex(3)
+    >>> y_true = pd.DataFrame({"a": [0.0, 0.5, 1.0]}, index=index)
+    >>> y_pred = Normal(
+    ...     mu=[[0.1], [0.4], [0.9]],
+    ...     sigma=[[1.0], [1.0], [1.0]],
+    ...     index=index,
+    ...     columns=pd.Index(["a"]),
+    ... )
+    >>> CRPS()(y_true, y_pred)
+    np.float64(0.2376810788616731)
+    """  # noqa: E501
 
     def __init__(self, multioutput="uniform_average", multivariate=False):
         self.multivariate = multivariate
@@ -1267,13 +1287,23 @@ class AUCalibration(_BaseDistrForecastingMetric):
           the metric is computed for entire row, results one score per row
         * if False, is univariate metric, per variable:
           the metric is computed per variable marginal, results in many scores per row
-    """  # noqa: E501
 
-    _tags = {
-        # CI and test flags
-        # -----------------
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
-    }
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.base._proba._normal import Normal
+    >>> from sktime.performance_metrics.forecasting.probabilistic import AUCalibration
+    >>> index = pd.RangeIndex(3)
+    >>> y_true = pd.DataFrame({"a": [0.0, 0.5, 1.0]}, index=index)
+    >>> y_pred = Normal(
+    ...     mu=[[0.1], [0.4], [0.9]],
+    ...     sigma=[[1.0], [1.0], [1.0]],
+    ...     index=index,
+    ...     columns=pd.Index(["a"]),
+    ... )
+    >>> AUCalibration()(y_true, y_pred)
+    np.float64(0.11111111111111112)
+    """  # noqa: E501
 
     def __init__(self, multioutput="uniform_average", multivariate=False):
         self.multivariate = multivariate


### PR DESCRIPTION
## LLM generated content, by DeepSeek

This PR was prepared with AI assistance (DeepSeek), reviewed and verified by running the doctests and test suites locally, as per the note in the issue template.

### Summary

Part of #10782 - adds runnable doctest Examples sections to the docstrings of three distributional prediction metrics in `sktime/performance_metrics/forecasting/probabilistic/_classes.py`:

* `LogLoss`
* `CRPS`
* `AUCalibration`

and removes the `test_class_has_doctest_example` entry from `tests:skip_by_name` for each of them, as prescribed by the issue.

The examples follow the pattern of the `PinballLoss` docstring in the same module and use the `Normal` distribution from `sktime.base._proba`:

```python
>>> y_pred = Normal(mu=[[0.1], [0.4], [0.9]], sigma=[[1.0], [1.0], [1.0]], index=index, columns=pd.Index(['a']))
>>> LogLoss()(y_true, y_pred)
np.float64(0.9239385332046727)
```

### Exclusion: SquaredDistrLoss

`SquaredDistrLoss` in the same module is left unchanged. A runnable example for it blocks on a bug in `BaseDistribution.pdfnorm`: the Monte Carlo fill-in calls `pd.concat(spl, axis=0).groupby(level=1, sort=False)`, which raises `ValueError: level > 0 or level < -1 only valid with MultiIndex` for any distribution whose `sample()` returns a flat index (i.e., every direct, non-fitted use). Reported separately as #11006, as advised in #10782.

### How this was tested

* `python -m doctest sktime/performance_metrics/forecasting/probabilistic/_classes.py` - all doctests pass (exit 0)
* `skbase.utils.doctest_run.run_doctest` passes for `LogLoss`, `CRPS`, `AUCalibration`
* full `TestAllObjects` suite for `LogLoss` (incl. `test_class_has_doctest_example`, `test_doctest_examples`, `test_estimator_tags`): 32 passed
* `pytest sktime/performance_metrics/forecasting/probabilistic/tests/`: 161 passed
* `ruff format --check` and `ruff check` clean

Note: removing the skip entries surfaced an empty-`_tags` subtlety - the three classes previously overrode `_tags` with only the skip entry. The override is removed entirely so the classes inherit the non-empty `_tags` of `_BaseDistrForecastingMetric` (`scitype:y_pred`, `lower_is_better`), which also satisfies the `test_estimator_tags` non-empty assertion.
