### PR TITLE
[ENH] better isolation of `HFTransformersForecaster` imports

### DIFF
--- a/sktime/forecasting/hf_transformers.py
+++ b/sktime/forecasting/hf_transformers.py
@@ -6,15 +6,6 @@ import numpy as np
 import pandas as pd
 from skbase.utils.dependencies import _check_soft_dependencies
 
-if _check_soft_dependencies("torch", severity="none"):
-    import torch
-    from torch.utils.data import Dataset
-else:
-
-    class Dataset:
-        """Dummy class if torch is unavailable."""
-
-
 from sktime.forecasting.base import BaseForecaster, ForecastingHorizon
 
 __author__ = ["benheid", "geetu040"]
@@ -370,6 +361,7 @@ class HFTransformersForecaster(BaseForecaster):
             config = config.from_dict(_config)
 
             # Load model and info
+            import torch
             import transformers
 
             prediction_model_class = None
@@ -403,6 +395,8 @@ class HFTransformersForecaster(BaseForecaster):
                     _model.weight.masked_fill(_model.weight.isnan(), 0.001),
                     requires_grad=True,
                 )
+
+        PyTorchDataset = _get_dataset_class()
 
         # Dataset preparation
         if self.validation_split is not None:
@@ -606,38 +600,44 @@ class HFTransformersForecaster(BaseForecaster):
         return test_params
 
 
-class PyTorchDataset(Dataset):
-    """Dataset for use in sktime deep learning forecasters."""
+def _get_dataset_class():
+    """Soft dependency import for the MomentPytorchDataset class."""
+    from torch.utils.data import Dataset
 
-    def __init__(self, y, seq_len, fh=None, X=None):
-        self.y = y.values
-        self.X = X.values if X is not None else X
-        self.seq_len = seq_len
-        self.fh = fh
+    class PyTorchDataset(Dataset):
+        """Dataset for use in sktime deep learning forecasters."""
 
-    def __len__(self):
-        """Return length of dataset."""
-        return max(len(self.y) - self.seq_len - self.fh + 1, 0)
+        def __init__(self, y, seq_len, fh=None, X=None):
+            self.y = y.values
+            self.X = X.values if X is not None else X
+            self.seq_len = seq_len
+            self.fh = fh
 
-    def __getitem__(self, i):
-        """Return data point."""
-        from torch import from_numpy, tensor
+        def __len__(self):
+            """Return length of dataset."""
+            return max(len(self.y) - self.seq_len - self.fh + 1, 0)
 
-        hist_y = tensor(self.y[i : i + self.seq_len]).float()
-        if self.X is not None:
-            exog_data = tensor(
-                self.X[i + self.seq_len : i + self.seq_len + self.fh]
-            ).float()
-            hist_exog = tensor(self.X[i : i + self.seq_len]).float()
-        else:
-            exog_data = tensor([[]] * self.fh)
-            hist_exog = tensor([[]] * self.seq_len)
-        return {
-            "past_values": hist_y,
-            "past_time_features": hist_exog,
-            "future_time_features": exog_data,
-            "past_observed_mask": (~hist_y.isnan()).to(int),
-            "future_values": from_numpy(
-                self.y[i + self.seq_len : i + self.seq_len + self.fh]
-            ).float(),
-        }
+        def __getitem__(self, i):
+            """Return data point."""
+            from torch import from_numpy, tensor
+
+            hist_y = tensor(self.y[i : i + self.seq_len]).float()
+            if self.X is not None:
+                exog_data = tensor(
+                    self.X[i + self.seq_len : i + self.seq_len + self.fh]
+                ).float()
+                hist_exog = tensor(self.X[i : i + self.seq_len]).float()
+            else:
+                exog_data = tensor([[]] * self.fh)
+                hist_exog = tensor([[]] * self.seq_len)
+            return {
+                "past_values": hist_y,
+                "past_time_features": hist_exog,
+                "future_time_features": exog_data,
+                "past_observed_mask": (~hist_y.isnan()).to(int),
+                "future_values": from_numpy(
+                    self.y[i + self.seq_len : i + self.seq_len + self.fh]
+                ).float(),
+            }
+
+    return PyTorchDataset


### PR DESCRIPTION
Improves isolation `HFTransformersForecaster` imports, so they are triggered only on execution and not on import of the class.

Improves performance of database-style access across forecasters.