### PR TITLE
[BUG] fix `RecursiveReductionForecaster` predict on a `PeriodIndex`

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -2669,6 +2669,21 @@ class RecursiveReductionForecaster(BaseForecaster, _ReducerMixin):
 
         return y_pred
 
+    @staticmethod
+    def _asfreq_freq(y):
+        """Return the frequency alias to pass to ``asfreq`` for ``y``, or None.
+
+        ``ForecastingHorizon.freq`` reports the ``DatetimeIndex`` offset alias,
+        e.g. ``"ME"`` for monthly. ``PeriodIndex.asfreq`` only accepts period
+        aliases, e.g. ``"M"``, and raises on ``"ME"``. Where the index carries a
+        frequency of its own, use that, so the alias always matches the index.
+        """
+        index = y.index
+        if index.nlevels > 1:
+            index = index.get_level_values(-1)
+
+        return getattr(index, "freqstr", None)
+
     def _predict_out_of_sample(self, X_pool, fh):
         """Recursive reducer: predict out of sample (ahead of cutoff)."""
         # very similar to _predict_concurrent of DirectReductionForecaster - refactor?
@@ -2694,11 +2709,12 @@ class RecursiveReductionForecaster(BaseForecaster, _ReducerMixin):
         y_pred_list = []
 
         for _ in y_lags_no_gaps:
-            if hasattr(self.fh, "freq") and self.fh.freq is not None:
+            freq = self._asfreq_freq(y_plus_preds)
+            if freq is not None:
                 y_plus_preds = apply_method_per_series(
                     y_plus_preds,
                     "asfreq",
-                    self.fh.freq,
+                    freq,
                     how="start",
                 )
             Xt = lagger_y_to_X.transform(y_plus_preds)

--- a/sktime/forecasting/compose/tests/test_reduce.py
+++ b/sktime/forecasting/compose/tests/test_reduce.py
@@ -887,3 +887,37 @@ def test_recursive_reduction_with_period_index():
     manual_pred = manual_lr.predict(manual_input)
 
     assert np.allclose(y_pred, manual_pred)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.forecasting", "sktime.split"]),
+    reason="run test only if forecasting or split module has changed",
+)
+@pytest.mark.parametrize(
+    "index",
+    [
+        pd.period_range("2020-01", periods=40, freq="M"),
+        pd.date_range("2020-01-31", periods=40, freq="ME"),
+        pd.date_range("2020-01-01", periods=40, freq="D"),
+        pd.RangeIndex(40),
+    ],
+    ids=["PeriodIndex-M", "DatetimeIndex-ME", "DatetimeIndex-D", "RangeIndex"],
+)
+def test_recursive_reduction_predict_index_types(index):
+    """Test out-of-sample predict for the supported index types.
+
+    ``ForecastingHorizon.freq`` reports the ``DatetimeIndex`` offset alias, e.g.
+    ``"ME"`` for monthly. Passing that to ``PeriodIndex.asfreq``, which only
+    accepts period aliases such as ``"M"``, raised
+    ``ValueError: Invalid frequency: ME``.
+    """
+    y = pd.Series(np.arange(40, dtype=float), index=index)
+
+    forecaster = RecursiveReductionForecaster(
+        estimator=LinearRegression(), window_length=6
+    )
+    forecaster.fit(y)
+    y_pred = forecaster.predict(fh=[1, 2, 3])
+
+    assert len(y_pred) == 3
+    assert not np.asarray(y_pred).ravel().tolist() == [np.nan] * 3


### PR DESCRIPTION
#### Reference Issues/PRs

No existing issue - found while writing docstring examples for the reducers
(#10782). I searched for a prior report of this and did not find one.

#### What does this implement/fix? Explain your changes.

`RecursiveReductionForecaster.predict` fails for any `PeriodIndex` input,
including `load_airline`:

```python
from sklearn.linear_model import LinearRegression
from sktime.datasets import load_airline
from sktime.forecasting.compose import RecursiveReductionForecaster

y = load_airline()                       # PeriodIndex, freq "M"
f = RecursiveReductionForecaster(estimator=LinearRegression(), window_length=12)
f.fit(y)                                 # fine
f.predict(fh=[1, 2, 3])                  # ValueError
```

```
ValueError: Invalid frequency: ME, failed to parse with error message:
ValueError("for Period, please use 'M' instead of 'ME'")
```

`_predict_out_of_sample` resamples the growing series with

```python
if hasattr(self.fh, "freq") and self.fh.freq is not None:
    y_plus_preds = apply_method_per_series(y_plus_preds, "asfreq", self.fh.freq, how="start")
```

`ForecastingHorizon.freq` reports the **`DatetimeIndex` offset alias**, so for
monthly data it is `"ME"`. `PeriodIndex.asfreq` only accepts **period aliases**
and rejects `"ME"`:

```pycon
>>> load_airline().index.freqstr
'M'
>>> fh.freq
'ME'
```

The mismatch appeared when pandas 2.2 renamed the month-end offset alias from
`M` to `ME`, splitting the two alias families apart.

The fix takes the alias from the index actually being resampled, which by
construction matches that index, rather than from the horizon.

Verified across index types, `window_length=6`, `fh=[1, 2, 3]`:

| index | on `main` | with this change |
| --- | --- | --- |
| `PeriodIndex` freq `M` | `ValueError: Invalid frequency: ME` | passes |
| `DatetimeIndex` freq `ME` | passes | passes |
| `DatetimeIndex` freq `D` | passes | passes |
| `RangeIndex` | passes | passes |
| hierarchical | passes | passes |

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the fix belongs here or in `ForecastingHorizon.freq`. Making `fh.freq`
  return a period alias when the horizon came from a `PeriodIndex` would fix
  this at the source, but that is a far wider blast radius, so I kept the change
  local to the reducer. Happy to go the other way if you prefer.
- The helper takes the last index level for multiindex input; please sanity check
  that against the hierarchical path.

#### Did you add any tests for the change?

Yes - `test_recursive_reduction_predict_index_types` in
`sktime/forecasting/compose/tests/test_reduce.py`, parametrized over
`PeriodIndex`, `DatetimeIndex` with `ME` and `D`, and `RangeIndex`.

The `PeriodIndex` case fails on `main` and passes with this change; the other
three pass either way, so they guard against a regression in the opposite
direction. The full `test_reduce.py` suite is green: 246 passed, 2 skipped.

Note on verification: I ran the `test_reduce.py` suite rather than a full
`check_estimator` on `RecursiveReductionForecaster`, which did not finish in a
reasonable time locally. Happy to report that separately if you would like it
before merging.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
