### PR TITLE
[DOC] add doctest examples for dummy catalogues

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4150,6 +4150,15 @@
       "contributions": [
         "test"
       ]
+    },
+    {
+      "login": "HuzaifaAbdulRehman",
+      "name": "Huzaifa Abdul Rehman",
+      "avatar_url": "https://avatars.githubusercontent.com/u/143286445?v=4",
+      "profile": "https://github.com/HuzaifaAbdulRehman",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/sktime/catalogues/classification/dummy/_dummy_classification.py
+++ b/sktime/catalogues/classification/dummy/_dummy_classification.py
@@ -7,7 +7,19 @@ from sktime.catalogues.base import BaseCatalogue
 
 
 class DummyClassificationCatalogue(BaseCatalogue):
-    """Dummy catalogue of datasets, classifiers, metrics, and cv."""
+    """Dummy catalogue of datasets, classifiers, metrics, and cv.
+
+    Examples
+    --------
+    >>> from sktime.catalogues import DummyClassificationCatalogue
+    >>> catalogue = DummyClassificationCatalogue()
+    >>> len(catalogue)
+    4
+    >>> "ArrowHead" in catalogue
+    True
+    >>> catalogue.get("dataset")
+    ['ArrowHead']
+    """
 
     _tags = {
         "authors": "jgyasu",

--- a/sktime/catalogues/classification/dummy/_dummy_classification.py
+++ b/sktime/catalogues/classification/dummy/_dummy_classification.py
@@ -19,6 +19,8 @@ class DummyClassificationCatalogue(BaseCatalogue):
     True
     >>> catalogue.get("dataset")
     ['ArrowHead']
+    >>> catalogue.get("dataset", as_object=True)[0].__name__
+    'ArrowHead'
     """
 
     _tags = {

--- a/sktime/catalogues/forecasting/dummy/_dummy_forecasting.py
+++ b/sktime/catalogues/forecasting/dummy/_dummy_forecasting.py
@@ -4,7 +4,19 @@ from sktime.catalogues.base import BaseCatalogue
 
 
 class DummyForecastingCatalogue(BaseCatalogue):
-    """Dummy catalogue of datasets, forecasters, metrics, and cv."""
+    """Dummy catalogue of datasets, forecasters, metrics, and cv.
+
+    Examples
+    --------
+    >>> from sktime.catalogues import DummyForecastingCatalogue
+    >>> catalogue = DummyForecastingCatalogue()
+    >>> len(catalogue)
+    5
+    >>> "Airline" in catalogue
+    True
+    >>> catalogue.get("dataset")
+    ['Airline']
+    """
 
     _tags = {
         "authors": "jgyasu",

--- a/sktime/catalogues/forecasting/dummy/_dummy_forecasting.py
+++ b/sktime/catalogues/forecasting/dummy/_dummy_forecasting.py
@@ -16,6 +16,8 @@ class DummyForecastingCatalogue(BaseCatalogue):
     True
     >>> catalogue.get("dataset")
     ['Airline']
+    >>> catalogue.get("dataset", as_object=True)[0].__name__
+    'Airline'
     """
 
     _tags = {


### PR DESCRIPTION
#### Reference Issues/PRs
Related to #10782

#### What does this implement/fix? Explain your changes.
`DummyForecastingCatalogue` and `DummyClassificationCatalogue` had no `>>>` in the docstring, so they fail `test_class_has_doctest_example`.

I added an `Examples` block on each class. It builds the catalogue, then checks `len`, membership, and `get("dataset")`. Public import, no download, no skip tag to remove.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
Whether the asserted lengths (5 and 4) and dataset names (Airline, ArrowHead) still match `_get`.

#### Did you add any tests for the change?
No new test files.

`pytest --doctest-modules sktime/catalogues/forecasting/dummy/_dummy_forecasting.py sktime/catalogues/classification/dummy/_dummy_classification.py`: 2 passed.

`check_estimator` (`test_class_has_doctest_example`, `test_doctest_examples`): both classes passed.

#### Any other comments?

#### PR checklist
##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
