### PR TITLE
[ENH] better isolation of `PykanForecaster` imports

### DIFF
--- a/sktime/forecasting/pykan.py
+++ b/sktime/forecasting/pykan.py
@@ -132,6 +132,9 @@ class PyKANForecaster(BaseForecaster):
         self : reference to self
         """
         from kan import KAN
+        import torch
+
+        PyTorchTrainDataset = _get_dataset_class()
 
         output_size = max(fh.to_relative(self.cutoff)._values)
         if X is not None:
@@ -224,6 +227,7 @@ class PyKANForecaster(BaseForecaster):
             Point predictions
         """
         from kan import KAN
+        import torch
 
         model = KAN(width=self._layer_sizes, grid=self._best_grid, **self._model_params)
         model.load_state_dict(self._state_dict)
@@ -289,35 +293,41 @@ class PyKANForecaster(BaseForecaster):
         return params
 
 
-class PyTorchTrainDataset(Dataset):
-    """Dataset for use in sktime deep learning forecasters."""
+def _get_dataset_class():
+    """Get the PyTorch dataset class for the forecaster."""
+    from torch.utils.data import Dataset
 
-    def __init__(self, y, seq_len, fh=None, X=None):
-        self.y = y.values
-        self.X = X.values if X is not None else X
-        self.seq_len = seq_len
-        self.fh = fh
+    class PyTorchTrainDataset(Dataset):
+        """Dataset for use in sktime deep learning forecasters."""
 
-    def __len__(self):
-        """Return length of dataset."""
-        return max(len(self.y) - self.seq_len - self.fh + 1, 0)
+        def __init__(self, y, seq_len, fh=None, X=None):
+            self.y = y.values
+            self.X = X.values if X is not None else X
+            self.seq_len = seq_len
+            self.fh = fh
 
-    def __getitem__(self, i):
-        """Return data point."""
-        from torch import from_numpy, tensor
+        def __len__(self):
+            """Return length of dataset."""
+            return max(len(self.y) - self.seq_len - self.fh + 1, 0)
 
-        hist_y = tensor(self.y[i : i + self.seq_len]).type(torch.float32)
-        if self.X is not None:
-            exog_data = (
-                tensor(self.X[i + self.seq_len : i + self.seq_len + self.fh])
-                .type(torch.float32)
-                .flatten()
+        def __getitem__(self, i):
+            """Return data point."""
+            from torch import cat, float32, from_numpy, tensor
+
+            window_end = i + self.seq_len
+
+            hist_y = tensor(self.y[i : window_end]).type(float32)
+            if self.X is not None:
+                exog_data = (
+                    tensor(self.X[window_end : window_end + self.fh])
+                    .type(float32)
+                    .flatten()
+                )
+            else:
+                exog_data = tensor([])
+            return (
+                cat([hist_y, exog_data]),
+                from_numpy(self.y[window_end : window_end + self.fh]).type(float32),
             )
-        else:
-            exog_data = tensor([])
-        return (
-            torch.cat([hist_y, exog_data]),
-            from_numpy(self.y[i + self.seq_len : i + self.seq_len + self.fh]).type(
-                torch.float32
-            ),
-        )
+
+    return PyTorchTrainDataset

--- a/sktime/forecasting/pykan.py
+++ b/sktime/forecasting/pykan.py
@@ -46,9 +46,7 @@ class PyKANForecaster(BaseForecaster):
 
     Examples
     --------
-    >>> from sktime.datasets import load_airline
     >>> from sktime.forecasting.pykan import PyKANForecaster
-    >>> y = load_airline()
     >>> forecaster = PyKANForecaster(hidden_layers=(1, 1), input_layer_size=2, grids=[2, 3], model_params={"k": 2}, fit_params={"steps": 1}, val_size=0.5, device="cpu")
     """
 

--- a/sktime/forecasting/pykan.py
+++ b/sktime/forecasting/pykan.py
@@ -4,18 +4,9 @@
 __author__ = ["benheid"]
 
 import pandas as pd
-from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.forecasting.base import BaseForecaster
 from sktime.split import temporal_train_test_split
-
-if _check_soft_dependencies(["pykan", "torch"], severity="none"):
-    import torch
-    from torch.utils.data import Dataset
-else:
-
-    class Dataset:
-        """Dummy class if torch is unavailable."""
 
 
 class PyKANForecaster(BaseForecaster):

--- a/sktime/forecasting/pykan.py
+++ b/sktime/forecasting/pykan.py
@@ -122,8 +122,8 @@ class PyKANForecaster(BaseForecaster):
         -------
         self : reference to self
         """
-        from kan import KAN
         import torch
+        from kan import KAN
 
         PyTorchTrainDataset = _get_dataset_class()
 
@@ -217,8 +217,8 @@ class PyKANForecaster(BaseForecaster):
             should be of the same type as seen in _fit, as in "y_inner_mtype" tag
             Point predictions
         """
-        from kan import KAN
         import torch
+        from kan import KAN
 
         model = KAN(width=self._layer_sizes, grid=self._best_grid, **self._model_params)
         model.load_state_dict(self._state_dict)
@@ -307,7 +307,7 @@ def _get_dataset_class():
 
             window_end = i + self.seq_len
 
-            hist_y = tensor(self.y[i : window_end]).type(float32)
+            hist_y = tensor(self.y[i:window_end]).type(float32)
             if self.X is not None:
                 exog_data = (
                     tensor(self.X[window_end : window_end + self.fh])

--- a/sktime/forecasting/pykan.py
+++ b/sktime/forecasting/pykan.py
@@ -47,7 +47,7 @@ class PyKANForecaster(BaseForecaster):
     Examples
     --------
     >>> from sktime.forecasting.pykan import PyKANForecaster
-    >>> forecaster = PyKANForecaster(hidden_layers=(1, 1), input_layer_size=2, grids=[2, 3], model_params={"k": 2}, fit_params={"steps": 1}, val_size=0.5, device="cpu")
+    >>> forecaster = PyKANForecaster()
     """
 
     _tags = {

--- a/sktime/forecasting/pykan.py
+++ b/sktime/forecasting/pykan.py
@@ -43,6 +43,13 @@ class PyKANForecaster(BaseForecaster):
     ----------
     .. [1] Liu, Ziming, et al. "KAN: Kolmogorov-Arnold Networks."
       arXiv preprint arXiv:2404.19756 (2024).
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.pykan import PyKANForecaster
+    >>> y = load_airline()
+    >>> forecaster = PyKANForecaster(hidden_layers=(1, 1), input_layer_size=2, grids=[2, 3], model_params={"k": 2}, fit_params={"steps": 1}, val_size=0.5, device="cpu")
     """
 
     _tags = {

--- a/sktime/forecasting/pykan.py
+++ b/sktime/forecasting/pykan.py
@@ -324,7 +324,7 @@ def _get_dataset_class():
                     .flatten()
                 )
             else:
-                exog_data = tensor([])
+                exog_data = tensor([], dtype=float32)
             return (
                 cat([hist_y, exog_data]),
                 from_numpy(self.y[window_end : window_end + self.fh]).type(float32),


### PR DESCRIPTION
Improves isolation `PykanForecaster` imports, so they are triggered only on execution and not on import of the class.

Improves performance of database-style access across forecasters.