### PR TITLE
[BUG] fix WhiteNoiseAugmenter KeyError on named-column DataFrame input

### DIFF
--- a/sktime/transformations/augmenter.py
+++ b/sktime/transformations/augmenter.py
@@ -104,7 +104,9 @@ class WhiteNoiseAugmenter(_AugmenterTags, BaseTransformer):
             raise TypeError(
                 "Type of parameter 'scale' must be a non-negative float value."
             )
-        return X[0] + norm.rvs(0, scale, size=len(X), random_state=self.random_state)
+        return X.iloc[:, 0] + norm.rvs(
+            0, scale, size=len(X), random_state=self.random_state
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/transformations/tests/test_augmenter.py
+++ b/sktime/transformations/tests/test_augmenter.py
@@ -65,6 +65,24 @@ def test_white_noise(parameter):
     assert checksums == expected_checksums_white_noise
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(aug.WhiteNoiseAugmenter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_white_noise_named_column_dataframe():
+    """Test that WhiteNoiseAugmenter accepts named-column DataFrame input.
+
+    Regression test for #11018: _transform accessed X[0], hard-coding the
+    column label 0, so a valid 1-column DataFrame with a named column
+    raised KeyError: 0.
+    """
+    X = pd.DataFrame({"v": [1.0, 2.0, 3.0, 4.0, 5.0]})
+    Xt = aug.WhiteNoiseAugmenter(scale=0.5, random_state=42).fit_transform(X)
+    assert isinstance(Xt, pd.DataFrame)
+    assert Xt.shape == X.shape
+    assert list(Xt.columns) == ["v"]
+
+
 # Test ReverseAugmenter
 expected_checksum_reverse = 17.757893
 


### PR DESCRIPTION
## LLM generated content, by DeepSeek

This PR was prepared with AI assistance (DeepSeek), reviewed and verified by running the test suite locally, as per the note in the issue template.

### Summary

Fixes #11018.

`WhiteNoiseAugmenter._transform` accessed the input as `X[0]`, hard-coding the column label `0`. A 1-column `pd.DataFrame` with a *named* column is a valid `Series` scitype input (the class's `X_inner_mtype` is `pd.DataFrame`), but raised `KeyError: 0`.

The fix uses positional access `X.iloc[:, 0]`, which works for all valid inputs: `pd.Series` (converted to a single-column DataFrame internally), unnamed-column DataFrames, and named-column DataFrames alike.

Note: PR #8282 ("ensure `WhiteNoiseAugmenter` supports `DataFrame` input") addressed a similar concern but was never merged, so the issue remains in the current code.

### Tests

Adds a regression test `test_white_noise_named_column_dataframe` covering a named-column DataFrame input, asserting shape and column-name preservation.

### How this was tested

* full `sktime/transformations/tests/test_augmenter.py`: 6 passed
* manual check: `pd.Series` and named-column `pd.DataFrame` routes both work, `scale` as callable unchanged
* `ruff format --check` and `ruff check` clean on both touched files
