### PR TITLE
[ENH] allow arbitrary torch.optim optimizer name strings in BaseDeepClassifierPytorch

### DIFF
--- a/sktime/classification/deep_learning/base/_base_torch.py
+++ b/sktime/classification/deep_learning/base/_base_torch.py
@@ -1,6 +1,6 @@
 """Abstract base class for the Pytorch neural network classifiers."""
 
-__authors__ = ["geetu040", "RecreationalMath"]
+__authors__ = ["geetu040", "RecreationalMath", "KingLizard1020"]
 
 __all__ = ["BaseDeepClassifierPytorch"]
 
@@ -11,6 +11,7 @@ import numpy as np
 from sklearn.preprocessing import LabelEncoder
 
 from sktime.classification.base import BaseClassifier
+from sktime.utils._lookup import _lookup
 from sktime.utils.dependencies import _safe_import
 
 ReduceLROnPlateau = _safe_import("torch.optim.lr_scheduler.ReduceLROnPlateau")
@@ -607,16 +608,21 @@ class BaseDeepClassifierPytorch(BaseClassifier):
         if self.optimizer is None:
             optimizer_class = _safe_import("torch.optim.Adam")
             optimizer_params = {"lr": self.lr}
-        # if optimizer is a string, look it up in the available optimizers
+        # if optimizer is a string, look it up in torch.optim (case-insensitive)
         elif isinstance(self.optimizer, str):
-            if self.optimizer.lower() not in self._all_optimizers:
-                raise ValueError(
-                    f"Unknown optimizer: {self.optimizer}. Please pass one of "
-                    f"{', '.join(self._all_optimizers)} for `optimizer`."
+            try:
+                optimizer_class = _lookup(
+                    self.optimizer,
+                    "torch.optim",
+                    alias_dict=self._all_optimizers,
                 )
-            optimizer_class = _safe_import(
-                f"torch.optim.{self._all_optimizers[self.optimizer.lower()]}"
-            )
+            except ValueError as err:
+                raise ValueError(
+                    f"Unknown optimizer: {self.optimizer}. Please pass a valid "
+                    "optimizer name from torch.optim "
+                    "(https://pytorch.org/docs/stable/optim.html#algorithms), "
+                    "or an optimizer class or instance."
+                ) from err
             optimizer_params = {"lr": self.lr}
         # if optimizer is an optimizer class, use it as is
         elif isinstance(self.optimizer, type) and issubclass(

--- a/sktime/classification/tests/test_base.py
+++ b/sktime/classification/tests/test_base.py
@@ -728,6 +728,34 @@ def test_pytorch_optimizer_invalid_raises():
             _mlp_torch_clf(optimizer=optimizer).fit(X_train, y_train)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("torch", severity="none")
+    or not run_test_module_changed(["sktime.classification", "sktime.utils._lookup"]),
+    reason="skip test if required soft dependency not available",
+)
+@pytest.mark.parametrize("optimizer", ["RAdam", "adamw", "SGD"])
+def test_pytorch_optimizer_str_from_torch_optim(optimizer):
+    """Arbitrary torch.optim names resolve, including names not in curated aliases."""
+    import torch
+
+    from sktime.datasets import load_unit_test
+
+    X_train, y_train = load_unit_test(split="train")
+
+    expected = {
+        "RAdam": torch.optim.RAdam,
+        "adamw": torch.optim.AdamW,
+        "SGD": torch.optim.SGD,
+    }[optimizer]
+
+    clf = _mlp_torch_clf(optimizer=optimizer)
+    # empty curated aliases: resolution must still succeed via torch.optim
+    clf._all_optimizers = {}
+    clf.fit(X_train, y_train)
+
+    assert isinstance(clf._optimizer, expected)
+
+
 DUMMY_EST_PARAMETERS_FOO = [None, 10.3, "string", {"key": "value"}, lambda x: x**2]
 
 

--- a/sktime/utils/_lookup.py
+++ b/sktime/utils/_lookup.py
@@ -1,0 +1,75 @@
+"""Utilities for looking up objects in modules by name or alias."""
+
+from sktime.utils.dependencies import _safe_import
+
+__author__ = ["KingLizard1020"]
+
+
+def _lowercase_importer(module_path):
+    """Import ``module_path`` and map lower-case names to canonical names.
+
+    Parameters
+    ----------
+    module_path : str
+        Dotted path of the module to inspect, for example ``"torch.optim"``.
+
+    Returns
+    -------
+    dict
+        Mapping from ``name.lower()`` to the original exported name.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If ``module_path`` cannot be imported.
+    """
+    module = _safe_import(module_path, return_object="None")
+    if module is None:
+        raise ModuleNotFoundError(f"Cannot import {module_path!r}.")
+    return {name.lower(): name for name in dir(module)}
+
+
+def _lookup(alias, module_path, alias_dict=None):
+    """Resolve ``alias`` to an object imported from ``module_path``.
+
+    Looks up ``alias`` case-insensitively among names exported by
+    ``module_path``. An optional ``alias_dict`` of extra aliases (typically
+    lower-case keys to canonical names) is merged on top of that map.
+
+    If a match is found, the object is imported with ``_safe_import``.
+    Otherwise a ``ValueError`` is raised.
+
+    Parameters
+    ----------
+    alias : str
+        Name or alias of the object to import.
+    module_path : str
+        Dotted path of the module to search, for example ``"torch.optim"``.
+    alias_dict : dict, optional
+        Optional mapping of aliases to canonical names. Keys are matched
+        case-insensitively.
+
+    Returns
+    -------
+    object
+        The imported object.
+
+    Raises
+    ------
+    ValueError
+        If ``alias`` cannot be resolved to a name in ``module_path``.
+    ModuleNotFoundError
+        If ``module_path`` cannot be imported.
+    """
+    name_map = _lowercase_importer(module_path)
+    if alias_dict is not None:
+        name_map.update({str(k).lower(): v for k, v in alias_dict.items()})
+
+    if not isinstance(alias, str) or alias.lower() not in name_map:
+        raise ValueError(f"{alias!r} is not a valid name in {module_path}.")
+
+    canonical = name_map[alias.lower()]
+    obj = _safe_import(f"{module_path}.{canonical}", return_object="None")
+    if obj is None:
+        raise ValueError(f"{alias!r} is not a valid name in {module_path}.")
+    return obj

--- a/sktime/utils/tests/test_lookup.py
+++ b/sktime/utils/tests/test_lookup.py
@@ -1,0 +1,72 @@
+"""Tests for case-insensitive module lookup utilities."""
+
+import pytest
+
+from sktime.tests.test_switch import run_test_module_changed
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils._lookup"]),
+    reason="Run if relevant content has changed.",
+)
+def test_lowercase_importer_maps_module_names():
+    """Names are indexed by their lower-case spelling."""
+    from sktime.utils._lookup import _lowercase_importer
+
+    name_map = _lowercase_importer("numpy")
+
+    assert name_map["scalartype"] == "ScalarType"
+    assert name_map["ndarray"] == "ndarray"
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils._lookup"]),
+    reason="Run if relevant content has changed.",
+)
+def test_lowercase_importer_missing_module_raises():
+    """A missing module path raises ModuleNotFoundError."""
+    from sktime.utils._lookup import _lowercase_importer
+
+    with pytest.raises(ModuleNotFoundError, match="not_a_real_module_xyz"):
+        _lowercase_importer("not_a_real_module_xyz")
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils._lookup"]),
+    reason="Run if relevant content has changed.",
+)
+@pytest.mark.parametrize("alias", ["ScalarType", "scalartype", "SCALARTYPE"])
+def test_lookup_is_case_insensitive(alias):
+    """Objects are resolved from a module by case-insensitive name."""
+    import numpy as np
+
+    from sktime.utils._lookup import _lookup
+
+    assert _lookup(alias, "numpy") is np.ScalarType
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils._lookup"]),
+    reason="Run if relevant content has changed.",
+)
+def test_lookup_uses_optional_alias_dict():
+    """Optional alias_dict maps extra aliases onto canonical names."""
+    import numpy as np
+
+    from sktime.utils._lookup import _lookup
+
+    obj = _lookup("st", "numpy", alias_dict={"st": "ScalarType"})
+
+    assert obj is np.ScalarType
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed(["sktime.utils._lookup"]),
+    reason="Run if relevant content has changed.",
+)
+def test_lookup_unknown_alias_raises():
+    """Unknown names raise ValueError after the module map is checked."""
+    from sktime.utils._lookup import _lookup
+
+    with pytest.raises(ValueError, match="not_a_real_name_xyz"):
+        _lookup("not_a_real_name_xyz", "numpy")


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #11051.

