### PR TITLE
[ENH] Make LSTMFCN TensorFlow conv layers dynamic via filter_sizes and kernel_sizes

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4150,6 +4150,15 @@
       "contributions": [
         "test"
       ]
+    },
+    {
+      "login": "nicolasdmolina",
+      "name": "Nicky Molina",
+      "avatar_url": "https://avatars.githubusercontent.com/u/223382489?v=4",
+      "profile": "https://github.com/nicolasdmolina",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/sktime/classification/deep_learning/lstmfcn/_lstmfcn_tf.py
+++ b/sktime/classification/deep_learning/lstmfcn/_lstmfcn_tf.py
@@ -32,10 +32,16 @@ class LSTMFCNClassifier(BaseDeepClassifier):
         the number of samples per gradient update.
     dropout : float, default=0.8
         controls dropout rate of LSTM layer
-    kernel_sizes : list of ints, default=[8, 5, 3]
-        specifying the length of the 1D convolution windows
-    filter_sizes : int, list of ints, default=[128, 256, 128]
-        size of filter for each conv layer
+    kernel_sizes : list or tuple of int, default=(8, 5, 3)
+        Length of the 1D convolution windows for each convolutional layer.
+        The number of convolutional layers is ``len(kernel_sizes)``.
+        Must have the same length as ``filter_sizes``.
+        Defaults match Karim et al. (2019): three layers with kernels 8, 5, 3.
+    filter_sizes : list or tuple of int, default=(128, 256, 128)
+        Number of filters for each convolutional layer.
+        The number of convolutional layers is ``len(filter_sizes)``.
+        Must have the same length as ``kernel_sizes``.
+        Defaults match Karim et al. (2019): three layers with 128, 256, 128 filters.
     lstm_size : int, default=8
         output dimension for LSTM layer
     attention : boolean, default=False
@@ -260,7 +266,23 @@ class LSTMFCNClassifier(BaseDeepClassifier):
             "lstm_size": 2,
             "attention": True,
         }
-        test_params = [param1, param2]
+
+        # Dynamic number of conv layers via list inputs
+        param3 = {
+            "n_epochs": 8,
+            "batch_size": 4,
+            "kernel_sizes": [3, 2],
+            "filter_sizes": [2, 4],
+        }
+
+        # Dynamic number of conv layers via tuple inputs
+        param4 = {
+            "n_epochs": 8,
+            "batch_size": 4,
+            "kernel_sizes": (3, 2),
+            "filter_sizes": (2, 4),
+        }
+        test_params = [param1, param2, param3, param4]
 
         if _check_soft_dependencies("keras", severity="none"):
             from keras.callbacks import LambdaCallback

--- a/sktime/networks/lstmfcn/_lstmfcn_tf.py
+++ b/sktime/networks/lstmfcn/_lstmfcn_tf.py
@@ -13,10 +13,16 @@ class LSTMFCNNetwork(BaseDeepNetwork):
 
     Parameters
     ----------
-    kernel_sizes : tuple of int, default=(8, 5, 3)
-        Length of the 1D convolution windows.
-    filter_sizes : tuple of int, default=(128, 256, 128)
-        Size of filter for each conv layer.
+    kernel_sizes : list or tuple of int, default=(8, 5, 3)
+        Length of the 1D convolution windows for each convolutional layer.
+        The number of convolutional layers is ``len(kernel_sizes)``.
+        Must have the same length as ``filter_sizes``.
+        Defaults match Karim et al. (2019): three layers with kernels 8, 5, 3.
+    filter_sizes : list or tuple of int, default=(128, 256, 128)
+        Number of filters for each convolutional layer.
+        The number of convolutional layers is ``len(filter_sizes)``.
+        Must have the same length as ``kernel_sizes``.
+        Defaults match Karim et al. (2019): three layers with 128, 256, 128 filters.
     random_state : int, default=0
         Seed for any needed random actions.
     lstm_size : int, default=8
