### PR TITLE
[DOC] add doctest examples for ScipyDist, KernelFromDist, DistFromKernel and ConstantPwTrafoPanel

### DIFF
--- a/sktime/dists_kernels/dist_to_kern.py
+++ b/sktime/dists_kernels/dist_to_kern.py
@@ -42,6 +42,17 @@ class KernelFromDist(BasePairwiseTransformerPanel):
     dist_diag : pairwise transformer of BasePairwiseTransformer scitype, or
         series-to-panel transformer of Basetransformer scitype, or
         callable np.ndarray (n_samples, nd) -> (n_samples, )
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.dists_kernels import FlatDist, ScipyDist
+    >>> from sktime.dists_kernels.dist_to_kern import KernelFromDist
+    >>> X = np.array([[[0.0, 0.0, 0.0]], [[1.0, 1.0, 1.0]]])
+    >>> kern = KernelFromDist(dist=FlatDist(ScipyDist()))
+    >>> kern.transform(X)
+    array([[ 0. , -1.5],
+           [-1.5,  0. ]])
     """
 
     _tags = {
@@ -54,7 +65,6 @@ class KernelFromDist(BasePairwiseTransformerPanel):
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(self, dist, dist_diag=None):
@@ -179,6 +189,17 @@ class DistFromKernel(BasePairwiseTransformerPanel):
     ----------
     kernel : pairwise transformer of BasePairwiseTransformer scitype, or
         callable np.ndarray (n_samples, nd) x (n_samples, nd) -> (n_samples x n_samples)
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.dists_kernels import SignatureKernel
+    >>> from sktime.dists_kernels.dist_to_kern import DistFromKernel
+    >>> X = np.array([[[0.0, 0.0, 0.0]], [[1.0, 1.0, 1.0]]])
+    >>> dist = DistFromKernel(kernel=SignatureKernel())
+    >>> np.round(dist.transform(X), 3)
+    array([[0.   , 4.243],
+           [4.243, 0.   ]])
     """
 
     _tags = {
@@ -191,7 +212,6 @@ class DistFromKernel(BasePairwiseTransformerPanel):
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(self, kernel):

--- a/sktime/dists_kernels/dummy.py
+++ b/sktime/dists_kernels/dummy.py
@@ -16,6 +16,15 @@ class ConstantPwTrafoPanel(BasePairwiseTransformerPanel):
     ----------
     constant : float, optional, default = 0
         the constant value that this transformer returns
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.dists_kernels import ConstantPwTrafoPanel
+    >>> X = np.array([[[0.0, 0.0, 0.0]], [[1.0, 1.0, 1.0]]])
+    >>> ConstantPwTrafoPanel(constant=42).transform(X)
+    array([[42., 42.],
+           [42., 42.]])
     """
 
     _tags = {
@@ -27,7 +36,6 @@ class ConstantPwTrafoPanel(BasePairwiseTransformerPanel):
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(self, constant=0):

--- a/sktime/dists_kernels/scipy_dist.py
+++ b/sktime/dists_kernels/scipy_dist.py
@@ -50,6 +50,20 @@ class ScipyDist(BasePairwiseTransformer):
         any kwargs passed to the metric in addition, i.e., to the function cdist
         common kwargs: ``w`` : array-like, same length as X.columns, weights for metric
         refer to scipy.spatial.distance.dist for a documentation of other extra kwargs
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.dists_kernels import ScipyDist
+    >>> X = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [1.0, 3.0, 2.0]})
+    >>> ScipyDist().transform(X)
+    array([[0.        , 2.23606798, 2.23606798],
+           [2.23606798, 0.        , 1.41421356],
+           [2.23606798, 1.41421356, 0.        ]])
+    >>> ScipyDist(metric="sqeuclidean").transform(X)
+    array([[0., 5., 5.],
+           [5., 0., 2.],
+           [5., 2., 0.]])
     """
 
     _tags = {


### PR DESCRIPTION
## LLM generated content, by DeepSeek

This PR was prepared with AI assistance (DeepSeek), reviewed and verified by running the doctests locally, as per the note in the issue template.

### Summary

Part of #10782 - adds runnable doctest Examples sections to the docstrings of four dependency-free pairwise transformers in `sktime.dists_kernels`, and removes the `test_class_has_doctest_example` entry from `tests:skip_by_name` for each of them, as prescribed by the issue:

* `ScipyDist` (`sktime/dists_kernels/scipy_dist.py`)
* `KernelFromDist` and `DistFromKernel` (`sktime/dists_kernels/dist_to_kern.py`)
* `ConstantPwTrafoPanel` (`sktime/dists_kernels/dummy.py`)

The `KernelFromDist` example uses `FlatDist(ScipyDist())` as the underlying distance, so the example requires no optional dependencies. The `DistFromKernel` example uses `SignatureKernel`, which is also dependency-free. All examples follow the style of existing docstring examples in the module.

This PR is structured as a separate, independent PR from #11005 (both are scoped to the recipe in #10782), so they can be reviewed and merged independently.

### How this was tested

* `skbase.utils.doctest_run.run_doctest` passes for all four classes
* `ruff format --check` and `ruff check` clean on `sktime/dists_kernels/`

Note on `DistFromAligner`: it also lacks an example, but a dependency-free example is not possible without an aligner that has no soft dependency (the default `AlignerDtwDtai` requires `dtaidistance`), so it is left for a follow-up.
