### PR TITLE
[DOC] add doctest examples for CUSUM, L2Saving, PenalisedScore, RandomIntervalSegmenter and ComposableTimeSeriesForestRegressor

### DIFF
--- a/sktime/detection/_anomaly_scores/_l2_saving.py
+++ b/sktime/detection/_anomaly_scores/_l2_saving.py
@@ -45,6 +45,16 @@ class L2Saving(BaseIntervalScorer):
     ----------
     .. [1] Fisch, A. T., Eckley, I. A., & Fearnhead, P. (2022). A linear
        time method for the detection of collective and point anomalies.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from sktime.detection._anomaly_scores._l2_saving import L2Saving
+    >>> X = pd.DataFrame({"v": [0.0, 0.0, 0.0, 0.0, 0.0, 5.0, 5.0, 5.0]})
+    >>> cuts = np.array([[0, 8]])
+    >>> L2Saving().evaluate(X, cuts)
+    array([[28.125]])
     """
 
     _tags = {

--- a/sktime/detection/_change_scores/_cusum.py
+++ b/sktime/detection/_change_scores/_cusum.py
@@ -45,6 +45,16 @@ class CUSUM(BaseIntervalScorer):
     .. [1] Page, E. S. (1954). Continuous inspection schemes. Biometrika.
     .. [2] Wang, D., Yu, Y., & Rinaldo, A. (2020). Univariate mean change
        point detection. Electronic Journal of Statistics.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from sktime.detection._change_scores._cusum import CUSUM
+    >>> X = pd.DataFrame({"v": [0.0, 0.0, 0.0, 0.0, 0.0, 5.0, 5.0, 5.0]})
+    >>> cuts = np.array([[0, 4, 8]])
+    >>> CUSUM().evaluate(X, cuts)
+    array([[5.30330086]])
     """
 
     _tags = {

--- a/sktime/detection/_compose.py
+++ b/sktime/detection/_compose.py
@@ -106,6 +106,18 @@ class PenalisedScore(BaseIntervalScorer):
        detection.
     .. [2] Tickle et al. (2021). A computationally efficient, high-dimensional
        multiple changepoint procedure.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from sktime.detection._anomaly_scores._l2_saving import L2Saving
+    >>> from sktime.detection._compose import PenalisedScore
+    >>> X = pd.DataFrame({"v": [0.0, 0.0, 0.0, 0.0, 0.0, 5.0, 5.0, 5.0]})
+    >>> cuts = np.array([[0, 8]])
+    >>> score = PenalisedScore(L2Saving(), penalty=2.0)
+    >>> score.evaluate(X, cuts)
+    array([[26.125]])
     """
 
     _tags = {

--- a/sktime/regression/compose/_ensemble.py
+++ b/sktime/regression/compose/_ensemble.py
@@ -168,6 +168,24 @@ class ComposableTimeSeriesForestRegressor(BaseTimeSeriesForest, BaseRegressor):
         None, optional (default=None)
         Not needed here, added in the constructor to align with base class \
             sharing both Classifier and Regressor parameters.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from sktime.regression.compose import ComposableTimeSeriesForestRegressor
+    >>> rng = np.random.RandomState(42)
+    >>> X = pd.DataFrame(
+    ...     {"v": rng.rand(12)},
+    ...     index=pd.MultiIndex.from_product(
+    ...         [["i0", "i1", "i2"], range(4)], names=["instance", "time"]
+    ...     ),
+    ... )
+    >>> y = pd.Series([1.0, 2.0, 3.0], index=["i0", "i1", "i2"])
+    >>> reg = ComposableTimeSeriesForestRegressor(n_estimators=5, random_state=42)
+    >>> reg = reg.fit(X, y)
+    >>> reg.predict(X)
+    array([1., 2., 3.])
     """
 
     _tags = {

--- a/sktime/transformations/segment.py
+++ b/sktime/transformations/segment.py
@@ -191,6 +191,23 @@ class RandomIntervalSegmenter(_DelegatedTransformer):
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by ``np.random``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.transformations.segment import RandomIntervalSegmenter
+    >>> X = pd.DataFrame(
+    ...     {"a": [1.0, 2.0, 3.0, 4.0], "b": [4.0, 3.0, 2.0, 1.0]},
+    ...     index=pd.MultiIndex.from_product(
+    ...         [["i0", "i1"], [0, 1]], names=["instance", "time"]
+    ...     ),
+    ... )
+    >>> t = RandomIntervalSegmenter(n_intervals=1, random_state=42)
+    >>> Xt = t.fit_transform(X)
+    >>> Xt.shape
+    (4, 2)
+    >>> list(Xt.columns)
+    ['a_0_2', 'b_0_2']
     """
 
     _tags = {


### PR DESCRIPTION
## LLM generated content, by DeepSeek

This PR was prepared with AI assistance (DeepSeek), reviewed and verified by running the doctests locally, as per the note in the issue template.

### Summary

Part of #10782 - adds runnable doctest Examples sections to five more dependency-free or sklearn-only classes:

* `CUSUM` (change score, `evaluate` with 3-column cuts)
* `L2Saving` (saving, `evaluate` with 2-column cuts)
* `PenalisedScore` (constant-penalty wrapper)
* `RandomIntervalSegmenter` (panel segmentation, seeded)
* `ComposableTimeSeriesForestRegressor` (small seeded forest, fit/predict round-trip)

The detection score examples use the `evaluate(X, cuts)` API of `BaseIntervalScorer`. `PenalisedScore` is shown consistent with `L2Saving`: the penalised value is exactly the L2 saving minus the penalty (`28.125 - 2.0 = 26.125`).

None of these classes had a `test_class_has_doctest_example` skip entry.

This is an independent PR, separate from #11005, #11007, #11009, #11010, #11011, #11012, #11013 and #11015.

### How this was tested

* `skbase.utils.doctest_run.run_doctest` passes for all five classes
* `ruff format --check` and `ruff check` clean on the five touched files
