### PR TITLE
[ENH] clean up soft dependency isolation patterns in `networks` module

### DIFF
--- a/sktime/networks/cinn.py
+++ b/sktime/networks/cinn.py
@@ -5,43 +5,15 @@ __author__ = ["benHeid"]
 import numpy as np
 from skbase.utils.dependencies import _check_soft_dependencies
 
-if _check_soft_dependencies("torch", severity="none"):
+
+def _CINNNetwork():
+    """Soft dependency isolation for the cINN network."""
+    import FrEIA.framework as Ff
+    import FrEIA.modules as Fm
     import torch
     import torch.nn as nn
 
-    NNModule = nn.Module
-else:
-
-    class NNModule:
-        """Dummy class if torch is unavailable."""
-
-
-if _check_soft_dependencies("FrEIA", severity="none"):
-    import FrEIA.framework as Ff
-    import FrEIA.modules as Fm
-
-
-class CINNNetwork:
-    """
-    Conditional Invertible Neural Network.
-
-    Parameters
-    ----------
-    horizon : int
-        Forecasting horizon.
-    cond_features : int
-        Number of features in the condition.
-    encoded_cond_size : int
-        Dimension of the encoded condition.
-    num_coupling_layers : int
-        Number of coupling layers in the cINN.
-    hidden_dim_size : int
-        Number of hidden units in the subnet.
-    activation : torch.nn.modules.Module
-        Activation function to use in the subnet.
-    """
-
-    class _CINNNetwork(NNModule):
+    class _CINNNetwork(nn.Module):
         def __init__(
             self,
             horizon,
@@ -176,6 +148,30 @@ class CINNNetwork:
             c = self._calculate_condition(c)
             return self.network(z, c=c, rev=True)[0].detach().numpy()
 
+
+    return _CINNNetwork
+
+
+class CINNNetwork:
+    """
+    Conditional Invertible Neural Network.
+
+    Parameters
+    ----------
+    horizon : int
+        Forecasting horizon.
+    cond_features : int
+        Number of features in the condition.
+    encoded_cond_size : int
+        Dimension of the encoded condition.
+    num_coupling_layers : int
+        Number of coupling layers in the cINN.
+    hidden_dim_size : int
+        Number of hidden units in the subnet.
+    activation : torch.nn.modules.Module
+        Activation function to use in the subnet.
+    """
+
     def __init__(
         self,
         horizon,
@@ -194,7 +190,7 @@ class CINNNetwork:
 
     def build(self):
         """Build the cINN."""
-        return self._CINNNetwork(
+        return _CINNNetwork()(
             self.horizon,
             self.cond_features,
             self.encoded_cond_size,

--- a/sktime/networks/cinn.py
+++ b/sktime/networks/cinn.py
@@ -3,7 +3,6 @@
 __author__ = ["benHeid"]
 
 import numpy as np
-from skbase.utils.dependencies import _check_soft_dependencies
 
 
 def _CINNNetwork():
@@ -147,7 +146,6 @@ def _CINNNetwork():
             """
             c = self._calculate_condition(c)
             return self.network(z, c=c, rev=True)[0].detach().numpy()
-
 
     return _CINNNetwork
 

--- a/sktime/networks/cinn.py
+++ b/sktime/networks/cinn.py
@@ -184,7 +184,12 @@ class CINNNetwork:
         self.encoded_cond_size = encoded_cond_size
         self.num_coupling_layers = num_coupling_layers
         self.hidden_dim_size = hidden_dim_size
-        self.activation = activation if activation is not None else nn.ReLU
+        self.activation = activation
+
+        if activation is None:
+            from torch import nn
+
+            self.activation = nn.ReLU()
 
     def build(self):
         """Build the cINN."""

--- a/sktime/networks/es_rnn.py
+++ b/sktime/networks/es_rnn.py
@@ -61,9 +61,9 @@ def _ESRNN():
             self.season1_length = season1_length
             self.season2_length = season2_length
             super().__init__()
-            self.level_coeff = torch.nn.Parameter(torch.rand(1), requires_grad=True)
-            self.seasonal_coeff_1 = torch.nn.Parameter(torch.rand(1), requires_grad=True)
-            self.seasonal_coeff_2 = torch.nn.Parameter(torch.rand(1), requires_grad=True)
+            self.level_coeff = nn.Parameter(torch.rand(1), requires_grad=True)
+            self.seasonal_coeff_1 = nn.Parameter(torch.rand(1), requires_grad=True)
+            self.seasonal_coeff_2 = nn.Parameter(torch.rand(1), requires_grad=True)
             self.input_layer = nn.Linear(input_shape, input_shape)
             self.lstm = nn.LSTM(
                 self.input_shape, self.hidden_size, self.num_layer, batch_first=True

--- a/sktime/networks/es_rnn.py
+++ b/sktime/networks/es_rnn.py
@@ -106,7 +106,7 @@ def _ESRNN():
             batch, seq_length, num_features = x.shape
             season1_length = self.season1_length
             if self.season1_length > seq_length:
-                warn(f"Input window should atleast cover one season,{seq_length}")
+                warn(f"Input window should at least cover one season,{seq_length}")
                 season1_length = seq_length
             level = x[:, :season1_length, :].mean(dim=1, keepdim=True)
             initial_seasonality_1 = x[:, :season1_length, :] / level
@@ -150,12 +150,12 @@ def _ESRNN():
             season1_length = self.season1_length
             if self.season1_length > seq_length:
                 season1_length = seq_length
-                warn(f"Input window should atleast cover one season,{seq_length}")
+                warn(f"Input window should at least cover one season,{seq_length}")
 
             season2_length = self.season2_length
             if self.season2_length > seq_length:
                 season2_length = seq_length
-                warn(f"Input window should atleast cover one season,{seq_length}")
+                warn(f"Input window should at least cover one season,{seq_length}")
 
             level = x[:, : max(season1_length, season2_length), :]
             level = level.mean(dim=1, keepdim=True)
@@ -216,7 +216,6 @@ def _ESRNN():
                 out_list = [last_output]
                 for t in range(self.pred_len - 1):
                     next_out = self.input_layer(last_output)
-                    next_out = next_out
                     lstm_out, (h, c) = self.lstm(next_out, (h, c))
                     next_output = self.output_layer(lstm_out)
                     out_list.append(next_output)
@@ -267,6 +266,8 @@ def _ESRNN():
                     * seasonality_2[:, -self.pred_len :, :]
                 )
                 return output_leveled
+
+    return _ESRNN
 
 
 class ESRNN:

--- a/sktime/networks/es_rnn.py
+++ b/sktime/networks/es_rnn.py
@@ -233,7 +233,6 @@ def _ESRNN():
                 out_list = [last_output]
                 for t in range(self.pred_len - 1):
                     next_out = self.input_layer(last_output)
-                    next_out = next_out
                     lstm_out, (h, c) = self.lstm(next_out, (h, c))
                     next_output = self.output_layer(lstm_out)
                     out_list.append(next_output)
@@ -252,7 +251,6 @@ def _ESRNN():
                 out_list = [last_output]
                 for t in range(self.pred_len - 1):
                     next_out = self.input_layer(last_output)
-                    next_out = next_out
                     lstm_out, (h, c) = self.lstm(next_out, (h, c))
                     next_output = self.output_layer(lstm_out)
                     out_list.append(next_output)

--- a/sktime/networks/es_rnn.py
+++ b/sktime/networks/es_rnn.py
@@ -328,7 +328,7 @@ class ESRNN:
 
     def pin_ball(self):
         """Return the default Pinball Loss."""
-        return _PinballLoss()
+        return _PinballLoss()()
 
     def _build(self):
         """Build the ES-RNN."""

--- a/sktime/networks/es_rnn.py
+++ b/sktime/networks/es_rnn.py
@@ -4,268 +4,269 @@ __author__ = ["Ankit-1204"]
 
 from warnings import warn
 
-from skbase.utils.dependencies import _check_soft_dependencies
 
-if _check_soft_dependencies("torch", severity="none"):
+def _PinballLoss():
+    """Soft dependency isolation for the Pinball Loss."""
     import torch
     import torch.nn as nn
 
-    NNModule = nn.Module
-else:
-
-    class NNModule:
-        """Dummy class if torch is unavailable."""
-
-
-class PinballLoss(NNModule):
-    """
-    Default Pinball/Quantile Loss.
-
-    Parameters
-    ----------
-    tau : Quantile Value
-    target : Ground truth
-    predec: Predicted value
-    loss = max( (predec-target)(1-tau), (target-predec)*tau)
-    """
-
-    def __init__(self, tau=0.49):
-        super().__init__()
-        self.tau = tau
-
-    def forward(self, predec, target):
-        """Calculate Pinball Loss."""
-        predec = predec.float()
-        target = target.float()
-        diff = predec - target
-        loss = torch.maximum(-diff * (1 - self.tau), diff * self.tau)
-        return loss.mean()
-
-
-class _ESRNN(NNModule):
-    def __init__(
-        self,
-        input_shape,
-        hidden_size,
-        pred_len,
-        num_layer,
-        season1_length,
-        season2_length,
-        seasonality,
-    ) -> None:
-        self.input_shape = input_shape
-        self.hidden_size = hidden_size
-        self.num_layer = num_layer
-        self.pred_len = pred_len
-        self.seasonality = seasonality
-        self.season1_length = season1_length
-        self.season2_length = season2_length
-        super().__init__()
-        self.level_coeff = torch.nn.Parameter(torch.rand(1), requires_grad=True)
-        self.seasonal_coeff_1 = torch.nn.Parameter(torch.rand(1), requires_grad=True)
-        self.seasonal_coeff_2 = torch.nn.Parameter(torch.rand(1), requires_grad=True)
-        self.input_layer = nn.Linear(input_shape, input_shape)
-        self.lstm = nn.LSTM(
-            self.input_shape, self.hidden_size, self.num_layer, batch_first=True
-        )
-        self.output_layer = nn.Linear(self.hidden_size, self.input_shape)
-
-    def _nonseasonal(self, x):
+    class PinballLoss(nn.Module):
         """
-        Calculate level component for time series without seasonal patterns.
-
-        Args:
-            x: Input tensor of shape (batch, seq_length, num_features)
-
-        Returns
-        -------
-            tuple: (level, remainder)
-        """
-        batch, seq_length, num_features = x.shape
-        level = x[:, 0, :]
-        level_coeff = torch.sigmoid(self.level_coeff)
-        for t in range(1, seq_length):
-            level = level_coeff * x[:, t, :] + (1 - level_coeff) * level
-
-        return level, x / level.unsqueeze(1)
-
-    def _single_seasonal(self, x):
-        """
-        Calculate and return the level and one seasonality components.
-
-        Used for single seasonality condition where the time series exhibits
-        one distinct seasonal patterns (e.g., Yearly pattern).
-
-        Args:
-            x: Input tensor of shape (batch, seq_length, num_features)
-
-        Returns
-        -------
-            tuple: (level, seasonality1, remainder)
-        """
-        batch, seq_length, num_features = x.shape
-        season1_length = self.season1_length
-        if self.season1_length > seq_length:
-            warn(f"Input window should atleast cover one season,{seq_length}")
-            season1_length = seq_length
-        level = x[:, :season1_length, :].mean(dim=1, keepdim=True)
-        initial_seasonality_1 = x[:, :season1_length, :] / level
-        seasonality_1 = []
-        for i in range(season1_length):
-            seasonality_1.append(torch.exp(initial_seasonality_1[:, i, :]))
-        level_coeff = torch.sigmoid(self.level_coeff)
-        seasonal_coeff_1 = torch.sigmoid(self.seasonal_coeff_1)
-        for i in range(seq_length):
-            new_level = level_coeff * (x[:, i, :] / seasonality_1[i]) + (
-                1 - level_coeff
-            ) * level.squeeze(1)
-
-            seasonality_1.append(
-                seasonal_coeff_1 * (x[:, i, :] / new_level)
-                + (1 - seasonal_coeff_1) * seasonality_1[i]
-            )
-            level = new_level.unsqueeze(1)
-        seasonality_1 = torch.stack(seasonality_1, dim=1)
-        return (
-            level,
-            seasonality_1,
-            x / (level * seasonality_1[:, -seq_length:, :]),
-        )
-
-    def _double_seasonal(self, x):
-        """
-        Calculate and return the level and two seasonality components.
-
-        Used for double seasonality condition where the time series exhibits
-        two distinct seasonal patterns (e.g., daily and weekly patterns).
-
-        Args:
-            x: Input tensor of shape (batch, seq_length, num_features)
-
-        Returns
-        -------
-            tuple: (level, seasonality1, seasonality2, remainder)
-        """
-        batch, seq_length, num_features = x.shape
-        season1_length = self.season1_length
-        if self.season1_length > seq_length:
-            season1_length = seq_length
-            warn(f"Input window should atleast cover one season,{seq_length}")
-
-        season2_length = self.season2_length
-        if self.season2_length > seq_length:
-            season2_length = seq_length
-            warn(f"Input window should atleast cover one season,{seq_length}")
-
-        level = x[:, : max(season1_length, season2_length), :].mean(dim=1, keepdim=True)
-        initial_seasonality_1 = x[:, :season1_length, :] / level
-        initial_seasonality_2 = x[:, :season2_length, :] / level
-        seasonality_1 = []
-        seasonality_2 = []
-        for i in range(season1_length):
-            seasonality_1.append(torch.exp(initial_seasonality_1[:, i, :]))
-        for i in range(season2_length):
-            seasonality_2.append(torch.exp(initial_seasonality_2[:, i, :]))
-
-        level_coeff = torch.sigmoid(self.level_coeff)
-        seasonal_coeff_1 = torch.sigmoid(self.seasonal_coeff_1)
-        seasonal_coeff_2 = torch.sigmoid(self.seasonal_coeff_2)
-        for i in range(seq_length):
-            new_level = level_coeff * (
-                x[:, i, :] / seasonality_1[i] * seasonality_2[i]
-            ) + (1 - level_coeff) * level.squeeze(1)
-
-            seasonality_1.append(
-                seasonal_coeff_1 * (x[:, i, :] / new_level * seasonality_2[i])
-                + (1 - seasonal_coeff_1) * seasonality_1[i]
-            )
-            seasonality_2.append(
-                seasonal_coeff_2 * (x[:, i, :] / new_level * seasonality_1[i])
-                + (1 - seasonal_coeff_2) * seasonality_2[i]
-            )
-            level = new_level.unsqueeze(1)
-        seasonality_1 = torch.stack(seasonality_1, dim=1)
-        seasonality_2 = torch.stack(seasonality_2, dim=1)
-        return (
-            level,
-            seasonality_1,
-            seasonality_2,
-            x
-            / (
-                level
-                * seasonality_1[:, -seq_length:, :]
-                * seasonality_2[:, -seq_length:, :]
-            ),
-        )
-
-    def forward(self, x):
-        """
-        Forward pass through ES-RNN.
+        Default Pinball/Quantile Loss.
 
         Parameters
         ----------
-        x : torch.Tensor
-            Input tensor of shape (batch_size, input_length).
+        tau : Quantile Value
+        target : Ground truth
+        predec: Predicted value
+        loss = max( (predec-target)(1-tau), (target-predec)*tau)
         """
-        if self.seasonality == "zero":
-            level, new_x = self._nonseasonal(x)
-            x_input = self.input_layer(new_x.float())
-            output, (h, c) = self.lstm(x_input)
-            last_output = self.output_layer(output[:, -1, :]).unsqueeze(1)
-            out_list = [last_output]
-            for t in range(self.pred_len - 1):
-                next_out = self.input_layer(last_output)
-                next_out = next_out
-                lstm_out, (h, c) = self.lstm(next_out, (h, c))
-                next_output = self.output_layer(lstm_out)
-                out_list.append(next_output)
-                last_output = next_output
-            output_seq = torch.stack(out_list, dim=0)
-            output_seq = output_seq.squeeze(2).transpose(0, 1)
-            output_leveled = (output_seq) * level.unsqueeze(1)
-            return output_leveled
 
-        elif self.seasonality == "single":
-            level, seasonality_1, new_x = self._single_seasonal(x)
-            x_input = self.input_layer(new_x.float())
-            output, (h, c) = self.lstm(x_input)
-            last_output = self.output_layer(output[:, -1, :]).unsqueeze(1)
-            out_list = [last_output]
-            for t in range(self.pred_len - 1):
-                next_out = self.input_layer(last_output)
-                next_out = next_out
-                lstm_out, (h, c) = self.lstm(next_out, (h, c))
-                next_output = self.output_layer(lstm_out)
-                out_list.append(next_output)
-                last_output = next_output
-            output_seq = torch.stack(out_list, dim=0)
-            output_seq = output_seq.squeeze(2).transpose(0, 1)
-            output_leveled = (
-                (output_seq) * level * seasonality_1[:, -self.pred_len :, :]
+        def __init__(self, tau=0.49):
+            super().__init__()
+            self.tau = tau
+
+        def forward(self, predec, target):
+            """Calculate Pinball Loss."""
+            predec = predec.float()
+            target = target.float()
+            diff = predec - target
+            loss = torch.maximum(-diff * (1 - self.tau), diff * self.tau)
+            return loss.mean()
+
+    return PinballLoss
+
+
+def _ESRNN():
+    """Soft dependency isolation for the ES-RNN."""
+    import torch
+    import torch.nn as nn
+
+    class _ESRNN(nn.Module):
+        def __init__(
+            self,
+            input_shape,
+            hidden_size,
+            pred_len,
+            num_layer,
+            season1_length,
+            season2_length,
+            seasonality,
+        ) -> None:
+            self.input_shape = input_shape
+            self.hidden_size = hidden_size
+            self.num_layer = num_layer
+            self.pred_len = pred_len
+            self.seasonality = seasonality
+            self.season1_length = season1_length
+            self.season2_length = season2_length
+            super().__init__()
+            self.level_coeff = torch.nn.Parameter(torch.rand(1), requires_grad=True)
+            self.seasonal_coeff_1 = torch.nn.Parameter(torch.rand(1), requires_grad=True)
+            self.seasonal_coeff_2 = torch.nn.Parameter(torch.rand(1), requires_grad=True)
+            self.input_layer = nn.Linear(input_shape, input_shape)
+            self.lstm = nn.LSTM(
+                self.input_shape, self.hidden_size, self.num_layer, batch_first=True
             )
-            return output_leveled
-        else:
-            level, seasonality_1, seasonality_2, new_x = self._double_seasonal(x)
-            x_input = self.input_layer(new_x.float())
-            output, (h, c) = self.lstm(x_input)
-            last_output = self.output_layer(output[:, -1, :]).unsqueeze(1)
-            out_list = [last_output]
-            for t in range(self.pred_len - 1):
-                next_out = self.input_layer(last_output)
-                next_out = next_out
-                lstm_out, (h, c) = self.lstm(next_out, (h, c))
-                next_output = self.output_layer(lstm_out)
-                out_list.append(next_output)
-                last_output = next_output
-            output_seq = torch.stack(out_list, dim=0)
-            output_seq = output_seq.squeeze(2).transpose(0, 1)
-            output_leveled = (
-                (output_seq)
-                * level
-                * seasonality_1[:, -self.pred_len :, :]
-                * seasonality_2[:, -self.pred_len :, :]
+            self.output_layer = nn.Linear(self.hidden_size, self.input_shape)
+
+        def _nonseasonal(self, x):
+            """
+            Calculate level component for time series without seasonal patterns.
+
+            Args:
+                x: Input tensor of shape (batch, seq_length, num_features)
+
+            Returns
+            -------
+                tuple: (level, remainder)
+            """
+            batch, seq_length, num_features = x.shape
+            level = x[:, 0, :]
+            level_coeff = torch.sigmoid(self.level_coeff)
+            for t in range(1, seq_length):
+                level = level_coeff * x[:, t, :] + (1 - level_coeff) * level
+
+            return level, x / level.unsqueeze(1)
+
+        def _single_seasonal(self, x):
+            """
+            Calculate and return the level and one seasonality components.
+
+            Used for single seasonality condition where the time series exhibits
+            one distinct seasonal patterns (e.g., Yearly pattern).
+
+            Args:
+                x: Input tensor of shape (batch, seq_length, num_features)
+
+            Returns
+            -------
+                tuple: (level, seasonality1, remainder)
+            """
+            batch, seq_length, num_features = x.shape
+            season1_length = self.season1_length
+            if self.season1_length > seq_length:
+                warn(f"Input window should atleast cover one season,{seq_length}")
+                season1_length = seq_length
+            level = x[:, :season1_length, :].mean(dim=1, keepdim=True)
+            initial_seasonality_1 = x[:, :season1_length, :] / level
+            seasonality_1 = []
+            for i in range(season1_length):
+                seasonality_1.append(torch.exp(initial_seasonality_1[:, i, :]))
+            level_coeff = torch.sigmoid(self.level_coeff)
+            seasonal_coeff_1 = torch.sigmoid(self.seasonal_coeff_1)
+            for i in range(seq_length):
+                new_level = level_coeff * (x[:, i, :] / seasonality_1[i]) + (
+                    1 - level_coeff
+                ) * level.squeeze(1)
+
+                seasonality_1.append(
+                    seasonal_coeff_1 * (x[:, i, :] / new_level)
+                    + (1 - seasonal_coeff_1) * seasonality_1[i]
+                )
+                level = new_level.unsqueeze(1)
+            seasonality_1 = torch.stack(seasonality_1, dim=1)
+            return (
+                level,
+                seasonality_1,
+                x / (level * seasonality_1[:, -seq_length:, :]),
             )
-            return output_leveled
+
+        def _double_seasonal(self, x):
+            """
+            Calculate and return the level and two seasonality components.
+
+            Used for double seasonality condition where the time series exhibits
+            two distinct seasonal patterns (e.g., daily and weekly patterns).
+
+            Args:
+                x: Input tensor of shape (batch, seq_length, num_features)
+
+            Returns
+            -------
+                tuple: (level, seasonality1, seasonality2, remainder)
+            """
+            batch, seq_length, num_features = x.shape
+            season1_length = self.season1_length
+            if self.season1_length > seq_length:
+                season1_length = seq_length
+                warn(f"Input window should atleast cover one season,{seq_length}")
+
+            season2_length = self.season2_length
+            if self.season2_length > seq_length:
+                season2_length = seq_length
+                warn(f"Input window should atleast cover one season,{seq_length}")
+
+            level = x[:, : max(season1_length, season2_length), :]
+            level = level.mean(dim=1, keepdim=True)
+            initial_seasonality_1 = x[:, :season1_length, :] / level
+            initial_seasonality_2 = x[:, :season2_length, :] / level
+            seasonality_1 = []
+            seasonality_2 = []
+            for i in range(season1_length):
+                seasonality_1.append(torch.exp(initial_seasonality_1[:, i, :]))
+            for i in range(season2_length):
+                seasonality_2.append(torch.exp(initial_seasonality_2[:, i, :]))
+
+            level_coeff = torch.sigmoid(self.level_coeff)
+            seasonal_coeff_1 = torch.sigmoid(self.seasonal_coeff_1)
+            seasonal_coeff_2 = torch.sigmoid(self.seasonal_coeff_2)
+            for i in range(seq_length):
+                new_level = level_coeff * (
+                    x[:, i, :] / seasonality_1[i] * seasonality_2[i]
+                ) + (1 - level_coeff) * level.squeeze(1)
+
+                seasonality_1.append(
+                    seasonal_coeff_1 * (x[:, i, :] / new_level * seasonality_2[i])
+                    + (1 - seasonal_coeff_1) * seasonality_1[i]
+                )
+                seasonality_2.append(
+                    seasonal_coeff_2 * (x[:, i, :] / new_level * seasonality_1[i])
+                    + (1 - seasonal_coeff_2) * seasonality_2[i]
+                )
+                level = new_level.unsqueeze(1)
+            seasonality_1 = torch.stack(seasonality_1, dim=1)
+            seasonality_2 = torch.stack(seasonality_2, dim=1)
+            return (
+                level,
+                seasonality_1,
+                seasonality_2,
+                x
+                / (
+                    level
+                    * seasonality_1[:, -seq_length:, :]
+                    * seasonality_2[:, -seq_length:, :]
+                ),
+            )
+
+        def forward(self, x):
+            """
+            Forward pass through ES-RNN.
+
+            Parameters
+            ----------
+            x : torch.Tensor
+                Input tensor of shape (batch_size, input_length).
+            """
+            if self.seasonality == "zero":
+                level, new_x = self._nonseasonal(x)
+                x_input = self.input_layer(new_x.float())
+                output, (h, c) = self.lstm(x_input)
+                last_output = self.output_layer(output[:, -1, :]).unsqueeze(1)
+                out_list = [last_output]
+                for t in range(self.pred_len - 1):
+                    next_out = self.input_layer(last_output)
+                    next_out = next_out
+                    lstm_out, (h, c) = self.lstm(next_out, (h, c))
+                    next_output = self.output_layer(lstm_out)
+                    out_list.append(next_output)
+                    last_output = next_output
+                output_seq = torch.stack(out_list, dim=0)
+                output_seq = output_seq.squeeze(2).transpose(0, 1)
+                output_leveled = (output_seq) * level.unsqueeze(1)
+                return output_leveled
+
+            elif self.seasonality == "single":
+                level, seasonality_1, new_x = self._single_seasonal(x)
+                x_input = self.input_layer(new_x.float())
+                output, (h, c) = self.lstm(x_input)
+                last_output = self.output_layer(output[:, -1, :]).unsqueeze(1)
+                out_list = [last_output]
+                for t in range(self.pred_len - 1):
+                    next_out = self.input_layer(last_output)
+                    next_out = next_out
+                    lstm_out, (h, c) = self.lstm(next_out, (h, c))
+                    next_output = self.output_layer(lstm_out)
+                    out_list.append(next_output)
+                    last_output = next_output
+                output_seq = torch.stack(out_list, dim=0)
+                output_seq = output_seq.squeeze(2).transpose(0, 1)
+                output_leveled = (
+                    (output_seq) * level * seasonality_1[:, -self.pred_len :, :]
+                )
+                return output_leveled
+            else:
+                level, seasonality_1, seasonality_2, new_x = self._double_seasonal(x)
+                x_input = self.input_layer(new_x.float())
+                output, (h, c) = self.lstm(x_input)
+                last_output = self.output_layer(output[:, -1, :]).unsqueeze(1)
+                out_list = [last_output]
+                for t in range(self.pred_len - 1):
+                    next_out = self.input_layer(last_output)
+                    next_out = next_out
+                    lstm_out, (h, c) = self.lstm(next_out, (h, c))
+                    next_output = self.output_layer(lstm_out)
+                    out_list.append(next_output)
+                    last_output = next_output
+                output_seq = torch.stack(out_list, dim=0)
+                output_seq = output_seq.squeeze(2).transpose(0, 1)
+                output_leveled = (
+                    (output_seq)
+                    * level
+                    * seasonality_1[:, -self.pred_len :, :]
+                    * seasonality_2[:, -self.pred_len :, :]
+                )
+                return output_leveled
 
 
 class ESRNN:
@@ -327,11 +328,11 @@ class ESRNN:
 
     def pin_ball(self):
         """Return the default Pinball Loss."""
-        return PinballLoss()
+        return _PinballLoss()
 
     def _build(self):
         """Build the ES-RNN."""
-        return _ESRNN(
+        return _ESRNN()(
             self.input_shape,
             self.hidden_size,
             self.pred_len,

--- a/sktime/networks/ltsf/models/linear.py
+++ b/sktime/networks/ltsf/models/linear.py
@@ -109,7 +109,7 @@ class LTSFLinearNetwork:
 
 
 def _LTSFDLinearNetwork():
-    """Returns the LTSF-DLinear Network class."""
+    """Return the LTSF-DLinear Network class."""
     from torch import nn
 
     class _LTSFDLinearNetwork(nn.Module):
@@ -240,7 +240,7 @@ class LTSFDLinearNetwork:
 
 
 def _LTSFNLinearNetwork():
-    """Factory function for LTSF-NLinear Network."""
+    """Return the LTSF-NLinear Network class."""
     from torch import nn
 
     class _LTSFNLinearNetwork(nn.Module):

--- a/sktime/networks/ltsf/models/linear.py
+++ b/sktime/networks/ltsf/models/linear.py
@@ -243,7 +243,7 @@ def _LTSFNLinearNetwork():
     """Factory function for LTSF-NLinear Network."""
     from torch import nn
 
-    class _LTSFNLinearNetwork(nn.module):
+    class _LTSFNLinearNetwork(nn.Module):
         def __init__(
             self,
             seq_len,

--- a/sktime/networks/ltsf/models/linear.py
+++ b/sktime/networks/ltsf/models/linear.py
@@ -1,58 +1,11 @@
 """Deep Learning Forecasters using LTSF-Linear Models."""
 
-from skbase.utils.dependencies import _check_soft_dependencies
 
-if _check_soft_dependencies("torch", severity="none"):
+def _LTSFLinearNetwork():
+    """Return the LTSF-Linear network class."""
     import torch.nn as nn
 
-    nn_module = nn.Module
-else:
-
-    class nn_module:
-        """Dummy class if torch is unavailable."""
-
-
-class LTSFLinearNetwork:
-    """LTSF-Linear Forecaster.
-
-    Implementation of the Long-Term Short-Term Feature (LTSF) linear forecaster,
-    aka LTSF-Linear, by Zeng et al [1]_.
-
-    Core logic is directly copied from the cure-lab LTSF-Linear implementation [2]_,
-    which is unfortunately not available as a package.
-
-    Parameters
-    ----------
-    seq_len : int
-        length of input sequence
-    pred_len : int
-        length of prediction (forecast horizon)
-    in_channels : int, default=None
-        number of input channels passed to network
-    individual : bool, default=False
-        boolean flag that controls whether the network treats each channel individually"
-        "or applies a single linear layer across all channels. If individual=True, the"
-        "a separate linear layer is created for each input channel. If"
-        "individual=False, a single shared linear layer is used for all channels."
-
-    References
-    ----------
-    .. [1] Zeng A, Chen M, Zhang L, Xu Q. 2023.
-    Are transformers effective for time series forecasting?
-    Proceedings of the AAAI conference on artificial intelligence 2023
-    (Vol. 37, No. 9, pp. 11121-11128).
-    .. [2] https://github.com/cure-lab/LTSF-Linear
-    """
-
-    _tags = {
-        # packaging info
-        # --------------
-        "authors": ["mixiancmx", "ailingzengzzz", "luca-miniati"],
-        # mixiancmx, ailingzengzzz for cure-lab code
-        "maintainers": ["luca-miniati"],
-    }
-
-    class _LTSFLinearNetwork(nn_module):
+    class _LTSFLinearNetwork(nn.Module):
         def __init__(
             self,
             seq_len,
@@ -100,23 +53,14 @@ class LTSFLinearNetwork:
                 x = self.Linear(x.permute(0, 2, 1)).permute(0, 2, 1)
             return x  # [Batch, Output Length, Channel]
 
-    def __init__(self, seq_len, pred_len, in_channels=1, individual=False):
-        self.seq_len = seq_len
-        self.pred_len = pred_len
-        self.in_channels = in_channels
-        self.individual = individual
-
-    def _build(self):
-        return self._LTSFLinearNetwork(
-            self.seq_len, self.pred_len, self.in_channels, self.individual
-        )
+    return _LTSFLinearNetwork
 
 
-class LTSFDLinearNetwork:
-    """LTSF-DLinear Forecaster.
+class LTSFLinearNetwork:
+    """LTSF-Linear Forecaster.
 
-    Implementation of the Long-Term Short-Term Feature (LTSF) decomposition linear
-    forecaster, aka LTSF-DLinear, by Zeng et al [1]_.
+    Implementation of the Long-Term Short-Term Feature (LTSF) linear forecaster,
+    aka LTSF-Linear, by Zeng et al [1]_.
 
     Core logic is directly copied from the cure-lab LTSF-Linear implementation [2]_,
     which is unfortunately not available as a package.
@@ -152,7 +96,23 @@ class LTSFDLinearNetwork:
         "maintainers": ["luca-miniati"],
     }
 
-    class _LTSFDLinearNetwork(nn_module):
+    def __init__(self, seq_len, pred_len, in_channels=1, individual=False):
+        self.seq_len = seq_len
+        self.pred_len = pred_len
+        self.in_channels = in_channels
+        self.individual = individual
+
+    def _build(self):
+        return _LTSFLinearNetwork()(
+            self.seq_len, self.pred_len, self.in_channels, self.individual
+        )
+
+
+def _LTSFDLinearNetwork():
+    """Returns the LTSF-DLinear Network class."""
+    from torch import nn
+
+    class _LTSFDLinearNetwork(nn.Module):
         def __init__(
             self,
             seq_len,
@@ -224,23 +184,14 @@ class LTSFDLinearNetwork:
             x = seasonal_output + trend_output
             return x.permute(0, 2, 1)  # to [Batch, Output length, Channel]
 
-    def __init__(self, seq_len, pred_len, in_channels=1, individual=False):
-        self.seq_len = seq_len
-        self.pred_len = pred_len
-        self.in_channels = in_channels
-        self.individual = individual
-
-    def _build(self):
-        return self._LTSFDLinearNetwork(
-            self.seq_len, self.pred_len, self.in_channels, self.individual
-        )
+    return _LTSFDLinearNetwork
 
 
-class LTSFNLinearNetwork:
-    """LTSF-NLinear Forecaster.
+class LTSFDLinearNetwork:
+    """LTSF-DLinear Forecaster.
 
-    Implementation of the Long-Term Short-Term Feature (LTSF) normalization linear
-    forecaster, aka LTSF-NLinear, by Zeng et al [1]_.
+    Implementation of the Long-Term Short-Term Feature (LTSF) decomposition linear
+    forecaster, aka LTSF-DLinear, by Zeng et al [1]_.
 
     Core logic is directly copied from the cure-lab LTSF-Linear implementation [2]_,
     which is unfortunately not available as a package.
@@ -276,7 +227,23 @@ class LTSFNLinearNetwork:
         "maintainers": ["luca-miniati"],
     }
 
-    class _LTSFNLinearNetwork(nn_module):
+    def __init__(self, seq_len, pred_len, in_channels=1, individual=False):
+        self.seq_len = seq_len
+        self.pred_len = pred_len
+        self.in_channels = in_channels
+        self.individual = individual
+
+    def _build(self):
+        return _LTSFDLinearNetwork()(
+            self.seq_len, self.pred_len, self.in_channels, self.individual
+        )
+
+
+def _LTSFNLinearNetwork():
+    """Factory function for LTSF-NLinear Network."""
+    from torch import nn
+
+    class _LTSFNLinearNetwork(nn.module):
         def __init__(
             self,
             seq_len,
@@ -328,6 +295,49 @@ class LTSFNLinearNetwork:
             x = x + seq_last
             return x  # [Batch, Output length, Channel]
 
+    return _LTSFNLinearNetwork
+
+
+class LTSFNLinearNetwork:
+    """LTSF-NLinear Forecaster.
+
+    Implementation of the Long-Term Short-Term Feature (LTSF) normalization linear
+    forecaster, aka LTSF-NLinear, by Zeng et al [1]_.
+
+    Core logic is directly copied from the cure-lab LTSF-Linear implementation [2]_,
+    which is unfortunately not available as a package.
+
+    Parameters
+    ----------
+    seq_len : int
+        length of input sequence
+    pred_len : int
+        length of prediction (forecast horizon)
+    in_channels : int, default=None
+        number of input channels passed to network
+    individual : bool, default=False
+        boolean flag that controls whether the network treats each channel individually"
+        "or applies a single linear layer across all channels. If individual=True, the"
+        "a separate linear layer is created for each input channel. If"
+        "individual=False, a single shared linear layer is used for all channels."
+
+    References
+    ----------
+    .. [1] Zeng A, Chen M, Zhang L, Xu Q. 2023.
+    Are transformers effective for time series forecasting?
+    Proceedings of the AAAI conference on artificial intelligence 2023
+    (Vol. 37, No. 9, pp. 11121-11128).
+    .. [2] https://github.com/cure-lab/LTSF-Linear
+    """
+
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": ["mixiancmx", "ailingzengzzz", "luca-miniati"],
+        # mixiancmx, ailingzengzzz for cure-lab code
+        "maintainers": ["luca-miniati"],
+    }
+
     def __init__(self, seq_len, pred_len, in_channels=1, individual=False):
         self.seq_len = seq_len
         self.pred_len = pred_len
@@ -335,6 +345,6 @@ class LTSFNLinearNetwork:
         self.individual = individual
 
     def _build(self):
-        return self._LTSFNLinearNetwork(
+        return _LTSFNLinearNetwork()(
             self.seq_len, self.pred_len, self.in_channels, self.individual
         )

--- a/sktime/networks/ltsf/models/transformers.py
+++ b/sktime/networks/ltsf/models/transformers.py
@@ -1,77 +1,10 @@
 """Deep Learning Forecaster using LTSF-Transformer Model."""
 
-from skbase.utils.dependencies import _check_soft_dependencies
-
-if _check_soft_dependencies("torch", severity="none"):
+def _LTSFTransformerNetwork():
+    """Return the LTSF-Transformer network class."""
     import torch.nn as nn
 
-    nn_module = nn.Module
-else:
-
-    class nn_module:
-        """Dummy class if torch is unavailable."""
-
-
-class LTSFTransformerNetwork:
-    """LTSF-Transformer Forecaster.
-
-    Implementation of the Long-Term Short-Term Feature (LTSF) transformer forecaster,
-    aka LTSF-Transformer, by Zeng et al [1]_.
-
-    Core logic is directly copied from the cure-lab LTSF-Linear implementation [2]_,
-    which is unfortunately not available as a package.
-
-    Parameters
-    ----------
-    seq_len : int
-        Length of the input sequence.
-        Preferred to be twice the pred_len.
-    pred_len : int
-        Length of the prediction sequence.
-    context_len : int, optional (default=2)
-        Length of the label sequence.
-        Preferred to be same as the pred_len.
-    position_encoding : bool, optional (default=True)
-        Whether to use positional encoding.
-        Positional encoding helps the model understand the order of elements
-        in the input sequence by adding unique positional information to each element.
-    temporal_encoding : bool, optional (default=True)
-        Whether to use temporal encoding.
-        Works only with DatetimeIndex and PeriodIndex, disabled otherwise.
-    temporal_encoding_type : str, optional (default="linear")
-        Type of temporal encoding to use, relevant only if temporal_encoding is True.
-        - "linear": Uses linear layer to encode temporal data.
-        - "embed": Uses embeddings layer with learnable weights.
-        - "fixed-embed": Uses embeddings layer with fixed sine-cosine values as weights.
-    d_model : int, optional (default=512)
-        Dimension of the model.
-    n_heads : int, optional (default=8)
-        Number of attention heads.
-    d_ff : int, optional (default=2048)
-        Dimension of the feedforward network model.
-    e_layers : int, optional (default=3)
-        Number of encoder layers.
-    d_layers : int, optional (default=2)
-        Number of decoder layers.
-    factor : int, optional (default=5)
-        Factor for the attention mechanism.
-    dropout : float, optional (default=0.1)
-        Dropout rate.
-    activation : str, optional (default="relu")
-        Activation function to use. Defaults to relu and otherwise gelu.
-    freq : str, optional (default="h")
-        Frequency of the input data, relevant only if temporal_encoding is True.
-
-    References
-    ----------
-    .. [1] Zeng A, Chen M, Zhang L, Xu Q. 2023.
-    Are transformers effective for time series forecasting?
-    Proceedings of the AAAI conference on artificial intelligence 2023
-    (Vol. 37, No. 9, pp. 11121-11128).
-    .. [2] https://github.com/cure-lab/LTSF-Linear
-    """
-
-    class _LTSFTransformerNetwork(nn_module):
+    class _LTSFTransformerNetwork(nn.Module):
         def __init__(
             self,
             seq_len,
@@ -248,6 +181,68 @@ class LTSFTransformerNetwork:
             else:
                 return dec_out[:, -self.pred_len :, :]  # [B, L, D]
 
+    return _LTSFTransformerNetwork
+
+
+class LTSFTransformerNetwork:
+    """LTSF-Transformer Forecaster.
+
+    Implementation of the Long-Term Short-Term Feature (LTSF) transformer forecaster,
+    aka LTSF-Transformer, by Zeng et al [1]_.
+
+    Core logic is directly copied from the cure-lab LTSF-Linear implementation [2]_,
+    which is unfortunately not available as a package.
+
+    Parameters
+    ----------
+    seq_len : int
+        Length of the input sequence.
+        Preferred to be twice the pred_len.
+    pred_len : int
+        Length of the prediction sequence.
+    context_len : int, optional (default=2)
+        Length of the label sequence.
+        Preferred to be same as the pred_len.
+    position_encoding : bool, optional (default=True)
+        Whether to use positional encoding.
+        Positional encoding helps the model understand the order of elements
+        in the input sequence by adding unique positional information to each element.
+    temporal_encoding : bool, optional (default=True)
+        Whether to use temporal encoding.
+        Works only with DatetimeIndex and PeriodIndex, disabled otherwise.
+    temporal_encoding_type : str, optional (default="linear")
+        Type of temporal encoding to use, relevant only if temporal_encoding is True.
+        - "linear": Uses linear layer to encode temporal data.
+        - "embed": Uses embeddings layer with learnable weights.
+        - "fixed-embed": Uses embeddings layer with fixed sine-cosine values as weights.
+    d_model : int, optional (default=512)
+        Dimension of the model.
+    n_heads : int, optional (default=8)
+        Number of attention heads.
+    d_ff : int, optional (default=2048)
+        Dimension of the feedforward network model.
+    e_layers : int, optional (default=3)
+        Number of encoder layers.
+    d_layers : int, optional (default=2)
+        Number of decoder layers.
+    factor : int, optional (default=5)
+        Factor for the attention mechanism.
+    dropout : float, optional (default=0.1)
+        Dropout rate.
+    activation : str, optional (default="relu")
+        Activation function to use. Defaults to relu and otherwise gelu.
+    freq : str, optional (default="h")
+        Frequency of the input data, relevant only if temporal_encoding is True.
+
+    References
+    ----------
+    .. [1] Zeng A, Chen M, Zhang L, Xu Q. 2023.
+    Are transformers effective for time series forecasting?
+    Proceedings of the AAAI conference on artificial intelligence 2023
+    (Vol. 37, No. 9, pp. 11121-11128).
+    .. [2] https://github.com/cure-lab/LTSF-Linear
+    """
+
     def __init__(
         self,
         seq_len,
@@ -291,7 +286,7 @@ class LTSFTransformerNetwork:
         self.c_out = c_out
 
     def _build(self):
-        return self._LTSFTransformerNetwork(
+        return _LTSFTransformerNetwork()(
             seq_len=self.seq_len,
             context_len=self.context_len,
             pred_len=self.pred_len,

--- a/sktime/networks/ltsf/models/transformers.py
+++ b/sktime/networks/ltsf/models/transformers.py
@@ -1,5 +1,6 @@
 """Deep Learning Forecaster using LTSF-Transformer Model."""
 
+
 def _LTSFTransformerNetwork():
     """Return the LTSF-Transformer network class."""
     import torch.nn as nn


### PR DESCRIPTION
Some of the soft dependency isolation patterns in the `networks` module are risky, since the soft dependencies are imported, fake dummy classes are created for inheritance, etc.

This PR moves most of such occurrences to the clear build pattern that the `BaseNetwork` children should use.