### PR TITLE
[BUG] fix HyperTreeNetARForecaster FutureWarning for PeriodIndex freq aliases

### DIFF
--- a/sktime/forecasting/hypertrees.py
+++ b/sktime/forecasting/hypertrees.py
@@ -157,6 +157,18 @@ class HyperTreeNetARForecaster(BaseForecaster):
             except ValueError:
                 freq = None
         self._freq = freq or "MS"
+        # Period aliases (M, Q, Y, A, Q-DEC, ...) are deprecated for
+        # pd.date_range, map to start-of-period equivalents.
+        if "-" in self._freq:
+            _base, _, _suffix = self._freq.partition("-")
+            _base = {"M": "MS", "Q": "QS", "Y": "YS", "A": "YS"}.get(
+                _base, _base
+            )
+            self._freq = _base + "-" + _suffix
+        else:
+            self._freq = {"M": "MS", "Q": "QS", "Y": "YS", "A": "YS"}.get(
+                self._freq, self._freq
+            )
         fcst_h = int(np.max(fh.to_relative(self.cutoff)._values))
         self._dates = pd.date_range(
             "2000-01-01", periods=self._train_len + fcst_h, freq=self._freq


### PR DESCRIPTION
Fixes #11072.

Ran into the FutureWarning when fitting on monthly PeriodIndex data like load_airline - freqstr gives M which date_range no longer likes.

This maps the period aliases to their start-of-period equivalents before calling date_range, including compound ones like Q-DEC and A-JAN. Went with start (MS/QS/YS) to match what hypertrees already does internally in TimeSeriesPreprocessor.

Checked that M, Q, Y, A, Q-DEC, A-JAN etc no longer warn and MS/QS/YS paths are unchanged. Could not run the full forecaster test locally since hypertrees-forecasting is not installed here, so relying on CI for that.