#### What does this implement/fix? Explain your changes.

`BaseDeepClassifierPytorch._instantiate_optimizer` currently resolves optimizer name strings only through a curated alias dictionary. Valid `torch.optim` names that are missing from that map (including optimizers added in later PyTorch versions) are rejected.

This adds a shared lookup utility in `sktime.utils._lookup`, split into two private helpers as described in the issue:

- `_lowercase_importer(module_path)` checks that the module can be imported, then builds `{name.lower(): name}` for names exported by that module
- `_lookup(alias, module_path, alias_dict=None)` merges an optional alias dictionary, resolves `alias` case-insensitively, and imports the object with `_safe_import`

`_instantiate_optimizer` then calls `_lookup` with `module_path="torch.optim"` and the existing lower-case aliases as `alias_dict`. Unknown names still raise `ValueError`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- The two private helpers in `sktime.utils._lookup`
- The string branch of `BaseDeepClassifierPytorch._instantiate_optimizer`

#### Did you add any tests for the change?

Yes.

- `sktime/utils/tests/test_lookup.py` covers case-insensitive lookup, optional `alias_dict`, a missing module, and an unknown name
- `test_pytorch_optimizer_str_from_torch_optim` in `sktime/classification/tests/test_base.py` checks that names such as `"RAdam"`, `"adamw"`, and `"SGD"` resolve even when the curated alias dict is empty

#### Any other comments?

Scope is limited to optimizer string lookup in `BaseDeepClassifierPytorch` plus the shared util. Activations and schedulers are left for follow-up, as discussed on the issue.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].