### PR TITLE
Allow arbitrary torch.optim optimizer names in BaseDeepClassifierPytorch

### DIFF
--- a/sktime/classification/deep_learning/base/_base_torch.py
+++ b/sktime/classification/deep_learning/base/_base_torch.py
@@ -609,14 +609,7 @@ class BaseDeepClassifierPytorch(BaseClassifier):
             optimizer_params = {"lr": self.lr}
         # if optimizer is a string, look it up in the available optimizers
         elif isinstance(self.optimizer, str):
-            if self.optimizer.lower() not in self._all_optimizers:
-                raise ValueError(
-                    f"Unknown optimizer: {self.optimizer}. Please pass one of "
-                    f"{', '.join(self._all_optimizers)} for `optimizer`."
-                )
-            optimizer_class = _safe_import(
-                f"torch.optim.{self._all_optimizers[self.optimizer.lower()]}"
-            )
+            optimizer_class = self._resolve_optimizer(self.optimizer, torchOptimizer)
             optimizer_params = {"lr": self.lr}
         # if optimizer is an optimizer class, use it as is
         elif isinstance(self.optimizer, type) and issubclass(
@@ -649,6 +642,45 @@ class BaseDeepClassifierPytorch(BaseClassifier):
             optimizer_params.update(self.optimizer_kwargs)
 
         return optimizer_class(self.network.parameters(), **optimizer_params)
+
+    def _resolve_optimizer(self, optimizer, torch_optimizer):
+        """Resolve an optimizer ``str`` to a ``torch.optim`` class.
+
+        Curated lower-case aliases in ``_all_optimizers`` take precedence.
+        Otherwise the name is looked up directly in ``torch.optim``,
+        case-insensitively, so that any optimizer shipped with PyTorch can be
+        passed as a string.
+
+        Parameters
+        ----------
+        optimizer : str
+            Name of the optimizer to resolve, e.g. ``"adamw"`` or ``"AdamW"``.
+        torch_optimizer : type
+            The ``torch.optim.Optimizer`` base class used to validate candidates.
+
+        Returns
+        -------
+        type
+            The resolved ``torch.optim`` optimizer class.
+        """
+        # curated lower-case aliases take precedence
+        aliases = self._all_optimizers or {}
+        if optimizer.lower() in aliases:
+            return _safe_import(f"torch.optim.{aliases[optimizer.lower()]}")
+
+        # fall back to a direct, case-insensitive lookup in torch.optim
+        torch_optim = _safe_import("torch.optim")
+        for attr_name in dir(torch_optim):
+            if attr_name.lower() == optimizer.lower():
+                attr = getattr(torch_optim, attr_name, None)
+                if isinstance(attr, type) and issubclass(attr, torch_optimizer):
+                    return attr
+
+        raise ValueError(
+            f"Unknown optimizer: {optimizer}. Please pass a valid torch.optim "
+            f"optimizer (e.g. one of {', '.join(sorted(aliases))}), "
+            "or an optimizer class or instance."
+        )
 
     def _instantiate_criterion(self):
         # if no criterion is passed, use CrossEntropyLoss as default

--- a/sktime/classification/deep_learning/tests/test_optimizer_resolution.py
+++ b/sktime/classification/deep_learning/tests/test_optimizer_resolution.py
@@ -1,0 +1,57 @@
+"""Tests for optimizer string resolution in ``BaseDeepClassifierPytorch``."""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from sktime.classification.deep_learning.mlp import MLPClassifier  # noqa: E402
+from sktime.utils.dependencies import _safe_import  # noqa: E402
+
+
+@pytest.fixture
+def optimizer_base_class():
+    """The ``torch.optim.Optimizer`` base class used to validate candidates."""
+    return _safe_import("torch.optim.Optimizer")
+
+
+@pytest.fixture
+def bare_clf():
+    """An unfitted classifier; ``_resolve_optimizer`` needs no fitted state."""
+    return MLPClassifier()
+
+
+def test_resolve_optimizer_curated_alias(bare_clf, optimizer_base_class):
+    """Lower-case aliases resolve via the curated ``_all_optimizers`` map."""
+    assert (
+        bare_clf._resolve_optimizer("adamw", optimizer_base_class)
+        is torch.optim.AdamW
+    )
+
+
+def test_resolve_optimizer_case_insensitive(bare_clf, optimizer_base_class):
+    """Arbitrary case works, e.g. ``"RMSprop"`` rather than ``"rmsprop"``."""
+    assert (
+        bare_clf._resolve_optimizer("RMSprop", optimizer_base_class)
+        is torch.optim.RMSprop
+    )
+
+
+def test_resolve_optimizer_falls_back_to_torch_optim(
+    bare_clf, optimizer_base_class, monkeypatch
+):
+    """Names not in the curated map are looked up directly in ``torch.optim``."""
+    class Muon(torch.optim.Optimizer):
+        def __init__(self, params, lr=1e-3):
+            super().__init__(params, {"lr": lr})
+
+        def step(self, closure=None):  # pragma: no cover - not called
+            raise NotImplementedError
+
+    monkeypatch.setattr(torch.optim, "Muon", Muon, raising=False)
+    assert bare_clf._resolve_optimizer("Muon", optimizer_base_class) is Muon
+
+
+def test_resolve_optimizer_unknown_raises(bare_clf, optimizer_base_class):
+    """Unknown names raise a ``ValueError`` with a helpful message."""
+    with pytest.raises(ValueError, match="Unknown optimizer"):
+        bare_clf._resolve_optimizer("NotAnOptimizer", optimizer_base_class)


### PR DESCRIPTION
## Summary

`BaseDeepClassifierPytorch._instantiate_optimizer` only resolved optimizer strings via a manually curated dict of lower-case aliases. Any optimizer added to `torch.optim` in future (or a valid name not present in the dict) was rejected, even though it is a valid `torch.optim` optimizer.

Fixes #11051.

## Changes

- Add a `_resolve_optimizer` helper that keeps the curated aliases as a fast path and falls back to a direct, **case-insensitive** lookup in `torch.optim`, validating candidates against `torch.optim.Optimizer`.
- Unknown names still raise a clear `ValueError`.

## Tests

Added `sktime/classification/deep_learning/tests/test_optimizer_resolution.py` covering:
- curated lower-case alias resolution (`adamw` -> `AdamW`)
- arbitrary case (`RMSprop` -> `RMSprop`)
- fallback to a `torch.optim` name not in the curated map (via a monkeypatched optimizer)
- unknown name raises `ValueError`

Tests are gated with `pytest.importorskip("torch")` and will run on CI (torch is not installed in my local env).