### PR TITLE
[BUG] ensure `DistFromAligner` treats symmetric property directly

### DIFF
--- a/sktime/dists_kernels/compose_from_align.py
+++ b/sktime/dists_kernels/compose_from_align.py
@@ -71,7 +71,10 @@ class DistFromAligner(BasePairwiseTransformerPanel):
         # find out whether we know that the resulting matrix is symmetric
         #   since aligner distances are always symmetric,
         #   we know it's the case for sure if X equals X2
-        if X2 is None:
+        # X2 is None covers direct calls to _transform;
+        #   X2 is X covers calls via transform, where the base class
+        #   already substituted X for a None X2 (identity is preserved)
+        if X2 is None or X2 is X:
             X2 = X
             symm = True
         else:

--- a/sktime/dists_kernels/tests/test_compose_from_align.py
+++ b/sktime/dists_kernels/tests/test_compose_from_align.py
@@ -1,0 +1,39 @@
+"""Tests for DistFromAligner symmetry."""
+
+import numpy as np
+
+from sktime.alignment.lucky import AlignerLuckyDtw
+from sktime.datasets import load_unit_test
+from sktime.dists_kernels.compose_from_align import DistFromAligner
+
+
+def test_dist_from_aligner_symmetric_when_x2_none():
+    """DistFromAligner must return a symmetric matrix when X2 is not passed.
+
+    Regression test for #11091: the symmetry shortcut in
+    DistFromAligner._transform was never triggered because the base class
+    transform() always passes X2 explicitly. With an aligner whose distance
+    depends on argument order (AlignerLuckyDtw tie-breaking), the resulting
+    self-distance matrix was asymmetric despite the ``symmetric: True`` tag.
+    """
+    X, _ = load_unit_test()
+    X = X[0:3]
+
+    dist_mat = DistFromAligner(AlignerLuckyDtw()).transform(X)
+
+    assert dist_mat.shape == (3, 3)
+    assert np.allclose(dist_mat, dist_mat.T), (
+        "self-distance matrix should be symmetric, got:\n"
+        f"{dist_mat}"
+    )
+
+
+def test_dist_from_aligner_full_matrix_when_x2_passed():
+    """DistFromAligner must compute the full matrix when a distinct X2 is passed."""
+    X, _ = load_unit_test()
+    X = X[0:3]
+    X2 = X[0:2]
+
+    dist_mat = DistFromAligner(AlignerLuckyDtw()).transform(X, X2)
+
+    assert dist_mat.shape == (3, 2)


### PR DESCRIPTION
Fixes #11091.

## Problem
`DistFromAligner` is tagged `symmetric: True`, but `BasePairwiseTransformerPanel.transform` always passes `X2` explicitly (it substitutes `X` for a `None` `X2`), so the `X2 is None` check in `DistFromAligner._transform` was dead code. The symmetry mirroring therefore never ran, and every ordered pair was computed via `aligner.fit([X[i], X2[j]]).get_distance()`.

With `AlignerLuckyDtw` (dependency-free, used in `get_test_params`), the greedy DTW path accumulation depends on argument order, so the resulting self-distance matrix was asymmetric:

```
[[       0.  1056844. 12946759.]
 [ 1056844.        0.   577195.]
 [ 1468054.   577195.        0.]]   # dist_mat[0,2] != dist_mat[2,0]
```

## Change
Detect the self-distance case via identity (`X2 is X`) in addition to the `None` check, so the mirrored upper/lower-triangle shortcut is actually used.

## Verification
- Reproduced the asymmetry before the change; matrix is symmetric after.
- Added `sktime/dists_kernels/tests/test_compose_from_align.py` (2 tests: symmetric self-distance, full matrix when distinct X2 passed).
- Local test run: `sktime/dists_kernels/tests/` → 247 passed (1 pre-existing failure in `test_scipy_dist.py` from a scipy `sokalmichener` metric rename, unrelated to this change).