### PR TITLE
[DOC] add doctest examples for Repeat, RepeatBootstrapTransformer and RandomSamplesAugmenter

### DIFF
--- a/sktime/split/compose/_repeat.py
+++ b/sktime/split/compose/_repeat.py
@@ -35,6 +35,16 @@ class Repeat(BaseSplitter):
         If True, repetitions are random, ``splitter`` is cloned for each repetition.
         Note: if a random seed is set in ``splitter``, the effect is the same
         as setting ``random_repeat`` to False, even if ``random_repeat`` is True.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.split import SingleWindowSplitter
+    >>> from sktime.split.compose import Repeat
+    >>> y = pd.Series(range(6), index=pd.period_range("2020-01", periods=6, freq="M"))
+    >>> spl = Repeat(SingleWindowSplitter(fh=[1], window_length=4), times=2)
+    >>> list(spl.split(y))
+    [(array([1, 2, 3, 4]), array([5])), (array([1, 2, 3, 4]), array([5]))]
     """
 
     _tags = {

--- a/sktime/transformations/augmenter.py
+++ b/sktime/transformations/augmenter.py
@@ -224,6 +224,17 @@ class RandomSamplesAugmenter(_AugmenterTags, BaseTransformer):
         If None, rely on ``self.random_state``.
         Default is None." [1]
 
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.transformations.augmenter import RandomSamplesAugmenter
+    >>> X = pd.DataFrame({"a": [1.0, 2.0, 3.0, 4.0]})
+    >>> RandomSamplesAugmenter(n=3, random_state=42).fit_transform(X)
+         0
+    0  2.0
+    1  4.0
+    2  1.0
+
     References and Footnotes
     ----------
 

--- a/sktime/transformations/bootstrap/_repeat.py
+++ b/sktime/transformations/bootstrap/_repeat.py
@@ -17,6 +17,19 @@ class RepeatBootstrapTransformer(BaseTransformer):
     ----------
     n_series : int, optional
         The number of repeats that will be generated, by default 10.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.transformations.bootstrap import RepeatBootstrapTransformer
+    >>> X = pd.DataFrame({"a": [1.0, 2.0]})
+    >>> t = RepeatBootstrapTransformer(n_series=2)
+    >>> t.fit_transform(X)
+           a
+    0 0  1.0
+      1  2.0
+    1 0  1.0
+      1  2.0
     """
 
     _tags = {


### PR DESCRIPTION
## LLM generated content, by DeepSeek

This PR was prepared with AI assistance (DeepSeek), reviewed and verified by running the doctests locally, as per the note in the issue template.

### Summary

Part of #10782 - adds runnable doctest Examples sections to the docstrings of three dependency-free objects, following the issue recipe:

* `Repeat` splitter (`sktime/split/compose/_repeat.py`)
* `RepeatBootstrapTransformer` (`sktime/transformations/bootstrap/_repeat.py`)
* `RandomSamplesAugmenter` (`sktime/transformations/augmenter.py`)

None of these classes had a `test_class_has_doctest_example` skip entry, so only the Examples sections are added. All examples were designed to be deterministic (`RandomSamplesAugmenter` pins `random_state=42`) and require no optional dependencies.

This is an independent PR, separate from #11005 and #11007, so all three can be reviewed and merged independently.

### How this was tested

* `skbase.utils.doctest_run.run_doctest` passes for all three classes
* `ruff format --check` and `ruff check` clean on the touched files
