### PR TITLE
[BUG] use an accepted index in the transformer categorical tests

### DIFF
--- a/sktime/transformations/tests/test_all_transformers.py
+++ b/sktime/transformations/tests/test_all_transformers.py
@@ -33,6 +33,30 @@ class TransformerFixtureGenerator(BaseFixtureGenerator):
     object_type_filter = "transformer"
 
 
+def _categorical_test_index(object_instance, n_timepoints=17):
+    """Return an index that ``object_instance`` accepts, or None for the default.
+
+    Some transformers only accept datetime-like indices, via the
+    ``enforce_index_type`` tag. Their support for categorical values in ``X`` is
+    independent of the index type, so the categorical tests below must not hand
+    them an index they reject, or they report an index failure as if it were a
+    missing categorical capability.
+    """
+    enforced = object_instance.get_tag("enforce_index_type", None, False)
+
+    if enforced is None:
+        return None
+    if not isinstance(enforced, (list, tuple)):
+        enforced = [enforced]
+
+    if pd.DatetimeIndex in enforced:
+        return pd.date_range("2023-01-01", periods=n_timepoints, freq="D")
+    if pd.PeriodIndex in enforced:
+        return pd.period_range("2023-01-01", periods=n_timepoints, freq="D")
+
+    return None
+
+
 class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
     """Module level tests for all sktime transformers."""
 
@@ -215,6 +239,11 @@ class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
         X = pd.DataFrame({"var_0": [i + 3 for i in range(17)]})
         y = pd.DataFrame({"var_0": [str(i % 3) for i in range(17)]})
 
+        index = _categorical_test_index(object_instance)
+        if index is not None:
+            X.index = index
+            y.index = index
+
         requires_y = object_instance.get_tag("requires_y")
         uses_y = object_instance.get_tag("y_inner_mtype") not in ["None", None]
         if requires_y or uses_y:
@@ -234,6 +263,11 @@ class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
         """
         X = pd.DataFrame({"var_0": [str(i % 3) for i in range(17)]})
         y = pd.DataFrame({"var_1": [i for i in range(17)]})
+
+        index = _categorical_test_index(object_instance)
+        if index is not None:
+            X.index = index
+            y.index = index
 
         if (
             object_instance.get_tag("capability:categorical_in_X")
@@ -265,3 +299,42 @@ class TestAllTransformers(TransformerFixtureGenerator, QuickTester):
 #                 X = _make_args(estimator, method)[0]
 #                 Xt = estimator.transform(X)
 #                 np.testing.assert_array_equal(X.index, Xt.index)
+
+
+def test_categorical_test_index_respects_enforce_index_type():
+    """Test that the categorical tests use an index the transformer accepts.
+
+    ``PeakTimeFeature`` and ``SeasonalDummiesOneHot`` accept categorical values in
+    ``X``, but only on a datetime-like index. Handing them the default
+    ``RangeIndex`` made them fail the categorical tests with an index error,
+    which reads as if the ``capability:categorical_in_X`` tag were wrong.
+    """
+    from sktime.transformations.peak import PeakTimeFeature
+    from sktime.transformations.summarize import WindowSummarizer
+
+    datetime_only = PeakTimeFeature.create_test_instance()
+    index = _categorical_test_index(datetime_only)
+    assert isinstance(index, (pd.DatetimeIndex, pd.PeriodIndex))
+    assert len(index) == 17
+
+    # a transformer without the tag keeps the default index
+    unconstrained = WindowSummarizer.create_test_instance()
+    assert _categorical_test_index(unconstrained) is None
+
+
+def test_categorical_X_passes_on_datetime_indexed_transformers():
+    """Test the datetime-only transformers really do accept categorical X."""
+    from sktime.transformations.dummies import SeasonalDummiesOneHot
+    from sktime.transformations.peak import PeakTimeFeature
+
+    for cls in (PeakTimeFeature, SeasonalDummiesOneHot):
+        instance = cls.create_test_instance()
+
+        X = pd.DataFrame({"var_0": [str(i % 3) for i in range(17)]})
+        y = pd.DataFrame({"var_1": [i for i in range(17)]})
+        index = _categorical_test_index(instance)
+        X.index = index
+        y.index = index
+
+        assert instance.get_tag("capability:categorical_in_X")
+        instance.fit_transform(X, y)


### PR DESCRIPTION
#### Reference Issues/PRs

No issue - found while investigating the pre-existing `test_categorical_X_passes`
failures I noted in #10918 and #10919. Related to the `capability:categorical_in_X`
work in #10851, #10808, #10842, #10856, #10902, #10905, all of which are on the
forecasting side; this is the transformer side.

#### What does this implement/fix? Explain your changes.

`test_categorical_X_passes` and `test_categorical_y_raises_error` build their
inputs with the default `RangeIndex`:

```python
X = pd.DataFrame({"var_0": [str(i % 3) for i in range(17)]})
y = pd.DataFrame({"var_1": [i for i in range(17)]})
```

Transformers that only accept datetime-like indices - declared through the
`enforce_index_type` tag - reject that index before they ever look at the
values. The index error is then reported as a categorical capability failure:

```
PeakTimeFeature() fails when passing categorical X, but has the
capability:categorical_in_X set to True. Please set the tag to False if the
estimator does not support categorical data in X.
Exception: Index type not supported
```

That message is misleading, and acting on its advice would introduce a bug -
the tag is correct. Both affected transformers accept categorical `X` perfectly
well once the index is one they support:

| | `RangeIndex` (what the test used) | `DatetimeIndex` + categorical `X` |
| --- | --- | --- |
| `PeakTimeFeature` | `ValueError: Index type not supported` | passes |
| `SeasonalDummiesOneHot` | `AttributeError: 'RangeIndex' object has no attribute 'freq'` | passes |

This adds a `_categorical_test_index` helper that derives the test index from
`enforce_index_type`, and uses it in the two categorical tests that construct
inputs and call `fit_transform`.

Effect on `check_estimator`:

| estimator | on `main` | with this change |
| --- | --- | --- |
| `PeakTimeFeature` | 157 checks, 4 failures | 157 checks, **0 failures** |
| `SeasonalDummiesOneHot` | 114 checks, 3 failures | 114 checks, **0 failures** |

`DateTimeFeatures` is affected the same way and is likewise fixed.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether deriving the index from `enforce_index_type` is the right approach, or
  whether these tests should instead use the scenario machinery to build inputs.
- I scanned every non-composite transformer with `capability:categorical_in_X`
  set to `True`. After this change, **8 still genuinely fail**, i.e. the tag does
  look wrong for them:

  | estimator | error |
  | --- | --- |
  | `DistanceFeatures` | `Pairwise transformers do not support categorical features in X.` |
  | `RandomIntervals` | `... SummaryTransformer ... does not support categorical ...` |
  | `PandasTransformAdaptor` | `unsupported operand type(s) for -: 'str' and 'str'` |
  | `PlateauFinder` | `ufunc 'isnan' not supported ...` |
  | `RandomIntervalFeatureExtractor` | `unsupported operand type(s) for /: 'str' and 'int'` |
  | `TimeBinAggregate` | `Could not convert string '1' to numeric` |
  | `SFA`, `SFAFast` | require a nested `pd.DataFrame` for `X` |

  I have deliberately left those out of this PR, since setting 8 tags to `False`
  is a behaviour change worth its own review, and `SFA`/`SFAFast` look like an
  input-format artifact rather than a tag error. Happy to open a follow-up for
  the genuine ones if you would like.

  These do not fail CI today only because the suite is differential - they run
  when the estimator is touched.

#### Did you add any tests for the change?

Yes, two in the same module:

- `test_categorical_test_index_respects_enforce_index_type`, checking the helper
  returns a datetime-like index for a constrained transformer and `None` for an
  unconstrained one
- `test_categorical_X_passes_on_datetime_indexed_transformers`, checking that
  `PeakTimeFeature` and `SeasonalDummiesOneHot` genuinely accept categorical `X`,
  which is the fact that makes their tag correct

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
