### PR TITLE
[ENH] migrate `remember_data` tag to `_BaseTag` class

### DIFF
--- a/docs/source/api_reference/tags.rst
+++ b/docs/source/api_reference/tags.rst
@@ -104,6 +104,7 @@ These tags are used to describe capabilities, properties, and behavior of foreca
     capability__random_state
     requires_fh_in_fit
     fit_is_empty
+    remember_data
     property__randomness
     X_y_must_have_same_index
 
@@ -171,6 +172,7 @@ transform a single time series object (``"transformer"`` type).
     capability__inverse_transform__range
     capability__bootstrap_index
     fit_is_empty
+    remember_data
     transform_returns_same_time_index
     skip_inverse_transform
     property__randomness

--- a/sktime/registry/_tags.py
+++ b/sktime/registry/_tags.py
@@ -953,6 +953,38 @@ class fit_is_empty(_BaseTag):
     }
 
 
+class remember_data(_BaseTag):
+    """Behaviour flag: whether the estimator remembers all data seen.
+
+    - String name: ``"remember_data"``
+    - Public behaviour flag
+    - Values: boolean, ``True`` / ``False``
+    - Example: ``True``
+    - Default: ``False`` (transformers)
+
+    This tag applies to transformers and forecasters.
+
+    If the tag is ``True``, the estimator memorizes data seen in ``fit``
+    and ``update`` as ``self._X``, ``self._y``, or similar attributes.
+
+    If the tag is ``False``, the estimator does not store all data seen.
+
+    For transformers, if this tag is ``True``, the ``fit_is_empty`` tag
+    must be ``False``, even if ``_fit`` is empty, because boilerplate
+    writes to ``self._X`` in ``fit``.
+    """
+
+    _tags = {
+        "tag_name": "remember_data",
+        "parent_type": ["forecaster", "transformer"],
+        "tag_type": "bool",
+        "short_descr": (
+            "whether estimator remembers all data seen as self._X, self._y, etc"
+        ),
+        "user_facing": True,
+    }
+
+
 class property__randomness(_BaseTag):
     """Property: Degree of randomness vs determinism of the estimator.
 
@@ -4020,12 +4052,6 @@ ESTIMATOR_TAG_REGISTER = [
         ),
         "which type the classifier falls under in the taxonomy of time series "
         "classification algorithms.",
-    ),
-    (
-        "remember_data",
-        ["forecaster", "transformer"],
-        "bool",
-        "whether estimator remembers all data seen as self._X, self._y, etc",
     ),
     (
         "reserved_params",


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #10804.

#### What does this implement/fix? Explain your changes.

Migrates the remaining `remember_data` tag from a plain tuple in `ESTIMATOR_TAG_REGISTER` to a `_BaseTag` class.

* Adds `remember_data` as a `_BaseTag` subclass in the general estimator tags section of `sktime/registry/_tags.py`, preserving the existing name, parent types (`forecaster`, `transformer`), value type (`bool`), and short description.
* Removes the legacy tuple from `ESTIMATOR_TAG_REGISTER` so the class is the single source of truth (classes are appended to the register automatically).
* Documents the tag in the forecaster and transformer sections of `docs/source/api_reference/tags.rst`.

This tag was still a tuple on current `main`. Open PRs under #10804 cover other remaining tuples (`enforce_index_type`, `pwtrafo_type`, `scitype:y`, `classifier_type`, `reserved_params`). An earlier comment claimed `remember_data` but no PR followed.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

* Class placement in the general estimator tags section (the tag applies to both forecasters and transformers).
* That the docstring matches existing `_BaseTag` patterns without changing tag semantics.

#### Did you add any tests for the change?

No new tests. Relies on existing focused registry tests (`sktime/registry/tests/test_tags.py` and `test_all_tags`).

#### Any other comments?

One tag only, as requested in #10804.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.