### PR TITLE
[ENH] aggregate python dependencies from composite components

### DIFF
--- a/sktime/base/_meta.py
+++ b/sktime/base/_meta.py
@@ -734,6 +734,81 @@ class _HeterogenousMetaEstimator:
         else:
             self.set_tags(**{mid_tag_name: mid_tag_val_not})
 
+    def _deps(self):
+        """Collect python_dependencies from all components recursively.
+
+        Returns
+        -------
+        list
+            Union of python_dependencies from all components, preserving nested
+            lists for disjunctive dependencies and maintaining deterministic ordering.
+        """
+        steps = getattr(self, self._steps_attr, [])
+        all_deps = []
+
+        for _, estimator in steps:
+            if isinstance(estimator, _HeterogenousMetaEstimator):
+                # Read only the nested composite's direct class/default tag;
+                # its instance tag may already contain an aggregated value.
+                deps = estimator.get_class_tag("python_dependencies", None)
+                if deps is not None:
+                    all_deps.append(deps)
+                component_deps = estimator._deps()
+                if component_deps:
+                    all_deps.append(component_deps)
+                continue
+
+            # Leaf estimators expose their dependency expression directly.
+            deps = estimator.get_tag("python_dependencies", None)
+            if deps is not None:
+                all_deps.append(deps)
+
+        # Combine and deduplicate while preserving dependency expressions.
+        return self._combine_dependencies(all_deps)
+
+    def _combine_dependencies(self, dep_list):
+        """Combine dependency lists while preserving disjunctive expressions.
+
+        Parameters
+        ----------
+        dep_list : list
+            List of component dependency specifications. Each item is either a
+            string or a component's top-level list of dependency specifications.
+
+        Returns
+        -------
+        list
+            Combined and deduplicated dependencies. Top-level lists are combined as
+            conjunctions, while nested lists remain disjunctions.
+        """
+        if not dep_list:
+            return []
+
+        def _deduplicate_structure(dep):
+            """Deduplicate nested dependency expressions while preserving order."""
+            if isinstance(dep, list):
+                result = []
+                for item in dep:
+                    item = _deduplicate_structure(item)
+                    if item not in result:
+                        result.append(item)
+                return result
+            return dep
+
+        combined = []
+        for dep in dep_list:
+            # A component's top-level list is an AND expression and can be
+            # combined with the composite's top-level list. Nested lists are OR.
+            dependencies = dep if isinstance(dep, list) else [dep]
+            for dependency in dependencies:
+                if dependency is None or dependency == "":
+                    continue
+                dependency = _deduplicate_structure(dependency)
+                if dependency not in combined:
+                    combined.append(dependency)
+
+        return combined
+
     def _sk_visual_block_(self):
         steps = getattr(self, self._steps_attr)
 

