### PR TITLE
[BUG] fix swapped `y_true`/`y_pred` in weighted branch of `median_absolute_percentage_error`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4150,6 +4150,16 @@
       "contributions": [
         "test"
       ]
+    },
+    {
+      "login": "MaxFreedomPollard",
+      "name": "Max Freedom Pollard",
+      "avatar_url": "https://avatars.githubusercontent.com/u/272618364?v=4",
+      "profile": "https://github.com/MaxFreedomPollard",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ]
 }

--- a/sktime/performance_metrics/forecasting/_functions.py
+++ b/sktime/performance_metrics/forecasting/_functions.py
@@ -1748,7 +1748,7 @@ def median_absolute_percentage_error(
         output_errors = _weighted_percentile(
             np.abs(
                 _percentage_error(
-                    y_pred, y_true, symmetric=symmetric, relative_to=relative_to
+                    y_true, y_pred, symmetric=symmetric, relative_to=relative_to
                 )
             ),
             sample_weight=horizon_weight,

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -592,3 +592,36 @@ def test_msle_no_stdout_on_index_mismatch():
     with contextlib.redirect_stdout(buf):
         mean_squared_log_error(y_true, y_pred)
     assert buf.getvalue() == ""
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.performance_metrics"]),
+    reason="Run if performance_metrics module has changed.",
+)
+def test_mdape_horizon_weight_denominator():
+    """median_absolute_percentage_error must use the same denominator when weighted.
+
+    The horizon_weight branch passed y_pred and y_true to _percentage_error in
+    swapped positional order, so the percentage error was taken relative to
+    y_pred when relative_to was "y_true" and vice versa. Uniform weights then
+    changed the reported value.
+    """
+    from sktime.performance_metrics.forecasting._functions import (
+        median_absolute_percentage_error,
+    )
+
+    # every prediction is twice the true value, so the error is 1.0 relative to
+    # y_true and 0.5 relative to y_pred, at every time point
+    y_true = np.array([1.0, 2.0, 4.0, 8.0])
+    y_pred = np.array([2.0, 4.0, 8.0, 16.0])
+    uniform = np.ones(len(y_true))
+
+    for relative_to, expected in [("y_true", 1.0), ("y_pred", 0.5)]:
+        unweighted = median_absolute_percentage_error(
+            y_true, y_pred, relative_to=relative_to
+        )
+        weighted = median_absolute_percentage_error(
+            y_true, y_pred, relative_to=relative_to, horizon_weight=uniform
+        )
+        assert np.allclose(unweighted, expected)
+        assert np.allclose(weighted, expected)


### PR DESCRIPTION
#### Reference Issues/PRs

None, found while reading `sktime/performance_metrics/forecasting/_functions.py`.

#### What does this implement/fix? Explain your changes.

`median_absolute_percentage_error` returns a different value when `horizon_weight` is passed than when it is not, even for uniform weights.

The two branches of the function disagree on the argument order. In `sktime/performance_metrics/forecasting/_functions.py`, the unweighted branch at line 1741 calls `_percentage_error(y_true, y_pred, symmetric=symmetric, relative_to=relative_to)`, while the `horizon_weight` branch at line 1751 calls `_percentage_error(y_pred, y_true, symmetric=symmetric, relative_to=relative_to)`.

`_percentage_error` in `sktime/performance_metrics/forecasting/_common.py` takes `y_true` and `y_pred` positionally, and picks the denominator from `relative_to`: `np.maximum(np.abs(y_true), eps)` for `"y_true"` and `np.maximum(np.abs(y_pred), eps)` for `"y_pred"`. Swapping the two arguments therefore swaps the denominator: with `relative_to="y_true"` the weighted branch divides by `y_pred`, and with `relative_to="y_pred"` it divides by `y_true`. The numerator `np.abs(y_true - y_pred)` is symmetric under the swap, and so is the `symmetric=True` denominator `np.maximum(np.abs(y_true) + np.abs(y_pred), eps) / 2`, which is why the wrong result only surfaces for the asymmetric variants.

This also reaches `MedianAbsolutePercentageError`. Its `evaluate` inherits `BaseForecastingErrorMetricFunc._evaluate`, which forwards `sample_weight` or `horizon_weight` to `median_absolute_percentage_error` and so hits the swapped branch, while its own `_evaluate_by_index` in `sktime/performance_metrics/forecasting/_medape.py` passes the arguments by keyword and is correct. The two entry points disagree on the same input.

The fix passes `y_true` and `y_pred` in the declared order. The regression test asserts that uniform weights leave the result unchanged, for both `relative_to` settings.

Reproduction on `main` before the fix, with predictions exactly twice the truth so that the error is 1.0 relative to `y_true` and 0.5 relative to `y_pred` at every time point:

```python
import numpy as np
from sktime.performance_metrics.forecasting._functions import median_absolute_percentage_error as mdape

y_true = np.array([1.0, 2.0, 4.0, 8.0])
y_pred = np.array([2.0, 4.0, 8.0, 16.0])
w = np.ones(4)

mdape(y_true, y_pred, relative_to="y_true")                     # 1.0
mdape(y_true, y_pred, relative_to="y_true", horizon_weight=w)   # 0.5, should be 1.0
mdape(y_true, y_pred, relative_to="y_pred")                     # 0.5
mdape(y_true, y_pred, relative_to="y_pred", horizon_weight=w)   # 1.0, should be 0.5
```

After the fix all four calls return the value expected from the definition.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether any downstream result is pinned to the old weighted `MdAPE` value. Nothing in `sktime` was: the full `sktime/performance_metrics` suite passes unchanged apart from the new test.
- The three sibling percentage metrics were checked and are already correct: `mean_absolute_percentage_error`, `mean_squared_percentage_error` and `median_squared_percentage_error` all pass `y_true, y_pred` in that order in every branch. On `main`, `grep -rn 'y_pred, y_true' sktime/performance_metrics/` matched only the line changed here, and matches nothing after this change.

#### Did you add any tests for the change?

Yes, `test_mdape_horizon_weight_denominator` in `sktime/performance_metrics/forecasting/tests/test_metrics.py`, in the style of the existing regression tests in that file.

It fails on unmodified `main` and passes with the fix:

```
$ python -m pytest sktime/performance_metrics/forecasting/tests/test_metrics.py -n 0 --only_changed_modules False -k mdape_horizon_weight -q
# on main, test only:
E   assert False
E    +  where False = np.allclose(np.float64(0.5), 1.0)
1 failed, 17 deselected in 0.31s
# with the fix:
1 passed, 17 deselected in 0.32s
```

Whole module, with the fix:

```
$ python -m pytest sktime/performance_metrics/ -n 2 --only_changed_modules False -q
1350 passed, 2 skipped, 1 xfailed in 12.30s

$ python -m pytest --doctest-modules sktime/performance_metrics/forecasting/_functions.py sktime/performance_metrics/forecasting/_medape.py -n 0 -q
22 passed in 0.37s

$ python -c "from sktime.utils.estimator_checks import check_estimator; from sktime.performance_metrics.forecasting import MedianAbsolutePercentageError; check_estimator(MedianAbsolutePercentageError, raise_exceptions=True)"
83 checks passed

$ pre-commit run --files .all-contributorsrc sktime/performance_metrics/forecasting/_functions.py sktime/performance_metrics/forecasting/tests/test_metrics.py
ruff format..............................................................Passed
ruff check...............................................................Passed
```

Run on macOS with Python 3.11.15, numpy 2.4.6, pandas 2.3.3, scikit-learn 1.7.2.

#### Any other comments?

No.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
