### PR TITLE
[DOC] add doctest examples for the 6 M4 competition catalogue classes

### DIFF
--- a/sktime/catalogues/forecasting/M4/_daily.py
+++ b/sktime/catalogues/forecasting/M4/_daily.py
@@ -9,6 +9,17 @@ class M4CompetitionCatalogueDaily(_BaseM4CompetitionCatalogue):
 
     This catalogue binds the M4 daily dataset with the standard set of
     classical forecasters and evaluates them using OWA with sp=7.
+
+    Examples
+    --------
+    >>> from sktime.catalogues.forecasting.M4 import M4CompetitionCatalogueDaily
+    >>> cat = M4CompetitionCatalogueDaily()
+    >>> len(cat)
+    13
+    >>> cat.get("dataset")
+    ["ForecastingData('m4_daily_dataset')"]
+    >>> "Naive_1" in cat
+    True
     """
 
     _tags = {

--- a/sktime/catalogues/forecasting/M4/_hourly.py
+++ b/sktime/catalogues/forecasting/M4/_hourly.py
@@ -9,6 +9,17 @@ class M4CompetitionCatalogueHourly(_BaseM4CompetitionCatalogue):
 
     This catalogue binds the M4 hourly dataset with the standard set of
     classical forecasters and evaluates them using OWA with sp=24.
+
+    Examples
+    --------
+    >>> from sktime.catalogues.forecasting.M4 import M4CompetitionCatalogueHourly
+    >>> cat = M4CompetitionCatalogueHourly()
+    >>> len(cat)
+    13
+    >>> cat.get("dataset")
+    ["ForecastingData('m4_hourly_dataset')"]
+    >>> "Naive_1" in cat
+    True
     """
 
     _tags = {

--- a/sktime/catalogues/forecasting/M4/_monthly.py
+++ b/sktime/catalogues/forecasting/M4/_monthly.py
@@ -9,6 +9,17 @@ class M4CompetitionCatalogueMonthly(_BaseM4CompetitionCatalogue):
 
     This catalogue binds the M4 monthly dataset with the standard set of
     classical forecasters and evaluates them using OWA with sp=12.
+
+    Examples
+    --------
+    >>> from sktime.catalogues.forecasting.M4 import M4CompetitionCatalogueMonthly
+    >>> cat = M4CompetitionCatalogueMonthly()
+    >>> len(cat)
+    13
+    >>> cat.get("dataset")
+    ["ForecastingData('m4_monthly_dataset')"]
+    >>> "Naive_1" in cat
+    True
     """
 
     _tags = {

--- a/sktime/catalogues/forecasting/M4/_quarterly.py
+++ b/sktime/catalogues/forecasting/M4/_quarterly.py
@@ -9,6 +9,17 @@ class M4CompetitionCatalogueQuarterly(_BaseM4CompetitionCatalogue):
 
     This catalogue binds the M4 quarterly dataset with the standard set of
     classical forecasters and evaluates them using OWA with sp=4.
+
+    Examples
+    --------
+    >>> from sktime.catalogues.forecasting.M4 import M4CompetitionCatalogueQuarterly
+    >>> cat = M4CompetitionCatalogueQuarterly()
+    >>> len(cat)
+    13
+    >>> cat.get("dataset")
+    ["ForecastingData('m4_quarterly_dataset')"]
+    >>> "Naive_1" in cat
+    True
     """
 
     _tags = {

--- a/sktime/catalogues/forecasting/M4/_weekly.py
+++ b/sktime/catalogues/forecasting/M4/_weekly.py
@@ -9,6 +9,17 @@ class M4CompetitionCatalogueWeekly(_BaseM4CompetitionCatalogue):
 
     This catalogue binds the M4 weekly dataset with the standard set of
     classical forecasters and evaluates them using OWA with sp=52.
+
+    Examples
+    --------
+    >>> from sktime.catalogues.forecasting.M4 import M4CompetitionCatalogueWeekly
+    >>> cat = M4CompetitionCatalogueWeekly()
+    >>> len(cat)
+    13
+    >>> cat.get("dataset")
+    ["ForecastingData('m4_weekly_dataset')"]
+    >>> "Naive_1" in cat
+    True
     """
 
     _tags = {

--- a/sktime/catalogues/forecasting/M4/_yearly.py
+++ b/sktime/catalogues/forecasting/M4/_yearly.py
@@ -9,6 +9,17 @@ class M4CompetitionCatalogueYearly(_BaseM4CompetitionCatalogue):
 
     This catalogue binds the M4 yearly dataset with the standard set of
     classical forecasters and evaluates them using OWA with sp=1.
+
+    Examples
+    --------
+    >>> from sktime.catalogues.forecasting.M4 import M4CompetitionCatalogueYearly
+    >>> cat = M4CompetitionCatalogueYearly()
+    >>> len(cat)
+    13
+    >>> cat.get("dataset")
+    ["ForecastingData('m4_yearly_dataset')"]
+    >>> "Naive_1" in cat
+    True
     """
 
     _tags = {


### PR DESCRIPTION
## LLM generated content, by DeepSeek

This PR was prepared with AI assistance (DeepSeek), reviewed and verified by running the doctests locally, as per the note in the issue template.

### Summary

Part of #10782 - adds runnable doctest Examples sections to the docstrings of the six M4 forecasting competition catalogue classes, following the issue recipe:

* `M4CompetitionCatalogueDaily`
* `M4CompetitionCatalogueHourly`
* `M4CompetitionCatalogueMonthly`
* `M4CompetitionCatalogueQuarterly`
* `M4CompetitionCatalogueWeekly`
* `M4CompetitionCatalogueYearly`

None of these classes had a `test_class_has_doctest_example` skip entry, so only the Examples sections are added. The examples only touch the catalogue API (`len`, `get`, `__contains__`), which returns lazy string specifications - so they download nothing and require no optional dependencies. Each example asserts the catalogue length, the bound dataset name, and membership of the `Naive_1` baseline.

This is an independent PR, separate from #11005, #11007, #11009, #11010 and #11011, so all can be reviewed and merged independently.

### How this was tested

* `skbase.utils.doctest_run.run_doctest` passes for all six classes
* `ruff format --check` and `ruff check` clean on `sktime/catalogues/forecasting/M4/`
