### PR TITLE
[BUG] fix RandomSamplesAugmenter raising TypeError instead of ValueError for invalid n

### DIFF
--- a/sktime/transformations/augmenter.py
+++ b/sktime/transformations/augmenter.py
@@ -248,7 +248,7 @@ class RandomSamplesAugmenter(_AugmenterTags, BaseTransformer):
             if n < 1 or not np.isfinite(n):
                 raise ValueError("n must be a finite number >= 1.")
         else:
-            raise ValueError("n must be int or float, not " + str(type(n))) + "."
+            raise ValueError("n must be int or float, not " + str(type(n)) + ".")
         self.n = n
         self.without_replacement = without_replacement
         self.random_state = random_state

--- a/sktime/transformations/tests/test_augmenter.py
+++ b/sktime/transformations/tests/test_augmenter.py
@@ -135,3 +135,14 @@ def test_random_samples(parameter):
         checksum = _calc_checksum(Xt)
         checksums.append(checksum)
     assert checksums == expected_checksums_random_samples
+
+
+@pytest.mark.parametrize("n", ["spam", None, [1, 2]])
+def test_random_samples_invalid_n_raises_value_error(n):
+    """Test that invalid n raises ValueError, not TypeError.
+
+    Regression test for #11014: the error message concatenation was outside
+    the raise parentheses, so a TypeError was raised instead of ValueError.
+    """
+    with pytest.raises(ValueError, match="n must be int or float"):
+        aug.RandomSamplesAugmenter(n=n)


### PR DESCRIPTION
## LLM generated content, by DeepSeek

This PR was prepared with AI assistance (DeepSeek), reviewed and verified by running the test suite locally, as per the note in the issue template.

### Summary

Fixes #11014.

In `RandomSamplesAugmenter.__init__`, the string concatenation of the final period sat outside the `raise ValueError(...)` parentheses:

```python
raise ValueError("n must be int or float, not " + str(type(n))) + "."
```

For `n` of any type other than `int` or `float`, Python evaluates `ValueError(...) + "."` and raises `TypeError: unsupported operand type(s) for +: 'ValueError' and 'str'` instead of the intended `ValueError`.

The fix moves the concatenation inside the parentheses, so the intended message `n must be int or float, not <class 'str'>.` is raised as a `ValueError`.

### Tests

Adds a parametrized regression test `test_random_samples_invalid_n_raises_value_error` covering `n='spam'`, `n=None` and `n=[1, 2]`, asserting `ValueError` with message match `"n must be int or float"` - all three raise `TypeError` before this fix.

### How this was tested

* full `sktime/transformations/tests/test_augmenter.py`: 8 passed
* `ruff format --check` and `ruff check` clean on both touched files
