### PR TITLE
[DOC] add docstring examples to the reduction forecasters

### DIFF
--- a/sktime/forecasting/compose/_reduce.py
+++ b/sktime/forecasting/compose/_reduce.py
@@ -1268,6 +1268,20 @@ class DirectTabularRegressionForecaster(_DirectReducer):
     window_length : int, optional (default=10)
         The length of the sliding window used to transform the series into
         a tabular matrix.
+
+    Examples
+    --------
+    >>> from sklearn.linear_model import LinearRegression
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.compose import DirectTabularRegressionForecaster
+    >>> y = load_airline()
+    >>> forecaster = DirectTabularRegressionForecaster(
+    ...     estimator=LinearRegression(), window_length=12
+    ... )
+    >>> forecaster.fit(y, fh=[1, 2, 3])
+    DirectTabularRegressionForecaster(...)
+    >>> y_pred = forecaster.predict()
+
     """
 
     def __init__(
@@ -1318,6 +1332,20 @@ class MultioutputTabularRegressionForecaster(_MultioutputReducer):
     window_length : int, optional (default=10)
         The length of the sliding window used to transform the series into
         a tabular matrix.
+
+    Examples
+    --------
+    >>> from sklearn.linear_model import LinearRegression
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.compose import MultioutputTabularRegressionForecaster
+    >>> y = load_airline()
+    >>> forecaster = MultioutputTabularRegressionForecaster(
+    ...     estimator=LinearRegression(), window_length=12
+    ... )
+    >>> forecaster.fit(y, fh=[1, 2, 3])
+    MultioutputTabularRegressionForecaster(...)
+    >>> y_pred = forecaster.predict()
+
     """
 
     _estimator_scitype = "tabular-regressor"
@@ -1346,6 +1374,20 @@ class RecursiveTabularRegressionForecaster(_RecursiveReducer):
     pooling: str {"local", "global"}, optional
         Specifies whether separate models will be fit at the level of each instance
         (local) of if you wish to fit a single model to all instances ("global").
+
+    Examples
+    --------
+    >>> from sklearn.linear_model import LinearRegression
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.compose import RecursiveTabularRegressionForecaster
+    >>> y = load_airline()
+    >>> forecaster = RecursiveTabularRegressionForecaster(
+    ...     estimator=LinearRegression(), window_length=12
+    ... )
+    >>> forecaster.fit(y)
+    RecursiveTabularRegressionForecaster(...)
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])
+
     """
 
     _tags = {
@@ -1404,6 +1446,20 @@ class DirRecTabularRegressionForecaster(_DirRecReducer):
     window_length : int, optional (default=10)
         The length of the sliding window used to transform the series into
         a tabular matrix
+
+    Examples
+    --------
+    >>> from sklearn.linear_model import LinearRegression
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.compose import DirRecTabularRegressionForecaster
+    >>> y = load_airline()
+    >>> forecaster = DirRecTabularRegressionForecaster(
+    ...     estimator=LinearRegression(), window_length=12
+    ... )
+    >>> forecaster.fit(y, fh=[1, 2, 3])
+    DirRecTabularRegressionForecaster(...)
+    >>> y_pred = forecaster.predict()
+
     """
 
     _estimator_scitype = "tabular-regressor"
