### PR TITLE
[DOC] Add SlopeTransformer usage example

### DIFF
--- a/sktime/transformations/slope.py
+++ b/sktime/transformations/slope.py
@@ -25,6 +25,15 @@ class SlopeTransformer(BaseTransformer):
     ----------
     num_intervals : int, number of approx equal segments
                     to split the time series into.
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sktime.transformations.slope import SlopeTransformer
+    >>> X = pd.DataFrame({"a": [pd.Series([1, 2, 3, 4])]})
+    >>> transformer = SlopeTransformer(num_intervals=2)
+    >>> Xt = transformer.fit_transform(X)
+    >>> Xt.iloc[0, 0].round(6).tolist()
+    [1.618034, 1.618034]
     """
 
     _tags = {


### PR DESCRIPTION
#### Reference Issues/PRs

N/A

#### What does this implement/fix? Explain your changes.

This PR adds an illustrative usage example to the `SlopeTransformer` docstring. The example demonstrates how to create a nested pandas DataFrame containing a time series, initialize `SlopeTransformer` with `num_intervals=2`, apply the transformer using `fit_transform`, and access the transformed slope values from the resulting DataFrame. The example produces `[1.618034, 1.618034]`.

#### Does your contribution introduce a new dependency? If yes, which one?

No. This contribution does not introduce any new dependencies.

#### What should a reviewer concentrate their feedback on?

- Correctness of the `SlopeTransformer` usage example.
- Clarity and readability of the example.
- Compliance with the existing sktime docstring and documentation style.

#### Did you add any tests for the change?

No new tests were added because this change only adds documentation to the existing `SlopeTransformer` docstring. The existing SlopeTransformer test suite was run successfully using `py -m pytest sktime/transformations/tests/test_slope_transformer.py`, with all 11 tests passing in 9.42 seconds.

#### Any other comments?

This is a documentation-only change intended to provide a clear, executable usage example for the existing `SlopeTransformer`.

#### PR checklist

##### For all contributions

- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [ ] Optionally, for added estimators: not applicable, as this PR does not add a new estimator.
- [x] The PR title starts with [DOC].

##### For new estimators

Not applicable. This PR does not introduce a new estimator.