### PR TITLE
[BUG] fix pdfnorm Monte Carlo fill-in for flat-index distributions

### DIFF
--- a/sktime/base/_proba/_base.py
+++ b/sktime/base/_proba/_base.py
@@ -451,8 +451,11 @@ class BaseDistribution(BaseObject):
         warn(self._method_error_msg("pdfnorm", fill_in=approx_method))
 
         # uses formula int p(x)^a dx = E[p(X)^{a-1}], and MC approximates the RHS
+        # keys=range(...) ensures a 2-level (sample, time) MultiIndex, so that
+        # groupby over level 1 aggregates the Monte Carlo samples per time index
         spl = [self.pdf(self.sample()) ** (a - 1) for _ in range(approx_spl_size)]
-        return pd.concat(spl, axis=0).groupby(level=1, sort=False).mean()
+        spl = pd.concat(spl, keys=range(approx_spl_size))
+        return spl.groupby(level=1, sort=False).mean()
 
     def _coerce_to_self_index_df(self, x):
         x = np.array(x)

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -33,10 +33,13 @@ __all__ = [
     "test_nested_set_params_and_alias",
     "test_get_fitted_params",
     "test_eq_dunder",
+    "test_pdfnorm_flat_index",
 ]
 
 from copy import deepcopy
 
+import numpy as np
+import pandas as pd
 import pytest
 from skbase.utils.dependencies import _check_soft_dependencies
 
@@ -566,3 +569,32 @@ def test_eq_dunder_checks_class():
 
     # comparison against a non-BaseObject must not raise, and must be unequal
     assert unrelated_1 != 42
+
+
+def test_pdfnorm_flat_index():
+    """Test that the pdfnorm Monte Carlo fill-in works with flat-index distributions.
+
+    Regression test for #11006: pdfnorm failed with
+    ValueError: level > 0 or level < -1 only valid with MultiIndex
+    for directly constructed distributions whose index is not a MultiIndex.
+    """
+    from sktime.base._proba._normal import Normal
+
+    idx = pd.RangeIndex(3)
+    distr = Normal(
+        mu=[[0.1], [0.4], [0.9]],
+        sigma=[[1.0], [1.0], [1.0]],
+        index=idx,
+        columns=pd.Index(["a"]),
+    )
+
+    res = distr.pdfnorm(a=2)
+
+    # result must have same rows and columns as the distribution
+    assert isinstance(res, pd.DataFrame)
+    assert (res.index == distr.index).all()
+    assert (res.columns == distr.columns).all()
+
+    # Normal with sigma=1: 2-norm of pdf is 1/(2*sigma*sqrt(pi)), MC approximates it
+    expected = 1 / (2 * np.sqrt(np.pi))
+    assert np.allclose(res.to_numpy(), expected, atol=0.1)

--- a/sktime/performance_metrics/forecasting/probabilistic/tests/test_distr_metrics.py
+++ b/sktime/performance_metrics/forecasting/probabilistic/tests/test_distr_metrics.py
@@ -10,12 +10,13 @@ from sktime.performance_metrics.forecasting.probabilistic._classes import (
     CRPS,
     AUCalibration,
     LogLoss,
+    SquaredDistrLoss,
 )
 from sktime.tests.test_switch import run_test_module_changed
 
 warnings.filterwarnings("ignore", category=FutureWarning)
 
-DISTR_METRICS = [CRPS, AUCalibration, LogLoss]
+DISTR_METRICS = [CRPS, AUCalibration, LogLoss, SquaredDistrLoss]
 
 normal_dists = [Normal]
 


### PR DESCRIPTION
## LLM generated content, by DeepSeek

This PR was prepared with AI assistance (DeepSeek), verified by running the test suites locally.

### Summary

Fixes #11006.

`BaseDistribution.pdfnorm` (Monte Carlo fill-in) failed with

```
ValueError: level > 0 or level < -1 only valid with MultiIndex
```

for any directly constructed distribution (flat index), e.g. `Normal(mu=..., sigma=..., index=...)` or the output of `NaiveForecaster(...).fit(y).predict_proba(fh)` in sktime 1.1.0. Root cause: `pd.concat(spl, axis=0)` of 1000 flat-index sample frames does not create a MultiIndex, so `groupby(level=1)` has no level 1 to group by.

### Fix

Mirror the pattern already used in the `cdf` fill-in a few lines above: `pd.concat` with `keys=range(approx_spl_size)`, creating a 2-level `(sample, time)` MultiIndex so that `groupby(level=1)` averages the Monte Carlo samples per time index. No other code path is changed.

### Effects

`SquaredDistrLoss` now works with directly constructed distributions and `predict_proba` outputs (previously always raised). It is added to the parametrized distribution metric tests, where it would have failed before this fix - i.e., the fix has true regression coverage.

### Tests

* new regression test `test_pdfnorm_flat_index` in `sktime/base/tests/test_base.py`: checks output shape/index and closeness of the MC estimate to the analytical value `1/(2*sigma*sqrt(pi))` for a standard Normal (passes)
* `SquaredDistrLoss` added to `DISTR_METRICS` in `test_distr_metrics.py`: 9 passed
* full `sktime/base/tests/test_base.py`: 17 passed
* verified manually that `SquaredDistrLoss()(y_true, y_pred)` works on both the direct route (sktime 1.1.0, exact fix-verification numbers in #11006 terms) and the fitted `NaiveForecaster` route
