### PR TITLE
[BUG] remove moved ensemble classifiers from `classification.compose.__all__`

### DIFF
--- a/sktime/classification/compose/__init__.py
+++ b/sktime/classification/compose/__init__.py
@@ -5,11 +5,9 @@
 __author__ = ["mloning", "fkiraly"]
 __all__ = [
     "ClassifierPipeline",
-    "ComposableTimeSeriesForestClassifier",
     "ColumnEnsembleClassifier",
     "MultiplexClassifier",
     "SklearnClassifierPipeline",
-    "WeightedEnsembleClassifier",
 ]
 
 from sktime.classification.compose._column_ensemble import ColumnEnsembleClassifier


### PR DESCRIPTION
# LLM generated content, by Claude Opus 5

#### Reference Issues/PRs

None. Found by checking that every `__all__` entry resolves.

#### What does this implement/fix? Explain your changes.

`sktime/classification/compose/__init__.py` still lists `ComposableTimeSeriesForestClassifier` and `WeightedEnsembleClassifier` in `__all__`. Both classes moved to `sktime.classification.ensemble` in #4532, and the compose re-exports were removed in the 0.20.0 deprecation actions (#4733). Only the `__all__` entries were left behind, so a star-import fails:

```console
$ python -c "from sktime.classification.compose import *"
AttributeError: module 'sktime.classification.compose' has no attribute 'ComposableTimeSeriesForestClassifier'
```

This PR removes the two stale entries (`+0/−2`). Both classes are still importable from `sktime.classification.ensemble`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Whether you'd prefer to keep a compose-level alias instead. The deprecation cycle for these names already ended in 0.20.0, so removing the entries seemed right.

#### Did you add any tests for the change?

No new test. I checked it manually:
- before: the star-import raises the `AttributeError` above
- after: `from sktime.classification.compose import *` succeeds, and `[n for n in __all__ if not hasattr(module, n)]` is `[]`

#### Any other comments?

AI-assisted, human reviewed.

#### PR checklist

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

🤖 Generated with [Claude Code](https://claude.com/claude-code)
