### PR TITLE
[ENH] "safe" mode in `craft` utility

### DIFF
--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -86,7 +86,8 @@ def craft(spec, safe=False):
     
     .. code-block:: text
 
-        expression ::= NAME | NAME "(" arguments ")"
+        expression ::= NAME | NAME "(" arguments ")" | expression BINOP expression
+                        | UNARYOP expression
 
         arguments  ::= positional_argument | keyword_argument| arguments "," arguments
 
@@ -99,6 +100,8 @@ def craft(spec, safe=False):
 
         NAME       ::= valid Python identifier, object name in ``sktime`` or ``sklearn``
         CONSTANT   ::= literal value (e.g., number, string, boolean)
+        BINOP      ::= valid Python binary operator (e.g., +, -, *, /)
+        UNARYOP    ::= valid Python unary operator (e.g., +, -, ~)
 
     This permits simple constructor calls such as ``A(a=42)``,
     or nested constructor calls such as ``A(a=42, b=B("test"))``, and only such calls.
@@ -190,7 +193,7 @@ def craft(spec, safe=False):
         try:
             obj = eval(
                 compile(expr_tree, "<craft>", "eval"),
-                {"__builtins__": {}},
+                {"__builtins__": {}} if safe else globals(),
                 register,
             )
         except Exception as e:
@@ -199,8 +202,8 @@ def craft(spec, safe=False):
                     "Error in craft utility: failed to evaluate specification: "
                     f"{spec}"
                 ) from e
