### PR TITLE
[BUG] fix `WhiteNoiseAugmenter` on named series and multivariate input

### DIFF
--- a/sktime/transformations/augmenter.py
+++ b/sktime/transformations/augmenter.py
@@ -104,7 +104,11 @@ class WhiteNoiseAugmenter(_AugmenterTags, BaseTransformer):
             raise TypeError(
                 "Type of parameter 'scale' must be a non-negative float value."
             )
-        return X[0] + norm.rvs(0, scale, size=len(X), random_state=self.random_state)
+        # add noise to every column, rather than to a column literally named 0 -
+        # X[0] only resolved for an unnamed univariate series, and dropped all but
+        # the first column for multivariate input
+        noise = norm.rvs(0, scale, size=X.shape, random_state=self.random_state)
+        return X + noise
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/sktime/transformations/tests/test_augmenter.py
+++ b/sktime/transformations/tests/test_augmenter.py
@@ -135,3 +135,58 @@ def test_random_samples(parameter):
         checksum = _calc_checksum(Xt)
         checksums.append(checksum)
     assert checksums == expected_checksums_random_samples
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(aug.WhiteNoiseAugmenter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_white_noise_augmenter_named_series():
+    """Test WhiteNoiseAugmenter on a named series and a DataFrame.
+
+    ``_transform`` returned ``X[0] + noise``, which only resolved when the single
+    column was literally labelled ``0`` - the case for an unnamed series, which
+    sktime converts to a one column frame named ``0``. Any named series or
+    DataFrame raised ``KeyError: 0``.
+    """
+    values = np.arange(20, dtype=float)
+    index = pd.date_range("2020-01-01", periods=20, freq="D")
+
+    named = pd.Series(values, index=index, name="passengers")
+    unnamed = pd.Series(values, index=index)
+
+    out_named = aug.WhiteNoiseAugmenter().fit_transform(named)
+    out_unnamed = aug.WhiteNoiseAugmenter().fit_transform(unnamed)
+    out_frame = aug.WhiteNoiseAugmenter().fit_transform(named.to_frame())
+
+    # the column label must not change the values
+    np.testing.assert_allclose(
+        np.asarray(out_named).ravel(), np.asarray(out_unnamed).ravel()
+    )
+    np.testing.assert_allclose(
+        np.asarray(out_named).ravel(), np.asarray(out_frame).ravel()
+    )
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(aug.WhiteNoiseAugmenter),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_white_noise_augmenter_multivariate():
+    """Test that all columns are kept and augmented, not just the first.
+
+    ``WhiteNoiseAugmenter`` sets ``capability:multivariate`` to True, so
+    multivariate input must come back with every column.
+    """
+    X = pd.DataFrame(
+        {"a": np.arange(20, dtype=float), "b": np.arange(20, dtype=float) * 2},
+        index=pd.date_range("2020-01-01", periods=20, freq="D"),
+    )
+
+    Xt = aug.WhiteNoiseAugmenter().fit_transform(X)
+
+    assert list(Xt.columns) == ["a", "b"]
+    assert Xt.shape == X.shape
+    # noise was actually added to both columns
+    assert not np.allclose(Xt["a"], X["a"])
+    assert not np.allclose(Xt["b"], X["b"])


### PR DESCRIPTION
#### Reference Issues/PRs

No existing issue - found by exercising every series transformer on
`load_airline`. I searched for a prior report and did not find one.

#### What does this implement/fix? Explain your changes.

`WhiteNoiseAugmenter._transform` ended with

```python
return X[0] + norm.rvs(0, scale, size=len(X), random_state=self.random_state)
```

`X` here is always a `pd.DataFrame`, since `X_inner_mtype` is `pd.DataFrame`.
`X[0]` is therefore a lookup of a column *labelled* `0`, not a positional one.
That label only exists when the input was an **unnamed** series, which sktime
converts to a one column frame named `0`. Anything else raises:

```python
>>> from sktime.datasets import load_airline
>>> from sktime.transformations.augmenter import WhiteNoiseAugmenter
>>> WhiteNoiseAugmenter().fit_transform(load_airline())
KeyError: 0
```

`load_airline()` is named `"Number of airline passengers"`, so the estimator
fails on one of the most common inputs in the docs. A `pd.DataFrame` fails the
same way, and it works only by accident when the series has no name.

The same expression also silently drops every column but the first, even though
the estimator sets `capability:multivariate` to `True`:

| input | on `main` | with this change |
| --- | --- | --- |
| unnamed `pd.Series` | works | works, identical values |
| named `pd.Series` | `KeyError: 0` | works |
| `pd.DataFrame`, 1 column | `KeyError: 0` | works |
| `pd.DataFrame`, 2 columns | `KeyError: 0` | both columns returned |

Adding the noise to the whole frame fixes both. The values for the case that
used to work are byte-identical - `norm.rvs` with `size=X.shape` draws the same
numbers as `size=len(X)` for a single column and the same `random_state`, which
the tests assert.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- `scale=np.std` is in `_allowed_statistics`, and `np.std` on a DataFrame gives a
  per column `Series`. That now broadcasts per column rather than collapsing to
  one scalar, which I believe is the intended reading of "scale by the standard
  deviation", but it is a behaviour change for multivariate input and worth a
  second opinion.
- Whether `capability:multivariate` should stay `True`. This PR makes the tag
  honest; the alternative would be to set it to `False`.

#### Did you add any tests for the change?

Yes, two in `sktime/transformations/tests/test_augmenter.py`:

- `test_white_noise_augmenter_named_series`, asserting a named series, an
  unnamed series and a DataFrame all give the same values
- `test_white_noise_augmenter_multivariate`, asserting both columns survive and
  both are augmented

Both fail on `main` and pass with this change. `check_estimator` on
`WhiteNoiseAugmenter` is 114 checks, 0 failures.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
