### PR TITLE
[DOC] Improve X-y-must-have-same-index tag docstring

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4150,6 +4150,15 @@
       "contributions": [
         "test"
       ]
+    },
+    {
+      "login":"Ayushagrawal-cse",
+      "name": "Ayush Agrawal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/191835489?v=4",
+      "profile" : "https://www.linkedin.com/in/bgp-ayush-agrawal/",
+      "contributions" : [
+        "doc"
+      ]
     }
   ]
 }

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -3960,18 +3960,22 @@ class info__source(_BaseTag):
 class X_y_must_have_same_index(_BaseTag):
     """Whether X and y must have compatible time indices.
 
-    If ``True``, the time index of ``X`` must contain the time index of
-    ``y`` during ``fit`` and ``update``. For forecasting operations with
-    a forecasting horizon ``fh``, the time index of ``X`` must also contain
-    the indices specified by ``fh``.
-
-    This tag indicates that the estimator requires exogenous data ``X`` to
-    be available at all time points required by the target series and
-    forecasting horizon.
-
     - String name: ``"X-y-must-have-same-index"``
     - Values: bool
     - Example: ``True``
+
+    If ``True``, the estimator cannot handle different indices for ``X`` and
+    ``y``.
+
+    For forecasters, this applies to ``fit``, ``update``, and ``predict``
+    when exogenous data ``X`` is used. During ``fit`` and ``update``,
+    ``X.index`` must contain ``y.index``. During ``predict``, ``X.index``
+    must contain the indices specified by the forecasting horizon ``fh``.
+
+    For transformers, this tag indicates whether the transformer can handle
+    different indices for ``X`` and ``y`` when both are provided. A value of
+    ``False`` means that the transformer requires compatible ``X`` and ``y``
+    indices.
     """
 
     _tags = {

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -3958,7 +3958,16 @@ class info__source(_BaseTag):
 
 
 class X_y_must_have_same_index(_BaseTag):
-    """Do X/y in fit/update and X/fh in predict have to be same indices.
+    """Whether X and y must have compatible time indices.
+
+    If ``True``, the time index of ``X`` must contain the time index of
+    ``y`` during ``fit`` and ``update``. For forecasting operations with
+    a forecasting horizon ``fh``, the time index of ``X`` must also contain
+    the indices specified by ``fh``.
+
+    This tag indicates that the estimator requires exogenous data ``X`` to
+    be available at all time points required by the target series and
+    forecasting horizon.
 
     - String name: ``"X-y-must-have-same-index"``
     - Values: bool


### PR DESCRIPTION
Fixes [#11046](https://github.com/sktime/sktime/issues/11046)

#### What does this implement/fix? Explain your changes.

Improves the docstring for the `X-y-must-have-same-index` tag in `sktime/registry/_tags.py`.

The documentation now clarifies the index compatibility requirements for `X` and `y`, with separate explanations for transformers and forecasters. For forecasters, it also describes the index requirements involving `X`, `y`, and the forecasting horizon `fh`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Did you add any tests for the change?

No new tests were added because this is a documentation-only change.

#### Any other comments?

This change only improves the documentation and does not modify the tag's behavior.

#### PR checklist

##### For all contributions

- [x] I've added myself to the list of contributors with any new badges I've earned :-)
- [x] The PR title starts with `[DOC]`.