-
-        return obj
+        else:
+            return obj
 
     elif safe:
         raise ValueError(
@@ -231,7 +234,7 @@ def _validate_ast(tree, register):
 
     The accepted grammar is intentionally small:
 
-        expression ::= NAME | NAME "(" arguments ")"
+        expression ::= NAME | NAME "(" arguments ")" | expression OP expression
 
         arguments  ::= positional_argument | keyword_argument| arguments "," arguments
 

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -202,6 +202,12 @@ def craft(spec, safe=False):
 
         return obj
 
+    elif safe:
+        raise ValueError(
+            "Error in craft utility: safe mode requires a single expression, "
+            f"but got a block of code: {spec}"
+        )
+
     else:
         # unsafe mode: attempt to execute the specification directly
         from textwrap import indent

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -280,6 +280,16 @@ def _validate_ast(tree, register):
     if isinstance(tree, ast.Constant):
         return True
 
+    # Literal containers are also safe provided all nested elements are safe.
+    if isinstance(tree, (ast.List, ast.Tuple, ast.Set)):
+        return all(_validate_ast(elt, reg) for elt in tree.elts)
+
+    if isinstance(tree, ast.Dict):
+        return all(
+            _validate_ast(key, reg) and _validate_ast(value, reg)
+            for key, value in zip(tree.keys, tree.values)
+        )
+
     # binary and unary operators (dunder operations)
     # are allowed, since this is how we can build pipelines
     allowed_binops = (

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -205,7 +205,7 @@ def craft(spec, safe=False):
         else:
             return obj
 
-    elif safe:
+    if safe:
         raise ValueError(
             "Error in craft utility: safe mode requires a single expression, "
             f"but got a block of code: {spec}"

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -259,9 +259,7 @@ def _validate_ast(tree, register):
     # available for variables. In particular, don't permit dunder names.
     if isinstance(tree, ast.Name):
         if tree.id.startswith("__") or tree.id not in register:
-            raise ValueError(
-                f"unsafe or unknown name in specification: {tree.id!r}"
-            )
+            return False
         return True
 
     # Constants are safe as values.
@@ -296,17 +294,13 @@ def _validate_ast(tree, register):
 
     if isinstance(tree, ast.BinOp):
         if not isinstance(tree.op, allowed_binops):
-            raise ValueError(
-                f"unsafe binary operator: {type(tree.op).__name__}"
-            )
+            return False
         _validate_ast(tree.left, register)
         _validate_ast(tree.right, register)
 
     elif isinstance(tree, ast.UnaryOp):
         if not isinstance(tree.op, allowed_unaryops):
-            raise ValueError(
-                f"unsafe unary operator: {type(tree.op).__name__}"
-            )
+            return False
         _validate_ast(tree.operand, register)
 
     if isinstance(tree, ast.Call):
@@ -317,9 +311,7 @@ def _validate_ast(tree, register):
         #   getattr(...)(...)
         #   (lambda: ...)(...)
         if not isinstance(tree.func, ast.Name):
-            raise ValueError(
-                "safe specifications only allow direct constructor calls"
-            )
+            return False
 
         _validate_ast(tree.func, register)
 
@@ -329,7 +321,7 @@ def _validate_ast(tree, register):
         for kw in tree.keywords:
             # **kwargs is represented by keyword.arg == None.
             if kw.arg is None:
-                raise ValueError("**kwargs are not allowed in safe specifications")
+                return False
             _validate_ast(kw.value, register)
 
         return True

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -78,9 +78,9 @@ def craft(spec, safe=False):
     unfitted estimator.
 
     ``craft`` recognizes estimators present in ``sktime`` and ``scikit-learn``,
-    and base python.
+    and base python (built-in types and functions).
 
-    If ``safe=True`` mode is enabld, only simple propositional expressions are allowed.
+    If ``safe=True`` mode is enabled, only simple propositional expressions are allowed.
 
     The accepted "safe" grammar is intentionally small:
     
@@ -97,7 +97,7 @@ def craft(spec, safe=False):
 
     .. code-block:: text
 
-        NAME       ::= valid Python identifier, object name in ``sktime`` or ``skpro``
+        NAME       ::= valid Python identifier, object name in ``sktime`` or ``sklearn``
         CONSTANT   ::= literal value (e.g., number, string, boolean)
 
     This permits simple constructor calls such as ``A(a=42)``,
@@ -256,6 +256,14 @@ def _validate_ast(tree, register):
     # if Expression, obtain node
     if isinstance(tree, ast.Expression):
         tree = tree.body
+
+        # The safe form must be a single expression.
+        if len(tree) != 1:
+            return False
+        tree = tree[0]
+        if not isinstance(tree, ast.Expr):
+            return False
+        tree = tree.value
 
     # Only names explicitly supplied in the estimator registry are
     # available for variables. In particular, don't permit dunder names.

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -251,6 +251,8 @@ def _validate_ast(tree, register):
     if not isinstance(tree, ast.Expression):
         raise ValueError("safe specification is not a valid expression")
 
+    reg = register  # for shorter expressions below
+
     # if Expression, obtain node
     if isinstance(tree, ast.Expression):
         tree = tree.body
@@ -258,9 +260,7 @@ def _validate_ast(tree, register):
     # Only names explicitly supplied in the estimator registry are
     # available for variables. In particular, don't permit dunder names.
     if isinstance(tree, ast.Name):
-        if tree.id.startswith("__") or tree.id not in register:
-            return False
-        return True
+        return tree.id in reg and not tree.id.startswith("__")
 
     # Constants are safe as values.
     # In particular, this allows strings, numbers, booleans, None, etc.
@@ -295,18 +295,14 @@ def _validate_ast(tree, register):
     if isinstance(tree, ast.BinOp):
         if not isinstance(tree.op, allowed_binops):
             return False
-        if not _validate_ast(tree.left, register):
-            return False
-        if not _validate_ast(tree.right, register):
-            return False
+        return _validate_ast(tree.left, reg) and _validate_ast(tree.right, reg)
 
     elif isinstance(tree, ast.UnaryOp):
         if not isinstance(tree.op, allowed_unaryops):
             return False
-        if not _validate_ast(tree.operand, register):
-            return False
+        return _validate_ast(tree.operand, reg)
 
-    if isinstance(tree, ast.Call):
+    elif isinstance(tree, ast.Call):
         # Only direct calls such as A(...) are allowed.
         #
         # This deliberately rejects:
@@ -316,18 +312,18 @@ def _validate_ast(tree, register):
         if not isinstance(tree.func, ast.Name):
             return False
 
-        if not _validate_ast(tree.func, register):
+        if not _validate_ast(tree.func, reg):
             return False
 
         for arg in tree.args:
-            if not _validate_ast(arg, register):
+            if not _validate_ast(arg, reg):
                 return False
 
         for kw in tree.keywords:
             # **kwargs is represented by keyword.arg == None.
             if kw.arg is None:
                 return False
-            if not _validate_ast(kw.value, register):
+            if not _validate_ast(kw.value, reg):
                 return False
 
         return True

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -328,6 +328,8 @@ def _validate_ast(tree, register):
 
         return True
 
+    # the above is an exhaustive list of what is allowed
+    # hence, if we reach this point, the AST contains an unsupported node type
     return False
 
 

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -20,7 +20,6 @@ will have the same effect as new_est = spec.clone()
 __author__ = ["fkiraly"]
 
 import ast
-from platform import node
 import re
 
 from sktime.registry._lookup import all_estimators

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -19,6 +19,8 @@ will have the same effect as new_est = spec.clone()
 
 __author__ = ["fkiraly"]
 
+import ast
+from platform import node
 import re
 
 from sktime.registry._lookup import all_estimators
@@ -51,7 +53,7 @@ def _extract_class_names(spec):
     return cls_name_list
 
 
-def craft(spec):
+def craft(spec, safe=False):
     """Instantiate an object from the specification string.
 
     The ``craft`` utility can be used to deserialize an estimator specification string,
@@ -79,6 +81,33 @@ def craft(spec):
     ``craft`` recognizes estimators present in ``sktime`` and ``scikit-learn``,
     and base python.
 
+    If ``safe=True`` mode is enabld, only simple propositional expressions are allowed.
+
+    The accepted "safe" grammar is intentionally small:
+    
+    .. code-block:: text
+
+        expression ::= NAME | NAME "(" arguments ")"
+
+        arguments  ::= positional_argument | keyword_argument| arguments "," arguments
+
+        positional_argument ::= expression | CONSTANT
+        keyword_argument    ::= NAME "=" (expression | CONSTANT)
+
+    Where
+
+    .. code-block:: text
+
+        NAME       ::= valid Python identifier, object name in ``sktime`` or ``skpro``
+        CONSTANT   ::= literal value (e.g., number, string, boolean)
+
+    This permits simple constructor calls such as ``A(a=42)``,
+    or nested constructor calls such as ``A(a=42, b=B("test"))``, and only such calls.
+
+    In particular, does not permit attribute access, lambdas, comprehensions, operators,
+    imports, assignments, function calls through arbitrary expressions, etc,
+    which are "unsafe" in the sense of allowing arbitrary code injection.
+
     Parameters
     ----------
     spec : str, sktime/skbase compatible object specification
@@ -88,7 +117,15 @@ def craft(spec):
         * option 1: a string that evaluates to an estimator
         * option 2: a sequence of assignments in valid python code,
           with the object to be defined preceded by a "return".
-          assignments can use names of classes as if all imports were present
+          assignments can use names of classes as if all imports were present.
+          Option 2 is not available in ``safe=True`` mode.
+
+    safe : bool, optional (default=False)
+        whether to enforce safe expressions according to the safe specification rules.
+    
+        * if True, only allow safe expressions according to the safe specification
+          rules, see above for the exact rules.
+        * if False, allow all expressions (default behavior).
 
     Returns
     -------
@@ -135,9 +172,35 @@ def craft(spec):
     register_sklearn = dict(_all_sklearn_estimators())  # noqa: F841
     register = {**register_sklearn, **register_sktime}
 
+    # Parse the specification once.
+    # Both safe and unsafe modes operate on the resulting AST.
+    tree = ast.parse(spec, mode="exec")
+
+    # safe mode: validate the AST before evaluation
+    if safe and not _validate_ast(tree, register):
+        raise ValueError(
+            "Error in craft utility: unsafe or invalid specification supplied: "
+            f"{spec}"
+        )
+
+    expr = tree.body[0].value
+    expr_tree = ast.Expression(body=expr)
+    ast.fix_missing_locations(expr_tree)
+
     try:
-        obj = eval(spec, globals(), register)
-    except Exception:
+        obj = eval(
+            compile(expr_tree, "<craft>", "eval"),
+            {"__builtins__": {}},
+            register,
+        )
+    except Exception as e:
+        if safe:
+            raise ValueError(
+                "Error in craft utility: failed to evaluate specification: "
+                f"{spec}"
+            ) from e
+
+        # unsafe mode: attempt to execute the specification directly
         from textwrap import indent
 
         spec_fun = indent(spec, "    ")
@@ -152,6 +215,87 @@ def build_obj():
         obj = eval("build_obj()", register, register)
 
     return obj
+
+
+def _validate_ast(tree, register):
+    """Validate that ``spec`` contains only safe constructor expressions.
+
+    The accepted grammar is intentionally small:
+
+        expression ::= NAME | NAME "(" arguments ")"
+
+        arguments  ::= positional_argument | keyword_argument| arguments "," arguments
+
+        positional_argument ::= expression | CONSTANT
+        keyword_argument    ::= NAME "=" (expression | CONSTANT)
+
+    This permits nested constructor calls such as:
+
+        A(a=42, b=B("test"))
+
+    and only such calls.
+    In particular, does not permit attribute access, lambdas, comprehensions, operators,
+    imports, assignments, function calls through arbitrary expressions, etc.
+
+    Parameters
+    ----------
+    tree : ast.Expression or ast.AST
+        The abstract syntax tree of the specification to validate.
+    register : dict
+        The registry of allowed names (estimators, methods, variables) for validation.
+
+    Returns
+    -------
+    bool
+        True if the AST is valid according to the safe spec rules, False otherwise.
+    """
+    if not isinstance(tree, ast.Expression):
+        raise ValueError("safe specification is not a valid expression")
+
+    # if Expression, obtain node
+    if isinstance(tree, ast.Expression):
+        tree = tree.body
+
+    if isinstance(tree, ast.Name):
+        # Only names explicitly supplied in the estimator registry are
+        # available. In particular, don't permit dunder names.
+        if tree.id.startswith("__") or tree.id not in register:
+            raise ValueError(
+                f"unsafe or unknown name in specification: {tree.id!r}"
+            )
+        return True
+
+    if isinstance(tree, ast.Constant):
+        # Constants are safe as values. In particular, this allows strings,
+        # numbers, booleans, None, etc.
+        return True
+
+    if isinstance(tree, ast.Call):
+        # Only direct calls such as A(...) are allowed.
+        #
+        # This deliberately rejects:
+        #   obj.A(...)
+        #   getattr(...)(...)
+        #   (lambda: ...)(...)
+        if not isinstance(tree.func, ast.Name):
+            raise ValueError(
+                "safe specifications only allow direct constructor calls"
+            )
+
+        _validate_ast(tree.func, register)
+
+        for arg in tree.args:
+            _validate_ast(arg, register)
+
+        for kw in tree.keywords:
+            # **kwargs is represented by keyword.arg == None.
+            if kw.arg is None:
+                raise ValueError("**kwargs are not allowed in safe specifications")
+            _validate_ast(kw.value, register)
+
+        return True
+
+    return False
 
 
 def deps(spec, include_test_deps=False):

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -182,23 +182,27 @@ def craft(spec, safe=False):
             f"{spec}"
         )
 
-    expr = tree.body[0].value
-    expr_tree = ast.Expression(body=expr)
-    ast.fix_missing_locations(expr_tree)
+    if len(tree.body) == 1 and isinstance(tree.body[0], ast.Expr):
+        expr = tree.body[0].value
+        expr_tree = ast.Expression(body=expr)
+        ast.fix_missing_locations(expr_tree)
 
-    try:
-        obj = eval(
-            compile(expr_tree, "<craft>", "eval"),
-            {"__builtins__": {}},
-            register,
-        )
-    except Exception as e:
-        if safe:
-            raise ValueError(
-                "Error in craft utility: failed to evaluate specification: "
-                f"{spec}"
-            ) from e
+        try:
+            obj = eval(
+                compile(expr_tree, "<craft>", "eval"),
+                {"__builtins__": {}},
+                register,
+            )
+        except Exception as e:
+            if safe:
+                raise ValueError(
+                    "Error in craft utility: failed to evaluate specification: "
+                    f"{spec}"
+                ) from e
 
+        return obj
+
+    else:
         # unsafe mode: attempt to execute the specification directly
         from textwrap import indent
 
@@ -248,22 +252,14 @@ def _validate_ast(tree, register):
     bool
         True if the AST is valid according to the safe spec rules, False otherwise.
     """
-    if not isinstance(tree, ast.Expression):
-        raise ValueError("safe specification is not a valid expression")
-
     reg = register  # for shorter expressions below
 
-    # if Expression, obtain node
-    if isinstance(tree, ast.Expression):
-        tree = tree.body
-
-        # The safe form must be a single expression.
-        if len(tree) != 1:
-            return False
-        tree = tree[0]
-        if not isinstance(tree, ast.Expr):
-            return False
-        tree = tree.value
+    if isinstance(tree, ast.Module):
+        return (
+            len(tree.body) == 1
+            and isinstance(tree.body[0], ast.Expr)
+            and _validate_ast(tree.body[0].value, reg)
+        )
 
     # Only names explicitly supplied in the estimator registry are
     # available for variables. In particular, don't permit dunder names.
@@ -305,12 +301,12 @@ def _validate_ast(tree, register):
             return False
         return _validate_ast(tree.left, reg) and _validate_ast(tree.right, reg)
 
-    elif isinstance(tree, ast.UnaryOp):
+    if isinstance(tree, ast.UnaryOp):
         if not isinstance(tree.op, allowed_unaryops):
             return False
         return _validate_ast(tree.operand, reg)
 
-    elif isinstance(tree, ast.Call):
+    if isinstance(tree, ast.Call):
         # Only direct calls such as A(...) are allowed.
         #
         # This deliberately rejects:

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -295,13 +295,16 @@ def _validate_ast(tree, register):
     if isinstance(tree, ast.BinOp):
         if not isinstance(tree.op, allowed_binops):
             return False
-        _validate_ast(tree.left, register)
-        _validate_ast(tree.right, register)
+        if not _validate_ast(tree.left, register):
+            return False
+        if not _validate_ast(tree.right, register):
+            return False
 
     elif isinstance(tree, ast.UnaryOp):
         if not isinstance(tree.op, allowed_unaryops):
             return False
-        _validate_ast(tree.operand, register)
+        if not _validate_ast(tree.operand, register):
+            return False
 
     if isinstance(tree, ast.Call):
         # Only direct calls such as A(...) are allowed.
@@ -313,16 +316,19 @@ def _validate_ast(tree, register):
         if not isinstance(tree.func, ast.Name):
             return False
 
-        _validate_ast(tree.func, register)
+        if not _validate_ast(tree.func, register):
+            return False
 
         for arg in tree.args:
-            _validate_ast(arg, register)
+            if not _validate_ast(arg, register):
+                return False
 
         for kw in tree.keywords:
             # **kwargs is represented by keyword.arg == None.
             if kw.arg is None:
                 return False
-            _validate_ast(kw.value, register)
+            if not _validate_ast(kw.value, register):
+                return False
 
         return True
 

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -178,14 +178,15 @@ def craft(spec, safe=False):
     # Both safe and unsafe modes operate on the resulting AST.
     tree = ast.parse(spec, mode="exec")
 
-    # safe mode: validate the AST before evaluation
-    if safe and not _validate_ast(tree, register):
-        raise ValueError(
-            "Error in craft utility: unsafe or invalid specification supplied: "
-            f"{spec}"
-        )
-
+    # single expression
     if len(tree.body) == 1 and isinstance(tree.body[0], ast.Expr):
+        # safe mode: validate the AST against the allowed constructors and operators
+        if safe and not _validate_ast(tree, register):
+            raise ValueError(
+                "Error in craft utility: unsafe or invalid specification supplied: "
+                f"{spec}"
+            )
+
         expr = tree.body[0].value
         expr_tree = ast.Expression(body=expr)
         ast.fix_missing_locations(expr_tree)
@@ -205,6 +206,7 @@ def craft(spec, safe=False):
         else:
             return obj
 
+    # safe mode only allows single expressions
     if safe:
         raise ValueError(
             "Error in craft utility: safe mode requires a single expression, "

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -202,6 +202,8 @@ def craft(spec, safe=False):
                 raise ValueError(
                     f"Error in craft utility: failed to evaluate specification: {spec}"
                 ) from e
+            else:
+                raise e
         else:
             return obj
 
@@ -235,19 +237,31 @@ def _validate_ast(tree, register):
 
     The accepted grammar is intentionally small:
 
-        expression ::= NAME | NAME "(" arguments ")" | expression OP expression
+    .. code-block:: text
 
-        arguments  ::= positional_argument | keyword_argument| arguments "," arguments
+        expression ::= NAME | NAME "(" arguments ")" | expression BINOP expression
+                        | UNARYOP expression
+
+        arguments  ::= positional_argument | keyword_argument | arguments "," arguments
 
         positional_argument ::= expression | CONSTANT
         keyword_argument    ::= NAME "=" (expression | CONSTANT)
+
+    Where
+
+    .. code-block:: text
+
+        NAME       ::= valid Python identifier, object name in ``sktime`` or ``sklearn``
+        CONSTANT   ::= literal value (e.g., number, string, boolean)
+        BINOP      ::= valid Python binary operator (e.g., +, -, *, /)
+        UNARYOP    ::= valid Python unary operator (e.g., +, -, ~)
 
     This permits nested constructor calls such as:
 
         A(a=42, b=B("test"))
 
     and only such calls.
-    In particular, does not permit attribute access, lambdas, comprehensions, operators,
+    In particular, does not permit attribute access, lambdas, comprehensions,
     imports, assignments, function calls through arbitrary expressions, etc.
 
     Parameters

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -255,19 +255,54 @@ def _validate_ast(tree, register):
     if isinstance(tree, ast.Expression):
         tree = tree.body
 
+    # Only names explicitly supplied in the estimator registry are
+    # available for variables. In particular, don't permit dunder names.
     if isinstance(tree, ast.Name):
-        # Only names explicitly supplied in the estimator registry are
-        # available. In particular, don't permit dunder names.
         if tree.id.startswith("__") or tree.id not in register:
             raise ValueError(
                 f"unsafe or unknown name in specification: {tree.id!r}"
             )
         return True
 
+    # Constants are safe as values.
+    # In particular, this allows strings, numbers, booleans, None, etc.
     if isinstance(tree, ast.Constant):
-        # Constants are safe as values. In particular, this allows strings,
-        # numbers, booleans, None, etc.
         return True
+
+    # binary and unary operators (dunder operations)
+    # are allowed, since this is how we can build pipelines
+    allowed_binops = (
+        ast.Add,
+        ast.Sub,
+        ast.Mult,
+        ast.Div,
+        ast.FloorDiv,
+        ast.Mod,
+        ast.Pow,
+        ast.MatMult,
+    )
+
+    allowed_unaryops = (
+        ast.UAdd,
+        ast.USub,
+        ast.Not,
+        ast.Invert,
+    )
+
+    if isinstance(tree, ast.BinOp):
+        if not isinstance(tree.op, allowed_binops):
+            raise ValueError(
+                f"unsafe binary operator: {type(tree.op).__name__}"
+            )
+        _validate_ast(tree.left, register)
+        _validate_ast(tree.right, register)
+
+    elif isinstance(tree, ast.UnaryOp):
+        if not isinstance(tree.op, allowed_unaryops):
+            raise ValueError(
+                f"unsafe unary operator: {type(tree.op).__name__}"
+            )
+        _validate_ast(tree.operand, register)
 
     if isinstance(tree, ast.Call):
         # Only direct calls such as A(...) are allowed.

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -89,7 +89,7 @@ def craft(spec, safe=False):
         expression ::= NAME | NAME "(" arguments ")" | expression BINOP expression
                         | UNARYOP expression
 
-        arguments  ::= positional_argument | keyword_argument| arguments "," arguments
+        arguments  ::= positional_argument | keyword_argument | arguments "," arguments
 
         positional_argument ::= expression | CONSTANT
         keyword_argument    ::= NAME "=" (expression | CONSTANT)

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -176,10 +176,19 @@ def craft(spec, safe=False):
 
     # Parse the specification once.
     # Both safe and unsafe modes operate on the resulting AST.
-    tree = ast.parse(spec, mode="exec")
+    try:
+        tree = ast.parse(spec, mode="exec")
+    except SyntaxError as e:
+        if safe:
+            raise ValueError(
+                f"Error in craft utility: failed to parse specification: {spec}"
+            ) from e
+        exec_parsed = False
+    else:
+        exec_parsed = True
 
     # single expression
-    if len(tree.body) == 1 and isinstance(tree.body[0], ast.Expr):
+    if exec_parsed and len(tree.body) == 1 and isinstance(tree.body[0], ast.Expr):
         # safe mode: validate the AST against the allowed constructors and operators
         if safe and not _validate_ast(tree, register):
             raise ValueError(

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -280,6 +280,11 @@ def _validate_ast(tree, register):
         ast.Mod,
         ast.Pow,
         ast.MatMult,
+        ast.BitOr,
+        ast.BitAnd,
+        ast.BitXor,
+        ast.LShift,
+        ast.RShift,
     )
 
     allowed_unaryops = (

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -83,7 +83,7 @@ def craft(spec, safe=False):
     If ``safe=True`` mode is enabled, only simple propositional expressions are allowed.
 
     The accepted "safe" grammar is intentionally small:
-    
+
     .. code-block:: text
 
         expression ::= NAME | NAME "(" arguments ")" | expression BINOP expression
@@ -124,7 +124,7 @@ def craft(spec, safe=False):
 
     safe : bool, optional (default=False)
         whether to enforce safe expressions according to the safe specification rules.
-    
+
         * if True, only allow safe expressions according to the safe specification
           rules, see above for the exact rules.
         * if False, allow all expressions (default behavior).
@@ -200,8 +200,7 @@ def craft(spec, safe=False):
         except Exception as e:
             if safe:
                 raise ValueError(
-                    "Error in craft utility: failed to evaluate specification: "
-                    f"{spec}"
+                    f"Error in craft utility: failed to evaluate specification: {spec}"
                 ) from e
         else:
             return obj

--- a/sktime/registry/_craft.py
+++ b/sktime/registry/_craft.py
@@ -106,7 +106,7 @@ def craft(spec, safe=False):
     This permits simple constructor calls such as ``A(a=42)``,
     or nested constructor calls such as ``A(a=42, b=B("test"))``, and only such calls.
 
-    In particular, does not permit attribute access, lambdas, comprehensions, operators,
+    In particular, does not permit attribute access, lambdas, comprehensions,
     imports, assignments, function calls through arbitrary expressions, etc,
     which are "unsafe" in the sense of allowing arbitrary code injection.
 

--- a/sktime/registry/tests/test_craft.py
+++ b/sktime/registry/tests/test_craft.py
@@ -108,58 +108,47 @@ def test_craft(spec, safe):
         "NaiveForecaster().fit",
         "NaiveForecaster().foo()",
         "NaiveForecaster.__init__",
-
         # Indirect / arbitrary function calls
         "getattr(NaiveForecaster(), 'fit')",
         "(NaiveForecaster)()",
         "(lambda: NaiveForecaster())()",
-
         # Lambdas
         "lambda: NaiveForecaster()",
         "NaiveForecaster(lam=lambda: 1)",
-
         # Comprehensions / generators
         "[NaiveForecaster() for _ in range(1)]",
         "{NaiveForecaster() for _ in range(1)}",
         "{i: NaiveForecaster() for i in range(1)}",
         "(NaiveForecaster() for _ in range(1))",
-
         # Arbitrary builtin/function names are not in the safe registry
         "eval('NaiveForecaster()')",
         "exec('x = 1')",
         "open('foo')",
         "getattr",
-
         # Dunder names / access
         "__import__('os')",
         "__builtins__",
         "NaiveForecaster().__class__",
         "NaiveForecaster().__dict__",
-
         # **kwargs expansion
         "NaiveForecaster(**{})",
-
         # Statements / multi-statement code
         "x = NaiveForecaster()",
         "NaiveForecaster(); NaiveForecaster()",
         "import os",
         "from os import path",
         "if True:\n    return NaiveForecaster()",
-
         # Unsupported expression forms
         "[NaiveForecaster()]",
         "{'estimator': NaiveForecaster()}",
         "(NaiveForecaster(),)",
         "NaiveForecaster() if True else NaiveForecaster()",
-
         # Boolean operators are deliberately not part of the safe grammar
         "NaiveForecaster() and NaiveForecaster()",
         "NaiveForecaster() or NaiveForecaster()",
-
         # Comparisons
         "NaiveForecaster() == NaiveForecaster()",
         "NaiveForecaster() < NaiveForecaster()",
-
         # Chained / indirect calls
         "NaiveForecaster()()",
         "(NaiveForecaster())()",

--- a/sktime/registry/tests/test_craft.py
+++ b/sktime/registry/tests/test_craft.py
@@ -78,13 +78,21 @@ if _check_soft_dependencies(["statsmodels"], severity="none"):
 
 
 @pytest.mark.parametrize("spec", specs)
-def test_craft(spec):
+@pytest.mark.parametrize("safe", [True, False])
+def test_craft(spec, safe):
     """Check that crafting works and is inverse to str coercion."""
-    crafted_obj = craft(spec)
+    spec_is_unsafe = "return" in spec
+
+    if safe and spec_is_unsafe:
+        with pytest.raises(ValueError):
+            craft(spec, safe=safe)
+        return
+
+    crafted_obj = craft(spec, safe=safe)
 
     new_spec = str(crafted_obj)
 
-    crafted_again = craft(new_spec)
+    crafted_again = craft(new_spec, safe=safe)
 
     assert crafted_again == crafted_obj
 

--- a/sktime/registry/tests/test_craft.py
+++ b/sktime/registry/tests/test_craft.py
@@ -101,6 +101,76 @@ def test_craft(spec, safe):
     assert crafted_again == crafted_obj
 
 
+@pytest.mark.parametrize(
+    "spec",
+    [
+        # Attribute access
+        "NaiveForecaster().fit",
+        "NaiveForecaster().foo()",
+        "NaiveForecaster.__init__",
+
+        # Indirect / arbitrary function calls
+        "getattr(NaiveForecaster(), 'fit')",
+        "(NaiveForecaster)()",
+        "(lambda: NaiveForecaster())()",
+
+        # Lambdas
+        "lambda: NaiveForecaster()",
+        "NaiveForecaster(lam=lambda: 1)",
+
+        # Comprehensions / generators
+        "[NaiveForecaster() for _ in range(1)]",
+        "{NaiveForecaster() for _ in range(1)}",
+        "{i: NaiveForecaster() for i in range(1)}",
+        "(NaiveForecaster() for _ in range(1))",
+
+        # Arbitrary builtin/function names are not in the safe registry
+        "eval('NaiveForecaster()')",
+        "exec('x = 1')",
+        "open('foo')",
+        "getattr",
+
+        # Dunder names / access
+        "__import__('os')",
+        "__builtins__",
+        "NaiveForecaster().__class__",
+        "NaiveForecaster().__dict__",
+
+        # **kwargs expansion
+        "NaiveForecaster(**{})",
+
+        # Statements / multi-statement code
+        "x = NaiveForecaster()",
+        "NaiveForecaster(); NaiveForecaster()",
+        "import os",
+        "from os import path",
+        "if True:\n    return NaiveForecaster()",
+
+        # Unsupported expression forms
+        "[NaiveForecaster()]",
+        "{'estimator': NaiveForecaster()}",
+        "(NaiveForecaster(),)",
+        "NaiveForecaster() if True else NaiveForecaster()",
+
+        # Boolean operators are deliberately not part of the safe grammar
+        "NaiveForecaster() and NaiveForecaster()",
+        "NaiveForecaster() or NaiveForecaster()",
+
+        # Comparisons
+        "NaiveForecaster() == NaiveForecaster()",
+        "NaiveForecaster() < NaiveForecaster()",
+
+        # Chained / indirect calls
+        "NaiveForecaster()()",
+        "(NaiveForecaster())()",
+    ],
+)
+def test_craft_safe_rejects_unsafe_specs(spec):
+    """Test that unsafe Python constructs are rejected in safe mode."""
+    with pytest.raises(ValueError, match="unsafe or invalid specification|safe mode"):
+        craft(spec, safe=True)
+
+
 @pytest.mark.parametrize("spec", specs)
 def test_deps(spec):
     """Check that deps retrieves the correct requirement sets."""

--- a/sktime/registry/tests/test_craft.py
+++ b/sktime/registry/tests/test_craft.py
@@ -110,7 +110,6 @@ def test_craft(spec, safe):
         "NaiveForecaster.__init__",
         # Indirect / arbitrary function calls
         "getattr(NaiveForecaster(), 'fit')",
-        "(NaiveForecaster)()",
         "(lambda: NaiveForecaster())()",
         # Lambdas
         "lambda: NaiveForecaster()",
@@ -139,9 +138,6 @@ def test_craft(spec, safe):
         "from os import path",
         "if True:\n    return NaiveForecaster()",
         # Unsupported expression forms
-        "[NaiveForecaster()]",
-        "{'estimator': NaiveForecaster()}",
-        "(NaiveForecaster(),)",
         "NaiveForecaster() if True else NaiveForecaster()",
         # Boolean operators are deliberately not part of the safe grammar
         "NaiveForecaster() and NaiveForecaster()",

--- a/sktime/registry/tests/test_craft.py
+++ b/sktime/registry/tests/test_craft.py
@@ -81,8 +81,11 @@ if _check_soft_dependencies(["statsmodels"], severity="none"):
 @pytest.mark.parametrize("safe", [True, False])
 def test_craft(spec, safe):
     """Check that crafting works and is inverse to str coercion."""
+    # hack - among test cases, all unsafe specs contain a "return" statement
+    # in general, this statement is not true, i.e., unsafe iff contains return
     spec_is_unsafe = "return" in spec
 
+    # test that unsafe specs correctly raise an error in safe mode
     if safe and spec_is_unsafe:
         with pytest.raises(ValueError):
             craft(spec, safe=safe)

--- a/sktime/registry/tests/test_craft.py
+++ b/sktime/registry/tests/test_craft.py
@@ -91,6 +91,7 @@ def test_craft(spec, safe):
             craft(spec, safe=safe)
         return
 
+    # test that crafting and re-crafting produces consistent results
     crafted_obj = craft(spec, safe=safe)
 
     new_spec = str(crafted_obj)


### PR DESCRIPTION
This PR adds a safe mode in the `craft` utility for estimator blueprint deserialization to prevent arbitrary code execution.

The safe mode, enabled when the new argument `safe=True`, works by parsing the evaluation tree and allowing only a minimal propositional syntax with propositions being `sktime` objects only, and arguments being constants only.

Possible operations in the propositional syntax are the unaryops and binops used to construct pipelines.

In particular, this disallows arbitary code blocks, but this allows for safe deserialization if specifications are produced by a system only - the coverage is all possible combinations of `sktime` and `scikit-learn` objects, even if the strings will become very long then.