### PR TITLE
[DOC] add doctest examples for TSCGridSearchCV, TSRGridSearchCV and RandomIntervals

### DIFF
--- a/sktime/classification/model_selection/_tune.py
+++ b/sktime/classification/model_selection/_tune.py
@@ -228,6 +228,22 @@ class TSCGridSearchCV(_DelegatedClassifier):
         for its final evaluation.
     sklearn.metrics.make_scorer : Make a scorer from a performance metric or
         loss function.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.classification.interval_based import TimeSeriesForestClassifier
+    >>> from sktime.classification.model_selection import TSCGridSearchCV
+    >>> rng = np.random.RandomState(42)
+    >>> X = rng.rand(6, 1, 10)
+    >>> y = np.array([0, 0, 0, 1, 1, 1])
+    >>> clf = TimeSeriesForestClassifier(n_estimators=3, random_state=42)
+    >>> gs = TSCGridSearchCV(clf, {"n_estimators": [3, 5]}, cv=2)
+    >>> gs = gs.fit(X, y)
+    >>> gs.best_params_
+    {'n_estimators': 3}
+    >>> float(round(gs.best_score_, 4))
+    0.6667
     """
 
     _tags = {

--- a/sktime/regression/model_selection/_tune.py
+++ b/sktime/regression/model_selection/_tune.py
@@ -226,6 +226,22 @@ class TSRGridSearchCV(_DelegatedRegressor):
         for its final evaluation.
     sklearn.metrics.make_scorer : Make a scorer from a performance metric or
         loss function.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sktime.regression.interval_based import TimeSeriesForestRegressor
+    >>> from sktime.regression.model_selection import TSRGridSearchCV
+    >>> rng = np.random.RandomState(42)
+    >>> X = rng.rand(6, 1, 10)
+    >>> y = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+    >>> reg = TimeSeriesForestRegressor(n_estimators=3, random_state=42)
+    >>> gs = TSRGridSearchCV(reg, {"n_estimators": [3, 5]}, cv=2)
+    >>> gs = gs.fit(X, y)
+    >>> gs.best_params_
+    {'n_estimators': 3}
+    >>> float(round(gs.best_score_, 4))
+    -13.4167
     """
 
     _tags = {

--- a/sktime/transformations/random_intervals.py
+++ b/sktime/transformations/random_intervals.py
@@ -43,6 +43,25 @@ class RandomIntervals(BaseTransformer):
     See Also
     --------
     SupervisedIntervals
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.transformations.random_intervals import RandomIntervals
+    >>> vals_a = [float(i % 10) for i in range(20)]
+    >>> vals_b = [float(9 - (i % 10)) for i in range(20)]
+    >>> X = pd.DataFrame(
+    ...     {"a": vals_a, "b": vals_b},
+    ...     index=pd.MultiIndex.from_product(
+    ...         [["i0", "i1"], range(10)], names=["instance", "time"]
+    ...     ),
+    ... )
+    >>> t = RandomIntervals(n_intervals=2, random_state=42)
+    >>> Xt = t.fit_transform(X)
+    >>> Xt.shape
+    (2, 14)
+    >>> Xt.iloc[0, 0]
+    np.float64(2.5)
     """
 
     _tags = {


### PR DESCRIPTION
## LLM generated content, by DeepSeek

This PR was prepared with AI assistance (DeepSeek), reviewed and verified by running the doctests locally, as per the note in the issue template.

### Summary

Part of #10782 - adds runnable doctest Examples sections to three more sklearn-only (no soft dependency) classes:

* `TSCGridSearchCV` - grid search over a small seeded `TimeSeriesForestClassifier`, `cv=2`, asserting `best_params_` and a rounded `best_score_`
* `TSRGridSearchCV` - same recipe with `TimeSeriesForestRegressor`
* `RandomIntervals` - seeded 2-interval transform of a small hierarchical panel, asserting output shape

`float(round(gs.best_score_, 4))` is used instead of printing the raw float, to stay robust against numpy 2 scalar repr changes.

None of these classes had a `test_class_has_doctest_example` skip entry.

This is an independent PR, separate from #11005, #11007, #11009, #11010, #11011, #11012, #11013, #11015 and #11016.

### How this was tested

* `skbase.utils.doctest_run.run_doctest` passes for all three classes
* `ruff format --check` and `ruff check` clean on the three touched files
