### PR TITLE
 [DOC/ENH] Warn when loading estimators saved with a different sktime version (#10579)

### DIFF
--- a/sktime/base/_base.py
+++ b/sktime/base/_base.py
@@ -297,6 +297,10 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
 
         from skbase.utils.dependencies import _check_soft_dependencies
 
+        import sktime
+
+        self._sktime_version = sktime.__version__
+
         if serialization_format not in SERIALIZATION_FORMATS:
             raise ValueError(
                 f"The provided `serialization_format`='{serialization_format}' "
@@ -352,7 +356,9 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         """
         import pickle
 
-        return pickle.loads(serial)
+        obj = pickle.loads(serial)
+        _check_loaded_version(obj)
+        return obj
 
     @classmethod
     def load_from_path(cls, serial):
@@ -370,7 +376,29 @@ class BaseObject(_HTMLDocumentationLinkMixin, _BaseObject):
         from zipfile import ZipFile
 
         with ZipFile(serial, "r") as file:
-            return pickle.loads(file.open("_obj").read())
+            obj = pickle.loads(file.open("_obj").read())
+        _check_loaded_version(obj)
+        return obj
+
+
+def _check_loaded_version(obj):
+    import warnings
+
+    import sktime
+
+    saved_version = getattr(obj, "_sktime_version", None)
+    current_version = sktime.__version__
+
+    if saved_version != current_version:
+        saved_ver_str = saved_version if saved_version is not None else "unknown (<1.1.0)"
+        warnings.warn(
+            f"The loaded estimator was saved using sktime version '{saved_ver_str}', "
+            f"which differs from the current sktime version '{current_version}'. "
+            "Loading estimators saved with a different sktime version is not guaranteed "
+            "to be compatible and may produce invalid estimators or unexpected behavior.",
+            UserWarning,
+            stacklevel=3,
+        )
 
 
 # todo 1.2.0: remove this class from inheritance in BaseObject

--- a/sktime/base/tests/test_base.py
+++ b/sktime/base/tests/test_base.py
@@ -566,3 +566,25 @@ def test_eq_dunder_checks_class():
 
     # comparison against a non-BaseObject must not raise, and must be unequal
     assert unrelated_1 != 42
+
+
+def test_save_load_version_warning():
+    """Test that a UserWarning is issued when loading an object saved under a different version."""
+    import pytest
+
+    from sktime.base import load
+
+    dummy = CompositionDummy(foo=42)
+    pkl = dummy.save()
+
+    # Loading under the same version should emit no warning
+    loaded = load(pkl)
+    assert loaded.foo == 42
+
+    # Simulate object saved under a different version
+    dummy._sktime_version = "0.0.1"
+    pkl_old = (type(dummy), dummy.save()[1])
+
+    with pytest.warns(UserWarning, match="differs from the current sktime version"):
+        loaded_old = load(pkl_old)
+        assert loaded_old.foo == 42


### PR DESCRIPTION
 ## Summary
Resolves #10579. Emits a `UserWarning` when deserializing an estimator whose saved `sktime`  version differs from `sktime.__version__` of the current runtime environment.

## Changes
 - Stored `_sktime_version` attribute on `BaseObject` during `save()`.
 - Added `_check_loaded_version()` helper called inside `load_from_serial()` and `load_from_path()`.
- Added unit test `test_save_load_version_warning` in `sktime/base/tests/test_base.py`.