### PR TITLE
[ENH] Add unconditional second test parameter sets for compositors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4150,6 +4150,16 @@
       "contributions": [
         "test"
       ]
+    },
+    {
+      "login": "Anusha0501",
+      "name": "Anusha",
+      "avatar_url": "https://avatars.githubusercontent.com/u/117845601?v=4",
+      "profile": "https://github.com/Anusha0501",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ]
 }

--- a/sktime/classification/ensemble/_weighted.py
+++ b/sktime/classification/ensemble/_weighted.py
@@ -269,6 +269,14 @@ class WeightedEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
         from sktime.classification.kernel_based import RocketClassifier
 
         params0 = {"classifiers": [DummyClassifier()]}
+        # second set is dependency-free and covers iterable weights
+        params0b = {
+            "classifiers": [
+                DummyClassifier(strategy="most_frequent"),
+                DummyClassifier(strategy="prior"),
+            ],
+            "weights": [2, 1],
+        }
 
         ests = [KNeighborsTimeSeriesClassifier, RocketClassifier]
         if _check_estimator_deps(ests, severity="none"):
@@ -288,6 +296,6 @@ class WeightedEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
                 "weights": 2,
                 "cv": 3,
             }
-            return [params0, params1, params2]
+            return [params0, params0b, params1, params2]
         else:
-            return params0
+            return [params0, params0b]

--- a/sktime/clustering/compose/_pipeline.py
+++ b/sktime/clustering/compose/_pipeline.py
@@ -345,16 +345,21 @@ class ClustererPipeline(_HeterogenousMetaEstimator, BaseClusterer):
         c = TimeSeriesDBSCAN.create_test_instance()
 
         params1 = {"transformers": [t1], "clusterer": c}
-        params = params + [params1]
+        # second set is also dependency-free: two transformers, same clusterer
+        params2 = {
+            "transformers": [t1, ExponentTransformer(power=0.5)],
+            "clusterer": TimeSeriesDBSCAN.create_test_instance(),
+        }
+        params = params + [params1, params2]
 
         if _check_estimator_deps(TimeSeriesKMeans, severity="none"):
             t1 = ExponentTransformer(power=2)
             t2 = ExponentTransformer(power=0.5)
             c = TimeSeriesKMeans(random_state=42)
 
-            params2 = {"transformers": [t1, t2], "clusterer": c}
+            params3 = {"transformers": [t1, t2], "clusterer": c}
 
-            params = params + [params2]
+            params = params + [params3]
 
         return params
 

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -156,9 +156,7 @@ EXCLUDED_TESTS_BY_TEST = {
         # The below estimators need to have their name removed from EXCLUDE_SOFT_DEPS
         # too after adding test parameters to them
         "BaggingForecaster",
-        "ClustererPipeline",
         "EnbPIForecaster",
-        "FittedParamExtractor",
         "ForecastingOptunaSearchCV",
         "HFTransformersForecaster",
         "ParamFitterPipeline",
@@ -168,7 +166,6 @@ EXCLUDED_TESTS_BY_TEST = {
         "SupervisedIntervals",
         "TSBootstrapAdapter",
         "ThetaModularForecaster",
-        "WeightedEnsembleClassifier",
     ],
     "test_doctest_examples": [
         # between-versions inconsistency how doctest handles np.float64.
@@ -207,9 +204,7 @@ EXCLUDED_TESTS_BY_TEST = {
 # estimators that have 2 test params only when their soft dependency is installed
 EXCLUDE_SOFT_DEPS = [
     "BaggingForecaster",
-    "ClustererPipeline",
     "EnbPIForecaster",
-    "FittedParamExtractor",
     "ForecastingOptunaSearchCV",
     "HFTransformersForecaster",
     "ParamFitterPipeline",
@@ -219,7 +214,6 @@ EXCLUDE_SOFT_DEPS = [
     "SupervisedIntervals",
     "TSBootstrapAdapter",
     "ThetaModularForecaster",
-    "WeightedEnsembleClassifier",
 ]
 
 # add EXCLUDED_TESTS_BY_TEST to EXCLUDED_TESTS

--- a/sktime/transformations/summarize/_extract.py
+++ b/sktime/transformations/summarize/_extract.py
@@ -520,12 +520,17 @@ class FittedParamExtractor(BaseTransformer):
         from sktime.forecasting.exp_smoothing import ExponentialSmoothing
         from sktime.forecasting.trend import TrendForecaster
 
-        # accessing a nested parameter
+        # accessing a nested parameter via a list of names
         params = [
             {
                 "forecaster": TrendForecaster(),
                 "param_names": ["regressor__intercept"],
-            }
+            },
+            # same dependency-free forecaster, string name path of _check_param_names
+            {
+                "forecaster": TrendForecaster(),
+                "param_names": "regressor__coef",
+            },
         ]
 
         # ExponentialSmoothing requires statsmodels


### PR DESCRIPTION
#### Reference Issues/PRs

- Part of #3429
- See also #1147 (good-first-issue getting started)

**Does not close #3429 or #1147.** Both are umbrella issues with remaining work. This PR completes the #3429 recipe only for:

- `FittedParamExtractor`
- `ClustererPipeline`
- `WeightedEnsembleClassifier`

#### What does this implement/fix? Explain your changes.

Adds a second **unconditional** (dependency-free) `get_test_params` set to three compositors that previously only had two sets when optional deps were installed. After this, `test_get_test_params_coverage` runs for them in every CI environment, not only when statsmodels / numba / rocket are present.

The first parameter set is unchanged so `create_test_instance()` behaviour stays the same.

| Estimator | Why coverage failed | Second unconditional set |
|---|---|---|
| `FittedParamExtractor` | Only `TrendForecaster` + list `param_names` was always available; `ExponentialSmoothing` is gated on statsmodels | Same `TrendForecaster`, `param_names="regressor__coef"` (string path) |
| `ClustererPipeline` | Second set used `TimeSeriesKMeans` (numba) | Two `ExponentTransformer`s + `TimeSeriesDBSCAN.create_test_instance()` |
| `WeightedEnsembleClassifier` | Extra sets used `KNeighborsTimeSeriesClassifier` / `RocketClassifier` | Two `DummyClassifier`s with `weights=[2, 1]` |

Soft-dependency sets are kept as extra entries when those packages are installed.

All three names are removed from:

- `EXCLUDED_TESTS_BY_TEST["test_get_test_params_coverage"]`
- `EXCLUDE_SOFT_DEPS`

in `sktime/tests/_config.py`, as required by the #3429 recipe.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether the second sets are substantially different from the first (`param_names` type, transformer chain length, ensemble weights).
- Whether they stay fast enough (dummy / trend / DBSCAN test instances; no extra deps).
- Scope: these three were in `EXCLUDE_SOFT_DEPS` and were not already claimed in #3429.

#### Did you add any tests for the change?

No new test files. This enables the existing framework tests `test_get_test_params_coverage` and `test_create_test_instance` for the three estimators.

#### Any other comments?

Happy to add more estimators from the remaining `EXCLUDE_SOFT_DEPS` list in a follow-up PR.

#### PR checklist

##### For all contributions
- [x] I've added myself to the list of contributors with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].