--- a/sktime/base/tests/test_deps.py
+++ b/sktime/base/tests/test_deps.py
@@ -1,0 +1,363 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for _deps dependency aggregation in _HeterogenousMetaEstimator.
+
+Tests in this module:
+
+    test_deps_single_component - tests _deps with a single component
+    test_deps_multiple_components - tests _deps with multiple components
+    test_deps_deduplication - tests that duplicate dependencies are deduplicated
+    test_deps_nested_composite - tests _deps with nested composites
+    test_deps_unfitted - tests _deps works for unfitted composites
+    test_deps_no_dependencies - tests _deps with components that have no dependencies
+    test_deps_preserve_own - tests that composite's own dependencies are preserved
+    test_deps_external_object - tests _deps with non-BaseObject components
+    test_deps_nested_list - tests nested list dependency structures
+"""
+
+__all__ = [
+    "test_deps_single_component",
+    "test_deps_multiple_components",
+    "test_deps_deduplication",
+    "test_deps_nested_composite",
+    "test_deps_unfitted",
+    "test_deps_no_dependencies",
+    "test_deps_preserve_own",
+    "test_deps_nested_list",
+    "test_deps_deduplication_nested",
+    "test_deps_multiple_components_with_nested_lists",
+    "test_deps_nested_composite_ignores_aggregate_override",
+    "test_deps_structurally_distinct_nested_lists",
+    "test_deps_real_transformer_pipeline_recompute",
+    "test_deps_dynamic_real_composites",
+]
+
+import pytest
+
+from sktime.base import BaseObject
+from sktime.base._meta import _HeterogenousMetaEstimator
+
+
+class DummyEstimatorWithDeps(BaseObject):
+    """Dummy estimator with python_dependencies tag for testing."""
+
+    _tags = {"python_dependencies": "numpy"}
+
+
+class DummyEstimatorWithMultipleDeps(BaseObject):
+    """Dummy estimator with multiple python_dependencies for testing."""
+
+    _tags = {"python_dependencies": ["numpy", "scipy"]}
+
+
+class DummyEstimatorWithNestedDeps(BaseObject):
+    """Dummy estimator with nested list dependencies for testing (OR semantics)."""
+
+    _tags = {"python_dependencies": [["numpy>=1.20", "pandas>=1.3"], "scikit-learn>=0.24"]}
+
+
+class DummyEstimatorNoDeps(BaseObject):
+    """Dummy estimator without python_dependencies tag for testing."""
+
+    pass
+
+
+class DummyEstimatorOwnDeps(BaseObject):
+    """Dummy estimator with its own dependencies for testing."""
+
+    _tags = {"python_dependencies": "pandas"}
+
+
+class DummyComposite(_HeterogenousMetaEstimator, BaseObject):
+    """Dummy composite for testing _deps without real sktime imports."""
+
+    _steps_attr = "_steps"
+
+    def __init__(self, steps):
+        self.steps = steps
+        super().__init__()
+
+    @property
+    def _steps(self):
+        return self.steps
+
+    @_steps.setter
+    def _steps(self, value):
+        self.steps = value
+
+
+def test_deps_single_component():
+    """Test _deps with a single component with dependencies."""
+    pipeline = DummyComposite([("estimator", DummyEstimatorWithDeps())])
+
+    deps = pipeline._deps()
+    assert isinstance(deps, list)
+    assert "numpy" in deps
+
+
+def test_deps_multiple_components():
+    """Test _deps with multiple components with different dependencies."""
+    pipeline = DummyComposite(
+        [
+            ("estimator1", DummyEstimatorWithDeps()),
+            ("estimator2", DummyEstimatorWithMultipleDeps()),
+        ]
+    )
+
+    deps = pipeline._deps()
+    assert isinstance(deps, list)
+    assert "numpy" in deps
+    assert "scipy" in deps
+
+
+def test_deps_deduplication():
+    """Test that duplicate dependencies are deduplicated."""
+    pipeline = DummyComposite(
+        [
+            ("estimator1", DummyEstimatorWithDeps()),
+            ("estimator2", DummyEstimatorWithDeps()),
+            ("estimator3", DummyEstimatorWithMultipleDeps()),
+        ]
+    )
+
+    deps = pipeline._deps()
+    assert isinstance(deps, list)
+    # numpy should appear only once despite being in multiple components
+    assert deps.count("numpy") == 1
+    assert "scipy" in deps
+
+
+def test_deps_nested_composite():
+    """Test _deps with nested composite/pipeline dependencies."""
+    inner_pipeline = DummyComposite([("estimator", DummyEstimatorWithDeps())])
+
+    outer_pipeline = DummyComposite(
+        [
+            ("inner", inner_pipeline),
+            ("estimator", DummyEstimatorWithMultipleDeps()),
+        ]
+    )
+
+    deps = outer_pipeline._deps()
+    assert isinstance(deps, list)
+    assert "numpy" in deps
+    assert "scipy" in deps
+
+
+def test_deps_unfitted():
+    """Test _deps works for unfitted composites."""
+    pipeline = DummyComposite(
+        [
+            ("estimator1", DummyEstimatorWithDeps()),
+            ("estimator2", DummyEstimatorWithMultipleDeps()),
+        ]
+    )
+
+    # Should work without fitting
+    deps = pipeline._deps()
+    assert isinstance(deps, list)
+    assert "numpy" in deps
+    assert "scipy" in deps
+
+
+def test_deps_no_dependencies():
+    """Test _deps with components that have no dependencies."""
+    pipeline = DummyComposite(
+        [
+            ("estimator1", DummyEstimatorNoDeps()),
+            ("estimator2", DummyEstimatorNoDeps()),
+        ]
+    )
+
+    deps = pipeline._deps()
+    assert isinstance(deps, list)
+    assert len(deps) == 0
+
+
+def test_deps_preserve_own():
+    """Test that composite's own dependencies are preserved in dynamic tag."""
+    class CompositeWithOwnDeps(DummyComposite):
+        _tags = {"python_dependencies": "pandas"}
+
+    pipeline = CompositeWithOwnDeps(
+        [
+            ("estimator1", DummyEstimatorWithDeps()),
+            ("estimator2", DummyEstimatorWithMultipleDeps()),
+        ]
+    )
+
+    # Check that component dependencies are collected
+    component_deps = pipeline._deps()
+    assert isinstance(component_deps, list)
+    assert "numpy" in component_deps
+    assert "scipy" in component_deps
+
+    # Check that composite's own dependencies are still accessible
+    own_deps = pipeline.get_class_tag("python_dependencies")
+    assert own_deps == "pandas"
+
+    # Check that combining works correctly
+    all_deps = ["pandas", component_deps]
+    combined = pipeline._combine_dependencies(all_deps)
+    assert isinstance(combined, list)
+    assert "pandas" in combined
+    assert "numpy" in combined
+    assert "scipy" in combined
+
+
+def test_deps_external_object():
+    """Test _deps with non-BaseObject components."""
+    class NotABaseObject:
+        def get_tag(self, tag_name, tag_value_default=None):
+            return tag_value_default
+
+    pipeline = DummyComposite(
+        [
+            ("external", NotABaseObject()),
+            ("estimator", DummyEstimatorWithDeps()),
+        ]
+    )
+
+    # Should handle the non-BaseObject gracefully via get_tag returning None
+    deps = pipeline._deps()
+    assert isinstance(deps, list)
+    assert "numpy" in deps
+
+
+def test_deps_nested_list():
+    """Test that nested list dependency structures are preserved."""
+    pipeline = DummyComposite([("estimator", DummyEstimatorWithNestedDeps())])
+
+    deps = pipeline._deps()
+    assert deps == [
+        ["numpy>=1.20", "pandas>=1.3"],
+        "scikit-learn>=0.24",
+    ]
+
+
+def test_deps_deduplication_nested():
+    """Test deduplication with nested dependency structures."""
+    class MockEstimatorWithNested(BaseObject):
+        _tags = {"python_dependencies": [["numpy", "scipy"], "pandas"]}
+
+    pipeline = DummyComposite([
+        ("est1", MockEstimatorWithNested()),
+        ("est2", MockEstimatorWithNested()),
+    ])
+
+    deps = pipeline._deps()
+    assert deps == [["numpy", "scipy"], "pandas"]
+
+
+def test_deps_multiple_components_with_nested_lists():
+    """Test that OR expressions from multiple components remain separate."""
+
+    class MockEstimatorWithOtherNested(BaseObject):
+        _tags = {"python_dependencies": [["darts", "u8darts"], "pandas"]}
+
+    pipeline = DummyComposite(
+        [
+            ("first", DummyEstimatorWithNestedDeps()),
+            ("second", MockEstimatorWithOtherNested()),
+        ]
+    )
+
+    assert pipeline._deps() == [
+        ["numpy>=1.20", "pandas>=1.3"],
+        "scikit-learn>=0.24",
+        ["darts", "u8darts"],
+        "pandas",
+    ]
+
+
+def test_deps_nested_composite_ignores_aggregate_override():
+    """Test nested composites use direct tags and recurse into components."""
+
+    class NestedComposite(DummyComposite):
+        _tags = {"python_dependencies": "nested-own"}
+
+    nested = NestedComposite([("leaf", DummyEstimatorWithDeps())])
+    nested.set_tags(**{"python_dependencies": ["stale", "aggregate"]})
+    outer = DummyComposite([("nested", nested)])
+
+    assert outer._deps() == ["nested-own", "numpy"]
+
+
+def test_deps_structurally_distinct_nested_lists():
+    """Test top-level AND and nested OR grouping are not conflated."""
+
+    class FirstShape(BaseObject):
+        _tags = {"python_dependencies": ["numpy", ["pandas", "polars"]]}
+
+    class SecondShape(BaseObject):
+        _tags = {"python_dependencies": [["numpy", "pandas"], "polars"]}
+
+    first = DummyComposite([("estimator", FirstShape())])
+    second = DummyComposite([("estimator", SecondShape())])
+
+    assert first._deps() == ["numpy", ["pandas", "polars"]]
+    assert second._deps() == [["numpy", "pandas"], "polars"]
+
+
+def test_deps_real_transformer_pipeline_recompute():
+    """Test dynamic aggregation is idempotent and clears replaced dependencies."""
+    from sktime.transformations.compose import TransformerPipeline
+    from sktime.transformations.exponent import ExponentTransformer
+
+    class TransformerWithDeps(ExponentTransformer):
+        _tags = {"python_dependencies": ["dep-a", ["dep-b", "dep-c"]]}
+
+    class ReplacementTransformer(ExponentTransformer):
+        _tags = {"python_dependencies": "dep-replacement"}
+
+    class PipelineWithOwnDeps(TransformerPipeline):
+        _tags = {"python_dependencies": "dep-own"}
+
+    pipeline = TransformerPipeline([TransformerWithDeps()])
+    expected = ["dep-a", ["dep-b", "dep-c"]]
+    pipeline.__dynamic_tags__()
+    assert pipeline.get_tag("python_dependencies") == expected
+    pipeline.__dynamic_tags__()
+    assert pipeline.get_tag("python_dependencies") == expected
+
+    pipeline.steps = [ReplacementTransformer()]
+    pipeline.__dynamic_tags__()
+    assert pipeline.get_tag("python_dependencies") == ["dep-replacement"]
+
+    owned_pipeline = PipelineWithOwnDeps([TransformerWithDeps()])
+    assert owned_pipeline.get_tag("python_dependencies") == [
+        "dep-own",
+        "dep-a",
+        ["dep-b", "dep-c"],
+    ]
+
+
+def test_deps_dynamic_real_composites():
+    """Test dynamic dependency tags on the concrete pipeline composites."""
+    try:
+        from sktime.forecasting.compose import (
+            ForecastingPipeline,
+            TransformedTargetForecaster,
+        )
+        from sktime.forecasting.naive import NaiveForecaster
+        from sktime.transformations.compose import TransformerPipeline
+        from sktime.transformations.exponent import ExponentTransformer
+    except (ImportError, OSError) as exc:
+        pytest.skip(f"real composite imports unavailable: {exc}")
+
+    class TransformerWithDeps(ExponentTransformer):
+        _tags = {"python_dependencies": ["dep-a", ["dep-b", "dep-c"]]}
+
+    transformer = TransformerWithDeps()
+    expected = ["dep-a", ["dep-b", "dep-c"]]
+
+    forecasting_pipeline = ForecastingPipeline([transformer, NaiveForecaster()])
+    target_pipeline = TransformedTargetForecaster([transformer, NaiveForecaster()])
+    transformer_pipeline = TransformerPipeline([transformer, TransformerWithDeps()])
+
+    assert forecasting_pipeline.get_tag("python_dependencies") == expected
+    assert target_pipeline.get_tag("python_dependencies") == expected
+    assert transformer_pipeline.get_tag("python_dependencies") == expected
+
+    nested_pipeline = TransformerPipeline([transformer])
+    outer_pipeline = TransformerPipeline([nested_pipeline, transformer])
+    assert outer_pipeline.get_tag("python_dependencies") == expected

