### PR TITLE
[BUG] resolve deprecated `sktime.forecasting` module aliases lazily

### DIFF
--- a/sktime/forecasting/__init__.py
+++ b/sktime/forecasting/__init__.py
@@ -3,6 +3,8 @@
 import sys
 import warnings
 from importlib import import_module
+from importlib.abc import Loader, MetaPathFinder
+from importlib.util import spec_from_loader
 
 # alias dictionary to map old module names to new module names
 # if an old module name is queried, imports work, but
@@ -23,8 +25,55 @@ _MODULE_ALIASES = {
 # imports do not need to be updated in the codebase
 
 
-for _module, _new_name in _MODULE_ALIASES.items():
-    sys.modules[f"{__name__}.{_module}"] = import_module(f".{_new_name}", __name__)
+def _alias_warning(old_name, new_name):
+    """Warn that ``old_name`` is deprecated in favour of ``new_name``."""
+    warnings.warn(
+        f"{__name__}.{old_name} is deprecated and has been renamed to "
+        f"{__name__}.{new_name}; please update your imports.",
+        FutureWarning,
+        stacklevel=3,
+    )
+
+
+class _AliasLoader(Loader):
+    """Loader returning the renamed module for a deprecated alias."""
+
+    def __init__(self, old_name, new_name):
+        self.old_name = old_name
+        self.new_name = new_name
+
+    def create_module(self, spec):
+        """Return the renamed module, so the alias is the very same object."""
+        _alias_warning(self.old_name, self.new_name)
+        return import_module(f".{self.new_name}", __name__)
+
+    def exec_module(self, module):
+        """Do nothing, the module was already executed on its real name."""
+
+
+class _AliasFinder(MetaPathFinder):
+    """Resolve deprecated ``sktime.forecasting`` submodule names on demand.
+
+    Registering the aliases eagerly imports every renamed module - including
+    the deep learning ones - at ``sktime.forecasting`` import time. Resolving
+    them lazily instead keeps the aliases importable without that cost.
+    """
+
+    def find_spec(self, fullname, path=None, target=None):
+        """Return a spec for a deprecated alias, or None if not an alias."""
+        prefix = f"{__name__}."
+        if not fullname.startswith(prefix):
+            return None
+
+        old_name = fullname[len(prefix) :]
+        new_name = _MODULE_ALIASES.get(old_name)
+        if new_name is None:
+            return None
+
+        return spec_from_loader(fullname, _AliasLoader(old_name, new_name))
+
+
+sys.meta_path.append(_AliasFinder())
 
 
 def __getattr__(name):

--- a/sktime/forecasting/tests/test_module_aliases.py
+++ b/sktime/forecasting/tests/test_module_aliases.py
@@ -1,0 +1,66 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for the deprecated module aliases in sktime.forecasting."""
+
+import subprocess
+import sys
+from importlib import import_module
+
+import pytest
+
+from sktime.forecasting import _MODULE_ALIASES
+
+
+def test_aliases_are_not_imported_eagerly():
+    """Test that importing sktime.forecasting does not import the aliases.
+
+    See issue #11027. The aliases used to be registered by importing every
+    renamed module at ``sktime.forecasting`` import time, which pulled in the
+    deep learning modules whether or not they were asked for.
+    """
+    code = (
+        "import sys, sktime.forecasting\n"
+        "from sktime.forecasting import _MODULE_ALIASES\n"
+        "loaded = [n for n in _MODULE_ALIASES.values()"
+        " if f'sktime.forecasting.{n}' in sys.modules]\n"
+        "print(loaded)\n"
+    )
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+
+    assert result.stdout.strip() == "[]", (
+        f"importing sktime.forecasting eagerly imported {result.stdout.strip()}"
+    )
+
+
+@pytest.mark.parametrize("old_name", sorted(_MODULE_ALIASES))
+def test_alias_submodule_import(old_name):
+    """Test that ``import sktime.forecasting.<old_name>`` still works."""
+    new_name = _MODULE_ALIASES[old_name]
+
+    with pytest.warns(FutureWarning, match="deprecated and has been renamed"):
+        aliased = import_module(f"sktime.forecasting.{old_name}")
+
+    renamed = import_module(f"sktime.forecasting.{new_name}")
+
+    # the alias must be the very same module object, not a second copy
+    assert aliased is renamed
+
+
+@pytest.mark.parametrize("old_name", sorted(_MODULE_ALIASES))
+def test_alias_attribute_access(old_name):
+    """Test that ``from sktime.forecasting import <old_name>`` still works."""
+    import sktime.forecasting
+
+    with pytest.warns(FutureWarning, match="deprecated and has been renamed"):
+        aliased = getattr(sktime.forecasting, old_name)
+
+    renamed = import_module(f"sktime.forecasting.{_MODULE_ALIASES[old_name]}")
+
+    assert aliased is renamed
+
+
+def test_unknown_submodule_still_raises():
+    """Test that the alias finder does not swallow genuinely missing modules."""
+    with pytest.raises(ModuleNotFoundError):
+        import_module("sktime.forecasting.this_module_does_not_exist")


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #11027.

#### What does this implement/fix? Explain your changes.

`sktime/forecasting/__init__.py` registered the deprecated module aliases eagerly:

```python
for _module, _new_name in _MODULE_ALIASES.items():
    sys.modules[f"{__name__}.{_module}"] = import_module(f".{_new_name}", __name__)
```

That imports all nine alias targets - `momentfm`, `hf_transformers`, `moirai`,
`pykan`, `timesfm`, `timesfm2`, `cinn`, `rbf`, `boxcox_biasadj` - on every
`import sktime.forecasting`, whether or not any of them was asked for. Measured
on this branch's environment:

| | modules in `sys.modules` |
| --- | --- |
| `import sktime.forecasting` on `main` | 1693 |
| `import sktime.forecasting` with this change | 1430 |

so the alias loop alone accounts for **263 modules**, about 16%. In an
environment that has the deep learning soft dependencies installed those
modules pull in `torch` and friends, which is the memory spike in the issue -
multiplied by every `pytest-xdist` worker.

The issue suggests simply removing the loop. That is not sufficient on its own:
the package level `__getattr__` only covers *attribute* access, so removing the
loop makes `import sktime.forecasting.timesfm_forecaster` fail with
`ModuleNotFoundError`, which would be a regression on the deprecated path this
aliasing exists to support.

Instead this registers a `MetaPathFinder` that resolves an alias on first
import. `create_module` returns the renamed module itself, so the alias is the
same object as before rather than a second copy:

```python
>>> import sktime.forecasting.timesfm2_forecaster as aliased
>>> import sktime.forecasting.timesfm2 as renamed
>>> aliased is renamed
True
```

One deliberate behaviour change: `import sktime.forecasting.<old_name>` now
raises the `FutureWarning` too. On `main` that form resolved silently, because
the eager loop had already put the alias in `sys.modules`, so only attribute
access warned. Warning on both seems closer to the intent of the deprecation,
but say the word if you would rather keep the submodule form silent until 2.0.
No module inside `sktime` imports the deprecated names, so this does not
introduce warnings into the test suite.

#### Does your contribution introduce a new dependency? If yes, which one?

No. `importlib.abc` and `importlib.util` are standard library.

#### What should a reviewer concentrate their feedback on?

- The added `FutureWarning` on the submodule import form, as described above.
- Whether appending to `sys.meta_path` at import time is acceptable here. I
  checked that estimator discovery is unaffected - `all_estimators` still finds
  156 forecasters and `sktime/registry/tests` passes, 220 tests.
- `# TODO 2.0.0` still applies - the finder is deleted wholesale in 2.0 along
  with the rest of the aliasing logic.

#### Did you add any tests for the change?

Yes, in a new `sktime/forecasting/tests/test_module_aliases.py` - the aliases had
no test coverage:

- `test_aliases_are_not_imported_eagerly`, the regression test, checks in a
  subprocess that no alias target is in `sys.modules` after importing
  `sktime.forecasting`
- `test_alias_submodule_import`, parametrized over all nine aliases, checks the
  `import a.b.c` form works, warns, and resolves to the same module object
- `test_alias_attribute_access`, same for the `from ... import` form
- `test_unknown_submodule_still_raises`, checks the finder does not swallow
  genuinely missing modules

10 of the 20 fail on `main`, all 20 pass with this change.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