@@ -44,7 +50,7 @@ class LSTMFCNNetwork(BaseDeepNetwork):
     --------
     >>> from sktime.networks.lstmfcn import LSTMFCNNetwork
     >>> network = LSTMFCNNetwork(
-    ...     kernel_sizes=(8, 5, 3), filter_sizes=(64, 128, 64), random_state=42
+    ...     kernel_sizes=(5, 3), filter_sizes=(64, 128), random_state=42
     ... )
     """
 
@@ -74,6 +80,33 @@ class LSTMFCNNetwork(BaseDeepNetwork):
 
         super().__init__()
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+        """
+        if not isinstance(self.filter_sizes, (list, tuple)):
+            raise ValueError(
+                f"filter_sizes must be a list or tuple, "
+                f"but got type {type(self.filter_sizes)}."
+            )
+        if not isinstance(self.kernel_sizes, (list, tuple)):
+            raise ValueError(
+                f"kernel_sizes must be a list or tuple, "
+                f"but got type {type(self.kernel_sizes)}."
+            )
+        if len(self.filter_sizes) != len(self.kernel_sizes):
+            raise ValueError(
+                f"filter_sizes and kernel_sizes must have the same length, "
+                f"but got {len(self.filter_sizes)} and {len(self.kernel_sizes)}."
+            )
+
+        super().__post_init__()
+
     def build_network(self, input_shape, **kwargs):
         """Construct a network and return its input and output layers.
 
@@ -99,32 +132,16 @@ class LSTMFCNNetwork(BaseDeepNetwork):
         x = keras.layers.LSTM(self.lstm_size)(x)
         x = keras.layers.Dropout(self.dropout)(x)
 
-        y = keras.layers.Conv1D(
-            self.filter_sizes[0],
-            self.kernel_sizes[0],
-            padding="same",
-            kernel_initializer="he_uniform",
-        )(input_layer)
-        y = keras.layers.BatchNormalization()(y)
-        y = keras.layers.Activation(self.activation)(y)
-
-        y = keras.layers.Conv1D(
-            self.filter_sizes[1],
-            self.kernel_sizes[1],
-            padding="same",
-            kernel_initializer="he_uniform",
-        )(y)
-        y = keras.layers.BatchNormalization()(y)
-        y = keras.layers.Activation(self.activation)(y)
-
-        y = keras.layers.Conv1D(
-            self.filter_sizes[2],
-            self.kernel_sizes[2],
-            padding="same",
-            kernel_initializer="he_uniform",
-        )(y)
-        y = keras.layers.BatchNormalization()(y)
-        y = keras.layers.Activation(self.activation)(y)
+        y = input_layer
+        for i in range(len(self.filter_sizes)):
+            y = keras.layers.Conv1D(
+                self.filter_sizes[i],
+                self.kernel_sizes[i],
+                padding="same",
+                kernel_initializer="he_uniform",
+            )(y)
+            y = keras.layers.BatchNormalization()(y)
+            y = keras.layers.Activation(self.activation)(y)
 
         y = keras.layers.GlobalAveragePooling1D()(y)
 
@@ -168,6 +185,16 @@ class LSTMFCNNetwork(BaseDeepNetwork):
                 "attention": False,
             },
             {},
+            # Dynamic number of conv layers via list inputs
+            {
+                "kernel_sizes": [5, 3],
+                "filter_sizes": [64, 128],
+            },
+            # Dynamic number of conv layers via tuple inputs
+            {
+                "kernel_sizes": (5, 3),
+                "filter_sizes": (64, 128),
+            },
         ]
 
         return params

--- a/sktime/regression/deep_learning/lstmfcn/_lstmfcn_tf.py
+++ b/sktime/regression/deep_learning/lstmfcn/_lstmfcn_tf.py
@@ -26,10 +26,16 @@ class LSTMFCNRegressor(BaseDeepRegressor):
         the number of samples per gradient update.
     dropout : float, default=0.8
         controls dropout rate of LSTM layer
-    kernel_sizes : list of ints, default=[8, 5, 3]
-        specifying the length of the 1D convolution windows
-    filter_sizes : int, list of ints, default=[128, 256, 128]
-        size of filter for each conv layer
+    kernel_sizes : list or tuple of int, default=(8, 5, 3)
+        Length of the 1D convolution windows for each convolutional layer.
+        The number of convolutional layers is ``len(kernel_sizes)``.
+        Must have the same length as ``filter_sizes``.
+        Defaults match Karim et al. (2019): three layers with kernels 8, 5, 3.
+    filter_sizes : list or tuple of int, default=(128, 256, 128)
+        Number of filters for each convolutional layer.
+        The number of convolutional layers is ``len(filter_sizes)``.
+        Must have the same length as ``kernel_sizes``.
+        Defaults match Karim et al. (2019): three layers with 128, 256, 128 filters.
     lstm_size : int, default=8
         output dimension for LSTM layer
     attention : boolean, default=False
@@ -248,7 +254,23 @@ class LSTMFCNRegressor(BaseDeepRegressor):
             "lstm_size": 2,
             "attention": True,
         }
-        test_params = [param1, param2]
+
+        # Dynamic number of conv layers via list inputs
+        param3 = {
+            "n_epochs": 8,
+            "batch_size": 4,
+            "kernel_sizes": [3, 2],
+            "filter_sizes": [2, 4],
+        }
+
+        # Dynamic number of conv layers via tuple inputs
+        param4 = {
+            "n_epochs": 8,
+            "batch_size": 4,
+            "kernel_sizes": (3, 2),
+            "filter_sizes": (2, 4),
+        }
+        test_params = [param1, param2, param3, param4]
 
         if _check_soft_dependencies("keras", severity="none"):
             from keras.callbacks import LambdaCallback


### PR DESCRIPTION
LLM generated content, by Grok 4.6

#### Reference Issues/PRs
Related to #9340. Follows the TensorFlow FCN change in #9618 and the PyTorch LSTM-FCN loop over `filter_sizes`.

Does not close #9340; that issue covers multiple TensorFlow networks. This PR is LSTMFCN only.

#### What does this implement/fix? Explain your changes.
The TensorFlow LSTM-FCN CNN arm still built exactly three `Conv1D` blocks by indexing `filter_sizes[0]/[1]/[2]` and `kernel_sizes[0]/[1]/[2]`. Passing a shorter or longer list crashed or silently ignored extra values.

This PR makes the number of convolutional layers `len(filter_sizes)` / `len(kernel_sizes)`:

- `LSTMFCNNetwork.build_network` loops over those sequences, same pattern as TensorFlow FCN and PyTorch LSTM-FCN.
- Defaults stay `kernel_sizes=(8, 5, 3)` and `filter_sizes=(128, 256, 128)` from Karim et al. (2019), so the previous 3-layer network is unchanged.
- `__post_init__` validates list/tuple types and equal lengths.
- `LSTMFCNClassifier` and `LSTMFCNRegressor` already accepted these params and pass them through; their docstrings now describe that length sets the layer count, and `get_test_params` covers 2-layer list and tuple configs.

No new `n_layers` parameter: layer count is inferred from the existing sequences, matching maintainer guidance on #9340.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- The conv loop in `sktime/networks/lstmfcn/_lstmfcn_tf.py` and whether default 3-layer behaviour is preserved.
- Validation in `LSTMFCNNetwork.__post_init__`.
- That classifier/regressor only document and test the already-exposed params (one model, one PR).

#### Did you add any tests for the change?
Yes. `get_test_params` on the network, classifier, and regressor now include 2-layer list and tuple settings in addition to the existing 3-layer defaults.

Local verification:
- `check_estimator(LSTMFCNNetwork)`: 59 tests passed
- Default network still has 3 `Conv1D` layers with filters `[128, 256, 128]` and kernels `(8, 5, 3)`
- 2-layer list/tuple configs build 2 `Conv1D` layers
- Mismatched or non-sequence sizes raise `ValueError`
- `LSTMFCNClassifier` / `LSTMFCNRegressor` constructor, clone, get/set params
- Fit/predict on `load_unit_test` with 2-layer configs
- pre-commit (ruff format/check and related hooks) on the changed files

#### Any other comments?
Claimed LSTMFCN on #9340. Other models already in progress (MACNN, ResNet, MCDCNN, CNTC) are untouched.

#### PR checklist
##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] I've added the estimator to the API reference
- [ ] I've added one or more illustrative usage examples to the docstring
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag