### PR TITLE
[BUG] fix ClaSP ROC-AUC trapezoid integration for numpy 2 and numba

### DIFF
--- a/sktime/transformations/_clasp_numba.py
+++ b/sktime/transformations/_clasp_numba.py
@@ -4,7 +4,6 @@ __author__ = ["ermshaua", "patrickzib"]
 
 import numpy as np
 import pandas as pd
-from skbase.utils.dependencies import _check_soft_dependencies
 
 from sktime.transformations.matrix_profile._mp_features import _sliding_dot_products
 from sktime.utils.numba.njit import njit
@@ -205,9 +204,6 @@ def _binary_f1_score(y_true, y_pred):
     return np.mean(f1_scores)
 
 
-NUMPY1 = _check_soft_dependencies("numpy<2", severity="none")
-
-
 @njit(fastmath=True, cache=True)
 def _roc_auc_score(y_score, y_true):
     """Compute roc-auc score.
@@ -266,12 +262,9 @@ def _roc_auc_score(y_score, y_true):
         else:
             return np.nan
 
-    if NUMPY1:
-        trapz = np.trapz
-    else:
-        trapz = np.trapezoid
-
-    area = direction * trapz(tpr, fpr)
+    # Manual trapezoid rule: numba cannot compile np.trapz (removed in
+    # numpy 2) nor np.trapezoid, so integrate with basic ops it supports.
+    area = direction * np.sum((tpr[1:] + tpr[:-1]) * np.diff(fpr) / 2.0)
     return area
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10759.

#### What does this implement/fix? Explain your changes.
Hi, ran into this while trying `ClaSPTransformer` with default settings on numpy 2 - `fit_transform` was blowing up in the ROC-AUC helper.

Turns out `_roc_auc_score` in `sktime/transformations/_clasp_numba.py` is `njit`-compiled, and it was switching between `np.trapz` and `np.trapezoid` based on the numpy version. That doesn't hold up: `np.trapz` is gone in numpy 2, and numba can't compile `np.trapezoid` either, so both paths fail under `njit`.

I replaced the call with the trapezoid rule written out using basic ops numba already supports elsewhere in the same function (`np.sum`, `np.diff`, slicing):

```python
area = direction * np.sum((tpr[1:] + tpr[:-1]) * np.diff(fpr) / 2.0)
```

Checked it against `np.trapezoid` on a quick example and it matches. Also dropped the now-unused `NUMPY1` flag and the `skbase` import since nothing else in the file needed them.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
Mainly whether the manual integration reads clearly and whether you'd prefer it pulled into a small helper. Happy to adjust the comment wording if it's too verbose.

#### Did you add any tests for the change?
I verified the file compiles and the manual formula matches `np.trapezoid` on a sample curve. I haven't added a dedicated unit test here since the existing ClaSP tests cover `fit_transform` end to end - let me know if you'd like a small regression test for the ROC-AUC path and I'll add it.

#### Any other comments?
Thanks for maintaining sktime - happy to address any feedback.

#### PR checklist
##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix
