### PR TITLE
[DOC] add doctest example for LuckyDtwDist

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4160,6 +4160,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "KingLizard1020",
+      "name": "Kailash Nelson",
+      "avatar_url": "https://avatars.githubusercontent.com/u/37966146?v=4",
+      "profile": "https://github.com/KingLizard1020",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/sktime/dists_kernels/lucky.py
+++ b/sktime/dists_kernels/lucky.py
@@ -23,6 +23,18 @@ class LuckyDtwDist(_DelegatedPairwiseTransformerPanel):
     ..[1] Stephan Spiegel, Brijnesh-Johannes Jain, and Sahin Albayrak.
         Fast time series classification under lucky time warping distance.
         Proceedings of the 29th Annual ACM Symposium on Applied Computing. 2014.
+
+    Examples
+    --------
+    >>> from sktime.datasets import load_unit_test
+    >>> from sktime.dists_kernels import LuckyDtwDist
+    >>>
+    >>> X, _ = load_unit_test()
+    >>> X = X[0:3]
+    >>> dist = LuckyDtwDist()
+    >>> dist_mat = dist.transform(X)
+    >>> dist_mat.shape
+    (3, 3)
     """
 
     _tags = {


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #10782.

#### What does this implement/fix? Explain your changes.

Adds a numpydoc `Examples` section with a runnable doctest to `LuckyDtwDist` (`sktime/dists_kernels/lucky.py`).

This is a single-class docs PR for the tracking issue. I ran the `all_estimators()` recipe on current upstream `main`, crossed-checked open issue comments and open PRs, and picked `LuckyDtwDist` because it still lacked `>>>`, was unclaimed, is exported from `sktime.dists_kernels`, and has no soft dependencies.

The example follows the `load_unit_test` + `transform` pattern used by neighbouring `dists_kernels` docstrings (`compose.py`, `DistFromAligner`). It asserts only `dist_mat.shape` for a 3-series panel so the doctest stays pandas-version robust. `LuckyDtwDist` had no `tests:skip_by_name` entry for `test_class_has_doctest_example`, so nothing was removed.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

* Whether the public `sktime.dists_kernels` import path and `load_unit_test` example match the intended usage.
* Shape-only assertion vs leaving the transform unasserted (as in `DistFromAligner`).

#### Did you add any tests for the change?

No new tests. The example is exercised by the existing `test_class_has_doctest_example` and `test_doctest_examples` checks.

#### Any other comments?

Claimed on #10782.

Verified locally:
* `check_estimator(LuckyDtwDist, tests_to_run=["test_class_has_doctest_example", "test_doctest_examples"])` — both PASSED
* `run_doctest(LuckyDtwDist)` — OK
* `ruff check` and `ruff format --check` on `sktime/dists_kernels/lucky.py` — clean

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-) (`doc` badge in `.all-contributorsrc`)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
