### PR TITLE
[DOC] add doctest examples for MultiplexClassifier, MultiplexRegressor and WindowedF1Score

### DIFF
--- a/sktime/classification/compose/_multiplexer.py
+++ b/sktime/classification/compose/_multiplexer.py
@@ -44,6 +44,20 @@ class MultiplexClassifier(_HeterogenousMetaEstimator, _DelegatedClassifier):
         If None, behaves as if the first classifier in the list is selected.
         Selects the classifier as which MultiplexClassifier behaves.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.classification.compose import MultiplexClassifier
+    >>> from sktime.classification.dummy import DummyClassifier
+    >>> X_train = np.array([[[0.0, 1.0, 2.0]], [[1.0, 2.0, 3.0]]])
+    >>> y_train = np.array(["a", "b"])
+    >>> X_test = np.array([[[0.0, 1.0, 2.0]]])
+    >>> clf = MultiplexClassifier([("dummy", DummyClassifier())])
+    >>> clf.fit(X_train, y_train)
+    MultiplexClassifier(classifiers=[('dummy', DummyClassifier())])
+    >>> clf.predict(X_test)
+    array(['a'], dtype='<U1')
+
     Attributes
     ----------
     classifier_ : sktime classifier
@@ -68,7 +82,6 @@ class MultiplexClassifier(_HeterogenousMetaEstimator, _DelegatedClassifier):
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     # attribute for _DelegatedClassifier, which then delegates

--- a/sktime/performance_metrics/detection/_f1score.py
+++ b/sktime/performance_metrics/detection/_f1score.py
@@ -19,6 +19,17 @@ class WindowedF1Score(BaseDetectionMetric):
     ----------
     margin : int, optional (default=0)
         Margin of error to consider a detected event as matched.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.performance_metrics.detection import WindowedF1Score
+    >>> y_true = pd.DataFrame({"ilocs": [10, 50]})
+    >>> y_pred = pd.DataFrame({"ilocs": [11, 52]})
+    >>> WindowedF1Score()(y_true, y_pred)
+    0.0
+    >>> WindowedF1Score(margin=2)(y_true, y_pred)
+    1.0
     """
 
     _tags = {
@@ -29,7 +40,6 @@ class WindowedF1Score(BaseDetectionMetric):
         "lower_is_better": False,  # higher F1 is better
         # CI and test flags
         # -----------------
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(self, margin=0):

--- a/sktime/regression/compose/_multiplexer.py
+++ b/sktime/regression/compose/_multiplexer.py
@@ -44,6 +44,20 @@ class MultiplexRegressor(_HeterogenousMetaEstimator, _DelegatedRegressor):
         If None, behaves as if the first regressor in the list is selected.
         Selects the regressor as which MultiplexRegressor behaves.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.regression.compose import MultiplexRegressor
+    >>> from sktime.regression.dummy import DummyRegressor
+    >>> X_train = np.array([[[0.0, 1.0, 2.0]], [[1.0, 2.0, 3.0]]])
+    >>> y_train = np.array([1.0, 2.0])
+    >>> X_test = np.array([[[0.0, 1.0, 2.0]]])
+    >>> reg = MultiplexRegressor([("dummy", DummyRegressor())])
+    >>> reg.fit(X_train, y_train)
+    MultiplexRegressor(regressors=[('dummy', DummyRegressor())])
+    >>> reg.predict(X_test)
+    array([1.5])
+
     Attributes
     ----------
     regressor_ : sktime regressor
@@ -67,7 +81,6 @@ class MultiplexRegressor(_HeterogenousMetaEstimator, _DelegatedRegressor):
         # CI and test flags
         # -----------------
         "tests:core": True,  # should tests be triggered by framework changes?
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     # attribute for _DelegatedRegressor, which then delegates


### PR DESCRIPTION
## LLM generated content, by DeepSeek

This PR was prepared with AI assistance (DeepSeek), reviewed and verified by running the doctests locally, as per the note in the issue template.

### Summary

Part of #10782 - adds runnable doctest Examples sections to the docstrings of three dependency-free objects and removes the `test_class_has_doctest_example` entry from `tests:skip_by_name` for each of them, as prescribed by the issue:

* `MultiplexClassifier` (`sktime/classification/compose/_multiplexer.py`)
* `MultiplexRegressor` (`sktime/regression/compose/_multiplexer.py`)
* `WindowedF1Score` (`sktime/performance_metrics/detection/_f1score.py`)

The multiplexer examples use the sktime dummy estimator components with small inline `numpy3D` arrays, so they require no optional dependencies and are deterministic. The `WindowedF1Score` example illustrates the effect of the `margin` parameter via two exact calls.

This is an independent PR, separate from #11005, #11007 and #11009, so all four can be reviewed and merged independently.

### How this was tested

* `skbase.utils.doctest_run.run_doctest` passes for all three classes
* `ruff format --check` and `ruff check` clean on the touched files
