### PR TITLE
[BUG] Preserve MPS wrapper metadata for PyTorch 2.14

### DIFF
--- a/sktime/forecasting/cinn.py
+++ b/sktime/forecasting/cinn.py
@@ -30,8 +30,7 @@ def default_sine(x, amplitude, phase, offset, amplitude2, amplitude3, phase2):
 
 
 class CINNForecaster(BaseDeepNetworkPyTorch):
-    """
-    Conditional Invertible Neural Network (cINN) Forecaster.
+    """Conditional Invertible Neural Network (cINN) Forecaster.
 
     This forecaster uses a cINN to forecast the time series. The cINN learns a
     bijective mapping between the time series and a normal distributed latent

--- a/sktime/tests/_test_vm.py
+++ b/sktime/tests/_test_vm.py
@@ -5,6 +5,7 @@ __all__ = ["run_test_vm"]
 import os
 import platform
 import re
+from functools import wraps
 
 from skbase.utils.dependencies import _check_soft_dependencies
 
@@ -48,7 +49,13 @@ def run_test_vm(cls_name):
         if platform.system() == "Darwin":
             import torch
 
-            torch.backends.mps.is_available = lambda: False
+            original_is_available = torch.backends.mps.is_available
+
+            @wraps(original_is_available)
+            def _is_available():
+                return False
+
+            torch.backends.mps.is_available = _is_available
 
     if _check_soft_dependencies("hf-xet", severity="none"):
         # to allow hf-xet to download models on macos runners on version `latest`


### PR DESCRIPTION

#### Fixes #11028 
Fixes the macOS CI failure for CINNForecaster with PyTorch 2.14.

### Problem
The macOS CI jobs were failing when running the CINNForecaster estimator tests with PyTorch 2.14 due to :

```AttributeError: 'function' object has no attribute '__wrapped__'```

The failure occurs because _test_vm.py disables MPS on macOS by replacing:

```python
torch.backends.mps.is_available = lambda: False
```
With PyTorch 2.14, torch._dynamo expects torch.backends.mps.is_available to retain its __wrapped__ attribute. Replacing it with a plain lambda removes this attribute and causes the import/optimizer initialization to fail.

### Changes : 
- Import wraps from functools.
- Replace the plain lambda used to disable MPS with a wrapped function.
- Preserve the original function's wrapper metadata, including wrapped, while continuing to return False for MPS availability.

The new implementation:
```python
original_is_available = torch.backends.mps.is_available

@wraps(original_is_available)
def _is_available():
return False

torch.backends.mps.is_available = _is_available
```



### Testing

Verified locally that:

- ```torch.backends.mps.is_available()``` returns False.
- ```torch.backends.mps.is_available``` retains the __wrapped__ attribute.
- ```torch._dynamo``` imports successfully.
- ```torch.optim.Adam``` initializes successfully.
- The regression test passes with: All Checks Passed

The macOS CI jobs will provide the final verification using the actual CINNForecaster test environment.

### Expected Result

The macOS CINNForecaster CI tests should run successfully without:

```AttributeError: 'function' object has no attribute '__wrapped__'```

while preserving the existing behavior of disabling MPS on macOS CI.


