### PR TITLE
fix: restore integer target shape in numpy3D/numpyflat store roundtrip

### DIFF
--- a/sktime/datatypes/_panel/_convert.py
+++ b/sktime/datatypes/_panel/_convert.py
@@ -1100,7 +1100,7 @@ def from_numpyflat_to_numpy3d(obj, store=None):
         and shape[1] % store["numpy_second_dim"] == 0
     ):
         shape_1 = store["numpy_second_dim"]
-        target_shape = (shape[0], shape_1, shape[1] / shape_1)
+        target_shape = (shape[0], shape_1, shape[1] // shape_1)
     else:
         target_shape = (shape[0], 1, shape[1])
 

--- a/sktime/datatypes/tests/test_convert_bugfixes.py
+++ b/sktime/datatypes/tests/test_convert_bugfixes.py
@@ -41,3 +41,28 @@ def test_convert_MvS_to_UvS_as_Series():
     w = convert_MvS_to_UvS_as_Series(z)
 
     assert y.name == w.name
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("sktime.datatypes"),
+    reason="Test only if sktime.datatypes or utils.parallel has been changed",
+)
+def test_numpy3d_numpyflat_store_roundtrip():
+    """Checks numpy3D -> numpyflat -> numpy3D roundtrip with a store.
+
+    Failure condition for bug #11092: the restore branch built the target
+    shape with true division, so ``reshape`` received a float and raised
+    ``TypeError: 'float' object cannot be interpreted as an integer``.
+    """
+    import numpy as np
+
+    from sktime.datatypes import convert
+
+    X = np.random.rand(3, 2, 5)
+    store = {}
+
+    flat = convert(X, "numpy3D", "numpyflat", "Panel", store=store)
+    restored = convert(flat, "numpyflat", "numpy3D", "Panel", store=store)
+
+    assert np.array_equal(restored, X)
+    assert restored.shape == X.shape


### PR DESCRIPTION
## Description

Fixes #11092.

A `numpy3D -> numpyflat -> numpy3D` roundtrip raised a `TypeError` whenever a `store` was passed. The restore branch in `from_numpyflat_to_numpy3d` built the target shape with true division:

```python
target_shape = (shape[0], shape_1, shape[1] / shape_1)
```

so `reshape` received a float (`TypeError: 'float' object cannot be interpreted as an integer`).

The branch is already guarded by `shape[1] % shape_1 == 0`, so `//` yields the same value as an integer.

## Changes

- `sktime/datatypes/_panel/_convert.py`: use floor division (`//`) for the third dimension of the restored `numpy3D` shape.
- `sktime/datatypes/tests/test_convert_bugfixes.py`: regression test `test_numpy3d_numpyflat_store_roundtrip` covering the `store`-based roundtrip.

## Verification

- New test passes.
- `test_convert_bugfixes.py`: 2 passed, 1 xfailed.
- `test_convert.py`: 213 passed.