### PR TITLE
[MNT] fix `skpro>=2` in notebook dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,7 @@ notebooks = [
   "pytorch-forecasting",
   "torch",
   "lightning>=2.0,<2.7",
-  "skpro",
+  "skpro>=2,<2.15.0",
   "statsforecast",
   'numba<0.68',
 ]
@@ -255,7 +255,7 @@ pandas1 = [
   "pandas<2.0.0",
 ]
 skpro = [
-  "skpro",
+  "skpro>=2,<2.15.0",
 ]
 compatibility_tests = [
   'catboost; python_version < "3.13"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,7 @@ notebooks = [
   "pytorch-forecasting",
   "torch",
   "lightning>=2.0,<2.7",
-  "skpro>=2,<2.15.0",
+  "skpro>=2",
   "statsforecast",
   'numba<0.68',
 ]
@@ -255,7 +255,7 @@ pandas1 = [
   "pandas<2.0.0",
 ]
 skpro = [
-  "skpro>=2,<2.15.0",
+  "skpro>=2",
 ]
 compatibility_tests = [
   'catboost; python_version < "3.13"',


### PR DESCRIPTION
### Summary
This PR aligns `skpro` version constraints across `pyproject.toml` to remove inconsistent resolver behavior in notebook and dependency-based environments.

## Why
The current dependency sets do not all express the same `skpro` minimum version. In practice, notebook environments may still resolve `skpro` without an explicit floor, which can lead to inconsistent or outdated installs across Python versions and dependency combinations.

## Changes
- Pin `skpro>=2` in the `notebooks` in `pyproject.toml` optional dependency set.
- Align the direct `skpro`  in `pyproject.toml` extra with `skpro>=2`.
- Keep the existing constraints in `forecasting` and `all_extras` consistent with the project’s supported `skpro` range.

## Verification
- Reinstalled notebook dependencies from a clean environment.
- Confirmed `uv pip list` resolves `skpro` to a `2.x` release.
- Ran notebook/example execution successfully after the dependency update.

## Related issue
Fixes #11080 