--- a/sktime/forecasting/compose/_pipeline.py
+++ b/sktime/forecasting/compose/_pipeline.py
@@ -456,6 +456,21 @@ class ForecastingPipeline(_Pipeline):
         self.clone_tags(self.forecaster_, tags_to_clone)
         self._anytagis_then_set("fit_is_empty", False, True, self.steps_)
 
+        # aggregate python_dependencies from all components
+        component_deps = self._deps()
+        # preserve composite's own direct dependencies if any
+        own_deps = self.get_class_tag("python_dependencies", None)
+        all_deps = []
+        if own_deps is not None:
+            if isinstance(own_deps, str):
+                all_deps.append(own_deps)
+            elif isinstance(own_deps, list):
+                all_deps.append(own_deps)
+        if component_deps:
+            all_deps.append(component_deps)
+        combined_deps = self._combine_dependencies(all_deps)
+        self.set_tags(**{"python_dependencies": combined_deps})
+
     @property
     def forecaster_(self):
         """Return reference to the forecaster in the pipeline.
@@ -920,6 +935,21 @@ class TransformedTargetForecaster(_Pipeline):
         #   create indices, and that behaviour is not tag-inspectable
         self.clone_tags(self.forecaster_, tags_to_clone)
         self._anytagis_then_set("fit_is_empty", False, True, self.steps_)
+
+        # aggregate python_dependencies from all components
+        component_deps = self._deps()
+        # preserve composite's own direct dependencies if any
+        own_deps = self.get_class_tag("python_dependencies", None)
+        all_deps = []
+        if own_deps is not None:
+            if isinstance(own_deps, str):
+                all_deps.append(own_deps)
+            elif isinstance(own_deps, list):
+                all_deps.append(own_deps)
+        if component_deps:
+            all_deps.append(component_deps)
+        combined_deps = self._combine_dependencies(all_deps)
+        self.set_tags(**{"python_dependencies": combined_deps})
 
         # above, we cloned the capability:exogenous tag,
         # but we also need to check whether X is used as y in some transformer

--- a/sktime/transformations/compose/_pipeline.py
+++ b/sktime/transformations/compose/_pipeline.py
@@ -207,6 +207,26 @@ class TransformerPipeline(_HeterogenousMetaEstimator, BaseTransformer):
     def _steps(self, value):
         self.steps = value
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values condition on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        # aggregate python_dependencies from all components
+        component_deps = self._deps()
+        # preserve composite's own direct dependencies if any
+        own_deps = self.get_class_tag("python_dependencies", None)
+        all_deps = []
+        if own_deps is not None:
+            if isinstance(own_deps, str):
+                all_deps.append(own_deps)
+            elif isinstance(own_deps, list):
+                all_deps.append(own_deps)
+        if component_deps:
+            all_deps.append(component_deps)
+        combined_deps = self._combine_dependencies(all_deps)
+        self.set_tags(**{"python_dependencies": combined_deps})
+
     def _check_steps(self, estimators):
         """Check Steps.
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #10951.