@@ -1422,6 +1478,20 @@ class DirectTimeSeriesRegressionForecaster(_DirectReducer):
     window_length : int, optional (default=10)
         The length of the sliding window used to transform the series into
         a tabular matrix.
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.compose import DirectTimeSeriesRegressionForecaster
+    >>> from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor
+    >>> y = load_airline()
+    >>> forecaster = DirectTimeSeriesRegressionForecaster(
+    ...     estimator=KNeighborsTimeSeriesRegressor(n_neighbors=1), window_length=12
+    ... )
+    >>> forecaster.fit(y, fh=[1, 2, 3])
+    DirectTimeSeriesRegressionForecaster(...)
+    >>> y_pred = forecaster.predict()
+
     """
 
     _estimator_scitype = "time-series-regressor"
@@ -1495,6 +1565,20 @@ class RecursiveTimeSeriesRegressionForecaster(_RecursiveReducer):
     window_length : int, optional (default=10)
         The length of the sliding window used to transform the series into
         a tabular matrix.
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.compose import RecursiveTimeSeriesRegressionForecaster
+    >>> from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor
+    >>> y = load_airline()
+    >>> forecaster = RecursiveTimeSeriesRegressionForecaster(
+    ...     estimator=KNeighborsTimeSeriesRegressor(n_neighbors=1), window_length=12
+    ... )
+    >>> forecaster.fit(y)
+    RecursiveTimeSeriesRegressionForecaster(...)
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])
+
     """
 
     _tags = {
@@ -1560,6 +1644,20 @@ class DirRecTimeSeriesRegressionForecaster(_DirRecReducer):
     window_length : int, optional (default=10)
         The length of the sliding window used to transform the series into
         a tabular matrix
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.compose import DirRecTimeSeriesRegressionForecaster
+    >>> from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor
+    >>> y = load_airline()
+    >>> forecaster = DirRecTimeSeriesRegressionForecaster(
+    ...     estimator=KNeighborsTimeSeriesRegressor(n_neighbors=1), window_length=12
+    ... )
+    >>> forecaster.fit(y, fh=[1, 2, 3])
+    DirRecTimeSeriesRegressionForecaster(...)
+    >>> y_pred = forecaster.predict()
+
     """
 
     _estimator_scitype = "time-series-regressor"
@@ -2061,6 +2159,20 @@ class DirectReductionForecaster(BaseForecaster, _ReducerMixin):
         * ``False`` : Window size differs for each forecasting horizon. Window
           length corresponds to (total observations + 1 - window_length +
           forecasting horizon).
+
+    Examples
+    --------
+    >>> from sklearn.linear_model import LinearRegression
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.forecasting.compose import DirectReductionForecaster
+    >>> y = load_airline()
+    >>> forecaster = DirectReductionForecaster(
+    ...     estimator=LinearRegression(), window_length=12
+    ... )
+    >>> forecaster.fit(y, fh=[1, 2, 3])
+    DirectReductionForecaster(...)
+    >>> y_pred = forecaster.predict()
+
     """
 
     _tags = {
@@ -2478,6 +2590,24 @@ class RecursiveReductionForecaster(BaseForecaster, _ReducerMixin):
         "panel" = second lowest level, one reduced model per panel level (-2)
         if there are 2 or less levels, "global" and "panel" result in the same
         if there is only 1 level (single time series), all three settings agree
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from sklearn.linear_model import LinearRegression
+    >>> from sktime.forecasting.compose import RecursiveReductionForecaster
+    >>> y = pd.Series(
+    ...     np.arange(40, dtype=float),
+    ...     index=pd.date_range("2020-01-01", periods=40, freq="D"),
+    ... )
+    >>> forecaster = RecursiveReductionForecaster(
+    ...     estimator=LinearRegression(), window_length=6
+    ... )
+    >>> forecaster.fit(y)
+    RecursiveReductionForecaster(...)
+    >>> y_pred = forecaster.predict(fh=[1, 2, 3])
+
     """
 
     _tags = {


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #10782. Sibling of the other doctest PRs in flight (#11009, #11016,
#11017 and others) - this one covers `forecasting/compose/_reduce.py`, which
none of those touch.

#### What does this implement/fix? Explain your changes.

Adds an `Examples` section to the nine estimator classes in
`sktime/forecasting/compose/_reduce.py` that had none:

| class | example uses |
| --- | --- |
| `DirectTabularRegressionForecaster` | `LinearRegression`, `fh` in `fit` |
| `MultioutputTabularRegressionForecaster` | `LinearRegression`, `fh` in `fit` |
| `RecursiveTabularRegressionForecaster` | `LinearRegression`, `fh` in `predict` |
| `DirRecTabularRegressionForecaster` | `LinearRegression`, `fh` in `fit` |
| `DirectTimeSeriesRegressionForecaster` | `KNeighborsTimeSeriesRegressor` |
| `RecursiveTimeSeriesRegressionForecaster` | `KNeighborsTimeSeriesRegressor` |
| `DirRecTimeSeriesRegressionForecaster` | `KNeighborsTimeSeriesRegressor` |
| `DirectReductionForecaster` | `LinearRegression`, `fh` in `fit` |
| `RecursiveReductionForecaster` | `LinearRegression` |

The examples follow the style of the existing `make_reduction` and `YfromX`
examples in the same module, including the `ClassName(...)` ellipsis for the
`fit` return.

Two notes on choices:

- The direct, dirrec and multioutput strategies require `fh` at `fit` time, so
  their examples pass it there; the recursive ones pass it at `predict`. That
  difference is worth showing, since it is a common first stumble with the
  reducers.
- `RecursiveReductionForecaster`'s example uses a `DatetimeIndex` series rather
  than `load_airline`. On `main`, that estimator raises
  `ValueError: Invalid frequency: ME` for `PeriodIndex` input, which I have
  filed a fix for in #11062. Once that merges the example could be switched to
  `load_airline` for consistency with the others - happy to do that here if
  #11062 lands first, or leave it as is.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the examples should show output, e.g. printing `y_pred`, rather than
  only binding it. I followed the existing `make_reduction` example, which does
  not print, to keep the doctests robust against numerical drift.
- `MultioutputTimeSeriesRegressionForecaster` is deliberately left without an
  example - it currently fails with
  `AttributeError: 'DataFrame' object has no attribute 'ravel'`, reported in
  #10829 and #10896 with fixes in #10832 and #10897. It should get an example
  once one of those merges.

#### Did you add any tests for the change?

The examples are doctests and are run as such:

```
pytest --doctest-modules sktime/forecasting/compose/_reduce.py
11 passed
```

nine new plus the two that already existed.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
