### PR TITLE
[MNT] remove unnecessary `from future` imports for defunct python 3.9 and lower versions

### DIFF
--- a/sktime/benchmarking/_incremental_store.py
+++ b/sktime/benchmarking/_incremental_store.py
@@ -15,8 +15,6 @@ format-specific checkpoint logic for every storage backend.
 Benchmark orchestration code should not import or use it directly.
 """
 
-from __future__ import annotations
-
 import hashlib
 import json
 import logging

--- a/sktime/benchmarking/_results_persistence.py
+++ b/sktime/benchmarking/_results_persistence.py
@@ -11,8 +11,6 @@ It coordinates two complementary mechanisms:
    `IncrementalResultStore`.
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 
 from sktime.benchmarking._benchmarking_dataclasses import ResultObject

--- a/sktime/libs/lag_llama/gluon/gluonts_torch_modules_loss_shim.py
+++ b/sktime/libs/lag_llama/gluon/gluonts_torch_modules_loss_shim.py
@@ -7,8 +7,6 @@ old pickle global, so :func:`torch.load` fails on newer GluonTS unless this
 shim is registered (see :func:`ensure_gluonts_torch_modules_loss_shim`).
 """
 
-from __future__ import annotations
-
 import importlib
 import sys
 import types

--- a/sktime/libs/lag_llama/gluon_utils/scalers/robust_scaler.py
+++ b/sktime/libs/lag_llama/gluon_utils/scalers/robust_scaler.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
-
 from sktime.utils.dependencies import _safe_import
 
 torch = _safe_import("torch")

--- a/sktime/libs/uni2ts/moirai2_forecast.py
+++ b/sktime/libs/uni2ts/moirai2_forecast.py
@@ -115,7 +115,7 @@ class Moirai2Forecast(L.LightningModule):
         past_feat_dynamic_real_dim: int,
         context_length: int,
         module_kwargs: dict | None = None,
-        module: Moirai2Module | None = None,
+        module = None,
     ):
         assert (module is not None) or (module_kwargs is not None), (
             "if module is not provided, module_kwargs is required"

--- a/sktime/libs/uni2ts/moirai2_forecast.py
+++ b/sktime/libs/uni2ts/moirai2_forecast.py
@@ -13,8 +13,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from __future__ import annotations
-
 import math
 import sys
 from contextlib import contextmanager

--- a/sktime/libs/uni2ts/moirai2_forecast.py
+++ b/sktime/libs/uni2ts/moirai2_forecast.py
@@ -115,7 +115,7 @@ class Moirai2Forecast(L.LightningModule):
         past_feat_dynamic_real_dim: int,
         context_length: int,
         module_kwargs: dict | None = None,
-        module = None,
+        module=None,
     ):
         assert (module is not None) or (module_kwargs is not None), (
             "if module is not provided, module_kwargs is required"

--- a/sktime/transformations/time_since.py
+++ b/sktime/transformations/time_since.py
@@ -1,8 +1,6 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """A transformer to compute the time elapsed since a reference time."""
 
-from __future__ import annotations
-
 __author__ = ["KishManani"]
 
 import datetime


### PR DESCRIPTION
The line `from __future__ import annotations` is the emdash of python. It is entirely unnecessary since `sktime` supports only version 3.10 and higher, and this was necessary only on older versions to ensure upwards compatibility.

Still in the training knowledge of AIs, but no longer needed...

FYI @jgyasu 😄