#### What does this implement/fix? Explain your changes.

Composite estimators, such as `ForecastingPipeline`, `TransformedTargetForecaster`, and `TransformerPipeline`, were not aggregating `python_dependencies` defined by their component estimators.

This PR:

- implements recursive dependency aggregation in `_HeterogenousMetaEstimator`
- traverses unfitted composite estimators through `_steps_attr`
- maintains the current semantics of top-level lists for AND requirements and nested lists for OR alternatives
- preserves dependencies defined directly by composite estimators
- prevents stale dependencies when components are replaced or dynamic tags are recomputed
- applies the aggregated dependencies to the relevant forecasting and transformation pipelines

Nested composite estimators are recursively traversed without relying on their already-aggregated instance-level dependency tag.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Recursive dependency aggregation in `_HeterogenousMetaEstimator`
- Preservation of the current semantics of nested dependency expressions
- Dynamic tag handling and avoidance of stale dependencies
- Integration with the three affected composite pipeline estimators

#### Did you add any tests for the change?

Yes.

Implemented test cases covering:

- dependency aggregation from a single component
- dependency aggregation from multiple components
- dependency deduplication
- nested composite estimators
- unfitted composite estimators
- dependencies defined directly by composite estimators
- preservation of nested OR dependency expressions
- repeated dynamic tag evaluation
- component replacement without stale dependencies
- integration with `ForecastingPipeline`, `TransformedTargetForecaster`, and `TransformerPipeline`

All dependency tests pass (`15 passed`).

#### Any other comments?

The implementation uses the existing `_steps_attr` mechanism to access unfitted blueprint components rather than introducing a new generic component traversal API.