### PR TITLE
[BUG] MeanAbsoluteScaledError applies sample_weight twice

### DIFF
--- a/sktime/performance_metrics/forecasting/_mase.py
+++ b/sktime/performance_metrics/forecasting/_mase.py
@@ -198,7 +198,11 @@ class MeanAbsoluteScaledError(_ScaledMetricTags, BaseForecastingErrorMetric):
 
         raw_values = raw_values / np.maximum(naive_error, eps)
 
-        raw_values = self._get_weighted_df(raw_values, **kwargs)
+        # sample_weight is already applied above, before the scaling. Applying
+        # _get_weighted_df a second time to the same frame squares the weights,
+        # because it is a plain df.mul(sample_weight, axis=0) with no idempotency
+        # guard. The naive denominator comes from y_train and does not depend on
+        # the weights, so one application is the whole of the weighting.
 
         return self._handle_multioutput(raw_values, multioutput)
 

--- a/sktime/performance_metrics/forecasting/tests/test_metrics.py
+++ b/sktime/performance_metrics/forecasting/tests/test_metrics.py
@@ -592,3 +592,64 @@ def test_msle_no_stdout_on_index_mismatch():
     with contextlib.redirect_stdout(buf):
         mean_squared_log_error(y_true, y_pred)
     assert buf.getvalue() == ""
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.performance_metrics"]),
+    reason="Run if performance_metrics module has changed.",
+)
+def test_mase_applies_sample_weight_once():
+    """MASE must apply sample_weight once, not twice.
+
+    _evaluate_by_index called _get_weighted_df on the same frame both before and
+    after dividing by the naive error. _get_weighted_df is df.mul(sample_weight,
+    axis=0) with no idempotency guard, so the weights were squared.
+
+    The naive denominator is computed from y_train and does not depend on the
+    weights, so weighted MASE must equal weighted MAE divided by that same
+    constant denominator. That invariant is the reference used here.
+    """
+    from sktime.performance_metrics.forecasting import (
+        MeanAbsoluteScaledError,
+    )
+
+    y_true = pd.DataFrame({"c": [3.0, 5.0, 4.0, 6.0, 5.0]})
+    y_pred = pd.DataFrame({"c": [2.8, 5.5, 4.2, 5.4, 5.3]})
+    y_train = pd.DataFrame({"c": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
+
+    naive_error = (y_train[1:] - y_train[:-1].values).abs().mean().iloc[0]
+
+    for sample_weight in (
+        np.array([1.0, 1.0, 1.0, 1.0, 1.0]),
+        np.array([0.5, 1.0, 1.0, 1.0, 1.5]),
+        np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+    ):
+        mase = MeanAbsoluteScaledError()
+        actual = mase(y_true, y_pred, y_train=y_train, sample_weight=sample_weight)
+
+        weighted_abs_error = (y_true - y_pred).abs().mul(sample_weight, axis=0)
+        expected = float((weighted_abs_error / naive_error).mean(axis=1).mean())
+
+        assert np.allclose(actual, expected), (
+            f"sample_weight={sample_weight}: got {actual}, expected {expected}"
+        )
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.performance_metrics"]),
+    reason="Run if performance_metrics module has changed.",
+)
+def test_mase_unweighted_is_unchanged():
+    """The unweighted and uniform-weight paths must be untouched by the fix."""
+    from sktime.performance_metrics.forecasting import MeanAbsoluteScaledError
+
+    y_true = pd.DataFrame({"c": [3.0, 5.0, 4.0, 6.0, 5.0]})
+    y_pred = pd.DataFrame({"c": [2.8, 5.5, 4.2, 5.4, 5.3]})
+    y_train = pd.DataFrame({"c": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
+
+    mase = MeanAbsoluteScaledError()
+    unweighted = mase(y_true, y_pred, y_train=y_train)
+    uniform = mase(
+        y_true, y_pred, y_train=y_train, sample_weight=np.ones(len(y_true))
+    )
+    assert np.allclose(unweighted, uniform)


### PR DESCRIPTION
#### Reference Issues/PRs

Related to #8635 (the `sample_weight` rework) and #9473, though neither covers this. See the note at the bottom.

#### What does this implement/fix? Explain your changes.

`MeanAbsoluteScaledError._evaluate_by_index` weights the same frame on both sides of the naive-error division:

```python
raw_values = (y_true - y_pred).abs()
raw_values = self._get_weighted_df(raw_values, **kwargs)      # first application
...
raw_values = raw_values / np.maximum(naive_error, eps)
raw_values = self._get_weighted_df(raw_values, **kwargs)      # second, same frame
```

`_get_weighted_df` is `df.mul(sample_weight, axis=0)` with no idempotency guard, so the weights end up squared.

The naive denominator is computed from `y_train` and does not depend on the weights, so weighted MASE should equal weighted MAE over that same constant denominator. Measured against that reference:

| sample_weight | sktime | correct | ratio |
|---|---|---|---|
| `None` | 0.36000000 | 0.36000000 | 1.000 |
| `[1, 1, 1, 1, 1]` | 0.36000000 | 0.36000000 | 1.000 |
| `[0.5, 1, 1, 1, 1.5]` | 0.40500000 | 0.37000000 | 1.095 |
| `[1, 2, 3, 4, 5]` | 4.22000000 | 1.14000000 | 3.702 |

The unweighted and uniform-weight cases are exact, which is why the existing tests do not catch it — none of them passes a non-uniform `sample_weight`.

**Consistency with the sibling metrics.** `MeanAbsoluteError` and `MeanAbsolutePercentageError` call `_get_weighted_df` once. `MeanSquaredError` calls it twice, but on two different variables in two different methods, which is correct. MASE is the only metric that applies it twice to the same frame within one method.

The fix removes the second call and leaves a comment saying why, so it does not get reinstated.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their time on?

Whether removing the second application is the intended semantics, i.e. that `sample_weight` scales the per-timepoint error and the naive denominator stays unweighted. That is what the invariant above assumes and what the other metrics do, but it is the one judgement call here.

#### Any other comments?

Two tests added to `test_metrics.py`: weighted MASE matches the weighted-MAE-over-naive-error reference across three weight vectors, and the unweighted and uniform-weight paths are unchanged. The first fails on `main`.

Ordering note on **#9473**: that PR adds `sample_weight` as an `__init__` argument to the forecasting metrics, including MASE. I pulled its diff — it only changes the constructor signature and does not touch `_evaluate_by_index`, so it neither fixes nor conflicts with this. It does make the double weighting reachable from the constructor as well as per call, so the two are complementary rather than competing.

#### PR checklist

- [x] Added tests, which fail on `main` and pass with this change
- [x] No new dependencies
- [x] Linked the related issues above

Written with AI assistance; I have read and can explain every changed line, and the numbers above are from a run I did myself.